### PR TITLE
fix(desktop): avoid relaunching without installing updates

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -129,13 +129,12 @@ export const SettingsGeneral: Component = () => {
         }
 
         const actions =
-          platform.update && platform.restart
+          platform.updateAndRestart
             ? [
                 {
                   label: language.t("toast.update.action.installRestart"),
                   onClick: async () => {
-                    await platform.update!()
-                    await platform.restart!()
+                    await platform.updateAndRestart!()
                   },
                 },
                 {

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -49,11 +49,11 @@ export type Platform = {
   /** Storage mechanism, defaults to localStorage */
   storage?: (name?: string) => SyncStorage | AsyncStorage
 
-  /** Check for updates (Tauri only) */
+  /** Check for a downloadable desktop update */
   checkUpdate?(): Promise<UpdateInfo>
 
-  /** Install updates (Tauri only) */
-  update?(): Promise<void>
+  /** Install the downloaded update using the platform restart flow */
+  updateAndRestart?(): Promise<void>
 
   /** Fetch override */
   fetch?: typeof fetch

--- a/packages/app/src/pages/error.tsx
+++ b/packages/app/src/pages/error.tsx
@@ -244,10 +244,9 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
   }
 
   async function installUpdate() {
-    if (!platform.update || !platform.restart) return
+    if (!platform.updateAndRestart) return
     await platform
-      .update()
-      .then(() => platform.restart!())
+      .updateAndRestart()
       .then(() => setStore("actionError", undefined))
       .catch((err) => {
         setStore("actionError", formatError(err, language.t))

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -366,7 +366,7 @@ export default function Layout(props: ParentProps) {
 
   const useUpdatePolling = () =>
     onMount(() => {
-      if (!platform.checkUpdate || !platform.update || !platform.restart) return
+      if (!platform.checkUpdate || !platform.updateAndRestart) return
 
       let toastId: number | undefined
       let interval: ReturnType<typeof setInterval> | undefined
@@ -384,8 +384,7 @@ export default function Layout(props: ParentProps) {
               {
                 label: language.t("toast.update.action.installRestart"),
                 onClick: async () => {
-                  await platform.update!()
-                  await platform.restart!()
+                  await platform.updateAndRestart!()
                 },
               },
               {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -337,11 +337,16 @@ function setupAutoUpdater() {
   })
 }
 
-let updateReady = false
+let downloadedUpdateVersion: string | undefined
 
 async function checkUpdate() {
   if (!UPDATER_ENABLED) return { updateAvailable: false }
-  updateReady = false
+  if (downloadedUpdateVersion) {
+    logger.log("returning cached downloaded update", {
+      version: downloadedUpdateVersion,
+    })
+    return { updateAvailable: true, version: downloadedUpdateVersion }
+  }
   logger.log("checking for updates", {
     currentVersion: app.getVersion(),
     channel: autoUpdater.channel,
@@ -367,7 +372,7 @@ async function checkUpdate() {
     logger.log("update available", { version })
     await autoUpdater.downloadUpdate()
     logger.log("update download completed", { version })
-    updateReady = true
+    downloadedUpdateVersion = version
     return { updateAvailable: true, version }
   } catch (error) {
     logger.error("update check failed", error)
@@ -376,7 +381,15 @@ async function checkUpdate() {
 }
 
 async function installUpdate() {
-  if (!updateReady) return
+  if (!downloadedUpdateVersion) {
+    logger.log("install update skipped", {
+      reason: "no downloaded update ready",
+    })
+    return
+  }
+  logger.log("installing downloaded update", {
+    version: downloadedUpdateVersion,
+  })
   killSidecar()
   autoUpdater.quitAndInstall()
 }

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -170,7 +170,7 @@ const createPlatform = (): Platform => {
       return window.api.checkUpdate()
     },
 
-    update: async () => {
+    updateAndRestart: async () => {
       const config = await window.api.getWindowConfig().catch(() => ({ updaterEnabled: false }))
       if (!config.updaterEnabled) return
       await window.api.installUpdate()

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -297,10 +297,15 @@ const createPlatform = (): Platform => {
       return { updateAvailable: true, version: next.version }
     },
 
-    update: async () => {
+    updateAndRestart: async () => {
       if (!UPDATER_ENABLED || !update) return
       if (ostype() === "windows") await commands.killSidecar().catch(() => undefined)
-      await update.install().catch(() => undefined)
+      const installed = await update
+        .install()
+        .then(() => true)
+        .catch(() => false)
+      if (!installed) return
+      await relaunch()
     },
 
     restart: async () => {


### PR DESCRIPTION
## Summary
- make desktop update installs go through a single `updateAndRestart` platform action instead of separate install and restart calls
- cache the downloaded Electron update version so later background checks do not clear install readiness before the user clicks install
- remove the old `update` platform API so the shared app only uses the platform-specific install-and-restart flow

## Testing
- bun typecheck (packages/app)
- bun typecheck (packages/desktop)
- bun typecheck (packages/desktop-electron)