### PR TITLE
refactor(config): migrate model-id and command to Effect Schema

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -15,7 +15,7 @@ const log = Log.create({ service: "config" })
 
 export const Info = z
   .object({
-    model: ConfigModelID.optional(),
+    model: ConfigModelID.zod.optional(),
     variant: z
       .string()
       .optional()

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -1,10 +1,12 @@
 export * as ConfigCommand from "./command"
 
 import { Log } from "../util"
-import z from "zod"
+import { Schema } from "effect"
 import { NamedError } from "@opencode-ai/shared/util/error"
 import { Glob } from "@opencode-ai/shared/util/glob"
 import { Bus } from "@/bus"
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
 import { configEntryNameFromPath } from "./entry-name"
 import { InvalidError } from "./error"
 import * as ConfigMarkdown from "./markdown"
@@ -12,15 +14,15 @@ import { ConfigModelID } from "./model-id"
 
 const log = Log.create({ service: "config" })
 
-export const Info = z.object({
-  template: z.string(),
-  description: z.string().optional(),
-  agent: z.string().optional(),
-  model: ConfigModelID.optional(),
-  subtask: z.boolean().optional(),
-})
+export const Info = Schema.Struct({
+  template: Schema.String,
+  description: Schema.optional(Schema.String),
+  agent: Schema.optional(Schema.String),
+  model: Schema.optional(ConfigModelID),
+  subtask: Schema.optional(Schema.Boolean),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
 
-export type Info = z.infer<typeof Info>
+export type Info = Schema.Schema.Type<typeof Info>
 
 export async function load(dir: string) {
   const result: Record<string, Info> = {}
@@ -49,7 +51,7 @@ export async function load(dir: string) {
       ...md.data,
       template: md.content.trim(),
     }
-    const parsed = Info.safeParse(config)
+    const parsed = Info.zod.safeParse(config)
     if (parsed.success) {
       result[config.name] = parsed.data
       continue

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -97,7 +97,7 @@ export const Info = z
     logLevel: Log.Level.optional().describe("Log level"),
     server: Server.optional().describe("Server configuration for opencode serve and web commands"),
     command: z
-      .record(z.string(), ConfigCommand.Info)
+      .record(z.string(), ConfigCommand.Info.zod)
       .optional()
       .describe("Command configuration, see https://opencode.ai/docs/commands"),
     skills: ConfigSkills.Info.zod.optional().describe("Additional skill folder paths"),
@@ -135,8 +135,10 @@ export const Info = z
       .array(z.string())
       .optional()
       .describe("When set, ONLY these providers will be enabled. All other providers will be ignored"),
-    model: ConfigModelID.describe("Model to use in the format of provider/model, eg anthropic/claude-2").optional(),
-    small_model: ConfigModelID.describe(
+    model: ConfigModelID.zod
+      .describe("Model to use in the format of provider/model, eg anthropic/claude-2")
+      .optional(),
+    small_model: ConfigModelID.zod.describe(
       "Small model to use for tasks like title generation in the format of provider/model",
     ).optional(),
     default_agent: z

--- a/packages/opencode/src/config/model-id.ts
+++ b/packages/opencode/src/config/model-id.ts
@@ -1,3 +1,14 @@
+import { Schema } from "effect"
 import z from "zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
 
-export const ConfigModelID = z.string().meta({ $ref: "https://models.dev/model-schema.json#/$defs/Model" })
+// The original Zod schema carried an external $ref pointing at the models.dev
+// JSON schema. That external reference is not a named SDK component — it is a
+// literal pointer to an outside schema — so the walker cannot re-derive it
+// from AST metadata. Preserve the exact original Zod via ZodOverride.
+export const ConfigModelID = Schema.String.annotate({
+  [ZodOverride]: z.string().meta({ $ref: "https://models.dev/model-schema.json#/$defs/Model" }),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+
+export type ConfigModelID = Schema.Schema.Type<typeof ConfigModelID>


### PR DESCRIPTION
## Summary

Two small coupled leaf migrations.

### \`model-id.ts\`

\`ConfigModelID\` moves to \`Schema.String\` with a \`ZodOverride\` annotation that preserves the literal external \`\$ref\` to \`https://models.dev/model-schema.json#/\$defs/Model\`. This is the first use of \`ZodOverride\` for a JSON-Schema external reference (vs a hand-written Zod constraint like \`startsWith\`) — the walker hands the override through unchanged so the OpenAPI output is byte-identical.

### \`command.ts\`

\`ConfigCommand.Info\` becomes a \`Schema.Struct\`. The \`load()\` function now parses via \`Info.zod.safeParse(...)\`. The \`model\` field consumes \`ConfigModelID\` directly as an Effect Schema (not via \`.zod\`) since both are now Schema-based.

## Consumer updates

Zod-side callers updated to \`.zod\`:
- \`config/config.ts\` root Info: \`ConfigCommand.Info.zod\`, \`ConfigModelID.zod\`
- \`config/agent.ts\` (still Zod internally): \`ConfigModelID.zod.optional()\`

## SDK impact

**Zero diff.** Confirmed via \`./packages/sdk/js/script/build.ts\`.

## Follow-ups

Next migrations: \`provider.ts\`, \`plugin.ts\` (needs walker tuple support), \`keybinds.ts\`, and then the harder ones with transforms (\`agent.ts#Info\`, \`permission.ts#Info\`, root \`config.ts#Info\`).