### PR TITLE
fix(plugin): support tilde (~/) paths in plugin config

### DIFF
--- a/packages/opencode/src/config/plugin.ts
+++ b/packages/opencode/src/config/plugin.ts
@@ -5,6 +5,7 @@ import { isPathPluginSpec, parsePluginSpecifier, resolvePathPluginTarget } from 
 import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 import path from "path"
+import os from "os"
 
 export const Options = Schema.Record(Schema.String, Schema.Unknown).pipe(withStatics((s) => ({ zod: zod(s) })))
 export type Options = Schema.Schema.Type<typeof Options>
@@ -58,6 +59,7 @@ export async function resolvePluginSpec(plugin: Spec, configFilepath: string): P
   const base = path.dirname(configFilepath)
   const file = (() => {
     if (spec.startsWith("file://")) return spec
+    if (spec.startsWith("~/")) return pathToFileURL(path.join(os.homedir(), spec.slice(2))).href
     if (path.isAbsolute(spec) || /^[A-Za-z]:[\\/]/.test(spec)) return pathToFileURL(spec).href
     return pathToFileURL(path.resolve(base, spec)).href
   })()

--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import os from "os"
 import { fileURLToPath, pathToFileURL } from "url"
 import npa from "npm-package-arg"
 import semver from "semver"
@@ -169,12 +170,13 @@ async function resolvePluginEntrypoint(spec: string, target: string, kind: Plugi
 }
 
 export function isPathPluginSpec(spec: string) {
-  return spec.startsWith("file://") || spec.startsWith(".") || isAbsolutePath(spec)
+  return spec.startsWith("file://") || spec.startsWith(".") || spec.startsWith("~/") || isAbsolutePath(spec)
 }
 
 export async function resolvePathPluginTarget(spec: string) {
   const raw = spec.startsWith("file://") ? fileURLToPath(spec) : spec
-  const file = path.isAbsolute(raw) || /^[A-Za-z]:[\\/]/.test(raw) ? raw : path.resolve(raw)
+  const expanded = raw.startsWith("~/") ? path.join(os.homedir(), raw.slice(2)) : raw
+  const file = path.isAbsolute(expanded) || /^[A-Za-z]:[\\/]/.test(expanded) ? expanded : path.resolve(expanded)
   const stat = await Filesystem.statAsync(file)
   if (!stat?.isDirectory()) {
     if (spec.startsWith("file://")) return spec

--- a/packages/opencode/test/plugin/shared.test.ts
+++ b/packages/opencode/test/plugin/shared.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
-import { parsePluginSpecifier } from "../../src/plugin/shared"
+import os from "os"
+import path from "path"
+import { isPathPluginSpec, parsePluginSpecifier, resolvePathPluginTarget } from "../../src/plugin/shared"
 
 describe("parsePluginSpecifier", () => {
   test("parses standard npm package without version", () => {
@@ -84,5 +86,46 @@ describe("parsePluginSpecifier", () => {
       pkg: "@opencode/acme",
       version: "latest",
     })
+  })
+})
+
+describe("isPathPluginSpec", () => {
+  test("recognizes file:// URL", () => {
+    expect(isPathPluginSpec("file:///home/user/plugin")).toBe(true)
+  })
+
+  test("recognizes relative path", () => {
+    expect(isPathPluginSpec("./my-plugin")).toBe(true)
+  })
+
+  test("recognizes absolute path", () => {
+    expect(isPathPluginSpec("/home/user/plugin")).toBe(true)
+  })
+
+  test("recognizes ~/ tilde path", () => {
+    expect(isPathPluginSpec("~/my-plugin")).toBe(true)
+  })
+
+  test("does not treat npm package as path", () => {
+    expect(isPathPluginSpec("my-package")).toBe(false)
+  })
+
+  test("does not treat scoped npm package as path", () => {
+    expect(isPathPluginSpec("@opencode/my-plugin")).toBe(false)
+  })
+})
+
+describe("resolvePathPluginTarget", () => {
+  test("expands ~/ to home directory", async () => {
+    // Create a real temp file under home dir to resolve against
+    const tmpName = `opencode-test-plugin-${Date.now()}.ts`
+    const tmpFile = path.join(os.homedir(), tmpName)
+    await Bun.write(tmpFile, "export default {}")
+    try {
+      const result = await resolvePathPluginTarget(`~/${tmpName}`)
+      expect(result).toBe(`file://${tmpFile}`)
+    } finally {
+      await Bun.file(tmpFile).exists() && (await import("fs")).promises.unlink(tmpFile)
+    }
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #23695

### Type of change

- [x] Bug fix

### What does this PR do?

`isPathPluginSpec()` in `plugin/shared.ts` only checked for `file://`, `.`-prefixed, and absolute paths. A `~/` path was not recognised as a local path, so it fell through to npm resolution and failed.

Added `~/` detection to `isPathPluginSpec()` and tilde expansion (via `os.homedir()`) to `resolvePathPluginTarget()` in `plugin/shared.ts` and `resolvePluginSpec()` in `config/plugin.ts`.

### How did you verify your code works?

Added unit tests for `isPathPluginSpec` and `resolvePathPluginTarget` covering `~/` paths. All 19 tests pass (`bun test test/plugin/shared.test.ts` from `packages/opencode`).

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR