### PR TITLE
fix(desktop): declare minimum Rust version 1.88

### DIFF
--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -4,7 +4,7 @@ Native OpenCode desktop app, built with Tauri v2.
 
 ## Prerequisites
 
-Building the desktop app requires additional Tauri dependencies (Rust toolchain, platform-specific libraries). See the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for setup instructions.
+Building the desktop app requires additional Tauri dependencies (Rust toolchain, platform-specific libraries). The desktop crate currently requires Rust 1.88 or newer. See the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for setup instructions.
 
 ## Development
 
@@ -29,4 +29,10 @@ If you see errors about Rust not being found, install it via [rustup](https://ru
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+If Cargo reports that the desktop crate requires a newer compiler, update Rust with:
+
+```bash
+rustup update
 ```

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "The open source AI coding agent"
 authors = ["Anomaly Innovations"]
 edition = "2024"
+rust-version = "1.88"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
### Issue for this PR

Closes #23611

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This declares the desktop crate's minimum Rust version as `1.88` in `packages/desktop/src-tauri/Cargo.toml` and documents that requirement in the desktop README.

The desktop build already needs a newer compiler than `1.85.1`, but without a crate-level minimum it fails with dependency-level errors instead of a direct Cargo message that the desktop crate itself requires a newer Rust toolchain.

### How did you verify your code works?

- `cargo +stable check` in `packages/desktop/src-tauri` now fails with a direct `opencode-desktop requires rustc 1.88` error on `rustc 1.85.1`
- `cargo +1.88.0 check` in `packages/desktop/src-tauri` succeeds
- repo typecheck passed during commit/push

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
