### PR TITLE
fix(tui): consume Enter in dialog useKeyboard handlers

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-go-upsell.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-go-upsell.tsx
@@ -77,6 +77,8 @@ export function DialogGoUpsell(props: DialogGoUpsellProps) {
       return
     }
     if (evt.name === "return") {
+      evt.preventDefault()
+      evt.stopPropagation()
       if (selected() === "subscribe") subscribe(props, dialog)
       else dismiss(props, dialog)
     }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-delete-failed.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-delete-failed.tsx
@@ -42,6 +42,8 @@ export function DialogSessionDeleteFailed(props: {
 
   useKeyboard((evt) => {
     if (evt.name === "return") {
+      evt.preventDefault()
+      evt.stopPropagation()
       void confirm()
     }
     if (evt.name === "left" || evt.name === "up") {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -15,6 +15,8 @@ export function DialogAlert(props: DialogAlertProps) {
 
   useKeyboard((evt) => {
     if (evt.name === "return") {
+      evt.preventDefault()
+      evt.stopPropagation()
       props.onConfirm?.()
       dialog.clear()
     }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
@@ -25,6 +25,8 @@ export function DialogConfirm(props: DialogConfirmProps) {
 
   useKeyboard((evt) => {
     if (evt.name === "return") {
+      evt.preventDefault()
+      evt.stopPropagation()
       if (store.active === "confirm") props.onConfirm?.()
       if (store.active === "cancel") props.onCancel?.()
       dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -35,6 +35,8 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
 
   useKeyboard((evt) => {
     if (evt.name === "return") {
+      evt.preventDefault()
+      evt.stopPropagation()
       props.onConfirm?.({
         filename: textarea.plainText,
         thinking: store.thinking,

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
@@ -11,6 +11,8 @@ export function DialogHelp() {
 
   useKeyboard((evt) => {
     if (evt.name === "return" || evt.name === "escape") {
+      evt.preventDefault()
+      evt.stopPropagation()
       dialog.clear()
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -29,6 +29,8 @@ export function DialogPrompt(props: DialogPromptProps) {
       return
     }
     if (evt.name === "return") {
+      evt.preventDefault()
+      evt.stopPropagation()
       props.onConfirm?.(textarea.plainText)
     }
   })


### PR DESCRIPTION
### Issue for this PR

Closes #23389 and #23803

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Seven TUI dialogs handled the `return` key in their `useKeyboard` callback but never called `evt.preventDefault()` or `evt.stopPropagation()`. opentui dispatches keypresses to global `useKeyboard` listeners first, then to the focused renderable; without consuming the event in the dialog's handler, Enter leaks past the dialog into the focused renderable underneath (typically the main prompt textarea).

With a custom `input_newline` keybind that includes bare `return`, confirming the dialog inserts a newline in the main prompt. With default keybinds it manifests as a silent empty-submit or unintended action — e.g. for #23803, pressing Enter on the update-available dialog also submits whatever was already typed in the prompt.

The fix adds the two consume calls to the `return` branch in:

- `ui/dialog-prompt.tsx` (session rename, OAuth code, API key, plugin-exposed `DialogPrompt`)
- `ui/dialog-export-options.tsx`
- `ui/dialog-confirm.tsx` (used by the update-available dialog and other generic confirms — #23803)
- `ui/dialog-alert.tsx`
- `ui/dialog-help.tsx`
- `component/dialog-go-upsell.tsx`
- `component/dialog-session-delete-failed.tsx`

Mirrors the consume pattern already used in `ui/dialog-select.tsx:205-213` and `component/dialog-workspace-unavailable.tsx:27-31`. Total diff: +14 LOC across 7 files, no change to dialog action behaviour.

### How did you verify your code works?

- `bun turbo typecheck` from repo root: 13/13 packages pass.
- Reproduced the original `DialogPrompt` leak locally with `"input_newline": "return,shift+return"` in `tui.json` (recordings on linked issue #23389): pre-fix, confirming session-rename inserted a newline in the main prompt; post-fix, main prompt untouched, dialog action unchanged.
- Audited every TUI file using `useKeyboard` to confirm no other dialog handlers were missing the consume calls; the 7 above are the complete set.

### Screenshots / recordings

Before/after recordings of the underlying bug class (demonstrated via `DialogPrompt`) are attached to issue #23389. The same root cause and fix shape applies to all 7 dialogs.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

AI assistance: OpenCode + anthropic/claude-opus-4-7 drafted the analysis and audit; human operator directed the scope and reviewed the fix.
