### PR TITLE
Add x-session-affinity header for Fireworks AI prompt caching

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1418,6 +1418,19 @@ const layer: Layer.Layer<
             ...model.headers,
           }
 
+        // Fireworks AI uses per-replica caching that requires session affinity via x-session-affinity header
+        // Without this, prompt caching is unreliable (cache misses when hitting different replicas)
+        // See: https://docs.fireworks.ai/guides/prompt-caching
+        // Only apply if we have a valid sessionId provided in options
+        const sessionId = options["sessionId"]
+        if ((model.providerID === "fireworks-ai" || model.providerID.startsWith("fireworks")) && 
+            typeof sessionId === "string" && sessionId.trim() !== "") {
+          options["headers"] = {
+            ...options["headers"],
+            "x-session-affinity": sessionId.trim(),
+          }
+        }
+
         const key = Hash.fast(
           JSON.stringify({
             providerID: model.providerID,


### PR DESCRIPTION
Fireworks AI uses per-replica in-memory caching that requires session affinity via the x-session-affinity HTTP header. Without this header, requests are routed to random replicas, causing cache misses even when the same session is reused.

This fix adds the x-session-affinity header for all Fireworks AI requests, using either a provided sessionId or a generated session identifier.

See: https://docs.fireworks.ai/guides/prompt-caching

### Issue for this PR

Closes #23450

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds cacheing hints as per their documentation

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Tested that opencode could still run with `bun dev` against fireworks.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
