### PR TITLE
[codex] Add CodeRabbit Skills to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -70,6 +70,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [CodeRabbit Skills](https://github.com/coderabbitai/skills)                                | Installable CodeRabbit review skills for OpenCode and 35+ agents |
 
 ---
 


### PR DESCRIPTION
## Summary
- add CodeRabbit Skills to the ecosystem page Projects table
- link the coderabbitai/skills repository for OpenCode users

## Testing
- git diff --check