### PR TITLE
refactor(core): derive provider schema .zod via effect-zod walker

### DIFF
--- a/packages/opencode/specs/effect/schema.md
+++ b/packages/opencode/specs/effect/schema.md
@@ -162,7 +162,7 @@ schema module with a clear domain.
 - [ ] `src/control-plane/schema.ts`
 - [ ] `src/permission/schema.ts`
 - [ ] `src/project/schema.ts`
-- [ ] `src/provider/schema.ts`
+- [x] `src/provider/schema.ts`
 - [ ] `src/pty/schema.ts`
 - [ ] `src/question/schema.ts`
 - [ ] `src/session/schema.ts`

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
-import z from "zod"
 
+import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 const providerIdSchema = Schema.String.pipe(Schema.brand("ProviderID"))
@@ -9,7 +9,7 @@ export type ProviderID = typeof providerIdSchema.Type
 
 export const ProviderID = providerIdSchema.pipe(
   withStatics((schema: typeof providerIdSchema) => ({
-    zod: z.string().pipe(z.custom<ProviderID>()),
+    zod: zod(schema),
     // Well-known providers
     opencode: schema.make("opencode"),
     anthropic: schema.make("anthropic"),
@@ -30,7 +30,7 @@ const modelIdSchema = Schema.String.pipe(Schema.brand("ModelID"))
 export type ModelID = typeof modelIdSchema.Type
 
 export const ModelID = modelIdSchema.pipe(
-  withStatics((_schema: typeof modelIdSchema) => ({
-    zod: z.string().pipe(z.custom<ModelID>()),
+  withStatics((schema: typeof modelIdSchema) => ({
+    zod: zod(schema),
   })),
 )


### PR DESCRIPTION
## Summary

- Replace hand-written `z.string().pipe(z.custom<T>())` wrappers in `src/provider/schema.ts` with `zod(schema)` from `@/util/effect-zod` so `ProviderID.zod` / `ModelID.zod` are derived from the canonical Effect Schema instead of maintained separately.
- Mark `src/provider/schema.ts` complete in `specs/effect/schema.md` progress tracker. Unblocks the session/message-v2 cluster that depends on provider IDs.

## Verification

- `bun typecheck` passes
- `bun run test test/util/effect-zod.test.ts` — 60/60 pass
- Regenerated SDK (`packages/sdk/openapi.json`, `packages/sdk/js/src/v2/gen/types.gen.ts`) — byte-identical