### PR TITLE
fix: set display 'summarized' for Opus 4.7 on Bedrock

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -628,6 +628,30 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/amazon-bedrock":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
       if (adaptiveEfforts) {
+        const isOpus47 = ["opus-4-7", "opus-4.7"].some((v) => model.api.id.includes(v))
+        // Opus 4.7 defaults thinking.display to "omitted", which sends empty
+        // thinking blocks that crash the Vercel AI SDK streaming transform
+        // ("reasoning part 0 not found"). The Bedrock SDK ignores `display`
+        // in reasoningConfig, so we bypass it and set additionalModelRequestFields
+        // directly to include display: "summarized".
+        if (isOpus47) {
+          return Object.fromEntries(
+            adaptiveEfforts.map((effort) => [
+              effort,
+              {
+                additionalModelRequestFields: {
+                  thinking: {
+                    type: "adaptive",
+                    display: "summarized",
+                  },
+                  output_config: {
+                    effort,
+                  },
+                },
+              },
+            ]),
+          )
+        }
         return Object.fromEntries(
           adaptiveEfforts.map((effort) => [
             effort,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2801,15 +2801,25 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
       expect(result.xhigh).toEqual({
-        reasoningConfig: {
-          type: "adaptive",
-          maxReasoningEffort: "xhigh",
+        additionalModelRequestFields: {
+          thinking: {
+            type: "adaptive",
+            display: "summarized",
+          },
+          output_config: {
+            effort: "xhigh",
+          },
         },
       })
       expect(result.max).toEqual({
-        reasoningConfig: {
-          type: "adaptive",
-          maxReasoningEffort: "max",
+        additionalModelRequestFields: {
+          thinking: {
+            type: "adaptive",
+            display: "summarized",
+          },
+          output_config: {
+            effort: "max",
+          },
         },
       })
     })


### PR DESCRIPTION
### Issue for this PR

Closes #23166 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opus 4.7 on Bedrock crashes with `reasoning part 0 not found` on first message with extended thinking enabled.

Opus 4.7 changed the default for `thinking.display` from `"summarized"` to `"omitted"`. Empty thinking blocks break the Vercel AI SDK streaming transform. #22873 fixed this for the Anthropic Messages API but missed Bedrock.
The Bedrock SDK's `reasoningConfig` schema doesn't have a `display` field at all -- it hardcodes `thinking: { type: "adaptive" }` and drops extra keys. So this fix bypasses `reasoningConfig` for Opus 4.7 and sets `additionalModelRequestFields` directly with `display: "summarized"`.

This applies the same 3-line fix to the Bedrock branch.

## Related
- #22873 
- #23166

### How did you verify your code works?

Ran the app locally using the Bedrock opus 4.7 model. (low, med, high, xhigh, max effort levels)

### Screenshots / recordings

<img width="755" height="769" alt="Screenshot 2026-04-18 at 12 22 53" src="https://github.com/user-attachments/assets/69c2849c-4849-49f9-bf02-1a57f9fd662c" />

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
