### PR TITLE
fix(app): use loadProvidersQuery key for per-directory provider refresh

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -19,7 +19,6 @@ import type { State, VcsCache } from "./types"
 import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
 import { QueryClient, queryOptions, skipToken } from "@tanstack/solid-query"
-import { loadSessionsQuery } from "../global-sync"
 
 type GlobalStore = {
   ready: boolean
@@ -349,7 +348,7 @@ export async function bootstrapDirectory(input: {
     const rev = (providerRev.get(input.directory) ?? 0) + 1
     providerRev.set(input.directory, rev)
     void input.queryClient.ensureQueryData({
-      ...loadSessionsQuery(input.directory),
+      ...loadProvidersQuery(input.directory),
       queryFn: () =>
         retry(() => input.sdk.provider.list())
           .then((x) => {


### PR DESCRIPTION
### Issue for this PR

Closes #23110

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the per-directory provider refresh in `bootstrapDirectory` so that it uses the correct query key.

Previously, the refresh was registered under `loadSessionsQuery(input.directory)` instead of `loadProvidersQuery(input.directory)`. Because session data is usually already cached by the time this code runs, `queryClient.ensureQueryData` short-circuits on the existing `loadSessions` cache and never calls the `queryFn`. As a result, `input.sdk.provider.list()` is never invoked for that directory, the per-directory provider list is not refreshed, and `provider_ready` remains `false`.

This leads to two user-visible behaviors:

1. On startup, the model picker appears empty for a few seconds. While `provider_ready` is `false`, `useProviders` falls back to `globalSync.data.provider`, so the picker only populates once the *global* `provider.list()` finishes. In 1.4.6 this was masked because the per-directory refresh was a fire-and-forget `retry(...)` instead of a query keyed under `loadSessions`.
2. For projects that define providers only in their local `opencode.jsonc` (for example `amazon-bedrock` with `enabled_providers: ["amazon-bedrock"]`), no providers show up at all. The global SDK never sees the project-level `provider` block, and the per-directory `provider.list()` that should read it never runs, so `globalSync.data.provider` is also empty and there is nothing to fall back to. This matches the linked issue’s debug logs, which show HTTP activity but no `service=provider` calls.

The fix is to change this call site to use `loadProvidersQuery(input.directory)` so that the per-directory provider state is wired to the correct query key and its subscribers. This also avoids polluting the `loadSessionsQuery` cache with the `null` result from the mis-keyed `queryFn`, which was previously unrelated to how the sessions query is normally populated.

I’ve also removed the now-unused `loadSessionsQuery` import from this file.

### How did you verify your code works?

- Manually verified that:
  - `loadSessionsQuery(dir)` still maps to the `[dir, "loadSessions"]` key used by `useQuery` subscribers in `sidebar-workspace.tsx`.
  - `loadProvidersQuery(dir)` maps to the `[dir, "providers"]` key used by the `useQuery` subscriber in `prompt-input.tsx`.
  - `bootstrap.ts:352` is the only place that writes to the directory-scoped providers query, so switching the key there correctly reconnects the existing subscribers.
- Confirmed locally that:
  - The model picker no longer shows an empty state for several seconds on startup.
  - A project that defines its providers only in `opencode.jsonc` now correctly populates providers in the picker.

### Screenshots / recordings

_Not applicable — this is a behavioral fix with no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR