### PR TITLE
fix(provider): auto-enable interleaved for reasoning models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1177,7 +1177,7 @@ const layer: Layer.Layer<
                     model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
                   pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
                 },
-                interleaved: model.interleaved ?? existingModel?.capabilities.interleaved ?? false,
+                interleaved: model.interleaved ?? existingModel?.capabilities.interleaved ?? (model.reasoning ? { field: "reasoning_content" } : false),
               },
               cost: {
                 input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,


### PR DESCRIPTION
### Issue for this PR

Closes #24104 (related)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When using @ai-sdk/openai-compatible with a model configured with reasoning: true, the interleaved capability defaulted to false. This caused reasoning_content in providerOptions to be silently dropped during message replay.

The fix is a one-line change in provider.ts: if model.interleaved is not explicitly set and no existing model data provides it, check model.reasoning and default to { field: "reasoning_content" } instead of false.

### How did you verify your code works?

- Tested locally with reasoning: true and no explicit interleaved → correctly defaults to { field: "reasoning_content" }
- Non-reasoning models still default to false (no regression)
- Explicit interleaved config still takes priority
- Models from models.dev with own interleaved data unaffected

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
