### PR TITLE
fix(tui): unsubscribe event listeners on component disposal

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -14,6 +14,7 @@ import {
   batch,
   Show,
   on,
+  onCleanup,
 } from "solid-js"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { Flag } from "@/flag/flag"
@@ -736,94 +737,97 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     },
   ])
 
-  event.on(TuiEvent.CommandExecute.type, (evt) => {
-    command.trigger(evt.properties.command)
-  })
+  const unsubs: Array<() => void> = [
+    event.on(TuiEvent.CommandExecute.type, (evt) => {
+      command.trigger(evt.properties.command)
+    }),
 
-  event.on(TuiEvent.ToastShow.type, (evt) => {
-    toast.show({
-      title: evt.properties.title,
-      message: evt.properties.message,
-      variant: evt.properties.variant,
-      duration: evt.properties.duration,
-    })
-  })
-
-  event.on(TuiEvent.SessionSelect.type, (evt) => {
-    route.navigate({
-      type: "session",
-      sessionID: evt.properties.sessionID,
-    })
-  })
-
-  event.on("session.deleted", (evt) => {
-    if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
-      route.navigate({ type: "home" })
+    event.on(TuiEvent.ToastShow.type, (evt) => {
       toast.show({
-        variant: "info",
-        message: "The current session was deleted",
+        title: evt.properties.title,
+        message: evt.properties.message,
+        variant: evt.properties.variant,
+        duration: evt.properties.duration,
       })
-    }
-  })
+    }),
 
-  event.on("session.error", (evt) => {
-    const error = evt.properties.error
-    if (error && typeof error === "object" && error.name === "MessageAbortedError") return
-    const message = errorMessage(error)
+    event.on(TuiEvent.SessionSelect.type, (evt) => {
+      route.navigate({
+        type: "session",
+        sessionID: evt.properties.sessionID,
+      })
+    }),
 
-    toast.show({
-      variant: "error",
-      message,
-      duration: 5000,
-    })
-  })
+    event.on("session.deleted", (evt) => {
+      if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
+        route.navigate({ type: "home" })
+        toast.show({
+          variant: "info",
+          message: "The current session was deleted",
+        })
+      }
+    }),
 
-  event.on("installation.update-available", async (evt) => {
-    const version = evt.properties.version
+    event.on("session.error", (evt) => {
+      const error = evt.properties.error
+      if (error && typeof error === "object" && error.name === "MessageAbortedError") return
+      const message = errorMessage(error)
 
-    const skipped = kv.get("skipped_version")
-    if (skipped && !semver.gt(version, skipped)) return
-
-    const choice = await DialogConfirm.show(
-      dialog,
-      `Update Available`,
-      `A new release v${version} is available. Would you like to update now?`,
-      "skip",
-    )
-
-    if (choice === false) {
-      kv.set("skipped_version", version)
-      return
-    }
-
-    if (choice !== true) return
-
-    toast.show({
-      variant: "info",
-      message: `Updating to v${version}...`,
-      duration: 30000,
-    })
-
-    const result = await sdk.client.global.upgrade({ target: version })
-
-    if (result.error || !result.data?.success) {
       toast.show({
         variant: "error",
-        title: "Update Failed",
-        message: "Update failed",
-        duration: 10000,
+        message,
+        duration: 5000,
       })
-      return
-    }
+    }),
 
-    await DialogAlert.show(
-      dialog,
-      "Update Complete",
-      `Successfully updated to OpenCode v${result.data.version}. Please restart the application.`,
-    )
+    event.on("installation.update-available", async (evt) => {
+      const version = evt.properties.version
 
-    void exit()
-  })
+      const skipped = kv.get("skipped_version")
+      if (skipped && !semver.gt(version, skipped)) return
+
+      const choice = await DialogConfirm.show(
+        dialog,
+        `Update Available`,
+        `A new release v${version} is available. Would you like to update now?`,
+        "skip",
+      )
+
+      if (choice === false) {
+        kv.set("skipped_version", version)
+        return
+      }
+
+      if (choice !== true) return
+
+      toast.show({
+        variant: "info",
+        message: `Updating to v${version}...`,
+        duration: 30000,
+      })
+
+      const result = await sdk.client.global.upgrade({ target: version })
+
+      if (result.error || !result.data?.success) {
+        toast.show({
+          variant: "error",
+          title: "Update Failed",
+          message: "Update failed",
+          duration: 10000,
+        })
+        return
+      }
+
+      await DialogAlert.show(
+        dialog,
+        "Update Complete",
+        `Successfully updated to OpenCode v${result.data.version}. Please restart the application.`,
+      )
+
+      void exit()
+    }),
+  ]
+  onCleanup(() => { for (const unsub of unsubs) unsub() })
 
   const plugin = createMemo(() => {
     if (!ready()) return

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -157,7 +157,7 @@ export function Prompt(props: PromptProps) {
   let promptPartTypeId = 0
   const event = useEvent()
 
-  event.on(TuiEvent.PromptAppend.type, (evt) => {
+  const unsubPromptAppend = event.on(TuiEvent.PromptAppend.type, (evt) => {
     if (!input || input.isDestroyed) return
     input.insertText(evt.properties.text)
     setTimeout(() => {
@@ -168,6 +168,7 @@ export function Prompt(props: PromptProps) {
       renderer.requestRender()
     }, 0)
   })
+  onCleanup(() => unsubPromptAppend())
 
   createEffect(() => {
     if (props.disabled) input.cursorColor = theme.backgroundElement

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -1,4 +1,5 @@
 import { useRenderer } from "@opentui/solid"
+import { onCleanup } from "solid-js"
 import { createSimpleContext } from "./helper"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { win32FlushInputBuffer } from "../win32"
@@ -54,7 +55,9 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
         message: store,
       },
     )
-    process.on("SIGHUP", () => exit())
+    const sighupHandler = () => exit()
+    process.on("SIGHUP", sighupHandler)
+    onCleanup(() => process.off("SIGHUP", sighupHandler))
     return exit
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
@@ -1,4 +1,4 @@
-import { createMemo } from "solid-js"
+import { createMemo, onCleanup } from "solid-js"
 import { Keybind } from "@/util"
 import { pipe, mapValues } from "remeda"
 import type { TuiConfig } from "@/cli/cmd/tui/config/tui"
@@ -27,6 +27,7 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
 
     let focus: Renderable | null
     let timeout: NodeJS.Timeout
+    onCleanup(() => { if (timeout) clearTimeout(timeout) })
     function leader(active: boolean) {
       if (active) {
         setStore("leader", true)

--- a/packages/opencode/src/cli/cmd/tui/context/project.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/project.tsx
@@ -1,4 +1,4 @@
-import { batch } from "solid-js"
+import { batch, onCleanup } from "solid-js"
 import type { Path, Workspace } from "@opencode-ai/sdk/v2"
 import { createStore, reconcile } from "solid-js/store"
 import { createSimpleContext } from "./helper"
@@ -61,11 +61,12 @@ export const { use: useProject, provider: ProjectProvider } = createSimpleContex
       })
     }
 
-    sdk.event.on("event", (event) => {
+    const unsubProjectEvent = sdk.event.on("event", (event) => {
       if (event.payload.type === "workspace.status") {
         setStore("workspace", "status", event.payload.properties.workspaceID, event.payload.properties.status)
       }
     })
+    onCleanup(() => unsubProjectEvent())
 
     return {
       data: store,

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -27,7 +27,7 @@ import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
-import { batch, onMount } from "solid-js"
+import { batch, onMount, onCleanup } from "solid-js"
 import { Log } from "@/util"
 import { emptyConsoleState, type ConsoleState } from "@/config/console-state"
 
@@ -111,7 +111,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const fullSyncedSessions = new Set<string>()
     let syncedWorkspace = project.workspace.current()
 
-    event.subscribe((event) => {
+    const unsubSync = event.subscribe((event) => {
       switch (event.type) {
         case "server.instance.disposed":
           void bootstrap()
@@ -349,6 +349,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
       }
     })
+    onCleanup(() => { unsubSync() })
 
     const exit = useExit()
     const args = useArgs()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -11,6 +11,7 @@ import {
   Show,
   Switch,
   useContext,
+  onCleanup,
 } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import path from "path"
@@ -221,7 +222,7 @@ export function Session() {
   })
 
   let lastSwitch: string | undefined = undefined
-  event.on("message.part.updated", (evt) => {
+  const unsubPartUpdated = event.on("message.part.updated", (evt) => {
     const part = evt.properties.part
     if (part.type !== "tool") return
     if (part.sessionID !== route.sessionID) return
@@ -251,7 +252,7 @@ export function Session() {
   const dialog = useDialog()
   const renderer = useRenderer()
 
-  event.on("session.status", (evt) => {
+  const unsubStatus = event.on("session.status", (evt) => {
     if (evt.properties.sessionID !== route.sessionID) return
     if (evt.properties.status.type !== "retry") return
     if (evt.properties.status.message !== SessionRetry.GO_UPSELL_MESSAGE) return
@@ -267,6 +268,8 @@ export function Session() {
       kv.set(GO_UPSELL_LAST_SEEN_AT, Date.now())
     })
   })
+
+  onCleanup(() => { unsubPartUpdated(); unsubStatus() })
 
   // Allow exit when in child session (prompt is hidden)
   const exit = useExit()


### PR DESCRIPTION
### Issue for this PR

Closes #24052 

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Cleans up `event.on()` and `event.subscribe()` subscriptions when Solid.js components unmount so listeners and their closures don't leak across session switches.

### How did you verify your code works?

I've been using this for weeks locally

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR