### PR TITLE
fix(core): more explicit routing to fix workspace instance issue

### DIFF
--- a/packages/opencode/src/server/routes/control/index.ts
+++ b/packages/opencode/src/server/routes/control/index.ts
@@ -7,7 +7,6 @@ import { Hono } from "hono"
 import { describeRoute, resolver, validator, openAPIRouteHandler } from "hono-openapi"
 import z from "zod"
 import { errors } from "../../error"
-import { WorkspaceRoutes } from "./workspace"
 
 export function ControlPlaneRoutes(): Hono {
   const app = new Hono()
@@ -158,5 +157,4 @@ export function ControlPlaneRoutes(): Hono {
         return c.json(true)
       },
     )
-    .route("/experimental/workspace", WorkspaceRoutes())
 }

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -15,7 +15,6 @@ import { Command } from "@/command"
 import { QuestionRoutes } from "./question"
 import { PermissionRoutes } from "./permission"
 import { Flag } from "@/flag/flag"
-import { WorkspaceID } from "@/control-plane/schema"
 import { ExperimentalHttpApiServer } from "./httpapi/server"
 import { ProjectRoutes } from "./project"
 import { SessionRoutes } from "./session"
@@ -30,8 +29,8 @@ import { SyncRoutes } from "./sync"
 import { AppRuntime } from "@/effect/app-runtime"
 import { InstanceMiddleware } from "./middleware"
 
-export const InstanceRoutes = (upgrade: UpgradeWebSocket, workspaceID?: WorkspaceID): Hono => {
-  const app = new Hono().use(InstanceMiddleware(workspaceID))
+export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
+  const app = new Hono()
 
   if (Flag.OPENCODE_EXPERIMENTAL_HTTPAPI) {
     const handler = ExperimentalHttpApiServer.webHandler().handler

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -14,6 +14,8 @@ import { ControlPlaneRoutes } from "./routes/control"
 import { UIRoutes } from "./routes/ui"
 import { GlobalRoutes } from "./routes/global"
 import { WorkspaceRouterMiddleware } from "./workspace"
+import { InstanceMiddleware } from "./routes/instance/middleware"
+import { WorkspaceRoutes } from "./routes/control/workspace"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -45,14 +47,9 @@ function create(opts: { cors?: string[] }) {
   if (Flag.OPENCODE_WORKSPACE_ID) {
     return {
       app: app
+        .use(InstanceMiddleware(Flag.OPENCODE_WORKSPACE_ID ? WorkspaceID.make(Flag.OPENCODE_WORKSPACE_ID) : undefined))
         .use(FenceMiddleware)
-        .route(
-          "/",
-          InstanceRoutes(
-            runtime.upgradeWebSocket,
-            Flag.OPENCODE_WORKSPACE_ID ? WorkspaceID.make(Flag.OPENCODE_WORKSPACE_ID) : undefined,
-          ),
-        ),
+        .route("/", InstanceRoutes(runtime.upgradeWebSocket)),
       runtime,
     }
   }
@@ -60,7 +57,13 @@ function create(opts: { cors?: string[] }) {
   return {
     app: app
       .route("/", ControlPlaneRoutes())
-      .use(WorkspaceRouterMiddleware(runtime.upgradeWebSocket))
+      .route(
+        "/",
+        new Hono()
+          .use(InstanceMiddleware())
+          .route("/experimental/workspace", WorkspaceRoutes())
+          .use(WorkspaceRouterMiddleware(runtime.upgradeWebSocket)),
+      )
       .route("/", InstanceRoutes(runtime.upgradeWebSocket))
       .route("/", UIRoutes()),
     runtime,


### PR DESCRIPTION
* `WorkspaceRoutes` actually needs `Instance` because it filters based on project id
* But I really don't want those routes to go _after_ the workspace router middleware. In case a client mistakenly passed `workspace` to one of these routes, we should still make sure it doesn't get routed which will cause bugs