### PR TITLE
fix: preserve empty reasoning_content for DeepSeek V4 thinking mode

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -185,24 +185,19 @@ function normalizeMessages(
         // Filter out reasoning parts from content
         const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
 
-        // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-        if (reasoningText) {
-          return {
-            ...msg,
-            content: filteredContent,
-            providerOptions: {
-              ...msg.providerOptions,
-              openaiCompatible: {
-                ...msg.providerOptions?.openaiCompatible,
-                [field]: reasoningText,
-              },
-            },
-          }
-        }
-
+        // Include reasoning_content | reasoning_details directly on the message for all assistant messages.
+        // Always set the field even when empty — some providers (e.g. DeepSeek) may return empty
+        // reasoning_content which still needs to be sent back in subsequent requests.
         return {
           ...msg,
           content: filteredContent,
+          providerOptions: {
+            ...msg.providerOptions,
+            openaiCompatible: {
+              ...msg.providerOptions?.openaiCompatible,
+              [field]: reasoningText,
+            },
+          },
         }
       }
 


### PR DESCRIPTION
### Issue for this PR

Closes #24104
Closes #24097
Closes #24130
Closes #24124
Closes #24135
Closes #24114
Closes #24111
Closes #17523

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem:** When using DeepSeek models (e.g. `deepseek-v4-pro`) with thinking mode enabled through the `@ai-sdk/openai-compatible` provider, multi-turn tool call chains fail with:

> `The 'reasoning_content' in the thinking mode must be passed back to the API.`

**Root cause:** DeepSeek's thinking mode can return `reasoning_content: ""` (empty string) on assistant messages within a tool call chain. This empty string is semantically meaningful — DeepSeek requires it to be sent back verbatim in subsequent requests. However, it gets dropped at two points:

1. **AI SDK** (`@ai-sdk/openai-compatible`): The response parser uses truthy checks (`if (reasoningContent)`, `reasoning.length > 0`) that discard empty `reasoning_content` before it ever reaches opencode's storage layer. No reasoning part is created, so the database has no record that reasoning occurred.

2. **opencode** (`transform.ts`): The interleaved transform uses `if (reasoningText)` — another truthy check — to decide whether to set the `reasoning_content` field in `providerOptions`. Even if a reasoning part existed with empty text, it would be dropped here.

**Fix:** Remove the `if (reasoningText)` guard in the interleaved transform. Always set `providerOptions.openaiCompatible[field]` for assistant messages. When `reasoningText` is empty, the AI SDK's `...metadata` spread in `convert-to-openai-compatible-chat-messages.ts` still carries `reasoning_content: ""` into the outgoing request, bypassing its own `reasoning.length > 0` discard. Single-location fix, no upstream changes needed.

**AI SDK upstream context:** The same issue was identified in `@ai-sdk/deepseek` and a fix is proposed in [vercel/ai#13203](https://github.com/vercel/ai/pull/13203), but that fix is provider-specific and does not cover `@ai-sdk/openai-compatible`.

**Trigger conditions (not every request hits this):**
1. DeepSeek thinking mode enabled (`thinking.type: "enabled"`)
2. Multi-turn tool call chain (assistant → tool → assistant → tool → ...)
3. An assistant message in the chain returns `reasoning_content: ""` (e.g. `reasoning_tokens: 0`)
4. That message is included in the next request's message history

### How did you verify your code works?

- All 135 existing tests in `test/provider/transform.test.ts` pass with the change
- `bun typecheck` passes
- Scoped to models with `interleaved: { field: "reasoning_content" }` only

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
