### PR TITLE
fix(tui): fail fast when a requested session is missing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -10,6 +10,9 @@ import { errorMessage } from "@/util/error"
 import { withTimeout } from "@/util/timeout"
 import { withNetworkOptions, resolveNetworkOptionsNoConfig } from "@/cli/network"
 import { Filesystem } from "@/util"
+import { SessionTable } from "@/session/session.sql"
+import { SessionID } from "@/session/schema"
+import { Database, eq } from "@/storage"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
@@ -129,6 +132,29 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
+
+      if (args.session) {
+        const sessionID = args.session
+        const exists = (() => {
+          try {
+            return !!Database.use((db) =>
+              db
+                .select({ id: SessionTable.id })
+                .from(SessionTable)
+                .where(eq(SessionTable.id, SessionID.make(sessionID)))
+                .get(),
+            )
+          } catch {
+            return false
+          }
+        })()
+
+        if (!exists) {
+          process.stderr.write(`session ${sessionID} does not exist in ${path.basename(Database.Path)} for ${cwd}\n`)
+          process.exitCode = 1
+          return
+        }
+      }
 
       const worker = new Worker(file, {
         env: Object.fromEntries(

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -1,19 +1,23 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
+import type { TuiThreadCommand } from "../../../src/cli/cmd/tui/thread"
 import { tmpdir } from "../../fixture/fixture"
 import * as App from "../../../src/cli/cmd/tui/app"
+import { SessionID } from "../../../src/session/schema"
+import { Database } from "../../../src/storage"
 import { Rpc } from "../../../src/util"
 import { UI } from "../../../src/cli/ui"
 import * as Timeout from "../../../src/util/timeout"
 import * as Network from "../../../src/cli/network"
 import * as Win32 from "../../../src/cli/cmd/tui/win32"
-import { TuiConfig } from "../../../src/cli/cmd/tui/config/tui"
 
 const stop = new Error("stop")
 const seen = {
   tui: [] as string[],
 }
+
+type ThreadArgs = Parameters<typeof TuiThreadCommand.handler>[0]
 
 function setup() {
   // Intentionally avoid mock.module() here: Bun keeps module overrides in cache
@@ -47,12 +51,12 @@ describe("tui thread", () => {
     mock.restore()
   })
 
-  async function call(project?: string) {
+  async function call(input: Partial<ThreadArgs> = {}) {
     const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
-    const args: Parameters<NonNullable<typeof TuiThreadCommand.handler>>[0] = {
+    const args: ThreadArgs = {
       _: [],
       $0: "opencode",
-      project,
+      project: undefined,
       prompt: "hi",
       model: undefined,
       agent: undefined,
@@ -65,6 +69,7 @@ describe("tui thread", () => {
       "mdns-domain": "opencode.local",
       mdnsDomain: "opencode.local",
       cors: [],
+      ...input,
     }
     return TuiThreadCommand.handler(args)
   }
@@ -96,7 +101,7 @@ describe("tui thread", () => {
     try {
       process.chdir(tmp.path)
       process.env.PWD = link
-      await expect(call(project)).rejects.toBe(stop)
+      await expect(call({ project })).rejects.toBe(stop)
       expect(seen.tui[0]).toBe(tmp.path)
     } finally {
       process.chdir(cwd)
@@ -115,5 +120,55 @@ describe("tui thread", () => {
 
   test("uses the real cwd after resolving a relative project from PWD", async () => {
     await check(".")
+  })
+
+  test("fails fast when the requested session does not exist", async () => {
+    setup()
+    await using tmp = await tmpdir()
+    const cwd = process.cwd()
+    const pwd = process.env.PWD
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+    const exitCode = process.exitCode
+    const stderr = spyOn(process.stderr, "write").mockImplementation(() => true)
+    const sessionID = SessionID.descending()
+    let workerCreated = false
+    seen.tui.length = 0
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    globalThis.Worker = class extends EventTarget {
+      constructor() {
+        super()
+        workerCreated = true
+      }
+      onerror = null
+      onmessage = null
+      onmessageerror = null
+      postMessage() {}
+      terminate() {}
+    } as unknown as typeof Worker
+
+    try {
+      process.chdir(tmp.path)
+      process.env.PWD = tmp.path
+      await expect(call({ session: sessionID })).resolves.toBeUndefined()
+      expect(process.exitCode).toBe(1)
+      expect(stderr).toHaveBeenCalledWith(
+        `session ${sessionID} does not exist in ${path.basename(Database.Path)} for ${tmp.path}\n`,
+      )
+      expect(workerCreated).toBe(false)
+      expect(seen.tui).toEqual([])
+    } finally {
+      process.chdir(cwd)
+      process.exitCode = exitCode ?? 0
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      globalThis.Worker = worker
+    }
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes: #23194

When `opencode` 1.4.9 is started with non-existent it freezes, earlier releases opened `undefined` session.
This fix fails-fast if specified session does not exist in the channel db in the directory

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
- Avoid booting the TUI worker when --session points to a session that does not exist in the active database.
- Check the session table directly before startup and exit non-zero with a message that includes the session id, database name, and resolved directory.
- Keep the validation cheap by using a single SQLite lookup instead of full instance bootstrap.

### How did you verify your code works?
- Manual testing
- Added a unit test

### Screenshots / recordings
<img width="748" height="36" alt="Screenshot 2026-04-17 at 6 35 03 PM" src="https://github.com/user-attachments/assets/91f86298-3a08-4ba8-9576-04fba18bcb65" />


### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
