### PR TITLE
refactor: pass formatter instance context explicitly

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -1,15 +1,17 @@
 import { Npm } from "../npm"
-import { Instance } from "../project/instance"
+import type { InstanceContext } from "../project/instance"
 import { Filesystem } from "../util"
 import { Process } from "../util"
 import { which } from "../util/which"
 import { Flag } from "@/flag/flag"
 
+export interface Context extends Pick<InstanceContext, "directory" | "worktree"> {}
+
 export interface Info {
   name: string
   environment?: Record<string, string>
   extensions: string[]
-  enabled(): Promise<string[] | false>
+  enabled(context: Context): Promise<string[] | false>
 }
 
 export const gofmt: Info = {
@@ -65,8 +67,8 @@ export const prettier: Info = {
     ".graphql",
     ".gql",
   ],
-  async enabled() {
-    const items = await Filesystem.findUp("package.json", Instance.directory, Instance.worktree)
+  async enabled(context) {
+    const items = await Filesystem.findUp("package.json", context.directory, context.worktree)
     for (const item of items) {
       const json = await Filesystem.readJson<{
         dependencies?: Record<string, string>
@@ -87,9 +89,9 @@ export const oxfmt: Info = {
     BUN_BE_BUN: "1",
   },
   extensions: [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"],
-  async enabled() {
+  async enabled(context) {
     if (!Flag.OPENCODE_EXPERIMENTAL_OXFMT) return false
-    const items = await Filesystem.findUp("package.json", Instance.directory, Instance.worktree)
+    const items = await Filesystem.findUp("package.json", context.directory, context.worktree)
     for (const item of items) {
       const json = await Filesystem.readJson<{
         dependencies?: Record<string, string>
@@ -137,10 +139,10 @@ export const biome: Info = {
     ".graphql",
     ".gql",
   ],
-  async enabled() {
+  async enabled(context) {
     const configs = ["biome.json", "biome.jsonc"]
     for (const config of configs) {
-      const found = await Filesystem.findUp(config, Instance.directory, Instance.worktree)
+      const found = await Filesystem.findUp(config, context.directory, context.worktree)
       if (found.length > 0) {
         const bin = await Npm.which("@biomejs/biome")
         if (bin) return [bin, "format", "--write", "$FILE"]
@@ -163,8 +165,8 @@ export const zig: Info = {
 export const clang: Info = {
   name: "clang-format",
   extensions: [".c", ".cc", ".cpp", ".cxx", ".c++", ".h", ".hh", ".hpp", ".hxx", ".h++", ".ino", ".C", ".H"],
-  async enabled() {
-    const items = await Filesystem.findUp(".clang-format", Instance.directory, Instance.worktree)
+  async enabled(context) {
+    const items = await Filesystem.findUp(".clang-format", context.directory, context.worktree)
     if (items.length > 0) {
       const match = which("clang-format")
       if (match) return [match, "-i", "$FILE"]
@@ -186,11 +188,11 @@ export const ktlint: Info = {
 export const ruff: Info = {
   name: "ruff",
   extensions: [".py", ".pyi"],
-  async enabled() {
+  async enabled(context) {
     if (!which("ruff")) return false
     const configs = ["pyproject.toml", "ruff.toml", ".ruff.toml"]
     for (const config of configs) {
-      const found = await Filesystem.findUp(config, Instance.directory, Instance.worktree)
+      const found = await Filesystem.findUp(config, context.directory, context.worktree)
       if (found.length > 0) {
         if (config === "pyproject.toml") {
           const content = await Filesystem.readText(found[0])
@@ -202,7 +204,7 @@ export const ruff: Info = {
     }
     const deps = ["requirements.txt", "pyproject.toml", "Pipfile"]
     for (const dep of deps) {
-      const found = await Filesystem.findUp(dep, Instance.directory, Instance.worktree)
+      const found = await Filesystem.findUp(dep, context.directory, context.worktree)
       if (found.length > 0) {
         const content = await Filesystem.readText(found[0])
         if (content.includes("ruff")) return ["ruff", "format", "$FILE"]
@@ -233,8 +235,8 @@ export const rlang: Info = {
 export const uvformat: Info = {
   name: "uv",
   extensions: [".py", ".pyi"],
-  async enabled() {
-    if (await ruff.enabled()) return false
+  async enabled(context) {
+    if (await ruff.enabled(context)) return false
     const uv = which("uv")
     if (uv == null) return false
     const output = await Process.run([uv, "format", "--help"], { nothrow: true })
@@ -286,9 +288,9 @@ export const dart: Info = {
 export const ocamlformat: Info = {
   name: "ocamlformat",
   extensions: [".ml", ".mli"],
-  async enabled() {
+  async enabled(context) {
     if (!which("ocamlformat")) return false
-    const items = await Filesystem.findUp(".ocamlformat", Instance.directory, Instance.worktree)
+    const items = await Filesystem.findUp(".ocamlformat", context.directory, context.worktree)
     if (items.length > 0) return ["ocamlformat", "-i", "$FILE"]
     return false
   },
@@ -357,8 +359,8 @@ export const rustfmt: Info = {
 export const pint: Info = {
   name: "pint",
   extensions: [".php"],
-  async enabled() {
-    const items = await Filesystem.findUp("composer.json", Instance.directory, Instance.worktree)
+  async enabled(context) {
+    const items = await Filesystem.findUp("composer.json", context.directory, context.worktree)
     for (const item of items) {
       const json = await Filesystem.readJson<{
         require?: Record<string, string>

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -37,18 +37,14 @@ export const layer = Layer.effect(
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
 
     const state = yield* InstanceState.make(
-      Effect.fn("Format.state")(function* (_ctx) {
+      Effect.fn("Format.state")(function* (ctx) {
         const commands: Record<string, string[] | false> = {}
         const formatters: Record<string, Formatter.Info> = {}
-        const context = {
-          directory: _ctx.directory,
-          worktree: _ctx.worktree,
-        }
 
         async function getCommand(item: Formatter.Info) {
           let cmd = commands[item.name]
           if (cmd === false || cmd === undefined) {
-            cmd = await item.enabled(context)
+            cmd = await item.enabled(ctx)
             commands[item.name] = cmd
           }
           return cmd

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -40,11 +40,15 @@ export const layer = Layer.effect(
       Effect.fn("Format.state")(function* (_ctx) {
         const commands: Record<string, string[] | false> = {}
         const formatters: Record<string, Formatter.Info> = {}
+        const context = {
+          directory: _ctx.directory,
+          worktree: _ctx.worktree,
+        }
 
         async function getCommand(item: Formatter.Info) {
           let cmd = commands[item.name]
           if (cmd === false || cmd === undefined) {
-            cmd = await item.enabled()
+            cmd = await item.enabled(context)
             commands[item.name] = cmd
           }
           return cmd
@@ -153,7 +157,7 @@ export const layer = Layer.effect(
               ...info,
               name,
               extensions: info.extensions ?? [],
-              enabled: builtIn && !info.command ? builtIn.enabled : async () => info.command ?? false,
+              enabled: builtIn && !info.command ? builtIn.enabled : async (_context) => info.command ?? false,
             }
           }
         }


### PR DESCRIPTION
## Summary
- thread `{ directory, worktree }` into formatter enablement checks instead of reading ambient `Instance.*` state in `formatter.ts`
- keep the existing formatter selection and config override behavior unchanged by passing the current instance context from `Format.state`

## Testing
- bun typecheck