### PR TITLE
fix(opencode): support encrypted_content and previous_response_id for OpenAI flows

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -179,14 +179,20 @@ function normalizeMessages(
     const field = model.capabilities.interleaved.field
     return msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
-        const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
-        const reasoningText = reasoningParts.map((part: any) => part.text).join("")
+        const reasoningParts = msg.content.filter((part): part is (typeof msg.content)[number] & { type: "reasoning" } => {
+          return part.type === "reasoning"
+        })
+        const reasoningText = reasoningParts.map((part) => part.text).join("")
+        const encryptedContent = reasoningParts.reduce<string | undefined>((result, part) => {
+          const next = part.providerOptions?.openai?.reasoningEncryptedContent
+          return typeof next === "string" && next ? next : result
+        }, undefined)
 
         // Filter out reasoning parts from content
-        const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
+        const filteredContent = msg.content.filter((part) => part.type !== "reasoning")
 
         // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-        if (reasoningText) {
+        if (reasoningText || encryptedContent) {
           return {
             ...msg,
             content: filteredContent,
@@ -194,7 +200,8 @@ function normalizeMessages(
               ...msg.providerOptions,
               openaiCompatible: {
                 ...msg.providerOptions?.openaiCompatible,
-                [field]: reasoningText,
+                ...(reasoningText ? { [field]: reasoningText } : {}),
+                ...(encryptedContent ? { encrypted_content: encryptedContent } : {}),
               },
             },
           }

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -302,6 +302,7 @@ export const layer: Layer.Layer<
       const msgs = structuredClone(selected.head)
       yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, { stripMedia: true })
+      const previousResponseId = MessageV2.previousResponseId({ messages: msgs, model })
       const ctx = yield* InstanceState.context
       const msg: MessageV2.Assistant = {
         id: MessageID.ascending(),
@@ -349,6 +350,7 @@ export const layer: Layer.Layer<
           },
         ],
         model,
+        options: previousResponseId ? { previousResponseId } : undefined,
       })
 
       if (result === "compact") {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -42,6 +42,7 @@ export type StreamInput = {
   tools: Record<string, Tool>
   retries?: number
   toolChoice?: "auto" | "required" | "none"
+  options?: Record<string, any>
 }
 
 export type StreamRequest = StreamInput & {
@@ -139,6 +140,7 @@ const live: Layer.Layer<
         mergeDeep(input.model.options),
         mergeDeep(input.agent.options),
         mergeDeep(variant),
+        mergeDeep(input.options ?? {}),
       )
       if (isOpenaiOauth) {
         options.instructions = system.join("\n")
@@ -365,6 +367,7 @@ const live: Layer.Layer<
         tools,
         toolChoice: input.toolChoice,
         maxOutputTokens: params.maxOutputTokens,
+        includeRawChunks: shouldIncludeRawChunks(input.model),
         abortSignal: input.abort,
         headers: {
           ...(input.model.providerID.startsWith("opencode")
@@ -448,6 +451,14 @@ function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" 
     Permission.merge(input.agent.permission, input.permission ?? []),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+}
+
+function shouldIncludeRawChunks(model: Provider.Model) {
+  return (
+    model.api.npm === "@ai-sdk/openai-compatible" &&
+    typeof model.capabilities.interleaved === "object" &&
+    model.capabilities.interleaved.field === "reasoning_content"
+  )
 }
 
 // Check if messages contain any tool-call content

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -256,6 +256,7 @@ export const StepFinishPart = PartBase.extend({
   reason: z.string(),
   snapshot: z.string().optional(),
   cost: z.number(),
+  metadata: z.record(z.string(), z.any()).optional(),
   tokens: z.object({
     total: z.number().optional(),
     input: z.number(),
@@ -838,6 +839,22 @@ export function toModelMessages(
   options?: { stripMedia?: boolean },
 ): Promise<ModelMessage[]> {
   return Effect.runPromise(toModelMessagesEffect(input, model, options).pipe(Effect.provide(EffectLogger.layer)))
+}
+
+export function previousResponseId(input: { messages: WithParts[]; model: Provider.Model }) {
+  for (let i = input.messages.length - 1; i >= 0; i--) {
+    const msg = input.messages[i]
+    if (msg.info.role !== "assistant") continue
+    if (msg.info.providerID !== input.model.providerID) continue
+    if (msg.info.modelID !== input.model.id) continue
+
+    for (let j = msg.parts.length - 1; j >= 0; j--) {
+      const part = msg.parts[j]
+      if (part.type !== "step-finish") continue
+      const responseId = part.metadata?.openai?.responseId
+      if (typeof responseId === "string" && responseId) return responseId
+    }
+  }
 }
 
 export function page(input: { sessionID: SessionID; limit: number; before?: string }) {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1,5 +1,6 @@
 import { Cause, Deferred, Effect, Layer, Context, Scope } from "effect"
 import * as Stream from "effect/Stream"
+import { mergeDeep } from "remeda"
 import { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { Config } from "@/config"
@@ -71,6 +72,7 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
+  pendingReasoningEncryptedContent: string | undefined
 }
 
 type StreamEvent = Event
@@ -121,6 +123,7 @@ export const layer: Layer.Layer<
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        pendingReasoningEncryptedContent: undefined,
       }
       let aborted = false
       const slog = log.clone().tag("session.id", input.sessionID).tag("messageID", input.assistantMessage.id)
@@ -130,6 +133,56 @@ export const layer: Layer.Layer<
           providerID: input.model.providerID,
           aborted,
         })
+
+      const mergeMetadata = (existing?: Record<string, any>, next?: Record<string, any>) => {
+        if (!existing) return next
+        if (!next) return existing
+        return mergeDeep(existing, next)
+      }
+
+      const encryptedContentFromRaw = (rawValue: unknown) => {
+        const parsed = (() => {
+          if (typeof rawValue === "string") {
+            try {
+              return JSON.parse(rawValue)
+            } catch {
+              return
+            }
+          }
+          return rawValue
+        })()
+        if (!isRecord(parsed) || !Array.isArray(parsed.choices)) return {}
+        const choice = parsed.choices[0]
+        if (!isRecord(choice) || !isRecord(choice.delta)) return {}
+        const delta = choice.delta
+        return {
+          encryptedContent:
+            typeof delta.encrypted_content === "string" && delta.encrypted_content ? delta.encrypted_content : undefined,
+          reasoningContent:
+            typeof delta.reasoning_content === "string"
+              ? delta.reasoning_content
+              : typeof delta.reasoning === "string"
+                ? delta.reasoning
+                : undefined,
+        }
+      }
+
+      const attachEncryptedContent = Effect.fn("SessionProcessor.attachEncryptedContent")(function* (encrypted: string) {
+        const active = Object.values(ctx.reasoningMap)
+        if (active.length === 0) return false
+
+        for (const part of active) {
+          part.metadata = mergeMetadata(part.metadata, {
+            openai: {
+              ...part.metadata?.openai,
+              reasoningEncryptedContent: encrypted,
+            },
+          })
+          yield* session.updatePart(part)
+        }
+
+        return true
+      })
 
       const settleToolCall = Effect.fn("SessionProcessor.settleToolCall")(function* (toolCallID: string) {
         const done = ctx.toolcalls[toolCallID]?.done
@@ -228,15 +281,26 @@ export const layer: Layer.Layer<
               type: "reasoning",
               text: "",
               time: { start: Date.now() },
-              metadata: value.providerMetadata,
+              metadata: mergeMetadata(
+                value.providerMetadata,
+                ctx.pendingReasoningEncryptedContent
+                  ? {
+                      openai: {
+                        reasoningEncryptedContent: ctx.pendingReasoningEncryptedContent,
+                      },
+                    }
+                  : undefined,
+              ),
             }
+            ctx.pendingReasoningEncryptedContent = undefined
             yield* session.updatePart(ctx.reasoningMap[value.id])
             return
 
           case "reasoning-delta":
             if (!(value.id in ctx.reasoningMap)) return
             ctx.reasoningMap[value.id].text += value.text
-            if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
+            if (value.providerMetadata)
+              ctx.reasoningMap[value.id].metadata = mergeMetadata(ctx.reasoningMap[value.id].metadata, value.providerMetadata)
             yield* session.updatePartDelta({
               sessionID: ctx.reasoningMap[value.id].sessionID,
               messageID: ctx.reasoningMap[value.id].messageID,
@@ -251,10 +315,22 @@ export const layer: Layer.Layer<
             // oxlint-disable-next-line no-self-assign -- reactivity trigger
             ctx.reasoningMap[value.id].text = ctx.reasoningMap[value.id].text
             ctx.reasoningMap[value.id].time = { ...ctx.reasoningMap[value.id].time, end: Date.now() }
-            if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
+            if (value.providerMetadata)
+              ctx.reasoningMap[value.id].metadata = mergeMetadata(ctx.reasoningMap[value.id].metadata, value.providerMetadata)
             yield* session.updatePart(ctx.reasoningMap[value.id])
             delete ctx.reasoningMap[value.id]
+            ctx.pendingReasoningEncryptedContent = undefined
             return
+
+          case "raw": {
+            const encrypted = encryptedContentFromRaw(value.rawValue)
+            if (!encrypted.encryptedContent) return
+            const attached = yield* attachEncryptedContent(encrypted.encryptedContent)
+            if (!attached && encrypted.reasoningContent) {
+              ctx.pendingReasoningEncryptedContent = encrypted.encryptedContent
+            }
+            return
+          }
 
           case "tool-input-start":
             if (ctx.assistantMessage.summary) {
@@ -372,6 +448,7 @@ export const layer: Layer.Layer<
               type: "step-finish",
               tokens: usage.tokens,
               cost: usage.cost,
+              metadata: value.providerMetadata,
             })
             yield* session.updateMessage(ctx.assistantMessage)
             if (ctx.snapshot) {
@@ -491,6 +568,7 @@ export const layer: Layer.Layer<
           })
         }
         ctx.reasoningMap = {}
+        ctx.pendingReasoningEncryptedContent = undefined
 
         yield* Effect.forEach(
           Object.values(ctx.toolcalls),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1476,6 +1476,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
+            const previousResponseId = MessageV2.previousResponseId({ messages: msgs, model })
             const system = [...env, ...(skills ? [skills] : []), ...instructions]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
@@ -1490,6 +1491,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               tools,
               model,
               toolChoice: format.type === "json_schema" ? "required" : undefined,
+              options: previousResponseId ? { previousResponseId } : undefined,
             })
 
             if (structured !== undefined) {

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -10,7 +10,7 @@ type Line = Record<string, unknown>
 
 type Flow =
   | { type: "text"; text: string }
-  | { type: "reason"; text: string }
+  | { type: "reason"; text: string; encryptedContent?: string }
   | { type: "tool-start"; id: string; name: string }
   | { type: "tool-args"; text: string }
   | { type: "usage"; usage: Usage }
@@ -88,8 +88,13 @@ function textLine(value: string) {
   return chunk({ delta: { content: value } })
 }
 
-function reasonLine(value: string) {
-  return chunk({ delta: { reasoning_content: value } })
+function reasonLine(value: string, encryptedContent?: string) {
+  return chunk({
+    delta: {
+      reasoning_content: value,
+      ...(encryptedContent ? { encrypted_content: encryptedContent } : {}),
+    },
+  })
 }
 
 function finishLine(reason: string, usage?: Usage) {
@@ -191,12 +196,12 @@ function responseMessageDone(id: string, seq: number) {
   }
 }
 
-function responseReason(id: string, seq: number) {
+function responseReason(id: string, seq: number, encryptedContent?: string) {
   return {
     type: "response.output_item.added",
     sequence_number: seq,
     output_index: 0,
-    item: { type: "reasoning", id, encrypted_content: null },
+    item: { type: "reasoning", id, encrypted_content: encryptedContent ?? null },
   }
 }
 
@@ -219,12 +224,12 @@ function responseReasonText(id: string, text: string, seq: number) {
   }
 }
 
-function responseReasonDone(id: string, seq: number) {
+function responseReasonDone(id: string, seq: number, encryptedContent?: string) {
   return {
     type: "response.output_item.done",
     sequence_number: seq,
     output_index: 0,
-    item: { type: "reasoning", id, encrypted_content: null },
+    item: { type: "reasoning", id, encrypted_content: encryptedContent ?? null },
   }
 }
 
@@ -300,7 +305,14 @@ function flow(item: Sse) {
     }
 
     if (delta && "reasoning_content" in delta && typeof delta.reasoning_content === "string") {
-      out.push({ type: "reason", text: delta.reasoning_content })
+      out.push({
+        type: "reason",
+        text: delta.reasoning_content,
+        encryptedContent:
+          "encrypted_content" in delta && typeof delta.encrypted_content === "string"
+            ? delta.encrypted_content
+            : undefined,
+      })
     }
 
     if (delta && "tool_calls" in delta && Array.isArray(delta.tool_calls)) {
@@ -333,6 +345,7 @@ function responses(item: Sse, model: string) {
   let seq = 1
   let msg: string | undefined
   let reason: string | undefined
+  let encryptedReason: string | undefined
   let hasMsg = false
   let hasReason = false
   let call:
@@ -361,10 +374,11 @@ function responses(item: Sse, model: string) {
 
     if (part.type === "reason") {
       reason ||= "rs_1"
+      encryptedReason = part.encryptedContent ?? encryptedReason
       if (!hasReason) {
         hasReason = true
         seq += 1
-        lines.push(responseReason(reason, seq))
+        lines.push(responseReason(reason, seq, encryptedReason))
         seq += 1
         lines.push(responseReasonPart(reason, seq))
       }
@@ -397,7 +411,7 @@ function responses(item: Sse, model: string) {
   }
   if (reason) {
     seq += 1
-    lines.push(responseReasonDone(reason, seq))
+    lines.push(responseReasonDone(reason, seq, encryptedReason))
   }
   if (call && !item.hang && !item.error) {
     seq += 1
@@ -470,8 +484,8 @@ export class Reply {
     return this
   }
 
-  reason(value: string) {
-    this.#tail = [...this.#tail, reasonLine(value)]
+  reason(value: string, encryptedContent?: string) {
+    this.#tail = [...this.#tail, reasonLine(value, encryptedContent)]
     return this
   }
 
@@ -611,7 +625,10 @@ namespace TestLLMServer {
     readonly text: (value: string, opts?: { usage?: Usage }) => Effect.Effect<void>
     readonly tool: (name: string, input: unknown) => Effect.Effect<void>
     readonly toolHang: (name: string, input: unknown) => Effect.Effect<void>
-    readonly reason: (value: string, opts?: { text?: string; usage?: Usage }) => Effect.Effect<void>
+    readonly reason: (
+      value: string,
+      opts?: { text?: string; usage?: Usage; encryptedContent?: string },
+    ) => Effect.Effect<void>
     readonly fail: (message?: unknown) => Effect.Effect<void>
     readonly error: (status: number, body: unknown) => Effect.Effect<void>
     readonly hang: Effect.Effect<void>
@@ -730,8 +747,11 @@ export class TestLLMServer extends Context.Service<TestLLMServer, TestLLMServer.
         toolHang: Effect.fn("TestLLMServer.toolHang")(function* (name: string, input: unknown) {
           queue(reply().pendingTool(name, input).hang().item())
         }),
-        reason: Effect.fn("TestLLMServer.reason")(function* (value: string, opts?: { text?: string; usage?: Usage }) {
-          const out = reply().reason(value)
+        reason: Effect.fn("TestLLMServer.reason")(function* (
+          value: string,
+          opts?: { text?: string; usage?: Usage; encryptedContent?: string },
+        ) {
+          const out = reply().reason(value, opts?.encryptedContent)
           if (opts?.text) out.text(opts.text)
           if (opts?.usage) out.usage(opts.usage)
           queue(out.stop().item())

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -923,6 +923,127 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
     expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
   })
 
+  test("DeepSeek includes encrypted_content alongside reasoning_content", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Let me think about this...",
+            providerOptions: {
+              openai: {
+                reasoningEncryptedContent: "encrypted-reasoning",
+              },
+            },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "test",
+            toolName: "bash",
+            input: { command: "echo hello" },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(
+      msgs,
+      {
+        id: ModelID.make("deepseek/deepseek-chat"),
+        providerID: ProviderID.make("deepseek"),
+        api: {
+          id: "deepseek-chat",
+          url: "https://api.deepseek.com",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        name: "DeepSeek Chat",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: false,
+          toolcall: true,
+          input: { text: true, audio: false, image: false, video: false, pdf: false },
+          output: { text: true, audio: false, image: false, video: false, pdf: false },
+          interleaved: {
+            field: "reasoning_content",
+          },
+        },
+        cost: {
+          input: 0.001,
+          output: 0.002,
+          cache: { read: 0.0001, write: 0.0002 },
+        },
+        limit: {
+          context: 128000,
+          output: 8192,
+        },
+        status: "active",
+        options: {},
+        headers: {},
+        release_date: "2023-04-01",
+      },
+      {},
+    )
+
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
+    expect(result[0].providerOptions?.openaiCompatible?.encrypted_content).toBe("encrypted-reasoning")
+  })
+
+  test("DeepSeek omits encrypted_content when reasoning metadata is missing", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Let me think about this..." },
+          { type: "text", text: "Answer" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(
+      msgs,
+      {
+        id: ModelID.make("deepseek/deepseek-chat"),
+        providerID: ProviderID.make("deepseek"),
+        api: {
+          id: "deepseek-chat",
+          url: "https://api.deepseek.com",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        name: "DeepSeek Chat",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: false,
+          toolcall: true,
+          input: { text: true, audio: false, image: false, video: false, pdf: false },
+          output: { text: true, audio: false, image: false, video: false, pdf: false },
+          interleaved: {
+            field: "reasoning_content",
+          },
+        },
+        cost: {
+          input: 0.001,
+          output: 0.002,
+          cache: { read: 0.0001, write: 0.0002 },
+        },
+        limit: {
+          context: 128000,
+          output: 8192,
+        },
+        status: "active",
+        options: {},
+        headers: {},
+        release_date: "2023-04-01",
+      },
+      {},
+    )
+
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
+    expect(result[0].providerOptions?.openaiCompatible?.encrypted_content).toBeUndefined()
+  })
+
   test("Non-DeepSeek providers leave reasoning content unchanged", () => {
     const msgs = [
       {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -668,9 +668,118 @@ describe("session.llm.stream", () => {
         expect(body.model).toBe(resolved.api.id)
         expect(body.stream).toBe(true)
         expect((body.reasoning as { effort?: string } | undefined)?.effort).toBe("high")
+        expect(body.previous_response_id).toBeUndefined()
 
         const maxTokens = body.max_output_tokens as number | undefined
         expect(maxTokens).toBe(undefined) // match codex cli behavior
+      },
+    })
+  })
+
+  test("sends previous_response_id for OpenAI responses calls when provided", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const source = await loadFixture("openai", "gpt-5.2")
+    const model = source.model
+
+    const responseChunks = [
+      {
+        type: "response.created",
+        response: {
+          id: "resp-2",
+          created_at: Math.floor(Date.now() / 1000),
+          model: model.id,
+          service_tier: null,
+        },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "item-2",
+        delta: "Hello again",
+        logprobs: null,
+      },
+      {
+        type: "response.completed",
+        response: {
+          incomplete_details: null,
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: null,
+            output_tokens: 1,
+            output_tokens_details: null,
+          },
+          service_tier: null,
+        },
+      },
+    ]
+    const request = waitRequest("/responses", createEventResponse(responseChunks, true))
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["openai"],
+            provider: {
+              openai: {
+                name: "OpenAI",
+                env: ["OPENAI_API_KEY"],
+                npm: "@ai-sdk/openai",
+                api: "https://api.openai.com/v1",
+                models: {
+                  [model.id]: model,
+                },
+                options: {
+                  apiKey: "test-openai-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.openai, ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-previous-response-id")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-previous-response-id"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("openai"), modelID: resolved.id, variant: "high" },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+          options: {
+            previousResponseId: "resp-prev",
+          },
+        })
+
+        const capture = await request
+        expect(capture.body.previous_response_id).toBe("resp-prev")
       },
     })
   })

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -949,6 +949,108 @@ describe("session.message-v2.toModelMessage", () => {
   })
 })
 
+describe("session.message-v2.previousResponseId", () => {
+  function stepFinish(messageID: string, id: string, metadata?: Record<string, unknown>): MessageV2.StepFinishPart {
+    return {
+      ...basePart(messageID, id),
+      type: "step-finish",
+      reason: "stop",
+      cost: 0,
+      metadata,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    }
+  }
+
+  test("returns the latest matching response id", () => {
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo("m-user"),
+        parts: [{ ...basePart("m-user", "u1"), type: "text", text: "hello" }] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo("m-assistant-1", "m-user", undefined, {
+          providerID: model.providerID,
+          modelID: model.id,
+        }),
+        parts: [stepFinish("m-assistant-1", "s1", { openai: { responseId: "resp-old" } })],
+      },
+      {
+        info: assistantInfo("m-assistant-2", "m-user", undefined, {
+          providerID: model.providerID,
+          modelID: model.id,
+        }),
+        parts: [
+          stepFinish("m-assistant-2", "s2", { openai: { responseId: "resp-mid" } }),
+          stepFinish("m-assistant-2", "s3", { openai: { responseId: "resp-latest" } }),
+        ],
+      },
+    ]
+
+    expect(MessageV2.previousResponseId({ messages: input, model })).toBe("resp-latest")
+  })
+
+  test("skips mismatched models and missing metadata", () => {
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo("m-assistant-1", "m-user", undefined, {
+          providerID: model.providerID,
+          modelID: model.id,
+        }),
+        parts: [stepFinish("m-assistant-1", "s1", { openai: { responseId: "resp-match" } })],
+      },
+      {
+        info: assistantInfo("m-assistant-2", "m-user", undefined, {
+          providerID: model.providerID,
+          modelID: ModelID.make("other-model"),
+        }),
+        parts: [stepFinish("m-assistant-2", "s2", { openai: { responseId: "resp-other-model" } })],
+      },
+      {
+        info: assistantInfo("m-assistant-3", "m-user", undefined, {
+          providerID: ProviderID.make("other-provider"),
+          modelID: model.id,
+        }),
+        parts: [stepFinish("m-assistant-3", "s3", { openai: { responseId: "resp-other-provider" } })],
+      },
+      {
+        info: assistantInfo("m-assistant-4", "m-user", undefined, {
+          providerID: model.providerID,
+          modelID: model.id,
+        }),
+        parts: [stepFinish("m-assistant-4", "s4")],
+      },
+    ]
+
+    expect(MessageV2.previousResponseId({ messages: input, model })).toBe("resp-match")
+  })
+
+  test("returns undefined when no matching response id exists", () => {
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo("m-assistant-1", "m-user", undefined, {
+          providerID: model.providerID,
+          modelID: model.id,
+        }),
+        parts: [
+          {
+            ...basePart("m-assistant-1", "r1"),
+            type: "reasoning",
+            text: "thinking",
+            time: { start: 0, end: 1 },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(MessageV2.previousResponseId({ messages: input, model })).toBeUndefined()
+  })
+})
+
 describe("session.message-v2.fromError", () => {
   test("serializes context_length_exceeded as ContextOverflowError", () => {
     const input = {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -412,6 +412,117 @@ it.live("session.processor effect tests capture reasoning from http mock", () =>
   ),
 )
 
+it.live("session.processor effect tests persist encrypted reasoning metadata from raw chunks", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.reason("think", { text: "done", encryptedContent: "encrypted-think" })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reason")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const base = yield* provider.getModel(ref.providerID, ref.modelID)
+        const mdl = {
+          ...base,
+          capabilities: {
+            ...base.capabilities,
+            reasoning: true,
+            interleaved: { field: "reasoning_content" as const },
+          },
+        }
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reason" }],
+          tools: {},
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const reasoning = parts.find((part): part is MessageV2.ReasoningPart => part.type === "reasoning")
+        const text = parts.find((part): part is MessageV2.TextPart => part.type === "text")
+
+        expect(value).toBe("continue")
+        expect(reasoning?.text).toBe("think")
+        expect(reasoning?.metadata?.openai?.reasoningEncryptedContent).toBe("encrypted-think")
+        expect(text?.text).toBe("done")
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests keep encrypted reasoning metadata when a tool call follows", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(reply().reason("think", "encrypted-think").tool("bash", { cmd: "pwd" }))
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reason then tool")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const base = yield* provider.getModel(ref.providerID, ref.modelID)
+        const mdl = {
+          ...base,
+          capabilities: {
+            ...base.capabilities,
+            reasoning: true,
+            interleaved: { field: "reasoning_content" as const },
+          },
+        }
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reason then tool" }],
+          tools: {},
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const reasoning = parts.find((part): part is MessageV2.ReasoningPart => part.type === "reasoning")
+        const tool = parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+
+        expect(value).toBe("continue")
+        expect(reasoning?.metadata?.openai?.reasoningEncryptedContent).toBe("encrypted-think")
+        expect(tool?.tool).toBe("bash")
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests reset reasoning state across retries", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -523,6 +523,85 @@ it.live("session.processor effect tests keep encrypted reasoning metadata when a
   ),
 )
 
+it.live("session.processor effect tests keep the latest encrypted reasoning metadata across raw chunks", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { reasoning_content: "think", encrypted_content: "encrypted-1" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { reasoning_content: " more", encrypted_content: "encrypted-2" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: {}, finish_reason: "stop" }],
+              },
+            ],
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reason twice")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const base = yield* provider.getModel(ref.providerID, ref.modelID)
+        const mdl = {
+          ...base,
+          capabilities: {
+            ...base.capabilities,
+            reasoning: true,
+            interleaved: { field: "reasoning_content" as const },
+          },
+        }
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reason twice" }],
+          tools: {},
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const reasoning = parts.find((part): part is MessageV2.ReasoningPart => part.type === "reasoning")
+
+        expect(value).toBe("continue")
+        expect(reasoning?.text).toBe("think more")
+        expect(reasoning?.metadata?.openai?.reasoningEncryptedContent).toBe("encrypted-2")
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests reset reasoning state across retries", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -249,6 +249,25 @@ function providerCfg(url: string) {
   }
 }
 
+function openaiProviderCfg(url: string) {
+  return {
+    enabled_providers: ["openai"],
+    provider: {
+      openai: {
+        options: {
+          apiKey: "test-openai-key",
+          baseURL: url,
+        },
+      },
+    },
+    agent: {
+      build: {
+        model: "openai/gpt-5.2",
+      },
+    },
+  }
+}
+
 const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
   const session = yield* Session.Service
   const msg = yield* session.updateMessage({
@@ -436,6 +455,52 @@ it.live("static loop consumes queued replies across turns", () =>
       expect(yield* llm.pending).toBe(0)
     }),
     { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop automatically reuses previous_response_id for matching OpenAI responses turns", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello one" }],
+      })
+      yield* llm.text("world one")
+
+      const first = yield* prompt.loop({ sessionID: session.id })
+      expect(first.info.role).toBe("assistant")
+      const firstFinish = first.parts.find((part): part is MessageV2.StepFinishPart => part.type === "step-finish")
+      expect(firstFinish?.metadata?.openai?.responseId).toBe("resp_test")
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello two" }],
+      })
+      yield* llm.text("world two")
+
+      const second = yield* prompt.loop({ sessionID: session.id })
+      expect(second.info.role).toBe("assistant")
+      expect(second.parts.some((part) => part.type === "text" && part.text === "world two")).toBe(true)
+
+      const hits = yield* llm.hits
+      expect(hits).toHaveLength(2)
+      expect(hits[0]?.url.pathname.endsWith("/responses")).toBe(true)
+      expect(hits[0]?.body.previous_response_id).toBeUndefined()
+      expect(hits[1]?.url.pathname.endsWith("/responses")).toBe(true)
+      expect(hits[1]?.body.previous_response_id).toBe("resp_test")
+    }),
+    { git: true, config: openaiProviderCfg },
   ),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #20847

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes two OpenAI replay gaps in `packages/opencode`.

- On the OpenAI Responses path, it persists `openai.responseId` on `step-finish` parts and reuses it as `previous_response_id` on later matching turns.
- On the OpenAI-compatible completions path, it captures streamed `encrypted_content` from raw chunks, stores it on reasoning metadata, and folds it back into replayed assistant messages.

It also adds regression tests for the two riskiest mock-only cases: automatic `previous_response_id` reuse in the prompt loop, and repeated raw chunks keeping the latest `encrypted_content` value.

### How did you verify your code works?

- `bun test --timeout 30000 test/provider/transform.test.ts test/session/message-v2.test.ts test/session/processor-effect.test.ts test/session/llm.test.ts`
- `bun test --timeout 30000 test/session/prompt-effect.test.ts -t "loop automatically reuses previous_response_id for matching OpenAI responses turns"`
- `bun typecheck`

Key coverage added in this PR:

- `test/session/processor-effect.test.ts`
  Verifies multiple raw chunks keep the latest `encrypted_content` on reasoning metadata.
- `test/session/prompt-effect.test.ts`
  Verifies the next matching OpenAI Responses turn automatically sends `previous_response_id`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
