### PR TITLE
fix(app): MEMORY / OOM crash - add experimental flag to disable vcs diff auto-fetch

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -596,7 +596,9 @@ export default function Page() {
   )
   const vcsQuery = createQuery(() => {
     const mode = vcsMode()
-    const enabled = !sync.data.config.experimental?.disable_vcs_diff && wantsReview() && sync.project?.vcs === "git"
+    const configReady = sync.status === "complete" || Object.keys(sync.data.config).length > 0
+    const enabled =
+      configReady && !sync.data.config.experimental?.disable_vcs_diff && wantsReview() && sync.project?.vcs === "git"
 
     return {
       queryKey: [...vcsKey(), mode] as const,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -596,7 +596,7 @@ export default function Page() {
   )
   const vcsQuery = createQuery(() => {
     const mode = vcsMode()
-    const enabled = wantsReview() && sync.project?.vcs === "git"
+    const enabled = !sync.data.config.experimental?.disable_vcs_diff && wantsReview() && sync.project?.vcs === "git"
 
     return {
       queryKey: [...vcsKey(), mode] as const,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -282,6 +282,9 @@ export const Info = Schema.Struct({
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),
+      disable_vcs_diff: Schema.optional(Schema.Boolean).annotate({
+        description: "Disable live VCS diff queries in the app session review UI",
+      }),
       batch_tool: Schema.optional(Schema.Boolean).annotate({ description: "Enable the batch tool" }),
       openTelemetry: Schema.optional(Schema.Boolean).annotate({
         description: "Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)",

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts
@@ -1,5 +1,6 @@
 import { Agent } from "@/agent/agent"
 import { Command } from "@/command"
+import { Config } from "@/config/config"
 import * as InstanceState from "@/effect/instance-state"
 import { Format } from "@/format"
 import { Global } from "@opencode-ai/core/global"
@@ -47,6 +48,10 @@ export const instanceHandlers = HttpApiBuilder.group(InstanceHttpApi, "instance"
     })
 
     const getVcsDiff = Effect.fn("InstanceHttpApi.vcsDiff")(function* (ctx: { query: { mode: Vcs.Mode } }) {
+      const cfg = yield* Config.Service
+      const config = yield* cfg.get()
+      if (config.experimental?.disable_vcs_diff) return [] satisfies Vcs.FileDiff[]
+
       return yield* vcs.diff(ctx.query.mode)
     })
 

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -11,6 +11,7 @@ import { InstanceRuntime } from "@/project/instance-runtime"
 import { Vcs } from "@/project/vcs"
 import { Agent } from "@/agent/agent"
 import { Skill } from "@/skill"
+import { Config } from "@/config/config"
 import { Global } from "@opencode-ai/core/global"
 import { LSP } from "@/lsp/lsp"
 import { Command } from "@/command"
@@ -288,6 +289,10 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, opts?: CorsOptions): H
       ),
       async (c) =>
         jsonRequest("InstanceRoutes.vcs.diff", c, function* () {
+          const cfg = yield* Config.Service
+          const config = yield* cfg.get()
+          if (config.experimental?.disable_vcs_diff) return [] satisfies Vcs.FileDiff[]
+
           const vcs = yield* Vcs.Service
           return yield* vcs.diff(c.req.valid("query").mode)
         }),

--- a/packages/opencode/test/server/httpapi-json-parity.test.ts
+++ b/packages/opencode/test/server/httpapi-json-parity.test.ts
@@ -95,6 +95,32 @@ afterEach(async () => {
 
 describe("HttpApi JSON parity", () => {
   it.live(
+    "returns empty VCS diff when disabled in config",
+    withTmp(
+      {
+        git: true,
+        config: {
+          experimental: {
+            disable_vcs_diff: true,
+          },
+          formatter: false,
+          lsp: false,
+        },
+      },
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => Bun.write(`${tmp.path}/changed.txt`, "hello\n"))
+
+          const headers = { "x-opencode-directory": tmp.path }
+          const path = `${InstancePaths.vcsDiff}?mode=git`
+
+          expect(yield* readJson("legacy disabled vcs diff", app(false), path, headers)).toEqual([])
+          expect(yield* readJson("httpapi disabled vcs diff", app(true), path, headers)).toEqual([])
+        }),
+    ),
+  )
+
+  it.live(
     "matches legacy JSON shape for safe GET endpoints",
     withTmp(
       {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1362,9 +1362,10 @@ export type Config = {
     }
     /**
      * Number of retries for chat completions on failure
-     */
+    */
     chatMaxRetries?: number
     disable_paste_summary?: boolean
+    disable_vcs_diff?: boolean
     /**
      * Enable the batch tool
      */

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1262,6 +1262,13 @@ export type Config = {
   }
   experimental?: {
     disable_paste_summary?: boolean
+    /**
+     * Disable live VCS diff queries in the app session review UI
+     */
+    disable_vcs_diff?: boolean
+    /**
+     * Enable the batch tool
+     */
     batch_tool?: boolean
     openTelemetry?: boolean
     primary_tools?: Array<string>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1262,13 +1262,7 @@ export type Config = {
   }
   experimental?: {
     disable_paste_summary?: boolean
-    /**
-     * Disable live VCS diff queries in the app session review UI
-     */
     disable_vcs_diff?: boolean
-    /**
-     * Enable the batch tool
-     */
     batch_tool?: boolean
     openTelemetry?: boolean
     primary_tools?: Array<string>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -12223,6 +12223,9 @@
               "disable_paste_summary": {
                 "type": "boolean"
               },
+              "disable_vcs_diff": {
+                "type": "boolean"
+              },
               "batch_tool": {
                 "type": "boolean"
               },


### PR DESCRIPTION
### Issue for this PR

Partially fixes #24049 and #22683

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an experimental `disable_vcs_diff` config flag and uses it to skip the web app's automatic `vcs.diff` fetch.

This is a mitigation for workspaces where `/vcs/diff` can be very expensive or crash the server, especially umbrella workspaces with nested git repos/worktrees.

This does not fully fix the underlying `/vcs/diff` scalability issue in #24049. It preserves the current default behavior and gives affected users an opt-in escape hatch while broader fixes are considered.

### How did you verify your code works?

Tested locally with a built `opencode` binary against a large umbrella workspace.

- With `experimental.disable_vcs_diff` unset, the existing behavior is unchanged.
- With `experimental.disable_vcs_diff: true`, the desktop-layout web UI no longer emits `GET /vcs/diff` from the automatic review/diff path.
- During active web UI use with the flag enabled, no new `/vcs/diff` requests, heap warnings, or OOM crashes were observed in the logs.
- Ran `bun --cwd packages/opencode typecheck`.
- Ran `bun --cwd packages/app typecheck`.
- Ran the repository pre-push hook, which completed `bun turbo typecheck` successfully.

### Screenshots / recordings

N/A. This is a config-gated behavior change, not a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR