### PR TITLE
refactor(core): migrate MessageV2 internal Cursor to Effect Schema

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -638,18 +638,20 @@ export type WithParts = {
   parts: Part[]
 }
 
-const Cursor = z.object({
-  id: MessageID.zod,
-  time: z.number(),
+const Cursor = Schema.Struct({
+  id: MessageID,
+  time: Schema.Number,
 })
-type Cursor = z.infer<typeof Cursor>
+type Cursor = typeof Cursor.Type
+
+const decodeCursor = Schema.decodeUnknownSync(Cursor)
 
 export const cursor = {
   encode(input: Cursor) {
     return Buffer.from(JSON.stringify(input)).toString("base64url")
   },
   decode(input: string) {
-    return Cursor.parse(JSON.parse(Buffer.from(input, "base64url").toString("utf8")))
+    return decodeCursor(JSON.parse(Buffer.from(input, "base64url").toString("utf8")))
   },
 }
 


### PR DESCRIPTION
Stacked on #23757.

Tiny cleanup — migrates the internal Cursor schema (used by paginated message queries) from Zod to Effect Schema. Not on the SDK surface.

## Acceptance check

- `bun typecheck` clean.
- `bun run test test/session` → 282 pass / 0 fail.
- `bun dev generate` byte-identical to committed `packages/sdk/openapi.json`.