### PR TITLE
feat(tui): add Explain option to permission prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -438,12 +438,22 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
               title="Permission required"
               header={header()}
               body={current.body}
-              options={{ once: "Allow once", always: "Allow always", reject: "Reject" }}
+              options={{ once: "Allow once", always: "Allow always", explain: "Explain", reject: "Reject" }}
               escapeKey="reject"
               fullscreen
               onSelect={(option) => {
                 if (option === "always") {
                   setStore("stage", "always")
+                  return
+                }
+                if (option === "explain") {
+                  void sdk.client.permission.reply({
+                    reply: "reject",
+                    requestID: props.request.id,
+                    workspace: project.workspace.current(),
+                    message:
+                      "Before I approve this, explain what this tool call does: which files or commands are affected, what behavior changes, and any risks. Then call the tool again with the same arguments.",
+                  })
                   return
                 }
                 if (option === "reject") {


### PR DESCRIPTION
### Issue for this PR

Refs #23729

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an "Explain" option between *Allow always* and *Reject* in the permission prompt. Pressing it sends a reject-with-feedback asking the agent to explain what the pending tool call does before deciding; the agent responds with the explanation and the permission re-asks.

Zero backend changes. 12-line change in `packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx`: adds the option and routes it through the existing reject-with-feedback path with a canned message.

Opening as **draft** because CONTRIBUTING.md asks for design approval on UI/feature work before a PR - posting this as a concrete reference alongside #23729. Happy to close and wait if you'd prefer that order; otherwise will flip to non-draft once the design is approved.

### How did you verify your code works?

- `bun run typecheck` passes clean
- `bunx oxlint` on the changed file: 0 new warnings
- Ran locally, triggered an edit permission, pressed Explain → agent received the feedback, explained the change, permission re-asked.

### Screenshots / recordings
<img width="2555" height="1438" alt="Image" src="https://github.com/user-attachments/assets/7c1df2a2-4556-4eb4-af42-e2248f29b8e1" />

<img width="2177" height="546" alt="Image" src="https://github.com/user-attachments/assets/5f52a02c-ff91-4e56-a21c-f7a2d28f415a" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR