### PR TITLE
fix: avoid hanging on slow project id discovery

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { createHash } from "node:crypto"
 import { and, Database, eq } from "../storage"
 import { ProjectTable } from "./project.sql"
 import { SessionTable } from "../session/session.sql"
@@ -17,6 +18,7 @@ import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 const log = Log.create({ service: "project" })
+const ROOT_COMMIT_TIMEOUT = "1000 millis" as const
 
 const ProjectVcs = Schema.Literal("git")
 
@@ -156,6 +158,9 @@ export const layer: Layer.Layer<
       return pathSvc.resolve(cwd, name)
     }
 
+    const fallbackProjectId = (worktree: string) =>
+      ProjectID.make(`path-${createHash("sha1").update(worktree).digest("hex")}`)
+
     const scope = yield* Scope.Scope
 
     const readCachedProjectId = Effect.fnUntraced(function* (dir: string) {
@@ -217,7 +222,17 @@ export const layer: Layer.Layer<
         }
 
         if (!id) {
-          const revList = yield* git(["rev-list", "--max-parents=0", "HEAD"], { cwd: sandbox })
+          const revList = yield* git(["rev-list", "--max-parents=0", "HEAD"], { cwd: sandbox }).pipe(
+            Effect.timeoutOrElse({
+              duration: ROOT_COMMIT_TIMEOUT,
+              orElse: () =>
+                Effect.succeed({
+                  code: 124,
+                  text: "",
+                  stderr: `opencode: timed out after ${ROOT_COMMIT_TIMEOUT}`,
+                } satisfies GitResult),
+            }),
+          )
           const roots = revList.text
             .split("\n")
             .filter(Boolean)
@@ -225,6 +240,10 @@ export const layer: Layer.Layer<
             .toSorted()
 
           id = roots[0] ? ProjectID.make(roots[0]) : undefined
+          if (!id && revList.code === 124) {
+            id = fallbackProjectId(worktree)
+            log.warn("rev-list timed out; using fallback project id", { sandbox, worktree, id })
+          }
           if (id) {
             yield* fs.writeFileString(pathSvc.join(worktree, ".git", "opencode"), id).pipe(Effect.ignore)
           }

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -68,6 +68,42 @@ function projectLayerWithFailure(failArg: string) {
   )
 }
 
+function projectLayerWithTimeout(timeoutArg: string) {
+  const timeoutSpawner = Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.gen(function* () {
+      const real = yield* ChildProcessSpawner.ChildProcessSpawner
+      return ChildProcessSpawner.make(
+        Effect.fnUntraced(function* (command) {
+          const std = ChildProcess.isStandardCommand(command) ? command : undefined
+          if (std?.command === "git" && std.args.some((a) => a === timeoutArg)) {
+            return ChildProcessSpawner.makeHandle({
+              pid: ChildProcessSpawner.ProcessId(0),
+              exitCode: Effect.never,
+              isRunning: Effect.succeed(true),
+              kill: () => Effect.void,
+              stdin: { [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") } as any,
+              stdout: Stream.empty,
+              stderr: Stream.empty,
+              all: Stream.empty,
+              getInputFd: () => ({ [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") }) as any,
+              getOutputFd: () => Stream.empty,
+              unref: Effect.succeed(Effect.void),
+            })
+          }
+          return yield* real.spawn(command)
+        }),
+      )
+    }),
+  ).pipe(Layer.provide(CrossSpawnSpawner.defaultLayer))
+
+  return Project.layer.pipe(
+    Layer.provide(timeoutSpawner),
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(NodePath.layer),
+  )
+}
+
 describe("Project.fromDirectory", () => {
   test("should handle git repository with no commits", async () => {
     await using tmp = await tmpdir()
@@ -140,6 +176,23 @@ describe("Project.fromDirectory git failure paths", () => {
     const { project, sandbox } = await run((svc) => svc.fromDirectory(tmp.path), layer)
     expect(project.worktree).toBe(tmp.path)
     expect(sandbox).toBe(tmp.path)
+  })
+
+  test("falls back to deterministic path id when rev-list times out", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const layer = projectLayerWithTimeout("rev-list")
+
+    const started = Date.now()
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path), layer)
+    const elapsed = Date.now() - started
+
+    expect(project.vcs).toBe("git")
+    expect(project.worktree).toBe(tmp.path)
+    expect(project.id).toMatch(/^path-[0-9a-f]{40}$/)
+    expect(elapsed).toBeLessThan(1800)
+
+    const opencodeFile = path.join(tmp.path, ".git", "opencode")
+    expect(await Bun.file(opencodeFile).exists()).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary
- add a timeout around root-commit project ID discovery so slow external-volume repos do not block project open indefinitely
- fall back to a deterministic path-based project ID when `git rev-list --max-parents=0 HEAD` stalls, and cache that fallback in `.git/opencode`
- cover the timeout fallback with a project test

## Why
Opening projects under `/Volumes/DATA` can freeze the web project picker even when simpler `/file` requests succeed. The strongest upstream code path points to `Project.fromDirectory` waiting on `git rev-list --max-parents=0 HEAD` during instance boot. On slow external or mounted volumes this can stall long enough to make the UI appear hung.

This keeps the normal stable-root-commit ID behavior for healthy repos, but stops project discovery from hanging forever when that git command does not return in time.

## Verification
- `bun test test/project/project.test.ts`
- `bun run typecheck`

## Notes
AI-assisted investigation and implementation from local reproduction on macOS `/Volumes` project roots.