### PR TITLE
fix(observability): standardize session telemetry attrs

### DIFF
--- a/packages/opencode/src/effect/logger.ts
+++ b/packages/opencode/src/effect/logger.ts
@@ -3,6 +3,8 @@ import { Log } from "@/util"
 
 type Fields = Record<string, unknown>
 
+const normalizeKey = (key: string) => (key === "sessionID" ? "session.id" : key)
+
 export interface Handle {
   readonly debug: (msg?: unknown, extra?: Fields) => Effect.Effect<void>
   readonly info: (msg?: unknown, extra?: Fields) => Effect.Effect<void>
@@ -12,7 +14,11 @@ export interface Handle {
 }
 
 const clean = (input?: Fields): Fields =>
-  Object.fromEntries(Object.entries(input ?? {}).filter((entry) => entry[1] !== undefined && entry[1] !== null))
+  Object.fromEntries(
+    Object.entries(input ?? {})
+      .filter((entry) => entry[1] !== undefined && entry[1] !== null)
+      .map(([key, value]) => [normalizeKey(key), value]),
+  )
 
 const text = (input: unknown): string => {
   // oxlint-disable-next-line no-base-to-string

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -74,7 +74,7 @@ const live: Layer.Layer<
         .clone()
         .tag("providerID", input.model.providerID)
         .tag("modelID", input.model.id)
-        .tag("sessionID", input.sessionID)
+        .tag("session.id", input.sessionID)
         .tag("small", (input.small ?? false).toString())
         .tag("agent", input.agent.name)
         .tag("mode", input.agent.mode)
@@ -317,6 +317,18 @@ const live: Layer.Layer<
       const tracer = cfg.experimental?.openTelemetry
         ? Option.getOrUndefined(yield* Effect.serviceOption(OtelTracer.OtelTracer))
         : undefined
+      const telemetryTracer = tracer
+        ? new Proxy(tracer, {
+            get(target, prop, receiver) {
+              if (prop !== "startSpan") return Reflect.get(target, prop, receiver)
+              return (...args: Parameters<typeof target.startSpan>) => {
+                const span = target.startSpan(...args)
+                span.setAttribute("session.id", input.sessionID)
+                return span
+              }
+            },
+          })
+        : undefined
 
       return streamText({
         onError(error) {
@@ -390,7 +402,7 @@ const live: Layer.Layer<
         experimental_telemetry: {
           isEnabled: cfg.experimental?.openTelemetry,
           functionId: "session.llm",
-          tracer,
+          tracer: telemetryTracer,
           metadata: {
             userId: cfg.username ?? "unknown",
             sessionId: input.sessionID,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -123,7 +123,7 @@ export const layer: Layer.Layer<
         reasoningMap: {},
       }
       let aborted = false
-      const slog = log.clone().tag("sessionID", input.sessionID).tag("messageID", input.assistantMessage.id)
+      const slog = log.clone().tag("session.id", input.sessionID).tag("messageID", input.assistantMessage.id)
 
       const parse = (e: unknown) =>
         MessageV2.fromError(e, {


### PR DESCRIPTION
## Summary
- normalize raw Effect log annotations from `sessionID` to the OTel-style `session.id` key
- tag the LLM and session processor logs with `session.id` directly for consistent cross-signal correlation
- wrap the AI SDK telemetry tracer so emitted AI spans include raw `session.id` alongside the existing SDK metadata

## Verification
- `bun run typecheck` in `packages/opencode`