### PR TITLE
fix(opencode): allow gpt-5.5 in Codex OAuth model list

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -110,6 +110,33 @@ interface TokenResponse {
   expires_in?: number
 }
 
+type CodexOAuthModel = {
+  api: {
+    id: string
+  }
+}
+
+export function filterCodexOAuthModels(provider: { models: Record<string, CodexOAuthModel> }) {
+  const allowedModels = new Set([
+    "gpt-5.1-codex",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
+    "gpt-5.2",
+    "gpt-5.2-codex",
+    "gpt-5.3-codex",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.5",
+  ])
+  for (const [modelId, model] of Object.entries(provider.models)) {
+    if (modelId.includes("codex")) continue
+    if (allowedModels.has(model.api.id)) continue
+    const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
+    if (match && parseFloat(match[1]) > 5.4) continue
+    delete provider.models[modelId]
+  }
+}
+
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
@@ -365,23 +392,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         if (auth.type !== "oauth") return {}
 
         // Filter models to only allowed Codex models for OAuth
-        const allowedModels = new Set([
-          "gpt-5.1-codex",
-          "gpt-5.1-codex-max",
-          "gpt-5.1-codex-mini",
-          "gpt-5.2",
-          "gpt-5.2-codex",
-          "gpt-5.3-codex",
-          "gpt-5.4",
-          "gpt-5.4-mini",
-        ])
-        for (const [modelId, model] of Object.entries(provider.models)) {
-          if (modelId.includes("codex")) continue
-          if (allowedModels.has(model.api.id)) continue
-          const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
-          if (match && parseFloat(match[1]) > 5.4) continue
-          delete provider.models[modelId]
-        }
+        filterCodexOAuthModels(provider)
 
         // Zero out costs for Codex (included with ChatGPT subscription)
         for (const model of Object.values(provider.models)) {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -3,6 +3,7 @@ import {
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
+  filterCodexOAuthModels,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
 
@@ -118,6 +119,36 @@ describe("plugin.codex", () => {
           refresh_token: "rt",
         }),
       ).toBe("acc-123")
+    })
+  })
+
+  describe("filterCodexOAuthModels", () => {
+    test("keeps gpt-5.5 for ChatGPT OAuth", () => {
+      const provider = {
+        models: {
+          "gpt-5.5": { api: { id: "gpt-5.5" } },
+          "gpt-5.4-nano": { api: { id: "gpt-5.4-nano" } },
+          "gpt-4.1": { api: { id: "gpt-4.1" } },
+        },
+      }
+
+      filterCodexOAuthModels(provider)
+
+      expect(Object.keys(provider.models)).toEqual(["gpt-5.5"])
+    })
+
+    test("keeps codex models and newer gpt-5 point releases", () => {
+      const provider = {
+        models: {
+          "gpt-5.3-codex": { api: { id: "gpt-5.3-codex" } },
+          "gpt-5.6": { api: { id: "gpt-5.6" } },
+          "gpt-5.4-pro": { api: { id: "gpt-5.4-pro" } },
+        },
+      }
+
+      filterCodexOAuthModels(provider)
+
+      expect(Object.keys(provider.models)).toEqual(["gpt-5.3-codex", "gpt-5.6"])
     })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #24036
Closes #24039

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `gpt-5.5` to the explicit Codex OAuth allowed model list for OpenAI. The existing numeric fallback already allows newer GPT-5 point releases, but listing `gpt-5.5` here makes the supported Codex OAuth surface clear now that `models.dev` includes the model.

### How did you verify your code works?

- `bun test test/plugin/codex.test.ts`
- `bun typecheck` from `packages/opencode`
- push hook: `bun turbo typecheck`
- macOS CLI build: `bun run build --single` from `packages/opencode` with `dist/opencode-darwin-arm64/bin/opencode --version` smoke test passing

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR