### PR TITLE
feat(tui): add tree-sitter-diff parser for diff syntax highlighting

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -286,5 +286,14 @@ export default {
         ],
       },
     },
+    {
+      filetype: "diff",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-diff/releases/download/v0.1.0/tree-sitter-diff.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/tree-sitter-grammars/tree-sitter-diff/refs/heads/main/queries/highlights.scm",
+        ],
+      },
+    },
   ],
 }


### PR DESCRIPTION
   Fenced code blocks with language `diff` were not syntax-highlighted because no tree-sitter-diff parser was registered. The theme already maps @diff.plus and @diff.minus to green/red colors, so only the parser entry was missing.         
                                                                                                                                                                                                                                               
   Closes #6831                                                                                                                                                                                                                                
                                                                                                                                                                                                                                               
   ### Issue for this PR                                                                                                                                                                                                                       
                                                                                                                                                                                                                                               
   Closes #6831                                                                                                                                                                                                                                
                                                                                                                                                                                                                                               
   ### Type of change                                                                                                                                                                                                                          
                                                                                                                                                                                                                                               
   - [ ] Bug fix                                                                                                                                                                                                                               
   - [x] New feature                                                                                                                                                                                                                           
   - [ ] Refactor / code improvement                                                                                                                                                                                                           
   - [ ] Documentation                                                                                                                                                                                                                         
                                                                                                                                                                                                                                               
   ### What does this PR do?                                                                                                                                                                                                                   
                                                                                                                                                                                                                                               
   Fenced ` ```diff ` code blocks rendered as plain unstyled text because no `tree-sitter-diff` parser was registered in `parsers-config.ts`. The theme in `theme.tsx` already maps `diff.plus` → green and `diff.minus` → red via                `getSyntaxRules()`, so the only missing piece was the parser itself.                                                                                                                                                                        
                                                                                                                                                                                                                                               
   This PR adds a single entry to `parsers-config.ts`:                                                                                                                                                                                         
   - WASM grammar: `tree-sitter-grammars/tree-sitter-diff` v0.1.0                                                                                                                                                                              
   - Highlight queries: from the same repo's `main` branch                                                                                                                                                                                     
                                                                                                                                                                                                                                               
   The entry follows the exact same pattern as every other parser in the file (e.g. `bash`, `toml`, `hcl`). No other files were changed.                                                                                                       
                                                                                                                                                                                                                                               
   ### How did you verify your code works?                                                                                                                                                                                                     
                                                                                                                                                                                                                                               
   - Built from source (`bun run build` in `packages/opencode`) — build succeeded, smoke test passed                                                                                                                                           
   - Typecheck passed across all 13 packages via `turbo typecheck`                                                                                                                                                                             
   - Verified the WASM binary is downloadable from the release URL                                                                                                                                                                             
   - Verified the highlight queries are valid and use capture names (`@diff.plus`, `@diff.minus`, `@attribute`, etc.) that are already mapped in the theme                                                                                     
                                                                                                                                                                                                                                               
   ### Screenshots / recordings

<img width="1160" height="406" alt="Screenshot 2026-04-17 104304" src="https://github.com/user-attachments/assets/d4244dbb-f828-4c50-aa22-453327dce15d" />                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
   ### Checklist                                                                                                                                                                                                                               
                                                                                                                                                                                                                                               
   - [x] I have tested my changes locally                                                                                                                                                                                                      
   - [x] I have not included unrelated changes in this PR 