### PR TITLE
feat(desktop): add support for Open in Windows Terminal in the header menu

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -39,6 +39,7 @@ const OPEN_APPS = [
   "warp",
   "xcode",
   "android-studio",
+  "windows-terminal",
   "powershell",
   "sublime-text",
 ] as const
@@ -85,6 +86,12 @@ const WINDOWS_APPS = [
   { id: "vscode", label: "session.header.open.app.vscode", icon: "vscode", openWith: "code" },
   { id: "cursor", label: "session.header.open.app.cursor", icon: "cursor", openWith: "cursor" },
   { id: "zed", label: "session.header.open.app.zed", icon: "zed", openWith: "zed" },
+  {
+    id: "windows-terminal",
+    label: "session.header.open.app.terminal",
+    icon: "windows-terminal",
+    openWith: "wt.exe",
+  },
   {
     id: "powershell",
     label: "session.header.open.app.powershell",

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -142,6 +142,11 @@ export function registerIpcHandlers(deps: Deps) {
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
     if (!app) return shell.openPath(path)
     await new Promise<void>((resolve, reject) => {
+      if (process.platform === "win32" && ["wt", "wt.exe"].includes(app.toLowerCase())) {
+        execFile("wt.exe", [], { cwd: path }, (err) => (err ? reject(err) : resolve()))
+        return
+      }
+
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)
       execFile(cmd, args, (err) => (err ? reject(err) : resolve()))

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -143,7 +143,7 @@ export function registerIpcHandlers(deps: Deps) {
     if (!app) return shell.openPath(path)
     await new Promise<void>((resolve, reject) => {
       if (process.platform === "win32" && ["wt", "wt.exe"].includes(app.toLowerCase())) {
-        execFile("wt.exe", [], { cwd: path }, (err) => (err ? reject(err) : resolve()))
+        execFile("wt.exe", ["-d", path], { cwd: path }, (err) => (err ? reject(err) : resolve()))
         return
       }
 

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -141,7 +141,11 @@ const createPlatform = (): Platform => {
     },
     async openPath(path: string, app?: string) {
       if (os === "windows") {
-        const resolvedApp = app ? await window.api.resolveAppPath(app).catch(() => null) : null
+        const resolvedApp = app
+          ? ["wt", "wt.exe"].includes(app.toLowerCase())
+            ? app
+            : await window.api.resolveAppPath(app).catch(() => null)
+          : null
         const resolvedPath = await (async () => {
           if (await isWslEnabled()) {
             const converted = await window.api.wslPath(path, "windows").catch(() => null)

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -178,9 +178,21 @@ fn open_path(_app: AppHandle, path: String, app_name: Option<String>) -> Result<
                         || name.eq_ignore_ascii_case("powershell.exe")
                 })
         });
+        let is_windows_terminal = app_name.as_ref().is_some_and(|v| {
+            std::path::Path::new(v)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.eq_ignore_ascii_case("wt") || name.eq_ignore_ascii_case("wt.exe")
+                })
+        });
 
         if is_powershell {
             return os::windows::open_in_powershell(path);
+        }
+
+        if is_windows_terminal {
+            return os::windows::open_in_windows_terminal(path);
         }
 
         return tauri_plugin_opener::open_path(path, app_name.as_deref())
@@ -546,7 +558,6 @@ fn spawn_cli_sync_task(app: AppHandle) {
         }
     });
 }
-
 
 fn get_sidecar_port() -> u32 {
     option_env!("OPENCODE_PORT")

--- a/packages/desktop/src-tauri/src/os/windows.rs
+++ b/packages/desktop/src-tauri/src/os/windows.rs
@@ -8,8 +8,8 @@ use windows_sys::Win32::{
     Foundation::ERROR_SUCCESS,
     System::{
         Registry::{
-            RegGetValueW, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, REG_EXPAND_SZ, REG_SZ,
-            RRF_RT_REG_EXPAND_SZ, RRF_RT_REG_SZ,
+            HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, REG_EXPAND_SZ, REG_SZ, RRF_RT_REG_EXPAND_SZ,
+            RRF_RT_REG_SZ, RegGetValueW,
         },
         Threading::{CREATE_NEW_CONSOLE, CREATE_NO_WINDOW},
     },
@@ -458,6 +458,26 @@ pub fn open_in_powershell(path: String) -> Result<(), String> {
         .args(["-NoExit"])
         .spawn()
         .map_err(|e| format!("Failed to start PowerShell: {e}"))?;
+
+    Ok(())
+}
+
+pub fn open_in_windows_terminal(path: String) -> Result<(), String> {
+    let path = PathBuf::from(path);
+    let dir = if path.is_dir() {
+        path
+    } else if let Some(parent) = path.parent() {
+        parent.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| format!("Failed to determine current directory: {e}"))?
+    };
+
+    Command::new("wt.exe")
+        .creation_flags(CREATE_NEW_CONSOLE)
+        .current_dir(dir)
+        .spawn()
+        .map_err(|e| format!("Failed to start Windows Terminal: {e}"))?;
 
     Ok(())
 }

--- a/packages/desktop/src-tauri/src/os/windows.rs
+++ b/packages/desktop/src-tauri/src/os/windows.rs
@@ -8,8 +8,8 @@ use windows_sys::Win32::{
     Foundation::ERROR_SUCCESS,
     System::{
         Registry::{
-            HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, REG_EXPAND_SZ, REG_SZ, RRF_RT_REG_EXPAND_SZ,
-            RRF_RT_REG_SZ, RegGetValueW,
+            RegGetValueW, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, REG_EXPAND_SZ, REG_SZ,
+            RRF_RT_REG_EXPAND_SZ, RRF_RT_REG_SZ,
         },
         Threading::{CREATE_NEW_CONSOLE, CREATE_NO_WINDOW},
     },
@@ -475,6 +475,7 @@ pub fn open_in_windows_terminal(path: String) -> Result<(), String> {
 
     Command::new("wt.exe")
         .creation_flags(CREATE_NEW_CONSOLE)
+        .args(["-d", &dir.to_string_lossy()])
         .current_dir(dir)
         .spawn()
         .map_err(|e| format!("Failed to start Windows Terminal: {e}"))?;

--- a/packages/ui/src/assets/icons/app/windows-terminal.svg
+++ b/packages/ui/src/assets/icons/app/windows-terminal.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="56" height="48" viewBox="0 0 48 48" fill="none">
+<path d="M0 13H16V6H2C0.9 6 0 6.9 0 8V13Z" fill="#CCCCCC"/>
+<path d="M32 6H16V13H32V6Z" fill="#999999"/>
+<path d="M48 13H32V6H46C47.1 6 48 6.9 48 8V13Z" fill="#666666"/>
+<path d="M46 42H2C0.9 42 0 41.1 0 40V12H48V40C48 41.1 47.1 42 46 42Z" fill="url(#paint0_linear)"/>
+<g filter="url(#filter0_dd)">
+<path d="M15.2 24.3L6.39999 33.1C5.89999 33.6 5.89999 34.3 6.39999 34.7L8.19999 36.5C8.69999 37 9.4 37 9.8 36.5L18.6 27.7C19.1 27.2 19.1 26.5 18.6 26.1L16.8 24.3C16.4 23.9 15.6 23.9 15.2 24.3Z" fill="url(#paint1_linear)"/>
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="6" y="24" width="13" height="13">
+<path d="M15.2 24.3L6.39999 33.1C5.89999 33.6 5.89999 34.3 6.39999 34.7L8.19999 36.5C8.69999 37 9.4 37 9.8 36.5L18.6 27.7C19.1 27.2 19.1 26.5 18.6 26.1L16.8 24.3C16.4 23.9 15.6 23.9 15.2 24.3Z" fill="url(#paint2_linear)"/>
+</mask>
+<g mask="url(#mask0)">
+<g filter="url(#filter1_dd)">
+<path d="M9.8 17.3L18.6 26.1C19.1 26.6 19.1 27.3 18.6 27.7L16.8 29.5C16.3 30 15.6 30 15.2 29.5L6.39999 20.7C5.89999 20.2 5.89999 19.5 6.39999 19.1L8.19999 17.3C8.59999 16.9 9.4 16.9 9.8 17.3Z" fill="url(#paint3_linear)"/>
+</g>
+</g>
+<path d="M9.8 17.3L18.6 26.1C19.1 26.6 19.1 27.3 18.6 27.7L16.8 29.5C16.3 30 15.6 30 15.2 29.5L6.39999 20.7C5.89999 20.2 5.89999 19.5 6.39999 19.1L8.19999 17.3C8.59999 16.9 9.4 16.9 9.8 17.3Z" fill="url(#paint4_linear)"/>
+</g>
+<g filter="url(#filter2_dd)">
+<path d="M40 32H24C23.4 32 23 32.4 23 33V36C23 36.6 23.4 37 24 37H40C40.6 37 41 36.6 41 36V33C41 32.4 40.6 32 40 32Z" fill="url(#paint5_linear)"/>
+</g>
+<defs>
+<filter id="filter0_dd" x="3.02499" y="15" width="18.95" height="25.875" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+</filter>
+<filter id="filter1_dd" x="3.02499" y="15" width="18.95" height="18.875" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+</filter>
+<filter id="filter2_dd" x="20" y="30" width="24" height="11" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear" x1="36.4462" y1="47.8257" x2="11.8217" y2="5.1748" gradientUnits="userSpaceOnUse">
+<stop stop-color="#333333"/>
+<stop offset="1" stop-color="#4D4D4D"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="14.5276" y1="33.9959" x2="10.4841" y2="26.9924" gradientUnits="userSpaceOnUse">
+<stop stop-color="#999999"/>
+<stop offset="1" stop-color="#B3B3B3"/>
+</linearGradient>
+<linearGradient id="paint2_linear" x1="14.5276" y1="33.9959" x2="10.4841" y2="26.9924" gradientUnits="userSpaceOnUse">
+<stop stop-color="#999999"/>
+<stop offset="1" stop-color="#B3B3B3"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="16.2747" y1="30.0336" x2="8.73699" y2="16.9781" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CCCCCC"/>
+<stop offset="1" stop-color="#E6E6E6"/>
+</linearGradient>
+<linearGradient id="paint4_linear" x1="16.2747" y1="30.0336" x2="8.73699" y2="16.9781" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CCCCCC"/>
+<stop offset="1" stop-color="#E6E6E6"/>
+</linearGradient>
+<linearGradient id="paint5_linear" x1="35.1496" y1="39.9553" x2="28.8504" y2="29.0447" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CCCCCC"/>
+<stop offset="1" stop-color="#E6E6E6"/>
+</linearGradient>
+</defs>
+</svg>

--- a/packages/ui/src/components/app-icon.tsx
+++ b/packages/ui/src/components/app-icon.tsx
@@ -14,6 +14,7 @@ import terminal from "../assets/icons/app/terminal.png"
 import textmate from "../assets/icons/app/textmate.png"
 import vscode from "../assets/icons/app/vscode.svg"
 import warp from "../assets/icons/app/warp.png"
+import windowsTerminal from "../assets/icons/app/windows-terminal.svg"
 import xcode from "../assets/icons/app/xcode.png"
 import zed from "../assets/icons/app/zed.svg"
 import zedDark from "../assets/icons/app/zed-dark.svg"
@@ -34,6 +35,7 @@ const icons = {
   antigravity,
   textmate,
   powershell,
+  "windows-terminal": windowsTerminal,
   "sublime-text": sublimetext,
 } satisfies Record<IconName, string>
 

--- a/packages/ui/src/components/app-icons/types.ts
+++ b/packages/ui/src/components/app-icons/types.ts
@@ -14,6 +14,7 @@ export const iconNames = [
   "android-studio",
   "antigravity",
   "textmate",
+  "windows-terminal",
   "powershell",
   "sublime-text",
 ] as const


### PR DESCRIPTION
### Issue for this PR

`N/A`: new feature request. No existing issue.

### Type of change

- [x] New feature

### What does this PR do?

- [x] Uses the [Windows Terminal icon](https://github.com/microsoft/terminal/blob/main/res/terminal/Terminal.svg) for the new menu item.
- [x] Adds a **Windows** only `Terminal` option to the session header's "Open in x" menu.
- [x] Wires the option through both desktop implementations: Tauri and Electron.

Note: `wt.exe -d <dir>` alone isn’t enough. working directory is important to ensure new tabs open in the same folder.

### How did you verify your code works?

- [x] Tested on Windows 11 with both Tauri and Electron builds. Verified that the `Terminal` option appears in the session header menu and opens the terminal in the correct directory.
- [x] Tested opening new tabs from the initial terminal to confirm they inherit the expected directory behavior.
- [ ] Not tested in Windows 10, but should work similarly since the Windows Terminal behavior is pretty consistent across os versions.

### Screenshots / recordings

_Video attached:_

https://github.com/user-attachments/assets/6ce27a47-86db-461c-b3e5-ff56527c3053

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
