### PR TITLE
fix: exempt StructuredOutput tool from permission filtering

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -447,7 +447,8 @@ function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" 
     Object.keys(input.tools),
     Permission.merge(input.agent.permission, input.permission ?? []),
   )
-  return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+  // StructuredOutput is an internal framework tool injected by prompt.ts; never permission-filter it.
+  return Record.filter(input.tools, (_, k) => k === "StructuredOutput" || (input.user.tools?.[k] !== false && !disabled.has(k)))
 }
 
 // Check if messages contain any tool-call content


### PR DESCRIPTION
### Issue for this PR

Fixes #23473

### Type of change

- [x] Bug fix

### What does this PR do?

\`output_schema\` in silently fails when the agent also has \`permission: { "*": deny }\`.

The cause is a double permission-filter. \`prompt.ts\` appends the \`StructuredOutput\` tool to the resolved tools map *after* its own permission filter, then passes the map to \`handle.process()\`. But \`llm.ts\` runs its own independent \`resolveTools()\` on that same map, so \`"*": deny\` strips \`StructuredOutput\` before the model call. The model never sees the tool and responds in plain text.

The fix is a single \`continue\` in \`llm.ts:resolveTools\` that skips \`StructuredOutput\`. It is an internal framework tool injected by \`prompt.ts\` — it is not a user-facing tool and must not be subject to user-defined permission rules.

### How did you verify your code works?

Reproduced the bug by creating an agent with \`output_schema\` + \`permission: { "*": deny }\` — the model responded in plain text. After the fix, it correctly calls \`StructuredOutput\` and returns structured JSON. Manually reverting the fix and confirming the bug returns also verified the cause.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR