### PR TITLE
fix(opencode): remove model ID blocklist from reasoning variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -404,17 +404,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
   const id = model.id.toLowerCase()
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
-  if (
-    id.includes("deepseek") ||
-    id.includes("minimax") ||
-    id.includes("glm") ||
-    id.includes("mistral") ||
-    id.includes("kimi") ||
-    id.includes("k2p5") ||
-    id.includes("qwen") ||
-    id.includes("big-pickle")
-  )
-    return {}
 
   // see: https://docs.x.ai/docs/guides/reasoning#control-how-hard-the-model-thinks
   if (id.includes("grok") && id.includes("grok-3-mini")) {
@@ -532,6 +521,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "venice-ai-sdk-provider":
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
     case "@ai-sdk/openai-compatible":
+      // zai/zhipuai GLM honors `thinking: { type }` (binary on/off).
+      if (["zai", "zhipuai"].some((id) => model.providerID.includes(id)) && model.family === "glm") {
+        return {
+          "thinking-off": { thinking: { type: "disabled" } },
+          "thinking-on": { thinking: { type: "enabled" } },
+        }
+      }
       return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
 
     case "@ai-sdk/azure":

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2071,46 +2071,21 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
-  test("deepseek returns empty object", () => {
+  test("glm with reasoning enabled returns thinking-off/thinking-on via openai-compatible", () => {
     const model = createMockModel({
-      id: "deepseek/deepseek-chat",
-      providerID: "deepseek",
+      id: "zai-coding/glm-5.1",
+      providerID: "zai-coding",
+      family: "glm",
       api: {
-        id: "deepseek-chat",
-        url: "https://api.deepseek.com",
+        id: "glm-5.1",
+        url: "https://open.bigmodel.cn/api/paas/v4",
         npm: "@ai-sdk/openai-compatible",
       },
     })
     const result = ProviderTransform.variants(model)
-    expect(result).toEqual({})
-  })
-
-  test("minimax returns empty object", () => {
-    const model = createMockModel({
-      id: "minimax/minimax-model",
-      providerID: "minimax",
-      api: {
-        id: "minimax-model",
-        url: "https://api.minimax.com",
-        npm: "@ai-sdk/openai-compatible",
-      },
-    })
-    const result = ProviderTransform.variants(model)
-    expect(result).toEqual({})
-  })
-
-  test("glm returns empty object", () => {
-    const model = createMockModel({
-      id: "glm/glm-4",
-      providerID: "glm",
-      api: {
-        id: "glm-4",
-        url: "https://api.glm.com",
-        npm: "@ai-sdk/openai-compatible",
-      },
-    })
-    const result = ProviderTransform.variants(model)
-    expect(result).toEqual({})
+    expect(Object.keys(result)).toEqual(["thinking-off", "thinking-on"])
+    expect(result["thinking-off"]).toEqual({ thinking: { type: "disabled" } })
+    expect(result["thinking-on"]).toEqual({ thinking: { type: "enabled" } })
   })
 
   test("mistral returns empty object", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #23334

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the hardcoded model ID blocklist from `variants()` in `transform.ts`. Instead of excluding models by name (deepseek, glm, minimax, mistral, kimi, qwen, etc.), reasoning effort variants are now gated solely by `capabilities.reasoning` from models.dev.

Verified that z-ai (GLM-5.1), DeepSeek, and Fireworks all support `reasoning_effort` through their openai-compatible APIs.

### How did you verify your code works?

From `packages/opencode`:

- `bun test test/provider/transform.test.ts`
- `bun typecheck`

Added focused coverage for:

- `deepseek` with `reasoning: true` on `@ai-sdk/openai-compatible` returning `low` / `medium` / `high`
- `deepseek` with `reasoning: false` returning `{}`
- `glm` with `reasoning: true` on `@ai-sdk/openai-compatible` returning `low` / `medium` / `high`
- `mistral` on `@ai-sdk/mistral` returning `{}` (handled by provider switch)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR