### PR TITLE
refactor: use instance state in small services

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -14,7 +14,6 @@ import { ConfigMCP } from "../config/mcp"
 import { Log } from "../util"
 import { NamedError } from "@opencode-ai/shared/util/error"
 import z from "zod/v4"
-import { Instance } from "../project/instance"
 import { Installation } from "../installation"
 import { InstallationVersion } from "../installation/version"
 import { withTimeout } from "@/util/timeout"
@@ -391,7 +390,7 @@ export const layer = Layer.effect(
       mcp: ConfigMCP.Info & { type: "local" },
     ) {
       const [cmd, ...args] = mcp.command
-      const cwd = Instance.directory
+      const cwd = yield* InstanceState.directory
       const transport = new StdioClientTransport({
         stderr: "pipe",
         command: cmd,

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -8,7 +8,6 @@ import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 import { FileWatcher } from "@/file/watcher"
 import { Git } from "@/git"
 import { Log } from "@/util"
-import { Instance } from "./instance"
 import z from "zod"
 
 const log = Log.create({ service: "vcs" })
@@ -205,21 +204,17 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Git.Serv
       }),
       diff: Effect.fn("Vcs.diff")(function* (mode: Mode) {
         const value = yield* InstanceState.get(state)
-        if (Instance.project.vcs !== "git") return []
+        const ctx = yield* InstanceState.context
+        if (ctx.project.vcs !== "git") return []
         if (mode === "git") {
-          return yield* track(
-            fs,
-            git,
-            Instance.directory,
-            (yield* git.hasHead(Instance.directory)) ? "HEAD" : undefined,
-          )
+          return yield* track(fs, git, ctx.directory, (yield* git.hasHead(ctx.directory)) ? "HEAD" : undefined)
         }
 
         if (!value.root) return []
         if (value.current && value.current === value.root.name) return []
-        const ref = yield* git.mergeBase(Instance.directory, value.root.ref)
+        const ref = yield* git.mergeBase(ctx.directory, value.root.ref)
         if (!ref) return []
-        return yield* compare(fs, git, Instance.directory, ref)
+        return yield* compare(fs, git, ctx.directory, ref)
       }),
     })
   }),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -13,7 +13,6 @@ import { type LanguageModelV3 } from "@ai-sdk/provider"
 import * as ModelsDev from "./models"
 import { Auth } from "../auth"
 import { Env } from "../env"
-import { Instance } from "../project/instance"
 import { InstallationVersion } from "../installation/version"
 import { Flag } from "../flag/flag"
 import { zod } from "@/util/effect-zod"
@@ -537,6 +536,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       const token = apiKey ?? (yield* dep.get("GITLAB_TOKEN"))
 
       const providerConfig = (yield* dep.config()).provider?.["gitlab"]
+      const directory = yield* InstanceState.directory
 
       const aiGatewayHeaders = {
         "User-Agent": `opencode/${InstallationVersion} gitlab-ai-provider/${GITLAB_PROVIDER_VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`,
@@ -591,10 +591,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
               auth?.type === "api" ? { "PRIVATE-TOKEN": token } : { Authorization: `Bearer ${token}` }
 
             log.info("gitlab model discovery starting", { instanceUrl })
-            const result = await discoverWorkflowModels(
-              { instanceUrl, getHeaders },
-              { workingDirectory: Instance.directory },
-            )
+            const result = await discoverWorkflowModels({ instanceUrl, getHeaders }, { workingDirectory: directory })
 
             if (!result.models.length) {
               log.info("gitlab model discovery skipped: no models found", {

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -8,7 +8,6 @@ import { Flag } from "@/flag/flag"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { Global } from "../global"
-import { Instance } from "../project/instance"
 import { Log } from "../util"
 import type { MessageV2 } from "./message-v2"
 import type { MessageID } from "./schema"
@@ -82,9 +81,10 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
       )
 
       const relative = Effect.fnUntraced(function* (instruction: string) {
+        const ctx = yield* InstanceState.context
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
           return yield* fs
-            .globUp(instruction, Instance.directory, Instance.worktree)
+            .globUp(instruction, ctx.directory, ctx.worktree)
             .pipe(Effect.catch(() => Effect.succeed([] as string[])))
         }
         if (!Flag.OPENCODE_CONFIG_DIR) {
@@ -119,12 +119,13 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
 
       const systemPaths = Effect.fn("Instruction.systemPaths")(function* () {
         const config = yield* cfg.get()
+        const ctx = yield* InstanceState.context
         const paths = new Set<string>()
 
         // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
           for (const file of FILES) {
-            const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
+            const matches = yield* fs.findUp(file, ctx.directory, ctx.worktree)
             if (matches.length > 0) {
               matches.forEach((item) => paths.add(path.resolve(item)))
               break
@@ -191,9 +192,9 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         const already = extract(messages)
         const results: { filepath: string; content: string }[] = []
         const s = yield* InstanceState.get(state)
+        const root = path.resolve(yield* InstanceState.directory)
 
         const target = path.resolve(filepath)
-        const root = path.resolve(Instance.directory)
         let current = path.dirname(target)
 
         // Walk upward from the file being read and attach nearby instruction files once per message.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer } from "effect"
 
-import { InstanceState } from "@/effect"
+import { Instance } from "../project/instance"
 
 import PROMPT_ANTHROPIC from "./prompt/anthropic.txt"
 import PROMPT_DEFAULT from "./prompt/default.txt"
@@ -43,18 +43,18 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const skill = yield* Skill.Service
-    const ctx = yield* InstanceState.context
 
     return Service.of({
       environment(model) {
+        const project = Instance.project
         return [
           [
             `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
             `Here is some useful information about the environment you are running in:`,
             `<env>`,
-            `  Working directory: ${ctx.directory}`,
-            `  Workspace root folder: ${ctx.worktree}`,
-            `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
+            `  Working directory: ${Instance.directory}`,
+            `  Workspace root folder: ${Instance.worktree}`,
+            `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
             `  Today's date: ${new Date().toDateString()}`,
             `</env>`,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer } from "effect"
 
-import { Instance } from "../project/instance"
+import { InstanceState } from "@/effect"
 
 import PROMPT_ANTHROPIC from "./prompt/anthropic.txt"
 import PROMPT_DEFAULT from "./prompt/default.txt"
@@ -43,18 +43,18 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const skill = yield* Skill.Service
+    const ctx = yield* InstanceState.context
 
     return Service.of({
       environment(model) {
-        const project = Instance.project
         return [
           [
             `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
             `Here is some useful information about the environment you are running in:`,
             `<env>`,
-            `  Working directory: ${Instance.directory}`,
-            `  Workspace root folder: ${Instance.worktree}`,
-            `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
+            `  Working directory: ${ctx.directory}`,
+            `  Workspace root folder: ${ctx.worktree}`,
+            `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
             `  Today's date: ${new Date().toDateString()}`,
             `</env>`,


### PR DESCRIPTION
## Summary
- replace ambient `Instance.*` reads in `vcs`, `provider`, `mcp`, `instruction`, and `system` with `InstanceState` context or directory reads
- keep behavior the same by threading the current instance context through existing Effect code paths and async callbacks
- remove the now-unused legacy `Instance` imports from those small service files

## Testing
- `bun typecheck` (from `packages/opencode`)