### PR TITLE
fix(provider): inject chat_template_kwargs for Nvidia NIM deepseek-v4 models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -416,8 +416,20 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         options: {
           headers: {
             "HTTP-Referer": "https://opencode.ai/",
-            "X-Title": "opencode",
+            "X-title": "opencode",
           },
+          fetch: async (url: any, opts: any) => {
+            if (opts && typeof opts.body === "string" && opts.body.includes("deepseek-v4")) {
+              try {
+                const body = JSON.parse(opts.body);
+                if (body.model && body.model.includes("deepseek-v4")) {
+                  body.chat_template_kwargs = { enable_thinking: true, thinking: true };
+                  opts.body = JSON.stringify(body);
+                }
+              } catch(e) {}
+            }
+            return globalThis.fetch(url, opts);
+          }
         },
       }),
     vercel: () =>


### PR DESCRIPTION
### Issue for this PR

Closes #24264

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Resolves an issue where Nvidia NIM's `deepseek-v4-flash` and `deepseek-v4-pro` models fail to return a response when used in OpenCode because the Nvidia NIM API explicitly requires `chat_template_kwargs: { enable_thinking: true, thinking: true }` in the root of the JSON payload for reasoning models.

Since the Vercel AI SDK strips unknown options, configuring this via `opencode.jsonc` does not work. This PR fixes the issue by intercepting the fetch request in the `nvidia` provider definition and manually injecting the required `chat_template_kwargs` into the JSON body when a `deepseek-v4` model is used.

### How did you verify your code works?
By locally overriding the provider configuration and confirming that the injected fetch wrapper successfully allows DeepSeek models from the Nvidia NIM API to stream reasoning and text responses.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
