### PR TITLE
fix(keybind): normalize Unicode uppercase chars from Turkish keyboard…

### DIFF
--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -1,6 +1,15 @@
 import { isDeepEqual } from "remeda"
 import type { ParsedKey } from "@opentui/core"
 
+const UNICODE_UPPER_TO_LOWER: Record<string, string> = {
+  "İ": "i",
+  "Ğ": "ğ",
+  "Ş": "ş",
+  "Ü": "ü",
+  "Ö": "ö",
+  "Ç": "ç",
+}
+
 /**
  * Keybind info derived from OpenTUI's ParsedKey with our custom `leader` field.
  * This ensures type compatibility and catches missing fields at compile time.
@@ -21,11 +30,19 @@ export function match(a: Info | undefined, b: Info): boolean {
  * This helper ensures all required fields are present and avoids manual object creation.
  */
 export function fromParsedKey(key: ParsedKey, leader = false): Info {
+  let name = key.name === " " ? "space" : key.name
+  let shift = key.shift
+
+  if (!shift && name.length === 1 && UNICODE_UPPER_TO_LOWER[name] !== undefined) {
+    name = UNICODE_UPPER_TO_LOWER[name]!
+    shift = true
+  }
+
   return {
-    name: key.name === " " ? "space" : key.name,
+    name,
     ctrl: key.ctrl,
     meta: key.meta,
-    shift: key.shift,
+    shift,
     super: key.super ?? false,
     leader,
   }


### PR DESCRIPTION
### Issue for this PR
Closes #23413

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Terminal on Turkish keyboard layout sends uppercase letters (İ, Ğ, Ş, Ü, Ö, Ç) as raw UTF-8 chars without shift flag set. When user hits `shift+i` in plugin manager dialog, terminal sends "İ" with `shift=false`. Keybind match expects `shift+i` (with `shift=true`), so match fails and search box gets "İ" instead of triggering the keybind.

Fixed in `fromParsedKey()` by adding explicit Unicode map. When we see these uppercase chars come in without shift flag, we normalize them to lowercase + `shift=true`. Now `shift+i` on Turkish keyboard matches the `shift+i` keybind definition.

Why it works: Turkish keyboard has two i's (i/ı), and uppercase İ is 2-byte UTF-8. Can't use `.toLowerCase()` because `"İ".toLowerCase() = "i\u0307"` (2 chars, wrong). Explicit map is reliable.

### How did you verify your code works?
Ran `bun run dev`, typed `shift+i` in plugins dialog. Keybind triggered, install dialog opened. Tested `shift+ı` (lowercase i + shift) still works. Existing tests pass.

### Screenshots / recordings
N/A - terminal keybind fix

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR