### PR TITLE
fix(acp): aggregate session usage in SQL instead of loading the full message list (closes #20695)

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -84,24 +84,19 @@ async function sendUsageUpdate(
   sessionID: string,
   directory: string,
 ): Promise<void> {
-  const messages = await sdk.session
-    .messages({ sessionID, directory }, { throwOnError: true })
+  const snapshot = await sdk.session
+    .usage({ sessionID, directory }, { throwOnError: true })
     .then((x) => x.data)
     .catch((error) => {
-      log.error("failed to fetch messages for usage update", { error })
+      log.error("failed to fetch usage snapshot", { error })
       return undefined
     })
 
-  if (!messages) return
+  if (!snapshot) return
 
-  const assistantMessages = messages.filter(
-    (m): m is { info: AssistantMessage; parts: SessionMessageResponse["parts"] } => m.info.role === "assistant",
-  )
+  const msg = snapshot.last
+  if (!msg) return
 
-  const lastAssistant = assistantMessages[assistantMessages.length - 1]
-  if (!lastAssistant) return
-
-  const msg = lastAssistant.info
   if (!msg.providerID || !msg.modelID) return
   const size = await getContextLimit(sdk, ProviderID.make(msg.providerID), ModelID.make(msg.modelID), directory)
 
@@ -111,7 +106,6 @@ async function sendUsageUpdate(
   }
 
   const used = msg.tokens.input + (msg.tokens.cache?.read ?? 0)
-  const totalCost = assistantMessages.reduce((sum, m) => sum + m.info.cost, 0)
 
   await connection
     .sessionUpdate({
@@ -120,7 +114,7 @@ async function sendUsageUpdate(
         sessionUpdate: "usage_update",
         used,
         size,
-        cost: { amount: totalCost, currency: "USD" },
+        cost: { amount: snapshot.totalCost, currency: "USD" },
       },
     })
     .catch((error) => {

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -702,6 +702,41 @@ export const SessionRoutes = lazy(() =>
       },
     )
     .get(
+      "/:sessionID/usage",
+      describeRoute({
+        summary: "Get session usage",
+        description:
+          "Return an aggregated usage snapshot for a session without loading the full message list into memory. Returns the latest assistant message (tokens, model/provider) and the total cost summed across all assistant messages.",
+        operationId: "session.usage",
+        responses: {
+          200: {
+            description: "Usage snapshot",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    last: MessageV2.Assistant.optional(),
+                    totalCost: z.number(),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: SessionID.zod,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        return c.json(MessageV2.usage(sessionID))
+      },
+    )
+    .get(
       "/:sessionID/message/:messageID",
       describeRoute({
         summary: "Get message",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -6,7 +6,7 @@ import { APICallError, convertToModelMessages, LoadAPIKeyError, type ModelMessag
 import { LSP } from "../lsp"
 import { Snapshot } from "@/snapshot"
 import { SyncEvent } from "../sync"
-import { Database, NotFoundError, and, desc, eq, inArray, lt, or } from "@/storage"
+import { Database, NotFoundError, and, desc, eq, inArray, lt, or, sql } from "@/storage"
 import { MessageTable, PartTable, SessionTable } from "./session.sql"
 import { ProviderError } from "@/provider"
 import { iife } from "@/util/iife"
@@ -890,6 +890,44 @@ export function* stream(sessionID: SessionID) {
     if (!next.more || !next.cursor) break
     before = next.cursor
   }
+}
+
+/**
+ * Aggregated usage snapshot for a single session, computed in SQL.
+ *
+ * Returns only the fields `sendUsageUpdate` actually needs: the latest
+ * assistant message (for tokens / providerID / modelID) and the total cost
+ * summed over all assistant messages. Keeps heap allocation O(1) instead of
+ * O(messages) that loading the full session message list would incur.
+ */
+export function usage(sessionID: SessionID): {
+  last: Assistant | undefined
+  totalCost: number
+} {
+  return Database.use((db) => {
+    const assistantPredicate = and(
+      eq(MessageTable.session_id, sessionID),
+      sql`json_extract(${MessageTable.data}, '$.role') = 'assistant'`,
+    )
+    const lastRow = db
+      .select()
+      .from(MessageTable)
+      .where(assistantPredicate)
+      .orderBy(desc(MessageTable.time_created), desc(MessageTable.id))
+      .limit(1)
+      .get()
+    const costRow = db
+      .select({
+        total: sql<number>`coalesce(sum(coalesce(json_extract(${MessageTable.data}, '$.cost'), 0)), 0)`,
+      })
+      .from(MessageTable)
+      .where(assistantPredicate)
+      .get()
+    return {
+      last: lastRow ? (info(lastRow) as Assistant) : undefined,
+      totalCost: costRow?.total ?? 0,
+    }
+  })
 }
 
 export function parts(message_id: MessageID) {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -158,6 +158,8 @@ import type {
   SessionUnshareResponses,
   SessionUpdateErrors,
   SessionUpdateResponses,
+  SessionUsageErrors,
+  SessionUsageResponses,
   SubtaskPartInput,
   SyncHistoryListErrors,
   SyncHistoryListResponses,
@@ -2239,6 +2241,38 @@ export class Session2 extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * Get session usage
+   *
+   * Return an aggregated usage snapshot for a session without loading the full message list into memory. Returns the latest assistant message (tokens, model/provider) and the total cost summed across all assistant messages.
+   */
+  public usage<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionUsageResponses, SessionUsageErrors, ThrowOnError>({
+      url: "/session/{sessionID}/usage",
+      ...options,
+      ...params,
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3820,6 +3820,43 @@ export type SessionPromptResponses = {
 
 export type SessionPromptResponse = SessionPromptResponses[keyof SessionPromptResponses]
 
+export type SessionUsageData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/usage"
+}
+
+export type SessionUsageErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionUsageError = SessionUsageErrors[keyof SessionUsageErrors]
+
+export type SessionUsageResponses = {
+  /**
+   * Usage snapshot
+   */
+  200: {
+    last?: AssistantMessage
+    totalCost: number
+  }
+}
+
+export type SessionUsageResponse = SessionUsageResponses[keyof SessionUsageResponses]
+
 export type SessionDeleteMessageData = {
   body?: never
   path: {


### PR DESCRIPTION
Closes #20695

## Summary

`sendUsageUpdate` in the ACP agent fetches the full message history of a session on every prompt completion, just to extract two scalar values (the last assistant message's tokens and the sum of assistant message costs). On long-lived sessions this makes each call O(messages) in heap allocation and, under bursty prompt completion, drives V8 into sustained GC pressure.

On my setup this ended in kernel OOM kills. After this patch the same workload runs without OOMs.

This PR replaces that call site with a dedicated aggregated endpoint that does the work in SQL.

## Disclosure

- All analysis, code, tests, and daemon rebuild in this PR were produced with **Claude Opus 4.6** as my coding assistant. I drove the session, reviewed every change, and verified the fix on my own deployment before submitting this PR. I am aware of the project's AI-submission preference and am disclosing this up front so reviewers can weigh the contribution on its technical merits.
- The reproduction numbers and the graphs below are **not model estimates**. They come from:
  - Direct `bun:sqlite` queries against my live `opencode.db` (sessions/messages/parts + aggregate sizes).
  - `journalctl --user -u opencode.service` on my host (systemd user service running `opencode-dev web`). OOM kill and restart events come straight from the unit log, not from the AI.
  - I asked the assistant to set up more verbose logging and then to parse/visualize the journal with Python (matplotlib). The data is real; the graphs are generated from that data.

## Problem

My personal deployment runs `opencode-dev web` as a systemd user service on Linux x64 with Bun + SQLite (WAL). I use it across very long sessions, and the service was repeatedly OOM-killed.

The hot path responsible was `sendUsageUpdate` in `packages/opencode/src/acp/agent.ts`. It calls `sdk.session.messages({ sessionID, directory })` with no `limit`, which hits `GET /session/:sessionID/message` with no pagination and goes through `MessageV2.page()` → `hydrate()` → SELECT on the `part` table for every message batch. The function then immediately discards 99% of that data and only reads:

- the last assistant message's `tokens.input` + `tokens.cache.read`
- `sum(assistantMessages.cost)`

On the largest session in my DB:

| Metric | Value |
|---|---|
| Messages | 2,391 |
| Assistant messages | 1,982 |
| Message parts | 9,078 |
| `message.data` total | 17.1 MB |
| `part.data` total | 58.5 MB |
| Duration | ~157 h |

Each `sendUsageUpdate` call loaded roughly `message + part` bytes per session into V8 heap, plus JSON deserialization and intermediate arrays. After enough prompt completions, RSS climbed above 21 GB and the kernel killed the process.

## Reproduction conditions (from my system)

- `opencode-dev web --port 4096 --hostname 0.0.0.0` running as a persistent systemd user service.
- Same conversation reused across many days; short bursts of prompt completions frequent enough that GC cannot reclaim the per-call allocation between calls.
- No special config; stock `opencode.db`, stock SDK flow. The trigger is just "long session + frequent prompts".

## Charts

All three charts are produced directly from my local DB and `journalctl` output.

**Per-call heap load and its composition before the fix**

![Payload overview](https://raw.githubusercontent.com/devcomfort/opencode/pr-assets/20695/assets/01_payload_overview.png)

**Burst heap pressure: before vs after, bar labels in MB, 768 MB GC reference line**

![Burst pressure](https://raw.githubusercontent.com/devcomfort/opencode/pr-assets/20695/assets/03_burst_pressure.png)

**OOM / kill / restart timeline from `journalctl --user -u opencode.service`**

![OOM timeline](https://raw.githubusercontent.com/devcomfort/opencode/pr-assets/20695/assets/04_oom_timeline.png)

## Fix

Three changes, all additive:

1. **`MessageV2.usage(sessionID)`** in `packages/opencode/src/session/message-v2.ts`
   - Two SQL queries against `MessageTable`, both scoped by `session_id` and `json_extract(data, '$.role') = 'assistant'`:
     - Latest assistant row: `ORDER BY time_created DESC, id DESC LIMIT 1`.
     - Total cost: `coalesce(sum(coalesce(json_extract(data, '$.cost'), 0)), 0)`.
   - Returns `{ last: Assistant | undefined, totalCost: number }`. Heap allocation is O(1).
   - Does not touch `PartTable` at all.

2. **`GET /session/:sessionID/usage`** in `packages/opencode/src/server/routes/instance/session.ts`
   - New route, documented via `describeRoute`, schema `{ last: MessageV2.Assistant.optional(), totalCost: z.number() }`.
   - Other callers of `GET /session/:sessionID/message` are untouched.

3. **`sendUsageUpdate`** in `packages/opencode/src/acp/agent.ts`
   - Replaces the `sdk.session.messages({ sessionID, directory })` call with `sdk.session.usage({ sessionID, directory })`.
   - Uses `snapshot.last` for tokens/provider/model and `snapshot.totalCost` directly.

The JS SDK is regenerated (`packages/sdk/js/src/v2/gen/{sdk,types}.gen.ts`).

## Verification

After applying the patch I rebuilt the single-platform binary (`bun run script/build.ts --single --skip-embed-web-ui --skip-install`), stopped the unit, swapped `/home/devcomfort/.local/bin/opencode-dev`, ran `systemctl --user daemon-reload`, and started it again.

Endpoint smoke test against the same worst-case session used above:

```
GET /session/ses_2869e0b1dffeMd65SgMqZ3HQT8/usage

{
  "last": {
    "role": "assistant",
    "providerID": "opencode",
    "modelID": "big-pickle",
    "cost": 0,
    "tokens": { "input": 0, "output": 0, "reasoning": 0, "cache": { "read": 0, "write": 0 } },
    "id": "msg_d9c7e8f48001h55GjkQaZuUoxM",
    "sessionID": "ses_2869e0b1dffeMd65SgMqZ3HQT8",
    "...": "..."
  },
  "totalCost": 37.48131459
}
```

The response is produced by two scoped SQL queries, not by materializing `session.messages()`.

## Impact summary

| Metric | Before (on my worst-case session) | After this PR |
|---|---|---|
| Heap allocated per `sendUsageUpdate` call | Tens of MB (scales with message + part bytes) | O(1): one assistant row + one scalar sum |
| `part` table access on this path | Full scan per call | None |
| OOM kills on my service (long session, heavy use) | Recurring | None observed after deploy |
| Behavior of `GET /session/:sessionID/message` | unchanged | unchanged |

Not asking the reviewer to take these numbers on faith. They are the motivation; the code change should stand on its own. The essential claim is narrower and testable: `sendUsageUpdate` no longer loads the session's message list or any message parts to compute the usage snapshot.

## Non-goals / Future work

- `summary.ts`, `compaction.ts` (prune branch), and `revert.ts` still call `session.messages()` without a limit. Those paths often legitimately need part content, so they're out of scope here. They each deserve their own analysis (purpose-built query, streaming, or incremental loading).
- The `part` LRU cache introduced elsewhere is not a substitute for this fix; the old path reloaded the whole session on every call and was too wide to cache effectively.
- It would probably be cleaner to also maintain a running `totalCost` per session on message insert, so even the aggregate SUM disappears. Left out of this PR to keep the change minimal.

## Checklist

- [x] No change to the existing `/session/:sessionID/message` endpoint contract
- [x] New endpoint is additive and schema-documented via `describeRoute`
- [x] SDK regenerated from the OpenAPI spec; no hand-edits to generated files
- [x] Verified on my local persistent daemon against the real worst-case session
- [x] AI-assisted nature of the analysis and patch is disclosed above
