### PR TITLE
docs: add opencode-moshi-live to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -37,6 +37,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
+| [opencode-moshi-live](https://github.com/young5lee/opencode-moshi-live)                            | Moshi Live Activity and notification plugin for OpenCode with completion, permission, and reply-needed state tracking |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |


### PR DESCRIPTION
### Issue for this PR

Closes #23625

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-moshi-live` to the ecosystem plugin list in the docs so OpenCode users can discover the Moshi integration.

The entry links to the public repository and describes that it sends completion, permission, and reply-needed updates to Moshi Live Activity and notifications.

### How did you verify your code works?

Checked the docs change locally in the repo and verified the ecosystem entry is a single-row docs update in the existing plugin table format.

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._