### PR TITLE
docs: clarify prompt supports multiple file references

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -340,6 +340,22 @@ Specify a custom system prompt file for this agent with the `prompt` config. The
 }
 ```
 
+### Using multiple files in prompt
+
+The `prompt` field can include both inline instructions and multiple file references. Each `{file:...}` will be expanded and combined into the final prompt.
+
+Example:
+
+```json
+{
+  "agent": {
+    "review": {
+      "prompt": "You are a code review agent.\n\n{file:./prompts/style-guide.txt}\n{file:./prompts/security.txt}"
+    }
+  }
+}
+```
+
 This path is relative to where the config file is located. So this works for both the global OpenCode config and the project specific config.
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #20356

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR improves the Agents documentation for the `prompt` field.

The existing documentation only showed usage with a single `{file:...}` reference. I added a new section explaining that the `prompt` field can combine inline instructions with multiple file references.

I also included an example demonstrating how multiple `{file:...}` entries can be used together.

### How did you verify your code works?

I verified the changes by reviewing the documentation locally and ensuring the formatting and markdown render correctly.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR