### PR TITLE
tui: boost favorites and recents when filtering model dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -119,8 +119,18 @@ export function DialogModel(props: { providerID?: string }) {
       : []
 
     if (needle) {
+      const isFavorite = (v: { providerID: string; modelID: string }) =>
+        favorites.some((f) => f.providerID === v.providerID && f.modelID === v.modelID)
+      const isRecent = (v: { providerID: string; modelID: string }) =>
+        recents.some((r) => r.providerID === v.providerID && r.modelID === v.modelID)
+      const matches = fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj)
+      const fav = matches.filter((x) => isFavorite(x.value))
+      const rec = matches.filter((x) => !isFavorite(x.value) && isRecent(x.value))
+      const rest = matches.filter((x) => !isFavorite(x.value) && !isRecent(x.value))
       return [
-        ...fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
+        ...fav,
+        ...rec,
+        ...rest,
         ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
       ]
     }


### PR DESCRIPTION
## Summary

When typing in the model selection dialog, favorites and recents previously lost all positional priority — they were demoted into the flat provider pool and ranked purely by fuzzysort score on `title` / `category`. A favorite would only rank high if its name happened to fuzzy-match well.

This change partitions the fuzzysort matches so favorites float to the top, recents come next, then everything else. Each group preserves fuzzysort's relative order, and the threshold still applies (non-matching favorites are not force-shown).

## Notes

- Only affects the typed-query path in `dialog-model.tsx`. No-query behavior is unchanged.
- Popular providers still tail the list unchanged.
- Drafting because the behavior may need a feel test before landing.