### PR TITLE
refactor(opencode): condense tool descriptions ~66% to cut system-prompt tokens

### DIFF
--- a/packages/opencode/src/tool/apply_patch.txt
+++ b/packages/opencode/src/tool/apply_patch.txt
@@ -1,18 +1,15 @@
-Use the `apply_patch` tool to edit files. Your patch language is a stripped‑down, file‑oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high‑level envelope:
+Edit files with stripped-down diff format. Envelope:
 
 *** Begin Patch
-[ one or more file sections ]
+[ file sections ]
 *** End Patch
 
-Within that envelope, you get a sequence of file operations.
-You MUST include a header to specify the action you are taking.
-Each operation starts with one of three headers:
+Each section MUST start with one header:
+- `*** Add File: <path>` — create new; all following lines prefixed `+`.
+- `*** Delete File: <path>` — remove; nothing follows.
+- `*** Update File: <path>` — patch in place. Optional `*** Move to: <path>` rename.
 
-*** Add File: <path> - create a new file. Every following line is a + line (the initial contents).
-*** Delete File: <path> - remove an existing file. Nothing follows.
-*** Update File: <path> - patch an existing file in place (optionally with a rename).
-
-Example patch:
+Example:
 
 ```
 *** Begin Patch
@@ -27,7 +24,4 @@ Example patch:
 *** End Patch
 ```
 
-It is important to remember:
-
-- You must include a header with your intended action (Add/Delete/Update)
-- You must prefix new lines with `+` even when creating a new file
+Remember: always include action header. New lines prefixed `+` even for new files.

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -1,117 +1,57 @@
-Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
+Run bash command in persistent shell session. Terminal ops only (git, npm, docker). Use dedicated tools for file/search ops.
 
-Be aware: OS: ${os}, Shell: ${shell}
+OS: ${os}, Shell: ${shell}
 
-All commands run in the current working directory by default. Use the `workdir` parameter if you need to run a command in a different directory. AVOID using `cd <directory> && <command>` patterns - use `workdir` instead.
+# Rules
+- Default cwd. Use `workdir` param to change dir. NEVER `cd X && cmd`.
+  - Good: `workdir="/foo/bar"` + command `pytest tests`. Bad: `cd /foo/bar && pytest tests`.
+- Quote paths with spaces: `rm "path with spaces/file.txt"`.
+  - Good: `mkdir "/Users/name/My Documents"`. Bad: `mkdir /Users/name/My Documents` (fails).
+- `command` required. Optional `timeout` ms (default 120000).
+- Write 5-10 word `description`.
+- Output > ${maxLines} lines or ${maxBytes} bytes truncated to file. Use Read offset/limit or Grep; NOT head/tail.
+- Before creating dirs/files, verify parent with `ls`.
+- Never use `-i` flag (rebase -i, add -i): no interactive.
 
-IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO NOT use it for file operations (reading, writing, editing, searching, finding files) - use the specialized tools for this instead.
+# Prefer dedicated tools over bash
+- find/ls → Glob
+- grep/rg → Grep
+- cat/head/tail → Read
+- sed/awk → Edit
+- echo >/heredoc → Write
+- echo/printf for user output → plain text
 
-Before executing the command, please follow these steps:
+# Parallel and chaining
+- Independent commands: multiple Bash calls in one message. E.g. `git status` + `git diff` → two Bash calls, one message.
+- ${chaining}
+- `;` only if failures OK. No newlines between commands (OK inside quoted strings).
 
-1. Directory Verification:
-   - If the command will create new directories or files, first use `ls` to verify the parent directory exists and is the correct location
-   - For example, before running "mkdir foo/bar", first use `ls foo` to check that "foo" exists and is the intended parent directory
+# Git safety (ALWAYS)
+- NEVER: update git config; destructive cmds (push --force, hard reset) unless user asks; skip hooks (--no-verify); force push main/master (warn user); commit without explicit request.
+- Unclear if user wants commit → ask first.
+- `--amend` only if ALL: user asked OR hook modified files AND HEAD commit made by you this session AND not pushed. If commit failed/rejected → new commit, not amend. If pushed → never amend unless user asks.
+- No empty commits.
 
-2. Command Execution:
-   - Always quote file paths that contain spaces with double quotes (e.g., rm "path with spaces/file.txt")
-   - Examples of proper quoting:
-     - mkdir "/Users/name/My Documents" (correct)
-     - mkdir /Users/name/My Documents (incorrect - will fail)
-     - python "/path/with spaces/script.py" (correct)
-     - python /path/with spaces/script.py (incorrect - will fail)
-   - After ensuring proper quoting, execute the command.
-   - Capture the output of the command.
+# Commit workflow (only on explicit request)
+1. Parallel: `git status`, `git diff`, `git log` (style).
+2. Draft message: type (add/update/fix/refactor/test/docs), why over what, 1-2 sentences. Skip secret files (.env, credentials.json); warn if user insists.
+3. Parallel: `git add`, `git commit -m`, then `git status` (sequential after commit).
+4. If hook fails → fix → new commit.
+- Never run non-git exploration during commit. Never use TodoWrite/Task. Don't push unless asked.
 
-Usage notes:
-  - The command argument is required.
-  - You can specify an optional timeout in milliseconds. If not specified, commands will time out after 120000ms (2 minutes).
-  - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
-  - If the output exceeds ${maxLines} lines or ${maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Do NOT use `head`, `tail`, or other truncation commands to limit output; the full output will already be captured to a file for more precise searching.
-
-  - Avoid using Bash with the `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
-    - File search: Use Glob (NOT find or ls)
-    - Content search: Use Grep (NOT grep or rg)
-    - Read files: Use Read (NOT cat/head/tail)
-    - Edit files: Use Edit (NOT sed/awk)
-    - Write files: Use Write (NOT echo >/cat <<EOF)
-    - Communication: Output text directly (NOT echo/printf)
-  - When issuing multiple commands:
-    - If the commands are independent and can run in parallel, make multiple Bash tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two Bash tool calls in parallel.
-    - ${chaining}
-    - Use ';' only when you need to run commands sequentially but don't care if earlier commands fail
-    - DO NOT use newlines to separate commands (newlines are ok in quoted strings)
-  - AVOID using `cd <directory> && <command>`. Use the `workdir` parameter to change directories instead.
-    <good-example>
-    Use workdir="/foo/bar" with command: pytest tests
-    </good-example>
-    <bad-example>
-    cd /foo/bar && pytest tests
-    </bad-example>
-
-# Committing changes with git
-
-Only create commits when requested by the user. If unclear, ask first. When the user asks you to create a new git commit, follow these steps carefully:
-
-Git Safety Protocol:
-- NEVER update the git config
-- NEVER run destructive/irreversible git commands (like push --force, hard reset, etc) unless the user explicitly requests them
-- NEVER skip hooks (--no-verify, --no-gpg-sign, etc) unless the user explicitly requests it
-- NEVER run force push to main/master, warn the user if they request it
-- Avoid git commit --amend. ONLY use --amend when ALL conditions are met:
-  (1) User explicitly requested amend, OR commit SUCCEEDED but pre-commit hook auto-modified files that need including
-  (2) HEAD commit was created by you in this conversation (verify: git log -1 --format='%an %ae')
-  (3) Commit has NOT been pushed to remote (verify: git status shows "Your branch is ahead")
-- CRITICAL: If commit FAILED or was REJECTED by hook, NEVER amend - fix the issue and create a NEW commit
-- CRITICAL: If you already pushed to remote, NEVER amend unless user explicitly requests it (requires force push)
-- NEVER commit changes unless the user explicitly asks you to. It is VERY IMPORTANT to only commit when explicitly asked, otherwise the user will feel that you are being too proactive.
-
-1. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following bash commands in parallel, each using the Bash tool:
-  - Run a git status command to see all untracked files.
-  - Run a git diff command to see both staged and unstaged changes that will be committed.
-  - Run a git log command to see recent commit messages, so that you can follow this repository's commit message style.
-2. Analyze all staged changes (both previously staged and newly added) and draft a commit message:
-  - Summarize the nature of the changes (eg. new feature, enhancement to an existing feature, bug fix, refactoring, test, docs, etc.). Ensure the message accurately reflects the changes and their purpose (i.e. "add" means a wholly new feature, "update" means an enhancement to an existing feature, "fix" means a bug fix, etc.).
-  - Do not commit files that likely contain secrets (.env, credentials.json, etc.). Warn the user if they specifically request to commit those files
-  - Draft a concise (1-2 sentences) commit message that focuses on the "why" rather than the "what"
-  - Ensure it accurately reflects the changes and their purpose
-3. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following commands:
-   - Add relevant untracked files to the staging area.
-   - Create the commit with a message
-   - Run git status after the commit completes to verify success.
-   Note: git status depends on the commit completing, so run it sequentially after the commit.
-4. If the commit fails due to pre-commit hook, fix the issue and create a NEW commit (see amend rules above)
-
-Important notes:
-- NEVER run additional commands to read or explore code, besides git bash commands
-- NEVER use the TodoWrite or Task tools
-- DO NOT push to the remote repository unless the user explicitly asks you to do so
-- IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
-- If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
-
-# Creating pull requests
-Use the gh command via the Bash tool for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a GitHub URL use the gh command to get the information needed.
-
-IMPORTANT: When the user asks you to create a pull request, follow these steps carefully:
-
-1. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following bash commands in parallel using the Bash tool, in order to understand the current state of the branch since it diverged from the main branch:
-   - Run a git status command to see all untracked files
-   - Run a git diff command to see both staged and unstaged changes that will be committed
-   - Check if the current branch tracks a remote branch and is up to date with the remote, so you know if you need to push to the remote
-   - Run a git log command and `git diff [base-branch]...HEAD` to understand the full commit history for the current branch (from the time it diverged from the base branch)
-2. Analyze all changes that will be included in the pull request, making sure to look at all relevant commits (NOT just the latest commit, but ALL commits that will be included in the pull request!!!), and draft a pull request summary
-3. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following commands in parallel:
-   - Create new branch if needed
-   - Push to remote with -u flag if needed
-   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
-<example>
-gh pr create --title "the pr title" --body "$(cat <<'EOF'
+# PR workflow (only on explicit request)
+Use `gh` for all GitHub ops (issues, PRs, checks, releases). GitHub URL given → use `gh` to fetch info.
+1. Parallel: `git status`, `git diff`, check upstream tracking, `git log` + `git diff [base]...HEAD` (ALL commits since divergence).
+2. Analyze all commits, draft summary.
+3. Parallel: create branch if needed, push -u if needed, `gh pr create` with HEREDOC body:
+```
+gh pr create --title "..." --body "$(cat <<'EOF'
 ## Summary
-<1-3 bullet points>
-</example>
+<1-3 bullets>
+EOF
+)"
+```
+- Never use TodoWrite/Task. Return PR URL.
 
-Important:
-- DO NOT use the TodoWrite or Task tools
-- Return the PR URL when you're done, so the user can see it
-
-# Other common operations
-- View comments on a GitHub PR: gh api repos/foo/bar/pulls/123/comments
+# Misc
+- PR comments: `gh api repos/foo/bar/pulls/123/comments`

--- a/packages/opencode/src/tool/codesearch.txt
+++ b/packages/opencode/src/tool/codesearch.txt
@@ -1,12 +1,7 @@
-- Search and get relevant context for any programming task using Exa Code API
-- Provides the highest quality and freshest context for libraries, SDKs, and APIs
-- Use this tool for ANY question or task related to programming
-- Returns comprehensive code examples, documentation, and API references
-- Optimized for finding specific programming patterns and solutions
+Code/API search via Exa Code API. Freshest context for libraries, SDKs, APIs. Use for any programming question.
 
-Usage notes:
-  - Adjustable token count (1000-50000) for focused or comprehensive results
-  - Default 5000 tokens provides balanced context for most queries
-  - Use lower values for specific questions, higher values for comprehensive documentation
-  - Supports queries about frameworks, libraries, APIs, and programming concepts
-  - Examples: 'React useState hook examples', 'Python pandas dataframe filtering', 'Express.js middleware'
+# Usage
+- Token count 1000-50000 (default 5000).
+- Lower = specific; higher = comprehensive docs.
+- Supports frameworks, libraries, APIs, patterns.
+- Examples: "React useState hook", "pandas dataframe filtering", "Express middleware".

--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -1,10 +1,10 @@
-Performs exact string replacements in files. 
+Exact string replacement in files.
 
-Usage:
-- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. 
-- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: line number + colon + space (e.g., `1: `). Everything after that space is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
-- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
-- Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
-- The edit will FAIL if `oldString` is not found in the file with an error "oldString not found in content".
-- The edit will FAIL if `oldString` is found multiple times in the file with an error "Found multiple matches for oldString. Provide more surrounding lines in oldString to identify the correct match." Either provide a larger string with more surrounding context to make it unique or use `replaceAll` to change every instance of `oldString`. 
-- Use `replaceAll` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
+# Rules
+- MUST Read file at least once in conversation before editing (else errors).
+- Preserve exact indentation from Read output. Line prefix format is `N: ` (number + colon + space); match only content AFTER that space. E.g. Read shows `42:   const x = 1` → oldString is `  const x = 1` (no `42: `). Never include prefix in oldString/newString.
+- Prefer editing existing files. Don't write new files unless required.
+- No emojis unless user asks.
+- FAIL if oldString not found.
+- FAIL if oldString matches multiple times → add surrounding context to make unique, OR use `replaceAll`.
+- `replaceAll`: use for rename/global replace.

--- a/packages/opencode/src/tool/glob.txt
+++ b/packages/opencode/src/tool/glob.txt
@@ -1,6 +1,7 @@
-- Fast file pattern matching tool that works with any codebase size
-- Supports glob patterns like "**/*.js" or "src/**/*.ts"
-- Returns matching file paths sorted by modification time
-- Use this tool when you need to find files by name patterns
-- When you are doing an open-ended search that may require multiple rounds of globbing and grepping, use the Task tool instead
-- You have the capability to call multiple tools in a single response. It is always better to speculatively perform multiple searches as a batch that are potentially useful.
+Fast glob file pattern matching.
+
+# Rules
+- Patterns: `**/*.js`, `src/**/*.ts`.
+- Returns paths sorted by mtime.
+- Open-ended multi-round search → use Task tool instead.
+- Batch multiple speculative searches in parallel tool calls.

--- a/packages/opencode/src/tool/grep.txt
+++ b/packages/opencode/src/tool/grep.txt
@@ -1,8 +1,8 @@
-- Fast content search tool that works with any codebase size
-- Searches file contents using regular expressions
-- Supports full regex syntax (eg. "log.*Error", "function\s+\w+", etc.)
-- Filter files by pattern with the include parameter (eg. "*.js", "*.{ts,tsx}")
-- Returns file paths and line numbers with at least one match sorted by modification time
-- Use this tool when you need to find files containing specific patterns
-- If you need to identify/count the number of matches within files, use the Bash tool with `rg` (ripgrep) directly. Do NOT use `grep`.
-- When you are doing an open-ended search that may require multiple rounds of globbing and grepping, use the Task tool instead
+Fast regex content search across codebase.
+
+# Rules
+- Full regex syntax (e.g. `log.*Error`, `function\s+\w+`).
+- Filter files with `include` (e.g. `*.js`, `*.{ts,tsx}`).
+- Returns paths + line numbers sorted by mtime.
+- Counting matches within files → use Bash with `rg`. Do NOT use `grep` binary.
+- Open-ended multi-round search → use Task tool instead.

--- a/packages/opencode/src/tool/lsp.txt
+++ b/packages/opencode/src/tool/lsp.txt
@@ -1,19 +1,18 @@
-Interact with Language Server Protocol (LSP) servers to get code intelligence features.
+LSP code intelligence operations.
 
-Supported operations:
-- goToDefinition: Find where a symbol is defined
-- findReferences: Find all references to a symbol
-- hover: Get hover information (documentation, type info) for a symbol
-- documentSymbol: Get all symbols (functions, classes, variables) in a document
-- workspaceSymbol: Search for symbols across the entire workspace
-- goToImplementation: Find implementations of an interface or abstract method
-- prepareCallHierarchy: Get call hierarchy item at a position (functions/methods)
-- incomingCalls: Find all functions/methods that call the function at a position
-- outgoingCalls: Find all functions/methods called by the function at a position
+# Ops
+- goToDefinition: where symbol defined
+- findReferences: all refs to symbol
+- hover: docs/type info
+- documentSymbol: all symbols in file
+- workspaceSymbol: search symbols workspace-wide
+- goToImplementation: impls of interface/abstract
+- prepareCallHierarchy: call hierarchy item at position
+- incomingCalls / outgoingCalls: callers / callees
 
-All operations require:
-- filePath: The file to operate on
-- line: The line number (1-based, as shown in editors)
-- character: The character offset (1-based, as shown in editors)
+# Required params (all ops)
+- filePath
+- line (1-based)
+- character (1-based)
 
-Note: LSP servers must be configured for the file type. If no server is available, an error will be returned.
+Errors if no LSP server configured for file type.

--- a/packages/opencode/src/tool/plan-enter.txt
+++ b/packages/opencode/src/tool/plan-enter.txt
@@ -1,14 +1,12 @@
-Use this tool to suggest switching to plan agent when the user's request would benefit from planning before implementation.
+Suggest switching to plan agent when task benefits from planning before implementation. Asks user to confirm switch.
 
-If they explicitly mention wanting to create a plan ALWAYS call this tool first.
+If user explicitly mentions wanting a plan, ALWAYS call this first.
 
-This tool will ask the user if they want to switch to plan agent.
+# Call when
+- Complex request benefits from planning
+- Want to research/design before changes
+- Multiple files or architectural decisions
 
-Call this tool when:
-- The user's request is complex and would benefit from planning first
-- You want to research and design before making changes
-- The task involves multiple files or significant architectural decisions
-
-Do NOT call this tool:
-- For simple, straightforward tasks
-- When the user explicitly wants immediate implementation
+# Skip when
+- Simple/straightforward task
+- User wants immediate implementation

--- a/packages/opencode/src/tool/plan-exit.txt
+++ b/packages/opencode/src/tool/plan-exit.txt
@@ -1,13 +1,11 @@
-Use this tool when you have completed the planning phase and are ready to exit plan agent.
+Exit plan agent after planning phase complete. Asks user to confirm switching to build agent for implementation.
 
-This tool will ask the user if they want to switch to build agent to start implementing the plan.
+# Call when
+- Plan written to plan file
+- Questions clarified with user
+- Plan ready for implementation
 
-Call this tool:
-- After you have written a complete plan to the plan file
-- After you have clarified any questions with the user
-- When you are confident the plan is ready for implementation
-
-Do NOT call this tool:
-- Before you have created or finalized the plan
-- If you still have unanswered questions about the implementation
-- If the user has indicated they want to continue planning
+# Skip when
+- Plan not yet created/finalized
+- Open questions remain
+- User wants to keep planning

--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -1,10 +1,6 @@
-Use this tool when you need to ask the user questions during execution. This allows you to:
-1. Gather user preferences or requirements
-2. Clarify ambiguous instructions
-3. Get decisions on implementation choices as you work
-4. Offer choices to the user about what direction to take.
+Ask user questions during execution. Use for: preferences, clarifying ambiguity, decisions mid-task, direction choices.
 
-Usage notes:
-- When `custom` is enabled (default), a "Type your own answer" option is added automatically; don't include "Other" or catch-all options
-- Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
-- If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
+# Usage
+- `custom` enabled (default) auto-adds "Type your own answer" option. Don't include "Other" or catch-all options.
+- Answers returned as array of labels. Set `multiple: true` for multi-select.
+- Recommended option → first in list, append "(Recommended)" to label.

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -1,14 +1,12 @@
-Read a file or directory from the local filesystem. If the path does not exist, an error is returned.
+Read file or directory from local filesystem. Errors if path missing.
 
-Usage:
-- The filePath parameter should be an absolute path.
-- By default, this tool returns up to 2000 lines from the start of the file.
-- The offset parameter is the line number to start from (1-indexed).
-- To read later sections, call this tool again with a larger offset.
-- Use the grep tool to find specific content in large files or files with long lines.
-- If you are unsure of the correct file path, use the glob tool to look up filenames by glob pattern.
-- Contents are returned with each line prefixed by its line number as `<line>: <content>`. For example, if a file has contents "foo\n", you will receive "1: foo\n". For directories, entries are returned one per line (without line numbers) with a trailing `/` for subdirectories.
-- Any line longer than 2000 characters is truncated.
-- Call this tool in parallel when you know there are multiple files you want to read.
-- Avoid tiny repeated slices (30 line chunks). If you need more context, read a larger window.
-- This tool can read image files and PDFs and return them as file attachments.
+# Rules
+- `filePath` must be absolute.
+- Returns up to 2000 lines from start by default. Use `offset` (1-indexed) for later sections, `limit` to cap.
+- Lines prefixed `N: <content>` (e.g. file `foo\n` → `1: foo\n`). Directories: one entry per line, trailing `/` for subdirs.
+- Lines > 2000 chars truncated.
+- Use Grep for content in large files.
+- Use Glob if unsure of path.
+- Read multiple known files in parallel.
+- Avoid tiny 30-line slices; read a larger window.
+- Reads images and PDFs as attachments.

--- a/packages/opencode/src/tool/skill.txt
+++ b/packages/opencode/src/tool/skill.txt
@@ -1,5 +1,5 @@
-Load a specialized skill when the task at hand matches one of the skills listed in the system prompt.
+Load specialized skill when task matches one listed in system prompt.
 
-Use this tool to inject the skill's instructions and resources into current conversation. The output may contain detailed workflow guidance as well as references to scripts, files, etc in the same directory as the skill.
+Injects skill's instructions + resources into conversation. May include workflow guidance and refs to scripts/files in skill's directory.
 
-The skill name must match one of the skills listed in your system prompt.
+Skill name must match one listed in system prompt.

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -1,57 +1,18 @@
-Launch a new agent to handle complex, multistep tasks autonomously.
+Launch new agent to handle complex, multistep tasks autonomously. Must specify `subagent_type`.
 
-When using the Task tool, you must specify a subagent_type parameter to select which agent type to use.
+# Use when
+- Executing custom slash commands. Pass slash command as entire prompt, e.g. `Task(description="Check file", prompt="/check-file path/to/file.py")`.
+- Agent description says "proactively" → use without user asking (e.g. run code-reviewer after writing significant code).
 
-When to use the Task tool:
-- When you are instructed to execute custom slash commands. Use the Task tool with the slash command invocation as the entire prompt. The slash command can take arguments. For example: Task(description="Check the file", prompt="/check-file path/to/file.py")
+# Don't use for
+- Reading specific file path → Read/Glob
+- Finding `class Foo` → Glob
+- Searching 2-3 known files → Read
+- Tasks unrelated to available agent descriptions
 
-When NOT to use the Task tool:
-- If you want to read a specific file path, use the Read or Glob tool instead of the Task tool, to find the match more quickly
-- If you are searching for a specific class definition like "class Foo", use the Glob tool instead, to find the match more quickly
-- If you are searching for code within a specific file or set of 2-3 files, use the Read tool instead of the Task tool, to find the match more quickly
-- Other tasks that are not related to the agent descriptions above
-
-
-Usage notes:
-1. Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
-2. When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result. The output includes a task_id you can reuse later to continue the same subagent session.
-3. Each agent invocation starts with a fresh context unless you provide task_id to resume the same subagent session (which continues with its previous messages and tool outputs). When starting fresh, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.
-4. The agent's outputs should generally be trusted
-5. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent. Tell it how to verify its work if possible (e.g., relevant test commands).
-6. If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
-
-Example usage (NOTE: The agents below are fictional examples for illustration only - use the actual agents listed above):
-
-<example_agent_descriptions>
-"code-reviewer": use this agent after you are done writing a significant piece of code
-"greeting-responder": use this agent when to respond to user greetings with a friendly joke
-</example_agent_description>
-
-<example>
-user: "Please write a function that checks if a number is prime"
-assistant: Sure let me write a function that checks if a number is prime
-assistant: First let me use the Write tool to write a function that checks if a number is prime
-assistant: I'm going to use the Write tool to write the following code:
-<code>
-function isPrime(n) {
-  if (n <= 1) return false
-  for (let i = 2; i * i <= n; i++) {
-    if (n % i === 0) return false
-  }
-  return true
-}
-</code>
-<commentary>
-Since a significant piece of code was written and the task was completed, now use the code-reviewer agent to review the code
-</commentary>
-assistant: Now let me use the code-reviewer agent to review the code
-assistant: Uses the Task tool to launch the code-reviewer agent
-</example>
-
-<example>
-user: "Hello"
-<commentary>
-Since the user is greeting, use the greeting-responder agent to respond with a friendly joke
-</commentary>
-assistant: "I'm going to use the Task tool to launch the with the greeting-responder agent"
-</example>
+# Usage
+- Launch multiple agents concurrently via parallel tool calls in one message.
+- Agent returns ONE final message. Not visible to user — summarize it back yourself. Output includes `task_id` to resume session later.
+- Fresh context each invocation unless `task_id` provided. Write highly detailed task description + exactly what info to return.
+- Trust agent output generally.
+- Tell agent: write code vs research only. Give verification method (test command) if possible.

--- a/packages/opencode/src/tool/todowrite.txt
+++ b/packages/opencode/src/tool/todowrite.txt
@@ -1,167 +1,46 @@
-Use this tool to create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
-It also helps the user understand the progress of the task and overall progress of their requests.
+Create/manage structured task list for current session. Track progress, organize complex work, show user progress.
 
-## When to Use This Tool
-Use this tool proactively in these scenarios:
+# Use when
+- Task has 3+ distinct steps
+- Non-trivial, needs planning
+- User explicitly asks for todo list
+- User gives multiple tasks (list/comma-separated)
+- New instructions arrive → capture as todos (edit freely as info changes)
+- After finishing task → mark complete, add follow-ups
+- Starting new task → mark `in_progress`. Only ONE `in_progress` at a time
 
-1. Complex multistep tasks - When a task requires 3 or more distinct steps or actions
-2. Non-trivial and complex tasks - Tasks that require careful planning or multiple operations
-3. User explicitly requests todo list - When the user directly asks you to use the todo list
-4. User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
-5. After receiving new instructions - Immediately capture user requirements as todos. Feel free to edit the todo list based on new information.
-6. After completing a task - Mark it complete and add any new follow-up tasks
-7. When you start working on a new task, mark the todo as in_progress. Ideally you should only have one todo as in_progress at a time. Complete existing tasks before starting new ones.
+# Skip when
+- Single trivial task (1 file edit, 1 command, 1 question answered)
+- Purely conversational/informational
+- < 3 trivial steps
 
-## When NOT to Use This Tool
+# Task states
+- pending: not started
+- in_progress: active (ONLY one at a time)
+- completed: done
+- cancelled: no longer needed
 
-Skip using this tool when:
-1. There is only a single, straightforward task
-2. The task is trivial and tracking it provides no organizational benefit
-3. The task can be completed in less than 3 trivial steps
-4. The task is purely conversational or informational
+# Management rules
+- Update status real-time
+- Mark complete IMMEDIATELY after finishing (no batching)
+- Complete current before starting next
+- Cancel tasks that become irrelevant
+- Break complex tasks into specific, actionable items with clear names
 
-NOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.
+# Examples
 
-## Examples of When to Use the Todo List
+USE — multi-feature request:
+> User: "Add dark mode toggle. Run tests and build when done."
+> Todos: 1) Add toggle component, 2) Wire state management, 3) Update themes, 4) Run tests + build.
+> Infer implicit tasks from user constraints.
 
-<example>
-User: I want to add a dark mode toggle to the application settings. Make sure you run the tests and build when you're done!
-Assistant: I'll help add a dark mode toggle to your application settings. Let me create a todo list to track this implementation.
-*Creates todo list with the following items:*
-1. Create dark mode toggle component in Settings page
-2. Add dark mode state management (context/store)
-3. Implement CSS-in-JS styles for dark theme
-4. Update existing components to support theme switching
-5. Run tests and build process, addressing any failures or errors that occur
-*Begins working on the first task*
+USE — discovered scope mid-task:
+> User: "Rename getCwd to getCurrentWorkingDirectory across project."
+> First grep → find 15 instances across 8 files → THEN create todos per file.
+> Create list AFTER scope known, not before.
 
-<reasoning>
-The assistant used the todo list because:
-1. Adding dark mode is a multi-step feature requiring UI, state management, and styling changes
-2. The user explicitly requested tests and build be run afterward
-3. The assistant inferred that tests and build need to pass by adding "Ensure tests and build succeed" as the final task
-</reasoning>
-</example>
+SKIP — single trivial:
+> User: "Add a comment to calculateTotal explaining what it does."
+> One edit, one location. Just do it. No todo list.
 
-<example>
-User: Help me rename the function getCwd to getCurrentWorkingDirectory across my project
-Assistant: Let me first search through your codebase to find all occurrences of 'getCwd'.
-*Uses grep or search tools to locate all instances of getCwd in the codebase*
-Assistant: I've found 15 instances of 'getCwd' across 8 different files. Let me create a todo list to track these changes.
-*Creates todo list with specific items for each file that needs updating*
-
-<reasoning>
-The assistant used the todo list because:
-1. First, the assistant searched to understand the scope of the task
-2. Upon finding multiple occurrences across different files, it determined this was a complex task with multiple steps
-3. The todo list helps ensure every instance is tracked and updated systematically
-4. This approach prevents missing any occurrences and maintains code consistency
-</reasoning>
-</example>
-
-
-<example>
-User: I need to implement these features for my e-commerce site: user registration, product catalog, shopping cart, and checkout flow.
-Assistant: I'll help implement these features. First, let's add all the features to the todo list.
-*Creates a todo list breaking down each feature into specific tasks based on the project architecture*
-Assistant: Let's start with user registration. This will involve creating database models, API endpoints, and frontend forms that integrate with your existing authentication system.
-
-<reasoning>
-The assistant used the todo list because:
-1. The user provided multiple complex features to implement in a comma separated list
-2. The todo list helps organize these large features into manageable tasks
-3. This approach allows for tracking progress across the entire implementation
-</reasoning>
-</example>
-
-<example>
-User: Can you help optimize my React application? It's rendering slowly and has performance issues.</user>
-Assistant: I'll help optimize your React application. First, let me examine your codebase to identify potential performance bottlenecks.
-*Reviews component structure, render patterns, state management, and data fetching*
-Assistant: After analyzing your codebase, I've identified several performance issues. Let me create a todo list to track our optimization efforts.
-*Creates todo list with items like: 1) Implement memoization for expensive calculations in ProductList, 2) Add virtualization for long lists in Dashboard, 3) Optimize image loading in Gallery component, 4) Fix state update loops in ShoppingCart, 5) Review bundle size and implement code splitting*
-Let's start by implementing memoization for the expensive calculations in your ProductList component.</assistant>
-
-<reasoning>
-The assistant used the todo list because:
-1. First, the assistant examined the codebase to identify specific performance issues
-2. Based on this analysis, it identified multiple optimization opportunities
-3. Performance optimization is a non-trivial task requiring multiple steps
-4. The todo list helps methodically track improvements across different components
-5. This systematic approach ensures all performance bottlenecks are addressed
-</reasoning>
-</example>
-
-## Examples of When NOT to Use the Todo List
-
-<example>
-User: How do I print 'Hello World' in Python?
-Assistant: In Python, you can print "Hello World" with this simple code:
-
-python
-print("Hello World")
-
-This will output the text "Hello World" to the console when executed.</assistant>
-
-<reasoning>
-The assistant did not use the todo list because this is a single, trivial task that can be completed in one step. There's no need to track multiple tasks or steps for such a straightforward request.
-</reasoning>
-</example>
-
-<example>
-User: What does the git status command do?
-Assistant: The git status command shows the current state of your working directory and staging area. It displays which changes have been staged, which haven't, and which files aren't being tracked by Git. This is a fundamental command for understanding the current state of your repository before making commits.
-
-<reasoning>
-The assistant did not use the todo list because this is an informational request with no actual coding task to complete. The user is simply asking for an explanation, not for the assistant to perform multiple steps or tasks.
-</reasoning>
-</example>
-
-<example>
-User: Can you add a comment to the calculateTotal function to explain what it does?
-Assistant: Sure, let me add a comment to the calculateTotal function to explain what it does.
-* Uses the Edit tool to add a comment to the calculateTotal function *
-
-<reasoning>
-The assistant did not use the todo list because this is a single, straightforward task confined to one location in the code. Adding a comment doesn't require tracking multiple steps or systematic organization.
-</reasoning>
-</example>
-
-<example>
-User: Run npm install for me and tell me what happens.
-Assistant: I'll run the npm install command for you.
-
-*Executes: npm install*
-
-The command completed successfully. Here's the output:
-[Output of npm install command]
-
-All dependencies have been installed according to your package.json file.
-
-<reasoning>
-The assistant did not use the todo list because this is a single command execution with immediate results. There are no multiple steps to track or organize, making the todo list unnecessary for this straightforward task.
-</reasoning>
-</example>
-
-## Task States and Management
-
-1. **Task States**: Use these states to track progress:
-   - pending: Task not yet started
-   - in_progress: Currently working on (limit to ONE task at a time)
-   - completed: Task finished successfully
-   - cancelled: Task no longer needed
-
-2. **Task Management**:
-   - Update task status in real-time as you work
-   - Mark tasks complete IMMEDIATELY after finishing (don't batch completions)
-   - Only have ONE task in_progress at any time
-   - Complete current tasks before starting new ones
-   - Cancel tasks that become irrelevant
-
-3. **Task Breakdown**:
-   - Create specific, actionable items
-   - Break complex tasks into smaller, manageable steps
-   - Use clear, descriptive task names
-
-When in doubt, use this tool. Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully.
-
+When in doubt, use it. Proactive tracking = thorough delivery.

--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -1,13 +1,7 @@
-- Fetches content from a specified URL
-- Takes a URL and optional format as input
-- Fetches the URL content, converts to requested format (markdown by default)
-- Returns the content in the specified format
-- Use this tool when you need to retrieve and analyze web content
+Fetch URL content. Converts to markdown (default), text, or html.
 
-Usage notes:
-  - IMPORTANT: if another tool is present that offers better web fetching capabilities, is more targeted to the task, or has fewer restrictions, prefer using that tool instead of this one.
-  - The URL must be a fully-formed valid URL
-  - HTTP URLs will be automatically upgraded to HTTPS
-  - Format options: "markdown" (default), "text", or "html"
-  - This tool is read-only and does not modify any files
-  - Results may be summarized if the content is very large
+# Rules
+- Prefer more targeted/capable tool if available.
+- URL must be fully-formed. HTTP auto-upgrades to HTTPS.
+- Read-only; no file changes.
+- Large results may be summarized.

--- a/packages/opencode/src/tool/websearch.txt
+++ b/packages/opencode/src/tool/websearch.txt
@@ -1,14 +1,8 @@
-- Search the web using Exa AI - performs real-time web searches and can scrape content from specific URLs
-- Provides up-to-date information for current events and recent data
-- Supports configurable result counts and returns the content from the most relevant websites
-- Use this tool for accessing information beyond knowledge cutoff
-- Searches are performed automatically within a single API call
+Web search via Exa AI. Real-time search + scrape URLs. Use for info beyond knowledge cutoff.
 
-Usage notes:
-  - Supports live crawling modes: 'fallback' (backup if cached unavailable) or 'preferred' (prioritize live crawling)
-  - Search types: 'auto' (balanced), 'fast' (quick results), 'deep' (comprehensive search)
-  - Configurable context length for optimal LLM integration
-  - Domain filtering and advanced search options available
+# Options
+- Live crawl: `fallback` (backup) or `preferred` (prioritize live).
+- Search type: `auto` (balanced), `fast`, `deep`.
+- Configurable context length. Domain filtering supported.
 
-The current year is {{year}}. You MUST use this year when searching for recent information or current events
-- Example: If the current year is 2026 and the user asks for "latest AI news", search for "AI news 2026", NOT "AI news 2025"
+Current year: {{year}}. MUST use this year for recent/current queries. Example: user asks "latest AI news" and year is 2026 → search "AI news 2026", not 2025.

--- a/packages/opencode/src/tool/write.txt
+++ b/packages/opencode/src/tool/write.txt
@@ -1,8 +1,8 @@
-Writes a file to the local filesystem.
+Write file to local filesystem.
 
-Usage:
-- This tool will overwrite the existing file if there is one at the provided path.
-- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
-- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
-- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
-- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
+# Rules
+- Overwrites existing file at path.
+- If file exists, MUST Read it first (else fails).
+- Prefer editing existing files. Don't write new unless required.
+- Don't proactively create *.md or README files unless user asks.
+- No emojis unless user asks.


### PR DESCRIPTION
### Issue for this PR

Refs #11995

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Condenses all 17 tool description files in `packages/opencode/src/tool/*.txt` into a terser style to cut system-prompt token overhead. These files are imported as raw strings and injected into every LLM turn's tool descriptions — per @DrDexter6000's analysis in #11995 they are NOT cacheable, so every character costs tokens on every request.

**Why the changes work:**
- Tool description `.txt` files are loaded via `import DESCRIPTION from "./bash.txt"` (same pattern in task.ts, apply_patch.ts, todo.ts, websearch.ts, etc.) and injected into the model's tool schema. Nothing parses them as structured data — the model reads them as natural-language instructions. Shorter, denser wording preserves instruction-following while reducing token cost.
- Placeholder substitutions (`${os}`, `${shell}`, `${chaining}`, `${maxLines}`, `${maxBytes}`, `${directory}`, `{{year}}`) use `.replaceAll` / `.replace` which are no-ops if the placeholder key is absent — so presence in the text is what matters, and all keys were preserved where originally used.
- I kept behavioral anchors (concrete examples) where models measurably depend on them — e.g. the `42: const x = 1` → strip prefix example in `edit.txt` prevents a common failure mode where the model includes the `N: ` line prefix in `oldString`.

**Impact:**

| Metric | Before | After | Cut |
|---|---|---|---|
| Total chars | 33,163 | 11,302 | **66%** |
| Approx tokens | ~9,475 | ~3,230 | **~6,250 saved/msg** |

Per-file breakdown (largest first):

| File | Before | After | Cut |
|---|---|---|---|
| bash.txt | 9,288 | 2,821 | 70% |
| todowrite.txt | 8,845 | 1,701 | 81% |
| task.txt | 3,732 | 1,041 | 72% |
| edit.txt | 1,369 | 674 | 51% |
| read.txt | 1,158 | 581 | 50% |
| apply_patch.txt | 1,098 | 669 | 39% |
| lsp.txt | 1,040 | 515 | 50% |
| websearch.txt | 976 | 443 | 55% |
| codesearch.txt | 802 | 348 | 57% |
| webfetch.txt | 750 | 247 | 67% |
| grep.txt | 689 | 359 | 48% |
| question.txt | 657 | 394 | 40% |
| write.txt | 623 | 290 | 53% |
| plan-enter.txt | 613 | 406 | 34% |
| plan-exit.txt | 579 | 318 | 45% |
| glob.txt | 545 | 234 | 57% |
| skill.txt | 399 | 261 | 35% |

**What's preserved:**
- All git safety rules (amend conditions, force-push guards, no-secrets commit, no `-i` flags, no empty commits, no Task/TodoWrite during commit, unclear-intent-ask-first, GitHub URL → `gh` routing)
- All placeholders listed above
- apply_patch format block verbatim (Begin/End Patch, Add/Update/Delete File, Move to, `+` prefix rule)
- 9 LSP operations + required params (filePath, line, character, 1-based)
- 4 todo states + one-in-progress rule
- Read-before-Edit requirement
- Full commit + PR workflow steps

**Behavioral anchors retained** (after a second review pass that judged the first cut too aggressive):
- `bash.txt`: workdir and path-quoting good/bad pairs, parallel call example
- `edit.txt`: `42: const x = 1` → strip `42: ` prefix example
- `read.txt`: `foo\n` → `1: foo\n` format anchor
- `todowrite.txt`: 3 compressed examples (use multi-feature, use discover-scope-then-list, skip trivial)
- `task.txt`: proactive code-reviewer pattern

**What was dropped:**
- Repeated "you can call multiple tools in a single response..." preamble
- Long `<reasoning>` blocks after each todowrite example
- Fictional agent examples labeled "use actual agents listed above"
- Double-stated rules (once in the instruction, once in prose)

### How did you verify your code works?

- Verified all placeholder substitution sites still have their keys present via `rg` across `packages/opencode/src/tool/`.
- Confirmed all `.txt` files are consumed only as raw strings by `import` statements in adjacent `.ts` files — no schema parsing, no format-sensitive consumers.
- Two-pass review: initial aggressive cut (88% on todowrite) produced rules-only output; audit flagged missing behavioral anchors, examples restored.
- No code changes, no schema changes — `.txt` content only. `.ts` consumers untouched.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
