### PR TITLE
docs: adding Mistral to docs as a provider (it is already a provider, just docs update) #23070

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1316,6 +1316,33 @@ To use Kimi K2 from Moonshot AI:
 
 ---
 
+### Mistral AI
+
+1.  Head over to the [Mistral AI console](https://console.mistral.ai/), create an account, and generate an API key.
+
+2. Run the `/connect` command and search for **Mistral AI**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your Mistral API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _Mistral Medium_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### Nebius Token Factory
 
 1. Head over to the [Nebius Token Factory console](https://tokenfactory.nebius.com/), create an account, and click **Add Key**.


### PR DESCRIPTION
### Issue for this PR
Mistral missing from documentation list of providers

Closes #23070

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

The issue is that Mistral is a provider for OpenCode, but they were missing from the OpenCode Providers list in the documentation. This PR adds instructions to the documentation for how to select Mistral as a provider. The change I made was to add to the documentation. I know it works because I built and ran the docs locally and previewed the changes.

I work at Mistral AI. Mistral is a provider option for OpenCode, but it wasn't listed in the docs, so I've added instructions.

### How did you verify your code works?

Built and ran the docs locally to preview the changes.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

This is not a UI change

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
