### PR TITLE
fix: preserve newlines in ACP command argument parsing

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1448,8 +1448,9 @@ export class Agent implements ACPAgent {
 
       if (!text.startsWith("/")) return
 
-      const [name, ...rest] = text.slice(1).split(/\s+/)
-      return { name, args: rest.join(" ").trim() }
+      const match = text.slice(1).match(/^(\S+)(?:\s([\s\S]*))?$/)
+      if (!match) return
+      return { name: match[1], args: (match[2] ?? "").trim() }
     })()
 
     const buildUsage = (msg: AssistantMessage): Usage => ({


### PR DESCRIPTION
### Issue for this PR

Closes #24012

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ACP command argument parsing in `agent.ts` destroys newlines. When an ACP client sends a command like `/pivot prometheus\nmy multi-line prompt`, the argument text arrives with all newlines replaced by spaces.

The bug is at the command extraction logic around line 1451. The old code does:

```typescript
const [name, ...rest] = text.slice(1).split(/\s+/)
return { name, args: rest.join(" ").trim() }
```

`split(/\s+/)` treats `\n`, `\r`, `\t` identically to spaces — it splits the entire string on every whitespace character. Then `rest.join(" ")` glues everything back with single spaces, losing the original whitespace structure.

The fix splits only on the first whitespace boundary and passes the rest through verbatim:

```typescript
const match = text.slice(1).match(/^(\S+)(?:\s([\s\S]*))?$/)
if (!match) return
return { name: match[1], args: (match[2] ?? "").trim() }
```

`(\S+)` captures the command name (no whitespace). `(?:\s([\s\S]*))?` optionally matches one whitespace delimiter then captures everything after it — including newlines — as-is. The `[\s\S]*` with no flags is the standard JS idiom for "match anything including newlines". Only `.trim()` on the final args string removes leading/trailing whitespace, which is the same behavior as before for edge-trimming.

### How did you verify your code works?

Tested end-to-end with an in-house ACP client sending a multi-line prompt via `/pivot prometheus\n<53 lines of markdown>`. (`pivot` is an custom tool that switches agent and then send the prompt) Before the fix, the prompt arrived at the plugin hook with all newlines collapsed to spaces. After the fix, newlines are preserved through the full pipeline: `agent.ts` → `prompt.ts` `$ARGUMENTS` substitution → plugin `command.execute.before` hook.

### Screenshots / recordings

_N/A — backend text processing change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR