### PR TITLE
refactor(config): migrate Server + Layout to Effect Schema

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -25,18 +25,20 @@ import { Context, Duration, Effect, Exit, Fiber, Layer, Option } from "effect"
 import { EffectFlock } from "@opencode-ai/shared/util/effect-flock"
 import { InstanceRef } from "@/effect/instance-ref"
 import { ConfigAgent } from "./agent"
+import { ConfigCommand } from "./command"
+import { ConfigFormatter } from "./formatter"
+import { ConfigLayout } from "./layout"
+import { ConfigLSP } from "./lsp"
+import { ConfigManaged } from "./managed"
 import { ConfigMCP } from "./mcp"
 import { ConfigModelID } from "./model-id"
-import { ConfigPlugin } from "./plugin"
-import { ConfigManaged } from "./managed"
-import { ConfigCommand } from "./command"
 import { ConfigParse } from "./parse"
-import { ConfigPermission } from "./permission"
-import { ConfigProvider } from "./provider"
-import { ConfigSkills } from "./skills"
 import { ConfigPaths } from "./paths"
-import { ConfigFormatter } from "./formatter"
-import { ConfigLSP } from "./lsp"
+import { ConfigPermission } from "./permission"
+import { ConfigPlugin } from "./plugin"
+import { ConfigProvider } from "./provider"
+import { ConfigServer } from "./server"
+import { ConfigSkills } from "./skills"
 import { ConfigVariable } from "./variable"
 import { Npm } from "@/npm"
 
@@ -73,23 +75,9 @@ async function resolveLoadedPlugins<T extends { plugin?: ConfigPlugin.Spec[] }>(
   return config
 }
 
-export const Server = z
-  .object({
-    port: z.number().int().positive().optional().describe("Port to listen on"),
-    hostname: z.string().optional().describe("Hostname to listen on"),
-    mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
-    mdnsDomain: z.string().optional().describe("Custom domain name for mDNS service (default: opencode.local)"),
-    cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),
-  })
-  .strict()
-  .meta({
-    ref: "ServerConfig",
-  })
-
-export const Layout = z.enum(["auto", "stretch"]).meta({
-  ref: "LayoutConfig",
-})
-export type Layout = z.infer<typeof Layout>
+export const Server = ConfigServer.Server.zod
+export const Layout = ConfigLayout.Layout.zod
+export type Layout = ConfigLayout.Layout
 
 export const Info = z
   .object({

--- a/packages/opencode/src/config/layout.ts
+++ b/packages/opencode/src/config/layout.ts
@@ -1,0 +1,10 @@
+import { Schema } from "effect"
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
+
+export const Layout = Schema.Literals(["auto", "stretch"])
+  .annotate({ identifier: "LayoutConfig" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type Layout = Schema.Schema.Type<typeof Layout>
+
+export * as ConfigLayout from "./layout"

--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -2,8 +2,6 @@ import { Schema } from "effect"
 import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
-// Positive integer: emits JSON Schema `type: integer, exclusiveMinimum: 0`
-// via the effect-zod walker's well-known refinement translation.
 const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
 
 export const Model = Schema.Struct({

--- a/packages/opencode/src/config/server.ts
+++ b/packages/opencode/src/config/server.ts
@@ -1,0 +1,20 @@
+import { Schema } from "effect"
+import { zod } from "@/util/effect-zod"
+
+export class Server extends Schema.Class<Server>("ServerConfig")({
+  port: Schema.optional(Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))).annotate({
+    description: "Port to listen on",
+  }),
+  hostname: Schema.optional(Schema.String).annotate({ description: "Hostname to listen on" }),
+  mdns: Schema.optional(Schema.Boolean).annotate({ description: "Enable mDNS service discovery" }),
+  mdnsDomain: Schema.optional(Schema.String).annotate({
+    description: "Custom domain name for mDNS service (default: opencode.local)",
+  }),
+  cors: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+    description: "Additional domains to allow for CORS",
+  }),
+}) {
+  static readonly zod = zod(this)
+}
+
+export * as ConfigServer from "./server"


### PR DESCRIPTION
## Summary

Extracts the inline `Server` and `Layout` definitions from `config.ts` into dedicated sibling modules (`config/server.ts`, `config/layout.ts`), using Effect Schema + the effect-zod walker.

- **`config/server.ts`** — `Schema.Class ServerConfig` with `port` constrained via `Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))`. Emits the same JSON Schema (`type: integer, exclusiveMinimum: 0`) as the prior `z.number().int().positive()`.
- **`config/layout.ts`** — `Schema.Literals(["auto", "stretch"])` with identifier `LayoutConfig` and a derived `zod` static.
- **`config.ts`** — re-exports `Server.zod` / `Layout.zod` so existing callers keep importing from `@/config/config` unchanged.

This was the work specifically paused waiting on the refinements walker (#23209), which is now merged.

## Drive-by

Removes the now-redundant migration comment from `config/provider.ts` `PositiveInt`. `Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))` is self-documenting. Stacks cleanly on top of #23215 (and if that lands first the rebase drops to just the comment deletion).

## Verification

- `bun typecheck` clean
- `bun run test test/` — 1987 pass / 0 fail
- SDK byte-identical (`packages/sdk/js/src/v2/gen/types.gen.ts` and `packages/sdk/openapi.json`)