### PR TITLE
docs: sync env vars with source code

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -557,30 +557,38 @@ OpenCode can be configured using environment variables.
 | Variable                              | Type    | Description                                       |
 | ------------------------------------- | ------- | ------------------------------------------------- |
 | `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
+| `OPENCODE_AUTH_CONTENT`               | string  | Inline JSON auth credentials                      |
 | `OPENCODE_CONFIG`                     | string  | Path to config file                               |
-| `OPENCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
 | `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
 | `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
-| `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads            |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models                        |
 | `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction              |
+| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
 | `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
 | `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
 | `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
+| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |
+| `OPENCODE_DISABLE_EXTERNAL_SKILLS`    | boolean | Disable loading skills from npm packages          |
+| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads            |
 | `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
 | `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
-| `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
-| `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
+| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
+| `OPENCODE_DISABLE_PROJECT_CONFIG`     | boolean | Disable loading project-level config              |
+| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
 | `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
+| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models                        |
+| `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
+| `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
+| `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
+| `OPENCODE_MODELS_PATH`                | string  | Custom path for models JSON cache file            |
+| `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
+| `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
 | `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
 | `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
-| `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
+| `OPENCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
+| `EXA_API_KEY`                         | string  | API key for Exa web search (requires `OPENCODE_ENABLE_EXA`) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`        | string  | OpenTelemetry OTLP exporter endpoint              |
+| `OTEL_EXPORTER_OTLP_HEADERS`          | string  | OpenTelemetry OTLP exporter headers               |
+| `OTEL_RESOURCE_ATTRIBUTES`            | string  | OpenTelemetry resource attributes (key=value pairs) |
 
 ---
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -555,6 +555,8 @@ Cloudflare AI Gateway lets you access models from OpenAI, Anthropic, Workers AI,
    export CLOUDFLARE_API_TOKEN=your-api-token
    ```
 
+   `CF_AIG_TOKEN` is also accepted as an alias for `CLOUDFLARE_API_TOKEN`.
+
 ---
 
 ### Cloudflare Workers AI
@@ -958,8 +960,15 @@ To use Google Vertex AI with OpenCode:
    :::
 
 2. Set the required environment variables:
-   - `GOOGLE_CLOUD_PROJECT`: Your Google Cloud project ID
-   - `VERTEX_LOCATION` (optional): The region for Vertex AI (defaults to `global`)
+   - Project ID (one of):
+     - `GOOGLE_CLOUD_PROJECT`
+     - `GCP_PROJECT`
+     - `GCLOUD_PROJECT`
+   - Location (optional, checked in this order):
+     - `GOOGLE_VERTEX_LOCATION`
+     - `GOOGLE_CLOUD_LOCATION`
+     - `VERTEX_LOCATION`
+     - Defaults to `us-central1` if none are set
    - Authentication (choose one):
      - `GOOGLE_APPLICATION_CREDENTIALS`: Path to your service account JSON key file
      - Authenticate using gcloud CLI: `gcloud auth application-default login`
@@ -975,11 +984,11 @@ To use Google Vertex AI with OpenCode:
    ```bash title="~/.bash_profile"
    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
    export GOOGLE_CLOUD_PROJECT=your-project-id
-   export VERTEX_LOCATION=global
+   export VERTEX_LOCATION=us-central1
    ```
 
 :::tip
-The `global` region improves availability and reduces errors at no extra cost. Use regional endpoints (e.g., `us-central1`) for data residency requirements. [Learn more](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-partner-models#regional_and_global_endpoints)
+The `global` region improves availability and reduces errors at no extra cost. Use it by setting `VERTEX_LOCATION=global`. Use regional endpoints (e.g., `us-central1`) for data residency requirements. [Learn more](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-partner-models#regional_and_global_endpoints)
 :::
 
 3. Run the `/models` command to select the model you want.

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -115,7 +115,7 @@ If your `opencode.json(c)` contains a `server` section, temporarily remove it an
 
 #### Check environment variables
 
-If you have `OPENCODE_PORT` set in your environment, the desktop app will try to use that port for the local server.
+If you have `OPENCODE_PORT` set in your environment, the desktop app will try to use that port for the local server. This env var only affects the desktop app, not the CLI.
 
 - Unset `OPENCODE_PORT` (or pick a free port) and restart.
 

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -115,7 +115,7 @@ If your `opencode.json(c)` contains a `server` section, temporarily remove it an
 
 #### Check environment variables
 
-If you have `OPENCODE_PORT` set in your environment, the desktop app will try to use that port for the local server. This env var only affects the desktop app, not the CLI.
+If you have `OPENCODE_PORT` set in your environment, the desktop app will try to use that port for the local server.
 
 - Unset `OPENCODE_PORT` (or pick a free port) and restart.
 


### PR DESCRIPTION
### Issue for this PR

Closes #24235

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Syncs env var docs with source code. Two files changed:

- cli.mdx - added 8 missing vars, sorted alphabetically
- providers.mdx - fixed Vertex AI default location, documented alternate env var names and CF_AIG_TOKEN alias

### How did I verify my code works?

Compared every env var in the docs against flag.ts, provider.ts, auth/index.ts, observability.ts, and mcp-exa.ts.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR