### PR TITLE
fix: reread local skill files when using skills

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -6,6 +6,7 @@ import { SessionID, MessageID } from "@/session/schema"
 import { Effect, Layer, Context } from "effect"
 import z from "zod"
 import { Config } from "../config"
+import { ConfigMarkdown } from "../config"
 import { MCP } from "../mcp"
 import { Skill } from "../skill"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
@@ -152,7 +153,9 @@ export const layer = Layer.effect(
           description: item.description,
           source: "skill",
           get template() {
-            return item.content
+            return ConfigMarkdown.parse(item.location)
+              .then((md) => md.content)
+              .catch(() => item.content)
           },
           hints: [],
         }

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -5,6 +5,7 @@ import { Effect } from "effect"
 import * as Stream from "effect/Stream"
 import { Ripgrep } from "../file/ripgrep"
 import { Skill } from "../skill"
+import { ConfigMarkdown } from "../config"
 import * as Tool from "./tool"
 import DESCRIPTION from "./skill.txt"
 
@@ -39,6 +40,10 @@ export const SkillTool = Tool.define(
 
           const dir = path.dirname(info.location)
           const base = pathToFileURL(dir).href
+          const content = yield* Effect.tryPromise(() => ConfigMarkdown.parse(info.location)).pipe(
+            Effect.map((md) => md.content.trim()),
+            Effect.catch(() => Effect.succeed(info.content.trim())),
+          )
           const limit = 10
           const files = yield* rg.files({ cwd: dir, follow: false, hidden: true, signal: ctx.abort }).pipe(
             Stream.filter((file) => !file.includes("SKILL.md")),
@@ -54,7 +59,7 @@ export const SkillTool = Tool.define(
               `<skill_content name="${info.name}">`,
               `# Skill: ${info.name}`,
               "",
-              info.content.trim(),
+              content,
               "",
               `Base directory for this skill: ${base}`,
               "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",


### PR DESCRIPTION
### Issue for this PR

Closes #19050

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Local skills were serving stale content because the cached markdown body was reused after `SKILL.md` changed.

This rereads the local `SKILL.md` file when the skill tool or a skill-backed slash command loads the skill, and falls back to the cached content if parsing fails.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR