### PR TITLE
feat(tui): add provider disconnect command

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -38,6 +38,7 @@ import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command
 import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
 import { DialogConsoleOrg } from "@tui/component/dialog-console-org"
+import { DialogProviderDisconnect } from "@tui/component/dialog-provider-disconnect"
 import { KeybindProvider, useKeybind } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
@@ -561,6 +562,19 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
       onSelect: () => {
         dialog.replace(() => <DialogProviderList />)
+      },
+      category: "Provider",
+    },
+    {
+      title: "Disconnect provider",
+      value: "provider.disconnect",
+      suggested: sync.data.provider_next.connected.length > 0,
+      enabled: sync.data.provider_next.connected.length > 0,
+      slash: {
+        name: "disconnect",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogProviderDisconnect />)
       },
       category: "Provider",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider-disconnect.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider-disconnect.tsx
@@ -1,0 +1,128 @@
+import { createMemo, createSignal } from "solid-js"
+import { useProject } from "@tui/context/project"
+import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
+import { useTheme } from "@tui/context/theme"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { useToast } from "@tui/ui/toast"
+import { isConsoleManagedProvider } from "@tui/util/provider-origin"
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) return error.message
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  )
+    return error.message
+  return JSON.stringify(error)
+}
+
+export function DialogProviderDisconnect() {
+  const sdk = useSDK()
+  const sync = useSync()
+  const project = useProject()
+  const toast = useToast()
+  const { theme } = useTheme()
+  const [pending, setPending] = createSignal<string>()
+
+  const options = createMemo(() => {
+    if (sync.data.provider_next.connected.length === 0) {
+      return [
+        {
+          title: "No connected providers",
+          value: "",
+          description: "Use /connect to add a provider",
+          disabled: true,
+        } satisfies DialogSelectOption<string>,
+      ]
+    }
+
+    return sync.data.provider_next.connected.map((providerID) => {
+      const provider =
+        sync.data.provider_next.all.find((item) => item.id === providerID) ??
+        sync.data.provider.find((item) => item.id === providerID)
+      const consoleManaged = isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, providerID)
+      const source = provider?.source ?? "api"
+      const disabled = pending() !== undefined || consoleManaged
+
+      return {
+        title:
+          pending() === providerID ? `Disconnecting ${provider?.name ?? providerID}` : (provider?.name ?? providerID),
+        value: providerID,
+        description: consoleManaged
+          ? "Managed by OpenCode Console"
+          : source === "api"
+            ? "API key"
+            : {
+                config: "Configured provider",
+                custom: "Custom provider",
+                env: "Environment credentials",
+              }[source],
+        footer: consoleManaged
+          ? `Managed by ${sync.data.console_state.activeOrgName ?? "OpenCode Console"}`
+          : providerID,
+        disabled,
+        gutter: <text fg={disabled ? theme.textMuted : theme.error}>x</text>,
+        async onSelect(dialog) {
+          if (disabled) return
+          setPending(providerID)
+          const result = await sdk.client.auth.remove({ providerID }).catch((error: unknown) => ({ error }))
+          if (result.error) {
+            toast.show({
+              variant: "error",
+              message: errorMessage(result.error),
+            })
+            setPending(undefined)
+            return
+          }
+
+          if (source !== "api") {
+            const disabledProviders = sync.data.config.disabled_providers ?? []
+            const update = await sdk.client.config
+              .update({
+                workspace: project.workspace.current(),
+                config: {
+                  ...sync.data.config,
+                  disabled_providers: disabledProviders.includes(providerID)
+                    ? disabledProviders
+                    : [...disabledProviders, providerID],
+                },
+              })
+              .catch((error: unknown) => ({ error }))
+            if (update.error) {
+              toast.show({
+                variant: "error",
+                message: errorMessage(update.error),
+              })
+              setPending(undefined)
+              return
+            }
+          }
+
+          await sdk.client.instance.dispose().catch((error) =>
+            toast.show({
+              variant: "warning",
+              message: `Disconnected, but refresh failed: ${errorMessage(error)}`,
+            }),
+          )
+          await sync.bootstrap({ fatal: false }).catch((error) =>
+            toast.show({
+              variant: "warning",
+              message: `Disconnected, but refresh failed: ${errorMessage(error)}`,
+            }),
+          )
+          toast.show({
+            variant: "info",
+            message: `${provider?.name ?? providerID} disconnected`,
+          })
+          setPending(undefined)
+          dialog.clear()
+        },
+      } satisfies DialogSelectOption<string>
+    })
+  })
+
+  return <DialogSelect title="Disconnect provider" options={options()} />
+}

--- a/packages/opencode/test/cli/tui/provider-disconnect.test.ts
+++ b/packages/opencode/test/cli/tui/provider-disconnect.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import path from "path"
+
+const root = path.resolve(import.meta.dir, "../../..")
+
+test("registers provider disconnect slash command", async () => {
+  const app = await Bun.file(path.join(root, "src/cli/cmd/tui/app.tsx")).text()
+
+  expect(app).toContain('value: "provider.disconnect"')
+  expect(app).toContain('name: "disconnect"')
+})
+
+test("provider disconnect dialog removes auth and refreshes sync", async () => {
+  const dialog = await Bun.file(path.join(root, "src/cli/cmd/tui/component/dialog-provider-disconnect.tsx")).text()
+
+  expect(dialog).toContain("sdk.client.auth.remove")
+  expect(dialog).toContain("sdk.client.instance.dispose")
+  expect(dialog).toContain("sync.bootstrap")
+})
+
+test("provider disconnect dialog handles non-api and managed providers", async () => {
+  const dialog = await Bun.file(path.join(root, "src/cli/cmd/tui/component/dialog-provider-disconnect.tsx")).text()
+
+  expect(dialog).toContain("disabled_providers")
+  expect(dialog).toContain("sdk.client.config")
+  expect(dialog).toContain(".update")
+  expect(dialog).toContain("isConsoleManagedProvider")
+  expect(dialog).toContain("Managed by")
+})
+
+test("provider disconnect dialog guards empty and duplicate submissions", async () => {
+  const dialog = await Bun.file(path.join(root, "src/cli/cmd/tui/component/dialog-provider-disconnect.tsx")).text()
+
+  expect(dialog).toContain("No connected providers")
+  expect(dialog).toContain("setPending")
+  expect(dialog).toContain("Disconnecting")
+})


### PR DESCRIPTION
### Issue for this PR

  Closes #23923

  ### Type of change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

Adds a `/disconnect` command to the tui so you can drop a connected provider without leaving opencode.

When you run it, it shows a picker with all currently connected providers. Api key ones just have their stored auth removed. Env, config, or custom providers get pushed into `disabled_providers` so they don’t instantly reconnect on refresh. Console-managed providers show up as managed and disabled since they’re meant to be handled from the console anyway.

It also covers the annoying edge cases like empty state, selecting the same provider twice while it’s disconnecting, and sdk or refresh failures with proper toasts.

  ### How did you verify your code works?

  Ran from `packages/opencode`:

  - `bun test test/cli/tui/provider-disconnect.test.ts`
  - `bun typecheck`

  The push hook also ran `bun turbo typecheck` successfully.

  ### Screenshots / recordings

  Not included.

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR