### PR TITLE
refactor: use InstanceState context in worktree cleanup paths

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -365,13 +365,14 @@ export const layer: Layer.Layer<
     }
 
     const remove = Effect.fn("Worktree.remove")(function* (input: RemoveInput) {
-      if (Instance.project.vcs !== "git") {
+      const ctx = yield* InstanceState.context
+      if (ctx.project.vcs !== "git") {
         throw new NotGitError({ message: "Worktrees are only supported for git projects" })
       }
 
       const directory = yield* canonical(input.directory)
 
-      const list = yield* git(["worktree", "list", "--porcelain"], { cwd: Instance.worktree })
+      const list = yield* git(["worktree", "list", "--porcelain"], { cwd: ctx.worktree })
       if (list.code !== 0) {
         throw new RemoveFailedError({ message: list.stderr || list.text || "Failed to read git worktrees" })
       }
@@ -389,9 +390,9 @@ export const layer: Layer.Layer<
       }
 
       yield* stopFsmonitor(entry.path)
-      const removed = yield* git(["worktree", "remove", "--force", entry.path], { cwd: Instance.worktree })
+      const removed = yield* git(["worktree", "remove", "--force", entry.path], { cwd: ctx.worktree })
       if (removed.code !== 0) {
-        const next = yield* git(["worktree", "list", "--porcelain"], { cwd: Instance.worktree })
+        const next = yield* git(["worktree", "list", "--porcelain"], { cwd: ctx.worktree })
         if (next.code !== 0) {
           throw new RemoveFailedError({
             message: removed.stderr || removed.text || next.stderr || next.text || "Failed to remove git worktree",
@@ -408,7 +409,7 @@ export const layer: Layer.Layer<
 
       const branch = entry.branch?.replace(/^refs\/heads\//, "")
       if (branch) {
-        const deleted = yield* git(["branch", "-D", branch], { cwd: Instance.worktree })
+        const deleted = yield* git(["branch", "-D", branch], { cwd: ctx.worktree })
         if (deleted.code !== 0) {
           throw new RemoveFailedError({
             message: deleted.stderr || deleted.text || "Failed to delete worktree branch",
@@ -498,17 +499,18 @@ export const layer: Layer.Layer<
     })
 
     const reset = Effect.fn("Worktree.reset")(function* (input: ResetInput) {
-      if (Instance.project.vcs !== "git") {
+      const ctx = yield* InstanceState.context
+      if (ctx.project.vcs !== "git") {
         throw new NotGitError({ message: "Worktrees are only supported for git projects" })
       }
 
       const directory = yield* canonical(input.directory)
-      const primary = yield* canonical(Instance.worktree)
+      const primary = yield* canonical(ctx.worktree)
       if (directory === primary) {
         throw new ResetFailedError({ message: "Cannot reset the primary workspace" })
       }
 
-      const list = yield* git(["worktree", "list", "--porcelain"], { cwd: Instance.worktree })
+      const list = yield* git(["worktree", "list", "--porcelain"], { cwd: ctx.worktree })
       if (list.code !== 0) {
         throw new ResetFailedError({ message: list.stderr || list.text || "Failed to read git worktrees" })
       }
@@ -520,7 +522,7 @@ export const layer: Layer.Layer<
 
       const worktreePath = entry.path
 
-      const base = yield* gitSvc.defaultBranch(Instance.worktree)
+      const base = yield* gitSvc.defaultBranch(ctx.worktree)
       if (!base) {
         throw new ResetFailedError({ message: "Default branch not found" })
       }
@@ -531,7 +533,7 @@ export const layer: Layer.Layer<
         const branch = base.ref.slice(sep + 1)
         yield* gitExpect(
           ["fetch", remote, branch],
-          { cwd: Instance.worktree },
+          { cwd: ctx.worktree },
           (r) => new ResetFailedError({ message: r.stderr || r.text || `Failed to fetch ${base.ref}` }),
         )
       }
@@ -574,7 +576,7 @@ export const layer: Layer.Layer<
         throw new ResetFailedError({ message: `Worktree reset left local changes:\n${status.text.trim()}` })
       }
 
-      yield* runStartScripts(worktreePath, { projectID: Instance.project.id }).pipe(
+      yield* runStartScripts(worktreePath, { projectID: ctx.project.id }).pipe(
         Effect.catchCause((cause) => Effect.sync(() => log.error("worktree start task failed", { cause }))),
         Effect.forkIn(scope),
       )


### PR DESCRIPTION
## Summary
- replace legacy ambient `Instance.*` reads in `packages/opencode/src/worktree/index.ts` remove/reset paths with yielded `InstanceState.context`
- keep the existing `Instance.provide(...)` bootstrap boundary in place because `InstanceBootstrap` still crosses into a non-migrated boundary

## Testing
- `bun typecheck` in `packages/opencode` *(fails locally: `tsgo` not found in this worktree environment)*
- `bunx --bun @typescript/native-preview --noEmit` in `packages/opencode` *(fails in existing workspace type setup; unrelated project-wide type errors surfaced)*