### PR TITLE
fix(provider): sanitize xAI tool schemas for OpenRouter and native xai provider

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1110,5 +1110,24 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
     schema = sanitizeGemini(schema)
   }
 
+  const isXaiTarget =
+    model.providerID === "xai"
+    || (model.providerID === "openrouter" && model.api.id.startsWith("x-ai/"))
+
+  if (isXaiTarget) {
+    const sanitizeXai = (obj: unknown): unknown => {
+      if (obj === null || typeof obj !== "object") return obj
+      if (Array.isArray(obj)) return obj.map(sanitizeXai)
+
+      return Object.fromEntries(
+        Object.entries(obj)
+          .filter(([key, value]) => !(key === "additionalProperties" && value === false))
+          .map(([key, value]) => [key, sanitizeXai(value)]),
+      )
+    }
+
+    schema = sanitizeXai(schema) as JSONSchema7
+  }
+
   return schema as JSONSchema7
 }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -855,6 +855,161 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
   })
 })
 
+describe("ProviderTransform.schema - xAI via OpenRouter", () => {
+  const xaiModel = {
+    providerID: "openrouter",
+    api: {
+      id: "x-ai/grok-4.1-fast",
+    },
+  } as any
+
+  test("removes additionalProperties false recursively", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        metadata: {
+          type: "object",
+          properties: {
+            cwd: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    } as any
+
+    const result = ProviderTransform.schema(xaiModel, schema) as any
+
+    expect(result.additionalProperties).toBeUndefined()
+    expect(result.properties.metadata.additionalProperties).toBeUndefined()
+  })
+
+  test("preserves object and true additionalProperties forms", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        answers: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+        passthrough: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(xaiModel, schema) as any
+
+    expect(result.properties.answers.additionalProperties).toEqual({ type: "string" })
+    expect(result.properties.passthrough.additionalProperties).toBe(true)
+  })
+
+  test("does not affect non-xAI OpenRouter models", () => {
+    const openrouterClaude = {
+      providerID: "openrouter",
+      api: {
+        id: "anthropic/claude-sonnet-4.5",
+      },
+    } as any
+
+    const schema = {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+      },
+      additionalProperties: false,
+    } as any
+
+    const result = ProviderTransform.schema(openrouterClaude, schema) as any
+
+    expect(result.additionalProperties).toBe(false)
+  })
+})
+
+describe("ProviderTransform.schema - xAI native provider", () => {
+  const xaiNativeModel = {
+    providerID: "xai",
+    api: {
+      id: "grok-4.1-fast",
+    },
+  } as any
+
+  test("removes additionalProperties false recursively", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+      },
+      additionalProperties: false,
+    } as any
+
+    const result = ProviderTransform.schema(xaiNativeModel, schema) as any
+
+    expect(result.additionalProperties).toBeUndefined()
+  })
+
+  test("preserves object and true additionalProperties forms", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        data: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+      },
+      additionalProperties: true,
+    } as any
+
+    const result = ProviderTransform.schema(xaiNativeModel, schema) as any
+
+    expect(result.properties.data.additionalProperties).toEqual({ type: "string" })
+    expect(result.additionalProperties).toBe(true)
+  })
+})
+
+describe("ProviderTransform.schema - xAI native provider", () => {
+  const xaiNativeModel = {
+    providerID: "xai",
+    api: {
+      id: "grok-4.1-fast",
+    },
+  } as any
+
+  test("removes additionalProperties false recursively", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+      },
+      additionalProperties: false,
+    } as any
+
+    const result = ProviderTransform.schema(xaiNativeModel, schema) as any
+
+    expect(result.additionalProperties).toBeUndefined()
+  })
+
+  test("preserves object and true additionalProperties forms", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        data: {
+          type: "object",
+          additionalProperties: { type: "string" },
+        },
+      },
+      additionalProperties: true,
+    } as any
+
+    const result = ProviderTransform.schema(xaiNativeModel, schema) as any
+
+    expect(result.properties.data.additionalProperties).toEqual({ type: "string" })
+    expect(result.additionalProperties).toBe(true)
+  })
+})
+
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   test("DeepSeek with tool calls includes reasoning_content in providerOptions", () => {
     const msgs = [


### PR DESCRIPTION
### Issue for this PR

Closes #23704

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Tool calling fails for xAI models (e.g. `grok-4.1-fast`) when used through OpenRouter or the native `xai` provider. The error is:

```
[xAI] Invalid request content: Schema validation failed: [standard_violation] /properties/properties/additionalProperties: property schema 'false' is not supported
```

xAI structured output docs state:
- `additionalProperties` defaults to `false` already
- schemas with boolean property schemas like `false` are rejected

So the fix strips `additionalProperties: false` from tool/input JSON schemas before sending to xAI. This preserves the intended strictness (since false is the default) while avoiding the validator rejection.

The change is scoped to:
- `providerID === "xai"` (native xAI provider)
- `providerID === "openrouter"` with `model.api.id.startsWith("x-ai/")` (xAI models via OpenRouter)

Non-xAI models are unaffected.

### How did you verify your code works?

Added unit tests in `packages/opencode/test/provider/transform.test.ts`:
- Verifies recursive removal of `additionalProperties: false` for both OpenRouter xAI and native xai provider
- Verifies object-valued and `true` `additionalProperties` are preserved
- Verifies non-xAI OpenRouter models are not affected

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR