### PR TITLE
fix: avoid timeout race in workspace.create for local workspaces

### DIFF
--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -121,18 +121,26 @@ export const create = fn(CreateInput, async (input) => {
   }
   await adaptor.create(config, env)
 
-  startSync(info)
-
-  await waitEvent({
-    timeout: TIMEOUT,
-    fn(event) {
-      if (event.workspace === info.id && event.payload.type === Event.Status.type) {
-        const { status } = event.payload.properties
-        return status === "error" || status === "connected"
-      }
-      return false
-    },
-  })
+  const target = await adaptor.target(info)
+  if (target.type === "local") {
+    // Local workspaces: directory was just created by adaptor.create().
+    // Set connected status eagerly to avoid racing startSync's async
+    // Filesystem.exists check against the waitEvent timeout.
+    setStatus(info.id, "connected")
+    startSync(info)
+  } else {
+    startSync(info)
+    await waitEvent({
+      timeout: TIMEOUT,
+      fn(event) {
+        if (event.workspace === info.id && event.payload.type === Event.Status.type) {
+          const { status } = event.payload.properties
+          return status === "error" || status === "connected"
+        }
+        return false
+      },
+    })
+  }
 
   return info
 })
@@ -567,9 +575,8 @@ async function startSync(space: Info) {
   const target = await adaptor.target(space)
 
   if (target.type === "local") {
-    void Filesystem.exists(target.directory).then((exists) => {
-      setStatus(space.id, exists ? "connected" : "error")
-    })
+    const exists = await Filesystem.exists(target.directory)
+    setStatus(space.id, exists ? "connected" : "error")
     return
   }
 


### PR DESCRIPTION
﻿### Issue for this PR

Closes #23746

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes `workspace.create()` always timing out with "Timed out waiting for global event" for local (worktree) workspaces on Windows.

There are two bugs in `packages/opencode/src/control-plane/workspace.ts`:

**1. Fire-and-forget race in `startSync`** (line 569): `void Filesystem.exists(...).then(...)` schedules the `setStatus("connected")` callback asynchronously. `create()` calls `waitEvent()` with a 5-second timeout, but on Windows the event loop consistently delays the `.then()` callback past the timeout. Fixed by awaiting the `Filesystem.exists` call directly.

**2. Missing status emit for local workspaces after create** (line 124): After `adaptor.create()` succeeds for a local workspace, the code falls through to `waitEvent()` waiting for a status change that depends on the async `startSync` completing first. For local targets (where the filesystem already exists), the fix eagerly sets `"connected"` status right after create, skipping the race entirely. Remote targets still go through the existing `waitEvent` path.

The workspace IS created successfully by `adaptor.create()` — only the status confirmation is broken, causing the API to return an error despite success.

### How did you verify your code works?

Built the patched binary (`bun run --cwd packages/opencode build --single --skip-embed-web-ui --skip-install`) and tested against stock v1.14.20 as a control:

- **Stock binary**: `POST /experimental/workspace` → ❌ `{"name":"UnknownError","data":{"message":"Error: Timed out waiting for global event"}}`
- **Patched binary**: `POST /experimental/workspace` → ✅ `200 OK` in 4.1 seconds, workspace fully functional

Tested on Windows 11 x64 with Bun 1.3.11.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
