### PR TITLE
Set active server before navigation and use replace navigation to avoid extra history entries

### DIFF
--- a/packages/app/src/components/dialog-select-server.tsx
+++ b/packages/app/src/components/dialog-select-server.tsx
@@ -354,11 +354,11 @@ export function DialogSelectServer() {
     dialog.close()
     if (persist && conn.type === "http") {
       server.add(conn)
-      navigate("/")
+      navigate("/", { replace: true })
       return
     }
-    navigate("/")
-    queueMicrotask(() => server.setActive(ServerConnection.key(conn)))
+    server.setActive(ServerConnection.key(conn))
+    navigate("/", { replace: true })
   }
 
   const handleAddChange = (value: string) => {

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -292,8 +292,8 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                       aria-disabled={blocked()}
                       onClick={() => {
                         if (blocked()) return
-                        navigate("/")
-                        queueMicrotask(() => server.setActive(key))
+                        server.setActive(key)
+                        navigate("/", { replace: true })
                       }}
                     >
                       <ServerHealthIndicator health={health[key]} />


### PR DESCRIPTION
### Issue for this PR

No issue linked

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a server-switching race in the desktop app. Previously the UI navigated to `/` first and deferred `server.setActive(...)` with `queueMicrotask`, which meant the next route could render before the active server had been updated. That could leave the app pointing at the wrong session/PTY and surface `Session not found` errors.

The fix updates the active server first, then navigates back to `/` with `replace: true` in both server-selection flows. This makes the state transition deterministic and avoids adding an extra history entry for a simple server switch.

### How did you verify your code works?

Reviewed the call flow in the app and confirmed the new order sets the active server before the route change. The existing repository tests and type checks were previously reported as passing for this change.

### Screenshots / recordings

![bug](https://github.com/user-attachments/assets/bb2c9f56-2acc-416a-947e-dccb0665a06a)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR