### PR TITLE
fix(opencode): evict gitignored files from shadow snapshot index

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -209,7 +209,7 @@ export const layer: Layer.Layer<
 
         const add = Effect.fnUntraced(function* () {
           yield* sync()
-          const [diff, other] = yield* Effect.all(
+          const [diff, other, cached] = yield* Effect.all(
             [
               git([...quote, ...args(["diff-files", "--name-only", "-z", "--", "."])], {
                 cwd: state.directory,
@@ -217,27 +217,41 @@ export const layer: Layer.Layer<
               git([...quote, ...args(["ls-files", "--others", "--exclude-standard", "-z", "--", "."])], {
                 cwd: state.directory,
               }),
+              // Files already staged in the shadow repo's index. We need this
+              // to catch paths that once passed --exclude-standard but are now
+              // gitignored: those drop out of `other` above, so without this
+              // they'd stay staged forever and every write-tree would keep
+              // rehashing them. See the "retroactively gitignored" test.
+              git([...quote, ...args(["ls-files", "--cached", "-z", "--", "."])], {
+                cwd: state.directory,
+              }),
             ],
-            { concurrency: 2 },
+            { concurrency: 3 },
           )
-          if (diff.code !== 0 || other.code !== 0) {
+          if (diff.code !== 0 || other.code !== 0 || cached.code !== 0) {
             log.warn("failed to list snapshot files", {
               diffCode: diff.code,
               diffStderr: diff.stderr,
               otherCode: other.code,
               otherStderr: other.stderr,
+              cachedCode: cached.code,
+              cachedStderr: cached.stderr,
             })
             return
           }
 
           const tracked = diff.text.split("\0").filter(Boolean)
           const untracked = other.text.split("\0").filter(Boolean)
+          const staged = cached.text.split("\0").filter(Boolean)
           const all = Array.from(new Set([...tracked, ...untracked]))
-          if (!all.length) return
+          // Check everything the shadow knows about, not just the new candidate
+          // set, so previously-staged files that are now gitignored get evicted.
+          const check = Array.from(new Set([...all, ...staged]))
+          if (!check.length) return
 
           // Resolve source-repo ignore rules against the exact candidate set.
           // --no-index keeps this pattern-based even when a path is already tracked.
-          const ignored = yield* ignore(all)
+          const ignored = yield* ignore(check)
 
           // Remove newly-ignored files from snapshot index to prevent re-adding
           if (ignored.size > 0) {

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -729,6 +729,59 @@ test("git info exclude keeps global excludes", async () => {
   })
 })
 
+test("untracked files retroactively gitignored are evicted from shadow index", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      // First snapshot: an untracked directory that is NOT yet gitignored
+      // gets staged into the shadow repo. Simulates e.g. a `.android-sdk` or
+      // `node_modules` directory the user created before updating .gitignore.
+      await $`mkdir -p ${tmp.path}/cache`.quiet()
+      await Filesystem.write(`${tmp.path}/cache/big.bin`, "X".repeat(100_000))
+      await Filesystem.write(`${tmp.path}/cache/other.bin`, "Y".repeat(100_000))
+
+      const before = await run(tmp.path, (snapshot) => snapshot.track())
+      expect(before).toBeTruthy()
+
+      // Between snapshots the user adds cache/ to .gitignore. The files
+      // themselves are NOT touched, so they will not appear in diff-files or
+      // ls-files --others on the second track() call. Prior to the fix this
+      // left them permanently staged in the shadow repo, growing memory and
+      // on-disk size on every subsequent snapshot.
+      await Filesystem.write(`${tmp.path}/.gitignore`, "cache/\n")
+      await Filesystem.write(`${tmp.path}/other.txt`, "unrelated change")
+
+      const after = await run(tmp.path, (snapshot) => snapshot.track())
+      expect(after).toBeTruthy()
+
+      // Directly inspect the shadow tree (diffFull filters gitignored paths
+      // for the UI, which is the right UX but the wrong signal for this bug).
+      // The shadow gitdir is {Global.Path.data}/snapshot/{projectId}/{Hash.fast(worktree)};
+      // locate it by finding the one whose `git ls-tree` contains the hash we
+      // wrote. Matching on worktree hash alone is brittle because multiple
+      // tests may share an XDG dir.
+      const { Global } = await import("../../src/global")
+      const root = `${Global.Path.data}/snapshot`
+      const candidates = await Array.fromAsync(new Bun.Glob("*/*").scan({ cwd: root, onlyFiles: false }))
+      const hits = await Promise.all(
+        candidates.map(async (rel) => {
+          const result = await $`git --git-dir=${root}/${rel} ls-tree -r ${after}`
+            .nothrow()
+            .quiet()
+          return result.exitCode === 0 ? result.stdout.toString() : null
+        }),
+      )
+      const list = hits.find((x): x is string => x !== null)
+      expect(list).toBeDefined()
+      expect(list!).not.toContain("cache/big.bin")
+      expect(list!).not.toContain("cache/other.bin")
+      expect(list!).toContain(".gitignore")
+      expect(list!).toContain("other.txt")
+    },
+  })
+})
+
 test("concurrent file operations during patch", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
Refs #20695 (memory megathread — the "files staged before being added to .gitignore stay forever" case described by @thdxr).

## Problem

`add()` only ran `check-ignore` against files that were in the current source candidate set (`diff-files` + `ls-files --others --exclude-standard`). Once a file was staged in the shadow repo on an early turn, then added to `.gitignore` but not modified afterwards, it fell out of both candidate lists — so the existing `ignore()` / `drop()` path never saw it.

It stayed in the shadow index forever, got rehashed into every `write-tree`, and bloated memory when sessions with large ex-untracked directories (`node_modules`, `.android-sdk`, `.venv`, …) were resumed.

## Fix

Also list the shadow repo's currently-cached paths with `git ls-files --cached`, union them into the `ignore()` check, and let the existing `drop()` call evict anything that now matches. One extra git call per `track()`, negligible for sane repos, and it finally lets the user recover memory by just adding the offender to `.gitignore` without needing to wipe `~/.local/share/opencode/snapshot`.

## Verification

New test `"untracked files retroactively gitignored are evicted from shadow index"` reproduces the bug: `cache/big.bin` and `cache/other.bin` get staged in the first `track()`, `cache/` is added to `.gitignore`, the files are not touched, and the second `track()` ought to drop them. I confirmed the test fails against `dev` and passes with this change. It inspects the shadow tree directly via `git ls-tree -r` because `diffFull` (correctly) filters gitignored paths from the user-facing diff, hiding the very rows we need to assert on.

Full snapshot suite still passes (52 pass, 1 skip, 1 pre-existing `chmod`-not-found failure on Windows that also fails on clean `dev`).
