### PR TITLE
feat(tui): show a resume aid in the sessions picker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -46,7 +46,7 @@ export function DialogSessionList() {
     >
   >({})
 
-  const loadingRecap = new Set<string>()
+  const inflightSessionSync = new Map<string, Promise<void>>()
 
   const [searchResults, { refetch }] = createResource(search, async (query) => {
     if (!query) return undefined
@@ -68,41 +68,52 @@ export function DialogSessionList() {
     return `${updated}:${state}`
   }
 
+  function deriveRecap(sessionID: string) {
+    const messages = (sync.data.message[sessionID] ?? []).map((info) => ({
+      info,
+      parts: sync.data.part[info.id] ?? [],
+    }))
+    const todos = sync.data.todo[sessionID] ?? []
+    return deriveSessionRecap({
+      messages,
+      todos,
+      status: sessionStatus()[sessionID],
+    })
+  }
+
   async function ensureRecap(sessionID: string | undefined) {
     if (!sessionID) return
-    if (loadingRecap.has(sessionID)) return
     const version = recapVersion(sessionID)
     if (recapBySession[sessionID]?.state === "ready" && recapBySession[sessionID]?.version === version) return
+    const running = inflightSessionSync.get(sessionID)
+    if (running) return
 
-    loadingRecap.add(sessionID)
     setRecapBySession(sessionID, {
       state: "loading",
       version,
     })
 
-    try {
-      const [messagesResult, todosResult] = await Promise.all([
-        sdk.client.session.messages({ sessionID, limit: 100 }),
-        sdk.client.session.todo({ sessionID }),
-      ])
-      const recap = deriveSessionRecap({
-        messages: messagesResult.data ?? [],
-        todos: todosResult.data ?? [],
-        status: sessionStatus()[sessionID],
+    const promise = sync.session
+      .sync(sessionID)
+      .then(() => {
+        setRecapBySession(sessionID, {
+          state: "ready",
+          version,
+          recap: deriveRecap(sessionID),
+        })
       })
-      setRecapBySession(sessionID, {
-        state: "ready",
-        version,
-        recap,
+      .catch(() => {
+        setRecapBySession(sessionID, {
+          state: "error",
+          version,
+        })
       })
-    } catch {
-      setRecapBySession(sessionID, {
-        state: "error",
-        version,
+      .finally(() => {
+        inflightSessionSync.delete(sessionID)
       })
-    } finally {
-      loadingRecap.delete(sessionID)
-    }
+
+    inflightSessionSync.set(sessionID, promise)
+    await promise
   }
 
   createEffect(() => {
@@ -249,14 +260,17 @@ export function DialogSessionList() {
 
   createEffect(() => {
     if (activeSessionID()) return
-    const first = options()[0]?.value
-    if (!first) return
-    setActiveSessionID(first)
-    void ensureRecap(first)
+    const next = currentSessionID() ?? options()[0]?.value
+    if (!next) return
+    setActiveSessionID(next)
+    void ensureRecap(next)
   })
 
   onMount(() => {
     dialog.setSize("large")
+    const current = currentSessionID()
+    setActiveSessionID(current)
+    void ensureRecap(current)
   })
 
   const selectedRecap = createMemo(() => {
@@ -312,7 +326,6 @@ export function DialogSessionList() {
         )
       }}
       onSelect={(option) => {
-        setActiveSessionID(option.value)
         route.navigate({
           type: "session",
           sessionID: option.value,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -2,7 +2,7 @@ import { useDialog } from "@tui/ui/dialog"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
-import { createMemo, createResource, createSignal, onMount } from "solid-js"
+import { createEffect, createMemo, createResource, createSignal, onMount } from "solid-js"
 import { Locale } from "@/util"
 import { useProject } from "@tui/context/project"
 import { useKeybind } from "../context/keybind"
@@ -17,6 +17,9 @@ import { DialogWorkspaceCreate, openWorkspaceSession, restoreWorkspaceSession } 
 import { Spinner } from "./spinner"
 import { errorMessage } from "@/util/error"
 import { DialogSessionDeleteFailed } from "./dialog-session-delete-failed"
+import { createStore } from "solid-js/store"
+import type { SessionStatus } from "@opencode-ai/sdk/v2"
+import { deriveSessionRecap, type SessionRecap } from "./session-recap"
 
 type WorkspaceStatus = "connected" | "connecting" | "disconnected" | "error"
 
@@ -30,7 +33,20 @@ export function DialogSessionList() {
   const sdk = useSDK()
   const toast = useToast()
   const [toDelete, setToDelete] = createSignal<string>()
+  const [activeSessionID, setActiveSessionID] = createSignal<string>()
   const [search, setSearch] = createDebouncedSignal("", 150)
+  const [recapBySession, setRecapBySession] = createStore<
+    Record<
+      string,
+      {
+        state: "loading" | "ready" | "error"
+        version?: string
+        recap?: SessionRecap
+      }
+    >
+  >({})
+
+  const loadingRecap = new Set<string>()
 
   const [searchResults, { refetch }] = createResource(search, async (query) => {
     if (!query) return undefined
@@ -40,6 +56,67 @@ export function DialogSessionList() {
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
   const sessions = createMemo(() => searchResults() ?? sync.data.session)
+
+  const sessionStatus = createMemo<Record<string, SessionStatus>>(() => sync.data.session_status ?? {})
+
+  function recapVersion(sessionID: string) {
+    const session = sessions().find((item) => item.id === sessionID)
+    const updated = session?.time.updated ?? 0
+    const status = sessionStatus()[sessionID]
+    const state =
+      !status ? "idle" : "attempt" in status ? `${status.type}:${status.attempt}:${status.message ?? ""}` : status.type
+    return `${updated}:${state}`
+  }
+
+  async function ensureRecap(sessionID: string | undefined) {
+    if (!sessionID) return
+    if (loadingRecap.has(sessionID)) return
+    const version = recapVersion(sessionID)
+    if (recapBySession[sessionID]?.state === "ready" && recapBySession[sessionID]?.version === version) return
+
+    loadingRecap.add(sessionID)
+    setRecapBySession(sessionID, {
+      state: "loading",
+      version,
+    })
+
+    try {
+      const [messagesResult, todosResult] = await Promise.all([
+        sdk.client.session.messages({ sessionID, limit: 100 }),
+        sdk.client.session.todo({ sessionID }),
+      ])
+      const recap = deriveSessionRecap({
+        messages: messagesResult.data ?? [],
+        todos: todosResult.data ?? [],
+        status: sessionStatus()[sessionID],
+      })
+      setRecapBySession(sessionID, {
+        state: "ready",
+        version,
+        recap,
+      })
+    } catch {
+      setRecapBySession(sessionID, {
+        state: "error",
+        version,
+      })
+    } finally {
+      loadingRecap.delete(sessionID)
+    }
+  }
+
+  createEffect(() => {
+    const current = currentSessionID()
+    if (!current) return
+    setActiveSessionID(current)
+    void ensureRecap(current)
+  })
+
+  createEffect(() => {
+    const active = activeSessionID()
+    if (!active) return
+    void ensureRecap(active)
+  })
 
   function createWorkspace() {
     dialog.replace(() => (
@@ -170,8 +247,22 @@ export function DialogSessionList() {
       })
   })
 
+  createEffect(() => {
+    if (activeSessionID()) return
+    const first = options()[0]?.value
+    if (!first) return
+    setActiveSessionID(first)
+    void ensureRecap(first)
+  })
+
   onMount(() => {
     dialog.setSize("large")
+  })
+
+  const selectedRecap = createMemo(() => {
+    const sessionID = activeSessionID()
+    if (!sessionID) return
+    return recapBySession[sessionID]
   })
 
   return (
@@ -181,10 +272,47 @@ export function DialogSessionList() {
       skipFilter={true}
       current={currentSessionID()}
       onFilter={setSearch}
-      onMove={() => {
+      onMove={(option) => {
         setToDelete(undefined)
+        setActiveSessionID(option.value)
+      }}
+      selectedDetails={() => {
+        const sessionID = activeSessionID()
+        if (!sessionID) return
+        const recap = selectedRecap()
+        return (
+          <box paddingLeft={4} paddingRight={4} paddingTop={1} flexDirection="column">
+            <text fg={theme.accent}>
+              <b>Resume Aid</b>
+            </text>
+            {recap?.state === "loading" && (
+              <text fg={theme.textMuted} paddingTop={1}>
+                Loading recap...
+              </text>
+            )}
+            {recap?.state === "error" && (
+              <text fg={theme.warning} paddingTop={1}>
+                Recap unavailable.
+              </text>
+            )}
+            {recap?.state === "ready" && recap.recap && (
+              <box flexDirection="column" paddingTop={1}>
+                <text fg={theme.textMuted}>
+                  <b>Done:</b> {recap.recap.done}
+                </text>
+                <text fg={theme.textMuted}>
+                  <b>Blocked:</b> {recap.recap.blocked}
+                </text>
+                <text fg={theme.textMuted}>
+                  <b>Next:</b> {recap.recap.next}
+                </text>
+              </box>
+            )}
+          </box>
+        )
       }}
       onSelect={(option) => {
+        setActiveSessionID(option.value)
         route.navigate({
           type: "session",
           sessionID: option.value,

--- a/packages/opencode/src/cli/cmd/tui/component/session-recap.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/session-recap.ts
@@ -1,0 +1,238 @@
+import type { Message, Part, SessionStatus, Todo } from "@opencode-ai/sdk/v2"
+
+export type SessionMessageWithParts = {
+  info: Message
+  parts: Part[]
+}
+
+export type SessionRecap = {
+  done: string
+  blocked: string
+  next: string
+}
+
+function compactWhitespace(value: string) {
+  return value.replace(/\s+/g, " ").trim()
+}
+
+function firstNonEmptyLine(value: string) {
+  const line = value
+    .split("\n")
+    .map((item) => item.trim())
+    .find((item) => !!item && !item.startsWith("#"))
+  return line ? compactWhitespace(line) : ""
+}
+
+function clip(value: string, max = 160) {
+  if (value.length <= max) return value
+  return `${value.slice(0, max - 1)}…`
+}
+
+function summarizeText(value: string, max = 160) {
+  const line = firstNonEmptyLine(value)
+  if (!line) return ""
+  return clip(line, max)
+}
+
+function extractSection(value: string, heading: string) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const regex = new RegExp(`^##\\s+${escaped}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`, "im")
+  const match = value.match(regex)
+  if (!match?.[1]) return ""
+  return summarizeText(match[1])
+}
+
+function latestAssistantSummaryText(messages: SessionMessageWithParts[]) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (!item || item.info.role !== "assistant" || item.info.summary !== true) continue
+    for (let j = item.parts.length - 1; j >= 0; j--) {
+      const part = item.parts[j]
+      if (!part || part.type !== "text" || part.synthetic || part.ignored) continue
+      const text =
+        extractSection(part.text, "Accomplished") ||
+        extractSection(part.text, "Discoveries") ||
+        summarizeText(part.text)
+      if (text) return text
+    }
+  }
+  return ""
+}
+
+function latestFallbackDone(messages: SessionMessageWithParts[]) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (!item) continue
+
+    if (item.info.role === "assistant") {
+      for (let j = item.parts.length - 1; j >= 0; j--) {
+        const part = item.parts[j]
+        if (!part || part.type !== "text" || part.synthetic || part.ignored) continue
+        const text = summarizeText(part.text)
+        if (text) return text
+      }
+      continue
+    }
+
+    const summary = summarizeText(item.info.summary?.body ?? "")
+    if (summary) return summary
+  }
+  return ""
+}
+
+function deriveBlocked(status: SessionStatus | undefined, messages: SessionMessageWithParts[]) {
+  if (status?.type === "busy") return "Session is currently running."
+  if (status?.type === "retry") {
+    const message = summarizeText(status.message ?? "")
+    return message ? `Retrying: ${message}` : `Retrying (attempt ${status.attempt}).`
+  }
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (!item || item.info.role !== "assistant" || !item.info.error) continue
+    const error = item.info.error as { message?: string; data?: { message?: string } }
+    const message = summarizeText(error.message ?? error.data?.message ?? "")
+    if (message) return message
+    return "Session encountered an error."
+  }
+
+  return "None."
+}
+
+function deriveNext(todos: Todo[]) {
+  const next = todos.find((todo) => todo.status === "in_progress" || todo.status === "pending")
+  if (next?.content) return summarizeText(next.content)
+  return "No pending tasks."
+}
+
+export function deriveSessionRecap(input: {
+  messages: SessionMessageWithParts[]
+  todos: Todo[]
+  status?: SessionStatus
+}): SessionRecap {
+  const done = latestAssistantSummaryText(input.messages) || latestFallbackDone(input.messages) || "No recap yet."
+  return {
+    done,
+    blocked: deriveBlocked(input.status, input.messages),
+    next: deriveNext(input.todos),
+  }
+}
+import type { Message, Part, SessionStatus, Todo } from "@opencode-ai/sdk/v2"
+
+export type SessionMessageWithParts = {
+  info: Message
+  parts: Part[]
+}
+
+export type SessionRecap = {
+  done: string
+  blocked: string
+  next: string
+}
+
+function compactWhitespace(value: string) {
+  return value.replace(/\s+/g, " ").trim()
+}
+
+function firstNonEmptyLine(value: string) {
+  const line = value
+    .split("\n")
+    .map((item) => item.trim())
+    .find((item) => !!item && !item.startsWith("#"))
+  return line ? compactWhitespace(line) : ""
+}
+
+function clip(value: string, max = 160) {
+  if (value.length <= max) return value
+  return `${value.slice(0, max - 1)}…`
+}
+
+function summarizeText(value: string, max = 160) {
+  const line = firstNonEmptyLine(value)
+  if (!line) return ""
+  return clip(line, max)
+}
+
+function extractSection(value: string, heading: string) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const regex = new RegExp(`^##\\s+${escaped}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`, "im")
+  const match = value.match(regex)
+  if (!match?.[1]) return ""
+  return summarizeText(match[1])
+}
+
+function latestAssistantSummaryText(messages: SessionMessageWithParts[]) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (!item || item.info.role !== "assistant" || item.info.summary !== true) continue
+    for (let j = item.parts.length - 1; j >= 0; j--) {
+      const part = item.parts[j]
+      if (!part || part.type !== "text" || part.synthetic || part.ignored) continue
+      const text =
+        extractSection(part.text, "Accomplished") ||
+        extractSection(part.text, "Discoveries") ||
+        summarizeText(part.text)
+      if (text) return text
+    }
+  }
+  return ""
+}
+
+function latestFallbackDone(messages: SessionMessageWithParts[]) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (!item) continue
+
+    if (item.info.role === "assistant") {
+      for (let j = item.parts.length - 1; j >= 0; j--) {
+        const part = item.parts[j]
+        if (!part || part.type !== "text" || part.synthetic || part.ignored) continue
+        const text = summarizeText(part.text)
+        if (text) return text
+      }
+      continue
+    }
+
+    const summary = summarizeText(item.info.summary?.body ?? "")
+    if (summary) return summary
+  }
+  return ""
+}
+
+function deriveBlocked(status: SessionStatus | undefined, messages: SessionMessageWithParts[]) {
+  if (status?.type === "busy") return "Session is currently running."
+  if (status?.type === "retry") {
+    const message = summarizeText(status.message ?? "")
+    return message ? `Retrying: ${message}` : `Retrying (attempt ${status.attempt}).`
+  }
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (!item || item.info.role !== "assistant" || !item.info.error) continue
+    const error = item.info.error as { message?: string; data?: { message?: string } }
+    const message = summarizeText(error.message ?? error.data?.message ?? "")
+    if (message) return message
+    return "Session encountered an error."
+  }
+
+  return "None."
+}
+
+function deriveNext(todos: Todo[]) {
+  const next = todos.find((todo) => todo.status === "in_progress" || todo.status === "pending")
+  if (next?.content) return summarizeText(next.content)
+  return "No pending tasks."
+}
+
+export function deriveSessionRecap(input: {
+  messages: SessionMessageWithParts[]
+  todos: Todo[]
+  status?: SessionStatus
+}): SessionRecap {
+  const done = latestAssistantSummaryText(input.messages) || latestFallbackDone(input.messages) || "No recap yet."
+  return {
+    done,
+    blocked: deriveBlocked(input.status, input.messages),
+    next: deriveNext(input.todos),
+  }
+      }

--- a/packages/opencode/src/cli/cmd/tui/component/session-recap.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/session-recap.ts
@@ -25,7 +25,7 @@ function firstNonEmptyLine(value: string) {
 
 function clip(value: string, max = 160) {
   if (value.length <= max) return value
-  return `${value.slice(0, max - 1)}…`
+  return `${value.slice(0, max - 1)}...`
 }
 
 function summarizeText(value: string, max = 160) {
@@ -35,11 +35,27 @@ function summarizeText(value: string, max = 160) {
 }
 
 function extractSection(value: string, heading: string) {
-  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  const regex = new RegExp(`^##\\s+${escaped}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`, "im")
-  const match = value.match(regex)
-  if (!match?.[1]) return ""
-  return summarizeText(match[1])
+  const lines = value.split("\n")
+  const headingLine = `## ${heading}`.toLowerCase()
+  let start = -1
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim().toLowerCase() === headingLine) {
+      start = i + 1
+      break
+    }
+  }
+
+  if (start === -1) return ""
+
+  const body: string[] = []
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.trim().startsWith("## ")) break
+    body.push(line)
+  }
+
+  return summarizeText(body.join("\n"))
 }
 
 function latestAssistantSummaryText(messages: SessionMessageWithParts[]) {
@@ -65,6 +81,7 @@ function latestFallbackDone(messages: SessionMessageWithParts[]) {
     if (!item) continue
 
     if (item.info.role === "assistant") {
+      if (!item.info.time.completed || item.info.error) continue
       for (let j = item.parts.length - 1; j >= 0; j--) {
         const part = item.parts[j]
         if (!part || part.type !== "text" || part.synthetic || part.ignored) continue
@@ -74,7 +91,8 @@ function latestFallbackDone(messages: SessionMessageWithParts[]) {
       continue
     }
 
-    const summary = summarizeText(item.info.summary?.body ?? "")
+    const summary =
+      typeof item.info.summary === "object" && item.info.summary ? summarizeText(item.info.summary.body ?? "") : ""
     if (summary) return summary
   }
   return ""
@@ -90,8 +108,8 @@ function deriveBlocked(status: SessionStatus | undefined, messages: SessionMessa
   for (let i = messages.length - 1; i >= 0; i--) {
     const item = messages[i]
     if (!item || item.info.role !== "assistant" || !item.info.error) continue
-    const error = item.info.error as { message?: string; data?: { message?: string } }
-    const message = summarizeText(error.message ?? error.data?.message ?? "")
+    const error = item.info.error as { message?: string; data?: { message?: string }; name?: string }
+    const message = summarizeText(error.message ?? error.data?.message ?? error.name ?? "")
     if (message) return message
     return "Session encountered an error."
   }
@@ -117,122 +135,3 @@ export function deriveSessionRecap(input: {
     next: deriveNext(input.todos),
   }
 }
-import type { Message, Part, SessionStatus, Todo } from "@opencode-ai/sdk/v2"
-
-export type SessionMessageWithParts = {
-  info: Message
-  parts: Part[]
-}
-
-export type SessionRecap = {
-  done: string
-  blocked: string
-  next: string
-}
-
-function compactWhitespace(value: string) {
-  return value.replace(/\s+/g, " ").trim()
-}
-
-function firstNonEmptyLine(value: string) {
-  const line = value
-    .split("\n")
-    .map((item) => item.trim())
-    .find((item) => !!item && !item.startsWith("#"))
-  return line ? compactWhitespace(line) : ""
-}
-
-function clip(value: string, max = 160) {
-  if (value.length <= max) return value
-  return `${value.slice(0, max - 1)}…`
-}
-
-function summarizeText(value: string, max = 160) {
-  const line = firstNonEmptyLine(value)
-  if (!line) return ""
-  return clip(line, max)
-}
-
-function extractSection(value: string, heading: string) {
-  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  const regex = new RegExp(`^##\\s+${escaped}\\s*$([\\s\\S]*?)(?=^##\\s+|\\Z)`, "im")
-  const match = value.match(regex)
-  if (!match?.[1]) return ""
-  return summarizeText(match[1])
-}
-
-function latestAssistantSummaryText(messages: SessionMessageWithParts[]) {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const item = messages[i]
-    if (!item || item.info.role !== "assistant" || item.info.summary !== true) continue
-    for (let j = item.parts.length - 1; j >= 0; j--) {
-      const part = item.parts[j]
-      if (!part || part.type !== "text" || part.synthetic || part.ignored) continue
-      const text =
-        extractSection(part.text, "Accomplished") ||
-        extractSection(part.text, "Discoveries") ||
-        summarizeText(part.text)
-      if (text) return text
-    }
-  }
-  return ""
-}
-
-function latestFallbackDone(messages: SessionMessageWithParts[]) {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const item = messages[i]
-    if (!item) continue
-
-    if (item.info.role === "assistant") {
-      for (let j = item.parts.length - 1; j >= 0; j--) {
-        const part = item.parts[j]
-        if (!part || part.type !== "text" || part.synthetic || part.ignored) continue
-        const text = summarizeText(part.text)
-        if (text) return text
-      }
-      continue
-    }
-
-    const summary = summarizeText(item.info.summary?.body ?? "")
-    if (summary) return summary
-  }
-  return ""
-}
-
-function deriveBlocked(status: SessionStatus | undefined, messages: SessionMessageWithParts[]) {
-  if (status?.type === "busy") return "Session is currently running."
-  if (status?.type === "retry") {
-    const message = summarizeText(status.message ?? "")
-    return message ? `Retrying: ${message}` : `Retrying (attempt ${status.attempt}).`
-  }
-
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const item = messages[i]
-    if (!item || item.info.role !== "assistant" || !item.info.error) continue
-    const error = item.info.error as { message?: string; data?: { message?: string } }
-    const message = summarizeText(error.message ?? error.data?.message ?? "")
-    if (message) return message
-    return "Session encountered an error."
-  }
-
-  return "None."
-}
-
-function deriveNext(todos: Todo[]) {
-  const next = todos.find((todo) => todo.status === "in_progress" || todo.status === "pending")
-  if (next?.content) return summarizeText(next.content)
-  return "No pending tasks."
-}
-
-export function deriveSessionRecap(input: {
-  messages: SessionMessageWithParts[]
-  todos: Todo[]
-  status?: SessionStatus
-}): SessionRecap {
-  const done = latestAssistantSummaryText(input.messages) || latestFallbackDone(input.messages) || "No recap yet."
-  return {
-    done,
-    blocked: deriveBlocked(input.status, input.messages),
-    next: deriveNext(input.todos),
-  }
-      }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -23,6 +23,7 @@ export interface DialogSelectProps<T> {
   onFilter?: (query: string) => void
   onSelect?: (option: DialogSelectOption<T>) => void
   skipFilter?: boolean
+  selectedDetails?: (option: DialogSelectOption<T> | undefined) => JSX.Element | undefined
   keybind?: {
     keybind?: Keybind.Info
     title: string
@@ -141,6 +142,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const height = createMemo(() => Math.min(rows(), Math.floor(dimensions().height / 2) - 6))
 
   const selected = createMemo(() => flat()[store.selected])
+  const selectedDetails = createMemo(() => props.selectedDetails?.(selected()))
 
   createEffect(
     on([() => store.filter, () => props.current], ([filter, current]) => {
@@ -361,6 +363,9 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
             )}
           </For>
         </scrollbox>
+      </Show>
+      <Show when={selectedDetails()}>
+        <box flexShrink={0}>{selectedDetails()}</box>
       </Show>
       <Show when={keybinds().length} fallback={<box flexShrink={0} />}>
         <box

--- a/packages/opencode/test/cli/tui/session-recap.test.ts
+++ b/packages/opencode/test/cli/tui/session-recap.test.ts
@@ -17,12 +17,12 @@ function userMessage(id: string, summaryBody?: string): Message {
   }
 }
 
-function assistantMessage(id: string, input: { summary?: boolean; error?: string } = {}): Message {
+function assistantMessage(id: string, input: { summary?: boolean; error?: string; completed?: boolean } = {}): Message {
   return {
     id,
     sessionID: "ses_1",
     role: "assistant",
-    time: { created: 2, completed: 3 },
+    time: { created: 2, completed: input.completed === false ? undefined : 3 },
     parentID: "msg_u_1",
     modelID: "claude",
     providerID: "anthropic",
@@ -124,5 +124,22 @@ describe("deriveSessionRecap", () => {
 
     const recap = deriveSessionRecap({ messages, todos: [] })
     expect(recap.done).toBe("Wired the selected-session recap block into the sessions dialog.")
+  })
+
+  test("ignores errored assistant output when deriving done", () => {
+    const messages: SessionMessageWithParts[] = [
+      {
+        info: assistantMessage("msg_a_1"),
+        parts: [textPart("msg_a_1", "Completed the first pass cleanly.")],
+      },
+      {
+        info: assistantMessage("msg_a_2", { error: "request failed" }),
+        parts: [textPart("msg_a_2", "This partial output should not become done.")],
+      },
+    ]
+
+    const recap = deriveSessionRecap({ messages, todos: [] })
+    expect(recap.done).toBe("Completed the first pass cleanly.")
+    expect(recap.blocked).toContain("request failed")
   })
 })

--- a/packages/opencode/test/cli/tui/session-recap.test.ts
+++ b/packages/opencode/test/cli/tui/session-recap.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test"
+import type { Message, Part, SessionStatus, Todo } from "@opencode-ai/sdk/v2"
+import { deriveSessionRecap, type SessionMessageWithParts } from "../../../src/cli/cmd/tui/component/session-recap"
+
+function userMessage(id: string, summaryBody?: string): Message {
+  return {
+    id,
+    sessionID: "ses_1",
+    role: "user",
+    time: { created: 1 },
+    summary: summaryBody ? { body: summaryBody, diffs: [] } : undefined,
+    agent: "default",
+    model: {
+      providerID: "anthropic",
+      modelID: "claude",
+    },
+  }
+}
+
+function assistantMessage(id: string, input: { summary?: boolean; error?: string } = {}): Message {
+  return {
+    id,
+    sessionID: "ses_1",
+    role: "assistant",
+    time: { created: 2, completed: 3 },
+    parentID: "msg_u_1",
+    modelID: "claude",
+    providerID: "anthropic",
+    mode: "default",
+    agent: "default",
+    path: { cwd: "/tmp", root: "/tmp" },
+    summary: input.summary,
+    cost: 0,
+    tokens: {
+      input: 1,
+      output: 1,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    error: input.error
+      ? {
+          name: "UnknownError",
+          data: { message: input.error },
+        }
+      : undefined,
+  }
+}
+
+function textPart(messageID: string, text: string): Part {
+  return {
+    id: `part_${messageID}`,
+    sessionID: "ses_1",
+    messageID,
+    type: "text",
+    text,
+  }
+}
+
+describe("deriveSessionRecap", () => {
+  test("prefers latest assistant summary for done", () => {
+    const messages: SessionMessageWithParts[] = [
+      {
+        info: userMessage("msg_u_1"),
+        parts: [],
+      },
+      {
+        info: assistantMessage("msg_a_1", { summary: true }),
+        parts: [textPart("msg_a_1", "Completed migration and wired the recap panel.")],
+      },
+    ]
+    const todos: Todo[] = [{ content: "Ship PR", status: "pending", priority: "high" }]
+    const recap = deriveSessionRecap({ messages, todos })
+
+    expect(recap.done).toContain("Completed migration")
+    expect(recap.next).toBe("Ship PR")
+    expect(recap.blocked).toBe("None.")
+  })
+
+  test("uses active work status as blocked when busy", () => {
+    const messages: SessionMessageWithParts[] = [
+      {
+        info: assistantMessage("msg_a_1"),
+        parts: [textPart("msg_a_1", "Working on follow-up checks.")],
+      },
+    ]
+    const todos: Todo[] = []
+    const status: SessionStatus = { type: "busy" }
+    const recap = deriveSessionRecap({ messages, todos, status })
+
+    expect(recap.blocked).toBe("Session is currently running.")
+  })
+
+  test("falls back to user summary body for done", () => {
+    const messages: SessionMessageWithParts[] = [
+      {
+        info: userMessage("msg_u_1", "Refined plan and identified remaining deployment risks."),
+        parts: [],
+      },
+    ]
+    const recap = deriveSessionRecap({ messages, todos: [] })
+
+    expect(recap.done).toContain("Refined plan")
+    expect(recap.next).toBe("No pending tasks.")
+  })
+
+  test("skips markdown headings and prefers accomplished section content", () => {
+    const messages: SessionMessageWithParts[] = [
+      {
+        info: assistantMessage("msg_a_2", { summary: true }),
+        parts: [
+          textPart(
+            "msg_a_2",
+            [
+              "## Goal",
+              "Ship the recap feature.",
+              "",
+              "## Accomplished",
+              "Wired the selected-session recap block into the sessions dialog.",
+            ].join("\n"),
+          ),
+        ],
+      },
+    ]
+
+    const recap = deriveSessionRecap({ messages, todos: [] })
+    expect(recap.done).toBe("Wired the selected-session recap block into the sessions dialog.")
+  })
+})


### PR DESCRIPTION
Closes #23723

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Adds a small Resume Aid panel to the TUI sessions picker.

When a session is selected, it derives three short fields from existing session data:
- Done
- Blocked
- Next

This uses the session messages, todos, and current status that opencode already has. It does not add a new storage layer.

### How did you verify your code works?
- Ran `bun test test/cli/tui/session-recap.test.ts` from `packages/opencode`
- Confirmed the targeted recap suite passes locally (`5 pass, 0 fail`)
- Ran `git diff --check`

### Screenshots / recordings
- Not included in this runtime yet. The change is in the TUI sessions dialog and can be recorded after publish if needed.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR