### PR TITLE
fix: fixed memory overflow issue(handle SIGINT/SIGTERM in web and serve commands)

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -15,7 +15,12 @@ export const ServeCommand = cmd({
     const server = await Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 
-    await new Promise(() => {})
-    await server.stop()
+    await new Promise<void>((resolve) => {
+      const shutdown = () => {
+        server.stop(true).finally(() => resolve())
+      }
+      process.once("SIGINT", shutdown)
+      process.once("SIGTERM", shutdown)
+    })
   },
 })

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -75,7 +75,12 @@ export const WebCommand = cmd({
       open(displayUrl).catch(() => {})
     }
 
-    await new Promise(() => {})
-    await server.stop()
+    await new Promise<void>((resolve) => {
+      const shutdown = () => {
+        server.stop(true).finally(() => resolve())
+      }
+      process.once("SIGINT", shutdown)
+      process.once("SIGTERM", shutdown)
+    })
   },
 })


### PR DESCRIPTION
### Issue for this PR
Fixes #21505
### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
### What does this PR do?
Both `opencode web` and `opencode serve` use `await new Promise(() => {})` to keep the process alive, but this makes the `server.stop()` call on the next line unreachable dead code. No SIGINT/SIGTERM handler is registered either.
When a user presses Ctrl+C, the CLI output stops but the backend process keeps running — the HTTP server holds the port, WebSocket connections stay open, MCP subprocesses (especially Docker-container-based ones, as noted in `index.ts` L237-240) remain alive, and all in-memory state (sessions, LLM response caches, file-watcher subscriptions) is never released.
On machines running multiple `opencode web` sessions (e.g. remote dev servers), each Ctrl+C leaves behind an orphan that continues consuming memory. These compound over time and can lead to OOM. The port also stays bound, so restarting `opencode web` fails with EADDRINUSE until the zombie is manually `kill -9`'d.
The fix registers `process.once("SIGINT" | "SIGTERM")` handlers in both commands that call `server.stop(true)` to force-close all connections, then resolve the keep-alive promise. This lets execution reach the existing `process.exit()` in `index.ts`'s finally block, which tears down remaining subprocesses.
### How did you verify your code works?
1. Ran `opencode web`, pressed Ctrl+C — process exits cleanly, port is released, no orphan processes remain
2. Ran `opencode serve`, sent SIGTERM — same clean shutdown behavior
3. `bun typecheck` passes with zero errors
### Screenshots / recordings
_N/A — not a UI change._
### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR