### PR TITLE
docs(plugin): clarify system transform hook guidance

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -287,6 +287,15 @@ export interface Hooks {
       }[]
     },
   ) => Promise<void>
+  /**
+   * Called after the base system prompt is assembled and before the request is sent.
+   *
+   * `output.system` is an ordered list of system prompt blocks. Plugins that are
+   * adding supplemental context should generally prefer merging that text into
+   * `output.system[0]` instead of pushing a new block, unless a separate system
+   * segment is explicitly required. Some OpenAI-compatible backends only accept a
+   * single system message at the start of the conversation.
+   */
   "experimental.chat.system.transform"?: (
     input: { sessionID?: string; model: Model },
     output: {


### PR DESCRIPTION
### Issue for this PR

Closes #23660

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

It adds guidance to the `experimental.chat.system.transform` hook docs in `packages/plugin/src/index.ts`.

The new note tells plugin authors to prefer merging supplemental context into `output.system[0]` instead of pushing a new block unless they explicitly need a separate system segment. This helps steer memory/context plugin authors away from producing multiple system messages on backends that only accept one.

### How did you verify your code works?

- `git diff --check`
- `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun --cwd packages/plugin typecheck`

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
