### PR TITLE
migrate Snapshot schemas to Effect Schema

### DIFF
--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -471,7 +471,7 @@ export const SessionRoutes = lazy(() =>
             description: "Successfully retrieved diff",
             content: {
               "application/json": {
-                schema: resolver(Snapshot.FileDiff.array()),
+                schema: resolver(Snapshot.FileDiff.zod.array()),
               },
             },
           },

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -366,7 +366,7 @@ export const User = Base.extend({
     .object({
       title: z.string().optional(),
       body: z.string().optional(),
-      diffs: Snapshot.FileDiff.array(),
+      diffs: Snapshot.FileDiff.zod.array(),
     })
     .optional(),
   agent: z.string(),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -127,7 +127,7 @@ export const Info = z
         additions: z.number(),
         deletions: z.number(),
         files: z.number(),
-        diffs: Snapshot.FileDiff.array().optional(),
+        diffs: Snapshot.FileDiff.zod.array().optional(),
       })
       .optional(),
     share: z
@@ -239,7 +239,7 @@ export const Event = {
     "session.diff",
     z.object({
       sessionID: SessionID.zod,
-      diff: Snapshot.FileDiff.array(),
+      diff: Snapshot.FileDiff.zod.array(),
     }),
   ),
   Error: BusEvent.define(

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -1,4 +1,4 @@
-import { Cause, Duration, Effect, Layer, Schedule, Semaphore, Context, Stream } from "effect"
+import { Cause, Duration, Effect, Layer, Schedule, Schema, Semaphore, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { formatPatch, structuredPatch } from "diff"
 import path from "path"
@@ -10,25 +10,25 @@ import { Hash } from "@opencode-ai/shared/util/hash"
 import { Config } from "../config"
 import { Global } from "../global"
 import { Log } from "../util"
+import { withStatics } from "@/util/schema"
+import { zod } from "@/util/effect-zod"
 
-export const Patch = z.object({
-  hash: z.string(),
-  files: z.string().array(),
+export const Patch = Schema.Struct({
+  hash: Schema.String,
+  files: Schema.mutable(Schema.Array(Schema.String)),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type Patch = typeof Patch.Type
+
+export const FileDiff = Schema.Struct({
+  file: Schema.String,
+  patch: Schema.String,
+  additions: Schema.Number,
+  deletions: Schema.Number,
+  status: Schema.optional(Schema.Literals(["added", "deleted", "modified"])),
 })
-export type Patch = z.infer<typeof Patch>
-
-export const FileDiff = z
-  .object({
-    file: z.string(),
-    patch: z.string(),
-    additions: z.number(),
-    deletions: z.number(),
-    status: z.enum(["added", "deleted", "modified"]).optional(),
-  })
-  .meta({
-    ref: "SnapshotFileDiff",
-  })
-export type FileDiff = z.infer<typeof FileDiff>
+  .annotate({ identifier: "SnapshotFileDiff" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type FileDiff = typeof FileDiff.Type
 
 const log = Log.create({ service: "snapshot" })
 const prune = "7.days"

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -153,15 +153,17 @@ export const EditTool = Tool.define(
             }).pipe(Effect.orDie),
           )
 
+          let additions = 0
+          let deletions = 0
+          for (const change of diffLines(contentOld, contentNew)) {
+            if (change.added) additions += change.count || 0
+            if (change.removed) deletions += change.count || 0
+          }
           const filediff: Snapshot.FileDiff = {
             file: filePath,
             patch: diff,
-            additions: 0,
-            deletions: 0,
-          }
-          for (const change of diffLines(contentOld, contentNew)) {
-            if (change.added) filediff.additions += change.count || 0
-            if (change.removed) filediff.deletions += change.count || 0
+            additions,
+            deletions,
           }
 
           yield* ctx.metadata({


### PR DESCRIPTION
## Summary

- Migrates `Snapshot.Patch` and `Snapshot.FileDiff` from Zod-first to Effect Schema with `.zod` compatibility shims
- Updates zod-boundary consumers (`session.ts`, `message-v2.ts`, route files) to use `.zod`
- Refactors `tool/edit.ts` to compute `additions`/`deletions` before constructing the readonly `FileDiff` object
- SDK openapi.json output is byte-identical

Part of the schema migration tracked in `specs/effect/schema.md`.