### PR TITLE
fix(tui): make sub-agent row clickable while task is running

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -7,7 +7,6 @@ import {
   For,
   Match,
   on,
-  onMount,
   Show,
   Switch,
   useContext,
@@ -1946,13 +1945,26 @@ function WebSearch(props: ToolProps<typeof WebSearchTool>) {
 function Task(props: ToolProps<typeof TaskTool>) {
   const { navigate } = useRoute()
   const sync = useSync()
+  const ctx = use()
 
-  onMount(() => {
-    if (props.metadata.sessionId && !sync.data.message[props.metadata.sessionId]?.length)
-      void sync.session.sync(props.metadata.sessionId)
+  const childSessionId = createMemo(() => {
+    const id = props.metadata.sessionId
+    if (typeof id === "string" && id) return id
+    const description = props.input.description
+    const subagentType = props.input.subagent_type
+    return sync.data.session
+      .filter((s) => s.parentID === ctx.sessionID)
+      .filter((s) => !description || s.title.startsWith(String(description)))
+      .filter((s) => !subagentType || s.title.includes(`@${String(subagentType)}`))
+      .toSorted((a, b) => (b.time.created ?? 0) - (a.time.created ?? 0))[0]?.id
   })
 
-  const messages = createMemo(() => sync.data.message[props.metadata.sessionId ?? ""] ?? [])
+  createEffect(() => {
+    const id = childSessionId()
+    if (id && !sync.data.message[id]?.length) void sync.session.sync(id)
+  })
+
+  const messages = createMemo(() => sync.data.message[childSessionId() ?? ""] ?? [])
 
   const tools = createMemo(() => {
     return messages().flatMap((msg) =>
@@ -2003,8 +2015,9 @@ function Task(props: ToolProps<typeof TaskTool>) {
       pending="Delegating..."
       part={props.part}
       onClick={() => {
-        if (props.metadata.sessionId) {
-          navigate({ type: "session", sessionID: props.metadata.sessionId })
+        const id = childSessionId()
+        if (id) {
+          navigate({ type: "session", sessionID: id })
         }
       }}
     >


### PR DESCRIPTION
### Issue for this PR

Closes #23324

### Type of change

- [x] Bug fix

### What does this PR do?

**The bug:** Clicking a sub-agent task row in the TUI while the task is running does nothing. The row only becomes interactive after the task completes.

**Why it happens:** The `Task` component's `onClick` checks `props.metadata.sessionId` before navigating. That field is set by `ctx.metadata()` in `task.ts`, which is called *after* a permission check and sub-session creation. During that window — and for the entire run if a permission prompt is blocking — `metadata.sessionId` is undefined and clicking silently fails.

**The fix:** Added a `childSessionId` reactive memo that first checks `metadata.sessionId`, then falls back to searching `sync.data.session` for a session matching the current session's `parentID` and the task's description/agent type. This mirrors the same approach used in the web app (`taskSession()` in `message-part.tsx`). The sub-agent row is now navigable as soon as the sub-session appears in the session list, before the metadata is propagated.

Also replaced `onMount` with `createEffect` for the sub-session message sync, so messages load whenever the child session ID resolves rather than only at component mount.

### How did you verify your code works?

Code review and tracing the data flow: `sessions.create()` fires a `session.updated` sync event before `ctx.metadata()` is called, so the sub-session is already in `sync.data.session` by the time the spinner appears. The fallback search picks it up immediately. After `ctx.metadata()` fires, `metadata.sessionId` takes over as the canonical source.

### Screenshots / recordings

_N/A — this is a clickability fix, not a visual change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR