### PR TITLE
fix(installation): respect GITHUB_TOKEN/GH_TOKEN for GitHub API release check

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -248,11 +248,12 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
           return data.version
         }
 
-        const response = yield* httpOk.execute(
-          HttpClientRequest.get("https://api.github.com/repos/anomalyco/opencode/releases/latest").pipe(
-            HttpClientRequest.acceptJson,
-          ),
-        )
+        const githubToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+        let githubRequest = HttpClientRequest.get(
+          "https://api.github.com/repos/anomalyco/opencode/releases/latest",
+        ).pipe(HttpClientRequest.acceptJson)
+        if (githubToken) githubRequest = githubRequest.pipe(HttpClientRequest.bearerToken(githubToken))
+        const response = yield* httpOk.execute(githubRequest)
         const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
         return data.tag_name.replace(/^v/, "")
       }, Effect.orDie)


### PR DESCRIPTION
### Issue for this PR

Closes #23461

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

## Problem

`opencode upgrade` (and the update-check on startup) calls `GET https://api.github.com/repos/anomalyco/opencode/releases/latest` without authentication. Unauthenticated GitHub API calls are capped at 60 requests/hour per IP. Users behind shared proxies or VPNs quickly exhaust this quota, causing 403 errors:

```
Error: Unexpected error, check log file...
StatusCode: non 2xx status code (403 GET https://api.github.com/repos/anomalyco/opencode/releases/latest)
```

Even when `GITHUB_TOKEN` was set in the environment or the user was authenticated via `gh auth login`, opencode did not use those credentials.

## Solution

Read `GITHUB_TOKEN` or `GH_TOKEN` from the environment and, when present, attach it as a `Authorization: Bearer <token>` header on the GitHub releases request. This raises the rate limit to 5,000 requests/hour, which is sufficient for any realistic usage pattern.

The change is in `Installation.latestImpl` — only the fallback GitHub API path (used by `curl` and unknown install methods) is affected. All other version sources (npm registry, Homebrew, Chocolatey, Scoop) are unchanged.

### How did you verify your code works?

- With `GITHUB_TOKEN` unset: behaviour is identical to before (no header sent).
- With `GITHUB_TOKEN` set to a valid PAT: the Authorization header is included, rate limit 5000/hr applies.
- With `GH_TOKEN` set (GitHub CLI convention): same as above.

### Screenshots / recordings

N/A — this is a backend/CLI change with no UI surface.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
