### PR TITLE
fix(provider): prevent duplicate OAuth requests to Google when using Vertex AI provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,4 +1,5 @@
 import os from "os"
+import fs from "fs/promises"
 import fuzzysort from "fuzzysort"
 import { Config } from "../config"
 import { mapValues, mergeDeep, omit, pickBy, sortBy } from "remeda"
@@ -443,16 +444,76 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         "us-central1",
       )
 
-      let authResult: { token: string; expiresAt: number } | null = null
-      const authPromise = Effect.tryPromise(async () => {
+const getAuthToken = yield* Effect.tryPromise(async () => {
         const { GoogleAuth } = await import("google-auth-library")
         const auth = new GoogleAuth()
+
+        let adcFilePath: string | null = null
+        try {
+          const envCreds = process.env.GOOGLE_APPLICATION_CREDENTIALS
+          if (envCreds) {
+            adcFilePath = envCreds
+          } else {
+            const home = os.homedir()
+            const defaultPath = path.join(home, ".config", "gcloud", "application_default_credentials.json")
+            try {
+              await fs.access(defaultPath)
+              adcFilePath = defaultPath
+            } catch {
+              // Not using default user ADC
+            }
+          }
+        } catch {
+          // Ignore
+        }
+
+        const getCacheFilePath = (): string | null => {
+          if (!adcFilePath) return null
+          if (adcFilePath.endsWith(".json")) {
+            return adcFilePath.replace(/\.json$/, "_access_token.json")
+          }
+          return `${adcFilePath}_access_token.json`
+        }
+
+        const cachePath = getCacheFilePath()
+        if (cachePath) {
+          try {
+            const content = await fs.readFile(cachePath, "utf8")
+            const parsed = JSON.parse(content)
+            if (parsed.access_token && typeof parsed.expires_at === "number" && parsed.expires_at > Date.now()) {
+              return { token: parsed.access_token, expiresAt: parsed.expires_at }
+            }
+          } catch {
+            // Cache miss or invalid
+          }
+        }
+
         const client = await auth.getApplicationDefault()
         const r = await client.credential.getAccessToken()
-        return { token: r.token ?? '', expiresAt: r.res?.data.expiry_date ?? 0 }
+        const result = { token: r.token ?? "", expiresAt: r.res?.data.expiry_date ?? 0 }
+
+        if (cachePath && result.expiresAt > 0) {
+          try {
+            const content = JSON.stringify(
+              {
+                access_token: result.token,
+                expires_at: result.expiresAt,
+                token_type: "Bearer",
+              },
+              null,
+              2,
+            )
+            await fs.writeFile(cachePath, content, { mode: 0o600 })
+          } catch {
+            // Ignore cache write errors
+          }
+        }
+
+        return result
       }).pipe(
         Effect.mapError(() => new Error("auth failed")),
         Effect.catch(() => Effect.succeed(null)),
+        Effect.cached,
       )
 
       const autoload = Boolean(project)
@@ -471,10 +532,19 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         options: {
           project,
           location,
-          fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-            if (!authResult) {
-              authResult = await Effect.runPromise(authPromise)
+          googleAuthOptions: {
+            authClient: {
+              getAccessToken: async () => {
+                const authResult = await Effect.runPromise(getAuthToken)
+                if (!authResult?.token) {
+                  throw new Error("Google Vertex AI auth failed: no valid access token")
+                }
+                return { token: authResult.token }
+              }
             }
+          },
+          fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+            const authResult = await Effect.runPromise(getAuthToken)
             if (!authResult?.token) {
               throw new Error("Google Vertex AI auth failed: no valid access token")
             }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -430,21 +430,34 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
-    "google-vertex": Effect.fnUntraced(function* (provider: Info) {
+    "google-vertex": Effect.fn("Provider.google-vertex")(function* (provider: Info) {
       const env = yield* dep.env()
       const project =
         provider.options?.project ?? env["GOOGLE_CLOUD_PROJECT"] ?? env["GCP_PROJECT"] ?? env["GCLOUD_PROJECT"]
 
       const location = String(
         provider.options?.location ??
-          env["GOOGLE_VERTEX_LOCATION"] ??
-          env["GOOGLE_CLOUD_LOCATION"] ??
-          env["VERTEX_LOCATION"] ??
-          "us-central1",
+        env["GOOGLE_VERTEX_LOCATION"] ??
+        env["GOOGLE_CLOUD_LOCATION"] ??
+        env["VERTEX_LOCATION"] ??
+        "us-central1",
+      )
+
+      let authResult: { token: string; expiresAt: number } | null = null
+      const authPromise = Effect.tryPromise(async () => {
+        const { GoogleAuth } = await import("google-auth-library")
+        const auth = new GoogleAuth()
+        const client = await auth.getApplicationDefault()
+        const r = await client.credential.getAccessToken()
+        return { token: r.token ?? '', expiresAt: r.res?.data.expiry_date ?? 0 }
+      }).pipe(
+        Effect.mapError(() => new Error("auth failed")),
+        Effect.catch(() => Effect.succeed(null)),
       )
 
       const autoload = Boolean(project)
       if (!autoload) return { autoload: false }
+
       return {
         autoload: true,
         vars(_options: Record<string, any>) {
@@ -459,14 +472,15 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           project,
           location,
           fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-            const { GoogleAuth } = await import("google-auth-library")
-            const auth = new GoogleAuth()
-            const client = await auth.getApplicationDefault()
-            const token = await client.credential.getAccessToken()
+            if (!authResult) {
+              authResult = await Effect.runPromise(authPromise)
+            }
+            if (!authResult?.token) {
+              throw new Error("Google Vertex AI auth failed: no valid access token")
+            }
 
             const headers = new Headers(init?.headers)
-            headers.set("Authorization", `Bearer ${token.token}`)
-
+            headers.set("Authorization", `Bearer ${authResult.token}`)
             return fetch(input, { ...init, headers })
           },
         },
@@ -607,9 +621,9 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
               log.info("gitlab model discovery skipped: no models found", {
                 project: result.project
                   ? {
-                      id: result.project.id,
-                      path: result.project.pathWithNamespace,
-                    }
+                    id: result.project.id,
+                    path: result.project.pathWithNamespace,
+                  }
                   : null,
               })
               return {}
@@ -750,7 +764,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       if (!apiToken) {
         throw new Error(
           "CLOUDFLARE_API_TOKEN (or CF_AIG_TOKEN) is required for Cloudflare AI Gateway. " +
-            "Set it via environment variable or run `opencode auth cloudflare-ai-gateway`.",
+          "Set it via environment variable or run `opencode auth cloudflare-ai-gateway`.",
         )
       }
 
@@ -943,7 +957,7 @@ interface State {
   varsLoaders: Record<string, CustomVarsLoader>
 }
 
-export class Service extends Context.Service<Service, Interface>()("@opencode/Provider") {}
+export class Service extends Context.Service<Service, Interface>()("@opencode/Provider") { }
 
 function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
   const result: Model["cost"] = {
@@ -1032,11 +1046,11 @@ export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
         cost: opts.cost ? mergeDeep(base.cost, cost(opts.cost)) : base.cost,
         options: opts.provider?.body
           ? Object.fromEntries(
-              Object.entries(opts.provider.body).map(([k, v]) => [
-                k.replace(/_([a-z])/g, (_, c) => c.toUpperCase()),
-                v,
-              ]),
-            )
+            Object.entries(opts.provider.body).map(([k, v]) => [
+              k.replace(/_([a-z])/g, (_, c) => c.toUpperCase()),
+              v,
+            ]),
+          )
           : base.options,
         headers: opts.provider?.headers ?? base.headers,
       }
@@ -1558,9 +1572,9 @@ const layer: Layer.Layer<
         try {
           const language = s.modelLoaders[model.providerID]
             ? await s.modelLoaders[model.providerID](sdk, model.api.id, {
-                ...provider.options,
-                ...model.options,
-              })
+              ...provider.options,
+              ...model.options,
+            })
             : sdk.languageModel(model.api.id)
           s.models.set(key, language)
           return language


### PR DESCRIPTION
### Issue for this PR

Closes #24281

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes duplicate and excessive OAuth token requests when using the Vertex AI provider. 

Previously, both opencode's fetch wrapper and the SDK called `google-auth-library` independently, causing 2 OAuth requests per LLM call instead of 1. Additionally, since the CLI process restarts every run, `google-auth-library` lost its in-memory token cache, resulting in fresh OAuth requests on every single `opencode` command.

The fix:
1. Pre-creates an auth promise at provider init (lazy, not executed)
2. Implements **disk caching** for the OAuth access token to `~/.config/gcloud/application_default_credentials_access_token.json`
3. Checks the disk cache before attempting to fetch a new token, respecting token expiry
4. Caches the token result in memory for subsequent API calls in the same CLI run
5. SDK now provides the Bearer token directly through the intercepted `fetch`, preventing the SDK from making its own duplicate OAuth request

### How did you verify your code works?

Enabled HTTP debug logging and verified only 1 `POST https://oauth2.googleapis.com/token` request is made per session instead of per LLM call. Furthermore, verified that running subsequent CLI commands uses the cached token on disk rather than re-requesting from Google.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR