### PR TITLE
feat(httpapi): bridge mcp status endpoint

### DIFF
--- a/packages/opencode/specs/effect/http-api.md
+++ b/packages/opencode/specs/effect/http-api.md
@@ -415,8 +415,9 @@ Current instance route inventory:
 - `file` - `bridged` (partial)
   bridged endpoints: `GET /file`, `GET /file/content`, `GET /file/status`
   defer search endpoints first
-- `mcp` - `later`
-  has JSON-only endpoints, but interactive OAuth/auth flows make it a worse early fit
+- `mcp` - `bridged` (partial)
+  bridged endpoints: `GET /mcp`
+  defer interactive OAuth/auth flows first
 - `session` - `defer`
   large, stateful, mixes CRUD with prompt/shell/command/share/revert flows and a streaming route
 - `event` - `defer`
@@ -451,6 +452,7 @@ Recommended near-term sequence:
 - [x] port `GET /config` full read endpoint
 - [x] port `workspace` read endpoints
 - [x] port `file` JSON read endpoints
+- [x] port `mcp` status read endpoint
 - [ ] decide when to remove the flag and make Effect routes the default
 
 ## Rule of thumb

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -30,6 +30,8 @@ import { EffectBridge } from "@/effect"
 import { InstanceState } from "@/effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
+import { zod as effectZod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
 
 const log = Log.create({ service: "mcp" })
 const DEFAULT_TIMEOUT = 30_000
@@ -69,50 +71,33 @@ export const Failed = NamedError.create(
 
 type MCPClient = Client
 
-export const Status = z
-  .discriminatedUnion("status", [
-    z
-      .object({
-        status: z.literal("connected"),
-      })
-      .meta({
-        ref: "MCPStatusConnected",
-      }),
-    z
-      .object({
-        status: z.literal("disabled"),
-      })
-      .meta({
-        ref: "MCPStatusDisabled",
-      }),
-    z
-      .object({
-        status: z.literal("failed"),
-        error: z.string(),
-      })
-      .meta({
-        ref: "MCPStatusFailed",
-      }),
-    z
-      .object({
-        status: z.literal("needs_auth"),
-      })
-      .meta({
-        ref: "MCPStatusNeedsAuth",
-      }),
-    z
-      .object({
-        status: z.literal("needs_client_registration"),
-        error: z.string(),
-      })
-      .meta({
-        ref: "MCPStatusNeedsClientRegistration",
-      }),
-  ])
-  .meta({
-    ref: "MCPStatus",
-  })
-export type Status = z.infer<typeof Status>
+const StatusConnected = Schema.Struct({ status: Schema.Literal("connected") }).annotate({
+  identifier: "MCPStatusConnected",
+})
+const StatusDisabled = Schema.Struct({ status: Schema.Literal("disabled") }).annotate({
+  identifier: "MCPStatusDisabled",
+})
+const StatusFailed = Schema.Struct({ status: Schema.Literal("failed"), error: Schema.String }).annotate({
+  identifier: "MCPStatusFailed",
+})
+const StatusNeedsAuth = Schema.Struct({ status: Schema.Literal("needs_auth") }).annotate({
+  identifier: "MCPStatusNeedsAuth",
+})
+const StatusNeedsClientRegistration = Schema.Struct({
+  status: Schema.Literal("needs_client_registration"),
+  error: Schema.String,
+}).annotate({ identifier: "MCPStatusNeedsClientRegistration" })
+
+export const Status = Schema.Union([
+  StatusConnected,
+  StatusDisabled,
+  StatusFailed,
+  StatusNeedsAuth,
+  StatusNeedsClientRegistration,
+])
+  .annotate({ identifier: "MCPStatus", discriminator: "status" })
+  .pipe(withStatics((s) => ({ zod: effectZod(s) })))
+export type Status = Schema.Schema.Type<typeof Status>
 
 // Store transports for OAuth servers to allow finishing auth
 type TransportWithAuth = StreamableHTTPClientTransport | SSEClientTransport

--- a/packages/opencode/src/server/routes/instance/httpapi/mcp.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/mcp.ts
@@ -1,0 +1,48 @@
+import { MCP } from "@/mcp"
+import { Effect, Layer, Schema } from "effect"
+import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+
+export const McpPaths = {
+  status: "/mcp",
+} as const
+
+export const McpApi = HttpApi.make("mcp")
+  .add(
+    HttpApiGroup.make("mcp")
+      .add(
+        HttpApiEndpoint.get("status", McpPaths.status, {
+          success: Schema.Record(Schema.String, MCP.Status),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.status",
+            summary: "Get MCP status",
+            description: "Get the status of all Model Context Protocol (MCP) servers.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "mcp",
+          description: "Experimental HttpApi MCP routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode experimental HttpApi",
+      version: "0.0.1",
+      description: "Experimental HttpApi surface for selected instance routes.",
+    }),
+  )
+
+export const mcpHandlers = Layer.unwrap(
+  Effect.gen(function* () {
+    const mcp = yield* MCP.Service
+
+    const status = Effect.fn("McpHttpApi.status")(function* () {
+      return yield* mcp.status()
+    })
+
+    return HttpApiBuilder.group(McpApi, "mcp", (handlers) => handlers.handle("status", status))
+  }),
+).pipe(Layer.provide(MCP.defaultLayer))

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -11,6 +11,7 @@ import { lazy } from "@/util/lazy"
 import { Filesystem } from "@/util"
 import { ConfigApi, configHandlers } from "./config"
 import { FileApi, fileHandlers } from "./file"
+import { McpApi, mcpHandlers } from "./mcp"
 import { PermissionApi, permissionHandlers } from "./permission"
 import { ProjectApi, projectHandlers } from "./project"
 import { ProviderApi, providerHandlers } from "./provider"
@@ -116,10 +117,12 @@ const ProviderSecured = ProviderApi.middleware(Authorization)
 const ConfigSecured = ConfigApi.middleware(Authorization)
 const WorkspaceSecured = WorkspaceApi.middleware(Authorization)
 const FileSecured = FileApi.middleware(Authorization)
+const McpSecured = McpApi.middleware(Authorization)
 
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(ConfigSecured).pipe(Layer.provide(configHandlers)),
   HttpApiBuilder.layer(FileSecured).pipe(Layer.provide(fileHandlers)),
+  HttpApiBuilder.layer(McpSecured).pipe(Layer.provide(mcpHandlers)),
   HttpApiBuilder.layer(ProjectSecured).pipe(Layer.provide(projectHandlers)),
   HttpApiBuilder.layer(QuestionSecured).pipe(Layer.provide(questionHandlers)),
   HttpApiBuilder.layer(PermissionSecured).pipe(Layer.provide(permissionHandlers)),

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -17,6 +17,7 @@ import { PermissionRoutes } from "./permission"
 import { Flag } from "@/flag/flag"
 import { ExperimentalHttpApiServer } from "./httpapi/server"
 import { FilePaths } from "./httpapi/file"
+import { McpPaths } from "./httpapi/mcp"
 import { ProjectRoutes } from "./project"
 import { SessionRoutes } from "./session"
 import { PtyRoutes } from "./pty"
@@ -52,6 +53,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
     app.get(FilePaths.list, (c) => handler(c.req.raw, context))
     app.get(FilePaths.content, (c) => handler(c.req.raw, context))
     app.get(FilePaths.status, (c) => handler(c.req.raw, context))
+    app.get(McpPaths.status, (c) => handler(c.req.raw, context))
   }
 
   return app

--- a/packages/opencode/src/server/routes/instance/mcp.ts
+++ b/packages/opencode/src/server/routes/instance/mcp.ts
@@ -21,7 +21,7 @@ export const McpRoutes = lazy(() =>
             description: "MCP server status",
             content: {
               "application/json": {
-                schema: resolver(z.record(z.string(), MCP.Status)),
+                schema: resolver(z.record(z.string(), MCP.Status.zod)),
               },
             },
           },
@@ -44,7 +44,7 @@ export const McpRoutes = lazy(() =>
             description: "MCP server added successfully",
             content: {
               "application/json": {
-                schema: resolver(z.record(z.string(), MCP.Status)),
+                schema: resolver(z.record(z.string(), MCP.Status.zod)),
               },
             },
           },
@@ -121,7 +121,7 @@ export const McpRoutes = lazy(() =>
             description: "OAuth authentication completed",
             content: {
               "application/json": {
-                schema: resolver(MCP.Status),
+                    schema: resolver(MCP.Status.zod),
               },
             },
           },
@@ -153,7 +153,7 @@ export const McpRoutes = lazy(() =>
             description: "OAuth authentication completed",
             content: {
               "application/json": {
-                schema: resolver(MCP.Status),
+                    schema: resolver(MCP.Status.zod),
               },
             },
           },

--- a/packages/opencode/test/server/httpapi-mcp.test.ts
+++ b/packages/opencode/test/server/httpapi-mcp.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Context } from "effect"
+import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
+import { McpPaths } from "../../src/server/routes/instance/httpapi/mcp"
+import { Instance } from "../../src/project/instance"
+import { Log } from "../../src/util"
+import { resetDatabase } from "../fixture/db"
+import { tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+const context = Context.empty() as Context.Context<unknown>
+
+function request(route: string, directory: string) {
+  return ExperimentalHttpApiServer.webHandler().handler(
+    new Request(`http://localhost${route}`, {
+      headers: {
+        "x-opencode-directory": directory,
+      },
+    }),
+    context,
+  )
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+  await resetDatabase()
+})
+
+describe("mcp HttpApi", () => {
+  test("serves status endpoint", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        mcp: {
+          demo: {
+            type: "local",
+            command: ["echo", "demo"],
+            enabled: false,
+          },
+        },
+      },
+    })
+
+    const response = await request(McpPaths.status, tmp.path)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ demo: { status: "disabled" } })
+  })
+})


### PR DESCRIPTION
## Summary
- Migrate MCP status DTOs to Effect Schema with derived Zod compatibility.
- Add experimental HttpApi route for `GET /mcp`.
- Add a focused MCP HttpApi status test.

## Testing
- `bun typecheck` from `packages/opencode`
- `bun run test:ci test/server/httpapi-mcp.test.ts` from `packages/opencode`
- `./packages/sdk/js/script/build.ts` (generated SDK unchanged)

## Stack
- Depends on `kit/httpapi-file-reads`.
- Next: `kit/httpapi-file-search-reads`.