### PR TITLE
fix(transform): add claude-opus-4.7 to isAnthropicAdaptive list

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -365,8 +365,8 @@ export namespace ProviderTransform {
     if (!model.capabilities.reasoning) return {}
 
     const id = model.id.toLowerCase()
-    const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) =>
-      model.api.id.includes(v),
+    const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "opus-4-7", "opus-4.7", "sonnet-4-6", "sonnet-4.6"].some(
+      (v) => model.api.id.includes(v),
     )
     const adaptiveEfforts = ["low", "medium", "high", "max"]
     if (

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2082,6 +2082,26 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
+    test("anthropic opus 4.7 models return adaptive thinking options", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-7",
+        providerID: "gateway",
+        api: {
+          id: "anthropic/claude-opus-4.7",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "high",
+      })
+    })
+
     test("anthropic models return anthropic thinking options", () => {
       const model = createMockModel({
         id: "anthropic/claude-sonnet-4",


### PR DESCRIPTION
### Issue for this PR

Fixes #23500

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`claude-opus-4.7` uses the adaptive thinking API (`thinking.type=adaptive` + `output_config.effort`), the same as `claude-opus-4.6`. However, it was missing from the `isAnthropicAdaptive` check in `transform.ts`:

```ts
const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) =>
  model.api.id.includes(v),
)
```

Without being in this list, `claude-opus-4.7` falls through to the legacy `thinking.type=enabled` path. GitHub Copilot explicitly rejects this with:

```
"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

The fix adds `"opus-4-7"` and `"opus-4.7"` to the array, matching the same pattern already used for `opus-4.6`.

### How did you verify your code works?

Added a test case for `claude-opus-4.7` mirroring the existing `claude-opus-4.6` test. Both pass:

```
bun test test/provider/transform.test.ts --test-name-pattern "opus"
2 pass, 0 fail
```

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR