### PR TITLE
fix(tui): apply default duration when toast.show called without duration

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -2,6 +2,8 @@ import { BusEvent } from "@/bus/bus-event"
 import { SessionID } from "@/session/schema"
 import z from "zod"
 
+export const TOAST_DEFAULT_DURATION_MS = 5000
+
 export const TuiEvent = {
   PromptAppend: BusEvent.define("tui.prompt.append", z.object({ text: z.string() })),
   CommandExecute: BusEvent.define(
@@ -36,7 +38,7 @@ export const TuiEvent = {
       title: z.string().optional(),
       message: z.string(),
       variant: z.enum(["info", "success", "warning", "error"]),
-      duration: z.number().default(5000).optional().describe("Duration in milliseconds"),
+      duration: z.number().default(TOAST_DEFAULT_DURATION_MS).optional().describe("Duration in milliseconds"),
     }),
   ),
   SessionSelect: BusEvent.define(

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -5,11 +5,9 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { SplitBorder } from "../component/border"
 import { TextAttributes } from "@opentui/core"
 import z from "zod"
-import { type TuiEvent } from "../event"
+import { TOAST_DEFAULT_DURATION_MS, type TuiEvent } from "../event"
 
 export type ToastOptions = z.infer<typeof TuiEvent.ToastShow.properties>
-
-const DEFAULT_DURATION_MS = 5000
 
 export function Toast() {
   const toast = useToast()
@@ -63,7 +61,7 @@ function init() {
       if (timeoutHandle) clearTimeout(timeoutHandle)
       timeoutHandle = setTimeout(() => {
         setStore("currentToast", null)
-      }, duration ?? DEFAULT_DURATION_MS).unref()
+      }, duration ?? TOAST_DEFAULT_DURATION_MS).unref()
     },
     error: (err: any) => {
       if (err instanceof Error)

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -9,6 +9,8 @@ import { type TuiEvent } from "../event"
 
 export type ToastOptions = z.infer<typeof TuiEvent.ToastShow.properties>
 
+const DEFAULT_DURATION_MS = 5000
+
 export function Toast() {
   const toast = useToast()
   const { theme } = useTheme()
@@ -61,7 +63,7 @@ function init() {
       if (timeoutHandle) clearTimeout(timeoutHandle)
       timeoutHandle = setTimeout(() => {
         setStore("currentToast", null)
-      }, duration).unref()
+      }, duration ?? DEFAULT_DURATION_MS).unref()
     },
     error: (err: any) => {
       if (err instanceof Error)


### PR DESCRIPTION
## Summary

Fixes #23613 — the "Copied to clipboard" toast (and any other toast whose caller does not pass `duration`) flashes and disappears almost immediately on macOS / everywhere.

## Root cause

`packages/opencode/src/cli/cmd/tui/ui/toast.tsx` reads `duration` directly from the `ToastOptions` argument:

```ts
show(options: ToastOptions) {
  const { duration, ...currentToast } = options
  setStore("currentToast", currentToast)
  if (timeoutHandle) clearTimeout(timeoutHandle)
  timeoutHandle = setTimeout(() => {
    setStore("currentToast", null)
  }, duration).unref()
}
```

The 5000ms default is declared only on the zod schema in `event.ts`:

```ts
duration: z.number().default(5000).optional().describe("Duration in milliseconds")
```

…but `ToastOptions` is `z.infer<…>`, so the schema is only ever consulted for typing — it is never `parse()`-d, and the default never reaches runtime.

All `Copied to clipboard` call sites omit `duration`:
- `packages/opencode/src/cli/cmd/tui/util/selection.ts`
- `packages/opencode/src/cli/cmd/tui/app.tsx`
- `packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx`
- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` (4 places)

So they hit `setTimeout(fn, undefined)`, which Node clamps to its minimum (~1ms). That matches the symptom in #23613 ("flashes for about a second and disappears almost immediately" since 1.14.19).

The regression was introduced when the toast was rewritten in SolidJS / opentui as part of #23175 — the previous Go TUI toast didn't share this codepath.

## Fix

Apply the same 5000ms default at the call site, so the zod-side default and runtime behavior agree:

```diff
-      }, duration).unref()
+      }, duration ?? DEFAULT_DURATION_MS).unref()
```

Hoisted the literal into a `DEFAULT_DURATION_MS` const in the same file so it stays in sync if anyone edits it.

## Verification

- `bun typecheck` clean.
- `bun lint packages/opencode/src/cli/cmd/tui/ui/toast.tsx` — 0 warnings, 0 errors.
- `prettier --check` passes.
- Diff is 3 lines, no behavior change for callers that already pass an explicit `duration`.

## Notes

I considered the alternative of running the schema through `parse()` inside `toast.show`, but that would add a per-toast zod cost and silently swallow shape errors that today surface as TS errors at compile time. The minimal call-site default is the same behavior the schema's `.default(5000)` was clearly intended to provide.