### PR TITLE
test: fix cross-spawn stderr race on Windows CI

### DIFF
--- a/packages/opencode/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/opencode/test/effect/cross-spawn-spawner.test.ts
@@ -169,7 +169,10 @@ describe("cross-spawn spawner", () => {
             'process.stderr.write("stderr\\n", done)',
           ].join("\n"),
         )
-        const [stdout, stderr] = yield* Effect.all([decodeByteStream(handle.stdout), decodeByteStream(handle.stderr)])
+        const [stdout, stderr] = yield* Effect.all(
+          [decodeByteStream(handle.stdout), decodeByteStream(handle.stderr)],
+          { concurrency: 2 },
+        )
         expect(stdout).toBe("stdout")
         expect(stderr).toBe("stderr")
       }),


### PR DESCRIPTION
## Summary
- read `stdout` and `stderr` concurrently in the cross-spawn spawner stderr test
- avoid the Windows CI race where the `stderr` subscriber can attach after the child has already exited
- keep the fix scoped to the flaky test path only

## Validation
- `bun test test/effect/cross-spawn-spawner.test.ts -t "captures both stdout and stderr" --rerun-each=200 --timeout=30000`
- local stress repro of the original sequential pattern failed immediately; the concurrent version passed