### PR TITLE
fix(ui): improve switch toggle accessibility and visual clarity

### DIFF
--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Icon } from "@opencode-ai/ui/icon"
+import { Spinner } from "@opencode-ai/ui/spinner"
 import { Switch } from "@opencode-ai/ui/switch"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { useMutation } from "@tanstack/solid-query"
@@ -373,7 +374,10 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                           }}
                         />
                         <span class="text-14-regular text-text-base truncate flex-1">{name}</span>
-                        <div onClick={(event) => event.stopPropagation()}>
+                        <div class="flex items-center gap-1.5" onClick={(event) => event.stopPropagation()}>
+                          <Show when={toggleMcp.isPending && toggleMcp.variables === name}>
+                            <Spinner class="size-3.5 text-text-weak" />
+                          </Show>
                           <Switch
                             checked={enabled()}
                             disabled={toggleMcp.isPending && toggleMcp.variables === name}
@@ -381,8 +385,12 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                               if (toggleMcp.isPending) return
                               toggleMcp.mutate(name)
                             }}
-                          />
+                            hideLabel
+                          >
+                            {enabled() ? `Disable ${name}` : `Enable ${name}`}
+                          </Switch>
                         </div>
+                        <span classList={{ "text-12-regular w-5 select-none": true, "text-text-base": enabled(), "text-text-weak": !enabled() }}>{enabled() ? "On" : "Off"}</span>
                       </button>
                     )
                   }}

--- a/packages/ui/src/components/switch.css
+++ b/packages/ui/src/components/switch.css
@@ -17,39 +17,54 @@
     border-width: 0;
   }
 
+  /* Track — mirrors Kumo sm: 32x16, relative, no border, no padding, ring for outline */
   [data-slot="switch-control"] {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    width: 28px;
+    width: 32px;
     height: 16px;
     flex-shrink: 0;
-    border-radius: 3px;
-    border: 1px solid var(--border-weak-base);
-    background: var(--surface-base);
-    transition:
-      background-color 150ms,
-      border-color 150ms;
+    border: none;
+    padding: 0;
+    border-radius: 5px;
+    corner-shape: squircle;
+    background-color: var(--border-weak-base);
+    box-shadow: 0 0 0 1px var(--border-base);
+    transition: all 150ms ease-out;
+
+    @media (prefers-color-scheme: dark) {
+      background-color: #3d3d3d;
+      box-shadow: 0 0 0 1px #4a4a4a;
+    }
   }
 
+  @supports (corner-shape: squircle) {
+    [data-slot="switch-control"],
+    [data-slot="switch-thumb"] {
+      border-radius: 10px;
+    }
+  }
+
+  /* Thumb — mirrors Kumo sm: 16x16, absolute top-0 bottom-0, inset radius to nest inside track */
   [data-slot="switch-thumb"] {
-    width: 14px;
-    height: 14px;
-    box-sizing: content-box;
+    position: absolute;
+    top: 0.5px;
+    bottom: 0.5px;
+    left: 0.5px;
+    width: 15px;
+    border: none;
+    border-radius: 5px;
+    corner-shape: squircle;
+    background-color: var(--icon-invert-base);
 
-    border-radius: 2px;
-    border: 1px solid var(--border-base);
-    background: var(--icon-invert-base);
-
-    /* shadows/shadow-xs */
+    @media (prefers-color-scheme: dark) {
+      background-color: var(--icon-invert-base);
+    }
     box-shadow:
-      0 1px 2px -1px rgba(19, 16, 16, 0.04),
-      0 1px 2px 0 rgba(19, 16, 16, 0.06),
-      0 1px 3px 0 rgba(19, 16, 16, 0.08);
-
-    transform: translateX(-1px);
-    transition:
-      transform 150ms,
-      background-color 150ms;
+      0 0 1px 0.5px rgba(0, 0, 0, 0.06),
+      0 1px 2px rgba(0, 0, 0, 0.06);
+    transition: all 150ms ease-out;
   }
 
   [data-slot="switch-label"] {
@@ -81,48 +96,37 @@
     letter-spacing: var(--letter-spacing-normal);
   }
 
+  /* Hover — no-op, let parent handle visual feedback */
   &:hover:not([data-disabled], [data-readonly]) [data-slot="switch-control"] {
-    border-color: var(--border-hover);
-    background-color: var(--surface-hover);
   }
 
   &:not([data-readonly]) [data-slot="switch-input"]:focus-visible ~ [data-slot="switch-control"] {
-    border-color: var(--border-focus);
-    box-shadow: var(--shadow-xs-border-focus);
+    outline: 2px solid var(--border-focus);
+    outline-offset: 2px;
   }
 
+  /* Checked — green track + ring, white thumb slides to right half */
   &[data-checked] [data-slot="switch-control"] {
-    box-sizing: border-box;
-    border-color: var(--icon-strong-base);
-    background-color: var(--icon-strong-base);
+    background-color: var(--icon-success-base, var(--icon-strong-base));
+    box-shadow: 0 0 0 1px var(--icon-success-base, var(--icon-strong-base));
   }
 
   &[data-checked] [data-slot="switch-thumb"] {
-    border: none;
-    transform: translateX(12px);
-    background-color: var(--icon-invert-base);
+    left: 16.5px;
+    background-color: #ffffff;
   }
 
   &[data-checked]:hover:not([data-disabled], [data-readonly]) [data-slot="switch-control"] {
-    border-color: var(--border-hover);
-    background-color: var(--surface-hover);
+    opacity: 0.85;
   }
 
   &[data-disabled] {
     cursor: not-allowed;
-  }
-
-  &[data-disabled] [data-slot="switch-control"] {
-    border-color: var(--border-disabled);
-    background-color: var(--surface-disabled);
-  }
-
-  &[data-disabled] [data-slot="switch-thumb"] {
-    background-color: var(--icon-disabled);
+    opacity: 0.5;
   }
 
   &[data-invalid] [data-slot="switch-control"] {
-    border-color: var(--border-error);
+    box-shadow: 0 0 0 1px var(--border-error);
   }
 
   &[data-readonly] {


### PR DESCRIPTION
### Issue for this PR

Closes #23580

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I was slightly confused by whether an MCP toggle was on or off, so I asked OpenCode what it thought. It was... wrong.

<img width="365" height="110" alt="Screenshot 2026-04-20 at 12 21 01 PM" src="https://github.com/user-attachments/assets/fcf26139-772c-416d-b474-1f6a25249804" />

<img width="612" height="129" alt="Image" src="https://github.com/user-attachments/assets/a73bc80c-74db-4a75-990a-c75d36f4db0b" />

It was on.

The switch component's checked and unchecked states are visually too similar — especially in dark mode — and there's no text or accessible label to disambiguate. This PR fixes that:

- **Squircle shape** for the switch track and thumb, with progressive enhancement via `corner-shape: squircle` (falls back to `border-radius: 5px`)
- **Green track** (`--icon-success-base`) when checked, so there's an unambiguous "on" color
- **White thumb** when checked, hardcoded to `#ffffff` so it's visible in both light and dark mode
- **Visible "On"/"Off" text label** next to MCP server toggles
- **Screen-reader-only accessible label** with the server name (e.g., "Disable foo-mcp") for a11y
- **Loading spinner** while MCP server connection is toggling, so users aren't left wondering what's happening

### How did you verify your code works?

Ran the app locally (`bun dev serve` + `bun run --cwd packages/app dev`) and tested toggling MCP servers in the status popover in both light and dark mode.

### Screenshots / recordings

#### Off
<img width="361" height="110" alt="Screenshot 2026-04-21 at 9 58 07 AM" src="https://github.com/user-attachments/assets/8bd207e0-184e-4d0b-b668-cfa0b0ecc26a" />

#### On
<img width="367" height="110" alt="Screenshot 2026-04-21 at 9 58 15 AM" src="https://github.com/user-attachments/assets/8f247c6f-5329-4079-9be4-9d5add4a56cf" />

#### Connecting/Loading
<img width="363" height="108" alt="Screenshot 2026-04-21 at 9 58 11 AM" src="https://github.com/user-attachments/assets/ab264394-a195-4ed9-82e1-ed95169acd33" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR