### PR TITLE
feat(acp): plumb structured output format through _meta

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1467,6 +1467,12 @@ export class Agent implements ACPAgent {
     })
 
     if (!cmd) {
+      // Forward optional structured-output format carried on ACP _meta.
+      // Clients opt in with `_meta: { opencode: { format: <OutputFormat> } }`
+      // mirroring the SDK's `session.prompt({ format })` shape added in #8161.
+      const formatResult = MessageV2.Format.safeParse((params._meta as any)?.opencode?.format)
+      const format = formatResult.success ? formatResult.data : undefined
+
       const response = await this.sdk.session.prompt({
         sessionID,
         model: {
@@ -1477,6 +1483,7 @@ export class Agent implements ACPAgent {
         parts,
         agent,
         directory,
+        ...(format && { format }),
       })
       const msg = response.data?.info
 
@@ -1485,7 +1492,7 @@ export class Agent implements ACPAgent {
       return {
         stopReason: "end_turn" as const,
         usage: msg ? buildUsage(msg) : undefined,
-        _meta: {},
+        _meta: msg?.structured !== undefined ? { opencode: { structured: msg.structured } } : {},
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
Forwards the structured-output `format` option through the ACP `prompt()` handler so ACP clients (IDEs, taskflow harnesses, other ACP-speaking tools) can request structured JSON output — the same capability the SDK gained in #8161.

Before this change, the SDK honored `session.prompt({ format })` but the ACP handler silently dropped it, leaving ACP clients unable to access structured output over the protocol. Motivated by the same use cases as #9320, #10456, and #5639.

### Changes
- Read `params._meta?.opencode?.format` in `Agent.prompt()`, validate it against the existing `MessageV2.Format` zod schema (the same one #8161 added), and forward it to `this.sdk.session.prompt({ ..., format })`.
- Echo the resulting `msg.structured` value back on the `PromptResponse._meta` as `{ opencode: { structured } }` when the model returned structured output.
- Uses ACP's standard `_meta` extension point with opencode's existing `_meta.opencode.*` namespacing convention (see `buildVariantMeta` at the same file).

### How did you verify your code works?
- `bun run typecheck` (tsgo --noEmit) — clean.
- `bun test test/acp/agent-interface.test.ts` — 1 pass, confirming `Agent` still implements the `ACPAgent` interface.
- Manual verification path: send an ACP `prompt` request with `_meta: { opencode: { format: { type: "json_schema", schema: { ... } } } }` and observe `response._meta.opencode.structured` containing the validated JSON.

### Notes
- Invalid `format` payloads silently fall through to plain-text mode (safeParse + optional chaining) — matches the SDK's `format.optional()` contract.
- Only the non-command branch is wired; slash commands (`/foo`) don't consume structured output.