### PR TITLE
fix(opencode): allow gpt-5.5 in Codex OAuth model list

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -374,6 +374,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           "gpt-5.3-codex",
           "gpt-5.4",
           "gpt-5.4-mini",
+          "gpt-5.5",
         ])
         for (const [modelId, model] of Object.entries(provider.models)) {
           if (modelId.includes("codex")) continue


### PR DESCRIPTION
### Issue for this PR

Related to #24036
Related to #24039

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `gpt-5.5` to the explicit Codex OAuth allowed model list for OpenAI. `models.dev` already includes the model, and this keeps the Codex OAuth allowlist aligned with that supported model surface.

### How did you verify your code works?

- `bun test test/plugin/codex.test.ts`
- `bun typecheck` from `packages/opencode`
- push hook: `bun turbo typecheck`
- macOS CLI build: `bun run build --single` from `packages/opencode` with `dist/opencode-darwin-arm64/bin/opencode --version` smoke test passing

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
