### PR TITLE
fix(app): use fetchQuery instead of ensureQueryData in global sync

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -204,7 +204,7 @@ function createGlobalSync() {
 
     const limit = Math.max(store.limit + SESSION_RECENT_LIMIT, SESSION_RECENT_LIMIT)
     const promise = queryClient
-      .ensureQueryData({
+      .fetchQuery({
         ...loadSessionsQuery(directory),
         queryFn: () =>
           loadRootSessionsWithFallback({


### PR DESCRIPTION
Replaces "ensureQueryData" with "fetchQuery" in the global sync context to align with the intended query behavior.