### PR TITLE
fix: when no LSP config is specified, LSP should still be used by default

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -664,6 +664,8 @@ export const layer = Layer.effect(
 
         if (!result.username) result.username = os.userInfo().username
 
+        if (result.lsp === undefined) result.lsp = true
+
         if (result.autoshare === true && !result.share) {
           result.share = "auto"
         }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -118,6 +118,7 @@ test("loads config with defaults when no files exist", async () => {
     fn: async () => {
       const config = await load()
       expect(config.username).toBeDefined()
+      expect(config.lsp).toBe(true)
     },
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #23417

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I was finding that the LSP wasn't being used.  I used OC to diagnose that OC wasn't using/activating LSPs when no config was specified.  It defaults to true when there is no LSP config.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Ran OC locally against itself and my C# code

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._