### PR TITLE
fix(ui): improve switch toggle accessibility and visual clarity

### DIFF
--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Icon } from "@opencode-ai/ui/icon"
+import { Spinner } from "@opencode-ai/ui/spinner"
 import { Switch } from "@opencode-ai/ui/switch"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { useMutation } from "@tanstack/solid-query"
@@ -373,7 +374,10 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                           }}
                         />
                         <span class="text-14-regular text-text-base truncate flex-1">{name}</span>
-                        <div onClick={(event) => event.stopPropagation()}>
+                        <div class="flex items-center gap-1.5" onClick={(event) => event.stopPropagation()}>
+                          <Show when={toggleMcp.isPending && toggleMcp.variables === name}>
+                            <Spinner class="size-3.5 text-text-weak" />
+                          </Show>
                           <Switch
                             checked={enabled()}
                             disabled={toggleMcp.isPending && toggleMcp.variables === name}
@@ -381,7 +385,11 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                               if (toggleMcp.isPending) return
                               toggleMcp.mutate(name)
                             }}
-                          />
+                            hideLabel
+                          >
+                            {enabled() ? `Disable ${name}` : `Enable ${name}`}
+                          </Switch>
+                          <span classList={{ "text-12-regular w-5 select-none": true, "text-text-base": enabled(), "text-text-weak": !enabled() }}>{enabled() ? "On" : "Off"}</span>
                         </div>
                       </button>
                     )

--- a/packages/ui/src/components/switch.css
+++ b/packages/ui/src/components/switch.css
@@ -20,25 +20,38 @@
   [data-slot="switch-control"] {
     display: inline-flex;
     align-items: center;
-    width: 28px;
-    height: 16px;
+    width: 32px;
+    height: 18px;
     flex-shrink: 0;
-    border-radius: 3px;
+    border-radius: 5px;
+    corner-shape: squircle;
     border: 1px solid var(--border-weak-base);
     background: var(--surface-base);
+    padding: 1px;
     transition:
       background-color 150ms,
       border-color 150ms;
   }
 
+  @supports (corner-shape: squircle) {
+    [data-slot="switch-control"] {
+      border-radius: 10px;
+    }
+
+    [data-slot="switch-thumb"] {
+      border-radius: 8px;
+    }
+  }
+
   [data-slot="switch-thumb"] {
     width: 14px;
     height: 14px;
-    box-sizing: content-box;
+    box-sizing: border-box;
 
-    border-radius: 2px;
-    border: 1px solid var(--border-base);
-    background: var(--icon-invert-base);
+    border-radius: 4px;
+    corner-shape: squircle;
+    border: none;
+    background: var(--icon-weak-base);
 
     /* shadows/shadow-xs */
     box-shadow:
@@ -46,7 +59,7 @@
       0 1px 2px 0 rgba(19, 16, 16, 0.06),
       0 1px 3px 0 rgba(19, 16, 16, 0.08);
 
-    transform: translateX(-1px);
+    transform: translateX(0px);
     transition:
       transform 150ms,
       background-color 150ms;
@@ -93,19 +106,20 @@
 
   &[data-checked] [data-slot="switch-control"] {
     box-sizing: border-box;
-    border-color: var(--icon-strong-base);
-    background-color: var(--icon-strong-base);
+    border-color: var(--icon-success-base, var(--icon-strong-base));
+    background-color: var(--icon-success-base, var(--icon-strong-base));
   }
 
   &[data-checked] [data-slot="switch-thumb"] {
     border: none;
-    transform: translateX(12px);
-    background-color: var(--icon-invert-base);
+    transform: translateX(14px);
+    background-color: #ffffff;
   }
 
   &[data-checked]:hover:not([data-disabled], [data-readonly]) [data-slot="switch-control"] {
-    border-color: var(--border-hover);
-    background-color: var(--surface-hover);
+    border-color: var(--icon-success-base, var(--icon-strong-base));
+    background-color: var(--icon-success-base, var(--icon-strong-base));
+    opacity: 0.85;
   }
 
   &[data-disabled] {


### PR DESCRIPTION
## Issue for this PR

Closes #23580

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

## What does this PR do?

<img width="365" height="110" alt="Screenshot 2026-04-20 at 12 21 01 PM" src="https://github.com/user-attachments/assets/fcf26139-772c-416d-b474-1f6a25249804" />


I was slightly confused by whether an MCP toggle was on or off, so I asked OpenCode what it thought. It was... wrong.

<img width="612" height="129" alt="Image" src="https://github.com/user-attachments/assets/a73bc80c-74db-4a75-990a-c75d36f4db0b" />

It was on.

The core problem is that the switch component's checked and unchecked states are visually too similar — especially in dark mode — and there's no text or accessible label to disambiguate. This PR addresses that with:

- **Squircle shape** for the switch track and thumb, with progressive enhancement via `corner-shape: squircle` (falls back to `border-radius: 5px`)
- **Green track** (`--icon-success-base`) when checked, so there's an unambiguous "on" color
- **White thumb** when checked, hardcoded to `#ffffff` so it's visible in both light and dark mode
- **Visible "On"/"Off" text label** next to MCP server toggles
- **Screen-reader-only accessible label** with the server name (e.g., "Disable foo-mcp") for a11y
- **Loading spinner** while MCP server connection is toggling, so users aren't left wondering what's happening

## How did you verify your code works?

Ran the app locally (`bun dev serve` + `bun run --cwd packages/app dev`) and tested toggling MCP servers in the status popover in both light and dark mode.

## Screenshots / recordings

### Off
<img width="361" height="106" alt="Screenshot 2026-04-20 at 12 03 35 PM" src="https://github.com/user-attachments/assets/e4f784b7-1794-447d-9a51-562dbd1abda2" />

### On
<img width="372" height="112" alt="Screenshot 2026-04-20 at 12 03 32 PM" src="https://github.com/user-attachments/assets/1f7f6a12-a87f-4b4a-8948-a4d9a5950fee" />

### Connecting/Loading
<img width="372" height="104" alt="Screenshot 2026-04-20 at 12 03 38 PM" src="https://github.com/user-attachments/assets/bd7a5028-d112-46a3-8f2c-1028279d2037" />

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR