### PR TITLE
fix(session): ensure new sessions appear in history

### DIFF
--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -179,7 +179,7 @@ export function createChildStoreManager(input: {
             lsp_ready: false,
             lsp: [],
             vcs: vcsStore.value,
-            limit: 5,
+            limit: 20,
             message: {},
             part: {},
           })

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -41,9 +41,10 @@ export function trimSessions(
     .filter((s) => !s.time?.archived)
     .sort((a, b) => cmp(a.id, b.id))
   const roots = all.filter((s) => !s.parentID)
+  const sortedRoots = roots.sort((a, b) => compareSessionRecent(a, b))
   const children = all.filter((s) => !!s.parentID)
-  const base = roots.slice(0, limit)
-  const recent = takeRecentSessions(roots.slice(limit), SESSION_RECENT_LIMIT, cutoff)
+  const base = sortedRoots.slice(0, limit)
+  const recent = takeRecentSessions(sortedRoots.slice(limit), SESSION_RECENT_LIMIT, cutoff)
   const keepRoots = [...base, ...recent]
   const keepRootIds = new Set(keepRoots.map((s) => s.id))
   const keepChildren = children.filter((s) => {


### PR DESCRIPTION
## Problem
Users cannot see newly created sessions in the session history list in both Web UI and Desktop versions.

## Root Cause
The `trimSessions()` function in `session-trim.ts` sorts root sessions by `session.id` instead of recency (`time.updated`). New sessions (with larger IDs) are excluded from the default display limit.

## Solution
Two fixes:
1. **Sort root sessions by recency** before applying the limit
2. **Increase default limit** from 5 to 20 for better user experience

## Changes
### 1. `packages/app/src/context/global-sync/session-trim.ts`
- Added sorting of root sessions by `compareSessionRecent` (time.updated descending)
- Updated `base` and `recent` selection to use the sorted list

### 2. `packages/app/src/context/global-sync/child-store.ts`
- Changed default session limit from `5` to `20`

## Impact
- New sessions now appear at the top of the history list
- Both Web UI and Desktop versions are fixed
- Maintains existing session trimming logic for archived/old sessions

## Testing
1. Start OpenCode Web UI
2. Create a new session
3. Verify it appears at the top of the session history list
4. Create more than 20 sessions to verify the limit works correctly