### PR TITLE
fix(tui): keep status-bar token usage reactive after first prompt and /compact

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -159,7 +159,7 @@ export function Prompt(props: PromptProps) {
   const usage = createMemo(() => {
     if (!props.sessionID) return
     const msg = sync.data.message[props.sessionID] ?? []
-    const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
+    const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant")
     if (!last) return
 
     const tokens =


### PR DESCRIPTION
### Issue for this PR

Closes #23962

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two related symptoms in the TUI prompt status bar token/cost display:

1. After the first prompt of a session, the token usage didn't appear, only after a second prompt was sent
2. After running `/compact`, the display didn't update, only changed once a new prompt was sent

The `usage` memo's `findLast` predicate filtered for assistants with `tokens.output > 0`. While a fresh assistant message is still streaming or just created, its `tokens.output` is 0, so `findLast` skipped it and the memo lost the reactive subscription that would have updated once tokens populated

The `if (tokens <= 0) return` guard right below the predicate already handles in-progress messages, so the predicate side filter was redundant and harmful. Dropping it lets `findLast` always track the most recent assistant; the memo updates as soon as tokens populate

One line change in `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`.

### How did you verify your code works?

Manually with `bun dev .`:

1. Sent the first prompt of a session → status bar populated with tokens/cost as soon as the response finished.
2. Ran `/compact` → status bar updated to the compaction summary assistant's tokens immediately.
3. Sent a follow-up prompt → status bar updated live as the new response streamed.

`bun run typecheck` from `packages/opencode` is green across all 13 workspaces.

### Screenshots / recordings

First prompt input
<img width="933" height="521" alt="image" src="https://github.com/user-attachments/assets/5397eebc-66f7-4b7a-9200-371ff0b86224" />

Token/cost changed after the first prompt
<img width="934" height="532" alt="image" src="https://github.com/user-attachments/assets/cabe0f38-8c6e-4a19-aa45-4d37d07aaa9e" />

Ran /compact
<img width="935" height="525" alt="image" src="https://github.com/user-attachments/assets/d1ac4e03-66bf-48de-ae0d-5e20d6f08d43" />

After compacted
<img width="931" height="524" alt="image" src="https://github.com/user-attachments/assets/679d3b0b-d911-4da2-9116-23cb82329bbd" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR