### PR TITLE
fix(tui): use sync themeMode getter (waitForThemeMode doesn't exist)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -129,7 +129,7 @@ export function tui(input: {
     }
 
     const renderer = await createCliRenderer(rendererConfig(input.config))
-    const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
+    const mode = renderer.themeMode ?? "dark"
 
     await render(() => {
       return (


### PR DESCRIPTION
### Issue for this PR

Closes #23504

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/opencode/src/cli/cmd/tui/app.tsx:132` calls `renderer.waitForThemeMode(1000)`, but that method does not exist on `CliRenderer` in `@opentui/core@0.1.99` (the pinned version in the workspace catalog). Only the synchronous `themeMode` getter is available.

This breaks `bun typecheck` on `dev` with TS2339, which also blocks pushes from any clean branch since the pre-push hook runs typecheck repo-wide.

The fix swaps to the sync getter. The `?? "dark"` fallback already handles the case where the terminal background hasn't been detected yet, so behavior is preserved:

```diff
- const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
+ const mode = renderer.themeMode ?? "dark"
```

### How did you verify your code works?

```
$ git checkout dev
$ bun typecheck
... opencode#typecheck: src/cli/cmd/tui/app.tsx(132,34): error TS2339:
    Property 'waitForThemeMode' does not exist on type 'CliRenderer'.

$ git checkout fix/tui-themeMode-typecheck
$ bun typecheck
✓ Tasks: 13 successful, 13 total
```

The TUI also still launches and renders correctly with the sync getter (smoke-tested locally with `bun dev .`).

### Screenshots / recordings

_n/a — typecheck regression, no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR