### PR TITLE
fix(electron): quit app on window-all-closed to kill sidecar on macOS

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -94,6 +94,14 @@ function setupApp() {
     killSidecar()
   })
 
+  // On macOS, closing all windows does not quit the app by default —
+  // the process stays alive in the Dock with the sidecar still running.
+  // Explicitly quit so the sidecar is cleaned up via before-quit/will-quit.
+  app.on("window-all-closed", () => {
+    killSidecar()
+    app.quit()
+  })
+
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.on(signal, () => {
       killSidecar()


### PR DESCRIPTION
### Issue for this PR

Closes #17068

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On macOS, closing the Electron window doesn't quit the app — it stays alive in the dock (standard macOS behavior). Because there's no `window-all-closed` handler, the `opencode-cli serve` sidecar process is never killed. Over multiple sessions, zombie sidecar processes accumulate, each consuming ~1GB RAM and pegging a CPU core at 100%.

The existing cleanup hooks (`before-quit`, `will-quit`) only fire when the app actually quits, not when the last window is closed.

This PR adds a `window-all-closed` handler that calls `killSidecar()` then `app.quit()`. This ensures the sidecar is terminated when the user closes the window on macOS, matching the behavior users expect.

I understand why this works: on macOS, Electron keeps running after the last window closes unless `app.quit()` is explicitly called. The existing `will-quit` handler already calls `killSidecar()`, but it never fires because the app never quits. Adding `window-all-closed` bridges that gap. On Linux/Windows, `window-all-closed` already triggers app quit by default, so this is a no-op there — but the explicit handler makes the intent clear across platforms.

### How did you verify your code works?

1. Built and ran the Electron desktop app on macOS (Apple Silicon)
2. Opened a session, ran commands to confirm `opencode-cli serve` was running
3. Closed the window (Cmd+W) — verified the sidecar process was killed and the app quit
4. Confirmed no zombie `opencode-cli` processes remained via `ps aux | grep opencode-cli`
5. Verified the fix doesn't affect the `before-quit`/`will-quit` flow (quitting via Cmd+Q still works)

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR