### PR TITLE
fix(cli): authenticate run in-process server requests

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -674,7 +674,15 @@ export const RunCommand = cmd({
         const request = new Request(input, init)
         return Server.Default().app.fetch(request)
       }) as typeof globalThis.fetch
-      const sdk = createOpencodeClient({ baseUrl: "http://opencode.internal", fetch: fetchFn })
+      const headers = (() => {
+        // Match the in-process server auth config; --password is only for --attach.
+        const password = Flag.OPENCODE_SERVER_PASSWORD
+        if (!password) return undefined
+        const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
+        const auth = `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+        return { Authorization: auth }
+      })()
+      const sdk = createOpencodeClient({ baseUrl: "http://opencode.internal", fetch: fetchFn, headers })
       await execute(sdk)
     })
   },

--- a/packages/opencode/test/cli/run.test.ts
+++ b/packages/opencode/test/cli/run.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.join(import.meta.dir, "../..")
+
+describe("run command", () => {
+  test("authenticates in-process server requests when server password is set", async () => {
+    await using dir = await tmpdir()
+    const proc = Bun.spawn({
+      cmd: [
+        process.execPath,
+        "run",
+        "--conditions=browser",
+        "./src/index.ts",
+        "run",
+        "--command",
+        "definitely-not-a-command",
+        "args",
+      ],
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        XDG_DATA_HOME: path.join(dir.path, "share"),
+        XDG_CACHE_HOME: path.join(dir.path, "cache"),
+        XDG_CONFIG_HOME: path.join(dir.path, "config"),
+        XDG_STATE_HOME: path.join(dir.path, "state"),
+        OPENCODE_TEST_HOME: path.join(dir.path, "home"),
+        OPENCODE_DB: ":memory:",
+        OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+        OPENCODE_DISABLE_PROJECT_CONFIG: "true",
+        OPENCODE_SERVER_PASSWORD: "secret",
+      },
+    })
+
+    const [, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+    const output = stdout + stderr
+
+    // The invalid command may exit non-zero; reaching command resolution proves auth did not block session creation.
+    expect(output).toContain('Command not found: "definitely-not-a-command"')
+    expect(output).not.toContain("Session not found")
+  }, 15_000)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #24204
Related: #14532

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run` fails with `Error: Session not found` when `OPENCODE_SERVER_PASSWORD` is set.

Plain `run` starts an in-process server and calls it through the SDK. That server still applies `AuthMiddleware`, but the in-process SDK client does not send Basic Auth headers. Session creation does not return usable session data, and the CLI reports `Session not found`.

This PR passes Basic Auth headers to the in-process SDK client using the same auth values the in-process server is configured with. The `--attach` path is unchanged because it already builds auth headers from `--password` or `OPENCODE_SERVER_PASSWORD`.

### How did you verify your code works?

Ran from `packages/opencode`:

```bash
bun test test/cli/run.test.ts
bun typecheck
```

The regression test runs `opencode run` in a child process with `OPENCODE_SERVER_PASSWORD` set and verifies the command reaches command resolution instead of failing with `Session not found`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR