### PR TITLE
fix(opencode): validate clipboard content type on Linux

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -5,6 +5,7 @@ import path from "path"
 import fs from "fs/promises"
 import * as Filesystem from "../../../../util/filesystem"
 import * as Process from "../../../../util/process"
+import { sniffAttachmentMime } from "../../../../util/media"
 
 // Lazy load which and clipboardy to avoid expensive execa/which/isexe chain at startup
 const getWhich = lazy(async () => {
@@ -93,13 +94,19 @@ export async function read(): Promise<Content | undefined> {
   if (os === "linux") {
     const wayland = await Process.run(["wl-paste", "-t", "image/png"], { nothrow: true })
     if (wayland.stdout.byteLength > 0) {
-      return { data: Buffer.from(wayland.stdout).toString("base64"), mime: "image/png" }
+      const mime = sniffAttachmentMime(new Uint8Array(wayland.stdout), "text/plain")
+      if (mime === "image/png") {
+        return { data: Buffer.from(wayland.stdout).toString("base64"), mime: "image/png" }
+      }
     }
     const x11 = await Process.run(["xclip", "-selection", "clipboard", "-t", "image/png", "-o"], {
       nothrow: true,
     })
     if (x11.stdout.byteLength > 0) {
-      return { data: Buffer.from(x11.stdout).toString("base64"), mime: "image/png" }
+      const mime = sniffAttachmentMime(new Uint8Array(x11.stdout), "text/plain")
+      if (mime === "image/png") {
+        return { data: Buffer.from(x11.stdout).toString("base64"), mime: "image/png" }
+      }
     }
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #23458

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Linux, `xclip -selection clipboard -t image/png -o` outputs raw bytes even when clipboard contains text (not an image). The code only checked `byteLength > 0`, so text like `¯\_(ツ)_/¯` was incorrectly labeled as `image/png` and sent to the model, which failed with "could not process image".

This fix uses the existing `sniffAttachmentMime()` function to validate PNG magic bytes before treating clipboard content as an image. This is the same pattern used in the `read` tool.

### How did you verify your code works?

1. `echo '¯\_(ツ)_/¯' | xclip -selection c`
2. Ctrl+V in OpenCode TUI
3. Text now pastes correctly instead of failing with "could not process image"

### Screenshots / recordings

N/A - not a UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR