### PR TITLE
fix: prefer real undo filenames over /dev/null

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -54,7 +54,6 @@ import { useSDK } from "@tui/context/sdk"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import type { DialogContext } from "@tui/ui/dialog"
 import { useKeybind } from "@tui/context/keybind"
-import { parsePatch } from "diff"
 import { useDialog } from "../../ui/dialog"
 import { TodoItem } from "../../component/todo-item"
 import { DialogMessage } from "./dialog-message"
@@ -88,6 +87,7 @@ import { getScrollAcceleration } from "../../util/scroll"
 import { TuiPluginRuntime } from "../../plugin"
 import { DialogGoUpsell } from "../../component/dialog-go-upsell"
 import { SessionRetry } from "@/session/retry"
+import { getRevertDiffFiles } from "../../util/revert-diff"
 
 addDefaultParsers(parsers.parsers)
 
@@ -991,31 +991,7 @@ export function Session() {
   const revertInfo = createMemo(() => session()?.revert)
   const revertMessageID = createMemo(() => revertInfo()?.messageID)
 
-  const revertDiffFiles = createMemo(() => {
-    const diffText = revertInfo()?.diff ?? ""
-    if (!diffText) return []
-
-    try {
-      const patches = parsePatch(diffText)
-      return patches.map((patch) => {
-        const filename = patch.newFileName || patch.oldFileName || "unknown"
-        const cleanFilename = filename.replace(/^[ab]\//, "")
-        return {
-          filename: cleanFilename,
-          additions: patch.hunks.reduce(
-            (sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("+")).length,
-            0,
-          ),
-          deletions: patch.hunks.reduce(
-            (sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("-")).length,
-            0,
-          ),
-        }
-      })
-    } catch {
-      return []
-    }
-  })
+  const revertDiffFiles = createMemo(() => getRevertDiffFiles(revertInfo()?.diff ?? ""))
 
   const revertRevertedMessages = createMemo(() => {
     const messageID = revertMessageID()

--- a/packages/opencode/src/cli/cmd/tui/util/revert-diff.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/revert-diff.ts
@@ -1,0 +1,24 @@
+import { parsePatch } from "diff"
+
+export function getRevertDiffFiles(diffText: string) {
+  if (!diffText) return []
+
+  try {
+    return parsePatch(diffText).map((patch) => {
+      const filename = [patch.newFileName, patch.oldFileName].find((item) => item && item !== "/dev/null") ?? "unknown"
+      return {
+        filename: filename.replace(/^[ab]\//, ""),
+        additions: patch.hunks.reduce(
+          (sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("+")).length,
+          0,
+        ),
+        deletions: patch.hunks.reduce(
+          (sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("-")).length,
+          0,
+        ),
+      }
+    })
+  } catch {
+    return []
+  }
+}

--- a/packages/opencode/test/cli/tui/revert-diff.test.ts
+++ b/packages/opencode/test/cli/tui/revert-diff.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { getRevertDiffFiles } from "../../../src/cli/cmd/tui/util/revert-diff"
+
+describe("revert diff", () => {
+  test("prefers the actual file path over /dev/null for added and deleted files", () => {
+    const files = getRevertDiffFiles(`diff --git a/new.txt b/new.txt
+new file mode 100644
+index 0000000..3b18e51
+--- /dev/null
++++ b/new.txt
+@@ -0,0 +1 @@
++new content
+diff --git a/old.txt b/old.txt
+deleted file mode 100644
+index 3b18e51..0000000
+--- a/old.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-old content
+`)
+
+    expect(files).toEqual([
+      {
+        filename: "new.txt",
+        additions: 1,
+        deletions: 0,
+      },
+      {
+        filename: "old.txt",
+        additions: 0,
+        deletions: 1,
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- prefer the non-`/dev/null` side of each Git patch when rendering the reverted file list in the TUI undo banner
- extract the revert diff parsing into a small helper so the filename selection logic is isolated and reusable
- add a focused TUI regression test covering added and deleted patches so undo consistently shows the real filenames

## Testing
- bun test test/cli/tui/revert-diff.test.ts test/snapshot/snapshot.test.ts
- bun typecheck