### PR TITLE
fix(task): propagate parent session permissions to sub-agents

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -1,5 +1,6 @@
 import * as Tool from "./tool"
 import DESCRIPTION from "./task.txt"
+import { Permission } from "@/permission"
 import { Session } from "../session"
 import { SessionID, MessageID } from "../session/schema"
 import { MessageV2 } from "../session/message-v2"
@@ -66,34 +67,45 @@ export const TaskTool = Tool.define(
         : undefined
       const nextSession =
         session ??
-        (yield* sessions.create({
-          parentID: ctx.sessionID,
-          title: params.description + ` (@${next.name} subagent)`,
-          permission: [
-            ...(canTodo
-              ? []
-              : [
-                  {
-                    permission: "todowrite" as const,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(canTask
-              ? []
-              : [
-                  {
-                    permission: id,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(cfg.experimental?.primary_tools?.map((item) => ({
-              pattern: "*",
-              action: "allow" as const,
-              permission: item,
-            })) ?? []),
-          ],
+        (yield* Effect.gen(function* () {
+          const parentSession = yield* sessions.get(ctx.sessionID).pipe(
+            Effect.catchCause(() => Effect.succeed(undefined)),
+          )
+
+          const childPermission = Permission.merge(
+            parentSession?.permission ?? [],
+            [
+              ...(canTodo
+                ? []
+                : [
+                    {
+                      permission: "todowrite" as const,
+                      pattern: "*" as const,
+                      action: "deny" as const,
+                    },
+                  ]),
+              ...(canTask
+                ? []
+                : [
+                    {
+                      permission: id,
+                      pattern: "*" as const,
+                      action: "deny" as const,
+                    },
+                  ]),
+              ...(cfg.experimental?.primary_tools?.map((item) => ({
+                pattern: "*",
+                action: "allow" as const,
+                permission: item,
+              })) ?? []),
+            ],
+          )
+
+          return yield* sessions.create({
+            parentID: ctx.sessionID,
+            title: params.description + ` (@${next.name} subagent)`,
+            permission: childPermission,
+          })
         }))
 
       const msg = yield* Effect.sync(() => MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }))

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -384,4 +384,70 @@ describe("tool.task", () => {
       },
     ),
   )
+
+  it.live("inherits parent session permissions when spawning sub-agents", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Session.Service
+          const { chat, assistant } = yield* seed()
+          const tool = yield* TaskTool
+          const def = yield* tool.init()
+          let seen: SessionPrompt.PromptInput | undefined
+          const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+          // Simulate Plan mode by setting edit: deny on parent
+          yield* sessions.setPermission({
+            sessionID: chat.id,
+            permission: [
+              {
+                permission: "edit" as const,
+                pattern: "*" as const,
+                action: "deny" as const,
+              },
+            ],
+          })
+
+          const result = yield* def.execute(
+            {
+              description: "inspect bug",
+              prompt: "look into the cache key path",
+              subagent_type: "general",
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+          const child = yield* sessions.get(result.metadata.sessionId)
+          expect(child.parentID).toBe(chat.id)
+
+          // Child should have inherited parent's edit: deny
+          const editRule = child.permission?.findLast(
+            (rule) => rule.permission === "edit",
+          )
+          expect(editRule?.action).toBe("deny")
+          // Child should still deny todowrite (subagent default)
+          const todoRule = child.permission?.findLast(
+            (rule) => rule.permission === "todowrite",
+          )
+          expect(todoRule?.action).toBe("deny")
+          // Child should deny task (subagent default)
+          const taskRule = child.permission?.findLast(
+            (rule) => rule.permission === "task",
+          )
+          expect(taskRule?.action).toBe("deny")
+        }),
+      {
+        config: {},
+      },
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #6527

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When spawning a sub-agent via the task tool, the child session was created with a blank permission array, losing any Plan mode restrictions (e.g. `edit: deny`) set on the parent. This allowed sub-agents to bypass the parent's read-only guardrails.

The child session now inherits the parent session's permission ruleset via `Permission.merge()` before applying its own sub-agent defaults. This ensures that restrictions like Plan mode (`edit: deny`) are preserved and cannot be bypassed by delegating to a sub-agent.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode` — no type errors in modified files
- Added regression test in `test/tool/task.test.ts` that:
  1. Sets parent session to `edit: deny`
  2. Spawns a sub-agent via `TaskTool`
  3. Asserts the child session inherits `edit: deny`
  4. Asserts child still gets sub-agent defaults (`todowrite: deny`, `task: deny`)

### Screenshots / recordings

_N/A — not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
