### PR TITLE
fix(opencode): stop retrying non-transient rate limits

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -60,6 +60,15 @@ export function retryable(error: Err) {
     // even when the provider SDK doesn't explicitly mark them as retryable.
     if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined
     if (error.data.responseBody?.includes("FreeUsageLimitError")) return GO_UPSELL_MESSAGE
+    // Non-transient rate limits (weekly/monthly quotas) should not be retried
+    // they won't resolve with backoff and can take days to reset.
+    const lower = error.data.message.toLowerCase()
+    if (
+      lower.includes("weekly") ||
+      lower.includes("monthly") ||
+      lower.includes("exceeded your")
+    )
+      return undefined
     return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
   }
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -230,6 +230,26 @@ describe("session.retry.retryable", () => {
     expect(retryable).toBeDefined()
     expect(retryable).toBe("Response decompression failed")
   })
+
+  test("does not retry weekly rate limit errors", () => {
+    const error = new MessageV2.APIError({
+      message: "Too Many Requests: Sorry, you've exceeded your weekly rate limit. Please review ...",
+      isRetryable: true,
+      statusCode: 429,
+    }).toObject() as MessageV2.APIError
+
+    expect(SessionRetry.retryable(error)).toBeUndefined()
+  })
+
+  test("does not retry monthly quota errors", () => {
+    const error = new MessageV2.APIError({
+      message: "You have exceeded your monthly usage quota",
+      isRetryable: true,
+      statusCode: 429,
+    }).toObject() as MessageV2.APIError
+
+    expect(SessionRetry.retryable(error)).toBeUndefined()
+  })
 })
 
 describe("session.message-v2.fromError", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #24011 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

retryable() trusted the AI SDK's isRetryable flag for 429 errors, which is always true, even for weekly/monthly quota limits that won't resolve with backoff. Added a message check for "weekly", "monthly", "exceeded your" to return undefined (stop) instead of retrying forever.

### How did you verify your code works?
- bun typecheck passes
- traced the code path: weekly limit 429 -> retryable() now returns undefined -> policy() stops
- manually verified behavior

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR