### PR TITLE
docs: update effect schema migration tracker

### DIFF
--- a/packages/opencode/specs/effect/schema.md
+++ b/packages/opencode/specs/effect/schema.md
@@ -254,8 +254,8 @@ Working rule for this cluster:
 5. Errors and event payloads last
    - `NamedError.create(...)` shapes can stay temporarily if converting them to
      `Schema.TaggedErrorClass` would force unrelated churn
-   - `SyncEvent.define(...)` and `BusEvent.define(...)` payloads can keep using
-     derived `.zod` until the sync/bus layers are migrated
+   - `SyncEvent.define(...)` and `BusEvent.define(...)` payloads can use
+     derived `.zod` at remaining zod-based HTTP/OpenAPI boundaries
 
 Possible later tightening after the Schema-first migration is stable:
 
@@ -284,25 +284,25 @@ Each tool declares its parameters via a zod schema. Tools are consumed by
 both the in-process runtime and the AI SDK's tool-calling layer, so the
 emitted JSON Schema must stay byte-identical.
 
-- [ ] `src/tool/apply_patch.ts`
-- [ ] `src/tool/bash.ts`
-- [ ] `src/tool/codesearch.ts`
-- [ ] `src/tool/edit.ts`
-- [ ] `src/tool/glob.ts`
-- [ ] `src/tool/grep.ts`
-- [ ] `src/tool/invalid.ts`
-- [ ] `src/tool/lsp.ts`
-- [ ] `src/tool/plan.ts`
-- [ ] `src/tool/question.ts`
-- [ ] `src/tool/read.ts`
-- [ ] `src/tool/registry.ts`
-- [ ] `src/tool/skill.ts`
-- [ ] `src/tool/task.ts`
-- [ ] `src/tool/todo.ts`
-- [ ] `src/tool/tool.ts`
-- [ ] `src/tool/webfetch.ts`
-- [ ] `src/tool/websearch.ts`
-- [ ] `src/tool/write.ts`
+- [x] `src/tool/apply_patch.ts`
+- [x] `src/tool/bash.ts`
+- [x] `src/tool/codesearch.ts`
+- [x] `src/tool/edit.ts`
+- [x] `src/tool/glob.ts`
+- [x] `src/tool/grep.ts`
+- [x] `src/tool/invalid.ts`
+- [x] `src/tool/lsp.ts`
+- [x] `src/tool/plan.ts`
+- [x] `src/tool/question.ts`
+- [x] `src/tool/read.ts`
+- [x] `src/tool/registry.ts`
+- [x] `src/tool/skill.ts`
+- [x] `src/tool/task.ts`
+- [x] `src/tool/todo.ts`
+- [x] `src/tool/tool.ts`
+- [x] `src/tool/webfetch.ts`
+- [x] `src/tool/websearch.ts`
+- [x] `src/tool/write.ts`
 
 ### HTTP route boundaries
 
@@ -313,8 +313,8 @@ which means touching them is largely mechanical once the domain side is
 done.
 
 - [ ] `src/server/error.ts`
-- [ ] `src/server/event.ts`
-- [ ] `src/server/projectors.ts`
+- [x] `src/server/event.ts`
+- [x] `src/server/projectors.ts`
 - [ ] `src/server/routes/control/index.ts`
 - [ ] `src/server/routes/control/workspace.ts`
 - [ ] `src/server/routes/global.ts`
@@ -346,7 +346,7 @@ piecewise.
 
 - [ ] `src/acp/agent.ts`
 - [ ] `src/agent/agent.ts`
-- [ ] `src/bus/bus-event.ts`
+- [x] `src/bus/bus-event.ts`
 - [ ] `src/bus/index.ts`
 - [ ] `src/cli/cmd/tui/config/tui-migrate.ts`
 - [ ] `src/cli/cmd/tui/config/tui-schema.ts`
@@ -376,7 +376,7 @@ piecewise.
 - [ ] `src/snapshot/index.ts`
 - [ ] `src/storage/db.ts`
 - [ ] `src/storage/storage.ts`
-- [x] `src/sync/index.ts` — public API (`SyncEvent.define`) is Schema-first; still stores derived zod `schema`/`properties` on each `Definition` as a compat bridge for `BusEvent` until `bus/bus-event.ts` migrates
+- [x] `src/sync/index.ts` — public API (`SyncEvent.define`) is Schema-first; `payloads()` still derives zod for the remaining HTTP/OpenAPI boundary
 - [ ] `src/util/fn.ts`
 - [ ] `src/util/log.ts`
 - [ ] `src/util/update-schema.ts`


### PR DESCRIPTION
## Summary
- Mark the completed tool schema migration items as done.
- Mark already-migrated bus/server event tracker items as done.
- Update the sync note now that BusEvent is Schema-first.

## Testing
- Not run; documentation-only change.