### PR TITLE
fix:PowerShell encoding for non-ASCII characters on Windows

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -283,7 +283,11 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
 
 function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && PS.has(name)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+    // Fix encoding for PowerShell on Windows to properly display non-ASCII characters
+    // Without this, [Console]::OutputEncoding defaults to system encoding (e.g., GB2312 on Chinese Windows)
+    // which causes garbled output when the terminal expects UTF-8
+    const encodedCommand = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${command}`
+    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", encodedCommand], {
       cwd,
       env,
       stdin: "ignore",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -283,9 +283,6 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
 
 function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && PS.has(name)) {
-    // Fix encoding for PowerShell on Windows to properly display non-ASCII characters
-    // Without this, [Console]::OutputEncoding defaults to system encoding (e.g., GB2312 on Chinese Windows)
-    // which causes garbled output when the terminal expects UTF-8
     const encodedCommand = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ${command}`
     return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", encodedCommand], {
       cwd,


### PR DESCRIPTION
### Issue for this PR

Closes #23636

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes PowerShell output encoding for non-ASCII characters on Windows by prepending `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8;` to commands.

**Not a duplicate of #14766**: That PR fixes TUI input encoding, this PR fixes bash tool output encoding. Different scenarios, different fix locations.

### How did you verify your code works?

Tested on Windows with Chinese filenames - `ls` now displays `笔记` correctly instead of garbled `ʼ`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR