### PR TITLE
fix(opencode): prefer semantic ACP tool title and input before completion

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -286,6 +286,7 @@ export class Agent implements ACPAgent {
               return
 
             case "running":
+              const input = this.toolInput(part)
               const output = this.bashOutput(part)
               const content: ToolCallContent[] = []
               if (output) {
@@ -300,9 +301,9 @@ export class Agent implements ACPAgent {
                           toolCallId: part.callID,
                           status: "in_progress",
                           kind: toToolKind(part.tool),
-                          title: part.tool,
-                          locations: toLocations(part.tool, part.state.input),
-                          rawInput: part.state.input,
+                          title: this.toolTitle(part),
+                          locations: toLocations(part.tool, input),
+                          rawInput: input,
                         },
                       })
                       .catch((error) => {
@@ -328,9 +329,9 @@ export class Agent implements ACPAgent {
                     toolCallId: part.callID,
                     status: "in_progress",
                     kind: toToolKind(part.tool),
-                    title: part.tool,
-                    locations: toLocations(part.tool, part.state.input),
-                    rawInput: part.state.input,
+                    title: this.toolTitle(part),
+                    locations: toLocations(part.tool, input),
+                    rawInput: input,
                     ...(content.length > 0 && { content }),
                   },
                 })
@@ -431,8 +432,8 @@ export class Agent implements ACPAgent {
                     toolCallId: part.callID,
                     status: "failed",
                     kind: toToolKind(part.tool),
-                    title: part.tool,
-                    rawInput: part.state.input,
+                    title: this.toolTitle(part),
+                    rawInput: this.toolInput(part),
                     content: [
                       {
                         type: "content",
@@ -839,6 +840,7 @@ export class Agent implements ACPAgent {
             this.bashSnapshots.delete(part.callID)
             break
           case "running":
+            const input = this.toolInput(part)
             const output = this.bashOutput(part)
             const runningContent: ToolCallContent[] = []
             if (output) {
@@ -858,9 +860,9 @@ export class Agent implements ACPAgent {
                   toolCallId: part.callID,
                   status: "in_progress",
                   kind: toToolKind(part.tool),
-                  title: part.tool,
-                  locations: toLocations(part.tool, part.state.input),
-                  rawInput: part.state.input,
+                  title: this.toolTitle(part),
+                  locations: toLocations(part.tool, input),
+                  rawInput: input,
                   ...(runningContent.length > 0 && { content: runningContent }),
                 },
               })
@@ -959,8 +961,8 @@ export class Agent implements ACPAgent {
                   toolCallId: part.callID,
                   status: "failed",
                   kind: toToolKind(part.tool),
-                  title: part.tool,
-                  rawInput: part.state.input,
+                  title: this.toolTitle(part),
+                  rawInput: this.toolInput(part),
                   content: [
                     {
                       type: "content",
@@ -1112,20 +1114,30 @@ export class Agent implements ACPAgent {
     return output
   }
 
+  private toolInput(part: ToolPart) {
+    return part.state.input ?? {}
+  }
+
+  private toolTitle(part: ToolPart) {
+    if ("title" in part.state && typeof part.state.title === "string") return part.state.title
+    return part.tool
+  }
+
   private async toolStart(sessionId: string, part: ToolPart) {
     if (this.toolStarts.has(part.callID)) return
     this.toolStarts.add(part.callID)
+    const input = this.toolInput(part)
     await this.connection
       .sessionUpdate({
         sessionId,
         update: {
           sessionUpdate: "tool_call",
           toolCallId: part.callID,
-          title: part.tool,
+          title: this.toolTitle(part),
           kind: toToolKind(part.tool),
           status: "pending",
-          locations: [],
-          rawInput: {},
+          locations: toLocations(part.tool, input),
+          rawInput: input,
         },
       })
       .catch((error) => {

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -35,6 +35,12 @@ function isToolCallUpdate(
   return update.sessionUpdate === "tool_call_update"
 }
 
+function isToolCall(
+  update: SessionUpdateParams["update"],
+): update is Extract<SessionUpdateParams["update"], { sessionUpdate: "tool_call" }> {
+  return update.sessionUpdate === "tool_call"
+}
+
 function toolEvent(
   sessionId: string,
   cwd: string,
@@ -609,6 +615,67 @@ describe("acp.agent event subscription", () => {
         expect(pendings.every((p) => p.update.sessionUpdate === "tool_call" && p.update.status === "pending")).toBe(
           true,
         )
+        stop()
+      },
+    })
+  })
+
+  test("prefers semantic title and input for pending and running tool events", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const input = { filePath: "/tmp/semantic.txt" }
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              sessionID: sessionId,
+              time: Date.now(),
+              part: {
+                id: "part_call_semantic",
+                sessionID: sessionId,
+                messageID: "msg_call_semantic",
+                type: "tool",
+                callID: "call_semantic",
+                tool: "read",
+                state: {
+                  status: "running",
+                  title: "Fetch cluster metadata",
+                  input,
+                  time: { start: Date.now() },
+                },
+              },
+            },
+          },
+        })
+        await new Promise((r) => setTimeout(r, 20))
+
+        const semanticUpdates = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .filter((u) => "toolCallId" in u && u.toolCallId === "call_semantic")
+
+        expect(semanticUpdates).toHaveLength(2)
+
+        const pending = semanticUpdates.find(isToolCall)
+        expect(pending).toBeDefined()
+        expect(pending?.title).toBe("Fetch cluster metadata")
+        expect(pending?.rawInput).toEqual(input)
+        expect(pending?.locations).toEqual([{ path: "/tmp/semantic.txt" }])
+
+        const running = semanticUpdates.find(isToolCallUpdate)
+        expect(running).toBeDefined()
+        expect(running?.status).toBe("in_progress")
+        expect(running?.title).toBe("Fetch cluster metadata")
+        expect(running?.rawInput).toEqual(input)
+        expect(running?.locations).toEqual([{ path: "/tmp/semantic.txt" }])
+
         stop()
       },
     })


### PR DESCRIPTION
### Issue for this PR

Closes #23947

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes ACP tool progress events using generic metadata before completion.

`tool_call` and `tool_call_update(status=in_progress)` were sending `part.tool` and sometimes empty input, so ACP clients showed generic labels like `bash` or `skill` while the tool was running.

This change makes ACP prefer semantic state before completion:
- `title`: `part.state.title ?? part.tool`
- `rawInput`: `part.state.input ?? {}`
- `locations`: recomputed from the best available input

Completed behavior is unchanged.

### How did you verify your code works?

- added ACP regression coverage in `packages/opencode/test/acp/event-subscription.test.ts`
- ran `bun test test/acp/event-subscription.test.ts` from `packages/opencode`
- ran `bun typecheck` from `packages/opencode`
- pre-push hook also ran the repo typecheck successfully during branch push

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
