### PR TITLE
fix(desktop-electron): avoid startup loading hang

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto"
 import { EventEmitter } from "node:events"
-import { existsSync } from "node:fs"
 import { createServer } from "node:net"
 import { homedir } from "node:os"
 import { join } from "node:path"
@@ -128,8 +127,6 @@ function setInitStep(step: InitStep) {
 }
 
 async function initialize() {
-  const needsMigration = !sqliteFileExists()
-  const sqliteDone = needsMigration ? defer<void>() : undefined
   let overlay: BrowserWindow | null = null
 
   const port = await getSidecarPort()
@@ -153,12 +150,7 @@ async function initialize() {
       setInitStep({ phase: "sqlite_waiting" })
       if (overlay) sendSqliteMigrationProgress(overlay, progress)
       if (mainWindow) sendSqliteMigrationProgress(mainWindow, progress)
-      if (progress.type === "Done") sqliteDone?.resolve()
     })
-
-    if (needsMigration) {
-      await sqliteDone?.promise
-    }
 
     await Promise.race([
       health.wait,
@@ -177,12 +169,10 @@ async function initialize() {
     deepLinks: pendingDeepLinks,
   }
 
-  if (needsMigration) {
-    const show = await Promise.race([loadingTask.then(() => false), delay(1_000).then(() => true)])
-    if (show) {
-      overlay = createLoadingWindow(globals)
-      await delay(1_000)
-    }
+  const show = await Promise.race([loadingTask.then(() => false), delay(1_000).then(() => true)])
+  if (show) {
+    overlay = createLoadingWindow(globals)
+    await delay(1_000)
   }
 
   await loadingTask
@@ -293,12 +283,6 @@ async function getSidecarPort() {
       server.close(() => resolve(port))
     })
   })
-}
-
-function sqliteFileExists() {
-  const xdg = process.env.XDG_DATA_HOME
-  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share")
-  return existsSync(join(base, "opencode", "opencode.db"))
 }
 
 function setupAutoUpdater() {

--- a/packages/desktop-electron/src/preload/index.ts
+++ b/packages/desktop-electron/src/preload/index.ts
@@ -5,10 +5,16 @@ const api: ElectronAPI = {
   killSidecar: () => ipcRenderer.invoke("kill-sidecar"),
   installCli: () => ipcRenderer.invoke("install-cli"),
   awaitInitialization: (onStep) => {
-    const handler = (_: unknown, step: InitStep) => onStep(step)
+    const handler = (_: unknown, step: InitStep) => {
+      onStep(step)
+      if (step.phase === "done") {
+        ipcRenderer.removeListener("init-step", handler)
+      }
+    }
     ipcRenderer.on("init-step", handler)
-    return ipcRenderer.invoke("await-initialization").finally(() => {
+    return ipcRenderer.invoke("await-initialization").catch((error) => {
       ipcRenderer.removeListener("init-step", handler)
+      throw error
     })
   },
   getDefaultServerUrl: () => ipcRenderer.invoke("get-default-server-url"),


### PR DESCRIPTION
### Issue for this PR

Closes #23308

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes an Electron desktop startup hang on macOS where the app can stay on `Just a moment...` even after the sidecar is ready.

The change does two things:
- keeps the preload `init-step` listener alive until the loading flow reaches `done`
- removes a startup wait in the Electron path that can block on sqlite migration state that is not resolved on this path

### How did you verify your code works?

I built the patched Electron desktop app locally on macOS arm64 and launched it with a clean local state. Before the change it stayed on the loading window. After the change it opened into the app successfully.

### Screenshots / recordings

_UI loading fix only. No screenshot attached._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
