### PR TITLE
fix(build): add prettier to devDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -450,6 +450,7 @@
         "@typescript/native-preview": "catalog:",
         "drizzle-kit": "catalog:",
         "drizzle-orm": "catalog:",
+        "prettier": "3.6.2",
         "typescript": "catalog:",
         "vscode-languageserver-types": "3.17.5",
         "why-is-node-running": "3.2.2",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -69,6 +69,7 @@
     "@typescript/native-preview": "catalog:",
     "drizzle-kit": "catalog:",
     "drizzle-orm": "catalog:",
+    "prettier": "3.6.2",
     "typescript": "catalog:",
     "vscode-languageserver-types": "3.17.5",
     "why-is-node-running": "3.2.2",


### PR DESCRIPTION
### Issue for this PR

Fixes #23256

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes build error caused by #23228, which added a prettier step to `generate.ts` which broke Nix builds due to missing dev dependency.

### How did you verify your code works?

Build succeeds

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
