### PR TITLE
feat(ui): auto-use MCP tool for MiniMax image paste

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -42,6 +42,7 @@ import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-workspace-create"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
+import os from "os"
 
 export type PromptProps = {
   sessionID?: string
@@ -1012,13 +1013,22 @@ export function Prompt(props: PromptProps) {
                 if (keybind.match("input_paste", e)) {
                   const content = await Clipboard.read()
                   if (content?.mime.startsWith("image/")) {
-                    e.preventDefault()
-                    await pasteAttachment({
-                      filename: "clipboard",
-                      mime: content.mime,
-                      content: content.data,
-                    })
-                    return
+                    const tempFile = path.join(os.tmpdir(), `clipboard-${Date.now()}.png`)
+                    await Filesystem.write(tempFile, Buffer.from(content.data, "base64"))
+
+                    // Only MiniMax models need this workaround - insert instruction to use MCP tool
+                    const modelId = local.model.parsed().model?.toLowerCase() ?? ""
+                    const providerId = local.model.parsed().provider?.toLowerCase() ?? ""
+                    const isMiniMax = modelId.includes("minimax") || providerId.includes("minimax")
+
+                    if (isMiniMax) {
+                      e.preventDefault()
+                      // Insert image file path with instruction for MiniMax model to use MCP tool
+                      const promptInstruction = `Please use MiniMax_understand_image tool to analyze this image: ${tempFile}`
+                      pasteText(promptInstruction, "[Image Analysis]")
+                      return
+                    }
+                    // For non-MiniMax models, let the default paste behavior continue
                   }
                   // If no image, let the default paste behavior continue
                 }
@@ -1088,6 +1098,27 @@ export function Prompt(props: PromptProps) {
                 if (props.disabled) {
                   event.preventDefault()
                   return
+                }
+
+                // Check clipboard for images first - handle image paste before any text processing
+                const clipboardContent = await Clipboard.read()
+                if (clipboardContent?.mime.startsWith("image/")) {
+                  const tempFile = path.join(os.tmpdir(), `clipboard-${Date.now()}.png`)
+                  await Filesystem.write(tempFile, Buffer.from(clipboardContent.data, "base64"))
+
+                  // Only MiniMax models need this workaround - insert instruction to use MCP tool
+                  const modelId = local.model.parsed().model?.toLowerCase() ?? ""
+                  const providerId = local.model.parsed().provider?.toLowerCase() ?? ""
+                  const isMiniMax = modelId.includes("minimax") || providerId.includes("minimax")
+
+                  if (isMiniMax) {
+                    event.preventDefault()
+                    // Insert image file path with instruction for MiniMax model to use MCP tool
+                    const promptInstruction = `Please use MiniMax_understand_image tool to analyze this image: ${tempFile}`
+                    pasteText(promptInstruction, "[Image Analysis]")
+                    return
+                  }
+                  // For non-MiniMax models, let the default paste behavior continue
                 }
 
                 // Normalize line endings at the boundary


### PR DESCRIPTION
When pasting an image with MiniMax model selected, save the image to a temp file and insert an instruction for the model to use the MiniMax_understand_image MCP tool to analyze it. This works around MiniMax's lack of direct image input support while preserving normal behavior for other models.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
