### PR TITLE
fix: #24090 preserve assistant tool_calls in openai-compatible replay

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -56,6 +56,85 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/LLM") {}
 
+type SourceToolCall = {
+  toolName: string
+  input: unknown
+  providerExecuted?: true
+  providerOptions?: Record<string, unknown>
+}
+
+function sourceToolCalls(messages: ModelMessage[]) {
+  const result = new Map<string, SourceToolCall>()
+  for (const message of messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) continue
+    for (const part of message.content) {
+      if (part.type !== "tool-call") continue
+      result.set(part.toolCallId, {
+        toolName: part.toolName,
+        input: part.input,
+        ...(part.providerExecuted ? { providerExecuted: true as const } : {}),
+        ...(part.providerOptions ? { providerOptions: part.providerOptions } : {}),
+      })
+    }
+  }
+  return result
+}
+
+function repairAssistantToolCallPrompt(prompt: ModelMessage[], messages: ModelMessage[]) {
+  const knownToolCalls = sourceToolCalls(messages)
+  if (knownToolCalls.size === 0) return prompt
+
+  const result = [...prompt]
+  for (let index = 0; index < result.length; index++) {
+    const message = result[index]
+    if (message.role !== "tool" || !Array.isArray(message.content)) continue
+
+    const toolResultIDs = message.content.flatMap((part) => (part.type === "tool-result" ? [part.toolCallId] : []))
+    if (toolResultIDs.length === 0) continue
+
+    let assistantIndex = -1
+    for (let scan = index - 1; scan >= 0; scan--) {
+      if (result[scan].role !== "assistant") continue
+      assistantIndex = scan
+      break
+    }
+    if (assistantIndex < 0) continue
+
+    const assistant = result[assistantIndex]
+    const assistantContent = Array.isArray(assistant.content)
+      ? [...assistant.content]
+      : [{ type: "text" as const, text: assistant.content }]
+    const existingToolCallIDs = new Set(
+      assistantContent.flatMap((part) => (part.type === "tool-call" ? [part.toolCallId] : [])),
+    )
+
+    const repairedToolCalls = toolResultIDs
+      .filter((toolCallID) => !existingToolCallIDs.has(toolCallID))
+      .flatMap((toolCallID) => {
+        const known = knownToolCalls.get(toolCallID)
+        if (!known) return []
+        return [
+          {
+            type: "tool-call" as const,
+            toolCallId: toolCallID,
+            toolName: known.toolName,
+            input: known.input,
+            ...(known.providerExecuted ? { providerExecuted: true as const } : {}),
+            ...(known.providerOptions ? { providerOptions: known.providerOptions } : {}),
+          },
+        ]
+      })
+    if (repairedToolCalls.length === 0) continue
+
+    result[assistantIndex] = {
+      ...assistant,
+      content: [...assistantContent, ...repairedToolCalls],
+    }
+  }
+
+  return result
+}
+
 const live: Layer.Layer<
   Service,
   never,
@@ -158,6 +237,7 @@ const live: Layer.Layer<
               ),
               ...input.messages,
             ]
+      const shouldRepairToolCallReplay = input.model.api.npm === "@ai-sdk/openai-compatible" && hasToolCalls(messages)
 
       const params = yield* plugin.trigger(
         "chat.params",
@@ -391,8 +471,14 @@ const live: Layer.Layer<
               specificationVersion: "v3" as const,
               async transformParams(args) {
                 if (args.type === "stream") {
+                  const repaired = shouldRepairToolCallReplay
+                    ? repairAssistantToolCallPrompt(args.params.prompt as ModelMessage[], messages)
+                    : args.params.prompt
                   // @ts-expect-error
-                  args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
+                  args.params.prompt = ProviderTransform.message(repaired, input.model, options)
+                  if (shouldRepairToolCallReplay) {
+                    args.params.prompt = repairAssistantToolCallPrompt(args.params.prompt as ModelMessage[], messages)
+                  }
                 }
                 return args.params
               },

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -709,6 +709,65 @@ function providerMeta(metadata: Record<string, any> | undefined) {
   return Object.keys(rest).length > 0 ? rest : undefined
 }
 
+type ReplayToolCall = {
+  toolName: string
+  input: Record<string, unknown>
+  providerExecuted?: true
+  providerOptions?: Record<string, unknown>
+}
+
+function repairAssistantToolCallReplay(messages: ModelMessage[], replayToolCalls: Map<string, ReplayToolCall>) {
+  const result = [...messages]
+  for (let index = 0; index < result.length; index++) {
+    const message = result[index]
+    if (message.role !== "tool" || !Array.isArray(message.content)) continue
+
+    const toolResultIDs = message.content.flatMap((part) => (part.type === "tool-result" ? [part.toolCallId] : []))
+    if (toolResultIDs.length === 0) continue
+
+    let assistantIndex = -1
+    for (let scan = index - 1; scan >= 0; scan--) {
+      if (result[scan].role !== "assistant") continue
+      assistantIndex = scan
+      break
+    }
+    if (assistantIndex < 0) continue
+
+    const assistant = result[assistantIndex]
+    const assistantContent = Array.isArray(assistant.content)
+      ? [...assistant.content]
+      : [{ type: "text" as const, text: assistant.content }]
+    const existingToolCallIDs = new Set(
+      assistantContent.flatMap((part) => (part.type === "tool-call" ? [part.toolCallId] : [])),
+    )
+
+    const missingToolCalls = toolResultIDs
+      .filter((toolCallID) => !existingToolCallIDs.has(toolCallID))
+      .flatMap((toolCallID) => {
+        const repaired = replayToolCalls.get(toolCallID)
+        if (!repaired) return []
+        return [
+          {
+            type: "tool-call" as const,
+            toolCallId: toolCallID,
+            toolName: repaired.toolName,
+            input: repaired.input,
+            ...(repaired.providerExecuted ? { providerExecuted: true as const } : {}),
+            ...(repaired.providerOptions ? { providerOptions: repaired.providerOptions } : {}),
+          },
+        ]
+      })
+    if (missingToolCalls.length === 0) continue
+
+    result[assistantIndex] = {
+      ...assistant,
+      content: [...assistantContent, ...missingToolCalls],
+    }
+  }
+
+  return result
+}
+
 export const toModelMessagesEffect = Effect.fnUntraced(function* (
   input: WithParts[],
   model: Provider.Model,
@@ -716,6 +775,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
+  const replayToolCalls = new Map<string, ReplayToolCall>()
   // Track media from tool results that need to be injected as user messages
   // for providers that don't support media in tool results.
   //
@@ -850,6 +910,13 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           })
         if (part.type === "tool") {
           toolNames.add(part.tool)
+          const callProviderMetadata = differentModel ? undefined : providerMeta(part.metadata)
+          replayToolCalls.set(part.callID, {
+            toolName: part.tool,
+            input: part.state.input,
+            ...(part.metadata?.providerExecuted ? { providerExecuted: true as const } : {}),
+            ...(callProviderMetadata ? { providerOptions: callProviderMetadata } : {}),
+          })
           if (part.state.status === "completed") {
             const outputText = part.state.time.compacted
               ? "[Old tool result content cleared]"
@@ -880,7 +947,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               input: part.state.input,
               output,
               ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
-              ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
+              ...(differentModel ? {} : { callProviderMetadata }),
             })
           }
           if (part.state.status === "error") {
@@ -893,7 +960,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
                 input: part.state.input,
                 output,
                 ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
-                ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
+                ...(differentModel ? {} : { callProviderMetadata }),
               })
             } else {
               assistantMessage.parts.push({
@@ -903,7 +970,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
                 input: part.state.input,
                 errorText: part.state.error,
                 ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
-                ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
+                ...(differentModel ? {} : { callProviderMetadata }),
               })
             }
           }
@@ -917,7 +984,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               input: part.state.input,
               errorText: "[Tool execution was interrupted]",
               ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
-              ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
+              ...(differentModel ? {} : { callProviderMetadata }),
             })
         }
         if (part.type === "reasoning") {
@@ -955,7 +1022,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 
   const tools = Object.fromEntries(Array.from(toolNames).map((toolName) => [toolName, { toModelOutput }]))
 
-  return yield* Effect.promise(() =>
+  const converted = yield* Effect.promise(() =>
     convertToModelMessages(
       result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")),
       {
@@ -964,6 +1031,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
       },
     ),
   )
+  return repairAssistantToolCallReplay(converted, replayToolCalls)
 })
 
 export function toModelMessages(

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -395,6 +395,207 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("replays assistant tool_calls alongside matching tool_call_id results for openai-compatible models", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "vivgrid"
+    const modelID = "gemini-3.1-pro-preview"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Done"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-replay-tool-calls")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-replay-tool-calls"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const history = [
+          {
+            info: {
+              id: "msg-user-replay",
+              sessionID,
+              role: "user",
+              time: { created: 1 },
+              agent: "test",
+              model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+            },
+            parts: [
+              {
+                id: "part-user-replay",
+                sessionID,
+                messageID: "msg-user-replay",
+                type: "text",
+                text: "Check for pdf files in /root",
+              },
+            ],
+          },
+          {
+            info: {
+              id: "msg-assistant-replay",
+              sessionID,
+              parentID: "msg-user-replay",
+              role: "assistant",
+              mode: "test",
+              agent: "test",
+              path: { cwd: "/root", root: "/" },
+              cost: 0,
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              modelID: resolved.id,
+              providerID: ProviderID.make(providerID),
+              time: { created: 2, completed: 3 },
+              finish: "tool-calls",
+            },
+            parts: [
+              {
+                id: "part-assistant-text-replay",
+                sessionID,
+                messageID: "msg-assistant-replay",
+                type: "text",
+                text: "I checked your home directory and looked for PDF files.",
+                time: { start: 0, end: 1 },
+              },
+              {
+                id: "part-tool-read-replay",
+                sessionID,
+                messageID: "msg-assistant-replay",
+                type: "tool",
+                tool: "read",
+                callID: "call-read-replay",
+                state: {
+                  status: "completed",
+                  input: { filePath: "/root" },
+                  output: "<path>/root</path>",
+                  metadata: {},
+                  title: "Read",
+                  time: { start: 2, end: 3 },
+                },
+              },
+              {
+                id: "part-tool-glob-replay",
+                sessionID,
+                messageID: "msg-assistant-replay",
+                type: "tool",
+                tool: "glob",
+                callID: "call-glob-replay",
+                state: {
+                  status: "completed",
+                  input: { pattern: "**/*.pdf", path: "/root" },
+                  output: "No files found",
+                  metadata: {},
+                  title: "Glob",
+                  time: { start: 4, end: 5 },
+                },
+              },
+            ],
+          },
+        ] as MessageV2.WithParts[]
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: [],
+          messages: await MessageV2.toModelMessages(history, resolved),
+          tools: {
+            read: tool({
+              description: "Stub read tool",
+              inputSchema: z.object({
+                filePath: z.string(),
+              }),
+              execute: async () => ({ output: "stub" }),
+            }),
+            glob: tool({
+              description: "Stub glob tool",
+              inputSchema: z.object({
+                pattern: z.string(),
+                path: z.string().optional(),
+              }),
+              execute: async () => ({ output: "stub" }),
+            }),
+          },
+        })
+
+        const capture = await request
+        const body = capture.body
+        expect(capture.url.pathname.endsWith("/chat/completions")).toBe(true)
+
+        type OutboundToolCall = {
+          id: string
+        }
+        type OutboundMessage = {
+          role: string
+          content?: unknown
+          tool_calls?: OutboundToolCall[]
+          tool_call_id?: string
+        }
+
+        const outboundMessages = (body.messages as OutboundMessage[]) ?? []
+        const replayAssistant = outboundMessages.find((msg) => msg.role === "assistant" && msg.tool_calls?.length)
+        expect(replayAssistant).toBeDefined()
+        expect(typeof replayAssistant?.content).toBe("string")
+
+        const assistantToolCallIds = new Set((replayAssistant?.tool_calls ?? []).map((call) => call.id))
+        expect(assistantToolCallIds.has("call-read-replay")).toBe(true)
+        expect(assistantToolCallIds.has("call-glob-replay")).toBe(true)
+
+        const outboundToolMessages = outboundMessages.filter((msg) => msg.role === "tool")
+        expect(outboundToolMessages.map((msg) => msg.tool_call_id)).toEqual(
+          expect.arrayContaining(["call-read-replay", "call-glob-replay"]),
+        )
+
+        for (const msg of outboundToolMessages) {
+          if (!msg.tool_call_id) continue
+          expect(assistantToolCallIds.has(msg.tool_call_id)).toBe(true)
+        }
+      },
+    })
+  })
+
   test("service stream cancellation cancels provider response body promptly", async () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -360,6 +360,106 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("preserves assistant tool-call ids for multiple completed tools", async () => {
+    const userID = "m-user-multi"
+    const assistantID = "m-assistant-multi"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1-multi"),
+            type: "text",
+            text: "check files",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1-multi"),
+            type: "text",
+            text: "I checked your files.",
+          },
+          {
+            ...basePart(assistantID, "a2-multi"),
+            type: "tool",
+            callID: "call-read",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "/root" },
+              output: "contents",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+          {
+            ...basePart(assistantID, "a3-multi"),
+            type: "tool",
+            callID: "call-glob",
+            tool: "glob",
+            state: {
+              status: "completed",
+              input: { pattern: "**/*.pdf", path: "/root" },
+              output: "No files found",
+              title: "Glob",
+              metadata: {},
+              time: { start: 2, end: 3 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "check files" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I checked your files." },
+          {
+            type: "tool-call",
+            toolCallId: "call-read",
+            toolName: "read",
+            input: { filePath: "/root" },
+            providerExecuted: undefined,
+          },
+          {
+            type: "tool-call",
+            toolCallId: "call-glob",
+            toolName: "glob",
+            input: { pattern: "**/*.pdf", path: "/root" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-read",
+            toolName: "read",
+            output: { type: "text", value: "contents" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call-glob",
+            toolName: "glob",
+            output: { type: "text", value: "No files found" },
+          },
+        ],
+      },
+    ])
+  })
+
   test("preserves jpeg tool-result media for anthropic models", async () => {
     const anthropicModel: Provider.Model = {
       ...model,


### PR DESCRIPTION
### Issue for this PR

Closes #24090

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes missing assistant `tool_calls` during OpenAI-compatible history replay.

I added a focused repair in `MessageV2.toModelMessagesEffect` so when replay contains `tool` result messages, the nearest preceding assistant message is guaranteed to include matching `tool-call` entries (rehydrated from recorded session tool parts, including original tool name/input).

I also added a send-time guard in `session/llm` middleware for OpenAI-compatible models. If tool-call parts are dropped during prompt conversion, the guard restores them from the original model-message source before provider serialization, keeping `tool_calls` and `tool_call_id` paired.

Regression coverage was added in:
- `packages/opencode/test/session/message-v2.test.ts`
- `packages/opencode/test/session/llm.test.ts`

### How did you verify your code works?

- Ran `bun --config=./bunfig.test.toml test test/session/llm.test.ts` locally (from `packages/opencode`) and all tests passed, including the new replay pairing case.
- Attempted `bun --config=./bunfig.test.toml test test/session/message-v2.test.ts`; this currently fails before test execution due a pre-existing initialization error in `src/session/session.ts` (`ReferenceError: Cannot access 'Assistant' before initialization`), not from this diff.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR