### PR TITLE
cli/tui: honor configured network defaults in thread mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -8,7 +8,7 @@ import { UI } from "@/cli/ui"
 import { Log } from "@/util"
 import { errorMessage } from "@/util/error"
 import { withTimeout } from "@/util/timeout"
-import { withNetworkOptions, resolveNetworkOptionsNoConfig } from "@/cli/network"
+import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import { Filesystem } from "@/util"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
@@ -182,7 +182,7 @@ export const TuiThreadCommand = cmd({
       const prompt = await input(args.prompt)
       const config = await TuiConfig.get()
 
-      const network = resolveNetworkOptionsNoConfig(args)
+      const network = await resolveNetworkOptions(args)
       const external =
         process.argv.includes("--port") ||
         process.argv.includes("--hostname") ||


### PR DESCRIPTION
Thread mode resolves network options without loading config-backed defaults, so configured hostname, port and mDNS settings are ignored unless they are passed on the command line.

Use the config-aware resolver so thread mode follows the same network resolution path as the rest of the CLI.

675a46e23e regressed a fix from 390b0a79
