### PR TITLE
refactor(config): drop ZodOverride from PositiveInt in provider.ts

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -1,12 +1,10 @@
 import { Schema } from "effect"
-import z from "zod"
-import { zod, ZodOverride } from "@/util/effect-zod"
+import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
-// Positive integer preserving exact Zod JSON Schema (type: integer, exclusiveMinimum: 0).
-const PositiveInt = Schema.Number.annotate({
-  [ZodOverride]: z.number().int().positive(),
-})
+// Positive integer: emits JSON Schema `type: integer, exclusiveMinimum: 0`
+// via the effect-zod walker's well-known refinement translation.
+const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
 
 export const Model = Schema.Struct({
   id: Schema.optional(Schema.String),


### PR DESCRIPTION
## Summary

Now that the effect-zod walker translates `Schema.isInt()` and `Schema.isGreaterThan(0)` into native zod `.int()` and `.gt(0)` (PR #23209), `PositiveInt` in `config/provider.ts` can use the canonical Effect Schema form and drop the hand-rolled `ZodOverride`.

## Diff

```diff
-import z from "zod"
-import { zod, ZodOverride } from "@/util/effect-zod"
+import { zod } from "@/util/effect-zod"

-// Positive integer preserving exact Zod JSON Schema (type: integer, exclusiveMinimum: 0).
-const PositiveInt = Schema.Number.annotate({
-  [ZodOverride]: z.number().int().positive(),
-})
+// Positive integer: emits JSON Schema `type: integer, exclusiveMinimum: 0`
+// via the effect-zod walker's well-known refinement translation.
+const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
```

## Why

This is the first production demo that PR #23209 removes the ZodOverride workaround for numeric refinements — the exact equivalence (Effect checks → `.int().positive()` JSON Schema) is asserted by the regression test added in that PR:

> test("chained isInt + isGreaterThan(0) matches z.number().int().positive()")

## Verification

- `bun typecheck` clean
- SDK output (`packages/sdk/js/src/v2/gen/types.gen.ts`) byte-identical
- `chunkTimeout` and the `Literal(false)` branch of the provider timeout union still resolve the same JSON Schema