### PR TITLE
feat: make opencode web embeddable in iframes at a subpath

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -85,7 +85,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -120,7 +120,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -147,7 +147,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.48",
@@ -171,7 +171,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -195,7 +195,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -229,7 +229,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -283,7 +283,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -313,7 +313,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -329,7 +329,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "effect": "catalog:",
@@ -342,7 +342,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@smithy/eventstream-codec": "4.2.14",
         "@smithy/util-utf8": "4.2.2",
@@ -360,7 +360,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -496,7 +496,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "effect": "catalog:",
@@ -534,7 +534,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -549,7 +549,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -584,7 +584,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -633,7 +633,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.14.47",
+      "version": "1.14.48",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -100,6 +100,14 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
 }
 
 const getCurrentUrl = () => {
+  // Honor the localStorage `defaultServerUrl` override if set so that the
+  // initial `servers[0]` entry matches the `defaultServer` key; otherwise
+  // `allServers().find(...)` in the server context falls back to
+  // `allServers()[0]` and the SDK ends up calling `location.origin` for
+  // control-plane ("/global/*") routes even when the user configured a
+  // different server URL via localStorage.
+  const lsDefault = readDefaultServerUrl()
+  if (lsDefault) return lsDefault
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -21,6 +21,10 @@ const sentry =
 
 export default defineConfig({
   plugins: [desktopPlugin, sentry] as any,
+  // Relative base so the built SPA can be served under any URL subpath
+  // (iframe embedding via reverse proxy) without requiring absolute-path
+  // asset resolution at the host origin.  Also works for direct-serve at `/`.
+  base: "./",
   server: {
     host: "0.0.0.0",
     allowedHosts: true,

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.14.47",
+  "version": "1.14.48",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/extensions/zed/extension.toml
+++ b/packages/extensions/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "opencode"
 name = "OpenCode"
 description = "The open source coding agent."
-version = "1.14.47"
+version = "1.14.48"
 schema_version = 1
 authors = ["Anomaly"]
 repository = "https://github.com/anomalyco/opencode"
@@ -11,26 +11,26 @@ name = "OpenCode"
 icon = "./icons/opencode.svg"
 
 [agent_servers.opencode.targets.darwin-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.47/opencode-darwin-arm64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.48/opencode-darwin-arm64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.darwin-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.47/opencode-darwin-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.48/opencode-darwin-x64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.47/opencode-linux-arm64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.48/opencode-linux-arm64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.47/opencode-linux-x64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.48/opencode-linux-x64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.windows-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.47/opencode-windows-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.48/opencode-windows-x64.zip"
 cmd = "./opencode.exe"
 args = ["acp"]

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "name": "@opencode-ai/http-recorder",
   "type": "module",
   "license": "MIT",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/server/shared/ui.ts
+++ b/packages/opencode/src/server/shared/ui.ts
@@ -12,8 +12,14 @@ const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
 
 export const UI_UPSTREAM = new URL("https://app.opencode.ai")
 
+// `'unsafe-eval'` is required because Zod 4 (workspace catalog `zod@4.1.8`)
+// JIT-compiles validators at schema-definition time via `new Function(...)`.
+// Every `z.object({...})` in the SPA bundle hits this; `'wasm-unsafe-eval'`
+// alone (which Firefox correctly distinguishes) is not sufficient. Removing
+// this requires switching the `app` package to `zod/mini` or downgrading to
+// zod 3 — both larger refactors.
 export const csp = (hash = "") =>
-  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src * data:`
+  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src * data:`
 export const DEFAULT_CSP = csp()
 
 export function themePreloadHash(body: string) {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.14.47",
+  "version": "1.14.48",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

No existing issue — self-motivated fix to enable embedding `opencode web`
inside an iframe under a reverse-proxy subpath. Happy to file one
retroactively if that's the workflow you prefer.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Lets `opencode web` work inside an `<iframe>` served from a URL subpath
(e.g. `/some/deep/path/<session-id>/`) under a reverse proxy. Four
small orthogonal changes, none of which affect a direct-at-root
deployment:

1. `packages/app/vite.config.ts` — `base: './'`. The built `index.html`
   and chunk imports now use relative asset paths so a document loaded
   under a subpath resolves assets against the current URL instead of
   the origin root. Fixes "asset requests return the SPA fallback HTML
   with the wrong MIME type" for subpath embeds.

2. `packages/opencode/src/server/routes/ui.ts` — add `'unsafe-eval'` to
   the embedded-UI CSP's `script-src`. The production bundle invokes
   `new Function(...)` at runtime: Zod 4 (`zod@4.1.8` via the workspace
   catalog) JIT-compiles its validators at schema-definition time,
   which is where v4's speed advantage over v3 comes from. Every
   `z.object({...})` in the bundle therefore needs `'unsafe-eval'`;
   the existing policy allowed `'wasm-unsafe-eval'` but not the
   broader keyword, so Firefox (stricter than Chromium here)
   correctly blocked the bundle once it ran in an iframe. Confirmed
   by tracing — the first `Function`-construct trap at page load
   fires from `packages/app/src/context/global-sdk.tsx:12`
   (`z.object({ name: z.literal('AbortError') })`) and the stack
   walks through `zod/v4/core/{core,schemas,util}.js`, the v4
   codegen pipeline. The relaxation is therefore not optional while
   we depend on zod 4 — alternatives are switching the `app` package
   to `zod/mini` (no-codegen entry, restricted API) or downgrading
   to zod 3, both larger refactors out of scope here.

3. `packages/app/src/entry.tsx` — `getCurrentUrl()` now honors the
   `localStorage.defaultServerUrl` override the same way
   `getDefaultUrl()` already does. Before, `servers[0].url` was
   hard-wired to `location.origin` while `defaultServer`'s key came
   from the override; the server-context resolver
   (`allServers().find(key === state.active) ?? allServers()[0]`) fell
   back to `allServers()[0]` when the two keys didn't align, and
   control-plane calls like `/global/config` and `/global/event`
   bypassed the override entirely. Aligning both entries fixes that.

4. `packages/opencode/src/server/routes/ui.ts` — extend `connect-src`
   to allow `https://opencode.ai`. `packages/app/src/context/highlights.tsx`
   fetches the release changelog from `https://opencode.ai/changelog.json`
   to surface release highlights. Under the previous
   `connect-src 'self' data:`, the fetch was blocked once the SPA ran
   from a non-opencode.ai origin (i.e. exactly the embed case). The
   expanded directive keeps the changelog feature working in
   embedded deployments and is consistent with the SPA's existing
   same-domain trust for that origin (`location.hostname.includes('opencode.ai')`
   in `entry.tsx`, and the production fallback proxy in `ui.ts`).

The commit message on `686a8dd63` has the per-change rationale in more
depth.

### How did you verify your code works?

Built from source (`bun run --cwd packages/opencode build`) and
installed `opencode-linux-x64/bin/opencode` on a Linux test box. Ran
the binary in two configurations:

- Direct at its own port (no proxy). Dashboard loads, project picker
  works, session/prompt round-trip works, provider auth works. No
  behavior change vs. unmodified opencode.
- Embedded in an iframe served by a reverse proxy under a deep URL
  path. Before these changes: asset requests resolved to the proxy's
  origin root (wrong MIME type, SPA-fallback HTML), CSP blocked `eval`
  when the SPA bundled code ran, and `/global/*` SDK calls went
  directly to `location.origin` ignoring the configured server URL.
  After these changes: iframe mounts, the SPA bundle executes, all
  SDK calls (including control-plane) route through the configured
  server URL via the proxy.

### Screenshots / recordings

_Not attached — happy to record if it'd help._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
