### PR TITLE
feat(opencode): add /context command

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
@@ -136,7 +136,7 @@ export function DialogSessionContext(props: DialogSessionContextProps) {
 
               <box flexDirection="row" justifyContent="space-between">
                 <text fg={theme.textMuted}>Breakdown (estimated · chars/4)</text>
-                <text fg={theme.textMuted}>↑↓ pgup pgdn scroll · hold ⌥/shift to select text</text>
+                <text fg={theme.textMuted}>↑↓ pgup pgdn scroll</text>
               </box>
 
               {/* Scrollable diagnostic breakdown. */}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
@@ -15,6 +15,8 @@ export type DialogSessionContextProps = {
 
 // Format a token count as `12.3k` for >=1000, plain otherwise.
 function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 10_000) return `${Math.round(n / 1000)}k`
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
   return n.toString()
 }
@@ -169,7 +171,8 @@ export function DialogSessionContext(props: DialogSessionContextProps) {
                               {section.label}
                             </text>
                             <text fg={theme.textMuted}>
-                              ~{formatTokens(section.tokens)} · {section.items.length}
+                              ~{formatTokens(section.tokens)}
+                              {section.key === "messages" ? "" : ` · ${section.items.length}`}
                             </text>
                           </box>
                           <Show

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
@@ -136,42 +136,99 @@ export function DialogSessionContext(props: DialogSessionContextProps) {
 
               <box flexDirection="row" justifyContent="space-between">
                 <text fg={theme.textMuted}>Breakdown (estimated · chars/4)</text>
-                <text fg={theme.textMuted}>↑↓ pgup pgdn scroll</text>
+                <text fg={theme.textMuted}>↑↓ pgup pgdn scroll · hold ⌥/shift to select text</text>
               </box>
 
               {/* Scrollable diagnostic breakdown. */}
               <scrollbox height={scrollHeight()} scrollAcceleration={getScrollAcceleration()}>
                 <box gap={1} paddingRight={2}>
                   <For each={data().sections}>
-                    {(section) => (
-                      <box>
-                        <box flexDirection="row" justifyContent="space-between">
-                          <text fg={theme.text} attributes={TextAttributes.BOLD}>
-                            {section.label}
-                          </text>
-                          <text fg={theme.textMuted}>
-                            ~{formatTokens(section.tokens)} · {section.items.length}
-                          </text>
+                    {(section) => {
+                      // Group items by `group` field when present; renders a
+                      // subheader per group with subtotal (e.g. MCP servers).
+                      const grouped = () => {
+                        const map = new Map<string, typeof section.items>()
+                        for (const it of section.items) {
+                          const k = it.group ?? ""
+                          if (!map.has(k)) map.set(k, [])
+                          map.get(k)!.push(it)
+                        }
+                        return Array.from(map.entries())
+                          .sort(([a], [b]) => a.localeCompare(b))
+                          .map(([g, items]) => ({
+                            group: g,
+                            items,
+                            tokens: items.reduce((acc, it) => acc + it.tokens, 0),
+                          }))
+                      }
+                      const hasGroups = () => section.items.some((i) => i.group)
+                      return (
+                        <box>
+                          <box flexDirection="row" justifyContent="space-between">
+                            <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                              {section.label}
+                            </text>
+                            <text fg={theme.textMuted}>
+                              ~{formatTokens(section.tokens)} · {section.items.length}
+                            </text>
+                          </box>
+                          <Show
+                            when={hasGroups()}
+                            fallback={
+                              <For each={section.items}>
+                                {(item) => (
+                                  <box flexDirection="row" gap={1}>
+                                    <text flexShrink={0} fg={theme.textMuted}>
+                                      ·
+                                    </text>
+                                    <text fg={theme.text} wrapMode="word">
+                                      {shortenPath(item.label, itemLabelMax())}
+                                      <span style={{ fg: theme.textMuted }}>
+                                        {"  ~"}
+                                        {formatTokens(item.tokens)}
+                                        {item.detail ? ` — ${item.detail}` : ""}
+                                      </span>
+                                    </text>
+                                  </box>
+                                )}
+                              </For>
+                            }
+                          >
+                            <For each={grouped()}>
+                              {(g) => (
+                                <box>
+                                  <box flexDirection="row" justifyContent="space-between">
+                                    <text fg={theme.text}>
+                                      <span style={{ fg: theme.textMuted }}>▸ </span>
+                                      {g.group || "ungrouped"}
+                                    </text>
+                                    <text fg={theme.textMuted}>
+                                      ~{formatTokens(g.tokens)} · {g.items.length}
+                                    </text>
+                                  </box>
+                                  <For each={g.items}>
+                                    {(item) => (
+                                      <box flexDirection="row" gap={1} paddingLeft={2}>
+                                        <text flexShrink={0} fg={theme.textMuted}>
+                                          ·
+                                        </text>
+                                        <text fg={theme.text} wrapMode="word">
+                                          {shortenPath(item.label, itemLabelMax())}
+                                          <span style={{ fg: theme.textMuted }}>
+                                            {"  ~"}
+                                            {formatTokens(item.tokens)}
+                                          </span>
+                                        </text>
+                                      </box>
+                                    )}
+                                  </For>
+                                </box>
+                              )}
+                            </For>
+                          </Show>
                         </box>
-                        <For each={section.items}>
-                          {(item) => (
-                            <box flexDirection="row" gap={1}>
-                              <text flexShrink={0} fg={theme.textMuted}>
-                                ·
-                              </text>
-                              <text fg={theme.text} wrapMode="word">
-                                {shortenPath(item.label, itemLabelMax())}
-                                <span style={{ fg: theme.textMuted }}>
-                                  {"  ~"}
-                                  {formatTokens(item.tokens)}
-                                  {item.detail ? ` — ${item.detail}` : ""}
-                                </span>
-                              </text>
-                            </box>
-                          )}
-                        </For>
-                      </box>
-                    )}
+                      )
+                    }}
                   </For>
                 </box>
               </scrollbox>

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
@@ -137,7 +137,7 @@ export function DialogSessionContext(props: DialogSessionContextProps) {
               </box>
 
               <box flexDirection="row" justifyContent="space-between">
-                <text fg={theme.textMuted}>Breakdown (estimated · chars/4)</text>
+                <text fg={theme.textMuted}>Breakdown (calibrated to last turn · chars/4 fallback if no usage yet)</text>
                 <text fg={theme.textMuted}>↑↓ pgup pgdn scroll</text>
               </box>
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
@@ -1,0 +1,184 @@
+import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/solid"
+import { createResource, For, Show } from "solid-js"
+
+import { useTheme } from "../context/theme"
+import { useSDK } from "@tui/context/sdk"
+import { useDialog } from "@tui/ui/dialog"
+import { getScrollAcceleration } from "@tui/util/scroll"
+
+export type DialogSessionContextProps = {
+  sessionID: string
+  providerID: string
+  modelID: string
+}
+
+// Format a token count as `12.3k` for >=1000, plain otherwise.
+function formatTokens(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
+  return n.toString()
+}
+
+// Render a horizontal bar using block glyphs.
+function bar(fraction: number, width: number): string {
+  const clamped = Math.max(0, Math.min(1, fraction))
+  const filled = Math.round(clamped * width)
+  return "█".repeat(filled) + "░".repeat(Math.max(0, width - filled))
+}
+
+// Shorten long filesystem paths by replacing a middle segment with `…`.
+function shortenPath(s: string, max: number): string {
+  if (s.length <= max) return s
+  const keep = Math.max(8, Math.floor((max - 1) / 2))
+  return s.slice(0, keep) + "…" + s.slice(s.length - keep)
+}
+
+export function DialogSessionContext(props: DialogSessionContextProps) {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const term = useTerminalDimensions()
+  dialog.setSize("full")
+
+  const [info] = createResource(
+    () => ({ sessionID: props.sessionID, providerID: props.providerID, modelID: props.modelID }),
+    async (input) => {
+      const result = await sdk.client.session.context(input)
+      return result.data
+    },
+  )
+
+  // Dialog uses "full" size: ~height/12 top padding from the framework.
+  // Header block is ~9 lines (title, model row, ctx row, bar, in/out row,
+  // blank, breakdown hint, blank). Reserve for chrome + bottom padding too.
+  const scrollHeight = () => {
+    const topPad = Math.max(1, Math.floor(term().height / 12))
+    const headerRows = 10
+    const chrome = 3
+    return Math.max(6, term().height - topPad - headerRows - chrome)
+  }
+  // Width cap for per-item labels so long absolute paths don't dominate.
+  const itemLabelMax = () => Math.max(32, Math.floor(term().width * 0.6))
+
+  // Color scale for usage bar.
+  const pressureColor = (frac: number, overflow: boolean, overBudget: boolean) => {
+    if (overflow || overBudget) return theme.error
+    if (frac >= 0.9) return theme.error
+    if (frac >= 0.7) return theme.warning
+    return theme.success
+  }
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Context
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+
+      <Show when={info.loading}>
+        <text fg={theme.textMuted}>Computing breakdown...</text>
+      </Show>
+
+      <Show when={info.error}>
+        <text fg={theme.error}>{info.error instanceof Error ? info.error.message : "Failed to load context"}</text>
+      </Show>
+
+      <Show when={info()}>
+        {(data) => {
+          const usage = () => data().usage
+          const denom = () => usage().usable
+          const fraction = () => (denom() > 0 ? usage().current / denom() : 0)
+          const barColor = () => pressureColor(fraction(), usage().overflow, usage().overBudget)
+          return (
+            <box gap={1}>
+              {/* Header / authoritative usage — always visible, never scrolled. */}
+              <box>
+                <text fg={theme.text}>
+                  <b>{data().model.providerID}</b>
+                  <span style={{ fg: theme.textMuted }}>/{data().model.modelID}</span>
+                  <span style={{ fg: theme.textMuted }}>{"   agent "}</span>
+                  <b>{data().agent}</b>
+                </text>
+                <text fg={theme.textMuted}>
+                  ctx {formatTokens(usage().contextLimit)} · usable {formatTokens(usage().usable)} · reserve{" "}
+                  {formatTokens(usage().outputReserve)}
+                </text>
+                <text>
+                  <span style={{ fg: barColor() }}>{bar(fraction(), 40)}</span>
+                  <span style={{ fg: theme.text }}>
+                    {"  "}
+                    {formatTokens(usage().current)} / {formatTokens(denom())}
+                  </span>
+                  <span style={{ fg: theme.textMuted }}> ({(fraction() * 100).toFixed(1)}%)</span>
+                  {usage().overflow ? (
+                    <span style={{ fg: theme.error }}>{"  OVERFLOW — compaction pending"}</span>
+                  ) : null}
+                  {usage().overBudget && !usage().overflow ? (
+                    <span style={{ fg: theme.warning }}>{"  OVER BUDGET — auto-compaction disabled"}</span>
+                  ) : null}
+                </text>
+                <Show when={usage().authoritative}>
+                  <text fg={theme.textMuted}>
+                    in {formatTokens(usage().input)} · out {formatTokens(usage().output)}
+                    {usage().reasoning > 0 ? ` · reasoning ${formatTokens(usage().reasoning)}` : ""}
+                    {usage().cacheRead > 0 ? ` · cache r ${formatTokens(usage().cacheRead)}` : ""}
+                    {usage().cacheWrite > 0 ? ` · cache w ${formatTokens(usage().cacheWrite)}` : ""}
+                  </text>
+                </Show>
+                <Show when={!usage().authoritative}>
+                  <text fg={theme.textMuted}>no assistant turn yet — breakdown below is estimated</text>
+                </Show>
+              </box>
+
+              <box flexDirection="row" justifyContent="space-between">
+                <text fg={theme.textMuted}>Breakdown (estimated · chars/4)</text>
+                <text fg={theme.textMuted}>↑↓ pgup pgdn scroll</text>
+              </box>
+
+              {/* Scrollable diagnostic breakdown. */}
+              <scrollbox height={scrollHeight()} scrollAcceleration={getScrollAcceleration()}>
+                <box gap={1} paddingRight={2}>
+                  <For each={data().sections}>
+                    {(section) => (
+                      <box>
+                        <box flexDirection="row" justifyContent="space-between">
+                          <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                            {section.label}
+                          </text>
+                          <text fg={theme.textMuted}>
+                            ~{formatTokens(section.tokens)} · {section.items.length}
+                          </text>
+                        </box>
+                        <For each={section.items}>
+                          {(item) => (
+                            <box flexDirection="row" gap={1}>
+                              <text flexShrink={0} fg={theme.textMuted}>
+                                ·
+                              </text>
+                              <text fg={theme.text} wrapMode="word">
+                                {shortenPath(item.label, itemLabelMax())}
+                                <span style={{ fg: theme.textMuted }}>
+                                  {"  ~"}
+                                  {formatTokens(item.tokens)}
+                                  {item.detail ? ` — ${item.detail}` : ""}
+                                </span>
+                              </text>
+                            </box>
+                          )}
+                        </For>
+                      </box>
+                    )}
+                  </For>
+                </box>
+              </scrollbox>
+            </box>
+          )
+        }}
+      </Show>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-context.tsx
@@ -172,7 +172,9 @@ export function DialogSessionContext(props: DialogSessionContextProps) {
                             </text>
                             <text fg={theme.textMuted}>
                               ~{formatTokens(section.tokens)}
-                              {section.key === "messages" ? "" : ` · ${section.items.length}`}
+                              {section.key === "messages" || section.key === "full_session"
+                                ? ""
+                                : ` · ${section.items.length}`}
                             </text>
                           </box>
                           <Show
@@ -187,9 +189,8 @@ export function DialogSessionContext(props: DialogSessionContextProps) {
                                     <text fg={theme.text} wrapMode="word">
                                       {shortenPath(item.label, itemLabelMax())}
                                       <span style={{ fg: theme.textMuted }}>
-                                        {"  ~"}
-                                        {formatTokens(item.tokens)}
-                                        {item.detail ? ` — ${item.detail}` : ""}
+                                        {item.tokens > 0 ? `  ~${formatTokens(item.tokens)}` : ""}
+                                        {item.detail ? `${item.tokens > 0 ? " — " : "  "}${item.detail}` : ""}
                                       </span>
                                     </text>
                                   </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -62,6 +62,7 @@ import { DialogConfirm } from "@tui/ui/dialog-confirm"
 import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
+import { DialogSessionContext } from "../../component/dialog-session-context"
 import { Sidebar } from "./sidebar"
 import { SubagentFooter } from "./subagent-footer.tsx"
 import { Flag } from "@/flag/flag"
@@ -511,6 +512,33 @@ export function Session() {
           providerID: selectedModel.providerID,
         })
         dialog.clear()
+      },
+    },
+    {
+      title: "View context breakdown",
+      value: "session.context",
+      keybind: "session_context",
+      category: "Session",
+      slash: {
+        name: "context",
+      },
+      onSelect: (dialog) => {
+        const selectedModel = local.model.current()
+        if (!selectedModel) {
+          toast.show({
+            variant: "warning",
+            message: "Connect a provider to inspect session context",
+            duration: 3000,
+          })
+          return
+        }
+        dialog.replace(() => (
+          <DialogSessionContext
+            sessionID={route.sessionID}
+            providerID={selectedModel.providerID}
+            modelID={selectedModel.modelID}
+          />
+        ))
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -9,7 +9,7 @@ import * as Selection from "@tui/util/selection"
 
 export function Dialog(
   props: ParentProps<{
-    size?: "medium" | "large" | "xlarge"
+    size?: "medium" | "large" | "xlarge" | "full" | "full"
     onClose: () => void
   }>,
 ) {
@@ -19,9 +19,14 @@ export function Dialog(
 
   let dismiss = false
   const width = () => {
+    if (props.size === "full") return Math.max(60, dimensions().width - 8)
     if (props.size === "xlarge") return 116
     if (props.size === "large") return 88
     return 60
+  }
+  const topPadding = () => {
+    if (props.size === "full") return Math.max(1, Math.floor(dimensions().height / 12))
+    return Math.floor(dimensions().height / 4)
   }
 
   return (
@@ -41,7 +46,7 @@ export function Dialog(
       alignItems="center"
       position="absolute"
       zIndex={3000}
-      paddingTop={dimensions().height / 4}
+      paddingTop={topPadding()}
       left={0}
       top={0}
       backgroundColor={RGBA.fromInts(0, 0, 0, 150)}
@@ -68,7 +73,7 @@ function init() {
       element: JSX.Element
       onClose?: () => void
     }[],
-    size: "medium" as "medium" | "large" | "xlarge",
+    size: "medium" as "medium" | "large" | "xlarge" | "full",
   })
 
   const renderer = useRenderer()
@@ -141,7 +146,7 @@ function init() {
     get size() {
       return store.size
     },
-    setSize(size: "medium" | "large" | "xlarge") {
+    setSize(size: "medium" | "large" | "xlarge" | "full") {
       setStore("size", size)
     },
   }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -9,7 +9,7 @@ import * as Selection from "@tui/util/selection"
 
 export function Dialog(
   props: ParentProps<{
-    size?: "medium" | "large" | "xlarge" | "full" | "full"
+    size?: "medium" | "large" | "xlarge" | "full"
     onClose: () => void
   }>,
 ) {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -16,6 +16,7 @@ export function Dialog(
   const dimensions = useTerminalDimensions()
   const { theme } = useTheme()
   const renderer = useRenderer()
+  const toast = useToast()
 
   let dismiss = false
   const width = () => {
@@ -54,6 +55,11 @@ export function Dialog(
       <box
         onMouseUp={(e) => {
           dismiss = false
+          // Copy-on-select: the DialogProvider wraps us in a copy handler, but
+          // our stopPropagation below prevents the event from reaching it.
+          // Trigger the copy directly so drag-selecting text inside the
+          // dialog auto-copies just like in the main session view.
+          if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) Selection.copy(renderer, toast)
           e.stopPropagation()
         }}
         width={width()}

--- a/packages/opencode/src/config/keybinds.ts
+++ b/packages/opencode/src/config/keybinds.ts
@@ -37,6 +37,7 @@ const KeybindsSchema = Schema.Struct({
   session_unshare: keybind("none", "Unshare current session"),
   session_interrupt: keybind("escape", "Interrupt current session"),
   session_compact: keybind("<leader>c", "Compact the session"),
+  session_context: keybind("none", "View session context breakdown"),
   messages_page_up: keybind("pageup,ctrl+alt+b", "Scroll messages up by one page"),
   messages_page_down: keybind("pagedown,ctrl+alt+f", "Scroll messages down by one page"),
   messages_line_up: keybind("ctrl+alt+y", "Scroll messages up by one line"),

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -27,6 +27,7 @@ import { SessionStatus } from "@/session/status"
 import { SessionRunState } from "@/session/run-state"
 import { SessionProcessor } from "@/session/processor"
 import { SessionCompaction } from "@/session/compaction"
+import { SessionContext } from "@/session/context"
 import { SessionRevert } from "@/session/revert"
 import { SessionSummary } from "@/session/summary"
 import { SessionPrompt } from "@/session/prompt"
@@ -76,6 +77,7 @@ export const AppLayer = Layer.mergeAll(
   SessionRunState.defaultLayer,
   SessionProcessor.defaultLayer,
   SessionCompaction.defaultLayer,
+  SessionContext.defaultLayer,
   SessionRevert.defaultLayer,
   SessionSummary.defaultLayer,
   SessionPrompt.defaultLayer,

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -8,6 +8,7 @@ import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
 import { SessionRunState } from "@/session/run-state"
 import { SessionCompaction } from "@/session/compaction"
+import { SessionContext } from "@/session/context"
 import { SessionRevert } from "@/session/revert"
 import { SessionShare } from "@/share"
 import { SessionStatus } from "@/session/status"
@@ -594,6 +595,48 @@ export const SessionRoutes = lazy(() =>
           })
           yield* prompt.loop({ sessionID })
           return true
+        }),
+    )
+    .get(
+      "/:sessionID/context",
+      describeRoute({
+        summary: "Get session context breakdown",
+        description:
+          "Compute a breakdown of what will be sent to the model on the next turn: system prompt, rules, " +
+          "skills, tool definitions, MCP tool definitions, and message history. Token counts for messages " +
+          "are taken from the last assistant turn's provider usage when available, and estimated otherwise.",
+        operationId: "session.context",
+        responses: {
+          200: {
+            description: "Session context breakdown",
+            content: {
+              "application/json": {
+                schema: resolver(SessionContext.ContextInfo.zod),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: SessionID.zod,
+        }),
+      ),
+      validator(
+        "query",
+        z.object({
+          providerID: ProviderID.zod,
+          modelID: ModelID.zod,
+        }),
+      ),
+      async (c) =>
+        jsonRequest("SessionRoutes.context", c, function* () {
+          const { sessionID } = c.req.valid("param")
+          const { providerID, modelID } = c.req.valid("query")
+          const ctx = yield* SessionContext.Service
+          return yield* ctx.compute({ sessionID, providerID, modelID })
         }),
     )
     .get(

--- a/packages/opencode/src/session/assemble.ts
+++ b/packages/opencode/src/session/assemble.ts
@@ -1,0 +1,174 @@
+import { Effect } from "effect"
+import { asSchema, type Tool as AITool } from "ai"
+import type { JSONSchema7 } from "@ai-sdk/provider"
+
+import { toJsonSchema } from "@/util/effect-zod"
+import { Provider, ProviderTransform } from "@/provider"
+import type { Agent } from "@/agent/agent"
+import type { MessageV2 } from "./message-v2"
+import { SystemPrompt } from "./system"
+
+// Extra system block appended when the user requests structured output.
+// Defined here (rather than in prompt.ts) so both the prompt pipeline and the
+// /context inspection endpoint stay in sync on what the model actually sees.
+export const STRUCTURED_OUTPUT_SYSTEM_PROMPT =
+  "IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema."
+
+export type LabeledSegment = {
+  // Short label used by the /context UI. Semantic categories (not positional).
+  kind: "base" | "agent_prompt" | "env" | "skills" | "instructions" | "user_system" | "structured_output"
+  label: string
+  text: string
+}
+
+export type SystemInput = {
+  model: Provider.Model
+  agent: Agent.Info
+  env: string[]
+  skills: string | undefined
+  instructions: string[]
+  userSystem: string | undefined
+  format: { type: "text" } | { type: "json_schema"; [k: string]: unknown }
+}
+
+// Build the system prompt segments in the **exact** order llm.ts uses before
+// plugin transforms. See session/llm.ts:99-111.
+//
+// Order (post-llm header construction):
+//   header = [agent.prompt || provider(model), ...middleSegments, userSystem]
+// where middleSegments is what session/prompt.ts calls `system` — namely:
+//   [env..., skills?, instructions..., structuredOutput?]
+//
+// This function returns both (a) the flat string list that caller code can
+// reduce/join however it wants, and (b) labeled segments so the /context
+// endpoint can display the breakdown.
+export function systemSegments(input: SystemInput): LabeledSegment[] {
+  const base: LabeledSegment[] = input.agent.prompt
+    ? [{ kind: "agent_prompt", label: `agent-prompt/${input.agent.name}`, text: input.agent.prompt }]
+    : SystemPrompt.provider(input.model).map((text, i) => ({
+        kind: "base" as const,
+        label: `base/${i}`,
+        text,
+      }))
+
+  const env: LabeledSegment[] = input.env.map((text, i) => ({
+    kind: "env" as const,
+    label: `env/${i}`,
+    text,
+  }))
+
+  const skills: LabeledSegment[] = input.skills
+    ? [{ kind: "skills", label: "skills", text: input.skills }]
+    : []
+
+  const instructions: LabeledSegment[] = input.instructions.map((text) => {
+    const newline = text.indexOf("\n")
+    const label =
+      newline > 0 && text.startsWith("Instructions from: ")
+        ? text.slice("Instructions from: ".length, newline).trim()
+        : "rules"
+    return { kind: "instructions", label, text }
+  })
+
+  const userSystem: LabeledSegment[] = input.userSystem
+    ? [{ kind: "user_system", label: "user-system", text: input.userSystem }]
+    : []
+
+  const structured: LabeledSegment[] =
+    input.format.type === "json_schema"
+      ? [{ kind: "structured_output", label: "structured-output", text: STRUCTURED_OUTPUT_SYSTEM_PROMPT }]
+      : []
+
+  return [...base, ...env, ...skills, ...instructions, ...structured, ...userSystem]
+}
+
+// Produce the "middle" list that session/prompt.ts passes into
+// handle.process({ system, ... }) — i.e. everything except the agent/provider
+// header and the user-per-turn override, which llm.ts adds on its own.
+export function middleSegments(input: {
+  env: string[]
+  skills: string | undefined
+  instructions: string[]
+  format: { type: "text" } | { type: "json_schema"; [k: string]: unknown }
+}): string[] {
+  const out = [...input.env, ...(input.skills ? [input.skills] : []), ...input.instructions]
+  if (input.format.type === "json_schema") out.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
+  return out
+}
+
+// Mirror of session/llm.ts:99-111: join agent/provider header + middle
+// segments + per-turn user.system into a single string the way the provider
+// sees it. Context inspection uses this to avoid drift.
+export function joinedHeader(input: {
+  model: Provider.Model
+  agent: Agent.Info
+  middle: string[]
+  userSystem: string | undefined
+}): string {
+  return [
+    ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
+    ...input.middle,
+    ...(input.userSystem ? [input.userSystem] : []),
+  ]
+    .filter((x) => x)
+    .join("\n")
+}
+
+// --- Tool rendering ---------------------------------------------------------
+
+export type RenderedTool = {
+  id: string
+  description: string | undefined
+  schema: JSONSchema7
+}
+
+// Render a built-in tool exactly the way session/prompt.ts does before handing
+// it to the AI SDK. The output matches what the provider receives on the wire.
+// Parameters typed via structural shape (rather than importing Tool.Def with
+// its generics) since we only read `id`, `description`, and `parameters`.
+export function renderBuiltinTool(
+  model: Provider.Model,
+  item: { id: string; description?: string; parameters: Parameters<typeof toJsonSchema>[0] },
+): RenderedTool {
+  return {
+    id: item.id,
+    description: item.description,
+    schema: ProviderTransform.schema(model, toJsonSchema(item.parameters)),
+  }
+}
+
+// Render an MCP-provided tool. `asSchema(...).jsonSchema` is typed as sync-or-
+// Promise by the AI SDK but is synchronous for the `jsonSchema()` wrappers we
+// construct; session/prompt.ts defensively wraps with `Effect.promise`, which
+// we mirror here for consistency.
+export const renderMcpTool = Effect.fn("Assemble.renderMcpTool")(function* (
+  model: Provider.Model,
+  key: string,
+  item: AITool,
+) {
+  const raw = yield* Effect.promise(() => Promise.resolve(asSchema(item.inputSchema).jsonSchema))
+  return {
+    id: key,
+    description: item.description,
+    schema: ProviderTransform.schema(model, raw),
+  } satisfies RenderedTool
+})
+
+// Key shape from mcp/index.ts is `<sanitized-client>_<sanitized-tool>`.
+export function mcpServerFromKey(key: string): string {
+  const sep = key.indexOf("_")
+  return sep > 0 ? key.slice(0, sep) : key
+}
+
+// --- Last-user agent lookup -------------------------------------------------
+
+// Walk messages backwards to find the agent the user most recently selected.
+// Used by both the summarize route and the context endpoint to keep the
+// breakdown aligned with what the next model call will use.
+export function lastUserAgent(msgs: readonly MessageV2.WithParts[]): string | undefined {
+  const match = msgs.findLast((m) => m.info.role === "user" && m.info.agent)
+  if (!match || match.info.role !== "user") return undefined
+  return match.info.agent
+}
+
+export * as SessionAssemble from "./assemble"

--- a/packages/opencode/src/session/context.ts
+++ b/packages/opencode/src/session/context.ts
@@ -9,6 +9,7 @@ import { Config } from "@/config"
 import { MCP } from "@/mcp"
 import { Provider, ProviderTransform } from "@/provider"
 import { ProviderID, ModelID } from "@/provider/schema"
+import { Skill } from "@/skill"
 import { ToolRegistry } from "@/tool"
 
 import * as Session from "./session"
@@ -29,6 +30,9 @@ export const ContextItem = Schema.Struct({
   tokens: Schema.Number,
   chars: Schema.Number,
   detail: Schema.optional(Schema.String),
+  // Optional logical grouping key. Currently used for MCP tools so the UI
+  // can render per-server subtotals under the single "MCP tools" section.
+  group: Schema.optional(Schema.String),
 })
   .annotate({ identifier: "SessionContextItem" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))
@@ -120,6 +124,27 @@ function stringItem(label: string, text: string, detail?: string): ContextItem {
   }
 }
 
+// Human-readable detail for each system-prompt segment so the /context UI
+// explains *what* the cryptic labels like `base/0` or `env/0` actually are.
+function describeSegment(s: SessionAssemble.LabeledSegment): string | undefined {
+  switch (s.kind) {
+    case "base":
+      return "Provider base prompt (model-family specific coding-agent system prompt)"
+    case "agent_prompt":
+      return "Agent-specific prompt override (from agent config)"
+    case "env":
+      return "Runtime environment: model id, cwd, workspace, git, platform, date"
+    case "user_system":
+      return "Per-turn user-supplied system text"
+    case "structured_output":
+      return "Structured-output tool enforcement"
+    case "instructions":
+      return "Project rules / AGENTS.md content"
+    case "skills":
+      return "Available skills (name + description injected into prompt)"
+  }
+}
+
 function buildSection(key: ContextSection["key"], label: string, items: ContextItem[]): ContextSection {
   return {
     key,
@@ -141,6 +166,7 @@ export const layer = Layer.effect(
     const registry = yield* ToolRegistry.Service
     const mcp = yield* MCP.Service
     const config = yield* Config.Service
+    const skill = yield* Skill.Service
 
     const compute = Effect.fn("SessionContext.compute")(function* (input: GetInput) {
       const model = yield* provider.getModel(input.providerID, input.modelID)
@@ -153,7 +179,11 @@ export const layer = Layer.effect(
       // --- Static breakdown (diagnostic) ------------------------------------
       const lastUser = msgs.findLast((m) => m.info.role === "user")
       const userSystem = lastUser?.info.role === "user" ? lastUser.info.system : undefined
-      const [skills, instructions] = yield* Effect.all([sys.skills(agent), instruction.system().pipe(Effect.orDie)])
+      const [skills, instructions, availableSkills] = yield* Effect.all([
+        sys.skills(agent),
+        instruction.system().pipe(Effect.orDie),
+        skill.available(agent),
+      ])
       const segments = SessionAssemble.systemSegments({
         model,
         agent,
@@ -164,10 +194,16 @@ export const layer = Layer.effect(
         format: { type: "text" },
       })
       const pickItems = (kinds: SessionAssemble.LabeledSegment["kind"][]): ContextItem[] =>
-        segments.filter((s) => kinds.includes(s.kind)).map((s) => stringItem(s.label, s.text))
+        segments.filter((s) => kinds.includes(s.kind)).map((s) => stringItem(s.label, s.text, describeSegment(s)))
 
       const systemItems = pickItems(["base", "agent_prompt", "env", "user_system", "structured_output"])
-      const skillsItems = pickItems(["skills"])
+      // Skills: show one row per available skill. The text used for size
+      // estimation is the skill's description — that is what's injected into
+      // the system prompt via `Skill.fmt`. Full skill content is only loaded
+      // on demand via the skill tool, so it's not counted here.
+      const skillsItems: ContextItem[] = availableSkills
+        .toSorted((a, b) => a.name.localeCompare(b.name))
+        .map((s) => stringItem(s.name, s.description, s.description))
       const rulesItems = pickItems(["instructions"])
 
       const agentMetaText = JSON.stringify(
@@ -208,11 +244,13 @@ export const layer = Layer.effect(
         if (!item.execute) continue
         const rendered = yield* SessionAssemble.renderMcpTool(model, key, item)
         const body = (rendered.description ?? "") + "\n" + JSON.stringify(rendered.schema)
+        const server = SessionAssemble.mcpServerFromKey(key)
         mcpItems.push({
           label: rendered.id,
           chars: body.length,
           tokens: Token.estimate(body),
-          detail: SessionAssemble.mcpServerFromKey(key),
+          detail: server,
+          group: server,
         })
       }
 
@@ -266,14 +304,41 @@ export const layer = Layer.effect(
             overflow: false,
           }
 
-      const messagesItems: ContextItem[] = [
-        {
-          label: `${msgs.length} message(s)`,
-          tokens: Token.estimate(messagesSerialized),
-          chars: messagesSerialized.length,
-          detail: usage.authoritative ? "superseded by usage above" : "estimated",
-        },
-      ]
+      const messagesItems: ContextItem[] = (() => {
+        if (msgs.length === 0) return []
+        const userMsgs = msgs.filter((m) => m.info.role === "user")
+        const asstMsgs = msgs.filter((m) => m.info.role === "assistant")
+        const sizeOf = (list: typeof msgs) =>
+          JSON.stringify(list.map((m) => ({ info: m.info, parts: m.parts })))
+        const userText = sizeOf(userMsgs)
+        const asstText = sizeOf(asstMsgs)
+        const totalDetail = usage.authoritative ? "superseded by usage above" : "estimated"
+        const items: ContextItem[] = [
+          {
+            label: `Total ${msgs.length} message(s)`,
+            tokens: Token.estimate(messagesSerialized),
+            chars: messagesSerialized.length,
+            detail: totalDetail,
+          },
+        ]
+        if (userMsgs.length > 0) {
+          items.push({
+            label: `User (${userMsgs.length})`,
+            tokens: Token.estimate(userText),
+            chars: userText.length,
+            detail: "prompts + attached parts",
+          })
+        }
+        if (asstMsgs.length > 0) {
+          items.push({
+            label: `Assistant (${asstMsgs.length}) — ${agent.name}`,
+            tokens: Token.estimate(asstText),
+            chars: asstText.length,
+            detail: "responses + tool calls + tool results",
+          })
+        }
+        return items
+      })()
 
       const sections: ContextSection[] = [
         buildSection("system", "System prompt", systemItems),
@@ -307,6 +372,7 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(ToolRegistry.defaultLayer),
     Layer.provide(MCP.defaultLayer),
     Layer.provide(Config.defaultLayer),
+    Layer.provide(Skill.defaultLayer),
   ),
 )
 

--- a/packages/opencode/src/session/context.ts
+++ b/packages/opencode/src/session/context.ts
@@ -40,7 +40,7 @@ export const ContextItem = Schema.Struct({
 export type ContextItem = Schema.Schema.Type<typeof ContextItem>
 
 export const ContextSection = Schema.Struct({
-  key: Schema.Literals(["system", "rules", "skills", "tools", "mcp_tools", "agent", "messages"]),
+  key: Schema.Literals(["system", "rules", "skills", "tools", "mcp_tools", "agent", "messages", "full_session"]),
   label: Schema.String,
   tokens: Schema.Number,
   chars: Schema.Number,
@@ -171,10 +171,12 @@ export const layer = Layer.effect(
 
     const compute = Effect.fn("SessionContext.compute")(function* (input: GetInput) {
       const model = yield* provider.getModel(input.providerID, input.modelID)
-      // Raw history from the store. Walked via filterCompacted to select only
-      // messages the LLM actually sees this turn (post any compaction rollups).
+      // Raw history (oldest-first) plus the compaction-filtered active
+      // window. filterCompactedEffect walks the newest-first stream and
+      // reverses internally, matching exactly what session/prompt.ts feeds
+      // into the LLM, so token totals align with what the model sees.
       const allMsgs = yield* sessions.messages({ sessionID: input.sessionID })
-      const msgs = MessageV2.filterCompacted(allMsgs)
+      const msgs = yield* MessageV2.filterCompactedEffect(input.sessionID)
 
       // Agent resolution mirrors session/prompt.ts behavior.
       const defaultAgentName = yield* agents.defaultAgent()
@@ -258,17 +260,20 @@ export const layer = Layer.effect(
         })
       }
 
-      // Pure-estimate messages block, always rendered as a diagnostic. When
-      // the authoritative usage supersedes it, the UI can use `detail` to
-      // explain that the line is not the top-line number.
-      const messagesSerialized = JSON.stringify(msgs.map((m) => ({ info: m.info, parts: m.parts })))
-
-      // --- Authoritative usage ---------------------------------------------
+      // Authoritative usage --------------------------------------------------      // --- Authoritative usage ---------------------------------------------
       // Walk backwards for the last assistant turn that reported usage. Gate
       // on `SessionOverflow.currentTokens > 0` (same expression overflow uses
       // to decide compaction) so the /context view can never disagree about
       // whether an authoritative number exists.
-      const lastAssistant = msgs.findLast((m) => m.info.role === "assistant")
+      // Authoritative usage: pick the most recent assistant turn that
+      // produced output, matching the sidebar's selection rule. Walking the
+      // *unfiltered* history makes the figure consistent with the sidebar
+      // even when the active window has been compacted (the compaction
+      // summary writer's reported usage IS the last live snapshot of the
+      // pre-compaction prefix).
+      const lastAssistant = allMsgs.findLast(
+        (m) => m.info.role === "assistant" && m.info.tokens.output > 0,
+      )
       const t =
         lastAssistant && lastAssistant.info.role === "assistant" && SessionOverflow.currentTokens(lastAssistant.info.tokens) > 0
           ? lastAssistant.info.tokens
@@ -317,22 +322,15 @@ export const layer = Layer.effect(
         const userText = sizeOf(userMsgs)
         const asstText = sizeOf(asstMsgs)
         const compactedOut = allMsgs.length - msgs.length
-        const totalDetail = usage.authoritative ? "superseded by usage above" : "estimated"
-        const compactedNote = compactedOut > 0 ? ` · ${compactedOut} older compacted out` : ""
-        const items: ContextItem[] = [
-          {
-            label: `Total ${msgs.length} message(s) in context`,
-            tokens: Token.estimate(messagesSerialized),
-            chars: messagesSerialized.length,
-            detail: totalDetail + compactedNote,
-          },
-        ]
+        const items: ContextItem[] = []
+        // Each role row is sized independently so the section subtotal in the
+        // header matches reality (no double-counting via a redundant Total).
         if (userMsgs.length > 0) {
           items.push({
             label: `User (${userMsgs.length})`,
             tokens: Token.estimate(userText),
             chars: userText.length,
-            detail: "prompts + attached parts (current session, post-compaction)",
+            detail: "prompts + attached parts",
           })
         }
         if (asstMsgs.length > 0) {
@@ -340,9 +338,69 @@ export const layer = Layer.effect(
             label: `Assistant (${asstMsgs.length}) — ${agent.name}`,
             tokens: Token.estimate(asstText),
             chars: asstText.length,
-            detail: "responses + tool calls + tool results (current session, post-compaction)",
+            detail: "responses + tool calls + tool results",
           })
         }
+        // Zero-token info row that explains scope + how many were rolled up
+        // by compaction. Estimated, current session only.
+        const scopeBits = [
+          `${msgs.length} in context`,
+          compactedOut > 0 ? `${compactedOut} compacted out` : null,
+          usage.authoritative ? "superseded by usage above" : "estimated",
+        ].filter((x): x is string => !!x)
+        items.push({
+          label: "Scope",
+          tokens: 0,
+          chars: 0,
+          detail: scopeBits.join(" · "),
+        })
+        return items
+      })()
+
+      // Full session: pre-compaction totals over the raw transcript. Lets the
+      // user see the cumulative size of everything ever written to this
+      // session, regardless of what's currently in the live context window.
+      const fullSessionItems: ContextItem[] = (() => {
+        if (allMsgs.length === 0) return []
+        const userAll = allMsgs.filter((m) => m.info.role === "user")
+        const asstAll = allMsgs.filter((m) => m.info.role === "assistant")
+        const sizeOf = (list: typeof allMsgs) =>
+          JSON.stringify(list.map((m) => ({ info: m.info, parts: m.parts })))
+        const userText = sizeOf(userAll)
+        const asstText = sizeOf(asstAll)
+        const totalCost = asstAll.reduce(
+          (acc, m) => acc + (m.info.role === "assistant" ? (m.info.cost ?? 0) : 0),
+          0,
+        )
+        const items: ContextItem[] = []
+        if (userAll.length > 0) {
+          items.push({
+            label: `User (${userAll.length})`,
+            tokens: Token.estimate(userText),
+            chars: userText.length,
+            detail: "all user prompts ever sent",
+          })
+        }
+        if (asstAll.length > 0) {
+          items.push({
+            label: `Assistant (${asstAll.length}) — ${agent.name}`,
+            tokens: Token.estimate(asstText),
+            chars: asstText.length,
+            detail: "all assistant turns + tool calls + results",
+          })
+        }
+        const compactedOut = allMsgs.length - msgs.length
+        const scopeBits = [
+          `${allMsgs.length} total message(s)`,
+          compactedOut > 0 ? `${compactedOut} rolled up by compaction` : "no compaction yet",
+          totalCost > 0 ? `$${totalCost.toFixed(4)} spent` : null,
+        ].filter((x): x is string => !!x)
+        items.push({
+          label: "Lifetime",
+          tokens: 0,
+          chars: 0,
+          detail: scopeBits.join(" · "),
+        })
         return items
       })()
 
@@ -353,7 +411,10 @@ export const layer = Layer.effect(
         buildSection("agent", "Agent", agentItems),
         buildSection("tools", "Built-in tools", toolItems),
         buildSection("mcp_tools", "MCP tools", mcpItems),
-        buildSection("messages", "Messages", messagesItems),
+        buildSection("messages", "Messages (in context)", messagesItems),
+        ...(fullSessionItems.length > 0
+          ? [buildSection("full_session", "Full session (raw, pre-compaction)", fullSessionItems)]
+          : []),
       ]
 
       return {

--- a/packages/opencode/src/session/context.ts
+++ b/packages/opencode/src/session/context.ts
@@ -1,0 +1,313 @@
+import { Context, Effect, Layer, Schema } from "effect"
+
+import { zod } from "@/util/effect-zod"
+import { withStatics } from "@/util/schema"
+import { Token } from "@/util"
+
+import { Agent } from "@/agent/agent"
+import { Config } from "@/config"
+import { MCP } from "@/mcp"
+import { Provider, ProviderTransform } from "@/provider"
+import { ProviderID, ModelID } from "@/provider/schema"
+import { ToolRegistry } from "@/tool"
+
+import * as Session from "./session"
+import { SessionID } from "./schema"
+import { SystemPrompt } from "./system"
+import { Instruction } from "./instruction"
+import { SessionAssemble } from "./assemble"
+import { SessionOverflow } from "./overflow"
+
+// --- API schema -------------------------------------------------------------
+
+// A single surfaced piece of context. `tokens` / `chars` are diagnostic
+// estimates produced by `Token.estimate` (chars/4 heuristic); they never drive
+// totals or overflow decisions. Use `Usage.current` for the authoritative
+// figure.
+export const ContextItem = Schema.Struct({
+  label: Schema.String,
+  tokens: Schema.Number,
+  chars: Schema.Number,
+  detail: Schema.optional(Schema.String),
+})
+  .annotate({ identifier: "SessionContextItem" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type ContextItem = Schema.Schema.Type<typeof ContextItem>
+
+export const ContextSection = Schema.Struct({
+  key: Schema.Literals(["system", "rules", "skills", "tools", "mcp_tools", "agent", "messages"]),
+  label: Schema.String,
+  tokens: Schema.Number,
+  chars: Schema.Number,
+  items: Schema.Array(ContextItem),
+})
+  .annotate({ identifier: "SessionContextSection" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type ContextSection = Schema.Schema.Type<typeof ContextSection>
+
+// Authoritative usage snapshot derived from the last completed assistant turn.
+// Mirrors `overflow.isOverflow` accounting (input + output + cache.read +
+// cache.write) so the /context report is consistent with what actually
+// triggers auto-compaction.
+export const Usage = Schema.Struct({
+  // True when figures come from the provider's reported LanguageModelUsage on
+  // the most recent assistant turn. False before any turn has completed — in
+  // that case `current` is 0 and the UI should fall back to diagnostics.
+  authoritative: Schema.Boolean,
+  // Last assistant turn raw usage (0 when !authoritative).
+  input: Schema.Number,
+  output: Schema.Number,
+  reasoning: Schema.Number,
+  cacheRead: Schema.Number,
+  cacheWrite: Schema.Number,
+  // The sum that `overflow.isOverflow` uses to decide compaction.
+  current: Schema.Number,
+  // Total context window the model advertises.
+  contextLimit: Schema.Number,
+  // Output token reservation honored by provider transforms.
+  outputReserve: Schema.Number,
+  // What overflow.usable() returns: context minus reserved output / compaction
+  // buffer. This is the effective budget for prompt content.
+  usable: Schema.Number,
+  // Raw `current >= usable` (independent of compaction config). Surfaces the
+  // true budget state even when auto-compaction is disabled.
+  overBudget: Schema.Boolean,
+  // Whether auto-compaction would trigger on the next turn. Equal to
+  // `overBudget` unless the user has disabled `compaction.auto`.
+  overflow: Schema.Boolean,
+})
+  .annotate({ identifier: "SessionContextUsage" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type Usage = Schema.Schema.Type<typeof Usage>
+
+export const ContextInfo = Schema.Struct({
+  model: Schema.Struct({
+    providerID: Schema.String,
+    modelID: Schema.String,
+  }),
+  agent: Schema.String,
+  usage: Usage,
+  // Diagnostic breakdown of static pieces assembled into the next call. Each
+  // item's `tokens` is a `Token.estimate` of its rendered content. Sum across
+  // sections is only an approximation of what the provider will count.
+  sections: Schema.Array(ContextSection),
+})
+  .annotate({ identifier: "SessionContextInfo" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type ContextInfo = Schema.Schema.Type<typeof ContextInfo>
+
+export const GetInput = Schema.Struct({
+  sessionID: SessionID,
+  providerID: ProviderID,
+  modelID: ModelID,
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type GetInput = Schema.Schema.Type<typeof GetInput>
+
+// --- Service ----------------------------------------------------------------
+
+export interface Interface {
+  readonly compute: (input: GetInput) => Effect.Effect<ContextInfo>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SessionContext") {}
+
+function stringItem(label: string, text: string, detail?: string): ContextItem {
+  return {
+    label,
+    chars: text.length,
+    tokens: Token.estimate(text),
+    detail,
+  }
+}
+
+function buildSection(key: ContextSection["key"], label: string, items: ContextItem[]): ContextSection {
+  return {
+    key,
+    label,
+    tokens: items.reduce((acc, it) => acc + it.tokens, 0),
+    chars: items.reduce((acc, it) => acc + it.chars, 0),
+    items,
+  }
+}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    const agents = yield* Agent.Service
+    const provider = yield* Provider.Service
+    const sys = yield* SystemPrompt.Service
+    const instruction = yield* Instruction.Service
+    const registry = yield* ToolRegistry.Service
+    const mcp = yield* MCP.Service
+    const config = yield* Config.Service
+
+    const compute = Effect.fn("SessionContext.compute")(function* (input: GetInput) {
+      const model = yield* provider.getModel(input.providerID, input.modelID)
+      const msgs = yield* sessions.messages({ sessionID: input.sessionID })
+
+      // Agent resolution mirrors session/prompt.ts behavior.
+      const defaultAgentName = yield* agents.defaultAgent()
+      const agent = yield* agents.get(SessionAssemble.lastUserAgent(msgs) ?? defaultAgentName)
+
+      // --- Static breakdown (diagnostic) ------------------------------------
+      const lastUser = msgs.findLast((m) => m.info.role === "user")
+      const userSystem = lastUser?.info.role === "user" ? lastUser.info.system : undefined
+      const [skills, instructions] = yield* Effect.all([sys.skills(agent), instruction.system().pipe(Effect.orDie)])
+      const segments = SessionAssemble.systemSegments({
+        model,
+        agent,
+        env: sys.environment(model),
+        skills,
+        instructions,
+        userSystem,
+        format: { type: "text" },
+      })
+      const pickItems = (kinds: SessionAssemble.LabeledSegment["kind"][]): ContextItem[] =>
+        segments.filter((s) => kinds.includes(s.kind)).map((s) => stringItem(s.label, s.text))
+
+      const systemItems = pickItems(["base", "agent_prompt", "env", "user_system", "structured_output"])
+      const skillsItems = pickItems(["skills"])
+      const rulesItems = pickItems(["instructions"])
+
+      const agentMetaText = JSON.stringify(
+        {
+          name: agent.name,
+          description: agent.description,
+          mode: agent.mode,
+          model: agent.model,
+          temperature: agent.temperature,
+          topP: agent.topP,
+          steps: agent.steps,
+        },
+        null,
+        2,
+      )
+      const agentItems: ContextItem[] = [
+        {
+          label: agent.name,
+          tokens: 0,
+          chars: agentMetaText.length,
+          detail: `${agent.mode} agent`,
+        },
+      ]
+
+      const toolDefs = yield* registry.tools({
+        providerID: input.providerID,
+        modelID: ModelID.make(model.api.id),
+        agent,
+      })
+      const toolItems: ContextItem[] = toolDefs.map((item) => {
+        const rendered = SessionAssemble.renderBuiltinTool(model, item)
+        const body = (rendered.description ?? "") + "\n" + JSON.stringify(rendered.schema)
+        return { label: rendered.id, chars: body.length, tokens: Token.estimate(body) }
+      })
+
+      const mcpItems: ContextItem[] = []
+      for (const [key, item] of Object.entries(yield* mcp.tools())) {
+        if (!item.execute) continue
+        const rendered = yield* SessionAssemble.renderMcpTool(model, key, item)
+        const body = (rendered.description ?? "") + "\n" + JSON.stringify(rendered.schema)
+        mcpItems.push({
+          label: rendered.id,
+          chars: body.length,
+          tokens: Token.estimate(body),
+          detail: SessionAssemble.mcpServerFromKey(key),
+        })
+      }
+
+      // Pure-estimate messages block, always rendered as a diagnostic. When
+      // the authoritative usage supersedes it, the UI can use `detail` to
+      // explain that the line is not the top-line number.
+      const messagesSerialized = JSON.stringify(msgs.map((m) => ({ info: m.info, parts: m.parts })))
+
+      // --- Authoritative usage ---------------------------------------------
+      // Walk backwards for the last assistant turn that reported usage. Gate
+      // on `SessionOverflow.currentTokens > 0` (same expression overflow uses
+      // to decide compaction) so the /context view can never disagree about
+      // whether an authoritative number exists.
+      const lastAssistant = msgs.findLast((m) => m.info.role === "assistant")
+      const t =
+        lastAssistant && lastAssistant.info.role === "assistant" && SessionOverflow.currentTokens(lastAssistant.info.tokens) > 0
+          ? lastAssistant.info.tokens
+          : undefined
+
+      const cfg = yield* config.get()
+      const usableBudget = SessionOverflow.usable({ cfg, model })
+      const outputReserve = ProviderTransform.maxOutputTokens(model)
+
+      const usage: Usage = t
+        ? {
+            authoritative: true,
+            input: t.input,
+            output: t.output,
+            reasoning: t.reasoning,
+            cacheRead: t.cache.read,
+            cacheWrite: t.cache.write,
+            current: SessionOverflow.currentTokens(t),
+            contextLimit: model.limit.context,
+            outputReserve,
+            usable: usableBudget,
+            overBudget: usableBudget > 0 && SessionOverflow.currentTokens(t) >= usableBudget,
+            overflow: SessionOverflow.isOverflow({ cfg, tokens: t, model }),
+          }
+        : {
+            authoritative: false,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            current: 0,
+            contextLimit: model.limit.context,
+            outputReserve,
+            usable: usableBudget,
+            overBudget: false,
+            overflow: false,
+          }
+
+      const messagesItems: ContextItem[] = [
+        {
+          label: `${msgs.length} message(s)`,
+          tokens: Token.estimate(messagesSerialized),
+          chars: messagesSerialized.length,
+          detail: usage.authoritative ? "superseded by usage above" : "estimated",
+        },
+      ]
+
+      const sections: ContextSection[] = [
+        buildSection("system", "System prompt", systemItems),
+        ...(skillsItems.length > 0 ? [buildSection("skills", "Skills", skillsItems)] : []),
+        buildSection("rules", "Rules / memory", rulesItems),
+        buildSection("agent", "Agent", agentItems),
+        buildSection("tools", "Built-in tools", toolItems),
+        buildSection("mcp_tools", "MCP tools", mcpItems),
+        buildSection("messages", "Messages", messagesItems),
+      ]
+
+      return {
+        model: { providerID: model.providerID, modelID: model.api.id },
+        agent: agent.name,
+        usage,
+        sections,
+      } satisfies ContextInfo
+    })
+
+    return Service.of({ compute })
+  }),
+)
+
+export const defaultLayer = Layer.suspend(() =>
+  layer.pipe(
+    Layer.provide(Session.defaultLayer),
+    Layer.provide(Agent.defaultLayer),
+    Layer.provide(Provider.defaultLayer),
+    Layer.provide(SystemPrompt.defaultLayer),
+    Layer.provide(Instruction.defaultLayer),
+    Layer.provide(ToolRegistry.defaultLayer),
+    Layer.provide(MCP.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+  ),
+)
+
+export * as SessionContext from "./context"

--- a/packages/opencode/src/session/context.ts
+++ b/packages/opencode/src/session/context.ts
@@ -313,14 +313,22 @@ export const layer = Layer.effect(
             overflow: false,
           }
 
+      // Convert in-context messages to the ModelMessage[] form that
+      // streamText actually receives. We size the categorized rows below
+      // against this wire form so they match what the provider tokenizes
+      // (raw stored {info, parts} JSON over-counts by 10-20x because it
+      // carries IDs, timestamps, parentID, model metadata, etc. that never
+      // leave the local DB).
+      const wireMsgs = yield* MessageV2.toModelMessagesEffect(msgs, model)
+      const wireUserMsgs = wireMsgs.filter((m) => m.role === "user")
+      const wireAsstMsgs = wireMsgs.filter((m) => m.role === "assistant" || m.role === "tool")
+
       const messagesItems: ContextItem[] = (() => {
         if (msgs.length === 0) return []
         const userMsgs = msgs.filter((m) => m.info.role === "user")
         const asstMsgs = msgs.filter((m) => m.info.role === "assistant")
-        const sizeOf = (list: typeof msgs) =>
-          JSON.stringify(list.map((m) => ({ info: m.info, parts: m.parts })))
-        const userText = sizeOf(userMsgs)
-        const asstText = sizeOf(asstMsgs)
+        const userText = JSON.stringify(wireUserMsgs)
+        const asstText = JSON.stringify(wireAsstMsgs)
         const compactedOut = allMsgs.length - msgs.length
         const items: ContextItem[] = []
         // Each role row is sized independently so the section subtotal in the
@@ -330,7 +338,7 @@ export const layer = Layer.effect(
             label: `User (${userMsgs.length})`,
             tokens: Token.estimate(userText),
             chars: userText.length,
-            detail: "prompts + attached parts",
+            detail: "prompts + attached parts (wire form)",
           })
         }
         if (asstMsgs.length > 0) {
@@ -338,7 +346,7 @@ export const layer = Layer.effect(
             label: `Assistant (${asstMsgs.length}) — ${agent.name}`,
             tokens: Token.estimate(asstText),
             chars: asstText.length,
-            detail: "responses + tool calls + tool results",
+            detail: "responses + tool calls + tool results (wire form)",
           })
         }
         // Zero-token info row that explains scope + how many were rolled up
@@ -417,11 +425,46 @@ export const layer = Layer.effect(
           : []),
       ]
 
+      // Self-calibration: when the last assistant turn produced authoritative
+      // token usage, derive the actual tokens-per-char ratio the provider's
+      // tokenizer applied to the prompt and propagate it to every categorized
+      // row. Providers' tokenizers often run denser than chars/4 on JSON-heavy
+      // payloads (Anthropic's BPE breaks tool schemas into many small tokens),
+      // so an uncalibrated sum can understate the bar by ~50% on tool-heavy
+      // turns. Falls back to chars/4 (already in `tokens`) when there's no
+      // authoritative usage yet.
+      //
+      // The calibration excludes:
+      //   - `full_session` — sized off raw stored JSON (carries IDs/timestamps
+      //     never sent on the wire), 10-20× wire size; would skew the ratio.
+      //   - the `agent` section — metadata row with `tokens: 0` by design (not
+      //     part of the prompt), should stay at zero.
+      const calibrated = (() => {
+        if (!usage.authoritative) return sections
+        const promptTokens = usage.input + usage.cacheRead + usage.cacheWrite
+        const includeInDenominator = (s: ContextSection) => s.key !== "full_session" && s.key !== "agent"
+        const sumChars = sections.filter(includeInDenominator).reduce((acc, s) => acc + s.chars, 0)
+        if (promptTokens <= 0 || sumChars <= 0) return sections
+        const ratio = promptTokens / sumChars
+        return sections.map((section) => {
+          if (!includeInDenominator(section)) return section
+          const items = section.items.map((it) => ({
+            ...it,
+            tokens: it.chars > 0 ? Math.max(0, Math.round(it.chars * ratio)) : it.tokens,
+          }))
+          return {
+            ...section,
+            items,
+            tokens: items.reduce((acc, it) => acc + it.tokens, 0),
+          }
+        })
+      })()
+
       return {
         model: { providerID: model.providerID, modelID: model.api.id },
         agent: agent.name,
         usage,
-        sections,
+        sections: calibrated,
       } satisfies ContextInfo
     })
 

--- a/packages/opencode/src/session/context.ts
+++ b/packages/opencode/src/session/context.ts
@@ -18,6 +18,7 @@ import { SystemPrompt } from "./system"
 import { Instruction } from "./instruction"
 import { SessionAssemble } from "./assemble"
 import { SessionOverflow } from "./overflow"
+import * as MessageV2 from "./message-v2"
 
 // --- API schema -------------------------------------------------------------
 
@@ -170,7 +171,10 @@ export const layer = Layer.effect(
 
     const compute = Effect.fn("SessionContext.compute")(function* (input: GetInput) {
       const model = yield* provider.getModel(input.providerID, input.modelID)
-      const msgs = yield* sessions.messages({ sessionID: input.sessionID })
+      // Raw history from the store. Walked via filterCompacted to select only
+      // messages the LLM actually sees this turn (post any compaction rollups).
+      const allMsgs = yield* sessions.messages({ sessionID: input.sessionID })
+      const msgs = MessageV2.filterCompacted(allMsgs)
 
       // Agent resolution mirrors session/prompt.ts behavior.
       const defaultAgentName = yield* agents.defaultAgent()
@@ -312,13 +316,15 @@ export const layer = Layer.effect(
           JSON.stringify(list.map((m) => ({ info: m.info, parts: m.parts })))
         const userText = sizeOf(userMsgs)
         const asstText = sizeOf(asstMsgs)
+        const compactedOut = allMsgs.length - msgs.length
         const totalDetail = usage.authoritative ? "superseded by usage above" : "estimated"
+        const compactedNote = compactedOut > 0 ? ` · ${compactedOut} older compacted out` : ""
         const items: ContextItem[] = [
           {
-            label: `Total ${msgs.length} message(s)`,
+            label: `Total ${msgs.length} message(s) in context`,
             tokens: Token.estimate(messagesSerialized),
             chars: messagesSerialized.length,
-            detail: totalDetail,
+            detail: totalDetail + compactedNote,
           },
         ]
         if (userMsgs.length > 0) {
@@ -326,7 +332,7 @@ export const layer = Layer.effect(
             label: `User (${userMsgs.length})`,
             tokens: Token.estimate(userText),
             chars: userText.length,
-            detail: "prompts + attached parts",
+            detail: "prompts + attached parts (current session, post-compaction)",
           })
         }
         if (asstMsgs.length > 0) {
@@ -334,7 +340,7 @@ export const layer = Layer.effect(
             label: `Assistant (${asstMsgs.length}) — ${agent.name}`,
             tokens: Token.estimate(asstText),
             chars: asstText.length,
-            detail: "responses + tool calls + tool results",
+            detail: "responses + tool calls + tool results (current session, post-compaction)",
           })
         }
         return items

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -11,7 +11,7 @@ import { Instance } from "@/project/instance"
 import type { Agent } from "@/agent/agent"
 import type { MessageV2 } from "./message-v2"
 import { Plugin } from "@/plugin"
-import { SystemPrompt } from "./system"
+import { SessionAssemble } from "./assemble"
 import { Flag } from "@/flag/flag"
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
@@ -98,16 +98,12 @@ const live: Layer.Layer<
 
       const system: string[] = []
       system.push(
-        [
-          // use agent prompt otherwise provider prompt
-          ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
-          // any custom prompt passed into this call
-          ...input.system,
-          // any custom prompt from last user message
-          ...(input.user.system ? [input.user.system] : []),
-        ]
-          .filter((x) => x)
-          .join("\n"),
+        SessionAssemble.joinedHeader({
+          model: input.model,
+          agent: input.agent,
+          middle: input.system,
+          userSystem: input.user.system,
+        }),
       )
 
       const header = system[0]

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -5,6 +5,14 @@ import type { MessageV2 } from "./message-v2"
 
 const COMPACTION_BUFFER = 20_000
 
+// Single source of truth for "how many tokens does this assistant turn
+// represent in the context window?" — matches how providers bill/account for
+// prompt+completion usage. `total` is honored first when the provider reports
+// it; the explicit sum is the AI-SDK-compatible fallback.
+export function currentTokens(tokens: MessageV2.Assistant["tokens"]): number {
+  return tokens.total || tokens.input + tokens.output + tokens.cache.read + tokens.cache.write
+}
+
 export function usable(input: { cfg: Config.Info; model: Provider.Model }) {
   const context = input.model.limit.context
   if (context === 0) return 0
@@ -20,7 +28,7 @@ export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistan
   if (input.cfg.compaction?.auto === false) return false
   if (input.model.limit.context === 0) return false
 
-  const count =
-    input.tokens.total || input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
-  return count >= usable(input)
+  return currentTokens(input.tokens) >= usable(input)
 }
+
+export * as SessionOverflow from "./overflow"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,7 +1,6 @@
 import path from "path"
 import os from "os"
 import z from "zod"
-import * as EffectZod from "@/util/effect-zod"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import { Log } from "../util"
@@ -10,14 +9,14 @@ import * as Session from "./session"
 import { Agent } from "../agent/agent"
 import { Provider } from "../provider"
 import { ModelID, ProviderID } from "../provider/schema"
-import { type Tool as AITool, tool, jsonSchema, type ToolExecutionOptions, asSchema } from "ai"
+import { type Tool as AITool, tool, jsonSchema, type ToolExecutionOptions } from "ai"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import { SessionCompaction } from "./compaction"
 import { Bus } from "../bus"
-import { ProviderTransform } from "../provider"
 import { SystemPrompt } from "./system"
 import { Instruction } from "./instruction"
 import { Plugin } from "../plugin"
+import { SessionAssemble } from "./assemble"
 import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
@@ -63,8 +62,6 @@ IMPORTANT:
 - The input must be valid JSON matching the required schema
 - Complete all necessary research and tool calls BEFORE calling this tool
 - This tool provides your final answer - no further actions are taken after calling it`
-
-const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema.`
 
 const log = Log.create({ service: "session.prompt" })
 const elog = EffectLogger.create({ service: "session.prompt" })
@@ -406,10 +403,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         providerID: input.model.providerID,
         agent: input.agent,
       })) {
-        const schema = ProviderTransform.schema(input.model, EffectZod.toJsonSchema(item.parameters))
+        const rendered = SessionAssemble.renderBuiltinTool(input.model, item)
         tools[item.id] = tool({
-          description: item.description,
-          inputSchema: jsonSchema(schema),
+          description: rendered.description,
+          inputSchema: jsonSchema(rendered.schema),
           execute(args, options) {
             return run.promise(
               Effect.gen(function* () {
@@ -448,9 +445,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const execute = item.execute
         if (!execute) continue
 
-        const schema = yield* Effect.promise(() => Promise.resolve(asSchema(item.inputSchema).jsonSchema))
-        const transformed = ProviderTransform.schema(input.model, schema)
-        item.inputSchema = jsonSchema(transformed)
+        const rendered = yield* SessionAssemble.renderMcpTool(input.model, key, item)
+        item.inputSchema = jsonSchema(rendered.schema)
         item.execute = (args, opts) =>
           run.promise(
             Effect.gen(function* () {
@@ -1479,9 +1475,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
-            const system = [...env, ...(skills ? [skills] : []), ...instructions]
             const format = lastUser.format ?? { type: "text" as const }
-            if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
+            const system = SessionAssemble.middleSegments({ env, skills, instructions, format })
             const result = yield* handle.process({
               user: lastUser,
               agent,

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -125,7 +125,7 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
         : fallback
   const client = () => read()
   let depth = 0
-  let size: "medium" | "large" | "xlarge" = "medium"
+  let size: "medium" | "large" | "xlarge" | "full" = "medium"
   const has = opts.theme?.has ?? (() => false)
   let selected = opts.theme?.selected ?? "opencode"
   const key = {

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -77,7 +77,7 @@ export type TuiKeybindSet = {
 }
 
 export type TuiDialogProps = {
-  size?: "medium" | "large" | "xlarge"
+  size?: "medium" | "large" | "xlarge" | "full"
   onClose: () => void
   children?: JSX.Element
 }
@@ -85,8 +85,8 @@ export type TuiDialogProps = {
 export type TuiDialogStack = {
   replace: (render: () => JSX.Element, onClose?: () => void) => void
   clear: () => void
-  setSize: (size: "medium" | "large" | "xlarge") => void
-  readonly size: "medium" | "large" | "xlarge"
+  setSize: (size: "medium" | "large" | "xlarge" | "full") => void
+  readonly size: "medium" | "large" | "xlarge" | "full"
   readonly depth: number
   readonly open: boolean
 }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -119,6 +119,8 @@ import type {
   SessionChildrenResponses,
   SessionCommandErrors,
   SessionCommandResponses,
+  SessionContextErrors,
+  SessionContextResponses,
   SessionCreateErrors,
   SessionCreateResponses,
   SessionDeleteErrors,
@@ -2143,6 +2145,42 @@ export class Session2 extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * Get session context breakdown
+   *
+   * Compute a breakdown of what will be sent to the model on the next turn: system prompt, rules, skills, tool definitions, MCP tool definitions, and message history. Token counts for messages are taken from the last assistant turn's provider usage when available, and estimated otherwise.
+   */
+  public context<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      providerID: string
+      modelID: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "providerID" },
+            { in: "query", key: "modelID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionContextResponses, SessionContextErrors, ThrowOnError>({
+      url: "/session/{sessionID}/context",
+      ...options,
+      ...params,
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1914,6 +1914,46 @@ export type McpResource = {
   client: string
 }
 
+export type SessionContextUsage = {
+  authoritative: boolean
+  input: number
+  output: number
+  reasoning: number
+  cacheRead: number
+  cacheWrite: number
+  current: number
+  contextLimit: number
+  outputReserve: number
+  usable: number
+  overBudget: boolean
+  overflow: boolean
+}
+
+export type SessionContextItem = {
+  label: string
+  tokens: number
+  chars: number
+  detail?: string
+}
+
+export type SessionContextSection = {
+  key: "system" | "rules" | "skills" | "tools" | "mcp_tools" | "agent" | "messages"
+  label: string
+  tokens: number
+  chars: number
+  items: Array<SessionContextItem>
+}
+
+export type SessionContextInfo = {
+  model: {
+    providerID: string
+    modelID: string
+  }
+  agent: string
+  usage: SessionContextUsage
+  sections: Array<SessionContextSection>
+}
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -3745,6 +3785,42 @@ export type SessionSummarizeResponses = {
 }
 
 export type SessionSummarizeResponse = SessionSummarizeResponses[keyof SessionSummarizeResponses]
+
+export type SessionContextData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query: {
+    directory?: string
+    workspace?: string
+    providerID: string
+    modelID: string
+  }
+  url: "/session/{sessionID}/context"
+}
+
+export type SessionContextErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionContextError = SessionContextErrors[keyof SessionContextErrors]
+
+export type SessionContextResponses = {
+  /**
+   * Session context breakdown
+   */
+  200: SessionContextInfo
+}
+
+export type SessionContextResponse = SessionContextResponses[keyof SessionContextResponses]
 
 export type SessionMessagesData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1938,7 +1938,7 @@ export type SessionContextItem = {
 }
 
 export type SessionContextSection = {
-  key: "system" | "rules" | "skills" | "tools" | "mcp_tools" | "agent" | "messages"
+  key: "system" | "rules" | "skills" | "tools" | "mcp_tools" | "agent" | "messages" | "full_session"
   label: string
   tokens: number
   chars: number

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1934,6 +1934,7 @@ export type SessionContextItem = {
   tokens: number
   chars: number
   detail?: string
+  group?: string
 }
 
 export type SessionContextSection = {


### PR DESCRIPTION
### Issue for this PR

Related to #11995 — this doesn't fix it, but makes the context a session actually uses visible and inspectable in the TUI so users can reason about what's filling their window.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `/context` slash command (and matching `session_context` keybind) that opens a dialog summarizing context usage for the current session.

Top of the dialog shows the authoritative numbers OpenCode already tracks internally — same source the overflow check uses:

- current / usable tokens with a colored bar (green < 70%, yellow 70–90%, red ≥ 90% or overflow)
- context limit and reserved output budget
- in / out / reasoning / cache read / cache write from the last assistant turn
- flags for `OVERFLOW — compaction pending` and `OVER BUDGET — auto-compaction disabled`

Below that is a scrollable, diagnostic breakdown grouped into sections: system prompt, skills, rules / memory (AGENTS.md etc.), agent, built-in tools, MCP tools, per-tool MCP entries, messages, and the last user turn. The per-item numbers are labeled as estimates (chars/4 heuristic) because not every slice has a real token count; the authoritative number on top is what OpenCode trusts.

Implementation notes:

- New `SessionContext` service + `GET /:sessionID/context` route, used by the TUI via the SDK (SDK regenerated).
- New `session/assemble.ts` holds the system/tool/MCP rendering helpers that were previously duplicated in `session/prompt.ts` and `session/llm.ts`; both now call through the shared module so the `/context` breakdown can't drift from what actually gets sent to the model.
- `session/overflow.ts` gains a small `currentTokens(...)` helper used by both overflow detection and the context service, so the displayed `current` matches overflow math exactly.
- Small framework addition: `Dialog` gets a `"full"` size tier (near-full terminal width, smaller top padding) so the breakdown has room to scroll. Plugin `Dialog` type union is widened to match; existing `medium/large/xlarge` behavior is unchanged.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` (clean).
- Ran `bun run dev` locally and exercised the feature on a real session:
  - `/context` opens the dialog
  - authoritative numbers match what the existing footer shows for the session
  - bar color changes with pressure; confirmed with a short and a large session
  - breakdown scrolls with ↑/↓ and PgUp/PgDn without clipping right/bottom
  - `Esc` closes the dialog and returns focus to the prompt
- Pre-existing fixture `test/fixture/tui-plugin.ts` updated to the widened size union so the plugin API typechecks.

### Screenshots / recordings

n/a — TUI-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
