### PR TITLE
docs: clarify bedrock inference profile setup

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -401,6 +401,32 @@ Amazon Bedrock supports AWS-specific configuration:
 Bearer tokens (`AWS_BEARER_TOKEN_BEDROCK` or `/connect`) take precedence over profile-based authentication. See [authentication precedence](/docs/providers#authentication-precedence) for details.
 :::
 
+For custom Bedrock application inference profiles, define a custom model and set its `id` to the full profile ARN:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "amazon-bedrock/claude-sonnet-custom",
+  "provider": {
+    "amazon-bedrock": {
+      "options": {
+        "region": "us-east-1",
+        "profile": "my-aws-profile",
+        "setCacheKey": true
+      },
+      "models": {
+        "claude-sonnet-custom": {
+          "id": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123example",
+          "name": "Claude Sonnet custom Bedrock profile"
+        }
+      }
+    }
+  }
+}
+```
+
+Use the full ARN in `id`, not the human-readable profile name. Keeping the custom model key Claude-like also helps Bedrock prompt caching apply correctly.
+
 [Learn more about Amazon Bedrock configuration](/docs/providers#amazon-bedrock).
 
 ---

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -278,18 +278,44 @@ For custom inference profiles, use the model and provider name in the key and se
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
+  "model": "amazon-bedrock/anthropic-claude-sonnet-4.5",
   "provider": {
     "amazon-bedrock": {
-      // ...
+      "options": {
+        "region": "us-east-1",
+        "profile": "my-aws-profile",
+        "setCacheKey": true
+      },
       "models": {
         "anthropic-claude-sonnet-4.5": {
-          "id": "arn:aws:bedrock:us-east-1:xxx:application-inference-profile/yyy"
+          "id": "arn:aws:bedrock:us-east-1:xxx:application-inference-profile/yyy",
+          "name": "Claude Sonnet custom Bedrock profile"
         }
       }
     }
   }
 }
 ```
+
+The important part is that the custom model key still looks like a Claude model name, while the underlying `id` is the full Bedrock application inference profile ARN.
+
+If you are creating the application profile yourself, the most reliable pattern is:
+
+1. Find the matching system-defined inference profile for the model
+2. Create your application inference profile from that system-defined profile
+3. Put the returned application inference profile ARN in `provider.amazon-bedrock.models.<name>.id`
+
+```bash
+aws bedrock create-inference-profile \
+  --inference-profile-name my-claude-profile \
+  --model-source copyFrom=arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6 \
+  --region us-east-1 \
+  --profile my-aws-profile
+```
+
+:::tip
+If Bedrock rejects a raw foundation model ARN with an on-demand inference error, use the matching system-defined inference profile ARN as `copyFrom` instead.
+:::
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This updates the Bedrock docs to make the custom application inference profile flow explicit instead of just mentioning that the model `id` can be an ARN.

It adds a fuller `opencode.json` example, calls out that the custom model key should still look Claude-like for caching, and documents the practical AWS flow of creating the application profile from the matching system-defined inference profile when Bedrock rejects the raw foundation model ARN.

### How did you verify your code works?

I verified the examples against a real Bedrock setup locally:

- created an application inference profile with AWS CLI
- confirmed the profile was `ACTIVE`
- invoked it successfully with `aws bedrock-runtime converse`
- checked that `opencode debug config` and `opencode models amazon-bedrock` picked up the custom model config

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR