### PR TITLE
feat(opencode): display cached token count inline in TUI

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -263,17 +263,19 @@ export function Prompt(props: PromptProps) {
     const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
     if (!last) return
 
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    if (tokens <= 0) return
+    const cached = last.tokens.cache.read + last.tokens.cache.write
+     const tokens =
+       last.tokens.input + last.tokens.output + last.tokens.reasoning + cached
+     if (tokens <= 0) return
 
-    const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
-    const cost = session?.cost ?? 0
-    return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
-      cost: cost > 0 ? money.format(cost) : undefined,
-    }
+     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+     const cost = session?.cost ?? 0
+     const tokenText = cached > 0 ? `${Locale.number(tokens)} (${Locale.number(cached)} cached)` : Locale.number(tokens)
+     return {
+       context: pct ? `${tokenText} (${pct})` : tokenText,
+       cost: cost > 0 ? money.format(cost) : undefined,
+     }
   })
 
   const [store, setStore] = createStore<{

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -21,17 +21,26 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
     if (!last) {
       return {
         tokens: 0,
+        cached: 0,
         percent: null,
       }
     }
 
+    const cached = last.tokens.cache.read + last.tokens.cache.write
     const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+      last.tokens.input + last.tokens.output + last.tokens.reasoning + cached
     const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     return {
       tokens,
+      cached,
       percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
     }
+  })
+
+  const tokenText = createMemo(() => {
+    const cached = state().cached
+    if (cached === 0) return `${state().tokens.toLocaleString()} tokens`
+    return `${state().tokens.toLocaleString()} tokens (${cached.toLocaleString()} cached)`
   })
 
   return (
@@ -39,7 +48,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       <text fg={theme().text}>
         <b>Context</b>
       </text>
-      <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
+      <text fg={theme().textMuted}>{tokenText()}</text>
       <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
       <text fg={theme().textMuted}>{money.format(cost())} spent</text>
     </box>

--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -35,8 +35,9 @@ export function SubagentFooter() {
     const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
     if (!last) return
 
+    const cached = last.tokens.cache.read + last.tokens.cache.write
     const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+      last.tokens.input + last.tokens.output + last.tokens.reasoning + cached
     if (tokens <= 0) return
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
@@ -48,8 +49,9 @@ export function SubagentFooter() {
       currency: "USD",
     })
 
+    const tokenText = cached > 0 ? `${Locale.number(tokens)} (${Locale.number(cached)} cached)` : Locale.number(tokens)
     return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
+      context: pct ? `${tokenText} (${pct})` : tokenText,
       cost: cost > 0 ? money.format(cost) : undefined,
     }
   })


### PR DESCRIPTION
### Issue for this PR

Closes #23109

### Type of change

- [x] New feature

### What does this PR do?

Shows \`(N cached)\` inline next to the token count in the sidebar context panel, prompt footer, and subagent footer when \`cache.read + cache.write > 0\`. No change when zero.

### How did you verify your code works?

Tested locally with Bedrock Sonnet 4.6. See screenshot below.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR