### PR TITLE
fix: preserve nix/direnv PATH in login shell for ! commands

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1664,8 +1664,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           "-c",
           "-l",
           `
+            _opencode_path="$PATH"
             [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
             [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
+            export PATH="$_opencode_path:$PATH"
             eval ${JSON.stringify(input.command)}
           `,
         ],
@@ -1675,8 +1677,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           "-c",
           "-l",
           `
+            _opencode_path="$PATH"
             shopt -s expand_aliases
             [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
+            export PATH="$_opencode_path:$PATH"
             eval ${JSON.stringify(input.command)}
           `,
         ],


### PR DESCRIPTION
### Issue for this PR

Closes #6468 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I added a small workaround in the shell invocation: I save $PATH first, then source profiles, then put the saved PATH back in front with export. It's simple and doesn't change the rest of the shell behavior.

### How did you verify your code works?

1. Entered a Nix dev environment (`nix develop` or `direnv`) where `just` and `bun` are available.
2. Launched OpenCode inside this environment.
3. Executed `!which just` and `!just --version` via the TUI. Before the fix, these failed; after the fix, they succeed.
4. Tested in a normal (non‑Nix) terminal with `!ls` and `!echo $PATH` to ensure no regression.

### Screenshots / recordings

N/A (no UI changes).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
