### PR TITLE
fix(session): honor noCacheTokens in usage accounting

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -322,11 +322,21 @@ export const getUsage = (input: { model: Provider.Model; usage: LanguageModelUsa
         0,
     ),
   )
+  const noCacheInputTokens = input.usage.inputTokenDetails?.noCacheTokens
 
   // AI SDK v6 normalized inputTokens to include cached tokens across all providers
   // (including Anthropic/Bedrock which previously excluded them). Always subtract cache
   // tokens to get the non-cached input count for separate cost calculation.
-  const adjustedInputTokens = safe(inputTokens - cacheReadInputTokens - cacheWriteInputTokens)
+  // When the SDK reports an explicit noCacheTokens field, trust it directly; some
+  // OpenAI-compatible providers only populate cachedInputTokens at the top level
+  // and leave inputTokens equal to prompt_tokens (which already includes cached),
+  // so a blind subtraction would double-count the cached portion.
+  const adjustedInputTokens = Math.max(
+    0,
+    noCacheInputTokens === undefined
+      ? safe(inputTokens - cacheReadInputTokens - cacheWriteInputTokens)
+      : safe(noCacheInputTokens - cacheWriteInputTokens),
+  )
 
   const total = input.usage.totalTokens
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1915,6 +1915,70 @@ describe("SessionNs.getUsage", () => {
     expect(result.tokens.cache.read).toBe(200)
   })
 
+  test("uses cachedInputTokens without double-counting when noCacheTokens is absent", () => {
+    // Repro for openai-compatible providers (e.g. DeepSeek, Moonshot) that report
+    // cachedInputTokens at the top level but leave inputTokenDetails empty. Upstream
+    // reports input=0, cache.read=0 because inputTokens already includes cached tokens
+    // and the fallback path subtracted them while cacheReadInputTokens also picked
+    // cachedInputTokens up, leading to a negative (clamped to 0) and missing cache.
+    const model = createModel({
+      context: 262_144,
+      output: 32_000,
+      cost: {
+        input: 0.95,
+        output: 4,
+        cache: { read: 0.16, write: 0 },
+      },
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: {
+        inputTokens: 14,
+        outputTokens: 43,
+        totalTokens: 57,
+        cachedInputTokens: 14,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: 43,
+          reasoningTokens: undefined,
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(0)
+    expect(result.tokens.cache.read).toBe(14)
+    expect(result.cost).toBeCloseTo((14 * 0.16 + 43 * 4) / 1_000_000, 10)
+  })
+
+  test("prefers explicit noCacheTokens when provider reports it alongside cachedInputTokens", () => {
+    const model = createModel({ context: 262_144, output: 32_000 })
+    const result = SessionNs.getUsage({
+      model,
+      usage: {
+        inputTokens: 36_441,
+        outputTokens: 17,
+        totalTokens: 36_458,
+        cachedInputTokens: 36_352,
+        inputTokenDetails: {
+          noCacheTokens: 89,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: 17,
+          reasoningTokens: undefined,
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(89)
+    expect(result.tokens.cache.read).toBe(36_352)
+  })
+
   test("handles anthropic cache write metadata", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     const result = SessionNs.getUsage({


### PR DESCRIPTION
### Issue for this PR

Closes #24189

### Type of change

- [x] Bug fix

### What does this PR do?

Some OpenAI-compatible providers (DeepSeek, Moonshot) report cached tokens via `usage.cachedInputTokens` and leave `usage.inputTokenDetails` empty. `usage.inputTokens` in that case equals raw `prompt_tokens`, which already includes the cached portion, so the current `inputTokens - cacheRead - cacheWrite` adjustment double-counts and goes negative — which is why #24189 sees `Cache Read: 0` on large prompts.

Prefer `inputTokenDetails.noCacheTokens` when the SDK populates it, and clamp the fallback at zero. No change for providers that already populate `inputTokenDetails` (Anthropic, Bedrock, Vertex).

### How did you verify your code works?

Two tests in `compaction.test.ts`: one reproducing the broken DeepSeek/Moonshot shape, one guarding the Anthropic-style path. `bun test test/session/compaction.test.ts` passes, `bun typecheck` clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR