### PR TITLE
docs: add MDNS workaround for WSL path issues in windows-wsl.mdx

### DIFF
--- a/packages/web/src/content/docs/windows-wsl.mdx
+++ b/packages/web/src/content/docs/windows-wsl.mdx
@@ -66,6 +66,31 @@ When using `--hostname 0.0.0.0`, set `OPENCODE_SERVER_PASSWORD` to secure the se
 OPENCODE_SERVER_PASSWORD=your-password opencode serve --hostname 0.0.0.0
 ```
 
+### Using MDNS (Alternative)
+
+If you encounter path resolution issues when connecting the Desktop App to WSL (such as UNC paths being sent incorrectly), you can use mDNS for automatic service discovery instead of IP-based connections:
+
+1. **Enable mirrored networking** in WSL (recommended for mDNS):
+
+   Create or edit `%USERPROFILE%\.wslconfig`:
+
+   ```ini
+   [wsl2]
+   networkingMode=mirrored
+   ```
+
+   See [Microsoft's WSL networking docs](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking) for more details.
+
+2. **Start the server with MDNS**:
+
+   ```bash
+   opencode serve --mdns --mdns-domain opencode.local --hostname 0.0.0.0 --port 4096
+   ```
+
+3. **Connect the Desktop App** to `http://opencode.local:4096`
+
+This approach avoids UNC path issues (e.g., `\\wsl.localhost\Debian`) because the server uses a hostname instead of Windows UNC paths.
+
 ---
 
 ## Web Client + WSL


### PR DESCRIPTION
### Issue for this PR

Closes #19473 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR adds documentation for using mDNS as a workaround for UNC path issues when connecting the OpenCode Desktop App to a WSL-hosted server.

Problem: When the Desktop App (Windows) connects to an OpenCode server running in WSL2, the project widget sends Windows UNC paths (e.g., \\wsl.localhost\Debian) to the server. The server concatenates this with its working directory, producing invalid paths like /home/me/\\wsl.localhost\Debian, which breaks all bash tool calls with misleading ENOENT errors. See issue #19473.

Solution: This documentation addition provides an alternative connection method using mDNS (--mdns --mdns-domain opencode.local) instead of IP-based connections. This avoids UNC path issues because:

The server uses a hostname (opencode.local) rather than the Windows UNC path
Clients connect via http://opencode.local:4096/ instead of dealing with path translation issues

### How did you verify your code works?
This is a documentation-only change. The commands and paths documented are based on:

The existing opencode serve flags (verified via opencode serve --help)
Microsoft's WSL mirrored networking documentation (linked)
### Screenshots / recordings

Not required since it's a documentation only chagne.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._