### PR TITLE
refactor(schema): use Schema.Int and consolidate PositiveInt/NonNegativeInt

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -4,6 +4,7 @@ import { Schema } from "effect"
 import z from "zod"
 import { Bus } from "@/bus"
 import { zod } from "@/util/effect-zod"
+import { PositiveInt } from "@/util/schema"
 import { Log } from "../util"
 import { NamedError } from "@opencode-ai/shared/util/error"
 import { Glob } from "@opencode-ai/shared/util/glob"
@@ -14,8 +15,6 @@ import { ConfigModelID } from "./model-id"
 import { ConfigPermission } from "./permission"
 
 const log = Log.create({ service: "config" })
-
-const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
 
 const Color = Schema.Union([
   Schema.String.check(Schema.isPattern(/^#[0-9a-fA-F]{6}$/)),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -25,7 +25,7 @@ import { Context, Duration, Effect, Exit, Fiber, Layer, Option, Schema } from "e
 import { EffectFlock } from "@opencode-ai/shared/util/effect-flock"
 import { InstanceRef } from "@/effect/instance-ref"
 import { zod, ZodOverride } from "@/util/effect-zod"
-import { withStatics } from "@/util/schema"
+import { NonNegativeInt, PositiveInt, withStatics } from "@/util/schema"
 import { ConfigAgent } from "./agent"
 import { ConfigCommand } from "./command"
 import { ConfigFormatter } from "./formatter"
@@ -87,9 +87,6 @@ export type Layout = ConfigLayout.Layout
 // exact zod directly, preserving component $refs.
 const AgentRef = Schema.Any.annotate({ [ZodOverride]: ConfigAgent.Info })
 const LogLevelRef = Schema.Any.annotate({ [ZodOverride]: Log.Level })
-
-const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
-const NonNegativeInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThanOrEqualTo(0))
 
 // The Effect Schema is the canonical source of truth. The `.zod` compatibility
 // surface is derived so existing Hono validators keep working without a parallel

--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -1,8 +1,6 @@
 import { Schema } from "effect"
 import { zod } from "@/util/effect-zod"
-import { withStatics } from "@/util/schema"
-
-const PositiveInt = Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))
+import { PositiveInt, withStatics } from "@/util/schema"
 
 export const Model = Schema.Struct({
   id: Schema.optional(Schema.String),

--- a/packages/opencode/src/config/server.ts
+++ b/packages/opencode/src/config/server.ts
@@ -1,9 +1,9 @@
 import { Schema } from "effect"
 import { zod } from "@/util/effect-zod"
-import { withStatics } from "@/util/schema"
+import { PositiveInt, withStatics } from "@/util/schema"
 
 export const Server = Schema.Struct({
-  port: Schema.optional(Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0))).annotate({
+  port: Schema.optional(PositiveInt).annotate({
     description: "Port to listen on",
   }),
   hostname: Schema.optional(Schema.String).annotate({ description: "Hostname to listen on" }),

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -17,7 +17,7 @@ import type { Provider } from "@/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect, Schema, Types } from "effect"
 import { zod, ZodOverride } from "@/util/effect-zod"
-import { withStatics } from "@/util/schema"
+import { NonNegativeInt, withStatics } from "@/util/schema"
 import { namedSchemaError } from "@/util/named-schema-error"
 import { EffectLogger } from "@/effect"
 
@@ -64,9 +64,7 @@ export class OutputFormatText extends Schema.Class<OutputFormatText>("OutputForm
 export class OutputFormatJsonSchema extends Schema.Class<OutputFormatJsonSchema>("OutputFormatJsonSchema")({
   type: Schema.Literal("json_schema"),
   schema: Schema.Record(Schema.String, Schema.Any).annotate({ identifier: "JSONSchema" }),
-  retryCount: Schema.Number.check(Schema.isInt())
-    .check(Schema.isGreaterThanOrEqualTo(0))
-    .pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed(2))),
+  retryCount: NonNegativeInt.pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed(2))),
 }) {
   static readonly zod = zod(this)
 }
@@ -138,8 +136,8 @@ export type ReasoningPart = Types.DeepMutable<Schema.Schema.Type<typeof Reasonin
 const filePartSourceBase = {
   text: Schema.Struct({
     value: Schema.String,
-    start: Schema.Number.check(Schema.isInt()),
-    end: Schema.Number.check(Schema.isInt()),
+    start: Schema.Int,
+    end: Schema.Int,
   }).annotate({ identifier: "FilePartSourceText" }),
 }
 
@@ -157,7 +155,7 @@ export const SymbolSource = Schema.Struct({
   path: Schema.String,
   range: LSP.Range,
   name: Schema.String,
-  kind: Schema.Number.check(Schema.isInt()),
+  kind: Schema.Int,
 })
   .annotate({ identifier: "SymbolSource" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))
@@ -196,8 +194,8 @@ export const AgentPart = Schema.Struct({
   source: Schema.optional(
     Schema.Struct({
       value: Schema.String,
-      start: Schema.Number.check(Schema.isInt()),
-      end: Schema.Number.check(Schema.isInt()),
+      start: Schema.Int,
+      end: Schema.Int,
     }),
   ),
 })
@@ -501,8 +499,8 @@ export const AgentPartInput = Schema.Struct({
   source: Schema.optional(
     Schema.Struct({
       value: Schema.String,
-      start: Schema.Number.check(Schema.isInt()),
-      end: Schema.Number.check(Schema.isInt()),
+      start: Schema.Int,
+      end: Schema.Int,
     }),
   ),
 })

--- a/packages/opencode/src/util/schema.ts
+++ b/packages/opencode/src/util/schema.ts
@@ -1,6 +1,16 @@
 import { Schema } from "effect"
 
 /**
+ * Integer greater than zero.
+ */
+export const PositiveInt = Schema.Int.check(Schema.isGreaterThan(0))
+
+/**
+ * Integer greater than or equal to zero.
+ */
+export const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
+
+/**
  * Attach static methods to a schema object. Designed to be used with `.pipe()`:
  *
  * @example


### PR DESCRIPTION
## Summary

Two small cleanups surfaced by an effect-smol audit — both byte-identical SDK, pure cosmetic semantically:

- Replace bare \`Schema.Number.check(Schema.isInt())\` with \`Schema.Int\` across \`session/message-v2.ts\` (8 sites). \`Schema.Int\` is the canonical effect-smol primitive for this check (packages/effect/src/Schema.ts:9424).
- Move \`PositiveInt\` and \`NonNegativeInt\` to \`util/schema.ts\`, replacing three identical local definitions in \`config/agent.ts\`, \`config/config.ts\`, and \`config/provider.ts\`. Also adopts them at inline sites in \`config/server.ts\` (port) and \`session/message-v2.ts\` (retryCount).

## Verification

- SDK output byte-identical: \`./packages/sdk/js/script/build.ts\` + clean \`git status packages/sdk\`.
- \`bun typecheck\` clean.