### PR TITLE
fix: expose actual Kimi/Moonshot API errors and resolve \$ref schema

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -57,6 +57,22 @@ function message(providerID: ProviderID, e: APICallError) {
       return "Unknown error"
     }
 
+    // Handle Vercel AI SDK wrapper error that loses upstream error details
+    // When providers like Kimi, OpenRouter, etc. return errors, the SDK wraps them
+    // with "Provider returned error" and stores the real error in metadata.raw
+    if (msg === "Provider returned error") {
+      try {
+        const body = JSON.parse(e.responseBody ?? "{}")
+        if (body.error?.metadata?.raw) {
+          const raw = JSON.parse(body.error.metadata.raw)
+          if (raw.error?.message) {
+            const providerName = body.error.metadata.provider_name ?? ""
+            return `${msg}: ${raw.error.message}${providerName ? ` (${providerName})` : ""}`
+          }
+        }
+      } catch {}
+    }
+
     if (!e.responseBody || (e.statusCode && msg !== STATUS_CODES[e.statusCode])) {
       return msg
     }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1031,6 +1031,53 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
   }
   */
 
+  // Handle Moonshot/Kimi models - they reject schemas with conflicting keywords after $ref expansion
+  // This typically happens when $ref is used and description exists both in ref and expanded schema
+  // Solution: completely remove $ref and inline the schema definition
+  if (model.providerID === "opencode" || model.api.id.includes("kimi") || model.api.id.includes("moonshot")) {
+    const definitions = (schema as JSONSchema7).definitions
+
+    const resolveRef = (ref: string): any => {
+      if (!ref.startsWith("#/") || !definitions) return undefined
+      const path = ref.slice(2).split("/")
+      let result: any = definitions
+      for (const key of path) {
+        result = result?.[key]
+      }
+      return result
+    }
+
+    const sanitizeMoonshot = (obj: any): any => {
+      if (obj === null || typeof obj !== "object") {
+        return obj
+      }
+
+      if (Array.isArray(obj)) {
+        return obj.map(sanitizeMoonshot)
+      }
+
+      const result: any = {}
+      for (const [key, value] of Object.entries(obj)) {
+        if (key === "$ref" && typeof value === "string") {
+          // Resolve $ref inline instead of keeping it
+          const resolved = resolveRef(value)
+          if (resolved) {
+            // Recursively sanitize the resolved schema and merge
+            Object.assign(result, sanitizeMoonshot(resolved))
+          }
+        } else if (typeof value === "object" && value !== null) {
+          result[key] = sanitizeMoonshot(value)
+        } else {
+          result[key] = value
+        }
+      }
+
+      return result
+    }
+
+    schema = sanitizeMoonshot(schema) as JSONSchema7
+  }
+
   // Convert integer enums to string enums for Google/Gemini
   if (model.providerID === "google" || model.api.id.includes("gemini")) {
     const isPlainObject = (node: unknown): node is Record<string, any> =>


### PR DESCRIPTION
### Issue for this PR

Closes #23665

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes two issues with Kimi K2.6 (and other Moonshot models) when used with OpenCode Go:

1. **Error message issue**: When the upstream API (Kimi/Moonshot) returns an error, the Vercel AI SDK wraps it with a generic "Provider returned error" message, hiding the actual error details. The fix extracts the real error from `error.metadata.raw` in `packages/opencode/src/provider/error.ts`.

2. **Schema validation issue**: Moonshot/Kimi APIs reject JSON schemas that have `$ref` with additional keywords (like `description`) that conflict after $ref expansion. The fix resolves `$ref` inline before sending the schema to the API in `packages/opencode/src/provider/transform.ts`.

### How did you verify your code works?

- Applied the fix locally
- Tested with Kimi K2.6 model
- Confirmed error messages now show actual upstream error details instead of "Provider returned error"
- Confirmed tool calls work without schema validation errors

### Screenshots / recordings

https://github.com/user-attachments/assets/31c418fe-81ab-4bd8-a144-62d52471cd8f



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
