### PR TITLE
feat(tui): add subagent status indicator in prompt footer

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -150,6 +150,35 @@ export function Prompt(props: PromptProps) {
   const dialog = useDialog()
   const toast = useToast()
   const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
+  const subagents = createMemo(() => {
+    if (!props.sessionID) return { total: 0, active: 0 }
+    const byParent = new Map<string, (typeof sync.data.session)[number][]>()
+    for (const s of sync.data.session) {
+      if (!s.parentID) continue
+      const list = byParent.get(s.parentID) ?? []
+      list.push(s)
+      byParent.set(s.parentID, list)
+    }
+    const descendants: (typeof sync.data.session)[number][] = []
+    const queue = [props.sessionID]
+    const visited = new Set<string>()
+    while (queue.length > 0) {
+      const pid = queue.pop()!
+      if (visited.has(pid)) continue
+      visited.add(pid)
+      const children = byParent.get(pid)
+      if (!children) continue
+      for (const c of children) {
+        descendants.push(c)
+        queue.push(c.id)
+      }
+    }
+    const active = descendants.filter((d) => {
+      const st = sync.data.session_status[d.id]?.type
+      return st === "busy" || st === "retry"
+    }).length
+    return { total: descendants.length, active }
+  })
   const history = usePromptHistory()
   const stash = usePromptStash()
   const command = useCommandPalette()
@@ -1761,6 +1790,12 @@ export function Prompt(props: PromptProps) {
                   </Switch>
                   <text fg={theme.text}>
                     {paletteShortcut()} <span style={{ fg: theme.textMuted }}>commands</span>
+                    <Show when={subagents().total > 0}>
+                      <span style={{ fg: subagents().active > 0 ? theme.warning : theme.textMuted }}>
+                        {subagents().active > 0 ? " ⚡" : " "}
+                        {subagents().active}/{subagents().total} sub agents
+                      </span>
+                    </Show>
                   </text>
                 </Match>
                 <Match when={store.mode === "shell"}>


### PR DESCRIPTION
### Issue for this PR

Closes #23784

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a subagent status indicator to the TUI prompt footer. Currently there is no visual indication of subagent activity in the main prompt view — users must navigate to the subagent view to check.

The change computes recursive descendant count (including nested subagents) from session data using BFS traversal, checks `session_status` for \"busy\" or \"retry\" states to determine active count, and conditionally renders in the prompt footer:
- Hidden when no subagents exist
- Shows `active/total sub agents` in muted color when no subagents are active
- Shows `⚡active/total sub agents` in warning color when subagents are active

### How did you verify your code works?

- Tested with multiple nested subagent hierarchies
- Verified count updates correctly as subagents complete or become active
- Verified indicator is hidden when no subagents exist

### Screenshots / recordings

**With active subagent:**
<img width="364" height="91" alt="subagent_status_with_active_subagent" src="https://github.com/user-attachments/assets/1c3a9832-0517-4c76-8b71-0adc704e8b12" />


**Without active subagent:**
<img width="361" height="86" alt="subagent_status_without_active_subagent" src="https://github.com/user-attachments/assets/b2f60d9b-f912-46e9-a8fd-46f4b962bfe5" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR