### PR TITLE
fix(tui): fail fast when attach server is unreachable

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -6,29 +6,7 @@ import { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { errorMessage } from "@/util/error"
 import { validateSession } from "./validate-session"
 
-const ATTACH_HEALTH_TIMEOUT_MS = 3000
-
-async function verifyAttachTarget(url: string, headers: RequestInit["headers"]): Promise<void> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), ATTACH_HEALTH_TIMEOUT_MS)
-
-  try {
-    const health = new URL("/global/health", url)
-    const response = await fetch(health, {
-      headers,
-      signal: controller.signal,
-    })
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} ${response.statusText}`)
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`Unable to connect to opencode server at ${url}: ${message}`)
-  } finally {
-    clearTimeout(timer)
-  }
-}
+const DEFAULT_ATTACH_HEALTH_TIMEOUT_MS = 3000
 
 export const AttachCommand = cmd({
   command: "attach <url>",
@@ -91,12 +69,36 @@ export const AttachCommand = cmd({
         return { Authorization: auth }
       })()
 
+      const attachHealthTimeoutMs = Math.max(1, Number(process.env.OPENCODE_ATTACH_HEALTH_TIMEOUT_MS) || DEFAULT_ATTACH_HEALTH_TIMEOUT_MS)
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), attachHealthTimeoutMs)
+      const displayUrl = (() => {
+        try {
+          const parsed = new URL(args.url)
+          parsed.username = ""
+          parsed.password = ""
+          parsed.search = ""
+          return parsed.toString()
+        } catch {
+          return args.url.replace(/\/\/[^/@]*@/, "//[redacted]@").replace(/\?.*$/, "")
+        }
+      })()
+
       try {
-        await verifyAttachTarget(args.url, headers)
+        const response = await fetch(new URL("/global/health", args.url), {
+          headers,
+          signal: controller.signal,
+        })
+        if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`)
       } catch (error) {
-        UI.error(error instanceof Error ? error.message : String(error))
+        const message = error instanceof Error && error.name === "AbortError"
+          ? `timed out after ${attachHealthTimeoutMs}ms`
+          : error instanceof Error ? error.message : String(error)
+        UI.error(`Unable to connect to opencode server at ${displayUrl}: ${message}`)
         process.exitCode = 1
         return
+      } finally {
+        clearTimeout(timer)
       }
 
       const config = await TuiConfig.get()

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -6,6 +6,30 @@ import { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { errorMessage } from "@/util/error"
 import { validateSession } from "./validate-session"
 
+const ATTACH_HEALTH_TIMEOUT_MS = 3000
+
+async function verifyAttachTarget(url: string, headers: RequestInit["headers"]): Promise<void> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), ATTACH_HEALTH_TIMEOUT_MS)
+
+  try {
+    const health = new URL("/global/health", url)
+    const response = await fetch(health, {
+      headers,
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Unable to connect to opencode server at ${url}: ${message}`)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export const AttachCommand = cmd({
   command: "attach <url>",
   describe: "attach to a running opencode server",
@@ -66,6 +90,15 @@ export const AttachCommand = cmd({
         const auth = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`
         return { Authorization: auth }
       })()
+
+      try {
+        await verifyAttachTarget(args.url, headers)
+      } catch (error) {
+        UI.error(error instanceof Error ? error.message : String(error))
+        process.exitCode = 1
+        return
+      }
+
       const config = await TuiConfig.get()
 
       try {

--- a/packages/opencode/test/cli/tui/attach.test.ts
+++ b/packages/opencode/test/cli/tui/attach.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
 import * as App from "../../../src/cli/cmd/tui/app"
 import { UI } from "../../../src/cli/ui"
 import * as Win32 from "../../../src/cli/cmd/tui/win32"
@@ -6,6 +6,10 @@ import * as Win32 from "../../../src/cli/cmd/tui/win32"
 describe("tui attach", () => {
   const originalFetch = globalThis.fetch
   const originalAttachHealthTimeout = process.env.OPENCODE_ATTACH_HEALTH_TIMEOUT_MS
+
+  beforeEach(() => {
+    process.exitCode = 0
+  })
 
   afterEach(() => {
     globalThis.fetch = originalFetch

--- a/packages/opencode/test/cli/tui/attach.test.ts
+++ b/packages/opencode/test/cli/tui/attach.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as App from "../../../src/cli/cmd/tui/app"
+import { UI } from "../../../src/cli/ui"
+import * as Win32 from "../../../src/cli/cmd/tui/win32"
+
+describe("tui attach", () => {
+  const originalFetch = globalThis.fetch
+  const originalExitCode = process.exitCode
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    process.exitCode = originalExitCode ?? 0
+    mock.restore()
+  })
+
+  async function call(overrides: Record<string, unknown> = {}) {
+    const { AttachCommand } = await import("../../../src/cli/cmd/tui/attach")
+    const args: Parameters<NonNullable<typeof AttachCommand.handler>>[0] = {
+      _: [],
+      $0: "opencode",
+      url: "http://127.0.0.1:65535",
+      dir: undefined,
+      continue: false,
+      session: undefined,
+      fork: false,
+      password: undefined,
+      ...overrides,
+    }
+    return AttachCommand.handler(args)
+  }
+
+  test("fails before starting the TUI when the target server is unreachable", async () => {
+    const tui = spyOn(App, "tui").mockResolvedValue(undefined)
+    const error = spyOn(UI, "error").mockImplementation(() => {})
+    spyOn(Win32, "win32DisableProcessedInput").mockImplementation(() => {})
+    spyOn(Win32, "win32InstallCtrlCGuard").mockReturnValue(undefined)
+    globalThis.fetch = mock(async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:65535")
+    }) as unknown as typeof fetch
+
+    await call()
+
+    expect(tui).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("Unable to connect to opencode server")
+    )
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/packages/opencode/test/cli/tui/attach.test.ts
+++ b/packages/opencode/test/cli/tui/attach.test.ts
@@ -5,11 +5,13 @@ import * as Win32 from "../../../src/cli/cmd/tui/win32"
 
 describe("tui attach", () => {
   const originalFetch = globalThis.fetch
-  const originalExitCode = process.exitCode
+  const originalAttachHealthTimeout = process.env.OPENCODE_ATTACH_HEALTH_TIMEOUT_MS
 
   afterEach(() => {
     globalThis.fetch = originalFetch
-    process.exitCode = originalExitCode ?? 0
+    process.exitCode = 0
+    if (originalAttachHealthTimeout === undefined) delete process.env.OPENCODE_ATTACH_HEALTH_TIMEOUT_MS
+    else process.env.OPENCODE_ATTACH_HEALTH_TIMEOUT_MS = originalAttachHealthTimeout
     mock.restore()
   })
 
@@ -45,5 +47,42 @@ describe("tui attach", () => {
       expect.stringContaining("Unable to connect to opencode server")
     )
     expect(process.exitCode).toBe(1)
+  })
+
+  test("redacts credentials and query params from attach errors", async () => {
+    const error = spyOn(UI, "error").mockImplementation(() => {})
+    spyOn(App, "tui").mockResolvedValue(undefined)
+    spyOn(Win32, "win32DisableProcessedInput").mockImplementation(() => {})
+    spyOn(Win32, "win32InstallCtrlCGuard").mockReturnValue(undefined)
+    globalThis.fetch = mock(async () => {
+      throw new Error("connect ECONNREFUSED")
+    }) as unknown as typeof fetch
+
+    await call({ url: "http://user:pass@127.0.0.1:65535/?token=secret" })
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("http://127.0.0.1:65535/"))
+    expect(error).not.toHaveBeenCalledWith(expect.stringContaining("user"))
+    expect(error).not.toHaveBeenCalledWith(expect.stringContaining("pass"))
+    expect(error).not.toHaveBeenCalledWith(expect.stringContaining("token"))
+    expect(error).not.toHaveBeenCalledWith(expect.stringContaining("secret"))
+  })
+
+  test("reports attach health check timeout clearly", async () => {
+    const error = spyOn(UI, "error").mockImplementation(() => {})
+    spyOn(App, "tui").mockResolvedValue(undefined)
+    spyOn(Win32, "win32DisableProcessedInput").mockImplementation(() => {})
+    spyOn(Win32, "win32InstallCtrlCGuard").mockReturnValue(undefined)
+    process.env.OPENCODE_ATTACH_HEALTH_TIMEOUT_MS = "1"
+    globalThis.fetch = mock(async (_input, init) => {
+      await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted", "AbortError"))
+        })
+      })
+    }) as unknown as typeof fetch
+
+    await call()
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("timed out after 1ms"))
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #23836

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode attach <url>` could start the full-screen TUI even when the target server was unreachable. In that case the terminal could get stuck in renderer startup instead of showing a clear connection failure.

This PR checks `/global/health` before creating the TUI renderer. If the server is unreachable or returns an unhealthy response, attach prints an error and exits with code 1. The displayed URL is sanitized so embedded credentials and query strings are not printed.

### How did you verify your code works?

Ran locally:

```bash
bun --cwd packages/opencode test test/cli/tui/attach.test.ts test/cli/tui/thread.test.ts test/cli/tui/use-event.test.tsx
cd packages/opencode && bun run typecheck
```

The targeted test run reported 10 passing tests.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
