### PR TITLE
fix(app): make prompt submit and newline rebindable

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -28,7 +28,8 @@ import { Select } from "@opencode-ai/ui/select"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { ModelSelectorPopover } from "@/components/dialog-select-model"
 import { useProviders } from "@/hooks/use-providers"
-import { useCommand } from "@/context/command"
+import { matchKeybind, parseKeybind, useCommand } from "@/context/command"
+import { useSettings } from "@/context/settings"
 import { Persist, persisted } from "@/utils/persist"
 import { usePermission } from "@/context/permission"
 import { useLanguage } from "@/context/language"
@@ -101,6 +102,11 @@ const EXAMPLES = [
 
 const NON_EMPTY_TEXT = /[^\s\u200B]/
 
+const PROMPT_SUBMIT_ID = "prompt.submit"
+const PROMPT_NEWLINE_ID = "prompt.newline"
+const DEFAULT_PROMPT_SUBMIT_KEYBIND = "enter"
+const DEFAULT_PROMPT_NEWLINE_KEYBIND = "shift+enter"
+
 export const PromptInput: Component<PromptInputProps> = (props) => {
   const sdk = useSDK()
   const queryOptions = useQueryOptions()
@@ -114,9 +120,34 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const dialog = useDialog()
   const providers = useProviders()
   const command = useCommand()
+  const settings = useSettings()
   const permission = usePermission()
   const language = useLanguage()
   const platform = usePlatform()
+
+  // Prompt keybinds are editor-local; disabled keeps them out of the global
+  // keymap while still exposing them in Keyboard Shortcuts.
+  command.register(() => [
+    {
+      id: PROMPT_SUBMIT_ID,
+      title: language.t("command.prompt.submit"),
+      keybind: DEFAULT_PROMPT_SUBMIT_KEYBIND,
+      disabled: true,
+    },
+    {
+      id: PROMPT_NEWLINE_ID,
+      title: language.t("command.prompt.newline"),
+      keybind: DEFAULT_PROMPT_NEWLINE_KEYBIND,
+      disabled: true,
+    },
+  ])
+
+  const submitKeybinds = createMemo(() =>
+    parseKeybind(settings.keybinds.get(PROMPT_SUBMIT_ID) ?? DEFAULT_PROMPT_SUBMIT_KEYBIND),
+  )
+  const newlineKeybinds = createMemo(() =>
+    parseKeybind(settings.keybinds.get(PROMPT_NEWLINE_ID) ?? DEFAULT_PROMPT_NEWLINE_KEYBIND),
+  )
   const { params, tabs, view } = useSessionLayout()
   let editorRef!: HTMLDivElement
   let fileInputRef: HTMLInputElement | undefined
@@ -1161,11 +1192,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       }
     }
 
-    // Handle Shift+Enter BEFORE IME check - Shift+Enter is never used for IME input
-    // and should always insert a newline regardless of composition state
-    if (event.key === "Enter" && event.shiftKey) {
+    // Handle newline before IME so Shift+Enter always inserts a newline.
+    if (matchKeybind(newlineKeybinds(), event)) {
       addPart({ type: "text", content: "\n", start: 0, end: 0 })
       event.preventDefault()
+      event.stopPropagation()
       return
     }
 
@@ -1228,9 +1259,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       return
     }
 
-    // Note: Shift+Enter is handled earlier, before IME check
-    if (event.key === "Enter" && !event.shiftKey) {
+    // Note: the newline keybind is handled earlier, before the IME check.
+    if (matchKeybind(submitKeybinds(), event)) {
       event.preventDefault()
+      event.stopPropagation()
       if (event.repeat) return
       if (
         working() &&

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -74,6 +74,8 @@ export const dict = {
   "command.model.variant.cycle.description": "Switch to the next effort level",
   "command.prompt.mode.shell": "Shell",
   "command.prompt.mode.normal": "Prompt",
+  "command.prompt.submit": "Submit prompt",
+  "command.prompt.newline": "Insert newline in prompt",
   "command.permissions.autoaccept.enable": "Auto-accept permissions",
   "command.permissions.autoaccept.disable": "Stop auto-accepting permissions",
   "command.workspace.toggle": "Toggle workspaces",


### PR DESCRIPTION
### Issue for this PR

Closes #16226

Related: #11898, #9836

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the web prompt composer submit/newline bindings configurable in the existing **Settings → Keyboard Shortcuts** screen.

The PR registers two prompt commands:

- `prompt.submit` — default `enter`
- `prompt.newline` — default `shift+enter`

They are registered as `disabled` command entries, so they appear in settings but do not join the global keymap. The prompt editor handles them locally with `settings.keybinds` + `matchKeybind`, preserving current defaults while allowing users to swap or customize the bindings.

No new config schema, settings screen, migration, or SDK generation required.

### How did you verify your code works?

- `bun turbo typecheck` from `packages/app`
- `bun test src/i18n/parity.test.ts src/components/prompt-input/submit.test.ts`
- Manual browser walkthrough against the built app, covering default and swapped bindings:

| Bindings | Key pressed | Observed |
| --- | --- | --- |
| Default `enter` submit / `shift+enter` newline | `Shift+Enter` | inserted `<br>` in the editor |
| Default `enter` submit / `shift+enter` newline | `Enter` on empty composer | prevented default, no submit/fetch |
| Swapped `shift+enter` submit / `enter` newline | `Enter` | inserted `<br>` in the editor |
| Swapped `shift+enter` submit / `enter` newline | `Shift+Enter` on empty composer | prevented default, no submit/fetch |

Also verified the Keyboard Shortcuts UI shows both rows under the **Prompt** group and reset-to-defaults restores `Enter` / `Shift+Enter`.

### Screenshots / recordings

**Before**
<img width="1298" height="849" alt="Keyboard shortcuts before prompt submit/newline entries" src="https://github.com/user-attachments/assets/5a4bcd6a-a5d3-4ceb-9be5-0172aadc0d10" />

**After**
<img width="1290" height="848" alt="Keyboard shortcuts after prompt submit/newline entries" src="https://github.com/user-attachments/assets/9d14549f-3f9b-4eef-be83-225ffa231a9e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Notes

- AI Assistance: OpenCode + openai/gpt-5.5
- Review: Human-directed the work and ran the browser walkthrough. Code inspected; behavior verified with DOM assertions and fetch monitoring.