### PR TITLE
fix(install): add --no-same-owner to tar to prevent UID/GID leak

### DIFF
--- a/install
+++ b/install
@@ -335,7 +335,7 @@ download_and_install() {
     fi
 
     if [ "$os" = "linux" ]; then
-        tar -xzf "$tmp_dir/$filename" -C "$tmp_dir"
+        tar --no-same-owner -xzf "$tmp_dir/$filename" -C "$tmp_dir"
     else
         unzip -q "$tmp_dir/$filename" -d "$tmp_dir"
     fi


### PR DESCRIPTION
## Summary

When the install script runs as root, `tar -xzf` preserves the UID/GID from the CI build tarball, leaving the installed binary owned by a non-existent user. This is a latent privilege-escalation vector if the binary is moved to a shared path.

## Changes

Added `--no-same-owner` to the `tar` invocation in the `install` script so extracted files are always owned by the invoking user.

## Verification

- Confirmed the fix targets the correct `tar` call (line 338)
- The `install_from_binary()` path is unaffected (uses `cp` without `-p`)
- `--no-same-owner` is POSIX-standard and supported by GNU tar, BSD tar, and BusyBox tar

Closes #23199