### PR TITLE
docs: clarify github token configuration

### DIFF
--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -67,10 +67,11 @@ Or you can set it up manually.
            uses: anomalyco/opencode/github@latest
            env:
              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+             # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            with:
              model: anthropic/claude-sonnet-4-20250514
              # share: true
-             # github_token: xxxx
+             # use_github_token: true
    ```
 
 3. **Store the API keys in secrets**
@@ -85,9 +86,9 @@ Or you can set it up manually.
 - `agent`: The agent to use. Must be a primary agent. Falls back to `default_agent` from config or `"build"` if not found.
 - `share`: Whether to share the OpenCode session. Defaults to **true** for public repositories.
 - `prompt`: Optional custom prompt to override the default behavior. Use this to customize how OpenCode processes requests.
-- `token`: Optional GitHub access token for performing operations such as creating comments, committing changes, and opening pull requests. By default, OpenCode uses the installation access token from the OpenCode GitHub App, so commits, comments, and pull requests appear as coming from the app.
+- `use_github_token`: When set to **true**, OpenCode uses the `GITHUB_TOKEN` environment variable directly instead of exchanging an OpenCode GitHub App token. By default, OpenCode uses the installation access token from the OpenCode GitHub App, so commits, comments, and pull requests appear as coming from the app.
 
-  Alternatively, you can use the GitHub Action runner's [built-in `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token) without installing the OpenCode GitHub App. Just make sure to grant the required permissions in your workflow:
+  To use the GitHub Action runner's [built-in `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token), set `use_github_token: true`, pass the token through `env`, and grant the required permissions in your workflow:
 
   ```yaml
   permissions:
@@ -97,7 +98,7 @@ Or you can set it up manually.
     issues: write
   ```
 
-  You can also use a [personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT) if preferred.
+  You can also pass a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) through `GITHUB_TOKEN` if preferred.
 
 ---
 

--- a/packages/web/src/content/docs/ko/github.mdx
+++ b/packages/web/src/content/docs/ko/github.mdx
@@ -67,11 +67,10 @@ opencode github install
            uses: anomalyco/opencode/github@latest
            env:
              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-             # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            with:
              model: anthropic/claude-sonnet-4-20250514
              # share: true
-             # use_github_token: true
+             # github_token: xxxx
    ```
 
 3. **Store the API keys in secrets**
@@ -86,9 +85,9 @@ opencode github install
 - `agent`: 사용할 agent입니다. primary agent여야 합니다. 찾지 못하면 config의 `default_agent`를 사용하고, 그것도 없으면 `"build"`로 fallback합니다.
 - `share`: OpenCode 세션 공유 여부입니다. public repo에서는 기본값이 **true**입니다.
 - `prompt`: 기본 동작을 override하는 선택형 custom prompt입니다. OpenCode의 요청 처리 방식을 조정할 때 사용합니다.
-- `use_github_token`: **true**로 설정하면 OpenCode GitHub App token exchange 대신 `GITHUB_TOKEN` 환경 변수를 직접 사용합니다. 기본적으로 OpenCode는 OpenCode GitHub App의 installation access token을 사용하므로, 커밋/댓글/PR 작성 주체가 app으로 표시됩니다.
+- `token`: 댓글 생성, 커밋, PR 생성 같은 작업을 수행할 때 사용하는 선택형 GitHub access token입니다. 기본적으로 OpenCode는 OpenCode GitHub App의 installation access token을 사용하므로, 커밋/댓글/PR 작성 주체가 app으로 표시됩니다.
 
-  GitHub Action runner의 [기본 제공 `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)을 사용하려면 `use_github_token: true`를 설정하고, 토큰을 `env`로 전달한 뒤, workflow에 필요한 permission을 부여하세요.
+  또는 OpenCode GitHub App을 설치하지 않고도 GitHub Action runner의 [기본 제공 `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)을 사용할 수 있습니다. 이 경우 workflow에 필요한 permission을 반드시 부여하세요.
 
   ```yaml
   permissions:
@@ -98,7 +97,7 @@ opencode github install
     issues: write
   ```
 
-  필요하면 [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT)도 `GITHUB_TOKEN`으로 전달해 사용할 수 있습니다.
+  필요하면 [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT)도 사용할 수 있습니다.
 
 ---
 

--- a/packages/web/src/content/docs/ko/github.mdx
+++ b/packages/web/src/content/docs/ko/github.mdx
@@ -67,10 +67,11 @@ opencode github install
            uses: anomalyco/opencode/github@latest
            env:
              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+             # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            with:
              model: anthropic/claude-sonnet-4-20250514
              # share: true
-             # github_token: xxxx
+             # use_github_token: true
    ```
 
 3. **Store the API keys in secrets**
@@ -85,9 +86,9 @@ opencode github install
 - `agent`: 사용할 agent입니다. primary agent여야 합니다. 찾지 못하면 config의 `default_agent`를 사용하고, 그것도 없으면 `"build"`로 fallback합니다.
 - `share`: OpenCode 세션 공유 여부입니다. public repo에서는 기본값이 **true**입니다.
 - `prompt`: 기본 동작을 override하는 선택형 custom prompt입니다. OpenCode의 요청 처리 방식을 조정할 때 사용합니다.
-- `token`: 댓글 생성, 커밋, PR 생성 같은 작업을 수행할 때 사용하는 선택형 GitHub access token입니다. 기본적으로 OpenCode는 OpenCode GitHub App의 installation access token을 사용하므로, 커밋/댓글/PR 작성 주체가 app으로 표시됩니다.
+- `use_github_token`: **true**로 설정하면 OpenCode GitHub App token exchange 대신 `GITHUB_TOKEN` 환경 변수를 직접 사용합니다. 기본적으로 OpenCode는 OpenCode GitHub App의 installation access token을 사용하므로, 커밋/댓글/PR 작성 주체가 app으로 표시됩니다.
 
-  또는 OpenCode GitHub App을 설치하지 않고도 GitHub Action runner의 [기본 제공 `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)을 사용할 수 있습니다. 이 경우 workflow에 필요한 permission을 반드시 부여하세요.
+  GitHub Action runner의 [기본 제공 `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)을 사용하려면 `use_github_token: true`를 설정하고, 토큰을 `env`로 전달한 뒤, workflow에 필요한 permission을 부여하세요.
 
   ```yaml
   permissions:
@@ -97,7 +98,7 @@ opencode github install
     issues: write
   ```
 
-  필요하면 [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT)도 사용할 수 있습니다.
+  필요하면 [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT)도 `GITHUB_TOKEN`으로 전달해 사용할 수 있습니다.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #23487

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the GitHub docs to match the current action interface. The docs previously referred to a `token` option and showed `github_token` in the workflow example, but the action uses `use_github_token` and reads the token from `GITHUB_TOKEN`.

### How did you verify your code works?

Compared the docs against `github/action.yml` and `packages/opencode/src/cli/cmd/github.ts` to confirm the current action inputs and environment variable handling.

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR