### PR TITLE
fix(provider): allow remote local-network hosts when proxy env vars are set

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -31,6 +31,76 @@ import { ModelID, ProviderID } from "./schema"
 
 const log = Log.create({ service: "provider" })
 
+const proxyKeys = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] as const
+const noProxyKeys = ["NO_PROXY", "no_proxy"] as const
+
+function privateIPv4(hostname: string) {
+  const match = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/.exec(hostname)
+  if (!match) return false
+
+  const a = Number.parseInt(match[1], 10)
+  const b = Number.parseInt(match[2], 10)
+  if (Number.isNaN(a) || Number.isNaN(b)) return false
+  if (a === 10 || a === 127) return true
+  if (a === 192 && b === 168) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 169 && b === 254) return true
+  return false
+}
+
+function privateIPv6(hostname: string) {
+  const host = hostname.toLowerCase()
+  if (host === "::1") return true
+  if (host.startsWith("fc") || host.startsWith("fd")) return true
+  if (host.startsWith("fe8") || host.startsWith("fe9") || host.startsWith("fea") || host.startsWith("feb"))
+    return true
+  return false
+}
+
+function bypassProxy(hostname: string) {
+  if (hostname === "localhost") return true
+  if (!hostname.includes(".")) return true
+  if (hostname.endsWith(".local")) return true
+  if (privateIPv4(hostname)) return true
+  if (privateIPv6(hostname)) return true
+  return false
+}
+
+function coveredByNoProxy(hostname: string, item: string) {
+  const next = item.trim().toLowerCase()
+  if (!next) return false
+  if (next === "*" || next === hostname) return true
+  if (!next.startsWith(".")) return false
+  return hostname.endsWith(next)
+}
+
+export function ensureNoProxyForBaseURL(baseURL: string | undefined) {
+  if (!baseURL) return
+  if (!proxyKeys.some((key) => Boolean(process.env[key]))) return
+
+  let url: URL
+  try {
+    url = new URL(baseURL)
+  } catch {
+    return
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return
+
+  const hostname = url.hostname.trim().toLowerCase()
+  if (!hostname || !bypassProxy(hostname)) return
+
+  for (const key of noProxyKeys) {
+    const existing = (process.env[key] ?? "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean)
+
+    if (existing.some((item) => coveredByNoProxy(hostname, item))) continue
+    process.env[key] = [...existing, hostname].join(",")
+  }
+}
+
 function shouldUseCopilotResponsesApi(modelID: string): boolean {
   const match = /^gpt-(\d+)/.exec(modelID)
   if (!match) return false
@@ -1420,7 +1490,10 @@ const layer: Layer.Layer<
           return url
         })
 
-        if (baseURL !== undefined) options["baseURL"] = baseURL
+        if (baseURL !== undefined) {
+          options["baseURL"] = baseURL
+          ensureNoProxyForBaseURL(baseURL)
+        }
         if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
         if (model.headers)
           options["headers"] = {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -8,6 +8,7 @@ import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin/index"
 import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
+import { ensureNoProxyForBaseURL } from "../../src/provider/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Filesystem } from "../../src/util"
 import { Env } from "../../src/env"
@@ -60,6 +61,52 @@ function paid(providers: Awaited<ReturnType<typeof list>>) {
   expect(item).toBeDefined()
   return Object.values(item.models).filter((model) => model.cost.input > 0).length
 }
+
+test("ensureNoProxyForBaseURL adds private host when proxy is configured", () => {
+  const previous = {
+    HTTP_PROXY: process.env.HTTP_PROXY,
+    HTTPS_PROXY: process.env.HTTPS_PROXY,
+    NO_PROXY: process.env.NO_PROXY,
+    no_proxy: process.env.no_proxy,
+  }
+  process.env.HTTP_PROXY = "http://proxy.internal:8080"
+  process.env.HTTPS_PROXY = "http://proxy.internal:8080"
+  process.env.NO_PROXY = "localhost"
+  process.env.no_proxy = "127.0.0.1"
+
+  ensureNoProxyForBaseURL("http://192.168.0.100:1234/v1")
+
+  expect(process.env.NO_PROXY?.split(",")).toContain("192.168.0.100")
+  expect(process.env.no_proxy?.split(",")).toContain("192.168.0.100")
+
+  process.env.HTTP_PROXY = previous.HTTP_PROXY
+  process.env.HTTPS_PROXY = previous.HTTPS_PROXY
+  process.env.NO_PROXY = previous.NO_PROXY
+  process.env.no_proxy = previous.no_proxy
+})
+
+test("ensureNoProxyForBaseURL keeps public hosts proxied", () => {
+  const previous = {
+    HTTP_PROXY: process.env.HTTP_PROXY,
+    HTTPS_PROXY: process.env.HTTPS_PROXY,
+    NO_PROXY: process.env.NO_PROXY,
+    no_proxy: process.env.no_proxy,
+  }
+  process.env.HTTP_PROXY = "http://proxy.internal:8080"
+  process.env.HTTPS_PROXY = "http://proxy.internal:8080"
+  process.env.NO_PROXY = "localhost"
+  process.env.no_proxy = "127.0.0.1"
+
+  ensureNoProxyForBaseURL("https://api.openai.com/v1")
+
+  expect(process.env.NO_PROXY).toBe("localhost")
+  expect(process.env.no_proxy).toBe("127.0.0.1")
+
+  process.env.HTTP_PROXY = previous.HTTP_PROXY
+  process.env.HTTPS_PROXY = previous.HTTPS_PROXY
+  process.env.NO_PROXY = previous.NO_PROXY
+  process.env.no_proxy = previous.no_proxy
+})
 
 test("provider loaded from env variable", async () => {
   await using tmp = await tmpdir({


### PR DESCRIPTION
## Summary
- detect local-network and LAN-style baseURL hosts (private IP ranges, .local, single-label hostnames)
- automatically add those hosts to NO_PROXY/no_proxy when HTTP(S)_PROXY is configured so requests bypass corporate proxies
- keep public hosts proxied; add tests for private-host and public-host behavior

## Testing
- bun test test/provider/provider.test.ts --test-name-pattern ensureNoProxyForBaseURL
- bun test test/provider/provider.test.ts --test-name-pattern plugin\ config\ providers\ persist\ after\ instance\ dispose\|plugin\ config\ enabled\ and\ disabled\ providers\ are\ honored

Closes #23900