### PR TITLE
fix: correct adaptive TUI theme luminance calculation

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -19,7 +19,7 @@ function parse(color: string): RGBA | null {
 
 function mode(background: RGBA | null): "dark" | "light" {
   if (!background) return "dark"
-  const luminance = (0.299 * background.r + 0.587 * background.g + 0.114 * background.b) / 255
+  const luminance = 0.299 * background.r + 0.587 * background.g + 0.114 * background.b
   return luminance > 0.5 ? "light" : "dark"
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes [#23810](https://github.com/anomalyco/opencode/issues/23810)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- remove the extra `/ 255` from TUI adaptive theme luminance calculation in `packages/opencode/src/cli/cmd/tui/util/terminal.ts`
- make terminal background detection use the repo's normalized `RGBA` channel values correctly so light terminals resolve to the light theme
- keep the existing dark fallback behavior when no terminal background is available

### How did you verify your code works?

- Local build: build in local Ubuntu machine and kitty/warp terminal. 

### Screenshots / recordings

#### Before
<img width="1853" height="2078" alt="Screenshot_22-Apr_17-11-56_8258" src="https://github.com/user-attachments/assets/3d4c3c13-3ae9-4868-9496-c1c525dd6149" />
<img width="1891" height="2106" alt="Screenshot_22-Apr_17-14-35_19176" src="https://github.com/user-attachments/assets/0561dee5-5d73-46c4-ac70-a6a2ed994422" />

#### After

<img width="1901" height="2106" alt="Screenshot_22-Apr_17-13-05_8484" src="https://github.com/user-attachments/assets/f3d574b0-1937-46c2-8947-696ebe8328ee" />
<img width="1904" height="2110" alt="Screenshot_22-Apr_17-14-50_5588" src="https://github.com/user-attachments/assets/9f398573-d96c-4d41-a251-c1b812452d53" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._