### PR TITLE
fix: recognize Anthropic raw body size overflow error for auto-compaction

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -25,6 +25,7 @@ const OVERFLOW_PATTERNS = [
   /prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
   /too large for model with \d+ maximum context length/i, // Mistral
   /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
+  /total message size exceeds/i, // Anthropic raw HTTP body size limit (distinct from token limit)
 ]
 
 function isOpenAiErrorRetryable(e: APICallError) {


### PR DESCRIPTION
## Summary

- Added `/total message size exceeds/i` to `OVERFLOW_PATTERNS` in `packages/opencode/src/provider/error.ts` to recognize Anthropic's raw HTTP body size limit error.

## Problem

Anthropic API enforces **two** independent limits:
1. **Token context limit** (e.g., 200K tokens) → returns `"prompt is too long"`
2. **Raw HTTP body size limit** (2MB = 2,097,152 bytes) → returns `"total message size X exceeds limit 2097152"`

When a conversation contains large base64-encoded images or extensive tool output, the serialized request body can exceed 2MB while the token count is still well within limits. In this scenario:

1. **Proactive overflow check** (`isOverflow()` in `overflow.ts`) only monitors token ratios → **doesn't trigger**
2. **Error pattern matching** (`OVERFLOW_PATTERNS` in `error.ts`) has no regex matching `"total message size exceeds limit"` → **doesn't trigger**
3. The error is classified as generic `api_error` instead of `context_overflow`
4. Auto-compaction never activates, and the **session stalls permanently**

## Fix

Added a single pattern to `OVERFLOW_PATTERNS`:

```typescript
/total message size exceeds/i, // Anthropic raw HTTP body size limit (distinct from token limit)
```

This ensures the error is correctly classified as `context_overflow`, which triggers the existing compaction recovery flow (summarization of old messages, aggressive truncation of tool outputs, etc.).

## Testing

- Verified that `"total message size 22432555 exceeds limit 2097152"` matches the new regex
- Verified that no existing pattern matches this error format (the closest, `/exceeds the limit of \d+/i`, requires "the" and "of" which are absent)

## Future Improvement (not in this PR)

A more robust solution would add a pre-flight byte size estimation in `overflow.ts` that checks the serialized JSON payload size against a configurable threshold before sending the request, triggering compaction proactively. This would prevent the error from occurring at all, rather than recovering from it after the fact.