### PR TITLE
fix: retry streamed provider error envelopes

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -89,16 +89,32 @@ export function retryable(error: Err) {
     }
   })
   if (!json || typeof json !== "object") return undefined
+  const nestedError =
+    "error" in json && typeof json.error === "object" && json.error !== null
+      ? (json.error as Record<string, unknown>)
+      : undefined
   const code = typeof json.code === "string" ? json.code : ""
+  const nestedCode = typeof nestedError?.code === "string" ? nestedError.code : ""
+  const nestedType = typeof nestedError?.type === "string" ? nestedError.type : ""
+  const nestedMessage = typeof nestedError?.message === "string" ? nestedError.message : undefined
 
-  if (json.type === "error" && json.error?.type === "too_many_requests") {
+  if (json.type === "error" && nestedType === "too_many_requests") {
     return "Too Many Requests"
   }
   if (code.includes("exhausted") || code.includes("unavailable")) {
     return "Provider is overloaded"
   }
-  if (json.type === "error" && typeof json.error?.code === "string" && json.error.code.includes("rate_limit")) {
+  if (json.type === "error" && nestedCode.includes("rate_limit")) {
     return "Rate Limited"
+  }
+  if (
+    json.type === "error" &&
+    (nestedType === "server_error" ||
+      nestedCode === "server_error" ||
+      nestedType === "upstream_error" ||
+      nestedCode === "stream_read_error")
+  ) {
+    return nestedMessage?.trim() ? nestedMessage : "Provider is overloaded"
   }
   return undefined
 }

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -129,6 +129,75 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
   })
 
+  test("retries streamed server_error json envelopes", () => {
+    const message =
+      "An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists."
+    const error = wrap(
+      JSON.stringify({
+        type: "error",
+        sequence_number: 2,
+        error: {
+          type: "server_error",
+          code: "server_error",
+          message,
+          param: null,
+        },
+      }),
+    )
+
+    expect(SessionRetry.retryable(error)).toBe(message)
+  })
+
+  test("retries streamed server_error json envelopes with empty messages", () => {
+    const error = wrap(
+      JSON.stringify({
+        type: "error",
+        sequence_number: 2,
+        error: {
+          type: "server_error",
+          code: "server_error",
+          message: "",
+          param: null,
+        },
+      }),
+    )
+
+    expect(SessionRetry.retryable(error)).toBe("Provider is overloaded")
+  })
+
+  test("retries streamed upstream stream_read_error json envelopes", () => {
+    const error = wrap(
+      JSON.stringify({
+        type: "error",
+        sequence_number: 0,
+        error: {
+          type: "upstream_error",
+          code: "stream_read_error",
+          message: "stream_read_error",
+        },
+      }),
+    )
+
+    expect(SessionRetry.retryable(error)).toBe("stream_read_error")
+  })
+
+  test("retries streamed upstream_error json envelopes with other codes", () => {
+    const message = "Upstream temporarily unavailable"
+    const error = wrap(
+      JSON.stringify({
+        type: "error",
+        sequence_number: 1,
+        error: {
+          type: "upstream_error",
+          code: "temporary_upstream_failure",
+          message,
+        },
+      }),
+    )
+
+    expect(SessionRetry.retryable(error)).toBe(message)
+  })
+
   test("maps overloaded provider codes", () => {
     const error = wrap(JSON.stringify({ code: "resource_exhausted" }))
     expect(SessionRetry.retryable(error)).toBe("Provider is overloaded")


### PR DESCRIPTION
### Issue for this PR

Closes #16214

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI can surface a streamed JSON error envelope like `{ type: "error", sequence_number: 2, error: { type: "server_error" } }`. When that envelope reaches `SessionRetry.retryable()` as a JSON `UnknownError` message, it has no HTTP status, so the existing 5xx retry fallback cannot classify it.

This change teaches `SessionRetry.retryable()` to inspect nested `error.type`, `error.code`, and `error.message` for those envelopes. It preserves the existing `too_many_requests` and `rate_limit` handling, and treats `server_error`, `upstream_error`, and `stream_read_error` envelopes as retryable. If the provider supplied an error message, that message is used as the retry reason; otherwise it falls back to `Provider is overloaded` so an empty streamed error message still retries.

I added regression tests for the OpenAI `server_error` shape from #16214, an empty-message `server_error`, upstream `stream_read_error`, and an upstream error with a non-`stream_read_error` code.

### How did you verify your code works?

- `bun test test/session/retry.test.ts` -> 31 pass, 0 fail
- `bun run typecheck`
- `git diff --check`

### Screenshots / recordings

N/A. This is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
