### PR TITLE
fix(opencode): untrace streaming event hot paths

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -213,7 +213,7 @@ export const layer: Layer.Layer<
         return true
       })
 
-      const handleEvent = Effect.fn("SessionProcessor.handleEvent")(function* (value: StreamEvent) {
+		const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
         switch (value.type) {
           case "start":
             yield* status.set(ctx.sessionID, { type: "busy" })

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -649,10 +649,10 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       return input.partID
     })
 
-    const updatePartDelta = Effect.fn("Session.updatePartDelta")(function* (input: {
-      sessionID: SessionID
-      messageID: MessageID
-      partID: PartID
+		const updatePartDelta = Effect.fnUntraced(function* (input: {
+			sessionID: SessionID
+			messageID: MessageID
+			partID: PartID
       field: string
       delta: string
     }) {


### PR DESCRIPTION
## Summary
- stop tracing `SessionProcessor.handleEvent`, which runs once per streamed event and generates a very high volume of low-value child spans
- stop tracing `Session.updatePartDelta`, which runs for text deltas and similarly floods the trace stream
- preserve higher-level spans while reducing exporter pressure that can orphan long-lived parents in motel

## Why
The local motel telemetry showed these two operations as the dominant span flood sources in `opencode`, with `SessionProcessor.handleEvent` and `Session.updatePartDelta` accounting for thousands of spans. Because they are very hot, short-lived internals, they can overwhelm export batching and make parent traces appear incomplete.

## Verification
- `bun install --frozen-lockfile`
- `bun run typecheck` in `packages/opencode`