### PR TITLE
fix: increase LSP initialize timeout for JDTLS and KotlinLS

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -275,7 +275,7 @@ export async function create(input: { serverID: string; server: LSPServer.Handle
         },
       },
     }),
-    INITIALIZE_TIMEOUT_MS,
+    input.server.initializeTimeout ?? INITIALIZE_TIMEOUT_MS,
   ).catch((err) => {
     logger.error("initialize error", { error: err })
     throw new InitializeError(

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -27,6 +27,8 @@ const output = (cmd: string[], opts: Process.RunOptions = {}) => Process.text(cm
 export interface Handle {
   process: ChildProcessWithoutNullStreams
   initialization?: Record<string, any>
+  /** Override the default 45 s initialize-request timeout (ms). */
+  initializeTimeout?: number
 }
 
 type RootFunction = (file: string, ctx: InstanceContext) => Promise<string | undefined>
@@ -1182,6 +1184,7 @@ export const JDTLS: Info = {
           cwd: root,
         },
       ),
+      initializeTimeout: 180_000,
     }
   },
 }
@@ -1281,6 +1284,7 @@ export const KotlinLS: Info = {
       process: spawn(launcherScript, ["--stdio"], {
         cwd: root,
       }),
+      initializeTimeout: 180_000,
     }
   },
 }


### PR DESCRIPTION
## Problem

JDTLS (Eclipse JDT Language Server) and KotlinLS are JVM-based language servers that must perform Gradle project sync and workspace indexing during the LSP `initialize` handshake. For real-world projects this routinely takes 60–180 seconds, well above the default 45 s timeout — causing every `lsp_diagnostics` call to fail with `LSP request timeout (method: initialize)`.

See #23982 for full diagnosis.

## Changes

- Add an optional `initializeTimeout` field to the `LSPServer.Handle` interface so built-in servers can declare their timeout needs
- Use it in `client.ts` with the existing `INITIALIZE_TIMEOUT_MS` (45 s) as the default — no behavior change for any other server
- Set `initializeTimeout: 180_000` (3 min) for **JDTLS** and **KotlinLS**, both of which are JVM-based and trigger Gradle sync during initialization

## Testing

All existing LSP tests pass:

```
31 pass, 0 fail across test/lsp/*
9 pass, 0 fail for test/config/lsp.test.ts
```

## Before / After

| Server | Before | After |
|--------|--------|-------|
| JDTLS | 45 s (always times out for Gradle projects) | 180 s |
| KotlinLS | 45 s (same issue) | 180 s |
| All others | 45 s | 45 s (unchanged) |

Closes #23982