### PR TITLE
fix(generate): make openapi output deterministic by formatting in-place

### DIFF
--- a/packages/opencode/src/cli/cmd/generate.ts
+++ b/packages/opencode/src/cli/cmd/generate.ts
@@ -25,7 +25,19 @@ export const GenerateCommand = {
         ]
       }
     }
-    const json = JSON.stringify(specs, null, 2)
+    const raw = JSON.stringify(specs, null, 2)
+
+    // Format through prettier so output is byte-identical to committed file
+    // regardless of whether ./script/format.ts runs afterward.
+    const prettier = await import("prettier")
+    const babel = await import("prettier/plugins/babel")
+    const estree = await import("prettier/plugins/estree")
+    const format = prettier.format ?? prettier.default?.format
+    const json = await format(raw, {
+      parser: "json",
+      plugins: [babel.default ?? babel, estree.default ?? estree],
+      printWidth: 120,
+    })
 
     // Wait for stdout to finish writing before process.exit() is called
     await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Pipes `bun dev generate` output through prettier before writing to stdout, so `bun dev generate > openapi.json` produces a file byte-identical to the committed version — no `./script/format.ts` step needed.

## Problem

`JSON.stringify(…, null, 2)` expands every array onto multiple lines:

```json
"required": [
  "healthy",
  "version"
]
```

Prettier (with `printWidth: 120`) collapses short arrays inline:

```json
"required": ["healthy", "version"]
```

Running `bun dev generate > openapi.json` without `./script/format.ts` afterward produced a ~2,600-line diff against the committed file. The full `./script/generate.ts` pipeline (generate → format) was always correct, and CI catches drift anyway, but the bare generate command was a footgun.

## Fix

After `JSON.stringify`, call `prettier.format()` with the standalone babel/estree plugins and `printWidth: 120` (matching the repo config). Uses `prettier.format ?? prettier.default?.format` to handle the `--conditions=browser` runtime that the `bun dev` entrypoint uses (which changes the module export shape).

`./script/format.ts` still runs in the full pipeline — it just becomes a no-op on `openapi.json` since the file is already formatted.