### PR TITLE
fix(app): stop using orphaned assistant messages for working state

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -151,18 +151,8 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   })
   const isWorking = createMemo(() => {
     if (hasPermissions()) return false
-    const pending = (sessionStore.message[props.session.id] ?? []).findLast(
-      (message) =>
-        message.role === "assistant" &&
-        typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
-    )
     const status = sessionStore.session_status[props.session.id]
-    return (
-      pending !== undefined ||
-      status?.type === "busy" ||
-      status?.type === "retry" ||
-      (status !== undefined && status.type !== "idle")
-    )
+    return status?.type === "busy" || status?.type === "retry" || (status !== undefined && status.type !== "idle")
   })
 
   const tint = createMemo(() => messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent))

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1497,10 +1497,7 @@ export default function Page() {
     })
 
   const busy = (sessionID: string) => {
-    if ((sync.data.session_status[sessionID] ?? { type: "idle" as const }).type !== "idle") return true
-    return (sync.data.message[sessionID] ?? []).some(
-      (item) => item.role === "assistant" && typeof item.time.completed !== "number",
-    )
+    return (sync.data.session_status[sessionID] ?? { type: "idle" as const }).type !== "idle"
   }
 
   const queuedFollowups = createMemo(() => {

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -259,7 +259,7 @@ export function MessageTimeline(props: {
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
-  const working = createMemo(() => !!pending() || sessionStatus().type !== "idle")
+  const working = createMemo(() => sessionStatus().type !== "idle")
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 
   const [timeoutDone, setTimeoutDone] = createSignal(true)


### PR DESCRIPTION
### Issue for this PR

Closes #17680, #18828, #21840, #21939

### Type of change

- [x] Bug fix

### What does this PR do?

The chat progress bar animation, session sidebar spinner, and followup dock all treated incomplete assistant messages (no `time.completed`) as evidence the session was still working. If the server restarted or a stream was interrupted mid-response, those orphaned messages caused permanent spinners even though `session_status` was correctly `"idle"`.

The send button did **not** have this bug because it only checked `session_status`. Now all three locations use the same source of truth — `session_status` from the backend — which is always correct after a fresh start.

Changes:
- `message-timeline.tsx` — `working` memo checks only `sessionStatus().type !== "idle"`
- `sidebar-items.tsx` — `isWorking` memo checks only `session_status` type
- `session.tsx` — `busy()` helper simplified to only check `session_status`

### How did you verify your code works?

1. Started a session, asked for a long story
2. Killed the server mid-response, restarted it
3. Confirmed the assistant message in the DB has no `time.completed`
4. Confirmed the progress bar and sidebar spinner now correctly show idle instead of permanently animating
5. `bun typecheck` passes in `packages/app`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR