### PR TITLE
fix(opencode): disable anthropic toolStreaming for proxy baseURLs

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -45,6 +45,14 @@ function sdkKey(npm: string): string | undefined {
   return undefined
 }
 
+function isOfficialAnthropicBaseURL(baseURL: string): boolean {
+  try {
+    return new URL(baseURL).hostname === "api.anthropic.com"
+  } catch {
+    return baseURL.includes("api.anthropic.com")
+  }
+}
+
 function normalizeMessages(
   msgs: ModelMessage[],
   model: Provider.Model,
@@ -795,6 +803,7 @@ export function options(input: {
   providerOptions?: Record<string, any>
 }): Record<string, any> {
   const result: Record<string, any> = {}
+  const providerBaseURL = input.providerOptions?.baseURL
 
   // openai and providers using openai package should set store to false by default.
   if (
@@ -908,6 +917,19 @@ export function options(input: {
       result["include"] = ["reasoning.encrypted_content"]
       result["reasoningSummary"] = "auto"
     }
+  }
+
+  // Anthropic-compatible gateways/proxies often reject tool schema fields injected
+  // by the SDK's default tool streaming behavior (e.g. eager_input_streaming).
+  // Default to compatibility mode for non-official Anthropic endpoints, while still
+  // allowing model/agent options to override later in the merge chain.
+  if (
+    input.model.api.npm === "@ai-sdk/anthropic" &&
+    typeof providerBaseURL === "string" &&
+    providerBaseURL.length > 0 &&
+    !isOfficialAnthropicBaseURL(providerBaseURL)
+  ) {
+    result["toolStreaming"] = false
   }
 
   if (input.model.providerID === "venice") {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -358,6 +358,88 @@ describe("ProviderTransform.options - gateway", () => {
   })
 })
 
+describe("ProviderTransform.options - anthropic proxy tool streaming compatibility", () => {
+  const sessionID = "test-session-123"
+
+  const createAnthropicModel = () =>
+    ({
+      id: "mify-claude/pa/claude-opus-4-7",
+      providerID: "mify-claude",
+      api: {
+        id: "pa/claude-opus-4-7",
+        url: "http://model.mify.ai.srv/anthropic/v1",
+        npm: "@ai-sdk/anthropic",
+      },
+      name: "Claude Opus 4.7",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: {
+        input: 0.001,
+        output: 0.002,
+        cache: { read: 0.0001, write: 0.0002 },
+      },
+      limit: {
+        context: 260_000,
+        output: 128_000,
+      },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  test("defaults toolStreaming=false for custom anthropic-compatible baseURL", () => {
+    const result = ProviderTransform.options({
+      model: createAnthropicModel(),
+      sessionID,
+      providerOptions: {
+        baseURL: "http://model.mify.ai.srv/anthropic/v1",
+      },
+    })
+
+    expect(result.toolStreaming).toBe(false)
+  })
+
+  test("does not force toolStreaming for official anthropic baseURL", () => {
+    const model = {
+      ...createAnthropicModel(),
+      providerID: "anthropic",
+      api: {
+        id: "claude-sonnet-4-20250514",
+        url: "https://api.anthropic.com/v1",
+        npm: "@ai-sdk/anthropic",
+      },
+    }
+    const result = ProviderTransform.options({
+      model,
+      sessionID,
+      providerOptions: {
+        baseURL: "https://api.anthropic.com/v1",
+      },
+    })
+
+    expect(result.toolStreaming).toBeUndefined()
+  })
+
+  test("matches official anthropic host even when URL is invalid but contains hostname", () => {
+    const result = ProviderTransform.options({
+      model: createAnthropicModel(),
+      sessionID,
+      providerOptions: {
+        baseURL: "api.anthropic.com/v1",
+      },
+    })
+
+    expect(result.toolStreaming).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.providerOptions", () => {
   const createModel = (overrides: Partial<any> = {}) =>
     ({


### PR DESCRIPTION
### Issue for this PR

Closes #23541

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Anthropic-compatible proxy/gateway endpoints can reject tool definitions with `tools.0.custom.eager_input_streaming: Extra inputs are not permitted`.

OpenCode already applies `toolStreaming = false` for GitHub Copilot's Anthropic shim, but this compatibility fallback was not applied to other custom providers using `@ai-sdk/anthropic` with non-official `baseURL`.

This PR generalizes that fallback in `ProviderTransform.options()`:
- when `model.api.npm === "@ai-sdk/anthropic"`
- and `provider.options.baseURL` is set and not official `api.anthropic.com`
- default `toolStreaming` to `false`

This works because it preserves official Anthropic behavior while disabling a tool-streaming shape that some Anthropic-compatible proxies reject.

### How did you verify your code works?

I ran the provider transform test suite locally:

```bash
cd packages/opencode
bun test test/provider/transform.test.ts
```

Result: pass (`136 pass`, `0 fail`).

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
