### PR TITLE
fix(task): prevent subagent_type hallucination with validation guard

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -54,7 +54,17 @@ export const TaskTool = Tool.define(
 
       const next = yield* agent.get(params.subagent_type)
       if (!next) {
-        return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
+        const available = (yield* agent.list())
+          .filter((a) => a.mode !== "primary")
+          .map((a) => a.name)
+          .sort()
+        return yield* Effect.fail(
+          new Error(
+            `Unknown agent type: "${params.subagent_type}" is not a valid agent type. ` +
+              `Available agents: ${available.length ? available.join(", ") : "(none)"}. ` +
+              `Retry with one of the available names exactly as listed.`,
+          ),
+        )
       }
 
       const canTask = next.permission.some((rule) => rule.permission === id)

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -20,38 +20,6 @@ Usage notes:
 5. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent. Tell it how to verify its work if possible (e.g., relevant test commands).
 6. If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
 
-Example usage (NOTE: The agents below are fictional examples for illustration only - use the actual agents listed above):
+IMPORTANT: The ONLY valid values for the `subagent_type` parameter are the agent names listed above in "Available agent types". You MUST copy one of those names verbatim. Do NOT invent or guess agent names (e.g. "general-purpose", "code-reviewer", "researcher") — if it is not in the list above, it does not exist and the call will fail.
 
-<example_agent_descriptions>
-"code-reviewer": use this agent after you are done writing a significant piece of code
-"greeting-responder": use this agent when to respond to user greetings with a friendly joke
-</example_agent_description>
-
-<example>
-user: "Please write a function that checks if a number is prime"
-assistant: Sure let me write a function that checks if a number is prime
-assistant: First let me use the Write tool to write a function that checks if a number is prime
-assistant: I'm going to use the Write tool to write the following code:
-<code>
-function isPrime(n) {
-  if (n <= 1) return false
-  for (let i = 2; i * i <= n; i++) {
-    if (n % i === 0) return false
-  }
-  return true
-}
-</code>
-<commentary>
-Since a significant piece of code was written and the task was completed, now use the code-reviewer agent to review the code
-</commentary>
-assistant: Now let me use the code-reviewer agent to review the code
-assistant: Uses the Task tool to launch the code-reviewer agent
-</example>
-
-<example>
-user: "Hello"
-<commentary>
-Since the user is greeting, use the greeting-responder agent to respond with a friendly joke
-</commentary>
-assistant: "I'm going to use the Task tool to launch the with the greeting-responder agent"
-</example>
+Reminder: only use the agents enumerated in "Available agent types" above. Never pass a `subagent_type` that is not in that list.


### PR DESCRIPTION
### Issue for this PR

Closes #23301

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The task tool prompt includes fictional example agents (`code-reviewer`, `greeting-responder`) that models copy verbatim, causing invalid `subagent_type` errors. I hit this repeatedly in normal usage — the model picks up the example names instead of the real agent names listed at the top of the description.

This PR removes the fictional examples and replaces them with an explicit instruction to use only the actual agent names. It also improves the error message when an invalid name is provided: instead of just saying "not a valid agent type", it now lists all available agent names so the model can self-correct on the first retry.

The examples section was probably useful early on, but now that real agent descriptions are dynamically injected into the prompt, the fictional names are just noise that confuses the model.

### How did you verify your code works?

Tested by repeatedly providing invalid agent names and confirming the error message now lists the actual available agents. With the old prompt the model would guess another fictional name on retry; with the new prompt it picks a real name from the list immediately.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR