### PR TITLE
docs: add Cavalry MCP example and ecosystem entry

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -79,3 +79,11 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+
+---
+
+## MCP Servers
+
+| Name                                                                     | Description                                                                                    |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| [cavalry-mcp](https://github.com/kacperchlebowicz/Cavalry-mcp)           | Connect OpenCode to Cavalry animation software. Create layers, animate, and render via natural language. |

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -509,3 +509,33 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### Cavalry
+
+Add the [Cavalry MCP server](https://github.com/kacperchlebowicz/Cavalry-mcp) to connect OpenCode to [Cavalry](https://cavalry.scenegroup.co/) animation software. Create layers, set attributes, animate with keyframes, render frames, and more through natural language. Requires Cavalry with Stallion script enabled.
+
+```json title="opencode.json" {4-7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "cavalry": {
+      "type": "local",
+      "command": ["npx", "-y", "kacperchlebowicz-cavalry-mcp"]
+    }
+  }
+}
+```
+
+Since we named our MCP server `cavalry`, you can add `use the cavalry tool` to your prompts to get the agent to use it.
+
+```txt "use the cavalry tool"
+Create a rectangle layer and animate its position over 2 seconds. use the cavalry tool
+```
+
+Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/).
+
+```md title="AGENTS.md"
+When working with Cavalry animation, use the `cavalry` tools to create layers, set attributes, and render frames.
+```


### PR DESCRIPTION
Adds the Cavalry MCP server to the docs:\n- New example on the MCP Servers page with install + config snippet\n- New entry on the Ecosystem page\n\nCavalry MCP connects OpenCode (and other LLMs) to Cavalry animation software for layer creation, keyframe animation, and rendering via natural language.\n\n- Repo: https://github.com/kacperchlebowicz/Cavalry-mcp\n- Marketplace: https://lobehub.com/mcp/kacperchlebowicz-cavalry-mcp