### PR TITLE
feat(opencode): use regex to whitelist/blacklist provider models

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -76,8 +76,18 @@ export class Info extends Schema.Class<Info>("ProviderConfig")({
   env: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
   id: Schema.optional(Schema.String),
   npm: Schema.optional(Schema.String),
-  whitelist: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
-  blacklist: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+  whitelist: Schema.optional(
+    Schema.mutable(Schema.Array(Schema.String)).annotate({
+      description:
+        "Allowed model filters. Plain strings match exact model IDs. Entries wrapped in /.../ are regex patterns matched against model IDs. Invalid regex patterns are ignored. Regex flags are not supported.",
+    }),
+  ),
+  blacklist: Schema.optional(
+    Schema.mutable(Schema.Array(Schema.String)).annotate({
+      description:
+        "Blocked model filters. Plain strings match exact model IDs. Entries wrapped in /.../ are regex patterns matched against model IDs. Invalid regex patterns are ignored. Regex flags are not supported.",
+    }),
+  ),
   options: Schema.optional(
     Schema.StructWithRest(
       Schema.Struct({

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -37,6 +37,18 @@ function shouldUseCopilotResponsesApi(modelID: string): boolean {
   return Number(match[1]) >= 5 && !modelID.startsWith("gpt-5-mini")
 }
 
+function matchesModelFilter(entry: string, modelID: string) {
+  if (entry.startsWith("/") && entry.endsWith("/") && entry.length >= 2) {
+    try {
+      return new RegExp(entry.slice(1, -1)).test(modelID)
+    } catch {
+      return false
+    }
+  }
+
+  return entry === modelID
+}
+
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
   if (!res.body) return res
@@ -1336,8 +1348,8 @@ const layer: Layer.Layer<
             if (model.status === "alpha" && !Flag.OPENCODE_ENABLE_EXPERIMENTAL_MODELS) delete provider.models[modelID]
             if (model.status === "deprecated") delete provider.models[modelID]
             if (
-              (configProvider?.blacklist && configProvider.blacklist.includes(modelID)) ||
-              (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))
+              (configProvider?.blacklist && configProvider.blacklist.some((entry) => matchesModelFilter(entry, modelID))) ||
+              (configProvider?.whitelist && !configProvider.whitelist.some((entry) => matchesModelFilter(entry, modelID)))
             )
               delete provider.models[modelID]
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -226,6 +226,99 @@ test("model blacklist excludes specific models", async () => {
   })
 })
 
+test("model whitelist supports regex filters", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              whitelist: ["/^claude-sonnet-/"],
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.anthropic]).toBeDefined()
+      const models = Object.keys(providers[ProviderID.anthropic].models)
+      expect(models).toContain("claude-sonnet-4-20250514")
+      expect(models.every((model) => model.startsWith("claude-sonnet-"))).toBeTrue()
+    },
+  })
+})
+
+test("model blacklist supports regex filters", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              blacklist: ["/^claude-opus-/"],
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.anthropic]).toBeDefined()
+      const models = Object.keys(providers[ProviderID.anthropic].models)
+      expect(models).not.toContain("claude-opus-4-20250514")
+      expect(models.some((model) => model.startsWith("claude-sonnet-"))).toBeTrue()
+    },
+  })
+})
+
+test("invalid regex filters are ignored", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              blacklist: ["/[abc/"],
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.anthropic]).toBeDefined()
+      const models = Object.keys(providers[ProviderID.anthropic].models)
+      expect(models).toContain("claude-sonnet-4-20250514")
+      expect(models).toContain("claude-opus-4-20250514")
+    },
+  })
+})
+
 test("custom model alias via config", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -885,6 +978,39 @@ test("whitelist and blacklist can be combined", async () => {
       expect(models).toContain("claude-sonnet-4-20250514")
       expect(models).not.toContain("claude-opus-4-20250514")
       expect(models.length).toBe(1)
+    },
+  })
+})
+
+test("whitelist and blacklist can be combined with regex filters", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              whitelist: ["/^claude-/"],
+              blacklist: ["/^claude-opus-/"],
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.anthropic]).toBeDefined()
+      const models = Object.keys(providers[ProviderID.anthropic].models)
+      expect(models).toContain("claude-sonnet-4-20250514")
+      expect(models).not.toContain("claude-opus-4-20250514")
+      expect(models.every((model) => model.startsWith("claude-"))).toBeTrue()
     },
   })
 })

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11147,12 +11147,14 @@
             "type": "string"
           },
           "whitelist": {
+            "description": "Allowed model filters. Plain strings match exact model IDs. Entries wrapped in /.../ are regex patterns matched against model IDs. Invalid regex patterns are ignored. Regex flags are not supported.",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
           "blacklist": {
+            "description": "Blocked model filters. Plain strings match exact model IDs. Entries wrapped in /.../ are regex patterns matched against model IDs. Invalid regex patterns are ignored. Regex flags are not supported.",
             "type": "array",
             "items": {
               "type": "string"


### PR DESCRIPTION
### Issue for this PR

Closes #18326

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds the ability to use regex patterns to whitelist/blacklist provider models in the config.

Before:
```jsonc
  "provider": {
    "opencode": {
      "blacklist": [
        "claude-3-5-haiku",
        "claude-haiku-4-5",
        "claude-opus-4-1",
        "claude-opus-4-5",
        "claude-opus-4-6",
        "claude-sonnet-4",
        "claude-sonnet-4-5",
        "claude-sonnet-4-6",
        "glm-4.6",
        "glm-4.7",
        "glm-4.7-free",
      ],
    },
```
Now:
```jsonc
  "provider": {
    "opencode": {
      "blacklist": [
        "/claude/", // all claude models
        "/glm-4(\\..*)?$/", // all glm 4.x models
      ],
    },
```

### How did you verify your code works?

I updated my config, ran the code in my local using `bun dev` and verified that the regex patterns in blacklist/whitelist in opencode.json file are getting picked up.

### Screenshots / recordings

Zen models before the change:

<img width="2608" height="1522" alt="CleanShot 2026-04-18 at 21 26 41@2x" src="https://github.com/user-attachments/assets/83c02d01-67c4-459b-bca4-b64f422b3a9d" />


Zen models after the change (claude models are now hidden): 

<img width="2608" height="1522" alt="CleanShot 2026-04-18 at 21 27 18@2x" src="https://github.com/user-attachments/assets/8c914f3d-1617-4aec-b63a-4ad5163a5f08" />

Config:

<img width="946" height="424" alt="CleanShot 2026-04-18 at 21 23 36@2x" src="https://github.com/user-attachments/assets/14335309-5b52-4be8-a13b-3f658104faf7" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
