### PR TITLE
fix: enable compaction prune by default

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -296,7 +296,7 @@ export const layer: Layer.Layer<
     // calls, then erases output of older tool calls to free context space
     const prune = Effect.fn("SessionCompaction.prune")(function* (input: { sessionID: SessionID }) {
       const cfg = yield* config.get()
-      if (!cfg.compaction?.prune) return
+      if (cfg.compaction?.prune === false) return
       log.info("pruning")
 
       const msgs = yield* session

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -601,98 +601,125 @@ describe("session.compaction.create", () => {
 })
 
 describe("session.compaction.prune", () => {
+  function createPrunableToolSession(dir: string) {
+    return Effect.gen(function* () {
+      const ssn = yield* SessionNs.Service
+      const info = yield* ssn.create({})
+      const a = yield* ssn.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID: info.id,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      })
+      yield* ssn.updatePart({
+        id: PartID.ascending(),
+        messageID: a.id,
+        sessionID: info.id,
+        type: "text",
+        text: "first",
+      })
+      const b: MessageV2.Assistant = {
+        id: MessageID.ascending(),
+        role: "assistant",
+        sessionID: info.id,
+        mode: "build",
+        agent: "build",
+        path: { cwd: dir, root: dir },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        parentID: a.id,
+        time: { created: Date.now() },
+        finish: "end_turn",
+      }
+      yield* ssn.updateMessage(b)
+      yield* ssn.updatePart({
+        id: PartID.ascending(),
+        messageID: b.id,
+        sessionID: info.id,
+        type: "tool",
+        callID: crypto.randomUUID(),
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: {},
+          output: "x".repeat(200_000),
+          title: "done",
+          metadata: {},
+          time: { start: Date.now(), end: Date.now() },
+        },
+      })
+      for (const text of ["second", "third"]) {
+        const msg = yield* ssn.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: info.id,
+          agent: "build",
+          model: ref,
+          time: { created: Date.now() },
+        })
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          messageID: msg.id,
+          sessionID: info.id,
+          type: "text",
+          text,
+        })
+      }
+      return info.id
+    })
+  }
+
   it.live(
-    "compacts old completed tool output",
+    "compacts old completed tool output by default",
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const compact = yield* SessionCompaction.Service
+        const ssn = yield* SessionNs.Service
+        const sessionID = yield* createPrunableToolSession(dir)
+
+        yield* compact.prune({ sessionID })
+
+        const msgs = yield* ssn.messages({ sessionID })
+        const part = msgs.flatMap((msg) => msg.parts).find((part) => part.type === "tool")
+        expect(part?.type).toBe("tool")
+        expect(part?.state.status).toBe("completed")
+        if (part?.type === "tool" && part.state.status === "completed") {
+          expect(part.state.time.compacted).toBeNumber()
+        }
+      }),
+    ),
+  )
+
+  it.live(
+    "does not compact old completed tool output when disabled",
     provideTmpdirInstance(
       (dir) =>
         Effect.gen(function* () {
           const compact = yield* SessionCompaction.Service
           const ssn = yield* SessionNs.Service
-          const info = yield* ssn.create({})
-          const a = yield* ssn.updateMessage({
-            id: MessageID.ascending(),
-            role: "user",
-            sessionID: info.id,
-            agent: "build",
-            model: ref,
-            time: { created: Date.now() },
-          })
-          yield* ssn.updatePart({
-            id: PartID.ascending(),
-            messageID: a.id,
-            sessionID: info.id,
-            type: "text",
-            text: "first",
-          })
-          const b: MessageV2.Assistant = {
-            id: MessageID.ascending(),
-            role: "assistant",
-            sessionID: info.id,
-            mode: "build",
-            agent: "build",
-            path: { cwd: dir, root: dir },
-            cost: 0,
-            tokens: {
-              output: 0,
-              input: 0,
-              reasoning: 0,
-              cache: { read: 0, write: 0 },
-            },
-            modelID: ref.modelID,
-            providerID: ref.providerID,
-            parentID: a.id,
-            time: { created: Date.now() },
-            finish: "end_turn",
-          }
-          yield* ssn.updateMessage(b)
-          yield* ssn.updatePart({
-            id: PartID.ascending(),
-            messageID: b.id,
-            sessionID: info.id,
-            type: "tool",
-            callID: crypto.randomUUID(),
-            tool: "bash",
-            state: {
-              status: "completed",
-              input: {},
-              output: "x".repeat(200_000),
-              title: "done",
-              metadata: {},
-              time: { start: Date.now(), end: Date.now() },
-            },
-          })
-          for (const text of ["second", "third"]) {
-            const msg = yield* ssn.updateMessage({
-              id: MessageID.ascending(),
-              role: "user",
-              sessionID: info.id,
-              agent: "build",
-              model: ref,
-              time: { created: Date.now() },
-            })
-            yield* ssn.updatePart({
-              id: PartID.ascending(),
-              messageID: msg.id,
-              sessionID: info.id,
-              type: "text",
-              text,
-            })
-          }
+          const sessionID = yield* createPrunableToolSession(dir)
 
-          yield* compact.prune({ sessionID: info.id })
+          yield* compact.prune({ sessionID })
 
-          const msgs = yield* ssn.messages({ sessionID: info.id })
+          const msgs = yield* ssn.messages({ sessionID })
           const part = msgs.flatMap((msg) => msg.parts).find((part) => part.type === "tool")
           expect(part?.type).toBe("tool")
-          expect(part?.state.status).toBe("completed")
           if (part?.type === "tool" && part.state.status === "completed") {
-            expect(part.state.time.compacted).toBeNumber()
+            expect(part.state.time.compacted).toBeUndefined()
           }
         }),
-
       {
         config: {
-          compaction: { prune: true },
+          compaction: { prune: false },
         },
       },
     ),


### PR DESCRIPTION
### Issue for this PR
Closes #24108
### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
### What does this PR do?
`compaction.prune` is documented as enabled by default, but the previous guard treated an unset value as disabled.
This changes pruning to skip only when `compaction.prune` is explicitly `false`, and adds regression tests for both default-enabled and explicitly-disabled behavior.
### How did you verify your code works?
- `bun test test/session/compaction.test.ts`
- `bun typecheck`
- pre-push hook: `bun turbo typecheck`
### Screenshots / recordings
N/A, no UI changes.
### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR