### PR TITLE
fix: use existingModel as fallback for interleaved field

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1177,7 +1177,7 @@ const layer: Layer.Layer<
                     model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
                   pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
                 },
-                interleaved: model.interleaved ?? false,
+                interleaved: model.interleaved ?? existingModel?.capabilities.interleaved ?? false,
               },
               cost: {
                 input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It use `existingModel.capabilities.interleaved` as fallback for model's `interleaved` field.

In previous PR for DeepSeek V4, https://github.com/anomalyco/opencode/pull/24146/changes

`interleaved` config is still needed for DeepSeek V4 models in `opencode.json` since config from `models.dev` is not used for the field.

### How did you verify your code works?

Locally checked, and it works.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR