### PR TITLE
fix(app): make prompt submit and newline rebindable

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -28,7 +28,8 @@ import { Select } from "@opencode-ai/ui/select"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { ModelSelectorPopover } from "@/components/dialog-select-model"
 import { useProviders } from "@/hooks/use-providers"
-import { useCommand } from "@/context/command"
+import { matchKeybind, parseKeybind, useCommand } from "@/context/command"
+import { useSettings } from "@/context/settings"
 import { Persist, persisted } from "@/utils/persist"
 import { usePermission } from "@/context/permission"
 import { useLanguage } from "@/context/language"
@@ -100,6 +101,11 @@ const EXAMPLES = [
 
 const NON_EMPTY_TEXT = /[^\s\u200B]/
 
+const PROMPT_SUBMIT_ID = "prompt.submit"
+const PROMPT_NEWLINE_ID = "prompt.newline"
+const DEFAULT_PROMPT_SUBMIT_KEYBIND = "enter"
+const DEFAULT_PROMPT_NEWLINE_KEYBIND = "shift+enter"
+
 export const PromptInput: Component<PromptInputProps> = (props) => {
   const sdk = useSDK()
 
@@ -112,9 +118,34 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const dialog = useDialog()
   const providers = useProviders()
   const command = useCommand()
+  const settings = useSettings()
   const permission = usePermission()
   const language = useLanguage()
   const platform = usePlatform()
+
+  // Register Enter / Shift+Enter as rebindable commands so they surface in
+  // the Keyboard Shortcuts settings UI (grouped under "Prompt" via the
+  // "prompt." id prefix). The actual dispatch stays local in handleKeyDown
+  // below so the editor always wins over the global keymap.
+  command.register(() => [
+    {
+      id: PROMPT_SUBMIT_ID,
+      title: language.t("command.prompt.submit"),
+      keybind: DEFAULT_PROMPT_SUBMIT_KEYBIND,
+    },
+    {
+      id: PROMPT_NEWLINE_ID,
+      title: language.t("command.prompt.newline"),
+      keybind: DEFAULT_PROMPT_NEWLINE_KEYBIND,
+    },
+  ])
+
+  const submitKeybinds = createMemo(() =>
+    parseKeybind(settings.keybinds.get(PROMPT_SUBMIT_ID) ?? DEFAULT_PROMPT_SUBMIT_KEYBIND),
+  )
+  const newlineKeybinds = createMemo(() =>
+    parseKeybind(settings.keybinds.get(PROMPT_NEWLINE_ID) ?? DEFAULT_PROMPT_NEWLINE_KEYBIND),
+  )
   const { params, tabs, view } = useSessionLayout()
   let editorRef!: HTMLDivElement
   let fileInputRef: HTMLInputElement | undefined
@@ -1165,11 +1196,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       }
     }
 
-    // Handle Shift+Enter BEFORE IME check - Shift+Enter is never used for IME input
-    // and should always insert a newline regardless of composition state
-    if (event.key === "Enter" && event.shiftKey) {
+    // Handle configured newline keybind BEFORE the IME check - the default
+    // (Shift+Enter) is never used for IME input and should always insert a
+    // newline regardless of composition state. Users who rebind the newline
+    // keybind to unmodified Enter accept that this takes precedence over IME.
+    if (matchKeybind(newlineKeybinds(), event)) {
       addPart({ type: "text", content: "\n", start: 0, end: 0 })
       event.preventDefault()
+      event.stopPropagation()
       return
     }
 
@@ -1232,9 +1266,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       return
     }
 
-    // Note: Shift+Enter is handled earlier, before IME check
-    if (event.key === "Enter" && !event.shiftKey) {
+    // Note: the newline keybind is handled earlier, before the IME check.
+    if (matchKeybind(submitKeybinds(), event)) {
       event.preventDefault()
+      event.stopPropagation()
       if (event.repeat) return
       if (
         working() &&

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -73,6 +73,8 @@ export const dict = {
   "command.model.variant.cycle.description": "Switch to the next effort level",
   "command.prompt.mode.shell": "Shell",
   "command.prompt.mode.normal": "Prompt",
+  "command.prompt.submit": "Submit prompt",
+  "command.prompt.newline": "Insert newline in prompt",
   "command.permissions.autoaccept.enable": "Auto-accept permissions",
   "command.permissions.autoaccept.disable": "Stop auto-accepting permissions",
   "command.workspace.toggle": "Toggle workspaces",


### PR DESCRIPTION
### Issue for this PR

Closes #16226

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Every shortcut in the web UI is rebindable via **Settings → Keyboard Shortcuts** — except the one users hit most: Enter / Shift+Enter in the prompt composer. `prompt-input.tsx` hardcodes `event.key === "Enter"`.

This PR registers two new web commands so they auto-surface in that settings page under the existing "Prompt" group (grouping is already driven by the `prompt.` id prefix in `settings-keybinds.tsx`):

- `prompt.submit` — default `enter`
- `prompt.newline` — default `shift+enter`

The two Enter branches in `handleKeyDown` now dispatch via `matchKeybind(submitKeybinds(), event)` / `matchKeybind(newlineKeybinds(), event)` against the configured bindings. `event.stopPropagation()` after a match so the editor always wins over the global keymap — prevents double-fire if a user picks a modified binding like `mod+enter`. The IME bail and the Shift+Enter-over-IME ordering are preserved.

Defaults match the previous hardcoded behavior byte-for-byte. No new config schema, no new settings UI, no migration. Same underlying ask as #11898 and #9836.

### How did you verify your code works?

- `bun typecheck` in `packages/app` — clean.
- `bun test src/i18n/parity.test.ts src/components/prompt-input/submit.test.ts` — 6 passed, 0 failed.
- Manual browser walkthrough pending (that's why this is Draft). Reviewer repro: open **Settings → Keyboard Shortcuts → Prompt**, confirm "Submit prompt" (`enter`) and "Insert newline in prompt" (`shift+enter`) appear, swap them, verify behavior in the composer.

### Screenshots / recordings

Will add once a maintainer signals they want this and I've run the manual walkthrough. There are no visual changes — the new rows just appear in the existing keybinds list under "Prompt".

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Notes

- AI Assistance: OpenCode + anthropic/claude-opus-4-7
- Review: Human operator (@CasualDeveloper) directed the work. Code changes not yet line-reviewed; manual browser walkthrough pending (see Verify section).
- Held as Draft pending design signal on #16226.
