### PR TITLE
fix(prompt): use display-width coordinates for extmark positions to handle CJK input correctly

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -344,11 +344,14 @@ export function Prompt(props: PromptProps) {
 
               if (!virtualText) return part
 
-              const newStart = content.indexOf(virtualText)
+              const stringIndex = content.indexOf(virtualText)
               // if the virtual text is deleted, remove the part
-              if (newStart === -1) return null
+              if (stringIndex === -1) return null
 
-              const newEnd = newStart + virtualText.length
+              // Convert JS string index to display-width coordinates
+              // because extmark system uses display-width (terminal columns)
+              const newStart = Bun.stringWidth(content.substring(0, stringIndex))
+              const newEnd = newStart + Bun.stringWidth(virtualText)
 
               if (part.type === "file" && part.source?.text) {
                 return {
@@ -699,7 +702,14 @@ export function Prompt(props: PromptProps) {
     const messageID = MessageID.ascending()
     let inputText = store.prompt.input
 
-    // Expand pasted text inline before submitting
+    // Expand pasted text inline before submitting.
+    // We replace virtual placeholder strings (e.g. "[Pasted ~27 lines]") with
+    // the original pasted content.  Extmark offsets come from the Zig native
+    // layer and may use display-width units that don't map 1:1 to JS string
+    // indices (CJK chars are 2 columns wide but 1 JS char).  To avoid any
+    // coordinate-system mismatch we locate each placeholder by its literal
+    // text value instead of slicing by offset.  Processing right-to-left
+    // (descending start) ensures earlier positions stay valid.
     const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
     const sortedExtmarks = allExtmarks.sort((a: { start: number }, b: { start: number }) => b.start - a.start)
 
@@ -707,10 +717,12 @@ export function Prompt(props: PromptProps) {
       const partIndex = store.extmarkToPartIndex.get(extmark.id)
       if (partIndex !== undefined) {
         const part = store.prompt.parts[partIndex]
-        if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
-          inputText = before + part.text + after
+        if (part?.type === "text" && part.text && part.source?.text?.value) {
+          const virtualText = part.source.text.value
+          const idx = inputText.lastIndexOf(virtualText)
+          if (idx !== -1) {
+            inputText = inputText.slice(0, idx) + part.text + inputText.slice(idx + virtualText.length)
+          }
         }
       }
     }
@@ -811,7 +823,7 @@ export function Prompt(props: PromptProps) {
   function pasteText(text: string, virtualText: string) {
     const currentOffset = input.visualCursor.offset
     const extmarkStart = currentOffset
-    const extmarkEnd = extmarkStart + virtualText.length
+    const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
 
     input.insertText(virtualText + " ")
 
@@ -852,7 +864,7 @@ export function Prompt(props: PromptProps) {
       return x.mime.startsWith("image/")
     }).length
     const virtualText = pdf ? `[PDF ${count + 1}]` : `[Image ${count + 1}]`
-    const extmarkEnd = extmarkStart + virtualText.length
+    const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
     const textToInsert = virtualText + " "
 
     input.insertText(textToInsert)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -699,7 +699,14 @@ export function Prompt(props: PromptProps) {
     const messageID = MessageID.ascending()
     let inputText = store.prompt.input
 
-    // Expand pasted text inline before submitting
+    // Expand pasted text inline before submitting.
+    // We replace virtual placeholder strings (e.g. "[Pasted ~27 lines]") with
+    // the original pasted content.  Extmark offsets come from the Zig native
+    // layer and may use display-width units that don't map 1:1 to JS string
+    // indices (CJK chars are 2 columns wide but 1 JS char).  To avoid any
+    // coordinate-system mismatch we locate each placeholder by its literal
+    // text value instead of slicing by offset.  Processing right-to-left
+    // (descending start) ensures earlier positions stay valid.
     const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
     const sortedExtmarks = allExtmarks.sort((a: { start: number }, b: { start: number }) => b.start - a.start)
 
@@ -707,10 +714,12 @@ export function Prompt(props: PromptProps) {
       const partIndex = store.extmarkToPartIndex.get(extmark.id)
       if (partIndex !== undefined) {
         const part = store.prompt.parts[partIndex]
-        if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
-          inputText = before + part.text + after
+        if (part?.type === "text" && part.text && part.source?.text?.value) {
+          const virtualText = part.source.text.value
+          const idx = inputText.lastIndexOf(virtualText)
+          if (idx !== -1) {
+            inputText = inputText.slice(0, idx) + part.text + inputText.slice(idx + virtualText.length)
+          }
         }
       }
     }
@@ -811,7 +820,7 @@ export function Prompt(props: PromptProps) {
   function pasteText(text: string, virtualText: string) {
     const currentOffset = input.visualCursor.offset
     const extmarkStart = currentOffset
-    const extmarkEnd = extmarkStart + virtualText.length
+    const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
 
     input.insertText(virtualText + " ")
 
@@ -852,7 +861,7 @@ export function Prompt(props: PromptProps) {
       return x.mime.startsWith("image/")
     }).length
     const virtualText = pdf ? `[PDF ${count + 1}]` : `[Image ${count + 1}]`
-    const extmarkEnd = extmarkStart + virtualText.length
+    const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
     const textToInsert = virtualText + " "
 
     input.insertText(textToInsert)


### PR DESCRIPTION
### Issue for this PR

Closes # *(no existing issue — discovered during code review)*

### Type of change

- [x] Bug fix

---

### What does this PR do?

**The Problem**

The extmark system in `@opentui/core` tracks positions using **display-width** (terminal column counts), not JavaScript string character indices. For ASCII text these two measures are identical, but CJK characters (Chinese, Japanese, Korean) occupy **2 terminal columns** while being only **1 JS character**. This mismatch caused corrupted text in several code paths whenever the user's prompt contained CJK characters alongside pasted attachments or file references.

Concretely, three bugs existed:

1. **`pasteText()` / `pasteAttachment()`** — `extmarkEnd` was computed as `extmarkStart + virtualText.length` (JS char count). For CJK-containing virtual text (e.g. a filename like `[SVG: 图片]`) the registered extmark region would be shorter than the visual span, so subsequent edits or expansions would mis-track the placeholder.

2. **`submit()` — pasted text expansion** — when building the final `inputText`, the code used `inputText.slice(0, extmark.start)` / `inputText.slice(extmark.end)` with raw extmark offsets. If anything before the placeholder contained CJK characters, the display-width offset ≠ JS index, so the slice landed at the wrong position and corrupted the submitted text.

3. **Editor-open path** — after the user edits the prompt in an external editor, the code relocated non-text parts by calling `content.indexOf(virtualText)` (correct JS index) but then assigned the result directly as the new `start`/`end` without converting to display-width, feeding wrong coordinates back into the extmark system.

**The Fixes**

| Location | Change |
|---|---|
| `pasteText()` | `extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)` |
| `pasteAttachment()` | `extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)` |
| `submit()` expansion loop | Locate placeholder via `lastIndexOf(virtualText)` on the JS string; expand by string position rather than extmark offset |
| Editor-open relocation | Find `stringIndex` with `content.indexOf()`, then convert: `newStart = Bun.stringWidth(content.substring(0, stringIndex))`, `newEnd = newStart + Bun.stringWidth(virtualText)` |

Using `Bun.stringWidth` converts JS-index positions to the display-width coordinates the extmark system expects. Switching to value-based lookup (`lastIndexOf`) in the submit path avoids the coordinate system entirely for that operation, which is both simpler and more robust.

---

### How did you verify your code works?

- Typed a prompt mixing CJK characters (e.g. `你好，请分析这个截图`) and pasted an image attachment; confirmed the `[Image 1]` placeholder tracks correctly and expands to the image data on submit without corrupting the surrounding text.
- Opened the external editor with a prompt containing CJK text and a file attachment; confirmed the file extmark position is correctly restored after saving.
- Verified pure-ASCII prompts with pasted content continue to work as before (for ASCII, `Bun.stringWidth(s) === s.length` so behaviour is unchanged).

---

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR