### PR TITLE
fix(plan): don't carry plan model into build agent on plan_exit

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -337,11 +337,18 @@ Goal: Write your final plan to the plan file (the only file you can edit).
 - Include the paths of critical files to be modified
 - Include a verification section describing how to test the changes end-to-end (run the code, use MCP tools, run tests)
 
-### Phase 5: Call plan_exit tool
-At the very end of your turn, once you have asked the user questions and are happy with your final plan file - you should always call plan_exit to indicate to the user that you are done planning.
-This is critical - your turn should only end with either asking the user a question or calling plan_exit. Do not stop unless it's for these 2 reasons.
+### Phase 5: Call plan_exit tool (MANDATORY)
+When your plan is fully complete and the plan file is written, you MUST call plan_exit. This is the ONLY way to exit plan mode — do not ask "Should I proceed?" or "Want me to implement this?" in plain text.
 
-**Important:** Use question tool to clarify requirements/approach, use plan_exit to request plan approval. Do NOT use question tool to ask "Is this plan okay?" - that's what plan_exit does.
+- Your plan is written to the plan file → call plan_exit
+- The task is simple and needs no detailed plan → call plan_exit
+- You finished answering the user's follow-up and updated the plan → call plan_exit
+
+Do NOT call plan_exit:
+- During phases 1-3 while you are still exploring or designing
+- When you need the user to clarify requirements (use question tool instead)
+
+**Important:** Use question tool to clarify requirements/approach. Use plan_exit ONLY to signal that planning is complete and request approval to build. Do NOT use question tool to ask "Is this plan okay?" — that is what plan_exit does.
 
 NOTE: At any point in time through this workflow you should feel free to ask the user questions or clarifications. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.
 </system-reminder>`,

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -5,9 +5,10 @@ import * as Tool from "./tool"
 import { Question } from "../question"
 import { Session } from "../session"
 import { MessageV2 } from "../session/message-v2"
+import { Agent } from "../agent/agent"
 import { Provider } from "../provider"
 import { Instance } from "../project/instance"
-import { type SessionID, MessageID, PartID } from "../session/schema"
+import { MessageID, PartID, type SessionID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
 function getLastModel(sessionID: SessionID) {
@@ -22,6 +23,7 @@ export const PlanExitTool = Tool.define(
   Effect.gen(function* () {
     const session = yield* Session.Service
     const question = yield* Question.Service
+    const agents = yield* Agent.Service
     const provider = yield* Provider.Service
 
     return {
@@ -49,7 +51,9 @@ export const PlanExitTool = Tool.define(
 
           if (answers[0]?.[0] === "No") yield* new Question.RejectedError()
 
-          const model = getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel())
+          const buildAgent = yield* agents.get("build")
+          const lastUserModel = getLastModel(ctx.sessionID)
+          const model = buildAgent.model ?? lastUserModel ?? (yield* provider.defaultModel())
 
           const msg: MessageV2.User = {
             id: MessageID.ascending(),
@@ -57,7 +61,7 @@ export const PlanExitTool = Tool.define(
             role: "user",
             time: { created: Date.now() },
             agent: "build",
-            model,
+            model: { providerID: model.providerID, modelID: model.modelID },
           }
           yield* session.updateMessage(msg)
           yield* session.updatePart({


### PR DESCRIPTION
### Issue for this PR

Closes #9296

### Type of change

- [x] Bug fix

### What does this PR do?

The plan_exit tool's `getLastModel()` scanned session history for the last user message's model. It's always returning the plan agent's model. This got set on the synthetic build message, overriding the build agent's configured model.

The fix, and this PR, resolves the build agent's model using the same 3-level fallback chain as `createUserMessage`: `buildAgent.model ?? lastUserModel ?? provider.defaultModel()`

Also strengthens the Phase 5 prompt to make `plan_exit` mandatory when planning is complete, since some models ignored the softer "you should" wording and asked in plain text instead of calling the tool.

### How did you verify your code works?
- `bun typecheck` passes
- Tested with OPENCODE_EXPERIMENTAL_PLAN_MODE=1, confirmed plan_exit tool registers and the interactive question UI appears correctly

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

