### PR TITLE
fix(tui): handle invisible codepoints when measuring label width

### DIFF
--- a/packages/opencode/src/util/locale.test.ts
+++ b/packages/opencode/src/util/locale.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "bun:test"
+import { truncate, truncateMiddle } from "./locale"
+
+describe("truncate", () => {
+  it("returns the string unchanged when its rendered width fits", () => {
+    const input = "hello"
+    expect(truncate(input, 10)).toBe(input)
+    expect(truncate(input, 5)).toBe(input)
+  })
+
+  it("does not truncate a U+200B-prefixed string whose rendered width equals the limit", () => {
+    const input = "\u200BSisyphus"
+    expect(Bun.stringWidth(input)).toBe(8)
+    expect(truncate(input, 8)).toBe(input)
+  })
+
+  it("truncates a U+200B-prefixed string whose rendered width exceeds the limit at the visible boundary", () => {
+    const input = "\u200BSisyphus: Ultraworker"
+    const result = truncate(input, 10)
+    expect(result.endsWith("…")).toBe(true)
+    const body = result.slice(0, -1)
+    expect(Bun.stringWidth(body) + 1).toBeLessThanOrEqual(10)
+    expect(Bun.stringWidth(result)).toBeLessThanOrEqual(10)
+    expect(result).toBe("\u200BSisyphus:…")
+  })
+
+  it("truncates plain ASCII to display width ending in ellipsis", () => {
+    const result = truncate("Sisyphus: Ultraworker", 10)
+    expect(result.endsWith("…")).toBe(true)
+    expect(Bun.stringWidth(result)).toBe(10)
+    expect(result).toBe("Sisyphus:…")
+  })
+
+  it("handles all zero-width codepoint variants (U+200C, U+200D, U+FEFF)", () => {
+    const zwnj = "\u200CSisyphus: Ultraworker"
+    const zwj = "\u200DSisyphus: Ultraworker"
+    const bom = "\uFEFFSisyphus: Ultraworker"
+    const resultZwnj = truncate(zwnj, 10)
+    const resultZwj = truncate(zwj, 10)
+    const resultBom = truncate(bom, 10)
+    expect(resultZwnj.endsWith("…")).toBe(true)
+    expect(resultZwj.endsWith("…")).toBe(true)
+    expect(resultBom.endsWith("…")).toBe(true)
+    expect(Bun.stringWidth(resultZwnj)).toBeLessThanOrEqual(10)
+    expect(Bun.stringWidth(resultZwj)).toBeLessThanOrEqual(10)
+    expect(Bun.stringWidth(resultBom)).toBeLessThanOrEqual(10)
+    expect(resultZwnj).toBe("\u200CSisyphus:…")
+    expect(resultZwj).toBe("\u200DSisyphus:…")
+    expect(resultBom).toBe("\uFEFFSisyphus:…")
+  })
+
+  it("truncates mixed strings containing a wide CJK grapheme, ZWSP, and ASCII correctly", () => {
+    const input = "中\u200BSisyphus: Ultraworker"
+    expect(Bun.stringWidth("中")).toBe(2)
+    const result = truncate(input, 10)
+    expect(result.endsWith("…")).toBe(true)
+    expect(Bun.stringWidth(result)).toBeLessThanOrEqual(10)
+    expect(result).toBe("中\u200BSisyphu…")
+  })
+})
+
+describe("truncateMiddle", () => {
+  it("returns the string unchanged when its rendered width is <= maxLength", () => {
+    const input = "hello world"
+    expect(truncateMiddle(input, 20)).toBe(input)
+    expect(truncateMiddle(input, 11)).toBe(input)
+  })
+
+  it("does not truncate a U+200B-prefixed string at exact width", () => {
+    const input = "\u200BSisyphus"
+    expect(Bun.stringWidth(input)).toBe(8)
+    expect(truncateMiddle(input, 8)).toBe(input)
+  })
+
+  it("truncates a long ZWSP-bearing string in the middle with correct widths", () => {
+    const input = "\u200BSisyphus: Ultraworker helps you"
+    const maxLength = 15
+    const result = truncateMiddle(input, maxLength)
+    expect(result.includes("…")).toBe(true)
+    expect(Bun.stringWidth(result)).toBeLessThanOrEqual(maxLength)
+    const ellipsisIndex = result.indexOf("…")
+    const startOut = result.slice(0, ellipsisIndex)
+    const endOut = result.slice(ellipsisIndex + 1)
+    const budget = maxLength - 1
+    const keepStart = Math.ceil(budget / 2)
+    const keepEnd = Math.floor(budget / 2)
+    expect(Bun.stringWidth(startOut)).toBeLessThanOrEqual(keepStart)
+    expect(Bun.stringWidth(endOut)).toBeLessThanOrEqual(keepEnd)
+    expect(result.startsWith("\u200B")).toBe(true)
+    expect(result.endsWith("u")).toBe(true)
+    expect(result).toBe("\u200BSisyphu…lps you")
+  })
+
+  it("uses a default maxLength of 35", () => {
+    const short = "a".repeat(35)
+    expect(truncateMiddle(short)).toBe(short)
+    const long = "a".repeat(50)
+    const result = truncateMiddle(long)
+    expect(result.includes("…")).toBe(true)
+    expect(Bun.stringWidth(result)).toBeLessThanOrEqual(35)
+  })
+
+  it("truncates plain ASCII with unchanged behavior", () => {
+    const input = "abcdefghijklmnopqrstuvwxyz"
+    const result = truncateMiddle(input, 10)
+    expect(result.includes("…")).toBe(true)
+    expect(Bun.stringWidth(result)).toBeLessThanOrEqual(10)
+    expect(result).toBe("abcde…wxyz")
+  })
+})

--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -59,18 +59,47 @@ export function duration(input: number) {
 }
 
 export function truncate(str: string, len: number): string {
-  if (str.length <= len) return str
-  return str.slice(0, len - 1) + "…"
+  if (Bun.stringWidth(str) <= len) return str
+  let out = ""
+  let width = 0
+  for (const char of str) {
+    const w = Bun.stringWidth(char)
+    if (width + w > len - 1) break
+    out += char
+    width += w
+  }
+  return out + "…"
 }
 
 export function truncateMiddle(str: string, maxLength: number = 35): string {
-  if (str.length <= maxLength) return str
+  if (Bun.stringWidth(str) <= maxLength) return str
 
   const ellipsis = "…"
-  const keepStart = Math.ceil((maxLength - ellipsis.length) / 2)
-  const keepEnd = Math.floor((maxLength - ellipsis.length) / 2)
+  const budget = maxLength - ellipsis.length
+  const keepStart = Math.ceil(budget / 2)
+  const keepEnd = Math.floor(budget / 2)
 
-  return str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)
+  let startOut = ""
+  let startWidth = 0
+  for (const char of str) {
+    const w = Bun.stringWidth(char)
+    if (startWidth + w > keepStart) break
+    startOut += char
+    startWidth += w
+  }
+
+  const chars = Array.from(str)
+  let endOut = ""
+  let endWidth = 0
+  for (let i = chars.length - 1; i >= 0; i--) {
+    const char = chars[i]
+    const w = Bun.stringWidth(char)
+    if (endWidth + w > keepEnd) break
+    endOut = char + endOut
+    endWidth += w
+  }
+
+  return startOut + ellipsis + endOut
 }
 
 export function pluralize(count: number, singular: string, plural: string): string {


### PR DESCRIPTION
### Issue for this PR

Closes #23376

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the agent label rendering corruption I reported in #23376.

The TUI's `truncate` and `truncateMiddle` helpers in `packages/opencode/src/util/locale.ts` used `str.length` to decide whether to truncate. That counts invisible codepoints (`U+200B`, `U+200C`, `U+200D`, `U+FEFF`) as one UTF 16 code unit each, even though they render as zero columns on screen. When a string fit in real rendered width but exceeded the limit in code unit count, the helper chopped visible letters and appended an ellipsis, producing labels like `Sisyphus: ltraworker`.

This PR switches the width check and the per character walk to `Bun.stringWidth`, which is already idiomatic in this repo for cursor math. Examples of existing `Bun.stringWidth` callers:

1. `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx:172`
2. `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx:373`
3. `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx:389`

Why it works: `Bun.stringWidth` reports 0 columns for the four zero width codepoints named above and 2 columns for wide graphemes like emoji, which matches the Unicode spec for terminal rendering width. Using it here makes both helpers correct for any string, not just ASCII.

Input strings without invisible codepoints behave identically to the old implementation. That is covered by the first test case in the new test file.

### How did you verify your code works?

Added a new co located test file `packages/opencode/src/util/locale.test.ts` with 11 cases. Ran it locally:

```
cd packages/opencode
bun test src/util/locale.test.ts
# 11 pass / 0 fail / 41 expect() calls / 329ms
```

Test cases covered:

1. Plain ASCII short strings are returned unchanged.
2. A `U+200B` prefixed string whose rendered width equals the limit is NOT truncated (repro of #23376).
3. A `U+200B` prefixed string whose rendered width exceeds the limit gets truncated at the visible boundary.
4. Plain ASCII truncation produces a result of display width equal to the limit and ending in the ellipsis.
5. All four invisible codepoints (`U+200B`, `U+200C`, `U+200D`, `U+FEFF`) are handled identically.
6. Mixed strings with emoji (width 2), ZWSP, and ASCII truncate at the correct visible boundary.
7. `truncateMiddle` returns the input unchanged when rendered width is within `maxLength`.
8. `truncateMiddle` at exact width with a ZWSP prefix is NOT truncated.
9. `truncateMiddle` on a long ZWSP bearing string produces `startOut + "…" + endOut` with correct widths against `keepStart` and `keepEnd`.
10. `truncateMiddle` default `maxLength` of 35 is preserved.
11. `truncateMiddle` on plain ASCII returns the same shape as before.

Typecheck note: the monorepo uses `bun turbo typecheck`. My sandbox could not complete the full workspace install cleanly (`bun install` stalled on the dep graph in my environment), so I limited automated verification to the targeted test file. The change is scoped to one module with no new imports and no new type surface. Happy to run any additional verification a maintainer wants.

Byte level evidence for the bug is in issue #23376.

### Screenshots / recordings

This is not a UI change in the visual sense, but the bug is a visible rendering defect. The simplest reproduction is the hex dump included in issue #23376:

```
e2 80 8b 53 69 73 79 70 68 75 73 20 3a 20 55 6c 74 72 61 77 6f 72 6b 65 72
```

That decodes to `U+200B` followed by `Sisyphus : Ultraworker`. With the old `truncate`, feeding that string at `len=22` returned `"\u200BSisyphus: Ultraworke…"` because `str.length` was 23. With the new `truncate`, `Bun.stringWidth(str)` is 22 so the string is returned unchanged. No ellipsis, no chopped letter.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
