### PR TITLE
feat: expose a session-scoped permission bridge for external providers

### DIFF
--- a/packages/opencode/src/provider/external-permission-bridge.ts
+++ b/packages/opencode/src/provider/external-permission-bridge.ts
@@ -1,0 +1,49 @@
+const REGISTRY_KEY = Symbol.for("opencode.externalProviderPermissionBridge")
+
+export type ExternalProviderPermissionDecision = {
+  behavior: "allow" | "deny"
+  message?: string
+}
+
+export type ExternalProviderPermissionRequest = {
+  sessionID: string
+  permission: string
+  patterns: string[]
+  always: string[]
+  metadata: Record<string, unknown>
+  tool?: {
+    callID: string
+    messageID?: string
+  }
+}
+
+export type ExternalProviderPermissionBridge = {
+  ask(input: ExternalProviderPermissionRequest): Promise<ExternalProviderPermissionDecision>
+}
+
+type RegistryShape = Map<string, ExternalProviderPermissionBridge>
+
+function registry(): RegistryShape {
+  const globalValue = globalThis as Record<PropertyKey, unknown>
+  const existing = globalValue[REGISTRY_KEY]
+  if (existing instanceof Map) return existing as RegistryShape
+
+  const created = new Map<string, ExternalProviderPermissionBridge>()
+  globalValue[REGISTRY_KEY] = created
+  return created
+}
+
+export function registerExternalProviderPermissionBridge(
+  sessionID: string,
+  bridge: ExternalProviderPermissionBridge,
+) {
+  const map = registry()
+  map.set(sessionID, bridge)
+
+  return () => {
+    const current = map.get(sessionID)
+    if (current === bridge) {
+      map.delete(sessionID)
+    }
+  }
+}

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -18,7 +18,7 @@ import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
 import { Bus } from "@/bus"
 import { Wildcard } from "@/util"
-import { SessionID } from "@/session/schema"
+import { MessageID, SessionID } from "@/session/schema"
 import { Auth } from "@/auth"
 import { Installation } from "@/installation"
 import { InstallationVersion } from "@/installation/version"
@@ -206,7 +206,13 @@ const live: Layer.Layer<
                 patterns: request.patterns,
                 metadata: request.metadata,
                 always: request.always,
-                tool: request.tool,
+                tool:
+                  request.tool?.messageID != null
+                    ? {
+                        callID: request.tool.callID,
+                        messageID: MessageID.make(request.tool.messageID),
+                      }
+                    : undefined,
                 ruleset,
               }),
             )

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -6,6 +6,7 @@ import { streamText, wrapLanguageModel, type ModelMessage, type Tool, tool, json
 import { mergeDeep, pipe } from "remeda"
 import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
 import { ProviderTransform } from "@/provider"
+import { registerExternalProviderPermissionBridge } from "@/provider/external-permission-bridge"
 import { Config } from "@/config"
 import { Instance } from "@/project/instance"
 import type { Agent } from "@/agent/agent"
@@ -193,6 +194,32 @@ const live: Layer.Layer<
         },
       )
 
+      const ruleset = Permission.merge(input.agent.permission, input.permission ?? [])
+      const bridge = yield* EffectBridge.make()
+      const unregisterExternalPermissionBridge = registerExternalProviderPermissionBridge(input.sessionID, {
+        ask: async (request) => {
+          try {
+            await bridge.promise(
+              perm.ask({
+                sessionID: SessionID.make(request.sessionID),
+                permission: request.permission,
+                patterns: request.patterns,
+                metadata: request.metadata,
+                always: request.always,
+                tool: request.tool,
+                ruleset,
+              }),
+            )
+            return { behavior: "allow" as const }
+          } catch (error) {
+            return {
+              behavior: "deny" as const,
+              message: error instanceof Error ? error.message : String(error),
+            }
+          }
+        },
+      })
+
       const tools = resolveTools(input)
 
       // LiteLLM and some Anthropic proxies require the tools parameter to be present
@@ -266,7 +293,6 @@ const live: Layer.Layer<
           return !match || match.action !== "ask"
         })
 
-        const bridge = yield* EffectBridge.make()
         const approvedToolsForSession = new Set<string>()
         workflowModel.approvalHandler = Instance.bind(async (approvalTools) => {
           const uniqueNames = [...new Set(approvalTools.map((t: { name: string }) => t.name))] as string[]
@@ -330,7 +356,7 @@ const live: Layer.Layer<
           })
         : undefined
 
-      return streamText({
+      const result = streamText({
         onError(error) {
           l.error("stream error", {
             error,
@@ -409,6 +435,11 @@ const live: Layer.Layer<
           },
         },
       })
+
+      return {
+        result,
+        cleanup: unregisterExternalPermissionBridge,
+      }
     })
 
     const stream: Interface["stream"] = (input) =>
@@ -420,9 +451,14 @@ const live: Layer.Layer<
               (ctrl) => Effect.sync(() => ctrl.abort()),
             )
 
-            const result = yield* run({ ...input, abort: ctrl.signal })
+            const running = yield* Effect.acquireRelease(
+              run({ ...input, abort: ctrl.signal }),
+              ({ cleanup }) => Effect.sync(cleanup),
+            )
 
-            return Stream.fromAsyncIterable(result.fullStream, (e) => (e instanceof Error ? e : new Error(String(e))))
+            return Stream.fromAsyncIterable(running.result.fullStream, (e) =>
+              e instanceof Error ? e : new Error(String(e)),
+            )
           }),
         ),
       )


### PR DESCRIPTION
### Issue for this PR

Closes N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds a tiny, generic bridge that lets external providers reuse OpenCode's existing `Permission.ask(...)` flow.

Concretely:
- it adds a session-scoped registry on `globalThis` in `packages/opencode/src/provider/external-permission-bridge.ts`
- it registers an entry for the active session in `packages/opencode/src/session/llm.ts`
- that entry calls the existing permission service with the current session and ruleset
- it unregisters the bridge automatically when the stream lifecycle ends

Why this works:
- built-in providers already run through OpenCode's permission system
- external providers do not currently have a generic way to hand a provider-initiated permission request back into that same system
- this bridge exposes the smallest reusable hook possible without changing existing built-in provider behavior

This is intentionally provider-agnostic. A provider still needs to translate its own control/tool protocol into this bridge.

### How did you verify your code works?

- ran local typecheck with Bun on the patched branch
- verified the branch compiles cleanly after the bridge registration/cleanup changes
- verified locally with an external-provider prototype that the provider can see the session-scoped bridge and call back into OpenCode's permission flow using the active session context

### Screenshots / recordings

N/A — no UI changes in this PR.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR