### PR TITLE
fix(app): allow Load More to refetch when trimmed session cache is insufficient

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -198,8 +198,11 @@ function createGlobalSync() {
         setStore("session", reconcile(next, { key: "id" }))
         cleanupDroppedSessionCaches(store, setStore, next, setSessionTodo)
       }
-      children.unpin(directory)
-      return
+      const rootCount = next.filter((s) => !s.parentID).length
+      if (rootCount >= store.limit || store.sessionTotal <= rootCount) {
+        children.unpin(directory)
+        return
+      }
     }
 
     const limit = Math.max(store.limit + SESSION_RECENT_LIMIT, SESSION_RECENT_LIMIT)


### PR DESCRIPTION
### Issue for this PR

Closes #23026

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When there are many sessions, clicking "Load More" often does nothing because `loadSessions` returns early when `meta.limit >= store.limit`, even though the store only keeps a trimmed subset of sessions. This change adds a root-count check so the function only skips the API call when we already have enough root sessions loaded or when there are no more sessions on the server.

### How did you verify your code works?

Reviewed the logic against the frontend state flow and confirmed the diff is minimal and safe.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR