### PR TITLE
fix: don't hang TUI when reattaching to a deleted session (#23344)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -182,8 +182,11 @@ export function Session() {
 
   createEffect(async () => {
     const previousWorkspace = project.workspace.current()
-    const result = await sdk.client.session.get({ sessionID: route.sessionID }, { throwOnError: true })
-    if (!result.data) {
+    // No `throwOnError` + explicit `.catch`: a 404 here (e.g. user passes -s
+    // for a deleted session) would otherwise bubble up as an unhandled rejection
+    // inside this async effect and hang the TUI with stdin in raw mode.
+    const result = await sdk.client.session.get({ sessionID: route.sessionID }).catch(() => undefined)
+    if (!result?.data) {
       toast.show({
         message: `Session not found: ${route.sessionID}`,
         variant: "error",
@@ -203,7 +206,16 @@ export function Session() {
         await sync.bootstrap({ fatal: false })
       } catch (e) {}
     }
-    await sync.session.sync(route.sessionID)
+    try {
+      await sync.session.sync(route.sessionID)
+    } catch (e) {
+      toast.show({
+        message: `Session not found: ${route.sessionID}`,
+        variant: "error",
+      })
+      navigate({ type: "home" })
+      return
+    }
     if (scroll) scroll.scrollBy(100_000)
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #23344

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Running `opencode -s <deleted-session-id>` would hang the terminal — no ctrl+c, no ~., terminal had to be killed.

Cause: in `routes/session/index.tsx`, the effect that loads the session calls `sdk.client.session.get({ sessionID }, { throwOnError: true })`. For a deleted session the server returns 404, so the SDK throws *before* the existing `if (!result.data)` guard can run its "Session not found" toast + `navigate({ type: "home" })` recovery path. The rejection surfaces inside an async `createEffect`, by which point the TUI has already entered raw-mode / alternate-screen — stdin is no longer reachable from the shell, so every keystroke is swallowed.

Fix: drop `throwOnError` and add an explicit `.catch(() => undefined)` so the existing recovery path actually runs. Also wrap the follow-up `sync.session.sync(route.sessionID)` in a try/catch (it also uses `throwOnError: true` internally) to cover the narrow race where the session is deleted between the two calls.

### How did you verify your code works?

- `bun typecheck` across all workspace packages (pre-push hook) — passes.
- `bun test --timeout 30000` in `packages/opencode` — 2002 pass / 11 skip / 1 todo / 0 fail.
- Traced the repro: `args.sessionID` → `route.navigate({ type: "session", ... })` in `app.tsx` → `Session()` mounts → the 404 from the get call is what killed the TUI before the guard could run. With the fix, the guard fires and you land on the home view with a "Session not found" toast.

### Screenshots / recordings

N/A — behavior change, not a visual change. The user-visible surface is an existing toast that was already coded but unreachable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR