### PR TITLE
feat(tui): add mouse-drag sidebar resize

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -13,12 +13,13 @@ import {
   useContext,
 } from "solid-js"
 import { Dynamic } from "solid-js/web"
+import { createStore } from "solid-js/store"
 import path from "path"
 import { useRoute, useRouteData } from "@tui/context/route"
 import { useProject } from "@tui/context/project"
 import { useSync } from "@tui/context/sync"
 import { useEvent } from "@tui/context/event"
-import { SplitBorder } from "@tui/component/border"
+import { EmptyBorder, SplitBorder } from "@tui/component/border"
 import { Spinner } from "@tui/component/spinner"
 import { selectedForeground, useTheme } from "@tui/context/theme"
 import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA } from "@opentui/core"
@@ -155,6 +156,15 @@ export function Session() {
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
   const [sidebarOpen, setSidebarOpen] = createSignal(false)
+  const [persistedSidebarWidth, setPersistedSidebarWidth] = kv.signal("sidebar_width", 42)
+  // Live override during mouse-drag so pixel-level updates don't thrash the kv disk writes.
+  const [liveSidebarWidth, setLiveSidebarWidth] = createSignal<number | null>(null)
+  const [sidebarDrag, setSidebarDrag] = createStore({
+    active: false,
+    startX: 0,
+    startWidth: 0,
+    hovered: false,
+  })
   const [conceal, setConceal] = createSignal(true)
   const [showThinking, setShowThinking] = kv.signal("thinking_visibility", true)
   const [timestamps, setTimestamps] = kv.signal<"hide" | "show">("timestamps", "hide")
@@ -173,7 +183,35 @@ export function Session() {
     return false
   })
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+
+  const SIDEBAR_RESIZE_HANDLE_WIDTH = 1
+  const SIDEBAR_MIN_WIDTH = 20
+  // Upper bound adapts to the terminal: never let the sidebar take more than half the screen,
+  // so dragging wide stays readable on borderline-wide terminals (~120 cols) rather than just the 160+ case.
+  const sidebarMaxWidth = createMemo(() =>
+    Math.max(SIDEBAR_MIN_WIDTH, Math.min(80, Math.floor(dimensions().width / 2))),
+  )
+  const clampSidebarWidth = (w: number) => Math.max(SIDEBAR_MIN_WIDTH, Math.min(sidebarMaxWidth(), w))
+  const sidebarWidth = createMemo(() => clampSidebarWidth(liveSidebarWidth() ?? persistedSidebarWidth()))
+  const contentWidth = createMemo(
+    () => dimensions().width - (sidebarVisible() ? sidebarWidth() + SIDEBAR_RESIZE_HANDLE_WIDTH : 0) - 4,
+  )
+
+  function sidebarDragStart(x: number) {
+    setSidebarDrag({ active: true, startX: x, startWidth: sidebarWidth() })
+  }
+  function sidebarDragMove(x: number) {
+    if (!sidebarDrag.active) return
+    // Sidebar sits on the right edge: dragging left (x decreases) widens it.
+    setLiveSidebarWidth(clampSidebarWidth(sidebarDrag.startWidth + (sidebarDrag.startX - x)))
+  }
+  function sidebarDragEnd() {
+    if (!sidebarDrag.active) return
+    const final = liveSidebarWidth()
+    setSidebarDrag("active", false)
+    setLiveSidebarWidth(null)
+    if (final !== null) setPersistedSidebarWidth(() => final)
+  }
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
@@ -1039,7 +1077,12 @@ export function Session() {
         tui: tuiConfig,
       }}
     >
-      <box flexDirection="row">
+      <box
+        flexDirection="row"
+        onMouseDrag={(e) => sidebarDragMove(e.x)}
+        onMouseUp={sidebarDragEnd}
+        onMouseDragEnd={sidebarDragEnd}
+      >
         <box flexGrow={1} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
           <Show when={session()}>
             <scrollbox
@@ -1196,7 +1239,23 @@ export function Session() {
         <Show when={sidebarVisible()}>
           <Switch>
             <Match when={wide()}>
-              <Sidebar sessionID={route.sessionID} />
+              <box
+                width={SIDEBAR_RESIZE_HANDLE_WIDTH}
+                height="100%"
+                backgroundColor={theme.backgroundPanel}
+                border={["left"]}
+                customBorderChars={{ ...EmptyBorder, vertical: "▏" }}
+                borderColor={
+                  sidebarDrag.active || sidebarDrag.hovered ? theme.warning : theme.backgroundPanel
+                }
+                onMouseOver={() => setSidebarDrag("hovered", true)}
+                onMouseOut={() => setSidebarDrag("hovered", false)}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  sidebarDragStart(e.x)
+                }}
+              />
+              <Sidebar sessionID={route.sessionID} width={sidebarWidth()} />
             </Match>
             <Match when={!wide()}>
               <box

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -8,7 +8,7 @@ import { TuiPluginRuntime } from "../../plugin"
 
 import { getScrollAcceleration } from "../../util/scroll"
 
-export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+export function Sidebar(props: { sessionID: string; overlay?: boolean; width?: number }) {
   const project = useProject()
   const sync = useSync()
   const { theme } = useTheme()
@@ -32,7 +32,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     <Show when={session()}>
       <box
         backgroundColor={theme.backgroundPanel}
-        width={42}
+        width={props.width ?? 42}
         height="100%"
         paddingTop={1}
         paddingBottom={1}


### PR DESCRIPTION
### Issue for this PR

Closes #6087

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the TUI right sidebar resizable by dragging its left edge. The sidebar width was previously hard-coded to 42 columns in `sidebar.tsx` and referenced again in `routes/session/index.tsx`; there was no way to change it short of patching the binary.

Behavior:
- 1-col resize handle sits at the sidebar/chat boundary. Idle: invisible (same bg as the panel). Hover/drag: highlighted in `theme.warning` (same yellow used by the permission prompt triangle, for visual consistency).
- Mouse drag adjusts width live; the persisted value is written once on drag-end, not on every pixel, to avoid thrashing the kv.json disk writes.
- Width clamped to `[20, min(80, floor(terminal_width / 2))]` - the dynamic upper bound prevents the sidebar from swallowing the chat on borderline-wide terminals (~120 cols).
- Persisted via the existing `kv.signal` under `sidebar_width`, survives restarts.
- Resize UI only appears in wide (inline) mode - in narrow/overlay mode the sidebar floats over the chat, where resizing has no meaning.

This picks up the design from #5917 (mouse-drag, width-persist, 20–80 clamp, 1px handle) which @agustif got a thumbs-up for from the team before it auto-closed at 60 days stale. The codebase had drifted too much (kv.signal refactor, no-floating-promises rule, etc.) for a clean rebase, so this is a fresh implementation with the same UX. @agustif is credited via `Co-Authored-By` on the commit.

Previous attempts:
- #5504 - keybind-based approach; maintainer (@rekram1-node) suggested mouse instead
- #5917 - mouse approach that got team approval but went stale
- #14271 - unrelated split-sidebar work, auto-closed for no linked issue

Opening as **draft** per CONTRIBUTING.md's design-approval expectation on UI features - happy to flip to ready-for-review once approved, or close if you'd prefer to discuss the design more on #6087 first.

### How did you verify your code works?

- `bun run typecheck` passes clean (tsgo, cache-bypassed full run)
- `bunx oxlint` on the changed files: 0 new warnings (19 baseline → 19 after)
- Ran locally with `bun dev .` - hovering the sidebar/chat boundary highlights the handle yellow, drag resizes, value persists across restarts. Tested at 120/160/200 terminal widths; dynamic clamp keeps chat readable.

### Screenshots / recordings

https://github.com/user-attachments/assets/d577ad93-be12-4bc4-bd0b-26540e71dcb0

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR