### PR TITLE
fix(opencode): handle unsupported import formats

### DIFF
--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -140,9 +140,16 @@ export const ImportCommand = cmd({
 
         exportData = transformed
       } else {
+        const fileExists = await Filesystem.exists(args.file)
+        if (!fileExists) {
+          process.stdout.write(`File not found: ${args.file}`)
+          process.stdout.write(EOL)
+          return
+        }
+
         exportData = await Filesystem.readJson<NonNullable<typeof exportData>>(args.file).catch(() => undefined)
         if (!exportData) {
-          process.stdout.write(`File not found: ${args.file}`)
+          process.stdout.write(`Unsupported format: ${args.file} is not a valid JSON session file`)
           process.stdout.write(EOL)
           return
         }


### PR DESCRIPTION
### Issue for this PR

Closes #23957 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opencode currently returns a misleading "File not found" message when importing unsupported file formats. This PR adds an early check for if a file exists and fails with `File not found` if it doesn't, or with `Unsupported format: ${args.file} is not a valid JSON session file` if it does but does not have a supported format.

### How did you verify your code works?

A quick `bun dev import foo.md` run.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
