### PR TITLE
feat: add Mistral Small reasoning variant support (issue #19479)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -408,7 +408,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("deepseek") ||
     id.includes("minimax") ||
     id.includes("glm") ||
-    id.includes("mistral") ||
     id.includes("kimi") ||
     id.includes("k2p5") ||
     id.includes("qwen") ||
@@ -713,7 +712,14 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
     case "@ai-sdk/mistral":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
-      return {}
+      // https://docs.mistral.ai/capabilities/reasoning/adjustable
+      if (!model.capabilities.reasoning) return {}
+      // Only Mistral Small 4 supports reasoning (mistral-small-2603, mistral-small-latest)
+      const mistralId = model.api.id.toLowerCase()
+      if (!mistralId.includes("mistral-small-2603") && !mistralId.includes("mistral-small-latest")) return {}
+      return {
+        high: { reasoningEffort: "high" },
+      }
 
     case "@ai-sdk/cohere":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/cohere

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2113,7 +2113,24 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
-  test("mistral returns empty object", () => {
+  test("mistral with reasoning returns variants", () => {
+    const model = createMockModel({
+      id: "mistral/mistral-small-latest",
+      providerID: "mistral",
+      api: {
+        id: "mistral-small-latest",
+        url: "https://api.mistral.com",
+        npm: "@ai-sdk/mistral",
+      },
+      capabilities: { reasoning: true },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      high: { reasoningEffort: "high" },
+    })
+  })
+
+  test("mistral without reasoning returns empty object", () => {
     const model = createMockModel({
       id: "mistral/mistral-large",
       providerID: "mistral",
@@ -2122,6 +2139,22 @@ describe("ProviderTransform.variants", () => {
         url: "https://api.mistral.com",
         npm: "@ai-sdk/mistral",
       },
+      capabilities: { reasoning: false },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({})
+  })
+
+  test("mistral large with reasoning returns empty object (only small supports reasoning)", () => {
+    const model = createMockModel({
+      id: "mistral/mistral-large",
+      providerID: "mistral",
+      api: {
+        id: "mistral-large-latest",
+        url: "https://api.mistral.com",
+        npm: "@ai-sdk/mistral",
+      },
+      capabilities: { reasoning: true },
     })
     const result = ProviderTransform.variants(model)
     expect(result).toEqual({})


### PR DESCRIPTION
### Issue for this PR

Closes #19479 

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds "high" effort to Mistral Small 4.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Tested the "high" setting and without the high setting locally. Thinking shows up consistently on high, and not on the default variant. See below screenshots.

`transform.test.ts` includes a test to check which models return what variants, and checks out on mistral-small-latest (supported) and mistral-large-latest (not supported).

### Screenshots / recordings

On high:

<img width="1087" height="310" alt="image" src="https://github.com/user-attachments/assets/96cda4c3-049e-43c4-b515-7e260037e2d1" />

Without it:

<img width="1126" height="287" alt="2026-04-21--21-40-10" src="https://github.com/user-attachments/assets/a895fbd1-68c3-43ef-98fd-49c8b5ade5ec" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
