### PR TITLE
fix(opencode): skip share sync for unshared sessions

### DIFF
--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -40,7 +40,7 @@ export type Share = typeof ShareSchema.Type
 type State = {
   queue: Map<string, { data: Map<string, Data> }>
   scope: Scope.Closeable
-  shared: Set<SessionID>
+  shared: Map<SessionID, boolean>
 }
 
 type Data =
@@ -120,7 +120,14 @@ export const layer = Layer.effect(
       return Effect.gen(function* () {
         if (disabled) return
         const s = yield* InstanceState.get(state)
-        if (!s.shared.has(sessionID)) return
+	        const cached = s.shared.get(sessionID)
+	        if (cached === false) return
+	        if (cached === undefined) {
+	          const share = yield* get(sessionID)
+	          const isShared = share !== undefined
+	          s.shared.set(sessionID, isShared)
+	          if (!isShared) return
+	        }
 
         const existing = s.queue.get(sessionID)
         if (existing) {
@@ -146,7 +153,7 @@ export const layer = Layer.effect(
 
     const state: InstanceState.InstanceState<State> = yield* InstanceState.make<State>(
       Effect.fn("ShareNext.state")(function* (_ctx) {
-        const cache: State = { queue: new Map(), scope: yield* Scope.make(), shared: new Set() }
+	        const cache: State = { queue: new Map(), scope: yield* Scope.make(), shared: new Map() }
 
         yield* Effect.addFinalizer(() =>
           Scope.close(cache.scope, Exit.void).pipe(
@@ -158,12 +165,7 @@ export const layer = Layer.effect(
           ),
         )
 
-        if (disabled) return cache
-
-        const existingShares = yield* db((db) => db.select({ sessionID: SessionShareTable.session_id }).from(SessionShareTable).all())
-        for (const row of existingShares) {
-          cache.shared.add(row.sessionID as SessionID)
-        }
+	        if (disabled) return cache
 
         const watch = <D extends { type: string }>(
           def: D,
@@ -245,7 +247,7 @@ export const layer = Layer.effect(
 
       const share = yield* get(sessionID)
       if (!share) {
-        s.shared.delete(sessionID)
+	        s.shared.set(sessionID, false)
         return
       }
 
@@ -318,7 +320,7 @@ export const layer = Layer.effect(
           .run(),
       )
       const s = yield* InstanceState.get(state)
-      s.shared.add(sessionID)
+	      s.shared.set(sessionID, true)
       yield* full(sessionID).pipe(
         Effect.catchCause((cause) =>
           Effect.sync(() => {
@@ -345,7 +347,7 @@ export const layer = Layer.effect(
 
       yield* db((db) => db.delete(SessionShareTable).where(eq(SessionShareTable.session_id, sessionID)).run())
       const s = yield* InstanceState.get(state)
-      s.shared.delete(sessionID)
+	      s.shared.set(sessionID, false)
       s.queue.delete(sessionID)
     })
 

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -118,6 +118,9 @@ export const layer = Layer.effect(
     function sync(sessionID: SessionID, data: Data[]): Effect.Effect<void> {
       return Effect.gen(function* () {
         if (disabled) return
+        const share = yield* get(sessionID)
+        if (!share) return
+
         const s = yield* InstanceState.get(state)
         const existing = s.queue.get(sessionID)
         if (existing) {

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -38,9 +38,9 @@ const ShareSchema = Schema.Struct({
 export type Share = typeof ShareSchema.Type
 
 type State = {
-  queue: Map<string, { data: Map<string, Data> }>
+  queue: Map<SessionID, Map<string, Data>>
   scope: Scope.Closeable
-  shared: Map<SessionID, boolean>
+  shared: Map<SessionID, Share | null>
 }
 
 type Data =
@@ -119,26 +119,20 @@ export const layer = Layer.effect(
     function sync(sessionID: SessionID, data: Data[]): Effect.Effect<void> {
       return Effect.gen(function* () {
         if (disabled) return
-        const s = yield* InstanceState.get(state)
-	        const cached = s.shared.get(sessionID)
-	        if (cached === false) return
-	        if (cached === undefined) {
-	          const share = yield* get(sessionID)
-	          const isShared = share !== undefined
-	          s.shared.set(sessionID, isShared)
-	          if (!isShared) return
-	        }
+        const share = yield* getCached(sessionID)
+        if (!share) return
 
+        const s = yield* InstanceState.get(state)
         const existing = s.queue.get(sessionID)
         if (existing) {
           for (const item of data) {
-            existing.data.set(key(item), item)
+            existing.set(key(item), item)
           }
           return
         }
 
         const next = new Map(data.map((item) => [key(item), item]))
-        s.queue.set(sessionID, { data: next })
+        s.queue.set(sessionID, next)
         yield* flush(sessionID).pipe(
           Effect.delay(1000),
           Effect.catchCause((cause) =>
@@ -153,19 +147,20 @@ export const layer = Layer.effect(
 
     const state: InstanceState.InstanceState<State> = yield* InstanceState.make<State>(
       Effect.fn("ShareNext.state")(function* (_ctx) {
-	        const cache: State = { queue: new Map(), scope: yield* Scope.make(), shared: new Map() }
+        const cache: State = { queue: new Map(), scope: yield* Scope.make(), shared: new Map() }
 
         yield* Effect.addFinalizer(() =>
           Scope.close(cache.scope, Exit.void).pipe(
             Effect.andThen(
               Effect.sync(() => {
                 cache.queue.clear()
+                cache.shared.clear()
               }),
             ),
           ),
         )
 
-	        if (disabled) return cache
+        if (disabled) return cache
 
         const watch = <D extends { type: string }>(
           def: D,
@@ -237,6 +232,18 @@ export const layer = Layer.effect(
       return { id: row.id, secret: row.secret, url: row.url } satisfies Share
     })
 
+    const getCached = Effect.fnUntraced(function* (sessionID: SessionID) {
+      const s = yield* InstanceState.get(state)
+      if (s.shared.has(sessionID)) {
+        const cached = s.shared.get(sessionID)
+        return cached === null ? undefined : cached
+      }
+
+      const share = yield* get(sessionID)
+      s.shared.set(sessionID, share ?? null)
+      return share
+    })
+
     const flush = Effect.fn("ShareNext.flush")(function* (sessionID: SessionID) {
       if (disabled) return
       const s = yield* InstanceState.get(state)
@@ -245,16 +252,13 @@ export const layer = Layer.effect(
 
       s.queue.delete(sessionID)
 
-      const share = yield* get(sessionID)
-      if (!share) {
-	        s.shared.set(sessionID, false)
-        return
-      }
+      const share = yield* getCached(sessionID)
+      if (!share) return
 
       const req = yield* request()
       const res = yield* HttpClientRequest.post(`${req.baseUrl}${req.api.sync(share.id)}`).pipe(
         HttpClientRequest.setHeaders(req.headers),
-        HttpClientRequest.bodyJson({ secret: share.secret, data: Array.from(queued.data.values()) }),
+        HttpClientRequest.bodyJson({ secret: share.secret, data: Array.from(queued.values()) }),
         Effect.flatMap((r) => http.execute(r)),
       )
 
@@ -320,7 +324,7 @@ export const layer = Layer.effect(
           .run(),
       )
       const s = yield* InstanceState.get(state)
-	      s.shared.set(sessionID, true)
+      s.shared.set(sessionID, result)
       yield* full(sessionID).pipe(
         Effect.catchCause((cause) =>
           Effect.sync(() => {
@@ -335,8 +339,13 @@ export const layer = Layer.effect(
     const remove = Effect.fn("ShareNext.remove")(function* (sessionID: SessionID) {
       if (disabled) return
       log.info("removing share", { sessionID })
-      const share = yield* get(sessionID)
-      if (!share) return
+      const s = yield* InstanceState.get(state)
+      const share = yield* getCached(sessionID)
+      if (!share) {
+        s.shared.delete(sessionID)
+        s.queue.delete(sessionID)
+        return
+      }
 
       const req = yield* request()
       yield* HttpClientRequest.delete(`${req.baseUrl}${req.api.remove(share.id)}`).pipe(
@@ -346,8 +355,7 @@ export const layer = Layer.effect(
       )
 
       yield* db((db) => db.delete(SessionShareTable).where(eq(SessionShareTable.session_id, sessionID)).run())
-      const s = yield* InstanceState.get(state)
-	      s.shared.set(sessionID, false)
+      s.shared.delete(sessionID)
       s.queue.delete(sessionID)
     })
 

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -40,6 +40,7 @@ export type Share = typeof ShareSchema.Type
 type State = {
   queue: Map<string, { data: Map<string, Data> }>
   scope: Scope.Closeable
+  shared: Set<SessionID>
 }
 
 type Data =
@@ -118,10 +119,9 @@ export const layer = Layer.effect(
     function sync(sessionID: SessionID, data: Data[]): Effect.Effect<void> {
       return Effect.gen(function* () {
         if (disabled) return
-        const share = yield* get(sessionID)
-        if (!share) return
-
         const s = yield* InstanceState.get(state)
+        if (!s.shared.has(sessionID)) return
+
         const existing = s.queue.get(sessionID)
         if (existing) {
           for (const item of data) {
@@ -146,7 +146,7 @@ export const layer = Layer.effect(
 
     const state: InstanceState.InstanceState<State> = yield* InstanceState.make<State>(
       Effect.fn("ShareNext.state")(function* (_ctx) {
-        const cache: State = { queue: new Map(), scope: yield* Scope.make() }
+        const cache: State = { queue: new Map(), scope: yield* Scope.make(), shared: new Set() }
 
         yield* Effect.addFinalizer(() =>
           Scope.close(cache.scope, Exit.void).pipe(
@@ -159,6 +159,11 @@ export const layer = Layer.effect(
         )
 
         if (disabled) return cache
+
+        const existingShares = yield* db((db) => db.select({ sessionID: SessionShareTable.session_id }).from(SessionShareTable).all())
+        for (const row of existingShares) {
+          cache.shared.add(row.sessionID as SessionID)
+        }
 
         const watch = <D extends { type: string }>(
           def: D,
@@ -239,7 +244,10 @@ export const layer = Layer.effect(
       s.queue.delete(sessionID)
 
       const share = yield* get(sessionID)
-      if (!share) return
+      if (!share) {
+        s.shared.delete(sessionID)
+        return
+      }
 
       const req = yield* request()
       const res = yield* HttpClientRequest.post(`${req.baseUrl}${req.api.sync(share.id)}`).pipe(
@@ -310,6 +318,7 @@ export const layer = Layer.effect(
           .run(),
       )
       const s = yield* InstanceState.get(state)
+      s.shared.add(sessionID)
       yield* full(sessionID).pipe(
         Effect.catchCause((cause) =>
           Effect.sync(() => {
@@ -335,6 +344,9 @@ export const layer = Layer.effect(
       )
 
       yield* db((db) => db.delete(SessionShareTable).where(eq(SessionShareTable.session_id, sessionID)).run())
+      const s = yield* InstanceState.get(state)
+      s.shared.delete(sessionID)
+      s.queue.delete(sessionID)
     })
 
     return Service.of({ init, url, request, create, remove })


### PR DESCRIPTION
## Summary
- stop `ShareNext` from queueing or scheduling sync work for sessions that have not actually been shared
- keep `create(sessionID)` as the point that performs the initial full sync after a share is created
- reduce unnecessary background churn and telemetry noise from no-op `ShareNext.flush` calls

## Why
`ShareNext` currently subscribes to session and message events for all sessions. For unshared sessions it still queues data and schedules a delayed `flush()`, only to discover later that there is no share row and return early. That is the wrong semantic boundary and creates avoidable background work.

The correct behavior is to do nothing until a session is actually shared.

## Verification
- `bun run typecheck` in `packages/opencode`