### PR TITLE
docs: clarify exit and interrupt behavior

### DIFF
--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -119,6 +119,14 @@ Some navigation keybinds intentionally do not use the leader key by default. For
 
 ---
 
+## Exit vs interrupt
+
+- `ctrl+c` exits OpenCode and leaves the current session running
+- `/exit` exits OpenCode and ends the current session
+- `Esc` interrupts the current response or tool call
+
+---
+
 ## Disable keybind
 
 You can disable a keybind by adding the key to `tui.json` with a value of "none".

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -119,6 +119,10 @@ Open external editor for composing messages. Uses the editor set in your `EDITOR
 
 Exit OpenCode. _Aliases_: `/quit`, `/q`
 
+`ctrl+c` exits OpenCode and leaves the current session running.
+`/exit` exits OpenCode and ends the current session.
+Use `Esc` to interrupt the current response or tool call.
+
 ```bash frame="none"
 /exit
 ```


### PR DESCRIPTION
### Issue for this PR

Closes #23478

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Clarifies the practical difference between `ctrl+c`, `/exit`, and `Esc` in the TUI docs.

The current docs list the keybinds, but they do not explain that exiting OpenCode and interrupting the current in-progress work are different actions. This adds that distinction to `tui.mdx` and `keybinds.mdx`.

### How did you verify your code works?

I verified the updated doc text locally and checked that the changes only affect `packages/web/src/content/docs/tui.mdx` and `packages/web/src/content/docs/keybinds.mdx`.

### Screenshots / recordings

_Not applicable. Docs-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
