### PR TITLE
feat(keybinds): add cmd/command alias and macOS display support

### DIFF
--- a/packages/opencode/src/util/keybind.test.ts
+++ b/packages/opencode/src/util/keybind.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { parse, toString } from "./keybind"
+
+describe("keybind", () => {
+  test("parses cmd as super", () => {
+    expect(parse("cmd+p")).toEqual(parse("super+p"))
+    expect(parse("command+p")).toEqual(parse("super+p"))
+  })
+
+  test("renders super as cmd on macOS", () => {
+    const original = process.platform
+    Object.defineProperty(process, "platform", { value: "darwin" })
+
+    expect(toString(parse("super+p")[0])).toBe("cmd+p")
+
+    Object.defineProperty(process, "platform", { value: original })
+  })
+})

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -37,7 +37,7 @@ export function toString(info: Info | undefined): string {
 
   if (info.ctrl) parts.push("ctrl")
   if (info.meta) parts.push("alt")
-  if (info.super) parts.push("super")
+  if (info.super) parts.push(process.platform === "darwin" ? "cmd" : "super")
   if (info.shift) parts.push("shift")
   if (info.name) {
     if (info.name === "delete") parts.push("del")
@@ -79,6 +79,8 @@ export function parse(key: string): Info[] {
           info.meta = true
           break
         case "super":
+        case "cmd":
+        case "command":
           info.super = true
           break
         case "shift":

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -148,6 +148,7 @@ Configure agents in your `opencode.json` config file:
     "build": {
       "mode": "primary",
       "model": "anthropic/claude-sonnet-4-20250514",
+      "variant": "high",
       "prompt": "{file:./prompts/build.txt}",
       "tools": {
         "write": true,
@@ -192,6 +193,7 @@ You can also define agents using markdown files. Place them in:
 description: Reviews code for quality and best practices
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
+variant: high
 temperature: 0.1
 tools:
   write: false
@@ -363,6 +365,33 @@ If you don’t specify a model, primary agents use the [model globally configure
 ```
 
 The model ID in your OpenCode config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
+
+---
+
+### Variant
+
+Use the `variant` config to set the default model variant for an agent.
+
+This is useful when the same model supports multiple built-in variants, such as OpenAI reasoning effort levels or Anthropic thinking budgets.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "build": {
+      "model": "openai/gpt-5",
+      "variant": "high"
+    },
+    "plan": {
+      "model": "openai/gpt-5",
+      "variant": "low"
+    }
+  }
+}
+```
+
+The variant applies when the agent is using its configured `model`. If you change models in the UI, the available variants and active selection may change too.
+
+For built-in variants and custom variant definitions, see [Models](/docs/models#variants).
 
 ---
 

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -389,7 +389,7 @@ This is useful when the same model supports multiple built-in variants, such as 
 }
 ```
 
-The variant applies when the agent is using its configured `model`. If you change models in the UI, the available variants and active selection may change too.
+The variant applies when the agent is using its configured `model`. If you change models in the UI, the available variants and active selection may change too. To switch variants at runtime, use the `variant_cycle` keybind or bind `variant_list` yourself in `tui.json`.
 
 For built-in variants and custom variant definitions, see [Models](/docs/models#variants).
 

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -5,6 +5,8 @@ description: Customize your keybinds.
 
 OpenCode has a list of keybinds that you can customize through `tui.json`.
 
+On macOS, you can use `cmd` as an alias for `super` in your config. In the UI, keybinds using `super` are displayed as `cmd` on macOS.
+
 ```json title="tui.json"
 {
   "$schema": "https://opencode.ai/tui.json",

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -217,7 +217,7 @@ You can override existing variants or add your own:
 
 ### Cycle variants
 
-Use the keybind `variant_cycle` to quickly switch between variants, or `variant_list` to open the variant picker. [Learn more](/docs/keybinds).
+Use the keybind `variant_cycle` to quickly switch between variants. `variant_list` is also available as a picker action, but it is unbound by default and must be mapped in your keybinds. [Learn more](/docs/keybinds).
 
 ---
 

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -133,11 +133,31 @@ You can also define custom variants that extend built-in ones. Variants let you 
 }
 ```
 
+You can use variants globally, switch them at runtime from the UI, or pin one on a specific agent with the agent `variant` option:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "model": "openai/gpt-5",
+      "variant": "high"
+    },
+    "plan": {
+      "model": "openai/gpt-5",
+      "variant": "low"
+    }
+  }
+}
+```
+
 ---
 
 ## Variants
 
 Many models support multiple variants with different configurations. OpenCode ships with built-in default variants for popular providers.
+
+Variants are named presets. In practice, they usually map to provider-specific model options like reasoning effort, thinking budgets, or verbosity settings.
 
 ### Built-in variants
 
@@ -197,7 +217,7 @@ You can override existing variants or add your own:
 
 ### Cycle variants
 
-Use the keybind `variant_cycle` to quickly switch between variants. [Learn more](/docs/keybinds).
+Use the keybind `variant_cycle` to quickly switch between variants, or `variant_list` to open the variant picker. [Learn more](/docs/keybinds).
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `cmd`/`command` as alias for `super` in keybind parse function
- Display `super` as `cmd` on macOS in `toString` function
- Add tests for cmd alias parsing and macOS display

Ref: #653