### PR TITLE
fix(provider): honor per-model reasoning token pricing

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -23,12 +23,14 @@ export const Model = Schema.Struct({
     Schema.Struct({
       input: Schema.Number,
       output: Schema.Number,
+      reasoning: Schema.optional(Schema.Number),
       cache_read: Schema.optional(Schema.Number),
       cache_write: Schema.optional(Schema.Number),
       context_over_200k: Schema.optional(
         Schema.Struct({
           input: Schema.Number,
           output: Schema.Number,
+          reasoning: Schema.optional(Schema.Number),
           cache_read: Schema.optional(Schema.Number),
           cache_write: Schema.optional(Schema.Number),
         }),

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -24,12 +24,14 @@ const ttl = 5 * 60 * 1000
 const Cost = Schema.Struct({
   input: Schema.Number,
   output: Schema.Number,
+  reasoning: Schema.optional(Schema.Number),
   cache_read: Schema.optional(Schema.Number),
   cache_write: Schema.optional(Schema.Number),
   context_over_200k: Schema.optional(
     Schema.Struct({
       input: Schema.Number,
       output: Schema.Number,
+      reasoning: Schema.optional(Schema.Number),
       cache_read: Schema.optional(Schema.Number),
       cache_write: Schema.optional(Schema.Number),
     }),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -855,11 +855,13 @@ const ProviderCacheCost = Schema.Struct({
 const ProviderCost = Schema.Struct({
   input: Schema.Number,
   output: Schema.Number,
+  reasoning: Schema.optional(Schema.Number),
   cache: ProviderCacheCost,
   experimentalOver200K: Schema.optional(
     Schema.Struct({
       input: Schema.Number,
       output: Schema.Number,
+      reasoning: Schema.optional(Schema.Number),
       cache: ProviderCacheCost,
     }),
   ),
@@ -949,6 +951,7 @@ function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
   const result: Model["cost"] = {
     input: c?.input ?? 0,
     output: c?.output ?? 0,
+    reasoning: c?.reasoning,
     cache: {
       read: c?.cache_read ?? 0,
       write: c?.cache_write ?? 0,
@@ -962,6 +965,7 @@ function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
       },
       input: c.context_over_200k.input,
       output: c.context_over_200k.output,
+      reasoning: c.context_over_200k.reasoning,
     }
   }
   return result
@@ -1182,6 +1186,7 @@ const layer: Layer.Layer<
               cost: {
                 input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
                 output: model?.cost?.output ?? existingModel?.cost?.output ?? 0,
+                reasoning: model?.cost?.reasoning ?? existingModel?.cost?.reasoning,
                 cache: {
                   read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
                   write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -352,9 +352,9 @@ export const getUsage = (input: { model: Provider.Model; usage: LanguageModelUsa
         .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
         .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
         .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
-        // TODO: update models.dev to have better pricing model, for now:
-        // charge reasoning tokens at the same rate as output tokens
-        .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
+        // Use the model's explicit reasoning rate when models.dev (or user config)
+        // exposes one, otherwise fall back to the output rate as before.
+        .add(new Decimal(tokens.reasoning).mul(costInfo?.reasoning ?? costInfo?.output ?? 0).div(1_000_000))
         .toNumber(),
     ),
     tokens,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -2089,6 +2089,62 @@ describe("SessionNs.getUsage", () => {
     expect(result.cost).toBe(3 + 1.5)
   })
 
+  test("uses explicit reasoning price when the model exposes one", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      cost: {
+        input: 0.6,
+        output: 4,
+        reasoning: 1,
+        cache: { read: 0.15, write: 0 },
+      },
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 120,
+        totalTokens: 1120,
+        inputTokenDetails: {
+          noCacheTokens: 800,
+          cacheReadTokens: 200,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: 20,
+          reasoningTokens: 100,
+        },
+      },
+    })
+
+    expect(result.cost).toBeCloseTo((800 * 0.6 + 20 * 4 + 100 * 1 + 200 * 0.15) / 1_000_000, 10)
+  })
+
+  test("falls back to output price for reasoning tokens when no reasoning cost is set", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      cost: {
+        input: 0.6,
+        output: 4,
+        cache: { read: 0, write: 0 },
+      },
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        inputTokenDetails: { noCacheTokens: 100, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+        outputTokenDetails: { textTokens: 20, reasoningTokens: 30 },
+      },
+    })
+
+    expect(result.cost).toBeCloseTo((100 * 0.6 + 20 * 4 + 30 * 4) / 1_000_000, 10)
+  })
+
   test.each(["@ai-sdk/anthropic", "@ai-sdk/amazon-bedrock", "@ai-sdk/google-vertex/anthropic"])(
     "computes total from components for %s models",
     (npm) => {


### PR DESCRIPTION
### Issue for this PR

Closes #24231

### Type of change

- [x] Bug fix

### What does this PR do?

Addresses the `TODO` in `Session.getUsage` that hardcoded reasoning tokens at the output rate. Adds an optional `reasoning` price to the cost schemas (`config/provider.ts`, `provider/models.ts`, `provider/provider.ts`), threads it through the user-override merge, and uses it in `getUsage` with the output rate as fallback.

Backward compatible — when `cost.reasoning` is absent, behavior is unchanged.

### How did you verify your code works?

Two tests in `compaction.test.ts`: one asserting reasoning tokens are charged at `cost.reasoning` when set, one guarding the fallback path. `bun test test/session/compaction.test.ts` passes, `bun typecheck` clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR