### PR TITLE
fix(opencode): validate clipboard content type on Linux

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -5,6 +5,7 @@ import path from "path"
 import fs from "fs/promises"
 import * as Filesystem from "../../../../util/filesystem"
 import * as Process from "../../../../util/process"
+import { sniffAttachmentMime } from "../../../../util/media"
 
 // Lazy load which and clipboardy to avoid expensive execa/which/isexe chain at startup
 const getWhich = lazy(async () => {
@@ -93,13 +94,19 @@ export async function read(): Promise<Content | undefined> {
   if (os === "linux") {
     const wayland = await Process.run(["wl-paste", "-t", "image/png"], { nothrow: true })
     if (wayland.stdout.byteLength > 0) {
-      return { data: Buffer.from(wayland.stdout).toString("base64"), mime: "image/png" }
+      const mime = sniffAttachmentMime(new Uint8Array(wayland.stdout), "text/plain")
+      if (mime === "image/png") {
+        return { data: Buffer.from(wayland.stdout).toString("base64"), mime: "image/png" }
+      }
     }
     const x11 = await Process.run(["xclip", "-selection", "clipboard", "-t", "image/png", "-o"], {
       nothrow: true,
     })
     if (x11.stdout.byteLength > 0) {
-      return { data: Buffer.from(x11.stdout).toString("base64"), mime: "image/png" }
+      const mime = sniffAttachmentMime(new Uint8Array(x11.stdout), "text/plain")
+      if (mime === "image/png") {
+        return { data: Buffer.from(x11.stdout).toString("base64"), mime: "image/png" }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Validate clipboard content using `sniffAttachmentMime()` before treating as PNG on Linux
- Fixes text being incorrectly identified as image when pasting via Ctrl+V

## Root Cause

On Linux, `xclip -selection clipboard -t image/png -o` outputs raw bytes even when clipboard contains text. The code only checked `byteLength > 0`, so text (e.g. Unicode like `¯\_(ツ)_/¯`) was labeled as `image/png` and sent to the model, which failed with "could not process image".

## Fix

Use the existing `sniffAttachmentMime()` function from `media.ts` to check for PNG magic bytes before returning clipboard content as an image. This is the same validation pattern used in the `read` tool.

## Verification

1. Copy text with Unicode: `echo '¯\_(ツ)_/¯' | xclip -selection c`
2. Ctrl+V in OpenCode TUI
3. Text now pastes correctly instead of failing with "could not process image"

Fixes #23458