### PR TITLE
fix(ui): allow changes preview to expand for files with only additions or deletions

### DIFF
--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -388,7 +388,7 @@ export const SessionReview = (props: SessionReviewProps) => {
                     const file = diff.file
 
                     // binary files have empty diffs that we can't render
-                    const diffCanRender = () => diff.additions !== 0 && diff.deletions !== 0
+                    const diffCanRender = () => diff.additions !== 0 || diff.deletions !== 0
 
                     const expanded = createMemo(() => open().includes(file))
                     const mounted = createMemo(() => expanded() && (!!store.visible[file] || pinned(file)))


### PR DESCRIPTION
### Issue for this PR

Closes #23398

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `diffCanRender` function used `&&` instead of `||`, requiring both additions AND deletions to be non-zero. This prevented expanding diffs for new files (only additions) or deleted files (only deletions).

Changed `&&` to `||` so files with either additions or deletions can be expanded.

### How did you verify your code works?

- Opened changes preview in desktop app
- Tested with a newly added file (only additions) → can now expand
- Tested with a deleted file (only deletions) → can now expand  
- Tested with a modified file (both additions and deletions) → still works

### Screenshots / recordings

_N/A - logic fix, no visual changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR