### PR TITLE
fix(opencode): rescrict github copilot opus 4.7 variants to "medium"

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -588,7 +588,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
 
       if (model.providerID === "github-copilot") {
-        if (model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")) {
+        if (model.api.id.includes("opus-4.7")) {
           return Object.fromEntries(["medium"].map((effort) => [effort, { reasoningEffort: effort }]))
         }
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -587,6 +587,12 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/google-vertex/anthropic":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
 
+      if (model.providerID === "github-copilot") {
+        if (model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")) {
+          return Object.fromEntries(["medium"].map((effort) => [effort, { reasoningEffort: effort }]))
+        }
+      }
+
       if (adaptiveEfforts) {
         return Object.fromEntries(
           adaptiveEfforts.map((effort) => [


### PR DESCRIPTION
### Issue for this PR

Closes #23082

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds case for Github Copilot Provider supporting only the "medium" reasoning variant.

Was able to confirm only this `reasoning_effort` from the error given to the user on the issue and also using the endpoint `https://api.githubcopilot.com/models` it return the following for opus 4.7.

```json
        {
            "capabilities": {
                "family": "claude-opus-4.7",
                ...
                "supports": {
                    "reasoning_effort": [
                        "medium"
                    ]
                }
            }
        }
```

### How did you verify your code works?

Ran on my local dev instance and was able to only cycle from default to medium

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR