### PR TITLE
docs: add universal plugins ecosystem entry

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -63,6 +63,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API         |
 | [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN              |
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                           |
+| [universal-plugins-for-ai-agents](https://github.com/777genius/universal-plugins-for-ai-agents) | Portable MCP plugin marketplace with native OpenCode manifests and cross-agent distribution |
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent  |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk   |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |


### PR DESCRIPTION
## Summary
- add universal-plugins-for-ai-agents to the ecosystem projects table
- link to the public multi-agent plugin marketplace repo
- describe it as a portable MCP plugin marketplace with native OpenCode support

## Testing
- not run (docs-only change)
