### PR TITLE
fix: handle Bun stream connection errors with automatic retry

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -28,6 +28,17 @@ interface FetchDecompressionError extends Error {
   path: string
 }
 
+/** Detect Bun fetch() stream connection errors (incomplete chunked read, peer closed, etc.) */
+function isStreamConnectionError(e: Error): boolean {
+  const msg = e.message.toLowerCase()
+  return (
+    msg.includes("peer closed connection") ||
+    msg.includes("incomplete chunked read") ||
+    msg.includes("unexpected end of stream") ||
+    msg.includes("socket hang up")
+  )
+}
+
 export const SYNTHETIC_ATTACHMENT_PROMPT = "Attached image(s) from tool result:"
 export { isMedia }
 
@@ -1159,6 +1170,18 @@ export function fromError(
           responseHeaders: parsed.responseHeaders,
           responseBody: parsed.responseBody,
           metadata: parsed.metadata,
+        },
+        { cause: e },
+      ).toObject()
+    case e instanceof Error && isStreamConnectionError(e):
+      return new APIError(
+        {
+          message: "Connection closed during streaming",
+          isRetryable: true,
+          metadata: {
+            code: "STREAM_CONNECTION_ERROR",
+            message: e.message,
+          },
         },
         { cause: e },
       ).toObject()

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -74,6 +74,16 @@ export function retryable(error: Err) {
     ) {
       return msg
     }
+    // Stream connection errors (Bun fetch incomplete chunked read, peer closed)
+    if (
+      lower.includes("peer closed connection") ||
+      lower.includes("incomplete chunked read") ||
+      lower.includes("connection closed during streaming") ||
+      lower.includes("unexpected end of stream") ||
+      lower.includes("socket hang up")
+    ) {
+      return "Connection closed during streaming — retrying"
+    }
   }
 
   const json = iife(() => {


### PR DESCRIPTION
## Problem

When the LLM provider closes the streaming connection mid-response, users see:

```
Preparing write...
Tool execution aborted
Type validation failed: Value: {"code":"InternalError","message":"peer closed connection without sending complete message body (incomplete chunked read)",...}
Error message: [{"code":"invalid_union","note":"No matching discriminator","discriminator":"type","message":"Invalid input"}]
```

The error cascades through 3 layers:
1. **Bun fetch** throws `peer closed connection without sending complete message body (incomplete chunked read)` -- not matched by any case in `fromError()`
2. Falls through to `NamedError.Unknown` which is **not retryable**
3. Session aborts instead of retrying, and the incomplete stream data fails Zod schema validation (`discriminator: "type"`)

## Fix

### `packages/opencode/src/session/message-v2.ts`
- Add `isStreamConnectionError()` helper to detect Bun fetch stream errors:
  - `peer closed connection`
  - `incomplete chunked read`
  - `unexpected end of stream`
  - `socket hang up`
- Map to `APIError` with `isRetryable: true` in `fromError()`

### `packages/opencode/src/session/retry.ts`
- Add matching patterns to `retryable()` so these errors trigger automatic retry with exponential backoff

## Result

Stream disconnects are now treated as transient errors and automatically retried instead of aborting the session.
