### PR TITLE
fix(opencode): handle AWS SSO session expiry with automatic re-login

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -32,8 +32,6 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
-import { Bus } from "@/bus"
-import { TuiEvent } from "@/cli/cmd/tui/event"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
@@ -345,21 +343,12 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
             return await rawProvider()
           } catch (e) {
             if (e instanceof Error && e.name === "CredentialsProviderError") {
-              void Bus.publish(TuiEvent.ToastShow, {
-                variant: "warning",
-                message: "AWS SSO session expired — re-authenticating...",
-                duration: 5000,
-              })
+              // AWS SSO session expired - attempt re-authentication
               await new Promise<void>((resolve, reject) => {
                 const args = ["sso", "login", ...(profile ? ["--profile", profile] : [])]
                 const child = spawn("aws", args, { stdio: "pipe" })
                 child.on("exit", (code) => {
                   if (code === 0) {
-                    void Bus.publish(TuiEvent.ToastShow, {
-                      variant: "success",
-                      message: "AWS SSO re-authentication successful",
-                      duration: 5000,
-                    })
                     resolve()
                   } else {
                     reject(e)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,6 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import os from "os"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import { spawn } from "child_process"
 import fuzzysort from "fuzzysort"
 import { Config } from "@/config/config"
 import { mapValues, mergeDeep, omit, pickBy, sortBy } from "remeda"
@@ -336,7 +337,23 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         // Build credential provider options (only pass profile if specified)
         const credentialProviderOptions = profile ? { profile } : {}
 
-        providerOptions.credentialProvider = fromNodeProviderChain(credentialProviderOptions)
+        const rawProvider = fromNodeProviderChain(credentialProviderOptions)
+        providerOptions.credentialProvider = async () => {
+          try {
+            return await rawProvider()
+          } catch (e) {
+            if (e instanceof Error && e.name === "CredentialsProviderError") {
+              await new Promise<void>((resolve, reject) => {
+                const args = ["sso", "login", ...(profile ? ["--profile", profile] : [])]
+                const child = spawn("aws", args, { stdio: "pipe" })
+                child.on("exit", (code) => (code === 0 ? resolve() : reject(e)))
+                child.on("error", () => reject(e))
+              })
+              return await rawProvider()
+            }
+            throw e
+          }
+        }
       }
 
       // Add custom endpoint if specified (endpoint takes precedence over baseURL)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -32,8 +32,6 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
-import { EventV2Bridge } from "@/event-v2-bridge"
-import { EventV2 } from "@opencode-ai/core/event"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
@@ -1318,9 +1316,6 @@ export const layer = Layer.effect(
     const plugin = yield* Plugin.Service
     const modelsDevSvc = yield* ModelsDev.Service
     const runtimeFlags = yield* RuntimeFlags.Service
-    const eventBridge = yield* EventV2Bridge.Service
-    const context = yield* Effect.context()
-    const runFork = Effect.runForkWith(context)
 
     const state = yield* InstanceState.make<State>(() =>
       Effect.gen(function* () {
@@ -1347,8 +1342,6 @@ export const layer = Layer.effect(
           config: () => config.get(),
           env: () => env.all(),
           get: (key: string) => env.get(key),
-          bridge: eventBridge,
-          runFork,
         }
 
         function mergeProvider(providerID: ProviderV2.ID, provider: Partial<Info>) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -348,6 +348,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
               void Bus.publish(TuiEvent.ToastShow, {
                 variant: "warning",
                 message: "AWS SSO session expired — re-authenticating...",
+                duration: 5000,
               })
               await new Promise<void>((resolve, reject) => {
                 const args = ["sso", "login", ...(profile ? ["--profile", profile] : [])]
@@ -357,6 +358,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
                     void Bus.publish(TuiEvent.ToastShow, {
                       variant: "success",
                       message: "AWS SSO re-authentication successful",
+                      duration: 5000,
                     })
                     resolve()
                   } else {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -32,6 +32,8 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { Bus } from "@/bus"
+import { TuiEvent } from "@/cli/cmd/tui/event"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
@@ -343,10 +345,24 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
             return await rawProvider()
           } catch (e) {
             if (e instanceof Error && e.name === "CredentialsProviderError") {
+              void Bus.publish(TuiEvent.ToastShow, {
+                variant: "warning",
+                message: "AWS SSO session expired — re-authenticating...",
+              })
               await new Promise<void>((resolve, reject) => {
                 const args = ["sso", "login", ...(profile ? ["--profile", profile] : [])]
                 const child = spawn("aws", args, { stdio: "pipe" })
-                child.on("exit", (code) => (code === 0 ? resolve() : reject(e)))
+                child.on("exit", (code) => {
+                  if (code === 0) {
+                    void Bus.publish(TuiEvent.ToastShow, {
+                      variant: "success",
+                      message: "AWS SSO re-authentication successful",
+                    })
+                    resolve()
+                  } else {
+                    reject(e)
+                  }
+                })
                 child.on("error", () => reject(e))
               })
               return await rawProvider()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -32,6 +32,8 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { EventV2 } from "@opencode-ai/core/event"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
@@ -1316,6 +1318,9 @@ export const layer = Layer.effect(
     const plugin = yield* Plugin.Service
     const modelsDevSvc = yield* ModelsDev.Service
     const runtimeFlags = yield* RuntimeFlags.Service
+    const eventBridge = yield* EventV2Bridge.Service
+    const context = yield* Effect.context()
+    const runFork = Effect.runForkWith(context)
 
     const state = yield* InstanceState.make<State>(() =>
       Effect.gen(function* () {
@@ -1342,6 +1347,8 @@ export const layer = Layer.effect(
           config: () => config.get(),
           env: () => env.all(),
           get: (key: string) => env.get(key),
+          bridge: eventBridge,
+          runFork,
         }
 
         function mergeProvider(providerID: ProviderV2.ID, provider: Partial<Info>) {


### PR DESCRIPTION
### Issue for this PR

Closes #23522 

### Type of change

- [x] Bug fix

### What does this PR do?

Intercepts `CredentialsProviderError` by `.name` before the AI SDK wraps it, spawns `aws sso login [--profile <name>]`, awaits exit 0,
retries credentials transparently — the AI SDK never sees an error and the session continues uninterrupted.

18 lines changed in 1 file (`packages/opencode/src/provider/provider.ts`).

### How did you verify your code works?

Tested manually by removing `~/.aws/sso/cache` and running a Bedrock prompt.

### Related

#18988

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR