### PR TITLE
fix: validate beta before pushing

### DIFF
--- a/script/beta.ts
+++ b/script/beta.ts
@@ -81,6 +81,39 @@ async function build() {
   }
 }
 
+async function validate() {
+  if (!(await typecheck())) return false
+  if (!(await build())) return false
+  return true
+}
+
+async function commitSmokeChanges() {
+  const out = await $`git status --porcelain`.text()
+  if (!out.trim()) {
+    console.log("Smoke check passed")
+    return true
+  }
+
+  try {
+    await $`git add -A`
+    await $`git commit -m "Fix beta integration"`
+  } catch (err) {
+    console.log(`Failed to commit smoke fixes: ${err}`)
+    return false
+  }
+
+  if (!(await validate())) return false
+
+  const left = await $`git status --porcelain`.text()
+  if (!left.trim()) {
+    console.log("Smoke check passed")
+    return true
+  }
+
+  console.log(`Smoke check left uncommitted changes:\n${left}`)
+  return false
+}
+
 async function install() {
   console.log("  Regenerating bun.lock...")
 
@@ -143,11 +176,15 @@ async function fix(pr: PR, files: string[], prs: PR[], applied: number[], idx: n
 }
 
 async function smoke(prs: PR[], applied: number[]) {
-  console.log("\nRunning final smoke check with opencode...")
+  console.log("\nRunning final smoke check...")
+
+  if (await validate()) return commitSmokeChanges()
+
+  console.log("\nTrying to fix final smoke check with opencode...")
 
   const done = lines(prs.filter((x) => applied.includes(x.number)))
   const prompt = [
-    "The beta merge batch is complete.",
+    "The beta merge batch is complete, but the deterministic final smoke check failed.",
     `Merged PRs on HEAD:\n${done}`,
     "Run `bun typecheck` at the repo root.",
     "Run `./script/build.ts --single` in `packages/opencode`.",
@@ -162,38 +199,8 @@ async function smoke(prs: PR[], applied: number[]) {
     return false
   }
 
-  if (!(await typecheck())) {
-    return false
-  }
-
-  if (!(await build())) {
-    return false
-  }
-
-  const out = await $`git status --porcelain`.text()
-  if (!out.trim()) {
-    console.log("Smoke check passed")
-    return true
-  }
-
-  try {
-    await $`git add -A`
-    await $`git commit -m "Fix beta integration"`
-  } catch (err) {
-    console.log(`Failed to commit smoke fixes: ${err}`)
-    return false
-  }
-
-  if (!(await typecheck())) {
-    return false
-  }
-
-  if (!(await build())) {
-    return false
-  }
-
-  console.log("Smoke check passed")
-  return true
+  if (!(await validate())) return false
+  return commitSmokeChanges()
 }
 
 async function main() {
@@ -294,27 +301,26 @@ async function main() {
     throw new Error(`${failed.length} PR(s) failed to merge`)
   }
 
-  if (applied.length > 0) {
-    console.log("\nSkipping final smoke check")
-  }
-
   console.log("\nChecking if beta branch has changes...")
   await $`git fetch origin beta`
 
-  const localTree = await $`git rev-parse beta^{tree}`.text()
-  const remoteTrees = (await $`git log origin/dev..origin/beta --format=%T`.text()).split("\n")
+  const remoteTree = (await $`git rev-parse origin/beta^{tree}`.text()).trim()
+  const localTree = (await $`git rev-parse beta^{tree}`.text()).trim()
 
-  const matchIdx = remoteTrees.indexOf(localTree.trim())
-  if (matchIdx !== -1) {
-    if (matchIdx !== 0) {
-      console.log(`Beta branch contains this sync, but additional commits exist after it. Leaving beta branch as is.`)
-    } else {
-      console.log("Beta branch has identical contents, no push needed")
-    }
+  if (localTree === remoteTree) {
+    console.log("Beta branch has identical contents, no push needed")
     return
   }
 
-  console.log("Force pushing beta branch...")
+  if (!(await smoke(prs, applied))) throw new Error("Final smoke check failed")
+
+  const validatedTree = (await $`git rev-parse beta^{tree}`.text()).trim()
+  if (validatedTree === remoteTree) {
+    console.log("Validated beta branch now matches remote contents, no push needed")
+    return
+  }
+
+  console.log("Force pushing validated beta branch...")
   await $`git push origin beta --force --no-verify`
 
   console.log("Successfully synced beta branch")

--- a/script/beta.ts
+++ b/script/beta.ts
@@ -304,19 +304,32 @@ async function main() {
   console.log("\nChecking if beta branch has changes...")
   await $`git fetch origin beta`
 
-  const remoteTree = (await $`git rev-parse origin/beta^{tree}`.text()).trim()
   const localTree = (await $`git rev-parse beta^{tree}`.text()).trim()
+  const remoteTrees = (await $`git log origin/dev..origin/beta --format=%T`.text()).split("\n")
 
-  if (localTree === remoteTree) {
-    console.log("Beta branch has identical contents, no push needed")
+  const matchIdx = remoteTrees.indexOf(localTree)
+  if (matchIdx !== -1) {
+    if (matchIdx !== 0) {
+      console.log(`Beta branch contains this sync, but additional commits exist after it. Leaving beta branch as is.`)
+    } else {
+      console.log("Beta branch has identical contents, no push needed")
+    }
     return
   }
 
   if (!(await smoke(prs, applied))) throw new Error("Final smoke check failed")
 
+  await $`git fetch origin beta`
+
   const validatedTree = (await $`git rev-parse beta^{tree}`.text()).trim()
-  if (validatedTree === remoteTree) {
-    console.log("Validated beta branch now matches remote contents, no push needed")
+  const remoteTreesAfterSmoke = (await $`git log origin/dev..origin/beta --format=%T`.text()).split("\n")
+  const matchIdxAfterSmoke = remoteTreesAfterSmoke.indexOf(validatedTree)
+  if (matchIdxAfterSmoke !== -1) {
+    if (matchIdxAfterSmoke !== 0) {
+      console.log(`Beta branch contains this validated sync, but additional commits exist after it. Leaving beta branch as is.`)
+    } else {
+      console.log("Validated beta branch now matches remote contents, no push needed")
+    }
     return
   }
 


### PR DESCRIPTION
## Summary
- Run the final beta smoke check before force-pushing so broken candidates fail the sync instead of moving beta.
- Keep the existing opencode repair path, then re-run typecheck and single-platform build before accepting generated fixes.
- Skip the push only when current origin/beta already has the candidate tree.

## Test
- git diff --check
- bun build script/beta.ts --target bun --outfile $env:TEMP\opencode-beta-check.js