### PR TITLE
fix(task): accept agent aliases and retry blank text-only subtask output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -83,7 +83,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -117,7 +117,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -144,7 +144,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.48",
@@ -168,7 +168,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -192,7 +192,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@opencode-ai/app": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -225,7 +225,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -269,7 +269,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -314,7 +314,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -459,7 +459,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "effect": "catalog:",
@@ -494,7 +494,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -509,7 +509,7 @@
     },
     "packages/shared": {
       "name": "@opencode-ai/shared",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -533,7 +533,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -568,7 +568,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -617,7 +617,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.14.19",
+      "version": "1.14.20",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/extensions/zed/extension.toml
+++ b/packages/extensions/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "opencode"
 name = "OpenCode"
 description = "The open source coding agent."
-version = "1.14.19"
+version = "1.14.20"
 schema_version = 1
 authors = ["Anomaly"]
 repository = "https://github.com/anomalyco/opencode"
@@ -11,26 +11,26 @@ name = "OpenCode"
 icon = "./icons/opencode.svg"
 
 [agent_servers.opencode.targets.darwin-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-darwin-arm64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-darwin-arm64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.darwin-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-darwin-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-darwin-x64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-linux-arm64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-linux-arm64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-linux-x64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-linux-x64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.windows-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.19/opencode-windows-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.20/opencode-windows-x64.zip"
 cmd = "./opencode.exe"
 args = ["acp"]

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/tool/task-runtime.ts
+++ b/packages/opencode/src/tool/task-runtime.ts
@@ -1,0 +1,85 @@
+import z from "zod"
+import type { MessageV2 } from "../session/message-v2"
+
+export const TaskAgentSelectorFields = {
+  subagent_type: z.string().optional().describe("The type of specialized agent to use for this task"),
+  agent: z.string().optional().describe("Alias for subagent_type accepted for compatibility with non-Claude models"),
+  agent_type: z.string().optional().describe("Alias for subagent_type accepted for compatibility with non-Claude models"),
+}
+
+export const TaskAgentSelector = z
+  .object(TaskAgentSelectorFields)
+  .superRefine((value, ctx) => {
+    if (resolveAgentType(value)) return
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["subagent_type"],
+      message: "Expected one of subagent_type, agent, or agent_type",
+    })
+  })
+
+export type TaskAgentSelectorInput = z.infer<typeof TaskAgentSelector>
+
+export function resolveAgentType(input: TaskAgentSelectorInput): string | undefined {
+  const candidates = [input.subagent_type, input.agent, input.agent_type]
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue
+    const normalized = candidate.trim()
+    if (normalized.length > 0) return normalized
+  }
+  return undefined
+}
+
+export function extractTaskResultText(result: MessageV2.WithParts): string {
+  return result.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .findLast((value) => value.trim().length > 0)
+    ?.trim() ?? ""
+}
+
+function hasToolActivity(result: MessageV2.WithParts): boolean {
+  return result.parts.some((part) => part.type === "tool")
+}
+
+export type TaskResultValidation =
+  | {
+      valid: true
+      outputText: string
+      retryable: false
+      reason?: undefined
+    }
+  | {
+      valid: false
+      outputText: ""
+      retryable: boolean
+      reason: string
+    }
+
+export function validateTaskResult(result: MessageV2.WithParts): TaskResultValidation {
+  const outputText = extractTaskResultText(result)
+  if (outputText.length > 0) {
+    return {
+      valid: true,
+      outputText,
+      retryable: false,
+    }
+  }
+
+  if (hasToolActivity(result)) {
+    return {
+      valid: false,
+      outputText: "",
+      retryable: false,
+      reason: "Task subagent produced no text output after running tools; automatic retry is not safe.",
+    }
+  }
+
+  return {
+    valid: false,
+    outputText: "",
+    retryable: true,
+    reason: "Task subagent produced no text output.",
+  }
+}

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -8,6 +8,7 @@ import { Agent } from "../agent/agent"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "../config"
 import { Effect } from "effect"
+import { TaskAgentSelectorFields, resolveAgentType, validateTaskResult } from "./task-runtime"
 
 export interface TaskPromptOps {
   cancel(sessionID: SessionID): void
@@ -16,11 +17,12 @@ export interface TaskPromptOps {
 }
 
 const id = "task"
+const MAX_EMPTY_RESULT_ATTEMPTS = 2
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
   prompt: z.string().describe("The task for the agent to perform"),
-  subagent_type: z.string().describe("The type of specialized agent to use for this task"),
+  ...TaskAgentSelectorFields,
   task_id: z
     .string()
     .describe(
@@ -29,6 +31,15 @@ const parameters = z.object({
     .optional(),
   command: z.string().describe("The command that triggered this task").optional(),
 })
+  .superRefine((value, ctx) => {
+    if (resolveAgentType(value)) return
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["subagent_type"],
+      message: "Expected one of subagent_type, agent, or agent_type",
+    })
+  })
 
 export const TaskTool = Tool.define(
   id,
@@ -39,22 +50,26 @@ export const TaskTool = Tool.define(
 
     const run = Effect.fn("TaskTool.execute")(function* (params: z.infer<typeof parameters>, ctx: Tool.Context) {
       const cfg = yield* config.get()
+      const subagentType = resolveAgentType(params)
+      if (!subagentType) {
+        return yield* Effect.fail(new Error("Expected one of subagent_type, agent, or agent_type"))
+      }
 
       if (!ctx.extra?.bypassAgentCheck) {
         yield* ctx.ask({
           permission: id,
-          patterns: [params.subagent_type],
+          patterns: [subagentType],
           always: ["*"],
           metadata: {
             description: params.description,
-            subagent_type: params.subagent_type,
+            subagent_type: subagentType,
           },
         })
       }
 
-      const next = yield* agent.get(params.subagent_type)
+      const next = yield* agent.get(subagentType)
       if (!next) {
-        return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
+        return yield* Effect.fail(new Error(`Unknown agent type: ${subagentType} is not a valid agent type`))
       }
 
       const canTask = next.permission.some((rule) => rule.permission === id)
@@ -115,6 +130,28 @@ export const TaskTool = Tool.define(
       const ops = ctx.extra?.promptOps as TaskPromptOps
       if (!ops) return yield* Effect.fail(new Error("TaskTool requires promptOps in ctx.extra"))
 
+      const promptWithRetry = (
+        input: SessionPrompt.PromptInput,
+        attempt = 1,
+      ): Effect.Effect<{ result: MessageV2.WithParts; outputText: string }, Error> =>
+        Effect.gen(function* () {
+          const result = yield* ops.prompt(input)
+          const validation = validateTaskResult(result)
+
+          if (validation.valid) {
+            return {
+              result,
+              outputText: validation.outputText,
+            }
+          }
+
+          if (!validation.retryable || attempt >= MAX_EMPTY_RESULT_ATTEMPTS) {
+            return yield* Effect.fail(new Error(validation.reason))
+          }
+
+          return yield* promptWithRetry(input, attempt + 1)
+        })
+
       const messageID = MessageID.ascending()
 
       function cancel() {
@@ -128,7 +165,7 @@ export const TaskTool = Tool.define(
         () =>
           Effect.gen(function* () {
             const parts = yield* ops.resolvePromptParts(params.prompt)
-            const result = yield* ops.prompt({
+            const { outputText } = yield* promptWithRetry({
               messageID,
               sessionID: nextSession.id,
               model: {
@@ -154,7 +191,7 @@ export const TaskTool = Tool.define(
                 `task_id: ${nextSession.id} (for resuming to continue this task if needed)`,
                 "",
                 "<task_result>",
-                result.parts.findLast((item) => item.type === "text")?.text ?? "",
+                outputText,
                 "</task_result>",
               ].join("\n"),
             }
@@ -169,6 +206,8 @@ export const TaskTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters,
+      formatValidationError: (error) =>
+        `The task tool was called with invalid arguments: ${error}. Use subagent_type, agent, or agent_type to identify the delegated agent and ensure exactly one of them contains a non-empty string.`,
       execute: (params: z.infer<typeof parameters>, ctx: Tool.Context) => run(params, ctx).pipe(Effect.orDie),
     }
   }),

--- a/packages/opencode/test/tool/task-runtime.test.ts
+++ b/packages/opencode/test/tool/task-runtime.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { resolveAgentType, validateTaskResult } from "../../src/tool/task-runtime"
+
+const sessionID = SessionID.make("ses_task_test")
+const messageID = MessageID.make("msg_task_test")
+
+function makeTextPart(text: string) {
+  return {
+    id: PartID.ascending(),
+    messageID,
+    sessionID,
+    type: "text" as const,
+    text,
+  }
+}
+
+function makeToolPart() {
+  return {
+    id: PartID.ascending(),
+    messageID,
+    sessionID,
+    type: "tool" as const,
+    callID: "call_123",
+    tool: "bash",
+    state: {
+      status: "completed" as const,
+      input: {},
+      output: "done",
+      title: "Run bash",
+      metadata: {},
+      time: { start: 1, end: 2 },
+    },
+  }
+}
+
+describe("tool.task-runtime", () => {
+  it("prefers subagent_type over alias fields", () => {
+    const resolved = resolveAgentType({
+      subagent_type: "general",
+      agent: "reviewer",
+      agent_type: "writer",
+    })
+
+    expect(resolved).toBe("general")
+  })
+
+  it("accepts agent when subagent_type is omitted", () => {
+    const resolved = resolveAgentType({
+      agent: "reviewer",
+      agent_type: "writer",
+    })
+
+    expect(resolved).toBe("reviewer")
+  })
+
+  it("accepts agent_type when it is the only selector", () => {
+    const resolved = resolveAgentType({
+      agent_type: "writer",
+    })
+
+    expect(resolved).toBe("writer")
+  })
+
+  it("marks blank text-only task results as retryable", () => {
+    const validation = validateTaskResult({
+      info: {} as never,
+      parts: [makeTextPart("   ")],
+    })
+
+    expect(validation.valid).toBe(false)
+    expect(validation.retryable).toBe(true)
+  })
+
+  it("does not retry blank results after tool activity", () => {
+    const validation = validateTaskResult({
+      info: {} as never,
+      parts: [makeToolPart(), makeTextPart("   ")],
+    })
+
+    expect(validation.valid).toBe(false)
+    expect(validation.retryable).toBe(false)
+  })
+
+  it("returns trimmed output text when present", () => {
+    const validation = validateTaskResult({
+      info: {} as never,
+      parts: [makeTextPart("intermediate"), makeTextPart(" final result ")],
+    })
+
+    expect(validation.valid).toBe(true)
+    if (validation.valid) {
+      expect(validation.outputText).toBe("final result")
+    }
+  })
+})

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -274,6 +274,165 @@ describe("tool.task", () => {
     ),
   )
 
+  it.live("execute accepts agent and agent_type aliases for subagent_type", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        const promptOps = stubOps({ text: "aliased" })
+
+        const exec = (input: Record<string, unknown>) =>
+          def.execute(
+            {
+              description: "inspect bug",
+              prompt: "look into the cache key path",
+              ...input,
+            } as any,
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+        const viaAgent = yield* exec({ agent: "general" })
+        const viaAgentType = yield* exec({ agent_type: "general" })
+
+        expect(viaAgent.output).toContain("aliased")
+        expect(viaAgentType.output).toContain("aliased")
+      }),
+    ),
+  )
+
+  it.live("execute retries blank text results before failing open", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let promptCount = 0
+        const promptOps = stubOps({
+          onPrompt: () => {
+            promptCount += 1
+          },
+          text: "",
+        })
+
+        const result = yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        ).pipe(Effect.exit)
+
+        expect(promptCount).toBe(2)
+        expect(result._tag).toBe("Failure")
+        expect(String(result)).toContain("produced no text output")
+      }),
+    ),
+  )
+
+  it.live("execute does not retry blank results after tool activity", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let promptCount = 0
+        const promptOps: TaskPromptOps = {
+          cancel() {},
+          resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+          prompt: (input) =>
+            Effect.sync(() => {
+              promptCount += 1
+              const id = MessageID.ascending()
+              return {
+                info: {
+                  id,
+                  role: "assistant",
+                  parentID: input.messageID ?? MessageID.ascending(),
+                  sessionID: input.sessionID,
+                  mode: input.agent ?? "general",
+                  agent: input.agent ?? "general",
+                  cost: 0,
+                  path: { cwd: "/tmp", root: "/tmp" },
+                  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                  modelID: input.model?.modelID ?? ref.modelID,
+                  providerID: input.model?.providerID ?? ref.providerID,
+                  time: { created: Date.now() },
+                  finish: "stop",
+                },
+                parts: [
+                  {
+                    id: PartID.ascending(),
+                    messageID: id,
+                    sessionID: input.sessionID,
+                    type: "tool" as const,
+                    callID: "call_1",
+                    tool: "bash",
+                    state: {
+                      status: "completed" as const,
+                      input: {},
+                      output: "done",
+                      title: "Run bash",
+                      metadata: {},
+                      time: { start: Date.now(), end: Date.now() },
+                    },
+                  },
+                  {
+                    id: PartID.ascending(),
+                    messageID: id,
+                    sessionID: input.sessionID,
+                    type: "text" as const,
+                    text: "",
+                  },
+                ],
+              }
+            }),
+        }
+
+        const result = yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        ).pipe(Effect.exit)
+
+        expect(promptCount).toBe(1)
+        expect(result._tag).toBe("Failure")
+        expect(String(result)).toContain("automatic retry is not safe")
+      }),
+    ),
+  )
+
   it.live("execute creates a child when task_id does not exist", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "name": "@opencode-ai/shared",
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.14.19",
+  "version": "1.14.20",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- accept `agent` and `agent_type` as compatibility aliases for `subagent_type` in the Task tool
- add a small task-runtime helper to centralize delegated selector resolution and result validation
- retry one blank text-only delegated result, but fail safe when tool activity already occurred

## Why
- non-Claude models can emit `agent` or `agent_type` instead of `subagent_type`
- delegated subagents can occasionally return an empty text result, which previously surfaced as a blank `<task_result>`
- we need a narrow runtime fix until upstream ships equivalent behavior

## Validation
- `bun run typecheck`
- `bun test --timeout 30000 test/tool/task-runtime.test.ts test/tool/task.test.ts`