### PR TITLE
fix: prevent question custom input from hiding submit button

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -373,7 +373,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const resizeInput = (el: HTMLTextAreaElement) => {
     el.style.height = "0px"
-    el.style.height = `${el.scrollHeight}px`
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`
   }
 
   const focusCustom = (el: HTMLTextAreaElement) => {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -1090,7 +1090,8 @@
     min-width: 0;
     cursor: text;
     resize: none;
-    overflow: hidden;
+    overflow-y: auto;
+    max-height: 120px;
     overflow-wrap: anywhere;
 
     &::placeholder {


### PR DESCRIPTION
### Issue for this PR

Closes #24109

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In web/serve mode, when the AI uses the `question` tool and the user clicks "Type your own answer", the textarea had no height limit. `resizeInput()` was setting `el.style.height = el.scrollHeight` with no cap, and the CSS used `overflow: hidden` which causes the element to expand rather than scroll internally. With enough text, the footer containing the Submit/Next/Dismiss buttons gets pushed out of the viewport entirely.

Fix: set `max-height: 120px` and `overflow-y: auto` on the textarea in CSS so it scrolls internally once it reaches ~6 lines. The JS `resizeInput` is updated to `Math.min(el.scrollHeight, 120)` to stay consistent with the CSS constraint.

### How did you verify your code works?

Ran the backend (`bun run --conditions=browser ./src/index.ts serve --port 4097`) and app dev server (`VITE_OPENCODE_SERVER_PORT=4097 bun dev -- --port 4444`) locally. Triggered a question with options, selected "Type your own answer", pasted a large block of text, and confirmed the Submit button remains visible and clickable. Also verified the broken behavior exists without the fix by reverting and retesting.

### Screenshots / recordings

_UI change — textarea now scrolls internally after ~6 lines, footer buttons always visible._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR