### PR TITLE
fix(desktop-electron): add CORS headers to main window webRequest

### DIFF
--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -100,6 +100,19 @@ export function createMainWindow() {
     },
   })
 
+  win.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
+    const { requestHeaders } = details
+    upsertKeyValue(requestHeaders, "Access-Control-Allow-Origin", ["*"])
+    callback({ requestHeaders })
+  })
+
+  win.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    const { responseHeaders = {} } = details
+    upsertKeyValue(responseHeaders, "Access-Control-Allow-Origin", ["*"])
+    upsertKeyValue(responseHeaders, "Access-Control-Allow-Headers", ["*"])
+    callback({ responseHeaders })
+  })
+
   state.manage(win)
   loadWindow(win, "index.html")
   wireZoom(win)
@@ -176,4 +189,18 @@ function wireZoom(win: BrowserWindow) {
   win.webContents.on("zoom-changed", () => {
     win.webContents.setZoomFactor(1)
   })
+}
+
+function upsertKeyValue(obj: Record<string, any>, keyToChange: string, value: any) {
+  const keyToChangeLower = keyToChange.toLowerCase()
+  for (const key of Object.keys(obj)) {
+    if (key.toLowerCase() === keyToChangeLower) {
+      // Reassign old key
+      obj[key] = value
+      // Done
+      return
+    }
+  }
+  // Insert at end instead
+  obj[keyToChange] = value
 }


### PR DESCRIPTION
## Summary

Adds CORS headers to the main window webRequest to allow cross-origin requests.

## Changes

- Added `onBeforeSendHeaders` handler to set `Access-Control-Allow-Origin: *` on outgoing requests
- Added `onHeadersReceived` handler to set `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers: *` on incoming responses
- Added `upsertKeyValue` helper function for case-insensitive header manipulation