### PR TITLE
fix(tui): fix Windows terminal input corruption from OSC escape seque…

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -47,8 +47,8 @@ export async function colors(): Promise<{
     let timeout: NodeJS.Timeout
 
     const cleanup = () => {
-      process.stdin.setRawMode(false)
       process.stdin.removeListener("data", handler)
+      process.stdin.setRawMode(false)
       clearTimeout(timeout)
     }
 
@@ -89,9 +89,13 @@ export async function colors(): Promise<{
     process.stdout.write("\x1b]11;?\x07")
     // Query foreground (OSC 10)
     process.stdout.write("\x1b]10;?\x07")
-    // Query palette colors 0-15 (OSC 4)
-    for (let i = 0; i < 16; i++) {
-      process.stdout.write(`\x1b]4;${i};?\x07`)
+    // OSC 4 palette queries are skipped on Windows: Windows Terminal does not
+    // reliably respond, causing raw mode to stay active for the full 1s timeout
+    // and leaking escape sequences into the TUI on stdin.
+    if (process.platform !== "win32") {
+      for (let i = 0; i < 16; i++) {
+        process.stdout.write(`\x1b]4;${i};?\x07`)
+      }
     }
 
     timeout = setTimeout(() => {
@@ -111,8 +115,8 @@ export async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
     let timeout: NodeJS.Timeout
 
     const cleanup = () => {
-      process.stdin.setRawMode(false)
       process.stdin.removeListener("data", handler)
+      process.stdin.setRawMode(false)
       clearTimeout(timeout)
     }
 


### PR DESCRIPTION
Issue for this PR

Closes #23867

Type of change

Bug fix

What does this PR do?

This PR fixes two Windows-specific bugs in packages/opencode/src/cli/cmd/tui/util/terminal.ts that could cause raw ANSI escape sequences to appear in the TUI and interfere with keyboard input.

1. Fix cleanup order in colors() and getTerminalBackgroundColor()

The cleanup logic called setRawMode(false) before removing the data listener.

On Windows, setRawMode(false) synchronously triggers the win32InstallCtrlCGuard hook, which calls SetConsoleMode. If PTY data arrives during that window, it can still be dispatched to the attached handler, causing partial escape sequences to leak into the TUI.

Fix: remove the listener first, then call setRawMode(false).

2. Skip OSC 4 palette queries on Windows

colors() sent 16 OSC 4 queries to detect the terminal palette. Windows Terminal does not reliably respond to these queries, which caused stdin to remain in raw mode for the full 
1000
1000 ms timeout.

During that time, keyboard and mouse input could be consumed by the temporary data handler, and unmatched escape sequences could appear as visible text in the TUI.

Fix: skip OSC 4 palette queries on win32.

How did you verify your code works?

Reviewed the win32InstallCtrlCGuard hook in win32.ts and confirmed that the setRawMode wrapper calls SetConsoleMode synchronously, validating the race condition.

Confirmed that Windows Terminal’s unreliable OSC 4 response behavior is documented in its issue tracker.

Ran bun typecheck in packages/opencode and verified that no new errors were introduced.

Checklist

I have tested my changes locally

I have not included unrelated changes in this PR