### PR TITLE
feat: add startup debug command

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -9,6 +9,7 @@ import { ScrapCommand } from "./scrap"
 import { SkillCommand } from "./skill"
 import { SnapshotCommand } from "./snapshot"
 import { AgentCommand } from "./agent"
+import { StartupCommand } from "./startup"
 
 export const DebugCommand = cmd({
   command: "debug",
@@ -22,6 +23,7 @@ export const DebugCommand = cmd({
       .command(ScrapCommand)
       .command(SkillCommand)
       .command(SnapshotCommand)
+      .command(StartupCommand)
       .command(AgentCommand)
       .command(PathsCommand)
       .command({

--- a/packages/opencode/src/cli/cmd/debug/startup.ts
+++ b/packages/opencode/src/cli/cmd/debug/startup.ts
@@ -1,0 +1,11 @@
+import { EOL } from "os"
+import { cmd } from "../cmd"
+
+export const StartupCommand = cmd({
+  command: "startup",
+  describe: "print startup timing",
+  builder: (yargs) => yargs,
+  handler() {
+    process.stdout.write(performance.now().toString() + EOL)
+  },
+})


### PR DESCRIPTION
## Summary
- Add `opencode debug startup` to print startup timing.
- Register the command under the existing debug command group.

## Testing
- `bun typecheck` in `packages/opencode`
- `bun turbo typecheck` via pre-push hook