### PR TITLE
fix(tui): defer CLI --agent flag until agent list loads

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -46,6 +46,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const visibleAgents = createMemo(() => sync.data.agent.filter((x) => !x.hidden))
       const [agentStore, setAgentStore] = createStore({
         current: undefined as string | undefined,
+        pending: undefined as string | undefined,
       })
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -57,6 +58,26 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         theme.error,
         theme.info,
       ])
+      // Resolve a pending agent name once the async agent list arrives.
+      // Callers (e.g. CLI --agent flag handled in onMount) may invoke set()
+      // before sync.data.agent has loaded; without this the initial set is
+      // dropped and the user sees "Agent not found".
+      createEffect(() => {
+        const name = agentStore.pending
+        if (!name) return
+        const list = agents()
+        if (list.length === 0) return
+        if (list.some((x) => x.name === name)) {
+          setAgentStore({ current: name, pending: undefined })
+          return
+        }
+        toast.show({
+          variant: "warning",
+          message: `Agent not found: ${name}`,
+          duration: 3000,
+        })
+        setAgentStore("pending", undefined)
+      })
       return {
         list() {
           return agents()
@@ -65,13 +86,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return agents().find((x) => x.name === agentStore.current) ?? agents().at(0)
         },
         set(name: string) {
+          if (agents().length === 0) {
+            setAgentStore("pending", name)
+            return
+          }
           if (!agents().some((x) => x.name === name))
             return toast.show({
               variant: "warning",
               message: `Agent not found: ${name}`,
               duration: 3000,
             })
-          setAgentStore("current", name)
+          setAgentStore({ current: name, pending: undefined })
         },
         move(direction: 1 | -1) {
           batch(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #23180

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode --agent Build --prompt "..."` reports `Agent not found: Build` even for built-in agents.

**Root cause:** the TUI `onMount` handler in `app.tsx:334` calls `local.agent.set(args.agent)` synchronously, but `sync.data.agent` is populated asynchronously after bootstrap (`sync.tsx:88` initializes `agent: []`). At the moment `onMount` runs, `agents()` is still empty, so the existence check in `agent.set()` fails and the selection is silently dropped.

The same issue is described in #23180 — the user even noted that the TUI agent tab shows up with a delay, which is exactly this async load.

**Fix:** track the requested name in `agentStore.pending` and resolve it via a `createEffect` once the agent list arrives. If the name still doesn't exist after agents load, the existing "Agent not found" toast is emitted. Direct calls (e.g. `/agent` dialog or hotkey) keep their immediate-validation path because by then `agents()` is already populated.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — clean.
- `bunx oxlint` — 0 errors, 4 warnings (all pre-existing in this file, unrelated to this change; verified by stashing the patch and re-linting).
- `bunx prettier --check` — clean.
- Pre-push hook (13 tasks) — all green.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR