### PR TITLE
fix(app): include limit in queryKey for loadSessions to fix loadMore not working

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -198,14 +198,17 @@ function createGlobalSync() {
         setStore("session", reconcile(next, { key: "id" }))
         cleanupDroppedSessionCaches(store, setStore, next, setSessionTodo)
       }
-      children.unpin(directory)
-      return
+      const rootCount = next.filter((s) => !s.parentID).length
+      if (store.sessionTotal <= rootCount) {
+        children.unpin(directory)
+        return
+      }
     }
 
     const limit = Math.max(store.limit + SESSION_RECENT_LIMIT, SESSION_RECENT_LIMIT)
     const promise = queryClient
       .ensureQueryData({
-        ...loadSessionsQuery(directory),
+        queryKey: [directory, "loadSessions", limit],
         queryFn: () =>
           loadRootSessionsWithFallback({
             directory,


### PR DESCRIPTION
## Summary

- Fixed 'Load More' sessions button not working due to React Query cache key issue
- Added `limit` parameter to queryKey in `loadSessions` function
- Fixed early return condition to only return when no more sessions to load

## Problem

The `loadSessions` function used `queryClient.ensureQueryData` with a queryKey that only included `[directory, 'loadSessions']`, missing the `limit` parameter. This caused:

1. First request gets cached
2. Subsequent 'Load More' requests return cached data
3. No new API requests are sent, UI doesn't update

## Fix

Include `limit` in the queryKey

## Test plan

1. Open a project with many sessions
2. Click 'Load More' button
3. Verify new sessions are loaded