### PR TITLE
fix(config): detect non-object frontmatter data from gray-matter

### DIFF
--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -72,10 +72,20 @@ export async function parse(filePath: string) {
 
   try {
     const md = matter(template)
+    // gray-matter may return md.data as a string instead of an object when YAML
+    // is malformed (e.g. "skill:true" without space after colon). Treat this as
+    // a parse failure so the fallback sanitizer gets a chance to fix it.
+    if (typeof md.data !== "object" || md.data === null || Array.isArray(md.data)) {
+      throw new Error("frontmatter parsed as non-object")
+    }
     return md
   } catch {
     try {
-      return matter(fallbackSanitization(template))
+      const fallback = matter(fallbackSanitization(template))
+      if (typeof fallback.data !== "object" || fallback.data === null || Array.isArray(fallback.data)) {
+        throw new Error("frontmatter parsed as non-object after sanitization")
+      }
+      return fallback
     } catch (err) {
       throw new FrontmatterError(
         {

--- a/packages/opencode/test/config/fixtures/invalid-yaml-frontmatter.md
+++ b/packages/opencode/test/config/fixtures/invalid-yaml-frontmatter.md
@@ -1,0 +1,5 @@
+---
+skill:true
+---
+
+This agent has a single invalid YAML line that gray-matter parses as a plain string.

--- a/packages/opencode/test/config/markdown.test.ts
+++ b/packages/opencode/test/config/markdown.test.ts
@@ -211,6 +211,42 @@ Always structure your responses using clear markdown formatting:
   })
 })
 
+describe("ConfigMarkdown: frontmatter with invalid YAML throws FrontmatterError", () => {
+  test("should throw FrontmatterError for unfixable invalid YAML", async () => {
+    try {
+      await ConfigMarkdown.parse(import.meta.dir + "/fixtures/invalid-yaml-frontmatter.md")
+      // should not reach here
+      expect(true).toBe(false)
+    } catch (err) {
+      expect(ConfigMarkdown.FrontmatterError.isInstance(err)).toBe(true)
+    }
+  })
+
+  test("should throw for frontmatter that parses as a non-object type", async () => {
+    // gray-matter can return numbers, booleans, arrays, or strings for
+    // certain malformed YAML.  All of these should be caught.
+    const cases = [
+      "---\n42\n---\ncontent",          // number
+      "---\ntrue\n---\ncontent",        // boolean
+      "---\n- item\n---\ncontent",      // array
+      "---\njust text\n---\ncontent",   // string
+    ]
+    for (const input of cases) {
+      const tmp = import.meta.dir + "/fixtures/_temp_nonobject.md"
+      const { writeFileSync, unlinkSync } = await import("fs")
+      writeFileSync(tmp, input)
+      try {
+        await ConfigMarkdown.parse(tmp)
+        expect(`should have thrown for: ${input}`).toBe("")
+      } catch (err) {
+        expect(ConfigMarkdown.FrontmatterError.isInstance(err)).toBe(true)
+      } finally {
+        try { unlinkSync(tmp) } catch {}
+      }
+    }
+  })
+})
+
 describe("ConfigMarkdown: frontmatter has weird model id", async () => {
   const result = await ConfigMarkdown.parse(import.meta.dir + "/fixtures/weird-model-id.md")
 


### PR DESCRIPTION
### Issue for this PR

Closes #24181

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`gray-matter` silently returns `md.data` as a string (or number, boolean, array) instead of throwing when YAML is malformed (e.g. `skill:true` without space after colon). The `...md.data` spread in `agent.ts` then produces garbage properties like `{0:'s', 1:'k', ...}`, and if `safeParse` still passes (because `name` from filename and `prompt` from content are valid), the agent loads with degraded config — no tools, no permissions, no model override — with zero error feedback.

The fix adds a type guard in `ConfigMarkdown.parse()` after both the initial `matter()` call and the fallback sanitization pass. If `md.data` is not a plain object, it's treated as a parse failure, which surfaces a `FrontmatterError` with a clear message pointing to the problematic file.

### How did you verify your code works?

- Added test fixture with `skill:true` (no space after colon) that triggers gray-matter's silent string return
- Added test verifying `FrontmatterError` is thrown for this case
- Added parameterized test covering all non-object return types: number (`42`), boolean (`true`), array (`- item`), and string (`just text`)
- All 39 tests pass in `test/config/markdown.test.ts`
- Verified existing tests (valid YAML, empty frontmatter, no frontmatter, markdown headers, weird model IDs) still pass unchanged

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR