### PR TITLE
feat(ui): Copy Relative and Absolute Paths from File Tree

### DIFF
--- a/packages/app/src/components/file-tree.test.ts
+++ b/packages/app/src/components/file-tree.test.ts
@@ -29,6 +29,15 @@ beforeAll(async () => {
   mock.module("@opencode-ai/ui/file-icon", () => ({ FileIcon: () => null }))
   mock.module("@opencode-ai/ui/icon", () => ({ Icon: () => null }))
   mock.module("@opencode-ai/ui/tooltip", () => ({ Tooltip: (props: { children?: unknown }) => props.children }))
+  mock.module("@opencode-ai/ui/context-menu", () => ({
+    ContextMenu: Object.assign((props: { children?: unknown }) => props.children, {
+      Trigger: (props: { children?: unknown }) => props.children,
+      Portal: (props: { children?: unknown }) => props.children,
+      Content: (props: { children?: unknown }) => props.children,
+      Item: (props: { children?: unknown }) => props.children,
+      ItemLabel: (props: { children?: unknown }) => props.children,
+    }),
+  }))
   const mod = await import("./file-tree")
   shouldListRoot = mod.shouldListRoot
   shouldListExpanded = mod.shouldListExpanded

--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -1,6 +1,8 @@
 import { useFile } from "@/context/file"
 import { encodeFilePath } from "@/context/file/path"
+import { useLanguage } from "@/context/language"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
 import {
@@ -13,10 +15,8 @@ import {
   splitProps,
   Switch,
   untrack,
-  type ComponentProps,
   type ParentProps,
 } from "solid-js"
-import { Dynamic } from "solid-js/web"
 import type { FileNode } from "@opencode-ai/sdk/v2"
 
 const MAX_DEPTH = 128
@@ -108,9 +108,7 @@ const withFileDragImage = (event: DragEvent) => {
 }
 
 const FileTreeNode = (
-  p: ParentProps &
-    ComponentProps<"div"> &
-    ComponentProps<"button"> & {
+  p: ParentProps & {
       node: FileNode
       level: number
       active?: string
@@ -119,8 +117,13 @@ const FileTreeNode = (
       kinds?: ReadonlyMap<string, Kind>
       marks?: Set<string>
       as?: "div" | "button"
+      type?: "button"
+      onClick?: (e: MouseEvent) => void
+      class?: string
+      classList?: { [k: string]: boolean | undefined }
     },
 ) => {
+  const language = useLanguage()
   const [local, rest] = splitProps(p, [
     "node",
     "level",
@@ -142,9 +145,18 @@ const FileTreeNode = (
     return kindTextColor(value)
   }
 
+  const handleCopyAbsolutePath = () => {
+    navigator.clipboard.writeText(local.node.absolute).catch(() => {})
+  }
+
+  const handleCopyRelativePath = () => {
+    navigator.clipboard.writeText(local.node.path).catch(() => {})
+  }
+
   return (
-    <Dynamic
-      component={local.as ?? "div"}
+    <ContextMenu modal={false} preventScroll={true}>
+      <ContextMenu.Trigger
+        as={local.as ?? "div"}
       classList={{
         "w-full min-w-0 h-6 flex items-center justify-start gap-x-1.5 rounded-md px-1.5 py-0 text-left hover:bg-surface-raised-base-hover active:bg-surface-base-active transition-colors cursor-pointer": true,
         "bg-surface-base-active": local.node.path === local.active,
@@ -186,7 +198,18 @@ const FileTreeNode = (
         }
         return <div class="shrink-0 size-1.5 mr-1.5 rounded-full" style={kindDotColor(value)} />
       })()}
-    </Dynamic>
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content>
+          <ContextMenu.Item onSelect={handleCopyAbsolutePath}>
+            <ContextMenu.ItemLabel>{language.t("filetree.contextMenu.copyPath")}</ContextMenu.ItemLabel>
+          </ContextMenu.Item>
+          <ContextMenu.Item onSelect={handleCopyRelativePath}>
+            <ContextMenu.ItemLabel>{language.t("filetree.contextMenu.copyRelativePath")}</ContextMenu.ItemLabel>
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu>
   )
 }
 

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -843,4 +843,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "فشل إنشاء أيقونة المشروع الدائمة",
   "error.childStore.storeCreateFailed": "فشل إنشاء المخزن",
   "terminal.connectionLost.abnormalClose": "تم إغلاق WebSocket بشكل غير طبيعي: {{code}}",
+
+  "filetree.contextMenu.copyPath": "نسخ المسار",
+  "filetree.contextMenu.copyRelativePath": "نسخ المسار النسبي",
 }

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -856,4 +856,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Falha ao criar ícone de projeto persistente",
   "error.childStore.storeCreateFailed": "Falha ao criar armazenamento",
   "terminal.connectionLost.abnormalClose": "WebSocket fechado anormalmente: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Copiar caminho",
+  "filetree.contextMenu.copyRelativePath": "Copiar caminho relativo",
 }

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -932,4 +932,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Nije uspjelo kreiranje trajne ikone projekta",
   "error.childStore.storeCreateFailed": "Nije uspjelo kreiranje skladišta",
   "terminal.connectionLost.abnormalClose": "WebSocket zatvoren nenormalno: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Kopiraj putanju",
+  "filetree.contextMenu.copyRelativePath": "Kopiraj relativnu putanju",
 }

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -926,4 +926,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Kunne ikke oprette vedvarende projektikon",
   "error.childStore.storeCreateFailed": "Kunne ikke oprette lager",
   "terminal.connectionLost.abnormalClose": "WebSocket lukkede unormalt: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Kopier sti",
+  "filetree.contextMenu.copyRelativePath": "Kopier relativ sti",
 }

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -868,4 +868,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Dauerhaftes Projekticon konnte nicht erstellt werden",
   "error.childStore.storeCreateFailed": "Speicher konnte nicht erstellt werden",
   "terminal.connectionLost.abnormalClose": "WebSocket abnormal geschlossen: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Pfad kopieren",
+  "filetree.contextMenu.copyRelativePath": "Relativen pfad kopieren",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -952,4 +952,7 @@ export const dict = {
   "workspace.reset.archived.one": "1 session will be archived.",
   "workspace.reset.archived.many": "{{count}} sessions will be archived.",
   "workspace.reset.note": "This will reset the workspace to match the default branch.",
+
+  "filetree.contextMenu.copyPath": "Copy path",
+  "filetree.contextMenu.copyRelativePath": "Copy relative path",
 }

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -939,4 +939,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Error al crear icono de proyecto persistente",
   "error.childStore.storeCreateFailed": "Error al crear almacén",
   "terminal.connectionLost.abnormalClose": "WebSocket cerrado anormalmente: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Copiar ruta",
+  "filetree.contextMenu.copyRelativePath": "Copiar ruta relativa",
 }

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -867,4 +867,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Échec de la création de l'icône de projet persistante",
   "error.childStore.storeCreateFailed": "Échec de la création du stockage",
   "terminal.connectionLost.abnormalClose": "WebSocket fermé anormalement : {{code}}",
+
+  "filetree.contextMenu.copyPath": "Copier le chemin",
+  "filetree.contextMenu.copyRelativePath": "Copier le chemin relatif",
 }

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -850,4 +850,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "永続プロジェクトアイコンの作成に失敗しました",
   "error.childStore.storeCreateFailed": "ストアの作成に失敗しました",
   "terminal.connectionLost.abnormalClose": "WebSocket が異常終了しました: {{code}}",
+
+  "filetree.contextMenu.copyPath": "パスをコピー",
+  "filetree.contextMenu.copyRelativePath": "相対パスをコピー",
 }

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -845,4 +845,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "영구 프로젝트 아이콘 생성 실패",
   "error.childStore.storeCreateFailed": "저장소 생성 실패",
   "terminal.connectionLost.abnormalClose": "WebSocket이 비정상적으로 닫힘: {{code}}",
+
+  "filetree.contextMenu.copyPath": "경로 복사",
+  "filetree.contextMenu.copyRelativePath": "상대 경로 복사",
 }

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -933,4 +933,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Kunne ikke opprette vedvarende prosjektikon",
   "error.childStore.storeCreateFailed": "Kunne ikke opprette lager",
   "terminal.connectionLost.abnormalClose": "WebSocket lukket unormalt: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Kopier sti",
+  "filetree.contextMenu.copyRelativePath": "Kopier relativ sti",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -854,4 +854,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Nie udało się utworzyć trwałej ikony projektu",
   "error.childStore.storeCreateFailed": "Nie udało się utworzyć magazynu",
   "terminal.connectionLost.abnormalClose": "WebSocket zamknięty nieprawidłowo: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Kopiuj ścieżkę",
+  "filetree.contextMenu.copyRelativePath": "Kopiuj ścieżkę względną",
 }

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -935,4 +935,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Не удалось создать постоянный значок проекта",
   "error.childStore.storeCreateFailed": "Не удалось создать хранилище",
   "terminal.connectionLost.abnormalClose": "WebSocket закрыт аварийно: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Копировать путь",
+  "filetree.contextMenu.copyRelativePath": "Копировать относительный путь",
 }

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -922,4 +922,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "ไม่สามารถสร้างไอคอนโปรเจกต์ถาวร",
   "error.childStore.storeCreateFailed": "ไม่สามารถสร้างที่เก็บ",
   "terminal.connectionLost.abnormalClose": "WebSocket ปิดอย่างผิดปกติ: {{code}}",
+
+  "filetree.contextMenu.copyPath": "คัดลอกเส้นทาง",
+  "filetree.contextMenu.copyRelativePath": "คัดลอกเส้นทางสัมพัทธ์",
 }

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -941,4 +941,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "Kalıcı proje simgesi oluşturulamadı",
   "error.childStore.storeCreateFailed": "Depo oluşturulamadı",
   "terminal.connectionLost.abnormalClose": "WebSocket anormal şekilde kapandı: {{code}}",
+
+  "filetree.contextMenu.copyPath": "Yolu kopyala",
+  "filetree.contextMenu.copyRelativePath": "Göreceli yolu kopyala",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -917,4 +917,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "创建持久化项目图标失败",
   "error.childStore.storeCreateFailed": "创建存储失败",
   "terminal.connectionLost.abnormalClose": "WebSocket 异常关闭：{{code}}",
+
+  "filetree.contextMenu.copyPath": "复制路径",
+  "filetree.contextMenu.copyRelativePath": "复制相对路径",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -913,4 +913,7 @@ export const dict = {
   "error.childStore.persistedProjectIconCreateFailed": "建立持續性專案圖示失敗",
   "error.childStore.storeCreateFailed": "建立儲存區失敗",
   "terminal.connectionLost.abnormalClose": "WebSocket 異常關閉：{{code}}",
+
+  "filetree.contextMenu.copyPath": "複製路徑",
+  "filetree.contextMenu.copyRelativePath": "複製相對路徑",
 } satisfies Partial<Record<Keys, string>>


### PR DESCRIPTION
### Issue for this PR

Closes #16019

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Contributes context menu to the file tree. Two items are available:
* <b>Copy path</b> copies absolute path to clipboard
* <b>Copy relative path</b> copies to clipboard path relative to project root

Menu item titles follow VSCode and their capitalization follows project sidebar context menu. Item titles translation to the supported languages is provided.

### How did you verify your code works?
* Checked that the menu can be invoked and its items act as expected
* Checked that menu invocation does not disable the file tree
* Checked that menu invocation does disable file tree scrolling
* Switched language in app setting to see that it affects the item titles

### Screenshots / recordings
<figure>
 <figcaption align="center"><b>Windows</b></figcaption>
<img width="689" height="396" alt="file-tree-menu-win" src="https://github.com/user-attachments/assets/0410a977-73c3-4cec-bf18-cd20400c7d2a" />
</figure>
<br><br>
<figure>
 <figcaption align="center"><b>Linux</b></figcaption>
<img width="682" height="344" alt="file-tree-menu-linux" src="https://github.com/user-attachments/assets/b0bd7fcf-3127-4655-8880-d7c3b4c9f282" />

</figure>


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
