### PR TITLE
fix(opencode): merge system prompts for non-anthropic providers

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -150,12 +150,7 @@ const live: Layer.Layer<
         : isWorkflow
           ? input.messages
           : [
-              ...system.map(
-                (x): ModelMessage => ({
-                  role: "system",
-                  content: x,
-                }),
-              ),
+              { role: "system" as const, content: system.join("\n") } satisfies ModelMessage,
               ...input.messages,
             ]
 

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { tool, type ModelMessage } from "ai"
 import { Cause, Effect, Exit, Stream } from "effect"
 import z from "zod"
+import { pathToFileURL } from "url"
 import { makeRuntime } from "../../src/effect/run-service"
 import { LLM } from "../../src/session/llm"
 import { Instance } from "../../src/project/instance"
@@ -557,6 +558,102 @@ describe("session.llm.stream", () => {
         const capture = await request
         const tools = capture.body.tools as Array<{ function?: { name?: string } }> | undefined
         expect(tools?.some((item) => item.function?.name === "question")).toBe(true)
+      },
+    })
+  })
+
+  test("combines plugin-added system prompts into one message for non-anthropic providers", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const pluginFile = path.join(dir, "plugin.ts")
+        await Bun.write(
+          pluginFile,
+          [
+            "export default async () => ({",
+            '  "experimental.chat.system.transform": (_input, output) => {',
+            '    output.system.push("Relevant memory goes here.")',
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            plugin: [pathToFileURL(pluginFile).href],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-system-merge")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-system-merge"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        const messages = capture.body.messages as Array<{ role: string; content: unknown }>
+        const systemMessages = messages.filter((message) => message.role === "system")
+        const systemContent = String(systemMessages[0]?.content ?? "")
+
+        expect(systemMessages).toHaveLength(1)
+        expect(systemContent).toContain("You are a helpful assistant.")
+        expect(systemContent).toContain("Relevant memory goes here.")
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #15059

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It collapses plugin-added system prompts into a single system message for non-OpenAI-OAuth, non-workflow requests.

That keeps the existing Anthropic-compatible/messages behavior untouched, but avoids vLLM-served Qwen models failing with `System message must be at the beginning.` when plugins append extra system context.

It also adds a regression test covering `experimental.chat.system.transform` with an Alibaba/Qwen fixture.

Related: #16560, #20785, previous attempts #15018 and #16981.

### How did you verify your code works?

- Added a regression test and verified the red/green cycle locally
- `~/.bun/bin/bun test packages/opencode/test/session/llm.test.ts`
- `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun turbo typecheck --filter=opencode`

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
