### PR TITLE
refactor(config): migrate lsp schemas to Effect Schema

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -189,7 +189,7 @@ export const Info = z
       .optional()
       .describe("MCP (Model Context Protocol) server configurations"),
     formatter: ConfigFormatter.Info.optional(),
-    lsp: ConfigLSP.Info.optional(),
+    lsp: ConfigLSP.Info.zod.optional(),
     instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
     layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
     permission: ConfigPermission.Info.optional(),

--- a/packages/opencode/src/config/lsp.ts
+++ b/packages/opencode/src/config/lsp.ts
@@ -1,37 +1,43 @@
 export * as ConfigLSP from "./lsp"
 
-import z from "zod"
+import { Schema } from "effect"
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
 import * as LSPServer from "../lsp/server"
 
-export const Disabled = z.object({
-  disabled: z.literal(true),
-})
+export const Disabled = Schema.Struct({
+  disabled: Schema.Literal(true),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
 
-export const Entry = z.union([
+export const Entry = Schema.Union([
   Disabled,
-  z.object({
-    command: z.array(z.string()),
-    extensions: z.array(z.string()).optional(),
-    disabled: z.boolean().optional(),
-    env: z.record(z.string(), z.string()).optional(),
-    initialization: z.record(z.string(), z.any()).optional(),
+  Schema.Struct({
+    command: Schema.mutable(Schema.Array(Schema.String)),
+    extensions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+    disabled: Schema.optional(Schema.Boolean),
+    env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+    initialization: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
   }),
-])
+]).pipe(withStatics((s) => ({ zod: zod(s) })))
 
-export const Info = z.union([z.boolean(), z.record(z.string(), Entry)]).refine(
-  (data) => {
-    if (typeof data === "boolean") return true
-    const serverIds = new Set(Object.values(LSPServer).map((server) => server.id))
+export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)]).pipe(
+  withStatics((s) => ({
+    zod: zod(s).refine(
+      (data) => {
+        if (typeof data === "boolean") return true
+        const serverIds = new Set(Object.values(LSPServer).map((server) => server.id))
 
-    return Object.entries(data).every(([id, config]) => {
-      if (config.disabled) return true
-      if (serverIds.has(id)) return true
-      return Boolean(config.extensions)
-    })
-  },
-  {
-    error: "For custom LSP servers, 'extensions' array is required.",
-  },
+        return Object.entries(data).every(([id, config]) => {
+          if (config.disabled) return true
+          if (serverIds.has(id)) return true
+          return Boolean(config.extensions)
+        })
+      },
+      {
+        error: "For custom LSP servers, 'extensions' array is required.",
+      },
+    ),
+  })),
 )
 
-export type Info = z.infer<typeof Info>
+export type Info = Schema.Schema.Type<typeof Info>


### PR DESCRIPTION
## Summary

Migrates \`ConfigLSP.Disabled\`, \`ConfigLSP.Entry\`, and \`ConfigLSP.Info\` to Effect Schema with \`.zod\` compat via \`@/util/effect-zod\`.

None of these had named OpenAPI refs in the original Zod, so all three use **Schema.Struct / Schema.Union** (anonymous inline — stays the same in the SDK).

## Preserving \`.refine()\`

The original \`Info\` had a runtime \`.refine()\` that enforces: custom (non-builtin) LSP server entries must include an \`extensions\` array. Effect Schema's walker doesn't translate Zod \`.refine()\` directly, so the refinement is applied to the **derived Zod** instead:

\`\`\`ts
export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)]).pipe(
  withStatics((s) => ({
    zod: zod(s).refine((data) => { ... }, { error: '...' }),
  })),
)
\`\`\`

Consumer in \`config.ts\` root \`Info\` uses \`ConfigLSP.Info.zod.optional()\`.

## SDK impact

**Zero diff.** Confirmed via \`./packages/sdk/js/script/build.ts\`.

## Follow-ups

Remaining config leaves: \`permission\` (partial planned in a separate PR), \`agent\`, \`command\`, \`plugin\`, \`model-id\`, \`keybinds\`, and root \`config.ts#Info\`.