### PR TITLE
fix(core): respect OPENCODE_CONFIG and OPENCODE_CONFIG_CONTENT in serve/web

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -194,7 +194,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -221,7 +221,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -243,7 +243,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -267,7 +267,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -381,7 +381,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "drizzle-orm": "catalog:",
@@ -435,7 +435,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -449,7 +449,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -461,7 +461,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -493,7 +493,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -509,7 +509,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -540,7 +540,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -559,7 +559,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -690,7 +690,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -766,7 +766,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -781,7 +781,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -796,7 +796,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -836,7 +836,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -849,7 +849,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -883,7 +883,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -902,7 +902,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -944,7 +944,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -971,7 +971,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1022,7 +1022,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -1,6 +1,5 @@
 import type { Argv, InferredOptionTypes } from "yargs"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
-import type { Config } from "@/config/config"
 import { Effect } from "effect"
 
 const options = {
@@ -55,7 +54,7 @@ function networkArgs() {
 
 export const resolveNetworkOptions = Effect.fn("Cli.resolveNetworkOptions")(function* (args: NetworkOptions) {
   const { Config } = yield* Effect.promise(() => import("@/config/config"))
-  const config = yield* Config.Service.use((cfg) => cfg.getGlobal())
+  const config = yield* Config.Service.use((cfg) => cfg.getGlobalWithOverrides())
   return resolveNetworkOptionsNoConfig(args, config)
 })
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -124,6 +124,7 @@ type State = {
 export interface Interface {
   readonly get: () => Effect.Effect<Info>
   readonly getGlobal: () => Effect.Effect<Info>
+  readonly getGlobalWithOverrides: () => Effect.Effect<Info>
   readonly getConsoleState: () => Effect.Effect<ConsoleState>
   readonly update: (config: Info) => Effect.Effect<void>
   readonly updateGlobal: (config: Info) => Effect.Effect<{ info: Info; changed: boolean }>
@@ -290,6 +291,40 @@ const layer = Layer.effect(
 
     const getGlobal = Effect.fn("Config.getGlobal")(function* () {
       return yield* cachedGlobal
+    })
+
+    const [cachedGlobalWithOverrides, invalidateGlobalWithOverrides] = yield* Effect.cachedInvalidateWithTTL(
+      Effect.gen(function* () {
+        let result = yield* cachedGlobal
+
+        const configPath = process.env["OPENCODE_CONFIG"]
+        if (configPath) {
+          result = mergeConfigConcatArrays(result, yield* loadFile(configPath))
+          Effect.logDebug("loaded custom config", { path: configPath })
+        }
+
+        const configContent = process.env["OPENCODE_CONFIG_CONTENT"]
+        if (configContent) {
+          const next = yield* loadConfig(configContent, {
+            dir: process.cwd(),
+            source: "OPENCODE_CONFIG_CONTENT",
+          })
+          result = mergeConfigConcatArrays(result, next)
+          Effect.logDebug("loaded custom config from OPENCODE_CONFIG_CONTENT")
+        }
+
+        return result
+      }).pipe(
+        Effect.tapError((error) =>
+          Effect.logError("failed to load global config with overrides, using defaults", { error: String(error) }),
+        ),
+        Effect.orElseSucceed((): Info => ({})),
+      ),
+      Duration.infinity,
+    )
+
+    const getGlobalWithOverrides = Effect.fn("Config.getGlobalWithOverrides")(function* () {
+      return yield* cachedGlobalWithOverrides
     })
 
     const ensureGitignore = Effect.fn("Config.ensureGitignore")(function* (dir: string) {
@@ -632,6 +667,7 @@ const layer = Layer.effect(
 
     const invalidate = Effect.fn("Config.invalidate")(function* () {
       yield* invalidateGlobal
+      yield* invalidateGlobalWithOverrides
     })
 
     const updateGlobal = Effect.fn("Config.updateGlobal")(function* (config: Info) {
@@ -662,6 +698,7 @@ const layer = Layer.effect(
     return Service.of({
       get,
       getGlobal,
+      getGlobalWithOverrides,
       getConsoleState,
       update,
       updateGlobal,

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2045,3 +2045,100 @@ test("parseManagedPlist handles empty config", async () => {
   )
   expect(config.$schema).toBe("https://opencode.ai/config.json")
 })
+
+const loadGlobalWithOverrides = () =>
+  Effect.runPromise(
+    Config.Service.use((svc) => svc.getGlobalWithOverrides()).pipe(Effect.scoped, Effect.provide(layer)),
+  )
+
+describe("getGlobalWithOverrides", () => {
+  const origConfig = process.env["OPENCODE_CONFIG"]
+  const origContent = process.env["OPENCODE_CONFIG_CONTENT"]
+
+  afterEach(async () => {
+    if (origConfig === undefined) delete process.env["OPENCODE_CONFIG"]
+    else process.env["OPENCODE_CONFIG"] = origConfig
+    if (origContent === undefined) delete process.env["OPENCODE_CONFIG_CONTENT"]
+    else process.env["OPENCODE_CONFIG_CONTENT"] = origContent
+    await clear(true)
+  })
+
+  test("returns global config when no env vars are set", async () => {
+    await using globalTmp = await tmpdir()
+    const prevConfigPath = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+    delete process.env["OPENCODE_CONFIG"]
+    delete process.env["OPENCODE_CONFIG_CONTENT"]
+    try {
+      await writeConfig(globalTmp.path, {
+        $schema: "https://opencode.ai/config.json",
+        server: { port: 4096, hostname: "127.0.0.1" },
+      })
+      await clear(true)
+      const config = await loadGlobalWithOverrides()
+      expect(config.server?.port).toBe(4096)
+      expect(config.server?.hostname).toBe("127.0.0.1")
+    } finally {
+      ;(Global.Path as { config: string }).config = prevConfigPath
+      await clear(true)
+    }
+  })
+
+  test("OPENCODE_CONFIG merges on top of global config", async () => {
+    await using globalTmp = await tmpdir()
+    await using overrideTmp = await tmpdir()
+    const prevConfigPath = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+    try {
+      await writeConfig(globalTmp.path, {
+        $schema: "https://opencode.ai/config.json",
+        server: { port: 4096, hostname: "127.0.0.1" },
+      })
+      await writeConfig(overrideTmp.path, {
+        $schema: "https://opencode.ai/config.json",
+        server: { port: 9090 },
+      })
+      process.env["OPENCODE_CONFIG"] = path.join(overrideTmp.path, "opencode.json")
+      await clear(true)
+      const config = await loadGlobalWithOverrides()
+      // OPENCODE_CONFIG port wins
+      expect(config.server?.port).toBe(9090)
+      // global hostname is preserved since OPENCODE_CONFIG doesn't define it
+      expect(config.server?.hostname).toBe("127.0.0.1")
+    } finally {
+      ;(Global.Path as { config: string }).config = prevConfigPath
+      await clear(true)
+    }
+  })
+
+  test("OPENCODE_CONFIG_CONTENT merges on top of global and OPENCODE_CONFIG", async () => {
+    await using globalTmp = await tmpdir()
+    await using overrideTmp = await tmpdir()
+    const prevConfigPath = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+    try {
+      await writeConfig(globalTmp.path, {
+        $schema: "https://opencode.ai/config.json",
+        server: { port: 4096, hostname: "127.0.0.1" },
+      })
+      await writeConfig(overrideTmp.path, {
+        $schema: "https://opencode.ai/config.json",
+        server: { port: 9090, hostname: "0.0.0.0" },
+      })
+      process.env["OPENCODE_CONFIG"] = path.join(overrideTmp.path, "opencode.json")
+      process.env["OPENCODE_CONFIG_CONTENT"] = JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        server: { port: 7777 },
+      })
+      await clear(true)
+      const config = await loadGlobalWithOverrides()
+      // OPENCODE_CONFIG_CONTENT port wins over both
+      expect(config.server?.port).toBe(7777)
+      // OPENCODE_CONFIG hostname is preserved since OPENCODE_CONFIG_CONTENT doesn't define it
+      expect(config.server?.hostname).toBe("0.0.0.0")
+    } finally {
+      ;(Global.Path as { config: string }).config = prevConfigPath
+      await clear(true)
+    }
+  })
+})

--- a/packages/opencode/test/fixture/config.ts
+++ b/packages/opencode/test/fixture/config.ts
@@ -6,6 +6,7 @@ export function make(overrides: Partial<Config.Interface> = {}) {
   return Config.Service.of({
     get: () => Effect.succeed({}),
     getGlobal: () => Effect.succeed({}),
+    getGlobalWithOverrides: () => Effect.succeed({}),
     getConsoleState: () => Effect.succeed(emptyConsoleState),
     update: () => Effect.void,
     updateGlobal: (config) => Effect.succeed({ info: config, changed: false }),

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes anomalyco/opencode#19078

### Type of change

- [x] Bug fix

### What does this PR do?

`opencode serve` and `opencode web` call `resolveNetworkOptions()`, which only loaded the global config via `cfg.getGlobal()`. This completely ignored the `OPENCODE_CONFIG` and `OPENCODE_CONFIG_CONTENT` environment variables, despite those being explicitly designed as global-scope config augmentation mechanisms.

The fix adds a new `getGlobalWithOverrides()` method to the `Config` service that:
1. Starts with the cached global config (same as `getGlobal()`)
2. Merges `OPENCODE_CONFIG` file on top if set
3. Merges `OPENCODE_CONFIG_CONTENT` inline JSON on top if set

The merge order matches the existing order in `loadInstanceState`. Both `Flag.OPENCODE_CONFIG` and `OPENCODE_CONFIG_CONTENT` are read at effect-execution time (not module load) so the cache invalidates correctly. The cache is invalidated via `invalidateGlobalWithOverrides` inside the existing `invalidate()` method, matching the same lifecycle as `cachedGlobal`.

`resolveNetworkOptions()` is updated to call `getGlobalWithOverrides()` instead of `getGlobal()`. Since both `serve` and `web` go through this function, both are fixed.

### How did you verify your code works?

Added 3 new tests in `test/config/config.test.ts` under a `getGlobalWithOverrides` describe block:
- Returns global config when no env vars are set
- `OPENCODE_CONFIG` merges on top of global (additive — fields not in the override are preserved from global)
- `OPENCODE_CONFIG_CONTENT` merges on top of both global and `OPENCODE_CONFIG`

All 3 pass. The one pre-existing failure (`permission config preserves key order`) is unrelated and present on `dev`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<img width="780" height="300" alt="image" src="https://github.com/user-attachments/assets/28de2c89-3bad-4e4b-b5f5-afab9c09f622" />

_Note: This is my first contribution to this project and I did use AI to help me investigate the issue, the code structure in this area and craft the fix. I spent time manually reviewing the code and the proposed solution before submitting._