### PR TITLE
fix(tui): defer --model validation until providers load

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -332,16 +332,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   onMount(() => {
     batch(() => {
       if (args.agent) local.agent.set(args.agent)
-      if (args.model) {
-        const { providerID, modelID } = Provider.parseModel(args.model)
-        if (!providerID || !modelID)
-          return toast.show({
-            variant: "warning",
-            message: `Invalid model format: ${args.model}`,
-            duration: 3000,
-          })
-        local.model.set({ providerID, modelID }, { recent: true })
-      }
+      // --model is now handled reactively in local.tsx (cliOverride) to avoid
+      // validation races — providers may not be loaded yet at mount time.
       if (args.sessionID && !args.fork) {
         route.navigate({
           type: "session",

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
-import { batch, createEffect, createMemo } from "solid-js"
+import { batch, createEffect, createMemo, createSignal } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
 import { uniqueBy } from "remeda"
@@ -158,17 +158,22 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         })
 
       const args = useArgs()
-      const fallbackModel = createMemo(() => {
-        if (args.model) {
-          const { providerID, modelID } = parseModel(args.model)
-          if (isModelValid({ providerID, modelID })) {
-            return {
-              providerID,
-              modelID,
-            }
-          }
-        }
 
+      // CLI --model override: resolved reactively once providers load.
+      // Highest priority — beats agent config and per-agent selections.
+      const [cliOverride, setCliOverride] = createSignal<{ providerID: string; modelID: string } | undefined>(undefined)
+      let cliOverrideApplied = false
+      createEffect(() => {
+        if (cliOverrideApplied || !args.model) return
+        const { providerID, modelID } = parseModel(args.model)
+        if (!providerID || !modelID) return
+        if (isModelValid({ providerID, modelID })) {
+          cliOverrideApplied = true
+          setCliOverride({ providerID, modelID })
+        }
+      })
+
+      const fallbackModel = createMemo(() => {
         if (sync.data.config.model) {
           const { providerID, modelID } = parseModel(sync.data.config.model)
           if (isModelValid({ providerID, modelID })) {
@@ -201,6 +206,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         const a = agent.current()
         return (
           getFirstValidModel(
+            cliOverride,
             () => a && modelStore.model[a.name],
             () => a && a.model,
             fallbackModel,
@@ -397,10 +403,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       },
     }
 
-    // Automatically update model when agent changes
+    // Automatically update model when agent changes (skip when CLI override is active)
     createEffect(() => {
       const value = agent.current()
       if (!value) return
+      if (cliOverride()) return
       if (value.model) {
         if (isModelValid(value.model))
           model.set({


### PR DESCRIPTION
### Issue for this PR

Closes #23270

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes `--model` flag being rejected at TUI startup because model validation runs before provider metadata loads.

Two problems:

1. **Race condition**: `app.tsx` `onMount` calls `model.set()` → `isModelValid()` checks `sync.data.provider` which is still empty → shows "not valid" toast for a valid model.

2. **Priority override**: Even when validation passes, the agent's configured model overwrites the CLI selection because the agent-change `createEffect` fires after mount.

**Fix**: Replace the eager `onMount` validation with a reactive `cliOverride` signal in `local.tsx` that resolves once providers load and takes highest priority in the model resolution chain. The agent-change effect skips auto-override when a CLI override is active.

### How did you verify your code works?

Traced the full execution path: `sync.tsx` bootstrap (async provider fetch) → `local.tsx` model resolution (`createEffect` reactivity on `sync.data.provider`) → `app.tsx` mount lifecycle. Confirmed SolidJS `createEffect` re-evaluates when provider data arrives, and `cliOverride` correctly participates in `getFirstValidModel` priority chain.

### Screenshots / recordings

N/A (logic-only change, no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR