### PR TITLE
fix(ripgrep): inline paths in PowerShell Expand-Archive command

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -252,12 +252,12 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | ChildPro
 
         if (config.extension === "zip") {
           const shell = (yield* Effect.sync(() => which("powershell.exe") ?? which("pwsh.exe"))) ?? "powershell.exe"
+          const escapedArchive = archive.replace(/'/g, "''")
+          const escapedDir = dir.replace(/'/g, "''")
           const result = yield* run(shell, [
             "-NoProfile",
             "-Command",
-            "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
-            archive,
-            dir,
+            `Expand-Archive -LiteralPath '${escapedArchive}' -DestinationPath '${escapedDir}' -Force`,
           ])
           if (result.code !== 0) {
             return yield* Effect.fail(error(result.stderr || result.stdout, result.code))


### PR DESCRIPTION
## What does this PR do?

Fixes the `Expand-Archive` error on Windows PowerShell when loading skills or running grep operations.

**Root cause:** PowerShell's `-Command` parameter does not reliably populate `$args` from trailing positional arguments — especially in Windows PowerShell 5.x. The archive and destination paths passed after the `-Command` string evaluate to null, causing `Expand-Archive` to fail with "argument is null or empty".

**Fix:** Inline the archive and destination paths directly into the PowerShell command string with proper single-quote escaping (`'` → `''`) instead of relying on `$args`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test

1. On Windows with PowerShell 5.x (not pwsh), remove any pre-installed `rg` binary
2. Run any opencode command that triggers ripgrep download (e.g., load a skill)
3. Verify `Expand-Archive` completes successfully instead of failing with null argument error

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code

Closes #23457