### PR TITLE
fix: emit completed assistant chat messages

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -213,6 +213,27 @@ export const layer: Layer.Layer<
         return true
       })
 
+      const emitAssistantChatMessage = Effect.fn("SessionProcessor.emitAssistantChatMessage")(function* () {
+        const parts = MessageV2.parts(ctx.assistantMessage.id)
+        yield* plugin.trigger(
+          "chat.message",
+          {
+            sessionID: ctx.sessionID,
+            agent: ctx.assistantMessage.agent,
+            model: {
+              providerID: ctx.assistantMessage.providerID,
+              modelID: ctx.assistantMessage.modelID,
+            },
+            messageID: ctx.assistantMessage.id,
+            variant: ctx.assistantMessage.variant,
+          },
+          {
+            message: ctx.assistantMessage,
+            parts,
+          },
+        )
+      })
+
       const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
         switch (value.type) {
           case "start":
@@ -518,6 +539,7 @@ export const layer: Layer.Layer<
         ctx.toolcalls = {}
         ctx.assistantMessage.time.completed = Date.now()
         yield* session.updateMessage(ctx.assistantMessage)
+        yield* emitAssistantChatMessage()
       })
 
       const halt = Effect.fn("SessionProcessor.halt")(function* (e: unknown) {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -35,6 +35,39 @@ const summary = Layer.succeed(
   }),
 )
 
+type ChatMessageCapture = {
+  input: {
+    sessionID: string
+    agent?: string
+    model?: { providerID: string; modelID: string }
+    messageID?: string
+    variant?: string
+  }
+  output: {
+    message: MessageV2.Info
+    parts: MessageV2.Part[]
+  }
+}
+
+function pluginSpy(options?: { chatMessages?: ChatMessageCapture[]; textComplete?: (text: string) => string }) {
+  return Layer.mock(Plugin.Service)({
+    trigger: <Name extends string, Input, Output>(name: Name, input: Input, output: Output) => {
+      if (name === "chat.message" && options?.chatMessages) {
+        options.chatMessages.push({
+          input: structuredClone(input as ChatMessageCapture["input"]),
+          output: structuredClone(output as ChatMessageCapture["output"]),
+        })
+      }
+      if (name === "experimental.text.complete" && options?.textComplete) {
+        ;(output as { text: string }).text = options.textComplete((output as { text: string }).text)
+      }
+      return Effect.succeed(output)
+    },
+    list: () => Effect.succeed([]),
+    init: () => Effect.void,
+  })
+}
+
 const ref = {
   providerID: ProviderID.make("test"),
   modelID: ModelID.make("test-model"),
@@ -155,23 +188,28 @@ const assistant = Effect.fn("TestSession.assistant")(function* (
 
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
-const deps = Layer.mergeAll(
-  Session.defaultLayer,
-  Snapshot.defaultLayer,
-  AgentSvc.defaultLayer,
-  Permission.defaultLayer,
-  Plugin.defaultLayer,
-  Config.defaultLayer,
-  LLM.defaultLayer,
-  Provider.defaultLayer,
-  status,
-).pipe(Layer.provideMerge(infra))
-const env = Layer.mergeAll(
-  TestLLMServer.layer,
-  SessionProcessor.layer.pipe(Layer.provide(summary), Layer.provideMerge(deps)),
-)
+function makeEnv(pluginLayer: Layer.Layer<Plugin.Service> = Plugin.defaultLayer) {
+  const deps = Layer.mergeAll(
+    Session.defaultLayer,
+    Snapshot.defaultLayer,
+    AgentSvc.defaultLayer,
+    Permission.defaultLayer,
+    pluginLayer,
+    Config.defaultLayer,
+    LLM.defaultLayer,
+    Provider.defaultLayer,
+    status,
+  ).pipe(Layer.provideMerge(infra))
+  return Layer.mergeAll(
+    TestLLMServer.layer,
+    SessionProcessor.layer.pipe(Layer.provide(summary), Layer.provideMerge(deps)),
+  )
+}
+
+const env = makeEnv()
 
 const it = testEffect(env)
+const itWithPlugin = (pluginLayer: Layer.Layer<Plugin.Service>) => testEffect(makeEnv(pluginLayer))
 
 const boot = Effect.fn("test.boot")(function* () {
   const processors = yield* SessionProcessor.Service
@@ -230,6 +268,61 @@ it.live("session.processor effect tests capture llm input cleanly", () =>
     { git: true, config: (url) => providerCfg(url) },
   ),
 )
+
+{
+  const chatMessages: ChatMessageCapture[] = []
+  itWithPlugin(
+    pluginSpy({
+      chatMessages,
+      textComplete: (text) => `${text}!`,
+    }),
+  ).live("session.processor emits one assistant chat.message with finalized text", () =>
+    provideTmpdirServer(
+      ({ dir, llm }) =>
+        Effect.gen(function* () {
+          const { processors, session, provider } = yield* boot()
+
+          yield* llm.text("hello")
+
+          const chat = yield* session.create({})
+          const parent = yield* user(chat.id, "hi")
+          const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+          const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+
+          const value = yield* handle.process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+            } satisfies MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "hi" }],
+            tools: {},
+          })
+
+          expect(value).toBe("continue")
+          expect(chatMessages).toHaveLength(1)
+          expect(chatMessages[0]?.output.message.role).toBe("assistant")
+          expect(chatMessages[0]?.output.parts.filter((part) => part.type === "text")).toHaveLength(1)
+          expect(chatMessages[0]?.output.parts.some((part) => part.type === "text" && part.text === "hello!")).toBe(
+            true,
+          )
+        }),
+      { git: true, config: (url) => providerCfg(url) },
+    ),
+  )
+}
 
 it.live("session.processor effect tests preserve text start time", () =>
   provideTmpdirServer(

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -150,7 +150,7 @@ const lsp = Layer.succeed(
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const run = SessionRunState.layer.pipe(Layer.provide(status))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
-function makeHttp() {
+function makeHttp(pluginLayer: Layer.Layer<Plugin.Service> = Plugin.defaultLayer) {
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -159,7 +159,7 @@ function makeHttp() {
     AgentSvc.defaultLayer,
     Command.defaultLayer,
     Permission.defaultLayer,
-    Plugin.defaultLayer,
+    pluginLayer,
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
     lsp,

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -150,7 +150,7 @@ const lsp = Layer.succeed(
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const run = SessionRunState.layer.pipe(Layer.provide(status))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
-function makeHttp(pluginLayer: Layer.Layer<Plugin.Service> = Plugin.defaultLayer) {
+function makeHttp() {
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -159,7 +159,7 @@ function makeHttp(pluginLayer: Layer.Layer<Plugin.Service> = Plugin.defaultLayer
     AgentSvc.defaultLayer,
     Command.defaultLayer,
     Permission.defaultLayer,
-    pluginLayer,
+    Plugin.defaultLayer,
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
     lsp,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -238,7 +238,7 @@ export interface Hooks {
       messageID?: string
       variant?: string
     },
-    output: { message: UserMessage; parts: Part[] },
+    output: { message: Message; parts: Part[] },
   ) => Promise<void>
   /**
    * Modify parameters sent to LLM


### PR DESCRIPTION
### Issue for this PR

Closes #22831

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`chat.message` already exposes populated `parts` for user messages, but current `dev` never emits a completed assistant `chat.message`. That leaves plugin authors with an asymmetric hook: they can observe finalized user messages but not finalized assistant messages through the same stable API.

This change emits one completed `chat.message` for assistant messages during processor cleanup, after the assistant message and its parts have been finalized. I also widened the plugin hook type from `UserMessage` to `Message` so the hook matches what runtime code now delivers.

I kept the change small on purpose:
- no new hooks
- no behavior changes to the existing user `chat.message` path
- no changes to experimental hooks

The fix works because the processor already has the finalized assistant message id and can read the final stored parts at cleanup time. Emitting the hook there gives plugins the same completed-message shape they already get for user messages.

### How did you verify your code works?

- Ran `bun test --timeout 30000 test/session/processor-effect.test.ts test/session/prompt-effect.test.ts`
- Ran `bun run typecheck`
- Added an assistant regression test that fails on clean `origin/dev` with `Expected length: 1 / Received length: 0`
- Re-ran that same test on this branch and confirmed it passes

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR