### PR TITLE
fix: ensure assistant message ID is always greater than parent user message ID

### DIFF
--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -83,4 +83,20 @@ export function timestamp(id: string): number {
   return Number(encoded / BigInt(0x1000))
 }
 
+export function ascendingAfter(prefix: keyof typeof prefixes, afterID: string): string {
+  const pre = prefixes[prefix]
+  const afterHex = afterID.slice(pre.length + 1, pre.length + 13)
+  const afterEncoded = BigInt("0x" + afterHex)
+  const nowFull = BigInt(Date.now()) * BigInt(0x1000)
+  const nowEncoded = nowFull & ((BigInt(1) << BigInt(48)) - BigInt(1))
+  const encoded = nowEncoded > afterEncoded ? nowEncoded + BigInt(1) : afterEncoded + BigInt(1)
+
+  const timeBytes = Buffer.alloc(6)
+  for (let i = 0; i < 6; i++) {
+    timeBytes[i] = Number((encoded >> BigInt(40 - 8 * i)) & BigInt(0xff))
+  }
+
+  return pre + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+}
+
 export * as Identifier from "./id"

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -304,7 +304,7 @@ export const layer: Layer.Layer<
       const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, { stripMedia: true })
       const ctx = yield* InstanceState.context
       const msg: MessageV2.Assistant = {
-        id: MessageID.ascending(),
+        id: MessageID.ascendingAfter(input.parentID),
         role: "assistant",
         parentID: input.parentID,
         sessionID: input.sessionID,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -536,7 +536,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const { task: taskTool } = yield* registry.named()
       const taskModel = task.model ? yield* getModel(task.model.providerID, task.model.modelID, sessionID) : model
       const assistantMessage: MessageV2.Assistant = yield* sessions.updateMessage({
-        id: MessageID.ascending(),
+        id: MessageID.ascendingAfter(lastUser.id),
         role: "assistant",
         parentID: lastUser.id,
         sessionID,
@@ -751,7 +751,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       yield* sessions.updatePart(userPart)
 
       const msg: MessageV2.Assistant = {
-        id: MessageID.ascending(),
+        id: MessageID.ascendingAfter(userMsg.id),
         sessionID: input.sessionID,
         parentID: userMsg.id,
         mode: input.agent,
@@ -1403,7 +1403,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           msgs = yield* insertReminders({ messages: msgs, agent, session })
 
           const msg: MessageV2.Assistant = {
-            id: MessageID.ascending(),
+            id: MessageID.ascendingAfter(lastUser.id),
             parentID: lastUser.id,
             role: "assistant",
             mode: agent.name,

--- a/packages/opencode/src/session/schema.ts
+++ b/packages/opencode/src/session/schema.ts
@@ -19,6 +19,7 @@ export const MessageID = Schema.String.annotate({ [ZodOverride]: Identifier.sche
   Schema.brand("MessageID"),
   withStatics((s) => ({
     ascending: (id?: string) => s.make(Identifier.ascending("message", id)),
+    ascendingAfter: (afterID: string) => s.make(Identifier.ascendingAfter("message", afterID)),
     zod: Identifier.schema("message").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
   })),
 )

--- a/packages/opencode/test/id/identifier.test.ts
+++ b/packages/opencode/test/id/identifier.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import { Identifier } from "../../src/id/id"
+
+describe("Identifier", () => {
+  describe("ascendingAfter", () => {
+    test("generates ID strictly greater than afterID", () => {
+      const parentId = Identifier.ascending("message")
+      const childId = Identifier.ascendingAfter("message", parentId)
+      expect(childId > parentId).toBe(true)
+      expect(childId.startsWith("msg_")).toBe(true)
+    })
+
+    test("handles same-millisecond parent ID", () => {
+      const now = Date.now()
+      const parentId = Identifier.create("msg", "ascending", now)
+      const childId = Identifier.ascendingAfter("message", parentId)
+      expect(childId > parentId).toBe(true)
+    })
+
+    test("handles clock skew: frontend 300ms ahead", () => {
+      const frontendTs = Date.now() + 300
+      const parentId = Identifier.create("msg", "ascending", frontendTs)
+      const childId = Identifier.ascendingAfter("message", parentId)
+      expect(childId > parentId).toBe(true)
+    })
+
+    test("handles extreme clock skew: frontend 5s ahead", () => {
+      const futureTs = Date.now() + 5000
+      const parentId = Identifier.create("msg", "ascending", futureTs)
+      const childId = Identifier.ascendingAfter("message", parentId)
+      expect(childId > parentId).toBe(true)
+    })
+
+    test("produces unique IDs on repeated calls", () => {
+      const parentId = Identifier.ascending("message")
+      const ids = new Set<string>()
+      for (let i = 0; i < 100; i++) {
+        ids.add(Identifier.ascendingAfter("message", parentId))
+      }
+      expect(ids.size).toBe(100)
+      for (const id of ids) {
+        expect(id > parentId).toBe(true)
+      }
+    })
+
+    test("does not interfere with ascending() monotonicity", () => {
+      const before = Identifier.ascending("message")
+      Identifier.ascendingAfter("message", before)
+      const after = Identifier.ascending("message")
+      expect(after > before).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #15657

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes a bug where the first assistant message after a user message could appear **above** the user message in the UI timeline, making it invisible to the user.

**Root cause**: When the frontend generates a user message ID using `Identifier.ascending("message")` and sends it to the backend, the backend creates the assistant message using `MessageID.ascending()`. Both calls use `Date.now()` internally. If the frontend and backend clocks are slightly out of sync (even by a few hundred milliseconds), the assistant message ID can end up **lexicographically smaller** than the user message ID. Since the UI sorts messages by ID string order, the assistant message appears before the user message.

**Fix**: Introduces `Identifier.ascendingAfter(prefix, afterID)` which operates in the truncated 48-bit encoding space to guarantee the generated ID is strictly greater than `afterID`. All four sites that create assistant messages now use `MessageID.ascendingAfter(parentID)` instead of `MessageID.ascending()`.

Key detail: the ID encoding only stores the lower 48 bits of `timestamp * 0x1000 + counter`, so the comparison must happen in that truncated space rather than against raw `Date.now()` values.

### How did you verify your code works?

- Added 6 unit tests in `test/id/identifier.test.ts` covering:
  - Normal case (backend time after frontend)
  - Same-millisecond parent ID
  - 300ms clock skew (frontend ahead)
  - 5s clock skew (extreme case)
  - 100 unique IDs generated from same parent
  - Non-interference with `ascending()` monotonicity
- All tests pass
- Typecheck passes with 0 new errors in changed files

### Screenshots / recordings

_N/A (backend logic change)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR