### PR TITLE
fix(tui): normalize Windows PATH casing in worker env

### DIFF
--- a/packages/opencode/src/util/opencode-process.ts
+++ b/packages/opencode/src/util/opencode-process.ts
@@ -17,8 +17,17 @@ export function ensureProcessMetadata(fallback: "main" | "worker") {
 }
 
 export function sanitizedProcessEnv(overrides?: Record<string, string>) {
-  const env = Object.fromEntries(
+  const env: Record<string, string> = Object.fromEntries(
     Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
   )
+
+  if (process.platform === "win32") {
+    const value = env.PATH ?? env.Path
+    if (value) {
+      env.PATH = value
+      env.Path = value
+    }
+  }
+
   return overrides ? Object.assign(env, overrides) : env
 }


### PR DESCRIPTION
### Issue for this PR

Closes #23192

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This addresses the Windows git-plugin install failure reported in #23192.

That issue is light on discussion, but it points at the same failure that was discussed earlier in #21826: git-backed plugins fail in the Windows CLI / TUI worker path with No git binary found in  even when git is installed and available from a normal shell.

This patch normalizes PATH / Path inside sanitizedProcessEnv() before the TUI thread passes the environment into its worker process on Windows.

I tracked the current failure on dev to that worker path. Keeping both PATH and Path avoids downstream tooling failing when it probes one casing but the worker only exposes the other.

### How did you verify your code works?

- un typecheck
- reproduced the failure on current origin/dev using a temporary superpowers@git+https://github.com/obra/superpowers.git plugin config and observed the No git binary found in  error in the TUI worker path
- reran the same scenario after this patch and verified the worker got past superpowers plugin loading without the git error and completed startup

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR