### PR TITLE
fix(provider): gate zai/zhipuai thinking injection on reasoning capability and restore GLM variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -407,7 +407,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (
     id.includes("deepseek") ||
     id.includes("minimax") ||
-    id.includes("glm") ||
     id.includes("mistral") ||
     id.includes("kimi") ||
     id.includes("k2p5") ||
@@ -828,7 +827,8 @@ export function options(input: {
 
   if (
     ["zai", "zhipuai"].some((id) => input.model.providerID.includes(id)) &&
-    input.model.api.npm === "@ai-sdk/openai-compatible"
+    input.model.api.npm === "@ai-sdk/openai-compatible" &&
+    input.model.capabilities.reasoning
   ) {
     result["thinking"] = {
       type: "enabled",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -169,6 +169,27 @@ describe("ProviderTransform.options - zai/zhipuai thinking", () => {
         clear_thinking: false,
       })
     })
+
+    test(`${providerID} should NOT set thinking cfg for non-reasoning model`, () => {
+      const result = ProviderTransform.options({
+        model: {
+          ...createModel(providerID),
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: true,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+        },
+        sessionID,
+        providerOptions: {},
+      })
+
+      expect(result.thinking).toBeUndefined()
+    })
   }
 })
 
@@ -2099,18 +2120,22 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
-  test("glm returns empty object", () => {
+  test("glm via openai-compatible returns reasoning efforts", () => {
     const model = createMockModel({
-      id: "glm/glm-4",
-      providerID: "glm",
+      id: "zai-coding-plan/glm-4.7",
+      providerID: "zai-coding-plan",
       api: {
-        id: "glm-4",
-        url: "https://api.glm.com",
+        id: "glm-4.7",
+        url: "https://open.bigmodel.cn/api/paas/v4",
         npm: "@ai-sdk/openai-compatible",
       },
     })
     const result = ProviderTransform.variants(model)
-    expect(result).toEqual({})
+    expect(result).toEqual({
+      low: { reasoningEffort: "low" },
+      medium: { reasoningEffort: "medium" },
+      high: { reasoningEffort: "high" },
+    })
   })
 
   test("mistral returns empty object", () => {


### PR DESCRIPTION
## Problem

Two related bugs affect z.ai / zhipuai providers.

### Bug 1 — Non-reasoning GLM models return empty responses

`options()` unconditionally injects `thinking: { type: "enabled", clear_thinking: false }` for **all** models whose `providerID` contains `"zai"` or `"zhipuai"`. Non-reasoning models (e.g. `glm-5-turbo`, `glm-4.5-flash`) do not support this parameter and silently return empty streaming responses.

Reproduced: model connects, `step-start` and `step-finish` events fire, but no text or reasoning parts are emitted.

### Bug 2 — GLM reasoning models show no variant selector in UI

`variants()` included `id.includes("glm")` in an early-return exclusion block, so GLM reasoning models routed via `@ai-sdk/openai-compatible` never reached the switch case that returns `{ low, medium, high }` effort variants. This was an unintended side-effect of an earlier fix targeting other providers.

## Fix

**`packages/opencode/src/provider/transform.ts`**

1. Add `&& input.model.capabilities.reasoning` guard to the z.ai thinking injection — thinking is only injected when the model actually supports reasoning.

2. Remove `id.includes("glm")` from the `variants()` exclusion block — GLM reasoning models now fall through to the `@ai-sdk/openai-compatible` switch case and correctly return `{ low, medium, high }` reasoning-effort variants.

**`packages/opencode/test/provider/transform.test.ts`**

- Update GLM variant test: asserts `{ low, medium, high }` efforts returned for a z.ai GLM reasoning model via `@ai-sdk/openai-compatible`.
- Add test per provider ID: non-reasoning z.ai model does **not** get `thinking` injected.

## Testing

```
bun test packages/opencode/test/provider/transform.test.ts
# 137 pass, 0 fail
```