### PR TITLE
ci: add platform-specific bun install flags

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,5 +1,10 @@
 name: "Setup Bun"
 description: "Setup Bun with caching and install dependencies"
+inputs:
+  install-flags:
+    description: "Additional flags to pass to 'bun install'"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -46,8 +51,8 @@ runs:
         # e.g. ./patches/ for standard-openapi
         # https://github.com/oven-sh/bun/issues/28147
         if [ "$RUNNER_OS" = "Windows" ]; then
-          bun install --linker hoisted
+          bun install --linker hoisted ${{ inputs.install-flags }}
         else
-          bun install
+          bun install ${{ inputs.install-flags }}
         fi
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -414,19 +414,15 @@ jobs:
           - host: "windows-2025"
             target: aarch64-pc-windows-msvc
             platform_flag: --win --arm64
-            bun_install_flags: --os=win32 --cpu=arm64
           - host: "blacksmith-4vcpu-windows-2025"
             target: x86_64-pc-windows-msvc
             platform_flag: --win
-            bun_install_flags: --os=win32 --cpu=x64
           - host: "blacksmith-4vcpu-ubuntu-2404"
             target: x86_64-unknown-linux-gnu
             platform_flag: --linux
-            bun_install_flags: --os=linux --cpu=x64
           - host: "blacksmith-4vcpu-ubuntu-2404"
             target: aarch64-unknown-linux-gnu
             platform_flag: --linux
-            bun_install_flags: --os=linux --cpu=arm64
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -443,6 +443,8 @@ jobs:
         run: echo "${{ secrets.APPLE_API_KEY_PATH }}" > $RUNNER_TEMP/apple-api-key.p8
 
       - uses: ./.github/actions/setup-bun
+        with:
+          install-flags: ${{ matrix.settings.bun_install_flags }}
 
       - name: Azure login
         if: runner.os == 'Windows'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -405,22 +405,28 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             platform_flag: --mac --x64
+            bun_install_flags: --os=darwin --cpu=x64
           - host: macos-latest
             target: aarch64-apple-darwin
             platform_flag: --mac --arm64
+            bun_install_flags: --os=darwin --cpu=arm64
           # github-hosted: blacksmith lacks ARM64 MSVC cross-compilation toolchain
           - host: "windows-2025"
             target: aarch64-pc-windows-msvc
             platform_flag: --win --arm64
+            bun_install_flags: --os=win32 --cpu=arm64
           - host: "blacksmith-4vcpu-windows-2025"
             target: x86_64-pc-windows-msvc
             platform_flag: --win
+            bun_install_flags: --os=win32 --cpu=x64
           - host: "blacksmith-4vcpu-ubuntu-2404"
             target: x86_64-unknown-linux-gnu
             platform_flag: --linux
+            bun_install_flags: --os=linux --cpu=x64
           - host: "blacksmith-4vcpu-ubuntu-2404"
             target: aarch64-unknown-linux-gnu
             platform_flag: --linux
+            bun_install_flags: --os=linux --cpu=arm64
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -402,11 +402,11 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-26-intel
             target: x86_64-apple-darwin
             platform_flag: --mac --x64
             bun_install_flags: --os=darwin --cpu=x64
-          - host: macos-latest
+          - host: macos-26
             target: aarch64-apple-darwin
             platform_flag: --mac --arm64
             bun_install_flags: --os=darwin --cpu=arm64


### PR DESCRIPTION
Adds `install-flags` input to the setup-bun composite action and passes platform-specific `--os` and `--cpu` flags in the publish workflow to ensure correct native dependencies are installed per target.