### PR TITLE
fix(opencode): incorrect light mode detection in terminals that misreport CSI mode 997

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,7 +1,7 @@
 import { render, TimeToFirstDraw, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import * as Clipboard from "@tui/util/clipboard"
 import * as Selection from "@tui/util/selection"
-import { createCliRenderer, MouseButton, type CliRendererConfig } from "@opentui/core"
+import { createCliRenderer, CliRenderer, MouseButton, type CliRendererConfig } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import {
   Switch,
@@ -86,6 +86,24 @@ function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   }
 }
 
+/**
+ * Some terminals (e.g. Ghostty) incorrectly report their appearance via CSI
+ * mode 997 — responding "light" despite having a dark background color. When
+ * CSI and the actual OSC 10/11 background luminance disagree, trust the color.
+ */
+function resolveThemeMode(renderer: CliRenderer, detected: "dark" | "light"): "dark" | "light" {
+  const oscBg: string | null = (renderer as any)._themeOscBackground
+  if (!oscBg || (renderer as any)._themeModeSource !== "csi") return detected
+  const hex = oscBg.replace("#", "")
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000
+  const inferred = brightness > 128 ? "light" : "dark"
+  if (inferred !== detected) return inferred
+  return detected
+}
+
 function errorMessage(error: unknown) {
   const formatted = FormatError(error)
   if (formatted !== undefined) return formatted
@@ -129,7 +147,7 @@ export function tui(input: {
     }
 
     const renderer = await createCliRenderer(rendererConfig(input.config))
-    const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
+    const mode = resolveThemeMode(renderer, (await renderer.waitForThemeMode(1000)) ?? "dark")
 
     await render(() => {
       return (


### PR DESCRIPTION
### Issue for this PR

Closes #20926

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ghostty (and potentially other terminals) responds to CSI mode 997 with "light" even when the actual terminal background is dark (`#000000`). Since `@opentui/core` gives CSI priority over OSC, the correct background color inference is discarded and OpenCode renders in light mode.

I traced the issue by logging the renderer internals after `waitForThemeMode` resolves:

```
source=csi, oscBg=#000000, oscFg=#f8f8f2
```

CSI says "light" but the real background is black — a clear contradiction. This happens even with `window-theme = dark` explicitly set in the Ghostty config, so it's not a user misconfiguration.

The fix adds a `resolveThemeMode()` function that cross-checks the CSI result against the actual OSC 10/11 background luminance (using the same weighted brightness formula as `@opentui/core`). When they disagree, the objective color measurement wins.

The function is a no-op when:
- Detection source wasn't CSI (no override needed)
- No OSC background color available (can't cross-check)
- CSI and OSC agree (no contradiction)

### How did you verify your code works?

1. Ran `bun run dev` in Ghostty with `background=#000000` → correctly renders in dark mode (was light before)
2. Changed Ghostty config to `background=#ffffff` → correctly renders in light mode (not forced dark)
3. `bun typecheck` passes across all packages

### Screenshots / recordings

_N/A — terminal-only change, behavior verified interactively._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR