### PR TITLE
refactor: remove redundant pending check from working memo

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -259,7 +259,7 @@ export function MessageTimeline(props: {
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
-  const working = createMemo(() => !!pending() || sessionStatus().type !== "idle")
+  const working = createMemo(() => sessionStatus().type !== "idle")
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 
   const [timeoutDone, setTimeoutDone] = createSignal(true)


### PR DESCRIPTION
It's possible for a session to be idle but the most recent message be pending, which would result in the progress bar showing. This change ties the progress bar directly to session state which matches the tui, but messages can still be pending and have the shimmer animation when the session is idle.