### PR TITLE
fix(snapshot): replace synchronous diff with git subprocess in diffFull

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -1,6 +1,6 @@
 import { Cause, Duration, Effect, Layer, Schedule, Semaphore, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { formatPatch, structuredPatch } from "diff"
+
 import path from "path"
 import z from "zod"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
@@ -700,19 +700,33 @@ export const layer: Layer.Layer<
               }
 
               const step = 100
-              const patch = (file: string, before: string, after: string) =>
-                formatPatch(structuredPatch(file, file, before, after, "", "", { context: Number.MAX_SAFE_INTEGER }))
 
               for (let i = 0; i < rows.length; i += step) {
                 const run = rows.slice(i, i + step)
-                const text = yield* load(run)
+
+                // Use git diff subprocess instead of the synchronous JS `diff` library
+                // (formatPatch/structuredPatch with Number.MAX_SAFE_INTEGER context lines
+                // blocks the event loop and freezes the TUI on large sessions).
+                const diff = yield* git(
+                  [
+                    ...quote,
+                    ...args(["diff", "--no-ext-diff", "--no-renames", from, to, "--", ...run.map((r) => r.file)]),
+                  ],
+                  { cwd: state.directory },
+                )
+                const patches = new Map<string, string>()
+                if (diff.code === 0 && diff.text.trim()) {
+                  for (const part of diff.text.split(/^(?=diff --git )/m)) {
+                    if (!part.trim()) continue
+                    const match = part.match(/^diff --git a\/(.+?) b\//)
+                    if (match) patches.set(match[1], part.trim())
+                  }
+                }
 
                 for (const row of run) {
-                  const hit = text?.get(row.file) ?? { before: "", after: "" }
-                  const [before, after] = row.binary ? ["", ""] : text ? [hit.before, hit.after] : yield* show(row)
                   result.push({
                     file: row.file,
-                    patch: row.binary ? "" : patch(row.file, before, after),
+                    patch: row.binary ? "" : (patches.get(row.file) ?? ""),
                     additions: row.additions,
                     deletions: row.deletions,
                     status: row.status,


### PR DESCRIPTION
### Issue for this PR

Fixes #23362

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Snapshot.diffFull()` calls `formatPatch(structuredPatch(..., { context: Number.MAX_SAFE_INTEGER }))` from the JS `diff` package synchronously on the main thread. On sessions with many file modifications, this blocks the event loop indefinitely — `strace` confirms all threads end up in `FUTEX_WAIT` with 0% CPU (async deadlock), freezing the TUI completely.

The trigger path is: `SessionSummary.summarize()` (fire-and-forget in `prompt.ts`) → `computeDiff` → `snapshot.diffFull()` → `formatPatch(structuredPatch(...))` → hang.

The regression was introduced in `b7fab49b6` (`refactor(snapshot): store unified patches in file diffs #21244`), identified via `git bisect` (9 steps between `v1.3.3` and HEAD). Parent commit `463318486` is the last good commit.

This PR replaces the synchronous JS diff call with `git diff --no-ext-diff --no-renames` run as a subprocess. This produces equivalent unified diff output, runs non-blocking (does not starve the event loop), and is faster for large diffs. The `diff` npm package import is removed from this file as it is no longer needed.

Also addresses the main bottleneck (# 2 in the ranking) described in #22650, but only verified on TUI — web/desktop may have additional bottlenecks documented in that issue.

### How did you verify your code works?

- Built the binary and tested manually on Linux x86_64 against a session that reliably triggered the freeze (fork session with many file modifications, resend last message).
- Without fix: TUI freezes immediately on resend, requires `kill -9`.
- With fix: session resumes normally, no freeze.
- Typecheck passes on all 13 packages.

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR