### PR TITLE
fix(ui): correct diff render condition logic

### DIFF
--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -388,7 +388,7 @@ export const SessionReview = (props: SessionReviewProps) => {
                     const file = diff.file
 
                     // binary files have empty diffs that we can't render
-                    const diffCanRender = () => diff.additions !== 0 && diff.deletions !== 0
+                    const diffCanRender = () => diff.additions !== 0 || diff.deletions !== 0
 
                     const expanded = createMemo(() => open().includes(file))
                     const mounted = createMemo(() => expanded() && (!!store.visible[file] || pinned(file)))


### PR DESCRIPTION
## Summary

Fixes the logic for determining if a diff can be rendered in the session review component.

## Changes

Changed the `diffCanRender` condition from `&&` to `||`:
- **Before**: `diff.additions !== 0 && diff.deletions !== 0` (required BOTH additions AND deletions)
- **After**: `diff.additions !== 0 || diff.deletions !== 0` (requires EITHER additions OR deletions)

## Why

Binary files with only additions or only deletions (not both) should still be renderable. The previous logic incorrectly required both to be non-zero, which would hide valid diffs.