### PR TITLE
fix(config): avoid parseManagedPlist crash on non-object JSON

### DIFF
--- a/packages/opencode/src/config/managed.ts
+++ b/packages/opencode/src/config/managed.ts
@@ -37,6 +37,9 @@ export function managedConfigDir() {
 
 export function parseManagedPlist(json: string): string {
   const raw = JSON.parse(json)
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return JSON.stringify({})
+  }
   for (const key of Object.keys(raw)) {
     if (PLIST_META.has(key)) delete raw[key]
   }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2337,3 +2337,10 @@ test("parseManagedPlist handles empty config", async () => {
   )
   expect(config.$schema).toBe("https://opencode.ai/config.json")
 })
+
+test("parseManagedPlist returns empty object for non-object JSON values", async () => {
+  expect(await ConfigManaged.parseManagedPlist("null")).toBe("{}")
+  expect(await ConfigManaged.parseManagedPlist("[]")).toBe("{}")
+  expect(await ConfigManaged.parseManagedPlist("1")).toBe("{}")
+  expect(await ConfigManaged.parseManagedPlist('"test"')).toBe("{}")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #22318

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`parseManagedPlist` assumed `JSON.parse()` always returned an object and called `Object.keys()` directly. When managed plist JSON was `null`, an array, or a primitive, it threw instead of safely falling back.

This adds a guard so non-object JSON values return `{}` and adds coverage for `null`, array, number, and string inputs.

### How did you verify your code works?

From `packages/opencode`:
- `bun test test/config/config.test.ts -t \"parseManagedPlist\"`
- `bun typecheck`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR