### PR TITLE
fix(provider): preserve custom User-Agent from provider.options.headers (#22608)

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -29,6 +29,14 @@ const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 type Result = Awaited<ReturnType<typeof streamText>>
 
+function hasUserAgent(headers: unknown): boolean {
+  if (!headers || typeof headers !== "object") return false
+  for (const key of Object.keys(headers as Record<string, unknown>)) {
+    if (key.toLowerCase() === "user-agent") return true
+  }
+  return false
+}
+
 export type StreamInput = {
   user: MessageV2.User
   sessionID: string
@@ -377,7 +385,13 @@ const live: Layer.Layer<
             : {
                 "x-session-affinity": input.sessionID,
                 ...(input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
-                "User-Agent": `opencode/${InstallationVersion}`,
+                // Only set the default User-Agent when the user has not configured
+                // one on the provider. Per-request headers are merged AFTER the
+                // SDK's config headers, so setting it unconditionally would override
+                // a custom User-Agent from provider.options.headers. See #22608.
+                ...(hasUserAgent(item.options?.headers)
+                  ? {}
+                  : { "User-Agent": `opencode/${InstallationVersion}` }),
               }),
           ...input.model.headers,
           ...headers,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1269,4 +1269,91 @@ describe("session.llm.stream", () => {
       },
     })
   })
+
+  // Regression test for https://github.com/anomalyco/opencode/issues/22608
+  test("preserves custom User-Agent from provider.options.headers", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                  headers: {
+                    "User-Agent": "KimiCLI/1.30.0",
+                    "X-Custom-Trace": "trace-123",
+                  },
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-custom-ua")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-custom-ua"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        const userAgent = capture.headers.get("user-agent") ?? ""
+        // Custom User-Agent from provider.options.headers must be preserved (possibly
+        // with ai-sdk suffixes). It must not be replaced by opencode's default.
+        expect(userAgent).toInclude("KimiCLI/1.30.0")
+        expect(userAgent).not.toInclude("opencode/")
+        // Other custom headers should also be forwarded.
+        expect(capture.headers.get("x-custom-trace")).toBe("trace-123")
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #22608.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom headers set on `provider.options.headers` in `opencode.json` were not reaching the upstream API for anything that collided with the headers opencode adds itself, most visibly `User-Agent`. The SDK places the user's headers inside `config.headers()`, and `session/llm.ts` attaches `User-Agent: opencode/<version>` at the per-request layer, so `combineHeaders` plus `withUserAgentSuffix` end up collapsing the two entries under the same lowercased key and opencode's value always wins. The revert in #12072 removed the earlier fetch-level merge but left this second collision in place, which is why the regression went unnoticed.

The fix only injects the default opencode `User-Agent` when the user has not already configured one on the provider, which is the exact condition under which the collision occurs. Model-level headers and plugin-hook headers keep working as before because they are spread after the base object and therefore override naturally.

### How did you verify your code works?

There is a regression test in `packages/opencode/test/session/llm.test.ts` that stands up a local Bun server behind a custom `@ai-sdk/openai-compatible` provider, sets `User-Agent: KimiCLI/1.30.0` together with an `X-Custom-Trace` entry in `options.headers`, drives a real stream through `LLM.stream`, and asserts the captured request still contains `KimiCLI/1.30.0`, no longer contains `opencode/`, and forwards `x-custom-trace` as configured. Running the same test against the unfixed code reproduces the bug directly.

`bun typecheck` is clean, `bun test test/session/llm.test.ts` (15 tests) and `bun test test/provider/provider.test.ts` (76 tests) both pass from `packages/opencode`, and I exercised the fix end-to-end against a gateway that requires a specific `User-Agent` to confirm `opencode.json` alone is now sufficient.

### Screenshots / recordings

N/A, this is a non-UI logic change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
