### PR TITLE
fix(tui): prevent model picker reset after first message in new session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -398,9 +398,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     }
 
     // Automatically update model when agent changes
+    let prevAgentName: string | undefined
     createEffect(() => {
       const value = agent.current()
       if (!value) return
+      if (value.name === prevAgentName) return
+      prevAgentName = value.name
       if (value.model) {
         if (isModelValid(value.model))
           model.set({


### PR DESCRIPTION
### Issue for this PR

Closes #23666

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `createEffect` in `local.tsx` that syncs the model on agent changes tracks `agent.current()` reactively. This means it fires on every `sync.data.agent` refresh (new object references), not just on actual agent name changes. After the first message completes, sync data refreshes → effect fires → overwrites the user's `/model` selection with the agent's configured default.

The fix adds a `prevAgentName` guard so the effect only runs its body when the agent name actually changes, preventing sync-triggered resets.

### How did you verify your code works?

Traced the reactive dependency chain: `agent.current()` → `agents()` → `sync.data.agent`. The effect has no deduplication, so any sync refresh that produces new agent objects triggers it. The `prevAgentName` guard ensures the model reset only happens on genuine agent switches. CI passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR