### PR TITLE
fix: pass provider options under correct keys for openai-compatible

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -998,13 +998,24 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
     return result
   }
 
-  const key = sdkKey(model.api.npm) ?? model.providerID
   // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
   // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
   // "azure" first. Pass both so model options work on either code path.
   if (model.api.npm === "@ai-sdk/azure") {
     return { openai: options, azure: options }
   }
+
+  // @ai-sdk/openai-compatible reads from providerOptions["openaiCompatible"],
+  // and also from providerOptions[config.provider.split(".")[0]]. sdkKey()
+  // has no entry for this package, and model.providerID may contain dots
+  // (e.g. "example.com"), which doesn't match the SDK's split(".")[0]
+  // lookup. Pass both so model options work on either code path.
+  if (model.api.npm === "@ai-sdk/openai-compatible") {
+    const providerKey = model.providerID.split(".")[0]
+    return { openaiCompatible: options, [providerKey]: options }
+  }
+
+  const key = sdkKey(model.api.npm) ?? model.providerID
   return { [key]: options }
 }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #23622

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The SDK looks up options under `providerOptions["openaiCompatible"]` and `providerOptions[config.provider.split(".")[0]]`, but we only provided them under `model.providerID`. When providerID contains dots (e.g. "example.com"), the keys don't match and options are silently dropped.

### How did you verify your code works?

Use the Steps to reproduce in the issue, and the `reasoning_effort` field exists in the request body.

<img width="595" height="326" alt="image" src="https://github.com/user-attachments/assets/b7669db0-93bc-40b8-889d-9a9f467f2589" />

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
