### PR TITLE
refactor: remove lazy cross-spawn runtime

### DIFF
--- a/packages/opencode/src/effect/cross-spawn-spawner.ts
+++ b/packages/opencode/src/effect/cross-spawn-spawner.ts
@@ -502,13 +502,4 @@ export const layer: Layer.Layer<ChildProcessSpawner, never, FileSystem.FileSyste
 
 export const defaultLayer = layer.pipe(Layer.provide(NodeFileSystem.layer), Layer.provide(NodePath.layer))
 
-import { lazy } from "@/util/lazy"
-
-const rt = lazy(async () => {
-  // Dynamic import to avoid circular dep: cross-spawn-spawner → run-service → Instance → project → cross-spawn-spawner
-  const { makeRuntime } = await import("@/effect/run-service")
-  return makeRuntime(ChildProcessSpawner, defaultLayer)
-})
-
-type RT = Awaited<ReturnType<typeof rt>>
-export const runPromiseExit: RT["runPromiseExit"] = async (...args) => (await rt()).runPromiseExit(...(args as [any]))
+export * as CrossSpawnSpawner from "./cross-spawn-spawner"


### PR DESCRIPTION
## Summary
- Remove the lazy dynamic runtime setup from the cross-spawn spawner module.
- Drop the unused `runPromiseExit` convenience export and keep the module namespace export.

## Testing
- `bun typecheck` from `packages/opencode`
- Pre-push `bun turbo typecheck`
