### PR TITLE
docs(schema): mark sync/index.ts migrated with compat-bridge note

### DIFF
--- a/packages/opencode/specs/effect/schema.md
+++ b/packages/opencode/specs/effect/schema.md
@@ -147,6 +147,17 @@ import `z` do so only for local `ZodOverride` bridges or for `z.ZodType`
 type annotations — the `export const <Info|Spec>` values are all Effect
 Schema at source.
 
+A file is considered "done" when:
+
+- its exported schema values (`Info`, `Input`, `Event`, `Definition`, etc.)
+  are authored as Effect Schema
+- any remaining zod is either a derived compat bridge (via `zod()` /
+  `zodObject()`), a `z.ZodType` type annotation, or a documented
+  `ZodOverride` escape hatch — never a hand-written parallel source of truth
+
+Files that meet this bar but still carry a compat bridge are checked off
+with an inline note describing the bridge and what unblocks its removal.
+
 - [x] skills, formatter, console-state, mcp, lsp, permission (leaves), model-id, command, plugin, provider
 - [x] server, layout
 - [x] keybinds
@@ -365,7 +376,7 @@ piecewise.
 - [ ] `src/snapshot/index.ts`
 - [ ] `src/storage/db.ts`
 - [ ] `src/storage/storage.ts`
-- [ ] `src/sync/index.ts`
+- [x] `src/sync/index.ts` — public API (`SyncEvent.define`) is Schema-first; still stores derived zod `schema`/`properties` on each `Definition` as a compat bridge for `BusEvent` until `bus/bus-event.ts` migrates
 - [ ] `src/util/fn.ts`
 - [ ] `src/util/log.ts`
 - [ ] `src/util/update-schema.ts`


### PR DESCRIPTION
## Summary

- Clarifies the completion criterion for the schema migration tracker: a file is "done" when its exported schema values are Effect Schema at source, even if derived zod is kept as a compat bridge for callers that have not migrated yet
- Checks off \`src/sync/index.ts\` with an inline note — \`SyncEvent.define\` is now Schema-first (all in-tree callers pass Schema), but it still stores derived \`schema\`/\`properties\` on each \`Definition\` until \`bus/bus-event.ts\` migrates

## Non-changes

- Considered also simplifying \`ProjectBus.publish({ type: def.type, properties: def.properties }, ...)\` → \`ProjectBus.publish(def, ...)\` in \`sync/index.ts\`, but passing the typed \`def\` narrows \`BusProperties<D>\` via \`effectProperties\`, which then rejects the loose \`Record<string, unknown>\` \`asRecord\` returns. The current inline literal is the reason \`BusProperties\` falls through to the zod branch. Deferred — will be cleaned up naturally when \`BusEvent\` migrates to Schema-first.