### PR TITLE
fix(grep): handle non-UTF-8 ripgrep output (lines.bytes)

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer"
 import path from "path"
 import z from "zod"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
@@ -48,22 +49,27 @@ const Begin = z.object({
   }),
 })
 
+const TextOrBytes = z
+  .object({
+    text: z.string().optional(),
+    bytes: z.string().optional(),
+  })
+  .transform((val) => ({
+    text: val.text ?? Buffer.from(val.bytes ?? "", "base64").toString("utf-8"),
+  }))
+
 export const Match = z.object({
   type: z.literal("match"),
   data: z.object({
     path: z.object({
       text: z.string(),
     }),
-    lines: z.object({
-      text: z.string(),
-    }),
+    lines: TextOrBytes,
     line_number: z.number(),
     absolute_offset: z.number(),
     submatches: z.array(
       z.object({
-        match: z.object({
-          text: z.string(),
-        }),
+        match: TextOrBytes,
         start: z.number(),
         end: z.number(),
       }),

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer"
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import * as Stream from "effect/Stream"
@@ -174,6 +175,27 @@ describe("file.ripgrep", () => {
       rg.files({ cwd: "/tmp/nonexistent-dir-12345" }).pipe(Stream.runCollect),
     ).pipe(Effect.provide(Ripgrep.defaultLayer), Effect.runPromiseExit)
     expect(exit._tag).toBe("Failure")
+  })
+
+  test("search handles non-UTF-8 encoded files gracefully", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Write a file with non-UTF-8 bytes (GBK-encoded Chinese)
+        // This simulates the scenario where ripgrep emits lines.bytes instead of lines.text
+        const gbkBytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3]) // "你好" in GBK
+        const content = Buffer.concat([Buffer.from("needle "), gbkBytes, Buffer.from("\n")])
+        await Bun.write(path.join(dir, "gbk.txt"), content)
+        // Also add a normal UTF-8 file to verify mixed results work
+        await Bun.write(path.join(dir, "utf8.txt"), "needle hello\n")
+      },
+    })
+
+    const result = await run(Ripgrep.Service.use((rg) => rg.search({ cwd: tmp.path, pattern: "needle" })))
+    expect(result.partial).toBe(false)
+    // Should return matches from both files without throwing
+    expect(result.items.length).toBeGreaterThanOrEqual(1)
+    const texts = result.items.map((item) => item.lines.text)
+    expect(texts.some((t) => t.includes("needle"))).toBe(true)
   })
 
   test("ignores RIPGREP_CONFIG_PATH in direct mode", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #23629

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Grep tool throws "invalid ripgrep output" when any file in the project contains non-UTF-8 characters (e.g. GBK/GB2312 encoded Chinese). This happens because ripgrep emits `lines.bytes` (base64) instead of `lines.text` for non-UTF-8 content, and the zod schema in `ripgrep.ts` only accepts `lines.text`.

The fix adds a `TextOrBytes` zod schema that accepts either `text` or `bytes`, base64-decoding the bytes variant. Applied to `lines` and `submatches[].match` fields. The transform outputs `{ text: string }` so downstream code (grep.ts) works without changes.

### How did you verify your code works?

- Added a test case in `ripgrep.test.ts` that creates a file with non-UTF-8 bytes (GBK-encoded) and verifies search completes without errors
- Existing tests are unaffected since the schema is backward-compatible (text paths unchanged)

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR