### PR TITLE
fix(desktop): adjust ui tool diff sticky header offset

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1269,7 +1269,7 @@ function ToolFileAccordion(props: { path: string; actions?: JSX.Element; childre
     <Accordion
       multiple
       data-scope="apply-patch"
-      style={{ "--sticky-accordion-offset": "40px" }}
+      style={{ "--sticky-accordion-offset": "calc(32px + var(--tool-content-gap))" }}
       defaultValue={[value()]}
     >
       <Accordion.Item value={value()}>
@@ -2061,7 +2061,7 @@ ToolRegistry.register({
                 <Accordion
                   multiple
                   data-scope="apply-patch"
-                  style={{ "--sticky-accordion-offset": "40px" }}
+                  style={{ "--sticky-accordion-offset": "calc(32px + var(--tool-content-gap))" }}
                   value={expanded()}
                   onChange={(value) => setExpanded(Array.isArray(value) ? value : value ? [value] : [])}
                 >


### PR DESCRIPTION
### Issue for this PR

Closes #23148

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fix the sticky header offset for file diffs in AI conversation tool responses so long diffs scroll cleanly without content peeking above the next file header.

### How did you verify your code works?

Tested my fix locally on the electron desktop app.

### Screenshots / recordings

**BEFORE**

https://github.com/user-attachments/assets/2a7bdc6a-16dc-4185-8821-28dd5d54eea0

**AFTER**

https://github.com/user-attachments/assets/80c3ab10-476d-4adc-aa9a-2d532191d08f

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR