### PR TITLE
refactor(config): migrate skills, formatter, console-state to Effect Schema

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -100,7 +100,7 @@ export const Info = z
       .record(z.string(), ConfigCommand.Info)
       .optional()
       .describe("Command configuration, see https://opencode.ai/docs/commands"),
-    skills: ConfigSkills.Info.optional().describe("Additional skill folder paths"),
+    skills: ConfigSkills.Info.zod.optional().describe("Additional skill folder paths"),
     watcher: z
       .object({
         ignore: z.array(z.string()).optional(),
@@ -188,7 +188,7 @@ export const Info = z
       )
       .optional()
       .describe("MCP (Model Context Protocol) server configurations"),
-    formatter: ConfigFormatter.Info.optional(),
+    formatter: ConfigFormatter.Info.zod.optional(),
     lsp: ConfigLSP.Info.zod.optional(),
     instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
     layout: Layout.optional().describe("@deprecated Always uses stretch layout."),

--- a/packages/opencode/src/config/console-state.ts
+++ b/packages/opencode/src/config/console-state.ts
@@ -1,15 +1,16 @@
-import z from "zod"
+import { Schema } from "effect"
+import { zod } from "@/util/effect-zod"
 
-export const ConsoleState = z.object({
-  consoleManagedProviders: z.array(z.string()),
-  activeOrgName: z.string().optional(),
-  switchableOrgCount: z.number().int().nonnegative(),
-})
+export class ConsoleState extends Schema.Class<ConsoleState>("ConsoleState")({
+  consoleManagedProviders: Schema.mutable(Schema.Array(Schema.String)),
+  activeOrgName: Schema.optional(Schema.String),
+  switchableOrgCount: Schema.Number,
+}) {
+  static readonly zod = zod(this)
+}
 
-export type ConsoleState = z.infer<typeof ConsoleState>
-
-export const emptyConsoleState: ConsoleState = {
+export const emptyConsoleState: ConsoleState = ConsoleState.make({
   consoleManagedProviders: [],
   activeOrgName: undefined,
   switchableOrgCount: 0,
-}
+})

--- a/packages/opencode/src/config/formatter.ts
+++ b/packages/opencode/src/config/formatter.ts
@@ -1,13 +1,17 @@
 export * as ConfigFormatter from "./formatter"
 
-import z from "zod"
+import { Schema } from "effect"
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
 
-export const Entry = z.object({
-  disabled: z.boolean().optional(),
-  command: z.array(z.string()).optional(),
-  environment: z.record(z.string(), z.string()).optional(),
-  extensions: z.array(z.string()).optional(),
-})
+export const Entry = Schema.Struct({
+  disabled: Schema.optional(Schema.Boolean),
+  command: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+  environment: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  extensions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
 
-export const Info = z.union([z.boolean(), z.record(z.string(), Entry)])
-export type Info = z.infer<typeof Info>
+export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)]).pipe(
+  withStatics((s) => ({ zod: zod(s) })),
+)
+export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/opencode/src/config/skills.ts
+++ b/packages/opencode/src/config/skills.ts
@@ -1,13 +1,16 @@
-import z from "zod"
+import { Schema } from "effect"
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
 
-export const Info = z.object({
-  paths: z.array(z.string()).optional().describe("Additional paths to skill folders"),
-  urls: z
-    .array(z.string())
-    .optional()
-    .describe("URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)"),
-})
+export const Info = Schema.Struct({
+  paths: Schema.optional(Schema.Array(Schema.String)).annotate({
+    description: "Additional paths to skill folders",
+  }),
+  urls: Schema.optional(Schema.Array(Schema.String)).annotate({
+    description: "URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)",
+  }),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
 
-export type Info = z.infer<typeof Info>
+export type Info = Schema.Schema.Type<typeof Info>
 
 export * as ConfigSkills from "./skills"

--- a/packages/opencode/src/server/routes/instance/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/experimental.ts
@@ -49,7 +49,7 @@ export const ExperimentalRoutes = lazy(() =>
             description: "Active Console provider metadata",
             content: {
               "application/json": {
-                schema: resolver(ConsoleState),
+                schema: resolver(ConsoleState.zod),
               },
             },
           },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1807,6 +1807,12 @@ export type Provider = {
   }
 }
 
+export type ConsoleState = {
+  consoleManagedProviders: Array<string>
+  activeOrgName?: string
+  switchableOrgCount: number
+}
+
 export type ToolIds = Array<string>
 
 export type ToolListItem = {
@@ -2933,11 +2939,7 @@ export type ExperimentalConsoleGetResponses = {
   /**
    * Active Console provider metadata
    */
-  200: {
-    consoleManagedProviders: Array<string>
-    activeOrgName?: string
-    switchableOrgCount: number
-  }
+  200: ConsoleState
 }
 
 export type ExperimentalConsoleGetResponse = ExperimentalConsoleGetResponses[keyof ExperimentalConsoleGetResponses]


### PR DESCRIPTION
## Summary

First wave of leaf schema migrations in `src/config`, moving from hand-written Zod to Effect Schema with `.zod` compat via `@/util/effect-zod`.

Migrated:
- `config/skills.ts` → `ConfigSkills.Info` (Schema.Struct — nested, no named ref)
- `config/formatter.ts` → `ConfigFormatter.Entry`, `ConfigFormatter.Info` (Schema.Struct — nested, no named refs)
- `config/console-state.ts` → `ConsoleState` (Schema.Class — endpoint response, **intentional named ref**)

Consumers in `config/config.ts` (root Zod `Info`) and `server/routes/instance/experimental.ts` (Hono resolver) updated to call `.zod`.

## Why

`specs/effect/http-api.md` establishes Effect Schema as the source of truth for route-boundary DTOs. Before each HttpApi slice can land cleanly, implicated leaf config schemas need to be Schema-first with `.zod` available for remaining Zod consumers. This PR is the first repeatable slice establishing the pattern.

## Schema.Class vs Schema.Struct rule

**Schema.Class** emits a named `$ref` in OpenAPI — produces a named export in the SDK:
```ts
export class Foo extends Schema.Class<Foo>("FooName")({ ... }) {
  static readonly zod = zod(this)
}
```

**Schema.Struct** stays anonymous inline in OpenAPI:
```ts
export const Foo = Schema.Struct({ ... }).pipe(
  withStatics((s) => ({ zod: zod(s) })),
)
export type Foo = Schema.Schema.Type<typeof Foo>
```

Rule applied here:
- Use **Schema.Class** when the schema is exposed directly by an endpoint or was already `.meta({ ref: ... })` in the old Zod schema.
- Use **Schema.Struct** when the schema is only nested inside another named schema — adding a ref would bloat SDK types for no gain.

## SDK impact

One intentional additive change: `ConsoleState` is now an exported named type in the SDK (previously inline on the `/experimental/console` endpoint). The shape is byte-identical, just promoted from anonymous to named. Consumers can now `import { ConsoleState }` from the SDK.

```diff
+ export type ConsoleState = {
+   consoleManagedProviders: Array<string>
+   activeOrgName?: string
+   switchableOrgCount: number
+ }
```

No other SDK surface changes. Skills and formatter schemas remain inline (nested in `Config` only).

## Notes

- `Schema.Array(Schema.String)` produces `ReadonlyArray` — wrapped in `Schema.mutable(...)` where callers expect `string[]`.
- `Schema.Record` is positional (`Schema.Record(key, value)`), `Schema.Union` takes an array.

## Follow-ups

- Migrate `mcp.ts` (3 named refs — `McpLocalConfig`, `McpOAuthConfig`, `McpRemoteConfig`) as next PR, using Schema.Class throughout.
- Then `permission`, `lsp`, `agent`, and finally root `config.ts#Info`.