### PR TITLE
feat(desktop-electron): add More Tools menu with Translate options

### DIFF
--- a/packages/desktop-electron/src/main/menu.ts
+++ b/packages/desktop-electron/src/main/menu.ts
@@ -65,23 +65,39 @@ export function createMenu(deps: Deps) {
         { role: "selectAll" },
       ],
     },
-    {
-      label: "View",
-      submenu: [
-        { label: "Toggle Sidebar", accelerator: "Cmd+B", click: () => deps.trigger("sidebar.toggle") },
-        { label: "Toggle Terminal", accelerator: "Ctrl+`", click: () => deps.trigger("terminal.toggle") },
-        { label: "Toggle File Tree", click: () => deps.trigger("fileTree.toggle") },
-        { type: "separator" },
-        { role: "reload" },
-        { role: "toggleDevTools" },
-        { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
-        { type: "separator" },
-        { role: "togglefullscreen" },
-      ],
-    },
+     {
+       label: "View",
+       submenu: [
+         { label: "Toggle Sidebar", accelerator: "Cmd+B", click: () => deps.trigger("sidebar.toggle") },
+         { label: "Toggle Terminal", accelerator: "Ctrl+`", click: () => deps.trigger("terminal.toggle") },
+         { label: "Toggle File Tree", click: () => deps.trigger("fileTree.toggle") },
+         { type: "separator" },
+         {
+           label: "More Tools",
+           submenu: [
+             { role: "toggleDevTools" },
+             { type: "separator" },
+             {
+               label: "Translate Selection",
+               accelerator: "CmdOrCtrl+Shift+T",
+               click: () => deps.trigger("translate.selection"),
+             },
+             {
+               label: "Translate Page",
+               click: () => deps.trigger("translate.page"),
+             },
+           ],
+         },
+         { type: "separator" },
+         { role: "reload" },
+         { type: "separator" },
+         { role: "resetZoom" },
+         { role: "zoomIn" },
+         { role: "zoomOut" },
+         { type: "separator" },
+         { role: "togglefullscreen" },
+       ],
+     },
     {
       label: "Go",
       submenu: [

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -306,6 +306,22 @@ render(() => {
     const cmd = useCommand()
     menuTrigger = (id) => cmd.trigger(id)
 
+    // Translate commands
+    cmd.register("translate.selection", () => {
+      const text = window.getSelection()?.toString().trim()
+      if (!text) return
+      const lang = prompt("Target language (e.g. zh, en, ja):", "zh")
+      if (!lang) return
+      window.open(`https://translate.google.com/?sl=auto&tl=${encodeURIComponent(lang)}&text=${encodeURIComponent(text)}`, "_blank")
+    })
+
+    cmd.register("translate.page", () => {
+      const lang = prompt("Target language (e.g. zh, en, ja):", "zh")
+      if (!lang) return
+      const url = encodeURIComponent(location.href)
+      window.open(`https://translate.google.com/translate?sl=auto&tl=${encodeURIComponent(lang)}&u=${url}`, "_blank")
+    })
+
     const theme = useTheme()
 
     createEffect(() => {


### PR DESCRIPTION
## Summary
- Add 'More Tools' submenu under View menu in desktop Electron app
- Add 'Translate Selection' menu item with CmdOrCtrl+Shift+T shortcut
- Add 'Translate Page' menu item
- Register translate commands in renderer with Google Translate integration

## Changes
- \packages/desktop-electron/src/main/menu.ts\: Added More Tools submenu with Translate options
- \packages/desktop-electron/src/renderer/index.tsx\: Registered translate.selection and translate.page commands

## Testing
- Menu items appear under View > More Tools
- Translate Selection opens Google Translate with selected text
- Translate Page opens Google Translate for current page