### PR TITLE
Fix shell cwd after login startup

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -798,9 +798,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             `
               [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
               [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
-              cd "$OPENCODE_CWD"
+              cd -- "$1"
               eval ${JSON.stringify(input.command)}
             `,
+            "opencode",
+            cwd,
           ],
         },
         bash: {
@@ -810,9 +812,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             `
               shopt -s expand_aliases
               [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
-              cd "$OPENCODE_CWD"
+              cd -- "$1"
               eval ${JSON.stringify(input.command)}
             `,
+            "opencode",
+            cwd,
           ],
         },
         cmd: { args: ["/c", input.command] },
@@ -831,7 +835,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const cmd = ChildProcess.make(sh, args, {
         cwd,
         extendEnv: true,
-        env: { ...shellEnv.env, OPENCODE_CWD: cwd, TERM: "dumb" },
+        env: { ...shellEnv.env, TERM: "dumb" },
         stdin: "ignore",
         forceKillAfter: "3 seconds",
       })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -787,6 +787,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const shellName = (
         process.platform === "win32" ? path.win32.basename(sh, ".exe") : path.basename(sh)
       ).toLowerCase()
+      const cwd = ctx.directory
       const invocations: Record<string, { args: string[] }> = {
         nu: { args: ["-c", input.command] },
         fish: { args: ["-c", input.command] },
@@ -795,10 +796,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             "-l",
             "-c",
             `
-              __oc_cwd=$PWD
               [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
               [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
-              cd "$__oc_cwd"
+              cd "$OPENCODE_CWD"
               eval ${JSON.stringify(input.command)}
             `,
           ],
@@ -808,10 +808,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             "-l",
             "-c",
             `
-              __oc_cwd=$PWD
               shopt -s expand_aliases
               [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
-              cd "$__oc_cwd"
+              cd "$OPENCODE_CWD"
               eval ${JSON.stringify(input.command)}
             `,
           ],
@@ -823,7 +822,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
 
       const args = (invocations[shellName] ?? invocations[""]).args
-      const cwd = ctx.directory
       const shellEnv = yield* plugin.trigger(
         "shell.env",
         { cwd, sessionID: input.sessionID, callID: part.callID },
@@ -833,7 +831,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const cmd = ChildProcess.make(sh, args, {
         cwd,
         extendEnv: true,
-        env: { ...shellEnv.env, TERM: "dumb" },
+        env: { ...shellEnv.env, OPENCODE_CWD: cwd, TERM: "dumb" },
         stdin: "ignore",
         forceKillAfter: "3 seconds",
       })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1078,6 +1078,30 @@ unix("shell completes a fast command on the preferred shell", () =>
   ),
 )
 
+unix("shell commands can change directory after startup", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { prompt, run, chat } = yield* boot()
+        const parent = path.dirname(dir)
+        const result = yield* prompt.shell({
+          sessionID: chat.id,
+          agent: "build",
+          command: "cd .. && pwd",
+        })
+
+        expect(result.info.role).toBe("assistant")
+        const tool = completedTool(result.parts)
+        if (!tool) return
+
+        expect(tool.state.output).toContain(parent)
+        expect(tool.state.metadata.output).toContain(parent)
+        yield* run.assertNotBusy(chat.id)
+      }),
+    { git: true, config: cfg },
+  ),
+)
+
 unix("shell lists files from the project directory", () =>
   provideTmpdirInstance(
     (dir) =>


### PR DESCRIPTION
## Summary
- Preserve the instance directory explicitly when running shell commands through login shell wrappers.
- Avoid relying on `$PWD` after shell startup files run, since CI can reset it to the repository workspace.

## Testing
- `bun run test test/session/prompt.test.ts -t "shell completes a fast command on the preferred shell"`
- `bun run test test/session/prompt.test.ts`
- `bun typecheck`

## Context
Linux unit CI began failing on `test/session/prompt.test.ts` with `pwd` returning `/home/runner/_work/opencode/opencode` instead of the temp instance directory. The failure appears on current `dev` and does not reproduce on macOS locally.