### PR TITLE
feat(server): auto-tag route spans with route params (session.id, message.id, …)

### DIFF
--- a/packages/opencode/src/server/routes/instance/trace.ts
+++ b/packages/opencode/src/server/routes/instance/trace.ts
@@ -4,18 +4,31 @@ import { AppRuntime } from "@/effect/app-runtime"
 
 type AppEnv = Parameters<typeof AppRuntime.runPromise>[0] extends Effect.Effect<any, any, infer R> ? R : never
 
+// Build the base span attributes for an HTTP handler: method, path, and every
+// matched route param (sessionID, messageID, partID, providerID, ptyID, …)
+// prefixed with `opencode.`. This makes each request's root span searchable
+// by ID in motel without having to parse the path string.
+export interface RequestLike {
+  readonly req: {
+    readonly method: string
+    readonly url: string
+    param(): Record<string, string>
+  }
+}
+
+export function requestAttributes(c: RequestLike): Record<string, string> {
+  const attributes: Record<string, string> = {
+    "http.method": c.req.method,
+    "http.path": new URL(c.req.url).pathname,
+  }
+  for (const [key, value] of Object.entries(c.req.param())) {
+    attributes[`opencode.${key}`] = value
+  }
+  return attributes
+}
+
 export function runRequest<A, E>(name: string, c: Context, effect: Effect.Effect<A, E, AppEnv>) {
-  const url = new URL(c.req.url)
-  return AppRuntime.runPromise(
-    effect.pipe(
-      Effect.withSpan(name, {
-        attributes: {
-          "http.method": c.req.method,
-          "http.path": url.pathname,
-        },
-      }),
-    ),
-  )
+  return AppRuntime.runPromise(effect.pipe(Effect.withSpan(name, { attributes: requestAttributes(c) })))
 }
 
 export async function jsonRequest<C extends Context, A, E>(

--- a/packages/opencode/test/server/trace-attributes.test.ts
+++ b/packages/opencode/test/server/trace-attributes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { requestAttributes } from "../../src/server/routes/instance/trace"
+
+function fakeContext(method: string, url: string, params: Record<string, string>) {
+  return {
+    req: {
+      method,
+      url,
+      param: () => params,
+    },
+  }
+}
+
+describe("requestAttributes", () => {
+  test("includes http method and path", () => {
+    const attrs = requestAttributes(fakeContext("GET", "http://localhost/session", {}))
+    expect(attrs["http.method"]).toBe("GET")
+    expect(attrs["http.path"]).toBe("/session")
+  })
+
+  test("strips query string from path", () => {
+    const attrs = requestAttributes(fakeContext("GET", "http://localhost/file/search?query=foo&limit=10", {}))
+    expect(attrs["http.path"]).toBe("/file/search")
+  })
+
+  test("tags route params with opencode.<param> prefix", () => {
+    const attrs = requestAttributes(
+      fakeContext("GET", "http://localhost/session/ses_abc/message/msg_def/part/prt_ghi", {
+        sessionID: "ses_abc",
+        messageID: "msg_def",
+        partID: "prt_ghi",
+      }),
+    )
+    expect(attrs["opencode.sessionID"]).toBe("ses_abc")
+    expect(attrs["opencode.messageID"]).toBe("msg_def")
+    expect(attrs["opencode.partID"]).toBe("prt_ghi")
+  })
+
+  test("produces no param attributes when no params are matched", () => {
+    const attrs = requestAttributes(fakeContext("POST", "http://localhost/config", {}))
+    expect(Object.keys(attrs).filter((k) => k.startsWith("opencode."))).toEqual([])
+  })
+
+  test("handles non-ID params (e.g. mcp :name) without mangling", () => {
+    const attrs = requestAttributes(
+      fakeContext("POST", "http://localhost/mcp/exa/connect", {
+        name: "exa",
+      }),
+    )
+    expect(attrs["opencode.name"]).toBe("exa")
+  })
+})


### PR DESCRIPTION
## Summary

Make every HTTP route span searchable by the IDs in its URL. `runRequest` / `jsonRequest` now extract every matched Hono route param (`c.req.param()`) and emit each one as an `opencode.<paramName>` span attribute, on top of the existing `http.method` / `http.path`.

## Why

Motel shows a trace's root span attributes under the TAGS panel. Before this change, a `SessionRoutes.prompt` root only had:

```
http.method: POST
http.path:   /session/ses_abc/prompt_async
```

You could not grep traces by `session.id` — you had to regex the path. With this change the same trace also carries:

```
opencode.sessionID: ses_abc
```

And for nested ID routes like `POST /session/:sessionID/message/:messageID/part/:partID`, all three IDs are tagged.

## Implementation

- Extracted a pure `requestAttributes(c)` function that returns the attribute map. Accepts a narrow `RequestLike` shape so it's easy to unit-test without standing up a real Hono app.
- `runRequest` is now a one-liner that wraps the effect with `Effect.withSpan(name, { attributes: requestAttributes(c) })`.
- `jsonRequest` is unchanged (it calls `runRequest` internally).

Since the helper delegates to `c.req.param()`, this picks up all existing route params automatically — `sessionID`, `messageID`, `partID`, `providerID`, `ptyID`, `projectID`, `permissionID`, `requestID`, `name`, etc. No per-handler changes required.

## Validation

- New unit test: `packages/opencode/test/server/trace-attributes.test.ts` — 5 cases covering method/path, query stripping, nested ID params, no-param routes, and non-ID params (MCP `:name`).
- `bun typecheck` ✓
- `bun run test` — 1942 pass / 0 fail.

## Follow-ups

- Could add well-known aliases (`session.id` in addition to `opencode.sessionID`) if OTel-standard naming is desired. Kept the name-preserving form for now so it matches the route definitions 1:1.
- Spans nested under the root will still have empty `attributes_json` — motel/OTel backends typically propagate ancestor tags visually. If we want every descendant span to literally carry the session ID, the next step is `Effect.annotateCurrentSpan` inside each `Effect.fn("Session.*")`.