### PR TITLE
fix: allow current project worktree directories by default

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -79,10 +79,14 @@ export const layer = Layer.effect(
     const provider = yield* Provider.Service
 
     const state = yield* InstanceState.make<State>(
-      Effect.fn("Agent.state")(function* (_ctx) {
+      Effect.fn("Agent.state")(function* (ctx) {
         const cfg = yield* config.get()
         const skillDirs = yield* skill.dirs()
-        const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
+        const whitelistedDirs = [
+          Truncate.GLOB,
+          path.join(Global.Path.data, "worktree", String(ctx.project.id), "*"),
+          ...skillDirs.map((dir) => path.join(dir, "*")),
+        ]
 
         const defaults = Permission.fromConfig({
           "*": "allow",

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { provideInstance, tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
+import { Global } from "../../src/global"
 import { Permission } from "../../src/permission"
 
 // Helper to evaluate permission for a tool with wildcard pattern
@@ -595,6 +596,21 @@ description: Permission skill.
   } finally {
     process.env.OPENCODE_TEST_HOME = home
   }
+})
+
+test("managed worktree directories are allowed for external_directory", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const build = await load(tmp.path, (svc) => svc.get("build"))
+      const target = path.join(Global.Path.data, "worktree", String(Instance.project.id), "sandbox", "notes.md")
+      const other = path.join(Global.Path.data, "worktree", "proj_other", "sandbox", "notes.md")
+      expect(Permission.evaluate("external_directory", target, build!.permission).action).toBe("allow")
+      expect(Permission.evaluate("external_directory", other, build!.permission).action).toBe("ask")
+    },
+  })
 })
 
 test("defaultAgent returns build when no default_agent config", async () => {


### PR DESCRIPTION
## Summary
- scope the default `external_directory` allowlist to `Global.Path.data/worktree/<current-project-id>/*`
- keep other projects' worktree directories on `ask` and cover both cases with an agent permission test

## Verification
- `bun test test/agent/agent.test.ts` (passed in the original checkout before moving the change)
- `bun typecheck` (passed in the original checkout before moving the change)
- rerunning those commands in the new worktree failed because the local workspace binaries were unavailable there (`@opentui/solid/preload`, `tsgo`)