### PR TITLE
fix(core): use file:// URLs for local dynamic import() on Windows+Node

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1507,8 +1507,8 @@ const layer: Layer.Layer<
           installedPath = model.api.npm
         }
 
-        // Node's ESM loader on Windows rejects bare absolute paths; dynamic import() needs
-        // a file:// URL. Bun accepts both, so this conversion is safe on either runtime.
+        // `installedPath` is a local entry path or an existing `file://` URL. Normalize
+        // only path inputs so Node on Windows accepts the dynamic import.
         const importSpec = installedPath.startsWith("file://") ? installedPath : pathToFileURL(installedPath).href
         const mod = await import(importSpec)
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -19,6 +19,7 @@ import { zod } from "@/util/effect-zod"
 import { iife } from "@/util/iife"
 import { Global } from "../global"
 import path from "path"
+import { pathToFileURL } from "url"
 import { Effect, Layer, Context, Schema, Types } from "effect"
 import { EffectBridge } from "@/effect"
 import { InstanceState } from "@/effect"
@@ -1506,7 +1507,10 @@ const layer: Layer.Layer<
           installedPath = model.api.npm
         }
 
-        const mod = await import(installedPath)
+        // Node's ESM loader on Windows rejects bare absolute paths; dynamic import() needs
+        // a file:// URL. Bun accepts both, so this conversion is safe on either runtime.
+        const importSpec = installedPath.startsWith("file://") ? installedPath : pathToFileURL(installedPath).href
+        const mod = await import(importSpec)
 
         const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
         const loaded = fn({

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -157,8 +157,8 @@ export const layer: Layer.Layer<
         if (matches.length) yield* config.waitForDependencies()
         for (const match of matches) {
           const namespace = path.basename(match, path.extname(match))
-          // Node's ESM loader on Windows rejects bare absolute paths; dynamic import()
-          // needs a file:// URL. Bun accepts both, so this is safe on either runtime.
+          // `match` is an absolute filesystem path from `Glob.scanSync(..., { absolute: true })`.
+          // Import it as `file://` so Node on Windows accepts the dynamic import.
           const mod = yield* Effect.promise(() => import(pathToFileURL(match).href))
           for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
             custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -157,9 +157,9 @@ export const layer: Layer.Layer<
         if (matches.length) yield* config.waitForDependencies()
         for (const match of matches) {
           const namespace = path.basename(match, path.extname(match))
-          const mod = yield* Effect.promise(
-            () => import(process.platform === "win32" ? match : pathToFileURL(match).href),
-          )
+          // Node's ESM loader on Windows rejects bare absolute paths; dynamic import()
+          // needs a file:// URL. Bun accepts both, so this is safe on either runtime.
+          const mod = yield* Effect.promise(() => import(pathToFileURL(match).href))
           for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
             custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
           }


### PR DESCRIPTION
## Summary
- convert local filesystem paths passed to dynamic `import()` into `file://` URLs for Windows Node compatibility
- keep existing behavior for imports that are already URLs; this change does not apply to bare module specifiers or virtual imports
- fix the desktop/electron Windows failure where Node rejected raw absolute paths with `Received protocol 'c:'`

## Notes
- `packages/opencode/src/tool/registry.ts`: discovered tool files are absolute filesystem paths from `Glob.scanSync(..., { absolute: true })`
- `packages/opencode/src/provider/provider.ts`: provider entrypoints are normalized only when they are local paths and left unchanged when already `file://`
- Bun 1.3.10/1.3.11 and current real plugin packages tested cleanly with `file://` for these paths; a separate Bun 1.3.10 `Npm.add()` package-layout issue is unrelated to this PR