### PR TITLE
fix(server): pass onError to hono streaming endpoints

### DIFF
--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -21,7 +21,9 @@ const log = Log.create({ service: "server" })
 export const GlobalDisposedEvent = BusEvent.define("global.disposed", z.object({}))
 
 async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>) => () => void) {
-  return streamSSE(c, async (stream) => {
+  return streamSSE(
+    c,
+    async (stream) => {
     const q = new AsyncQueue<string | null>()
     let done = false
 
@@ -67,7 +69,13 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
     } finally {
       stop()
     }
-  })
+    },
+    // Without an onError handler hono's streamSSE falls back to
+    // console.error(e), which prints a Bun-formatted stack to stderr.
+    async (err) => {
+      log.error("global event stream callback failed", { err })
+    },
+  )
 }
 
 export const GlobalRoutes = lazy(() =>

--- a/packages/opencode/src/server/routes/instance/event.ts
+++ b/packages/opencode/src/server/routes/instance/event.ts
@@ -36,7 +36,9 @@ export const EventRoutes = () =>
       c.header("Cache-Control", "no-cache, no-transform")
       c.header("X-Accel-Buffering", "no")
       c.header("X-Content-Type-Options", "nosniff")
-      return streamSSE(c, async (stream) => {
+      return streamSSE(
+        c,
+        async (stream) => {
         const q = new AsyncQueue<string | null>()
         let done = false
 
@@ -83,6 +85,15 @@ export const EventRoutes = () =>
         } finally {
           stop()
         }
-      })
+        },
+        // Without an onError handler hono's streamSSE falls back to
+        // console.error(e) which prints a Bun-formatted stack to stderr —
+        // see https://github.com/anomalyco/opencode/issues/17521.
+        // Route to our Logger so it lands in the log file (or stderr only
+        // when --print-logs is on), keeping the user-facing terminal clean.
+        async (err) => {
+          log.error("event stream callback failed", { err })
+        },
+      )
     },
   )

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -876,16 +876,29 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         c.status(200)
         c.header("Content-Type", "application/json")
-        return stream(c, async (stream) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const msg = await runRequest(
-            "SessionRoutes.prompt",
-            c,
-            SessionPrompt.Service.use((svc) => svc.prompt({ ...body, sessionID })),
-          )
-          void stream.write(JSON.stringify(msg))
-        })
+        return stream(
+          c,
+          async (stream) => {
+            const sessionID = c.req.valid("param").sessionID
+            const body = c.req.valid("json")
+            const msg = await runRequest(
+              "SessionRoutes.prompt",
+              c,
+              SessionPrompt.Service.use((svc) => svc.prompt({ ...body, sessionID })),
+            )
+            void stream.write(JSON.stringify(msg))
+          },
+          // Without an onError handler hono's stream() falls back to
+          // console.error(e), which prints a Bun-formatted source-context
+          // stack trace to stderr. The caller already gets the error
+          // through ErrorMiddleware (which serializes NamedErrors into the
+          // JSON response). Route any escaped error to our Logger so it
+          // lands in the log file (not the user-facing terminal).
+          // See https://github.com/anomalyco/opencode/issues/17521.
+          async (err) => {
+            log.error("session.prompt stream callback failed", { err })
+          },
+        )
       },
     )
     .post(

--- a/packages/opencode/test/server/stream-onerror.test.ts
+++ b/packages/opencode/test/server/stream-onerror.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test for upstream issue #17521 / #10631:
+ *
+ * Hono's `stream()` and `streamSSE()` helpers fall back to `console.error(e)`
+ * when the streaming callback throws and no `onError` handler is provided.
+ * In opencode that turns any user-input error (bad model id, missing provider,
+ * etc.) into a Bun-formatted source-context stack trace dumped to the user's
+ * terminal — the very issue that #10631 / #17521 / #16925 are filed for.
+ *
+ * The fix is to ALWAYS pass an `onError` handler that routes through our
+ * Logger (which by default writes to a log file, not stderr). This test is a
+ * static check: it grep-scans `src/server/routes/**` for `streamSSE(` and
+ * `stream(` calls and asserts each one is followed (within a reasonable
+ * window) by an `async (err)` / `(err)` argument. Cheap and catches regressions
+ * the second someone forgets it on a new endpoint.
+ */
+
+import { describe, expect, it } from "bun:test"
+import { Glob } from "@opencode-ai/shared/util/glob"
+import path from "path"
+
+const ROOT = path.join(import.meta.dir, "..", "..", "src", "server", "routes")
+
+async function listRouteFiles(): Promise<string[]> {
+  return Glob.scan("**/*.ts", { cwd: ROOT, absolute: true, include: "file" })
+}
+
+describe("server streaming endpoints have onError handlers", () => {
+  it("every streamSSE/stream callsite passes onError so errors don't reach console.error", async () => {
+    const files = await listRouteFiles()
+    expect(files.length).toBeGreaterThan(0)
+
+    const violations: { file: string; line: number; snippet: string }[] = []
+
+    for (const file of files) {
+      const text = await Bun.file(file).text()
+      const lines = text.split("\n")
+
+      // Find the line where streamSSE( or stream( starts.
+      // Note the parenthesis is required so we don't match `import { stream }` etc.
+      const opens: { kind: "streamSSE" | "stream"; line: number }[] = []
+      lines.forEach((line, i) => {
+        if (/\bstreamSSE\(/.test(line)) opens.push({ kind: "streamSSE", line: i })
+        else if (/(?:return|=)\s*stream\(/.test(line)) opens.push({ kind: "stream", line: i })
+      })
+
+      // For each opener, find the matching closing `)` by tracking paren depth
+      // across the rest of the file, then check whether the section between has
+      // exactly two top-level callbacks (the cb + onError) instead of just one.
+      for (const open of opens) {
+        // Locate the index of the opening "(" of this call
+        const startLine = lines[open.line]
+        const startCol = startLine.indexOf(open.kind + "(") + open.kind.length
+        let depth = 0
+        let lineIdx = open.line
+        let colIdx = startCol
+        let topLevelCommas = 0
+        let scanned = 0
+        outer: for (; lineIdx < lines.length; lineIdx++) {
+          const line = lines[lineIdx]
+          for (; colIdx < line.length; colIdx++) {
+            const ch = line[colIdx]
+            scanned++
+            if (scanned > 50_000) break outer // safety bail-out
+            if (ch === "(") depth++
+            else if (ch === ")") {
+              depth--
+              if (depth === 0) break outer
+            } else if (ch === "," && depth === 1) {
+              topLevelCommas++
+            }
+          }
+          colIdx = 0
+        }
+        // Args = topLevelCommas + 1 (e.g. 1 comma → 2 args). For both stream
+        // helpers the signature is (c, cb, onError?), so we need 3 args = 2
+        // top-level commas to ensure onError is present.
+        if (topLevelCommas < 2) {
+          violations.push({
+            file: path.relative(ROOT, file),
+            line: open.line + 1,
+            snippet: `${open.kind}( ... ${topLevelCommas + 1} top-level argument(s), expected 3 (c, cb, onError)`,
+          })
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const detail = violations.map((v) => `  ${v.file}:${v.line}  ${v.snippet}`).join("\n")
+      throw new Error(
+        `streamSSE/stream callsites missing onError handler — these will console.error stack traces on user-input errors. Fix: add an onError callback that logs via our Logger.\n\n${detail}\n\nSee https://github.com/anomalyco/opencode/issues/17521`,
+      )
+    }
+    expect(violations).toEqual([])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #17521
Closes #10631
Closes #16925

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hono's `stream()` and `streamSSE()` fall back to `console.error(e)` when the streaming callback throws and no `onError` is given. opencode wasn't passing `onError` on three streaming endpoints, so any user-input error (bad model id, missing provider, etc.) printed a Bun-formatted stack trace to stderr in addition to the friendly error message that the SDK already gives.

Affected endpoints — each now passes an `onError` that routes through the existing Logger:
- `/event` (`instance/event.ts`)
- `/global/event` (`global.ts`)
- `/session/:sessionID/prompt` (`instance/session.ts`)

The Logger writes to a log file by default (or to stderr when `--print-logs` is set), so the user-facing terminal stays clean while `--print-logs` still surfaces the same info for debugging.

### How did you verify your code works?

```
$ opencode run --model nonexistent/badmodel "hi"
```

Before: [28 lines of stack trace], then `Error: Model not found: ...`

After: just `Error: Model not found: nonexistent/badmodel.`

Also added a static test in `test/server/stream-onerror.test.ts` that scans `src/server/routes/**` and fails if any new `streamSSE(` / `stream(` callsite is added without an `onError` argument — so this regression can't sneak back in on future endpoints.

### Screenshots / recordings

_n/a — terminal-only change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR