### PR TITLE
fix: lazy session error schema

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -284,7 +284,8 @@ export const Event = {
       sessionID: Schema.optional(SessionID),
       // Reuses MessageV2.Assistant.fields.error (already Schema.optional) so
       // the derived zod keeps the same discriminated-union shape on the bus.
-      error: MessageV2.Assistant.fields.error,
+      // Schema.suspend defers access to break circular init in compiled binaries.
+      error: Schema.suspend(() => MessageV2.Assistant.fields.error),
     }),
   ),
 }

--- a/packages/opencode/src/util/effect-zod.ts
+++ b/packages/opencode/src/util/effect-zod.ts
@@ -256,6 +256,8 @@ function body(ast: SchemaAST.AST): z.ZodTypeAny {
       return array(ast)
     case "Declaration":
       return decl(ast)
+    case "Suspend":
+      return z.lazy(() => walk(ast.thunk()))
     default:
       return fail(ast)
   }


### PR DESCRIPTION
## Summary
- Defer `MessageV2.Assistant.fields.error` access with `Schema.suspend` to avoid compiled binary circular initialization crashes.
- Add `Suspend` support to the Effect Schema to Zod walker so OpenAPI/event payload generation still handles the suspended field.

## Test
- `bun typecheck` from `packages/opencode`
- `bun ./script/build.ts --single` from `packages/opencode`
- `bun -e "const session = await import('./src/session/session.ts'); const { BusEvent } = await import('./src/bus/bus-event.ts'); console.log(BusEvent.payloads().length, session.Event.Error.type)"` from `packages/opencode`