### PR TITLE
fix(plugin): add env parameter to WorkspaceAdaptor.create type

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -49,7 +49,11 @@ export type WorkspaceAdaptor = {
   name: string
   description: string
   configure(config: WorkspaceInfo): WorkspaceInfo | Promise<WorkspaceInfo>
-  create(config: WorkspaceInfo, from?: WorkspaceInfo): Promise<void>
+  create(
+    config: WorkspaceInfo,
+    env: Record<string, string | undefined>,
+    from?: WorkspaceInfo,
+  ): Promise<void>
   remove(config: WorkspaceInfo): Promise<void>
   target(config: WorkspaceInfo): WorkspaceTarget | Promise<WorkspaceTarget>
 }


### PR DESCRIPTION
Align the published plugin type with the control-plane signature in `packages/opencode/src/control-plane/types.ts`, which already declares `env` as the second parameter and matches the runtime invocation at `packages/opencode/src/control-plane/workspace.ts:121`. No runtime change.

### Issue for this PR

Closes #23233

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor / code improvement
* [ ] Documentation

### What does this PR do?

Aligns the published plugin type with the control-plane signature. The control-plane type and call site already agree; only the plugin-facing type was inconsistent. Plugin authors implementing custom remote workspace adaptors lacked the `env` parameter in `create`, so forwarded env vars (OPENCODE_AUTH_CONTENT, OPENCODE_WORKSPACE_ID, OPENCODE_EXPERIMENTAL_WORKSPACES, OTEL_EXPORTER_OTLP_*) never reached the sandbox.

### How did you verify your code works?

Ran `bun run typecheck` in `packages/plugin` → passes. The widened type is safe: TypeScript allows implementations with fewer parameters, so adaptors typed as `(config)` or `(config, env)` still compile.

### Screenshots / recordings

N/A — type-only change.

### Checklist

* [x] I have tested my changes locally
* [x] I have not included unrelated changes
