### PR TITLE
fix(provider): complete DeepSeek reasoning_content round-trip for multi-turn conversations

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1177,7 +1177,7 @@ const layer: Layer.Layer<
                     model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
                   pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
                 },
-                interleaved: model.interleaved ?? existingModel?.capabilities.interleaved ?? false,
+                interleaved: model.interleaved ?? existingModel?.capabilities.interleaved ?? (model.reasoning ? { field: "reasoning_content" } : false),
               },
               cost: {
                 input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -208,14 +208,18 @@ function normalizeMessages(
         // Include reasoning_content | reasoning_details directly on the message for all assistant messages.
         // Always set the field even when empty — some providers (e.g. DeepSeek) may return empty
         // reasoning_content which still needs to be sent back in subsequent requests.
+        // Preserve existing providerOptions[field] when content no longer has reasoning
+        // parts (e.g. after a prior transform pass already extracted them). The first
+        // pass sets the field from reasoning parts; on subsequent passes reasoningText
+        // is empty and must not overwrite the preserved value from DB.
         return {
           ...msg,
           content: filteredContent,
           providerOptions: {
             ...msg.providerOptions,
             [sdk]: {
-              ...msg.providerOptions?.[sdk],
               [field]: reasoningText,
+              ...msg.providerOptions?.[sdk],
             },
           },
         }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -176,7 +176,8 @@ function normalizeMessages(
   }
 
   // Deepseek requires all assistant messages to have reasoning on them
-  if (model.api.id.includes("deepseek")) {
+  // Check both API ID and model ID to cover OpenRouter-routed DeepSeek models
+  if (model.api.id.includes("deepseek") || model.id.includes("deepseek")) {
     msgs = msgs.map((msg) => {
       if (msg.role !== "assistant") return msg
       if (Array.isArray(msg.content)) {
@@ -195,6 +196,7 @@ function normalizeMessages(
 
   if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
     const field = model.capabilities.interleaved.field
+    const sdk = sdkKey(model.api.npm) ?? "openaiCompatible"
     return msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
         const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
@@ -211,14 +213,44 @@ function normalizeMessages(
           content: filteredContent,
           providerOptions: {
             ...msg.providerOptions,
-            openaiCompatible: {
-              ...msg.providerOptions?.openaiCompatible,
+            [sdk]: {
+              ...msg.providerOptions?.[sdk],
               [field]: reasoningText,
             },
           },
         }
       }
 
+      return msg
+    })
+  }
+
+  // When reasoning is active but interleaved is not configured, still inject empty reasoning_content
+  // for ALL assistant messages. This covers historical messages from DB that were stored before
+  // reasoning mode was enabled — they have no reasoning part to extract but DeepSeek's API still
+  // requires reasoning_content on every assistant turn in thinking mode.
+  if (model.capabilities.reasoning) {
+    msgs = msgs.map((msg) => {
+      if (msg.role !== "assistant") return msg
+      if (Array.isArray(msg.content)) {
+        const sdk = sdkKey(model.api.npm) ?? "openaiCompatible"
+        return {
+          ...msg,
+          providerOptions: {
+            ...msg.providerOptions,
+            [sdk]: {
+              ...msg.providerOptions?.[sdk],
+              reasoning_content: "",
+            },
+          },
+        }
+      }
+      if (typeof msg.content === "string") {
+        return {
+          ...msg,
+          content: [{ type: "text" as const, text: msg.content }, { type: "reasoning" as const, text: "" }],
+        }
+      }
       return msg
     })
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -246,9 +246,17 @@ function normalizeMessages(
         }
       }
       if (typeof msg.content === "string") {
+        const sdk = sdkKey(model.api.npm) ?? "openaiCompatible"
         return {
           ...msg,
           content: [{ type: "text" as const, text: msg.content }, { type: "reasoning" as const, text: "" }],
+          providerOptions: {
+            ...msg.providerOptions,
+            [sdk]: {
+              ...msg.providerOptions?.[sdk],
+              reasoning_content: "",
+            },
+          },
         }
       }
       return msg


### PR DESCRIPTION
### Issue for this PR

Closes #24104
Related: #24203

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the complete two-layer bug where `reasoning_content` is dropped on conversation replay for DeepSeek thinking mode. PR #24218 addresses layer 1 only — this PR covers all three layers:

**Layer 1 — `interleaved` not auto-enabled for reasoning models**
When a model has `reasoning: true` but no explicit `interleaved` config, the interleaved transform is skipped entirely and `reasoning_content` is never set in `providerOptions`.

**Layer 2 — Hardcoded `openaiCompatible` key breaks non-standard SDKs**
The interleaved transform hardcodes `providerOptions.openaiCompatible`, but OpenRouter's SDK key is `"openrouter"`. The remap logic at line ~336 does not cover this because it only remaps from `model.providerID`, not from `openaiCompatible`.

**Layer 3 — Historical messages have no reasoning part**
Messages stored in DB before reasoning mode was enabled have no reasoning part to extract. The interleaved transform only processes messages with existing reasoning parts, so these get skipped. DeepSeek rejects the request because `reasoning_content` is missing.

### Changes

1. **provider.ts**: Auto-enable `interleaved: { field: "reasoning_content" }` for models with `reasoning: true`
2. **transform.ts**: Use dynamic SDK key (`sdkKey(model.api.npm)`) instead of hardcoded `"openaiCompatible"` — fixes OpenRouter and other non-standard providers
3. **transform.ts**: New fallback that injects `reasoning_content: ""` for ALL assistant messages when `capabilities.reasoning` is true — covers historical messages with no reasoning part
4. **transform.ts**: Expand DeepSeek detection to check `model.id` in addition to `model.api.id` — covers OpenRouter-routed DeepSeek models

### How did you verify your code works?

- [x] Reasoning models now auto-enable interleaved (no manual config needed)
- [x] OpenRouter provider uses correct `"openrouter"` key in providerOptions
- [x] All assistant messages get `reasoning_content` injected when reasoning is active
- [x] Non-reasoning models unaffected (gated on `capabilities.reasoning`)
- [x] Explicit `interleaved` config still takes priority (`??` operator)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR