### PR TITLE
fix(snapshot): avoid E2BIG during batched revert checkout

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -459,9 +459,13 @@ export const layer: Layer.Layer<
                 if (list.length) {
                   log.info("reverting", { hash: first.hash, files: list.length })
                   const result = yield* git(
-                    [...core, ...args(["checkout", first.hash, "--", ...list.map((item) => item.file)])],
+                    [
+                      ...core,
+                      ...args(["checkout", "--pathspec-from-file=-", "--pathspec-file-nul", first.hash]),
+                    ],
                     {
                       cwd: state.worktree,
+                      stdin: feed(list.map((item) => item.rel)),
                     },
                   )
                   if (result.code !== 0) {


### PR DESCRIPTION
## Summary
- switch batched snapshot revert checkout to use --pathspec-from-file=- and --pathspec-file-nul
- send batched relative paths through stdin instead of argv to prevent command-line length overflows
- keep existing fallback behavior unchanged when batched checkout fails

## Testing
- bun test test/snapshot/snapshot.test.ts (from packages/opencode)

Closes #23758