### PR TITLE
feat(tui): show session ID in sidebar on non-prod channels

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -3,7 +3,7 @@ import { useSync } from "@tui/context/sync"
 import { createMemo, Show } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { useTuiConfig } from "../../context/tui-config"
-import { InstallationVersion } from "@/installation/version"
+import { InstallationChannel, InstallationVersion } from "@/installation/version"
 import { TuiPluginRuntime } from "../../plugin"
 
 import { getScrollAcceleration } from "../../util/scroll"
@@ -62,6 +62,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 <text fg={theme.text}>
                   <b>{session()!.title}</b>
                 </text>
+                <Show when={InstallationChannel !== "latest"}>
+                  <text fg={theme.textMuted}>{props.sessionID}</text>
+                </Show>
                 <Show when={session()!.workspaceID}>
                   <text fg={theme.textMuted}>
                     <span style={{ fg: workspaceStatus() === "connected" ? theme.success : theme.error }}>●</span>{" "}


### PR DESCRIPTION
## Summary

Render the current session ID under the session title in the TUI sidebar on local / dev / beta channels (gated on `InstallationChannel !== "latest"`).

## Why

There was no stable identifier visible anywhere in the TUI for the active session. Correlating a running opencode conversation with OpenTelemetry traces (e.g. when debugging with motel) required guessing by session title, which is auto-generated and often collides. The session ID is the only reliable key.

## Scope

- Renders the full `props.sessionID` as a muted line directly under the session title inside the existing sidebar title slot.
- Hidden on the `latest` (prod) channel; visible on `local`, `dev`, `beta`.
- Footer still shows the build version — unchanged.

## Validation

- `bun typecheck` ✓