### PR TITLE
fix(ui): use parentID matching instead of positional scan for assistant messages

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -267,14 +267,12 @@ export function SessionTurn(
       if (!msg) return emptyAssistant
 
       const messages = allMessages() ?? emptyMessages
-      const index = messageIndex()
-      if (index < 0) return emptyAssistant
+      if (messageIndex() < 0) return emptyAssistant
 
       const result: AssistantMessage[] = []
-      for (let i = index + 1; i < messages.length; i++) {
+      for (let i = 0; i < messages.length; i++) {
         const item = messages[i]
         if (!item) continue
-        if (item.role === "user") break
         if (item.role === "assistant" && item.parentID === msg.id) result.push(item as AssistantMessage)
       }
       return result


### PR DESCRIPTION
### Issue for this PR

Closes #14236
Closes #23092

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

fix issue described in #23092

### How did you verify your code works?

- Verified the fix resolves the real-world case from #14236 / #23092 where a 3124ms clock skew caused Assistant 1 to sort before the user message and disappear
- Ran `bun typecheck` in `packages/ui` — passes
- Confirmed revert, fork, and retry flows are unaffected: reverted messages are filtered before rendering (server deletes them via `SyncEvent`), fork generates fresh IDs, retry assistant messages share the same `parentID` regardless of scan direction

### Screenshots / recordings

see below

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
