### PR TITLE
refactor(core): derive all schema.ts leaves' .zod via effect-zod walker

### DIFF
--- a/packages/opencode/specs/effect/schema.md
+++ b/packages/opencode/specs/effect/schema.md
@@ -161,7 +161,7 @@ schema module with a clear domain.
 
 - [ ] `src/control-plane/schema.ts`
 - [ ] `src/permission/schema.ts`
-- [ ] `src/project/schema.ts`
+- [x] `src/project/schema.ts`
 - [x] `src/provider/schema.ts`
 - [ ] `src/pty/schema.ts`
 - [ ] `src/question/schema.ts`

--- a/packages/opencode/specs/effect/schema.md
+++ b/packages/opencode/specs/effect/schema.md
@@ -159,15 +159,15 @@ Schema at source.
 These are the highest-priority next targets. Each is a small, self-contained
 schema module with a clear domain.
 
-- [ ] `src/control-plane/schema.ts`
-- [ ] `src/permission/schema.ts`
+- [x] `src/control-plane/schema.ts`
+- [x] `src/permission/schema.ts`
 - [x] `src/project/schema.ts`
 - [x] `src/provider/schema.ts`
-- [ ] `src/pty/schema.ts`
-- [ ] `src/question/schema.ts`
-- [ ] `src/session/schema.ts`
-- [ ] `src/sync/schema.ts`
-- [ ] `src/tool/schema.ts`
+- [x] `src/pty/schema.ts`
+- [x] `src/question/schema.ts`
+- [x] `src/session/schema.ts`
+- [x] `src/sync/schema.ts`
+- [x] `src/tool/schema.ts`
 
 ### Session domain
 

--- a/packages/opencode/src/control-plane/schema.ts
+++ b/packages/opencode/src/control-plane/schema.ts
@@ -1,8 +1,7 @@
 import { Schema } from "effect"
-import z from "zod"
 
 import { Identifier } from "@/id/id"
-import { ZodOverride } from "@/util/effect-zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 const workspaceIdSchema = Schema.String.annotate({ [ZodOverride]: Identifier.schema("workspace") }).pipe(
@@ -14,6 +13,6 @@ export type WorkspaceID = typeof workspaceIdSchema.Type
 export const WorkspaceID = workspaceIdSchema.pipe(
   withStatics((schema: typeof workspaceIdSchema) => ({
     ascending: (id?: string) => schema.make(Identifier.ascending("workspace", id)),
-    zod: Identifier.schema("workspace").pipe(z.custom<WorkspaceID>()),
+    zod: zod(schema),
   })),
 )

--- a/packages/opencode/src/permission/schema.ts
+++ b/packages/opencode/src/permission/schema.ts
@@ -1,8 +1,7 @@
 import { Schema } from "effect"
-import z from "zod"
 
 import { Identifier } from "@/id/id"
-import { ZodOverride } from "@/util/effect-zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
 import { Newtype } from "@/util/schema"
 
 export class PermissionID extends Newtype<PermissionID>()(
@@ -13,5 +12,5 @@ export class PermissionID extends Newtype<PermissionID>()(
     return this.make(Identifier.ascending("permission", id))
   }
 
-  static readonly zod = Identifier.schema("permission") as unknown as z.ZodType<PermissionID>
+  static readonly zod = zod(this)
 }

--- a/packages/opencode/src/project/schema.ts
+++ b/packages/opencode/src/project/schema.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
-import z from "zod"
 
+import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 const projectIdSchema = Schema.String.pipe(Schema.brand("ProjectID"))
@@ -10,6 +10,6 @@ export type ProjectID = typeof projectIdSchema.Type
 export const ProjectID = projectIdSchema.pipe(
   withStatics((schema: typeof projectIdSchema) => ({
     global: schema.make("global"),
-    zod: z.string().pipe(z.custom<ProjectID>()),
+    zod: zod(schema),
   })),
 )

--- a/packages/opencode/src/pty/schema.ts
+++ b/packages/opencode/src/pty/schema.ts
@@ -1,8 +1,7 @@
 import { Schema } from "effect"
-import z from "zod"
 
 import { Identifier } from "@/id/id"
-import { ZodOverride } from "@/util/effect-zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 const ptyIdSchema = Schema.String.annotate({ [ZodOverride]: Identifier.schema("pty") }).pipe(Schema.brand("PtyID"))
@@ -12,6 +11,6 @@ export type PtyID = typeof ptyIdSchema.Type
 export const PtyID = ptyIdSchema.pipe(
   withStatics((schema: typeof ptyIdSchema) => ({
     ascending: (id?: string) => schema.make(Identifier.ascending("pty", id)),
-    zod: Identifier.schema("pty").pipe(z.custom<PtyID>()),
+    zod: zod(schema),
   })),
 )

--- a/packages/opencode/src/question/schema.ts
+++ b/packages/opencode/src/question/schema.ts
@@ -1,8 +1,7 @@
 import { Schema } from "effect"
-import z from "zod"
 
 import { Identifier } from "@/id/id"
-import { ZodOverride } from "@/util/effect-zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
 import { Newtype } from "@/util/schema"
 
 export class QuestionID extends Newtype<QuestionID>()(
@@ -13,5 +12,5 @@ export class QuestionID extends Newtype<QuestionID>()(
     return this.make(Identifier.ascending("question", id))
   }
 
-  static readonly zod = Identifier.schema("question") as unknown as z.ZodType<QuestionID>
+  static readonly zod = zod(this)
 }

--- a/packages/opencode/src/session/schema.ts
+++ b/packages/opencode/src/session/schema.ts
@@ -1,15 +1,14 @@
 import { Schema } from "effect"
-import z from "zod"
 
 import { Identifier } from "@/id/id"
-import { ZodOverride } from "@/util/effect-zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 export const SessionID = Schema.String.annotate({ [ZodOverride]: Identifier.schema("session") }).pipe(
   Schema.brand("SessionID"),
   withStatics((s) => ({
     descending: (id?: string) => s.make(Identifier.descending("session", id)),
-    zod: Identifier.schema("session").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
+    zod: zod(s),
   })),
 )
 
@@ -19,7 +18,7 @@ export const MessageID = Schema.String.annotate({ [ZodOverride]: Identifier.sche
   Schema.brand("MessageID"),
   withStatics((s) => ({
     ascending: (id?: string) => s.make(Identifier.ascending("message", id)),
-    zod: Identifier.schema("message").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
+    zod: zod(s),
   })),
 )
 
@@ -29,7 +28,7 @@ export const PartID = Schema.String.annotate({ [ZodOverride]: Identifier.schema(
   Schema.brand("PartID"),
   withStatics((s) => ({
     ascending: (id?: string) => s.make(Identifier.ascending("part", id)),
-    zod: Identifier.schema("part").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
+    zod: zod(s),
   })),
 )
 

--- a/packages/opencode/src/sync/schema.ts
+++ b/packages/opencode/src/sync/schema.ts
@@ -1,14 +1,13 @@
 import { Schema } from "effect"
-import z from "zod"
 
 import { Identifier } from "@/id/id"
-import { ZodOverride } from "@/util/effect-zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 export const EventID = Schema.String.annotate({ [ZodOverride]: Identifier.schema("event") }).pipe(
   Schema.brand("EventID"),
   withStatics((s) => ({
     ascending: (id?: string) => s.make(Identifier.ascending("event", id)),
-    zod: Identifier.schema("event").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
+    zod: zod(s),
   })),
 )

--- a/packages/opencode/src/tool/schema.ts
+++ b/packages/opencode/src/tool/schema.ts
@@ -1,8 +1,7 @@
 import { Schema } from "effect"
-import z from "zod"
 
 import { Identifier } from "@/id/id"
-import { ZodOverride } from "@/util/effect-zod"
+import { zod, ZodOverride } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
 
 const toolIdSchema = Schema.String.annotate({ [ZodOverride]: Identifier.schema("tool") }).pipe(Schema.brand("ToolID"))
@@ -12,6 +11,6 @@ export type ToolID = typeof toolIdSchema.Type
 export const ToolID = toolIdSchema.pipe(
   withStatics((schema: typeof toolIdSchema) => ({
     ascending: (id?: string) => schema.make(Identifier.ascending("tool", id)),
-    zod: Identifier.schema("tool").pipe(z.custom<ToolID>()),
+    zod: zod(schema),
   })),
 )


### PR DESCRIPTION
## Summary

Replace hand-written `z.custom<T>()` wrappers across all remaining `src/*/schema.ts` leaf modules with `zod(schema)` from `@/util/effect-zod`. Each ID schema already carries either a `ZodOverride` annotation (`Identifier.schema(...)`) or a plain `Schema.brand(...)`, so the walker returns the same zod value with the proper branded type attached.

### Files migrated
- `src/project/schema.ts`
- `src/control-plane/schema.ts`
- `src/permission/schema.ts`
- `src/pty/schema.ts`
- `src/question/schema.ts`
- `src/session/schema.ts` (SessionID, MessageID, PartID)
- `src/sync/schema.ts`
- `src/tool/schema.ts`

All checked off in `specs/effect/schema.md` progress tracker — the entire `src/*/schema.ts` leaf section is now complete, unblocking the session/message-v2 migration cluster.

## Verification

- `bun typecheck` passes
- Regenerated SDK (`packages/sdk/openapi.json`, `packages/sdk/js/src/v2/gen/types.gen.ts`) — byte-identical