### PR TITLE
feat(app): support message annotations

### DIFF
--- a/packages/app/e2e/backend.ts
+++ b/packages/app/e2e/backend.ts
@@ -62,6 +62,13 @@ function tail(input: string[]) {
   return input.slice(-40).join("")
 }
 
+function cleanEnv() {
+  const env = { ...process.env }
+  delete env["OPENCODE_SERVER_PASSWORD"]
+  delete env["OPENCODE_SERVER_USERNAME"]
+  return env
+}
+
 export async function startBackend(label: string, input?: { llmUrl?: string }): Promise<Handle> {
   const port = await freePort()
   const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), `opencode-e2e-${label}-`))
@@ -69,7 +76,7 @@ export async function startBackend(label: string, input?: { llmUrl?: string }): 
   const repoDir = path.resolve(appDir, "../..")
   const opencodeDir = path.join(repoDir, "packages", "opencode")
   const env = {
-    ...process.env,
+    ...cleanEnv(),
     OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
     OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
     OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",

--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -1,5 +1,6 @@
 export const promptSelector = '[data-component="prompt-input"]'
-const terminalPanelSelector = '#terminal-panel[aria-hidden="false"]'
+export const promptSubmitSelector = '[data-action="prompt-submit"]'
+export const terminalPanelSelector = '#terminal-panel[aria-hidden="false"]'
 export const terminalSelector = `${terminalPanelSelector} [data-component="terminal"]`
 export const sessionComposerDockSelector = '[data-component="session-prompt-dock"]'
 export const questionDockSelector = '[data-component="dock-prompt"][data-kind="question"]'
@@ -63,3 +64,20 @@ export const listItemKeyStartsWithSelector = (prefix: string) => `${listItemSele
 export const listItemKeySelector = (key: string) => `${listItemSelector}[data-key="${key}"]`
 
 export const keybindButtonSelector = (id: string) => `[data-keybind-id="${id}"]`
+
+export const messageAnnotationTriggerSelector = '[data-component="message-annotation-trigger"]'
+export const messageAnnotationTriggerOpenSelector = '[data-action="message-annotation-trigger-open"]'
+export const messageAnnotationPopoverSelector = '[data-component="message-annotation-popover"]'
+export const messageAnnotationHeadSelector = '[data-slot="message-annotation-head"]'
+export const messageAnnotationInputSelector = '[data-component="message-annotation-input"]'
+export const messageAnnotationSaveSelector = '[data-action="message-annotation-save"]'
+export const messageAnnotationCancelSelector = '[data-action="message-annotation-cancel"]'
+export const messageAnnotationBasketSelector = '[data-component="message-annotation-basket"]'
+export const messageAnnotationCardSelector = '[data-component="line-comment"][data-variant="editor"][data-inline]'
+export const messageAnnotationCommentSelector = '[data-slot="line-comment-textarea"]'
+export const messageAnnotationRemoveSelector = '[data-slot="line-comment-action"][data-variant="ghost"]'
+
+export const sessionMessageSelector = (id: string) => `[data-message-id="${id}"]`
+
+export const sessionMessageSelectionSelector = (input: { id: string; role: "assistant" | "user" }) =>
+  `[data-message-selection="true"][data-message-selection-id="${input.id}"][data-message-role="${input.role}"]`

--- a/packages/app/e2e/session/session-message-annotations.spec.ts
+++ b/packages/app/e2e/session/session-message-annotations.spec.ts
@@ -1,0 +1,541 @@
+import type { Locator, Page } from "@playwright/test"
+import * as fs from "node:fs/promises"
+import { fileURLToPath } from "node:url"
+import { test, expect } from "../fixtures"
+import { withSession } from "../actions"
+import {
+  messageAnnotationBasketSelector,
+  messageAnnotationCardSelector,
+  messageAnnotationCommentSelector,
+  messageAnnotationHeadSelector,
+  messageAnnotationInputSelector,
+  messageAnnotationPopoverSelector,
+  messageAnnotationRemoveSelector,
+  messageAnnotationSaveSelector,
+  messageAnnotationTriggerOpenSelector,
+  messageAnnotationTriggerSelector,
+  promptSelector,
+  promptSubmitSelector,
+  sessionMessageSelectionSelector,
+} from "../selectors"
+import { modKey } from "../utils"
+
+type Assistant = Parameters<typeof test>[0]["assistant"]
+type Sdk = Parameters<typeof withSession>[0]
+type Pick = Parameters<typeof select>[1]
+type Variant = "icon" | "toolbar" | "mini"
+
+const dir = fileURLToPath(new URL("../../../../.sisyphus/evidence/", import.meta.url))
+const file = (name: string) => fileURLToPath(new URL(`../../../../.sisyphus/evidence/${name}`, import.meta.url))
+
+const body = (parts: Array<{ type: string; text?: string }>) =>
+  parts
+    .filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n")
+
+const promptText = async (page: Page) =>
+  page.locator(promptSelector).evaluate((el) => (el.textContent ?? "").replace(/\u200B/g, "").trim())
+
+const selText = async (page: Page) =>
+  page.evaluate(() => (window.getSelection()?.toString() ?? "").replace(/\u200B/g, ""))
+
+async function armCopy(page: Page) {
+  await page.evaluate(() => {
+    const win = window as Window & { __task7?: { copy?: string | null } }
+    const state = win.__task7 ?? (win.__task7 = {})
+    state.copy = null
+    document.addEventListener(
+      "copy",
+      (event) => {
+        state.copy = event.clipboardData?.getData("text/plain") || window.getSelection()?.toString() || ""
+      },
+      { once: true, capture: true },
+    )
+  })
+}
+
+const copied = (page: Page) =>
+  page.evaluate(() => {
+    const win = window as Window & { __task7?: { copy?: string | null } }
+    return win.__task7?.copy ?? null
+  })
+
+async function clear(page: Page) {
+  await page.evaluate(() => {
+    window.getSelection()?.removeAllRanges()
+    document.dispatchEvent(new Event("selectionchange", { bubbles: true }))
+  })
+}
+
+async function setVariant(page: Page, variant: Variant) {
+  await page.evaluate((variant) => {
+    const win = window as Window & {
+      __opencode_e2e?: {
+        messageAnnotation?: {
+          enabled?: boolean
+          variant?: string
+        }
+      }
+    }
+    win.__opencode_e2e = {
+      ...win.__opencode_e2e,
+      messageAnnotation: {
+        ...win.__opencode_e2e?.messageAnnotation,
+        enabled: true,
+        variant,
+      },
+    }
+  }, variant)
+}
+
+const point = (loc: Locator) => loc.evaluate((el) => ({ left: el.style.left, top: el.style.top }))
+
+const select = async (
+  page: Page,
+  input: {
+    startSel: string
+    startText: string
+    endSel?: string
+    endText?: string
+  },
+) =>
+  page.evaluate((input) => {
+    const find = (sel: string, text: string, edge: "start" | "end") => {
+      const root = document.querySelector(sel)
+      if (!(root instanceof Element)) throw new Error(`Missing selection root: ${sel}`)
+
+      const walk = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+      while (walk.nextNode()) {
+        const node = walk.currentNode
+        const value = node.textContent ?? ""
+        const index = edge === "start" ? value.indexOf(text) : value.lastIndexOf(text)
+        if (index === -1) continue
+        return {
+          node,
+          offset: edge === "start" ? index : index + text.length,
+          root,
+        }
+      }
+
+      throw new Error(`Missing selection text: ${text}`)
+    }
+
+    const start = find(input.startSel, input.startText, "start")
+    const end = find(input.endSel ?? input.startSel, input.endText ?? input.startText, "end")
+    const range = document.createRange()
+    range.setStart(start.node, start.offset)
+    range.setEnd(end.node, end.offset)
+
+    const sel = window.getSelection()
+    if (!sel) throw new Error("Missing window selection")
+    sel.removeAllRanges()
+    sel.addRange(range)
+    document.dispatchEvent(new Event("selectionchange", { bubbles: true }))
+    end.root.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }))
+  }, input)
+
+async function list(sdk: Sdk, sessionID: string) {
+  return sdk.session.messages({ sessionID, limit: 100 }).then((r) => r.data ?? [])
+}
+
+async function showTrigger(input: {
+  page: Page
+  pick: Pick
+  text: string
+  trg: Locator
+  pop: Locator
+}) {
+  await expect(
+    async () => {
+      await select(input.page, input.pick)
+      await expect(input.trg).toBeVisible()
+      await expect(input.pop).toHaveCount(0)
+      await expect.poll(() => selText(input.page), { timeout: 3_000 }).toBe(input.text)
+    },
+    { message: `Expected annotation trigger for ${input.text}` },
+  ).toPass({ timeout: 30_000, intervals: [250, 500, 1_000] })
+}
+
+async function openEditor(input: {
+  page: Page
+  pick: Pick
+  btn: Locator
+  trg: Locator
+  pop: Locator
+  head: Locator
+  note: Locator
+  save: Locator
+  text: string
+}) {
+  if ((await input.btn.count()) === 0) {
+    await showTrigger({ page: input.page, pick: input.pick, text: input.text, trg: input.trg, pop: input.pop })
+  }
+
+  await expect(input.btn).toBeVisible()
+  await expect(input.pop).toHaveCount(0)
+  await input.btn.click()
+  await expect(input.pop).toBeVisible()
+  await expect(input.trg).toHaveCount(0)
+  await expect(input.head).toHaveText(input.text)
+  await expect
+    .poll(
+      () =>
+        input.pop
+          .evaluate((el) => ({ opacity: el.style.opacity, pointer: el.style.pointerEvents }))
+          .catch(() => ({ opacity: "", pointer: "" })),
+      { timeout: 3_000 },
+    )
+    .toEqual({ opacity: "1", pointer: "auto" })
+  await expect(input.note).toBeVisible()
+  await expect(input.note).toBeEditable()
+  await expect(input.note).toBeFocused()
+  await expect(input.save).toBeDisabled()
+}
+
+async function reject(input: {
+  page: Page
+  pick: Pick
+  trg: Locator
+  pop: Locator
+  basket: Locator
+  count: number
+  start?: Locator
+  end?: Locator
+}) {
+  await expect(
+    async () => {
+      if (input.start) {
+        await input.start.scrollIntoViewIfNeeded()
+        await expect(input.start).toBeVisible()
+      }
+
+      if (input.end) {
+        await input.end.scrollIntoViewIfNeeded()
+        await expect(input.end).toBeVisible()
+      }
+
+      await select(input.page, input.pick)
+      await expect(input.trg).toHaveCount(0)
+      await expect(input.pop).toHaveCount(0)
+      await expect(input.basket).toHaveCount(input.count)
+    },
+    { message: "Expected invalid selection to stay rejected" },
+  ).toPass({ timeout: 30_000, intervals: [250, 500, 1_000] })
+}
+
+async function shot(input: {
+  page: Page
+  variant: Variant
+  pick: Pick
+  text: string
+  trg: Locator
+  btn: Locator
+  pop: Locator
+}) {
+  await expect(
+    async () => {
+      await setVariant(input.page, input.variant)
+      await showTrigger({ page: input.page, pick: input.pick, text: input.text, trg: input.trg, pop: input.pop })
+      await expect(input.btn).toHaveAttribute("data-variant", input.variant)
+      await expect(input.btn).toBeVisible()
+
+      const box = await input.btn.boundingBox()
+      if (!box || box.width <= 0 || box.height <= 0) {
+        throw new Error(`Expected visible trigger box for ${input.variant}`)
+      }
+
+      const size = await input.page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }))
+      const x = Math.max(0, Math.floor(box.x) - 2)
+      const y = Math.max(0, Math.floor(box.y) - 2)
+      const clip = {
+        x,
+        y,
+        width: Math.min(Math.ceil(box.width) + 4, size.width - x),
+        height: Math.min(Math.ceil(box.height) + 4, size.height - y),
+      }
+
+      if (clip.width <= 0 || clip.height <= 0) {
+        throw new Error(`Expected positive screenshot clip for ${input.variant}`)
+      }
+
+      await input.page.screenshot({ path: file(`task-7-message-annotation-${input.variant}.png`), clip })
+    },
+    { message: `Expected visible ${input.variant} annotation trigger for screenshot capture` },
+  ).toPass({ timeout: 30_000, intervals: [250, 500, 1_000] })
+
+  await clear(input.page)
+  await expect(input.trg).toHaveCount(0)
+}
+
+async function seed(input: {
+  assistant: Assistant
+  sdk: Sdk
+  sessionID: string
+  prompt: string
+  reply: string
+}) {
+  await input.assistant.reply(input.reply)
+  await input.sdk.session.prompt({
+    sessionID: input.sessionID,
+    parts: [{ type: "text", text: input.prompt }],
+  })
+
+  let id: string | undefined
+  await expect
+    .poll(
+      async () => {
+        const items = await list(input.sdk, input.sessionID)
+        const users = items.filter(
+          (item) => item.info.role === "user" && body(item.parts).includes(input.prompt),
+        )
+        const assistant = items.find(
+          (item) => item.info.role === "assistant" && body(item.parts).includes(input.reply),
+        )
+        if (users.length === 0 || !assistant) return false
+        id = assistant.info.id
+        return true
+      },
+      { timeout: 120_000, intervals: [250, 500, 1_000] },
+    )
+    .toBe(true)
+
+  if (!id) throw new Error("Expected an assistant message id")
+
+  return { id, reply: input.reply }
+}
+
+test.setTimeout(180_000)
+
+test("message annotations require an explicit trigger click, preserve copy, export comments, and reject invalid selection", async ({
+  assistant,
+  page,
+  project,
+}) => {
+  const stamp = Date.now()
+  const a = `Alpha sentence ${stamp}.`
+  const b = `Beta sentence ${stamp}.`
+  const c = `Cross sentence ${stamp}.`
+  const s = `Space lead ${stamp}   Space tail ${stamp}`
+  const keep = `Keep alpha ${stamp}`
+  const remove = `Remove beta ${stamp}`
+  const draft = `Follow up ${stamp}`
+  const firstPrompt = `Seed first annotation ${stamp}`
+  const secondPrompt = `Seed second annotation ${stamp}`
+  const thirdPrompt = `Seed whitespace annotation ${stamp}`
+  const title = `e2e message annotations ${stamp}`
+
+  await project.open()
+
+  await withSession(project.sdk, title, async (session) => {
+    project.trackSession(session.id)
+    const sdk = project.sdk
+
+    const one = await seed({
+      assistant,
+      sdk,
+      sessionID: session.id,
+      prompt: firstPrompt,
+      reply: `${a}\n\n${b}`,
+    })
+    const two = await seed({
+      assistant,
+      sdk,
+      sessionID: session.id,
+      prompt: secondPrompt,
+      reply: c,
+    })
+    const three = await seed({
+      assistant,
+      sdk,
+      sessionID: session.id,
+      prompt: thirdPrompt,
+      reply: s,
+    })
+
+    await project.gotoSession(session.id)
+
+    const before = await list(sdk, session.id)
+    const users = before.filter((item) => item.info.role === "user").length
+    const oneSel = sessionMessageSelectionSelector({ id: one.id, role: "assistant" })
+    const twoSel = sessionMessageSelectionSelector({ id: two.id, role: "assistant" })
+    const threeSel = sessionMessageSelectionSelector({ id: three.id, role: "assistant" })
+    const trg = page.locator(messageAnnotationTriggerSelector)
+    const btn = page.locator(messageAnnotationTriggerOpenSelector)
+    const pop = page.locator(messageAnnotationPopoverSelector)
+    const head = page.locator(messageAnnotationHeadSelector)
+    const promptSubmit = page.locator(promptSubmitSelector)
+    const note = page.locator(messageAnnotationInputSelector)
+    const save = page.locator(messageAnnotationSaveSelector)
+    const alpha = page.getByText(a, { exact: true }).last()
+    const cross = page.getByText(c, { exact: true }).last()
+    const basket = page.locator(messageAnnotationBasketSelector)
+
+    await expect(page.locator(oneSel).first()).toBeVisible({ timeout: 60_000 })
+    await expect(page.locator(threeSel).first()).toBeVisible({ timeout: 60_000 })
+    await expect(page.locator(promptSelector)).toBeVisible()
+
+    await showTrigger({
+      page,
+      pick: { startSel: oneSel, startText: a },
+      text: a,
+      trg,
+      pop,
+    })
+    await expect(btn).toHaveAttribute("data-variant", "icon")
+    await armCopy(page)
+    await page.keyboard.press(`${modKey}+C`)
+    await expect.poll(() => copied(page), { timeout: 5_000 }).toBe(a)
+    await expect.poll(() => selText(page), { timeout: 5_000 }).toBe(a)
+
+    const first = await point(trg)
+    await openEditor({ page, pick: { startSel: oneSel, startText: a }, btn, trg, pop, head, note, save, text: a })
+    await note.fill("draft")
+
+    await showTrigger({
+      page,
+      pick: { startSel: oneSel, startText: b },
+      text: b,
+      trg,
+      pop,
+    })
+    await expect(note).toHaveCount(0)
+    expect(await point(trg)).not.toEqual(first)
+
+    await openEditor({ page, pick: { startSel: oneSel, startText: b }, btn, trg, pop, head, note, save, text: b })
+    await expect(note).toHaveValue("")
+
+    await note.fill(keep)
+    await save.click()
+
+    await expect(pop).toHaveCount(0)
+    await expect(basket).toBeVisible()
+    await expect(page.locator(messageAnnotationCardSelector)).toHaveCount(1)
+    await expect(promptSubmit).toHaveAttribute("aria-label", "Add comment to prompt")
+
+    const notes = page.locator(messageAnnotationCommentSelector)
+    await notes.first().fill(`${keep} edited`)
+    await expect(notes.first()).toHaveValue(`${keep} edited`)
+
+    await showTrigger({
+      page,
+      pick: { startSel: oneSel, startText: a },
+      text: a,
+      trg,
+      pop,
+    })
+
+    await openEditor({ page, pick: { startSel: oneSel, startText: a }, btn, trg, pop, head, note, save, text: a })
+    await note.fill(remove)
+    await save.click()
+
+    await expect(page.locator(messageAnnotationCardSelector)).toHaveCount(2)
+    await expect(promptSubmit).toHaveAttribute("aria-label", "Add comments to prompt")
+    await page.locator(messageAnnotationRemoveSelector).nth(1).click()
+    await expect(page.locator(messageAnnotationCardSelector)).toHaveCount(1)
+    await expect(page.locator(messageAnnotationCommentSelector).first()).toHaveValue(`${keep} edited`)
+    await expect(promptSubmit).toHaveAttribute("aria-label", "Add comment to prompt")
+
+    await page.locator(promptSelector).click()
+    await page.keyboard.type(draft)
+    await promptSubmit.click()
+
+    await expect.poll(() => promptText(page), { timeout: 30_000 }).toContain(draft)
+    await expect.poll(() => promptText(page), { timeout: 30_000 }).toContain("# Conversation Feedback")
+    await expect.poll(() => promptText(page), { timeout: 30_000 }).toContain(b)
+    await expect.poll(() => promptText(page), { timeout: 30_000 }).toContain(`${keep} edited`)
+    await expect(basket).toHaveCount(0)
+    await expect(promptSubmit).toHaveAttribute("aria-label", "Send")
+    await expect
+      .poll(async () => (await list(sdk, session.id)).filter((item) => item.info.role === "user").length, {
+        timeout: 30_000,
+      })
+      .toBe(users)
+
+    await promptSubmit.click()
+
+    await expect
+      .poll(
+        async () => {
+          const items = await list(sdk, session.id)
+          const count = items.filter((item) => item.info.role === "user").length
+          return (
+            count === users + 1 &&
+            items.some(
+              (item) =>
+                item.info.role === "user" &&
+                body(item.parts).includes(draft) &&
+                body(item.parts).includes("# Conversation Feedback") &&
+                body(item.parts).includes(b) &&
+                body(item.parts).includes(`${keep} edited`) &&
+                !body(item.parts).includes(remove),
+            )
+          )
+        },
+        { timeout: 90_000, intervals: [250, 500, 1_000] },
+      )
+      .toBe(true)
+
+    await reject({
+      page,
+      start: alpha,
+      end: cross,
+      pick: { startSel: oneSel, startText: a, endSel: twoSel, endText: c },
+      trg,
+      pop,
+      basket,
+      count: 0,
+    })
+    await reject({
+      page,
+      pick: { startSel: threeSel, startText: "   " },
+      trg,
+      pop,
+      basket,
+      count: 0,
+    })
+  })
+})
+
+test("message annotation trigger variants save deterministic preview artifacts", async ({ assistant, page, project }) => {
+  const stamp = Date.now()
+  const quote = `Variant preview ${stamp} with enough detail to keep the trigger screenshots deterministic across icon toolbar and mini.`
+  const prompt = `Seed variant preview ${stamp}`
+  const title = `e2e message annotation previews ${stamp}`
+
+  await fs.mkdir(dir, { recursive: true })
+  await project.open()
+
+  await withSession(project.sdk, title, async (session) => {
+    project.trackSession(session.id)
+    const sdk = project.sdk
+    const item = await seed({
+      assistant,
+      sdk,
+      sessionID: session.id,
+      prompt,
+      reply: quote,
+    })
+
+    await project.gotoSession(session.id)
+
+    const sel = sessionMessageSelectionSelector({ id: item.id, role: "assistant" })
+    const trg = page.locator(messageAnnotationTriggerSelector)
+    const btn = page.locator(messageAnnotationTriggerOpenSelector)
+    const pop = page.locator(messageAnnotationPopoverSelector)
+
+    await expect(page.locator(sel).first()).toBeVisible({ timeout: 60_000 })
+
+    for (const variant of ["icon", "toolbar", "mini"] as const) {
+      await shot({
+        page,
+        variant,
+        pick: { startSel: sel, startText: quote },
+        text: quote,
+        trg,
+        btn,
+        pop,
+      })
+    }
+  })
+})

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -7,6 +7,8 @@ import { selectionFromLines, type SelectedLineRange, useFile } from "@/context/f
 import {
   ContentPart,
   DEFAULT_PROMPT,
+  type FileContextItem,
+  type MessageContextItem,
   isPromptEqual,
   Prompt,
   usePrompt,
@@ -41,6 +43,8 @@ import { createPromptAttachments } from "./prompt-input/attachments"
 import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
 import {
   canNavigateHistoryAtCursor,
+  isPromptHistoryFileComment,
+  isPromptHistoryMessageComment,
   navigatePromptHistory,
   prependHistoryEntry,
   type PromptHistoryComment,
@@ -51,8 +55,10 @@ import {
 import { createPromptSubmit, type FollowupDraft } from "./prompt-input/submit"
 import { PromptPopover, type AtOption, type SlashCommand } from "./prompt-input/slash-popover"
 import { PromptContextItems } from "./prompt-input/context-items"
+import { contextFiles, contextMessages, MessageAnnotations } from "./prompt-input/message-annotations"
 import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
+import { promptAction } from "./prompt-input/action"
 import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
 
@@ -287,30 +293,30 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       .join("")
     return text.trim().length === 0 && imageAttachments().length === 0 && commentCount() === 0
   })
-  const stopping = createMemo(() => working() && blank())
+  const fileItems = createMemo(() => contextFiles(prompt.context.items(), store.mode))
+  const messageAnnotations = createMemo(() => contextMessages(prompt.context.items(), store.mode))
+  const action = createMemo(() =>
+    promptAction({
+      blank: blank(),
+      count: messageAnnotations().length,
+      working: working(),
+      t: (key) => language.t(key as Parameters<typeof language.t>[0]),
+    }),
+  )
   const tip = () => {
-    if (stopping()) {
-      return (
-        <div class="flex items-center gap-2">
-          <span>{language.t("prompt.action.stop")}</span>
-          <span class="text-icon-base text-12-medium text-[10px]!">{language.t("common.key.esc")}</span>
-        </div>
-      )
-    }
+    const value = action()
 
     return (
       <div class="flex items-center gap-2">
-        <span>{language.t("prompt.action.send")}</span>
-        <Icon name="enter" size="small" class="text-icon-base" />
+        <span>{value.label}</span>
+        {value.hint.kind === "text" ? (
+          <span class="text-icon-base text-12-medium text-[10px]!">{value.hint.label}</span>
+        ) : (
+          <Icon name={value.hint.name} size="small" class="text-icon-base" />
+        )}
       </div>
     )
   }
-
-  const contextItems = createMemo(() => {
-    const items = prompt.context.items()
-    if (store.mode !== "shell") return items
-    return items.filter((item) => !item.comment?.trim())
-  })
 
   const hasUserPrompt = createMemo(() => {
     const sessionID = params.id
@@ -351,14 +357,27 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const historyComments = () => {
     const byID = new Map(comments.all().map((item) => [`${item.file}\n${item.id}`, item] as const))
-    return prompt.context.items().flatMap((item) => {
-      if (item.type !== "file") return []
+    return prompt.context.items().flatMap<PromptHistoryComment>((item) => {
       const comment = item.comment?.trim()
       if (!comment) return []
 
-      const selection = item.commentID ? byID.get(`${item.path}\n${item.commentID}`)?.selection : undefined
+      if (item.type === "message") {
+        return [
+          {
+            type: "message",
+            annotationID: item.annotationID,
+            messageID: item.messageID,
+            role: item.role,
+            quote: item.quote,
+            comment,
+            preview: item.preview,
+          } satisfies PromptHistoryComment,
+        ]
+      }
+
+      const match = item.commentID ? byID.get(`${item.path}\n${item.commentID}`) : undefined
       const nextSelection =
-        selection ??
+        match?.selection ??
         (item.selection
           ? ({
               start: item.selection.startLine,
@@ -369,11 +388,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
       return [
         {
+          type: "file",
           id: item.commentID ?? item.key,
           path: item.path,
           selection: { ...nextSelection },
           comment,
-          time: item.commentID ? (byID.get(`${item.path}\n${item.commentID}`)?.time ?? Date.now()) : Date.now(),
+          time: item.commentID ? (match?.time ?? Date.now()) : Date.now(),
           origin: item.commentOrigin,
           preview: item.preview,
         } satisfies PromptHistoryComment,
@@ -382,8 +402,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const applyHistoryComments = (items: PromptHistoryComment[]) => {
+    const files = items.filter(isPromptHistoryFileComment)
+    const messages = items.filter(isPromptHistoryMessageComment)
+
     comments.replace(
-      items.map((item) => ({
+      files.map((item) => ({
         id: item.id,
         file: item.path,
         selection: { ...item.selection },
@@ -392,13 +415,24 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       })),
     )
     prompt.context.replaceComments(
-      items.map((item) => ({
+      files.map((item) => ({
         type: "file" as const,
         path: item.path,
         selection: selectionFromLines(item.selection),
         comment: item.comment,
         commentID: item.id,
         commentOrigin: item.origin,
+        preview: item.preview,
+      })),
+    )
+    prompt.context.replaceMessages(
+      messages.map((item) => ({
+        type: "message" as const,
+        annotationID: item.annotationID,
+        messageID: item.messageID,
+        role: item.role,
+        quote: item.quote,
+        comment: item.comment,
         preview: item.preview,
       })),
     )
@@ -1018,15 +1052,30 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         }
 
         for (const item of edit.context) {
-          prompt.context.add({
-            type: item.type,
+          if (item.type === "message") {
+            const next: MessageContextItem = {
+              type: "message",
+              annotationID: item.annotationID,
+              messageID: item.messageID,
+              role: item.role,
+              quote: item.quote,
+              comment: item.comment,
+              preview: item.preview,
+            }
+            prompt.context.add(next)
+            continue
+          }
+
+          const next: FileContextItem = {
+            type: "file",
             path: item.path,
             selection: item.selection,
             comment: item.comment,
             commentID: item.commentID,
             commentOrigin: item.commentOrigin,
             preview: item.preview,
-          })
+          }
+          prompt.context.add(next)
         }
 
         setStore("mode", "normal")
@@ -1307,8 +1356,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           type={store.draggingType}
           label={language.t(store.draggingType === "@mention" ? "prompt.dropzone.file.label" : "prompt.dropzone.label")}
         />
+        <MessageAnnotations
+          items={messageAnnotations()}
+          update={prompt.context.updateMessage}
+          remove={prompt.context.removeMessage}
+          placeholder={language.t("ui.lineComment.placeholder")}
+          deleteLabel={language.t("common.delete")}
+        />
         <PromptContextItems
-          items={contextItems()}
+          items={fileItems()}
           active={(item) => {
             const active = comments.active()
             return !!item.commentID && item.commentID === active?.id && item.path === active?.file
@@ -1415,17 +1471,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             />
 
             <div class="flex items-center gap-1 pointer-events-auto">
-              <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
+              <Tooltip placement="top" inactive={action().inactive} value={tip()}>
                 <IconButton
                   data-action="prompt-submit"
                   type="submit"
-                  disabled={store.mode !== "normal" || (!working() && blank())}
+                  disabled={store.mode !== "normal" || action().inactive}
                   tabIndex={store.mode === "normal" ? undefined : -1}
-                  icon={stopping() ? "stop" : "arrow-up"}
+                  icon={action().icon}
                   variant="primary"
                   class="size-8"
                   style={buttons()}
-                  aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
+                  aria-label={action().label}
                 />
               </Tooltip>
             </div>

--- a/packages/app/src/components/prompt-input/action.test.ts
+++ b/packages/app/src/components/prompt-input/action.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test"
+import { promptAction } from "./action"
+
+const t = (key: string) => key
+
+describe("promptAction", () => {
+  test("always prioritizes stop over pending annotation export states", () => {
+    expect(
+      promptAction({
+        blank: false,
+        count: 1,
+        working: true,
+        t,
+      }),
+    ).toEqual({
+      kind: "stop",
+      label: "prompt.action.stop",
+      icon: "stop",
+      hint: {
+        kind: "text",
+        label: "common.key.esc",
+      },
+      inactive: false,
+    })
+
+    expect(
+      promptAction({
+        blank: false,
+        count: 3,
+        working: true,
+        t,
+      }),
+    ).toEqual({
+      kind: "stop",
+      label: "prompt.action.stop",
+      icon: "stop",
+      hint: {
+        kind: "text",
+        label: "common.key.esc",
+      },
+      inactive: false,
+    })
+  })
+
+  test("resolves single annotation export copy", () => {
+    expect(
+      promptAction({
+        blank: false,
+        count: 1,
+        working: false,
+        t,
+      }),
+    ).toEqual({
+      kind: "addCommentToPrompt",
+      label: "prompt.action.addCommentToPrompt",
+      icon: "arrow-up",
+      hint: {
+        kind: "icon",
+        name: "enter",
+      },
+      inactive: false,
+    })
+  })
+
+  test("resolves multi annotation export copy", () => {
+    expect(
+      promptAction({
+        blank: false,
+        count: 3,
+        working: false,
+        t,
+      }),
+    ).toEqual({
+      kind: "addCommentsToPrompt",
+      label: "prompt.action.addCommentsToPrompt",
+      icon: "arrow-up",
+      hint: {
+        kind: "icon",
+        name: "enter",
+      },
+      inactive: false,
+    })
+  })
+
+  test("falls back to send only after annotation export states", () => {
+    expect(
+      promptAction({
+        blank: true,
+        count: 0,
+        working: false,
+        t,
+      }),
+    ).toEqual({
+      kind: "send",
+      label: "prompt.action.send",
+      icon: "arrow-up",
+      hint: {
+        kind: "icon",
+        name: "enter",
+      },
+      inactive: true,
+    })
+  })
+
+  test("keeps blank send inactive and non-blank send active", () => {
+    expect(
+      promptAction({
+        blank: true,
+        count: 0,
+        working: false,
+        t,
+      }).inactive,
+    ).toBe(true)
+
+    expect(
+      promptAction({
+        blank: false,
+        count: 0,
+        working: false,
+        t,
+      }).inactive,
+    ).toBe(false)
+  })
+
+  test("keeps idle send active for image-only drafts", () => {
+    expect(
+      promptAction({
+        blank: false,
+        count: 0,
+        working: false,
+        t,
+      }),
+    ).toEqual({
+      kind: "send",
+      label: "prompt.action.send",
+      icon: "arrow-up",
+      hint: {
+        kind: "icon",
+        name: "enter",
+      },
+      inactive: false,
+    })
+  })
+
+  test("keeps idle send active for file-comment-only drafts", () => {
+    expect(
+      promptAction({
+        blank: false,
+        count: 0,
+        working: false,
+        t,
+      }),
+    ).toEqual({
+      kind: "send",
+      label: "prompt.action.send",
+      icon: "arrow-up",
+      hint: {
+        kind: "icon",
+        name: "enter",
+      },
+      inactive: false,
+    })
+  })
+})

--- a/packages/app/src/components/prompt-input/action.ts
+++ b/packages/app/src/components/prompt-input/action.ts
@@ -1,0 +1,76 @@
+type Input = {
+  blank: boolean
+  count: number
+  working: boolean
+  t: (key: string) => string
+}
+
+type Hint =
+  | {
+      kind: "icon"
+      name: "enter"
+    }
+  | {
+      kind: "text"
+      label: string
+    }
+
+export type PromptAction = {
+  kind: "stop" | "addCommentToPrompt" | "addCommentsToPrompt" | "send"
+  label: string
+  icon: "stop" | "arrow-up"
+  hint: Hint
+  inactive: boolean
+}
+
+export function promptAction(input: Input): PromptAction {
+  if (input.working) {
+    return {
+      kind: "stop",
+      label: input.t("prompt.action.stop"),
+      icon: "stop",
+      hint: {
+        kind: "text",
+        label: input.t("common.key.esc"),
+      },
+      inactive: false,
+    }
+  }
+
+  if (input.count === 1) {
+    return {
+      kind: "addCommentToPrompt",
+      label: input.t("prompt.action.addCommentToPrompt"),
+      icon: "arrow-up",
+      hint: {
+        kind: "icon",
+        name: "enter",
+      },
+      inactive: false,
+    }
+  }
+
+  if (input.count > 1) {
+    return {
+      kind: "addCommentsToPrompt",
+      label: input.t("prompt.action.addCommentsToPrompt"),
+      icon: "arrow-up",
+      hint: {
+        kind: "icon",
+        name: "enter",
+      },
+      inactive: false,
+    }
+  }
+
+  return {
+    kind: "send",
+    label: input.t("prompt.action.send"),
+    icon: "arrow-up",
+    hint: {
+      kind: "icon",
+      name: "enter",
+    },
+    inactive: input.blank,
+  }
+}

--- a/packages/app/src/components/prompt-input/history.test.ts
+++ b/packages/app/src/components/prompt-input/history.test.ts
@@ -8,12 +8,14 @@ import {
   prependHistoryEntry,
   promptLength,
   type PromptHistoryComment,
+  type PromptHistoryStoredEntry,
 } from "./history"
 
 const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
 const text = (value: string): Prompt => [{ type: "text", content: value, start: 0, end: value.length }]
 const comment = (id: string, value = "note"): PromptHistoryComment => ({
+  type: "file",
   id,
   path: "src/a.ts",
   selection: { start: 2, end: 4 },
@@ -21,6 +23,15 @@ const comment = (id: string, value = "note"): PromptHistoryComment => ({
   time: 1,
   origin: "review",
   preview: "const a = 1",
+})
+const message = (id: string, value = "note"): PromptHistoryComment => ({
+  type: "message",
+  annotationID: id,
+  messageID: `msg-${id}`,
+  role: "assistant",
+  quote: `quote ${id}`,
+  comment: value,
+  preview: `preview ${id}`,
 })
 
 describe("prompt-input history", () => {
@@ -95,10 +106,58 @@ describe("prompt-input history", () => {
     expect(up.entry.comments).toEqual([comment("c1")])
   })
 
+  test("navigatePromptHistory keeps mixed file and message annotations through history", () => {
+    const entries = [
+      {
+        prompt: text("mixed"),
+        comments: [comment("c1"), message("m1")],
+      },
+    ]
+
+    const up = navigatePromptHistory({
+      direction: "up",
+      entries,
+      historyIndex: -1,
+      currentPrompt: text("draft"),
+      currentComments: [],
+      savedPrompt: null,
+    })
+
+    expect(up.handled).toBe(true)
+    if (!up.handled) throw new Error("expected handled")
+    expect(up.entry.comments).toEqual([comment("c1"), message("m1")])
+  })
+
   test("normalizePromptHistoryEntry supports legacy prompt arrays", () => {
     const entry = normalizePromptHistoryEntry(text("legacy"))
     expect(entry.prompt[0]?.type === "text" ? entry.prompt[0].content : "").toBe("legacy")
     expect(entry.comments).toEqual([])
+  })
+
+  test("normalizePromptHistoryEntry supports legacy file comment payloads", () => {
+    const entry = normalizePromptHistoryEntry({
+      prompt: text("legacy"),
+      comments: [
+        {
+          id: "c1",
+          path: "src/a.ts",
+          selection: { start: 2, end: 4 },
+          comment: "note",
+          time: 1,
+          origin: "review",
+          preview: "const a = 1",
+        },
+      ],
+    } satisfies PromptHistoryStoredEntry)
+
+    expect(entry.comments).toEqual([comment("c1")])
+  })
+
+  test("prependHistoryEntry deduplicates mixed annotations deterministically", () => {
+    const first = prependHistoryEntry([], text("hello"), [message("m1"), comment("c1")])
+    const deduped = prependHistoryEntry(first, text("hello"), [comment("c1"), message("m1")])
+
+    expect(deduped).toBe(first)
   })
 
   test("helpers clone prompt and count text content length", () => {

--- a/packages/app/src/components/prompt-input/history.ts
+++ b/packages/app/src/components/prompt-input/history.ts
@@ -1,11 +1,12 @@
-import type { Prompt } from "@/context/prompt"
+import type { MessageContextItem, Prompt } from "@/context/prompt"
 import type { SelectedLineRange } from "@/context/file"
 
 const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
 export const MAX_HISTORY = 100
 
-export type PromptHistoryComment = {
+export type PromptHistoryFileComment = {
+  type: "file"
   id: string
   path: string
   selection: SelectedLineRange
@@ -15,12 +16,31 @@ export type PromptHistoryComment = {
   preview?: string
 }
 
+export type PromptHistoryMessageComment = {
+  type: "message"
+  annotationID: string
+  messageID: string
+  role: MessageContextItem["role"]
+  quote: string
+  comment: string
+  preview?: string
+}
+
+export type PromptHistoryComment = PromptHistoryFileComment | PromptHistoryMessageComment
+
+type PromptHistoryStoredComment = PromptHistoryComment | Omit<PromptHistoryFileComment, "type">
+
 export type PromptHistoryEntry = {
   prompt: Prompt
   comments: PromptHistoryComment[]
 }
 
-export type PromptHistoryStoredEntry = Prompt | PromptHistoryEntry
+export type PromptHistoryStoredEntry =
+  | Prompt
+  | {
+      prompt: Prompt
+      comments: PromptHistoryStoredComment[]
+    }
 
 export function canNavigateHistoryAtCursor(direction: "up" | "down", text: string, cursor: number, inHistory = false) {
   const position = Math.max(0, Math.min(cursor, text.length))
@@ -52,11 +72,26 @@ function cloneSelection(selection: SelectedLineRange): SelectedLineRange {
   }
 }
 
-export function clonePromptHistoryComments(comments: PromptHistoryComment[]) {
-  return comments.map((comment) => ({
-    ...comment,
-    selection: cloneSelection(comment.selection),
-  }))
+export function isPromptHistoryFileComment(comment: PromptHistoryComment): comment is PromptHistoryFileComment {
+  return comment.type === "file"
+}
+
+export function isPromptHistoryMessageComment(comment: PromptHistoryComment): comment is PromptHistoryMessageComment {
+  return comment.type === "message"
+}
+
+function clonePromptHistoryComment(comment: PromptHistoryStoredComment): PromptHistoryComment {
+  if ("type" in comment && comment.type === "message") return { ...comment }
+
+  const file = "type" in comment ? comment : { ...comment, type: "file" as const }
+  return {
+    ...file,
+    selection: cloneSelection(file.selection),
+  }
+}
+
+export function clonePromptHistoryComments(comments: PromptHistoryStoredComment[]) {
+  return comments.map(clonePromptHistoryComment)
 }
 
 export function normalizePromptHistoryEntry(entry: PromptHistoryStoredEntry): PromptHistoryEntry {
@@ -68,7 +103,7 @@ export function normalizePromptHistoryEntry(entry: PromptHistoryStoredEntry): Pr
   }
   return {
     prompt: clonePromptParts(entry.prompt),
-    comments: clonePromptHistoryComments(entry.comments),
+    comments: clonePromptHistoryComments(entry.comments ?? []),
   }
 }
 
@@ -100,6 +135,19 @@ export function prependHistoryEntry(
 }
 
 function isCommentEqual(commentA: PromptHistoryComment, commentB: PromptHistoryComment) {
+  if (commentA.type !== commentB.type) return false
+  if (isPromptHistoryMessageComment(commentA) && isPromptHistoryMessageComment(commentB)) {
+    return (
+      commentA.messageID === commentB.messageID &&
+      commentA.role === commentB.role &&
+      commentA.quote === commentB.quote &&
+      commentA.comment === commentB.comment &&
+      commentA.preview === commentB.preview
+    )
+  }
+
+  if (!isPromptHistoryFileComment(commentA) || !isPromptHistoryFileComment(commentB)) return false
+
   return (
     commentA.path === commentB.path &&
     commentA.comment === commentB.comment &&
@@ -110,6 +158,16 @@ function isCommentEqual(commentA: PromptHistoryComment, commentB: PromptHistoryC
     commentA.selection.side === commentB.selection.side &&
     commentA.selection.endSide === commentB.selection.endSide
   )
+}
+
+function isCommentGroupEqual(groupA: PromptHistoryComment[], groupB: PromptHistoryComment[]) {
+  if (groupA.length !== groupB.length) return false
+  for (let i = 0; i < groupA.length; i++) {
+    const commentA = groupA[i]
+    const commentB = groupB[i]
+    if (!commentA || !commentB || !isCommentEqual(commentA, commentB)) return false
+  }
+  return true
 }
 
 function isPromptEqual(promptA: PromptHistoryStoredEntry, promptB: PromptHistoryStoredEntry) {
@@ -138,13 +196,13 @@ function isPromptEqual(promptA: PromptHistoryStoredEntry, promptB: PromptHistory
     if (partA.type === "agent" && partA.name !== (partB.type === "agent" ? partB.name : "")) return false
     if (partA.type === "image" && partA.id !== (partB.type === "image" ? partB.id : "")) return false
   }
-  if (entryA.comments.length !== entryB.comments.length) return false
-  for (let i = 0; i < entryA.comments.length; i++) {
-    const commentA = entryA.comments[i]
-    const commentB = entryB.comments[i]
-    if (!commentA || !commentB || !isCommentEqual(commentA, commentB)) return false
-  }
-  return true
+  const filesA = entryA.comments.filter(isPromptHistoryFileComment)
+  const filesB = entryB.comments.filter(isPromptHistoryFileComment)
+  if (!isCommentGroupEqual(filesA, filesB)) return false
+
+  const messagesA = entryA.comments.filter(isPromptHistoryMessageComment)
+  const messagesB = entryB.comments.filter(isPromptHistoryMessageComment)
+  return isCommentGroupEqual(messagesA, messagesB)
 }
 
 type HistoryNavInput = {

--- a/packages/app/src/components/prompt-input/message-annotations.cases.tsx
+++ b/packages/app/src/components/prompt-input/message-annotations.cases.tsx
@@ -1,0 +1,307 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { createComponent as CreateComponent } from "solid-js"
+import type { createStore as CreateStore } from "solid-js/store"
+import type { ContextItem, MessageContextItem } from "@/context/prompt"
+
+let createComponent: typeof CreateComponent
+let createStore: typeof CreateStore
+let render: typeof import("solid-js/web").render
+let MessageAnnotations: typeof import("./message-annotations").MessageAnnotations
+let contextFiles: typeof import("./message-annotations").contextFiles
+let contextMessages: typeof import("./message-annotations").contextMessages
+let dir = ""
+const cwd = new URL("../../../", import.meta.url).pathname
+
+const clean = new Set<VoidFunction>()
+
+const hold = (fn: VoidFunction) => {
+  let live = true
+
+  const drop = () => {
+    if (!live) return
+    live = false
+    clean.delete(drop)
+    fn()
+  }
+
+  clean.add(drop)
+  return drop
+}
+
+type Item = ContextItem & { key: string }
+type FileItem = Item & { type: "file" }
+type MessageItem = MessageContextItem & {
+  key: string
+  path: never
+  selection?: never
+  commentID?: never
+  commentOrigin?: never
+}
+
+function createPrompt(items: MessageItem[]) {
+  const [state, setState] = createStore({ items })
+
+  return {
+    items: () => state.items,
+    remove: (annotationID: string) =>
+      setState("items", (list) => list.filter((item) => item.annotationID !== annotationID)),
+    update: (annotationID: string, next: Partial<MessageItem>) =>
+      setState("items", (list) =>
+        list.map((item) => {
+          if (item.annotationID !== annotationID) return item
+          return { ...item, ...next, path: item.path }
+        }),
+      ),
+  }
+}
+
+const msg = (id: string, comment = `comment ${id}`, role: MessageItem["role"] = "assistant"): MessageItem => ({
+  type: "message",
+  key: `message:${id}`,
+  annotationID: id,
+  messageID: `msg-${id}`,
+  role,
+  quote: `quote ${id}\nline ${id}`,
+  preview: `preview ${id}`,
+  comment,
+  path: undefined as never,
+})
+
+const file = (id: string, comment = `file ${id}`): FileItem => ({
+  type: "file",
+  key: `file:${id}`,
+  path: `src/${id}.ts`,
+  comment,
+  commentID: id,
+  selection: { startLine: 1, startChar: 0, endLine: 2, endChar: 0 },
+})
+
+const tick = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const basket = () => document.querySelector('[data-component="message-annotation-basket"]')
+const items = () => Array.from(document.querySelectorAll('[data-component="line-comment"]')) as HTMLDivElement[]
+const comments = () =>
+  Array.from(document.querySelectorAll('[data-slot="line-comment-textarea"]')) as HTMLTextAreaElement[]
+const remove = () => Array.from(document.querySelectorAll('[data-slot="line-comment-action"]')) as HTMLButtonElement[]
+const quotes = () => Array.from(document.querySelectorAll('[data-slot="line-comment-text"]')) as HTMLDivElement[]
+const previews = () => Array.from(document.querySelectorAll('[data-slot="line-comment-label"]')) as HTMLDivElement[]
+const plain = (value: unknown) => JSON.parse(JSON.stringify(value))
+
+const mount = (prompt: ReturnType<typeof createPrompt>, placeholder = "Añadir comentario", deleteLabel = "Eliminar") => {
+  const node = document.createElement("div")
+  document.body.append(node)
+
+  return hold(
+    render(
+      () =>
+        createComponent(MessageAnnotations, {
+          get items() {
+            return prompt.items()
+          },
+          update: prompt.update,
+          remove: prompt.remove,
+          placeholder,
+          deleteLabel,
+        }),
+      node,
+    ),
+  )
+}
+
+beforeAll(async () => {
+  const entry = "../message-annotations.tsx"
+  dir = new URL(`./.tmp-message-annotations-${Date.now()}/`, import.meta.url).pathname
+  const fs = await import("node:fs/promises")
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(
+    `${dir}/entry.ts`,
+    [
+      'export { createComponent } from "solid-js"',
+      'export { createStore } from "solid-js/store"',
+      'export { render } from "solid-js/web"',
+      `export { MessageAnnotations, contextFiles, contextMessages } from ${JSON.stringify(entry)}`,
+      "",
+    ].join("\n"),
+  )
+  const build = Bun.spawnSync(
+    ["bun", "build", `${dir}/entry.ts`, "--outdir", dir, "--target", "browser", "--format", "esm"],
+    {
+      cwd,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+  if (build.exitCode !== 0)
+    throw new Error(new TextDecoder().decode(build.stderr) || "Failed to build message annotations test bundle")
+
+  const mod = await import(`${dir}/entry.js`)
+  createComponent = mod.createComponent
+  createStore = mod.createStore
+  render = mod.render
+  MessageAnnotations = mod.MessageAnnotations
+  contextFiles = mod.contextFiles
+  contextMessages = mod.contextMessages
+})
+
+afterAll(async () => {
+  if (!dir) return
+  const fs = await import("node:fs/promises")
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+afterEach(() => {
+  for (const drop of [...clean]) {
+    drop()
+  }
+
+  document.body.innerHTML = ""
+})
+
+describe("MessageAnnotations", () => {
+  test("basket keeps canonical line-comment copy and creation order", async () => {
+    const prompt = createPrompt([msg("a1", "first note"), msg("a2", "second note", "user")])
+    const dispose = mount(prompt)
+    await tick()
+
+    expect(basket()).toBeTruthy()
+    expect(items()).toHaveLength(2)
+    expect(comments()).toHaveLength(2)
+    expect(remove()).toHaveLength(2)
+    expect(quotes()).toHaveLength(2)
+    expect(previews()).toHaveLength(2)
+    expect(comments()[0]?.getAttribute("placeholder")).toBe("Añadir comentario")
+    expect(comments()[1]?.getAttribute("placeholder")).toBe("Añadir comentario")
+    expect(remove()[0]?.getAttribute("aria-label")).toBe("Eliminar")
+    expect(remove()[0]?.textContent).toBe("Eliminar")
+    expect(remove()[1]?.getAttribute("aria-label")).toBe("Eliminar")
+    expect(items().map((item) => item.getAttribute("data-comment-id"))).toEqual(["a1", "a2"])
+    expect(items()[0]?.getAttribute("data-inline")).toBe("")
+    expect(items()[0]?.getAttribute("data-variant")).toBe("editor")
+    expect(items()[0]?.textContent).toContain("assistant")
+    expect(previews()[0]?.textContent).toBe("preview a1")
+    expect(items()[1]?.textContent).toContain("user")
+    expect(previews()[1]?.textContent).toBe("preview a2")
+    expect(quotes()[0]?.textContent).toBe("quote a1\nline a1")
+    expect(quotes()[1]?.textContent).toBe("quote a2\nline a2")
+
+    dispose()
+  })
+
+  test("inline editing mutates only the targeted annotation", async () => {
+    const prompt = createPrompt([msg("a1", "first note"), msg("a2", "second note", "user")])
+    const dispose = mount(prompt)
+    await tick()
+
+    comments()[1]!.value = "updated second"
+    comments()[1]!.dispatchEvent(new Event("input", { bubbles: true }))
+    await tick()
+
+    expect(plain(prompt.items())).toEqual([
+      {
+        type: "message",
+        key: "message:a1",
+        annotationID: "a1",
+        messageID: "msg-a1",
+        role: "assistant",
+        quote: "quote a1\nline a1",
+        preview: "preview a1",
+        comment: "first note",
+      },
+      {
+        type: "message",
+        key: "message:a2",
+        annotationID: "a2",
+        messageID: "msg-a2",
+        role: "user",
+        quote: "quote a2\nline a2",
+        preview: "preview a2",
+        comment: "updated second",
+      },
+    ])
+
+    dispose()
+  })
+
+  test("delete removes only the targeted annotation", async () => {
+    const prompt = createPrompt([msg("a1", "drop me"), msg("a2", "keep me")])
+    const dispose = mount(prompt)
+    await tick()
+
+    remove()[0]!.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    await tick()
+
+    expect(plain(prompt.items())).toEqual([
+      {
+        type: "message",
+        key: "message:a2",
+        annotationID: "a2",
+        messageID: "msg-a2",
+        role: "assistant",
+        quote: "quote a2\nline a2",
+        preview: "preview a2",
+        comment: "keep me",
+      },
+    ])
+    dispose()
+
+    const next = mount(prompt)
+    await tick()
+
+    expect(items()).toHaveLength(1)
+    expect(items()[0]?.getAttribute("data-comment-id")).toBe("a2")
+    expect(previews()[0]?.textContent).toBe("preview a2")
+    expect(quotes()[0]?.textContent).toBe("quote a2\nline a2")
+
+    next()
+  })
+
+  test("shell mode hides the basket and multiline quotes stay stable", async () => {
+    const prompt = createPrompt([msg("a1", "keep quote")])
+    const dispose = mount(prompt)
+    await tick()
+
+    expect(items()).toHaveLength(1)
+    expect(quotes()[0]?.textContent).toBe("quote a1\nline a1")
+    expect(quotes()[0]?.innerHTML).toContain("\n")
+    dispose()
+
+    const mixed: Item[] = [file("c1", "file note"), msg("a1", "one"), msg("a2", "two")]
+
+    expect(contextFiles(mixed, "normal")).toMatchObject([{ type: "file", path: "src/c1.ts", commentID: "c1" }])
+    expect(contextMessages(mixed, "normal")).toMatchObject([
+      { type: "message", annotationID: "a1" },
+      { type: "message", annotationID: "a2" },
+    ])
+    expect(contextMessages(mixed, "shell")).toEqual([])
+    expect(contextFiles(mixed, "shell")).toEqual([])
+
+    const node = document.createElement("div")
+    document.body.append(node)
+
+    const shell = hold(
+      render(
+        () =>
+          createComponent(MessageAnnotations, {
+            items: contextMessages(mixed, "shell"),
+            update: prompt.update,
+            remove: prompt.remove,
+            placeholder: "Añadir comentario",
+            deleteLabel: "Eliminar",
+          }),
+        node,
+      ),
+    )
+    await tick()
+
+    expect(basket()).toBeNull()
+
+    shell()
+  })
+})

--- a/packages/app/src/components/prompt-input/message-annotations.test.tsx
+++ b/packages/app/src/components/prompt-input/message-annotations.test.tsx
@@ -1,0 +1,24 @@
+import { describe, test } from "bun:test"
+
+const cwd = new URL("../../../", import.meta.url).pathname
+
+const run = () =>
+  Bun.spawnSync(
+    ["bun", "test", "--preload", "./happydom.ts", "./src/components/prompt-input/message-annotations.cases.tsx"],
+    {
+      cwd,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+
+const text = (buf: Uint8Array<ArrayBufferLike>) => new TextDecoder().decode(buf)
+
+describe("MessageAnnotations", () => {
+  test("runs isolated canonical line-comment bundle coverage", () => {
+    const out = run()
+    if (out.exitCode === 0) return
+
+    throw new Error(`${text(out.stdout)}\n${text(out.stderr)}`.trim())
+  })
+})

--- a/packages/app/src/components/prompt-input/message-annotations.tsx
+++ b/packages/app/src/components/prompt-input/message-annotations.tsx
@@ -1,0 +1,248 @@
+/** @jsx h */
+
+import h from "solid-js/h"
+import { Component, For, Show } from "solid-js"
+import type { ContextItem, MessageContextItem } from "@/context/prompt"
+
+const styles = `
+[data-component="line-comment"] {
+  position: relative;
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: flex-start;
+}
+
+[data-component="line-comment"][data-open] {
+  z-index: var(--line-comment-open-z, 100);
+}
+
+[data-component="line-comment"] [data-slot="line-comment-popover"] {
+  position: relative;
+  flex: 1 1 0%;
+  width: auto;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  border-radius: 14px;
+  background: var(--surface-raised-stronger-non-alpha);
+  box-shadow: var(--shadow-xxs-border);
+  padding: 8px;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-content"] {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-head"] {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-text"] {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-x-large);
+  letter-spacing: var(--letter-spacing-normal);
+  color: var(--text-strong);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-tools"] {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-label"] {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-large);
+  letter-spacing: var(--letter-spacing-normal);
+  color: var(--text-weak);
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-editor"] {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-textarea"] {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  padding: 8px;
+  border-radius: var(--radius-md);
+  background: var(--surface-base);
+  border: 1px solid var(--border-base);
+  color: var(--text-strong);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-large);
+}
+
+[data-component="line-comment"] [data-slot="line-comment-textarea"]:focus {
+  outline: none;
+  box-shadow: var(--shadow-xs-border-select);
+}
+
+[data-component="line-comment"] [data-slot="line-comment-action"] {
+  border: 1px solid var(--border-base);
+  background: var(--surface-base);
+  color: var(--text-strong);
+  border-radius: var(--radius-md);
+  height: 28px;
+  padding: 0 10px;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-small);
+  font-weight: var(--font-weight-medium);
+}
+
+[data-component="line-comment"] [data-slot="line-comment-action"][data-variant="ghost"] {
+  background: transparent;
+}
+`
+
+let installed = false
+
+function install() {
+  if (installed) return
+  if (typeof document === "undefined") return
+
+  const id = "opencode-message-annotation-line-comment-styles"
+  if (document.getElementById(id)) {
+    installed = true
+    return
+  }
+
+  const style = document.createElement("style")
+  style.id = id
+  style.textContent = styles
+  document.head.appendChild(style)
+  installed = true
+}
+
+install()
+
+type Entry = ContextItem & { key: string }
+type FileItem = Entry & { type: "file" }
+type Item = MessageContextItem & {
+  key: string
+  path: never
+  selection?: never
+  commentID?: never
+  commentOrigin?: never
+}
+
+type MessageAnnotationsProps = {
+  items: Item[]
+  update: (annotationID: string, next: Omit<Partial<MessageContextItem>, "annotationID" | "type">) => void
+  remove: (annotationID: string) => void
+  placeholder: string
+  deleteLabel: string
+}
+
+export const contextFiles = (items: Entry[], mode: "normal" | "shell") => {
+  const list = items.filter((item): item is FileItem => item.type === "file")
+  if (mode !== "shell") return list
+  return list.filter((item) => !item.comment?.trim())
+}
+
+export const contextMessages = (items: Entry[], mode: "normal" | "shell") => {
+  if (mode === "shell") return []
+  return items.filter((item): item is Item => item.type === "message")
+}
+
+const line = (item: Item) => item.preview?.trim() || item.quote.replace(/\s+/g, " ").trim()
+
+export const MessageAnnotations: Component<MessageAnnotationsProps> = (props) => {
+  return (
+    <Show when={props.items.length > 0}>
+      <div
+        data-component="message-annotation-basket"
+        data-message-selection-ignore="true"
+        class="px-2 pt-2 flex flex-col gap-2"
+      >
+        <For each={props.items}>
+          {(item) => (
+            <div
+              data-component="line-comment"
+              data-prevent-autofocus=""
+              data-variant="editor"
+              data-comment-id={item.annotationID}
+              data-open=""
+              data-inline=""
+            >
+              <div data-slot="line-comment-popover" data-inline-body="">
+                <div data-slot="line-comment-editor">
+                  <div data-slot="line-comment-content">
+                    <div data-slot="line-comment-head">
+                      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                        <span
+                          classList={{
+                            "shrink-0 rounded-md px-1.5 py-0.5 text-10-medium uppercase tracking-wide": true,
+                            "bg-surface-base text-syntax-property": item.role === "user",
+                            "bg-surface-interactive-hover text-syntax-type": item.role === "assistant",
+                          }}
+                        >
+                          {item.role}
+                        </span>
+                        <div data-slot="line-comment-label" class="flex-1 truncate">
+                          {line(item)}
+                        </div>
+                      </div>
+                      <div data-slot="line-comment-tools">
+                        <button
+                          type="button"
+                          data-slot="line-comment-action"
+                          data-variant="ghost"
+                          onClick={() => props.remove(item.annotationID)}
+                          aria-label={props.deleteLabel}
+                        >
+                          {props.deleteLabel}
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      data-slot="line-comment-text"
+                      class="max-h-36 overflow-auto rounded-md border border-border-base bg-surface-base p-2"
+                    >
+                      {item.quote}
+                    </div>
+                  </div>
+
+                  <textarea
+                    data-slot="line-comment-textarea"
+                    rows={Math.max(item.comment?.split("\n").length ?? 1, 2)}
+                    value={item.comment ?? ""}
+                    placeholder={props.placeholder}
+                    onInput={(event) => props.update(item.annotationID, { comment: event.currentTarget.value })}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  )
+}

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -1,7 +1,68 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import type { Message } from "@opencode-ai/sdk/v2/client"
 import type { Prompt } from "@/context/prompt"
+import { exportMessageFeedback } from "@/utils/message-feedback"
 
 let createPromptSubmit: typeof import("./submit").createPromptSubmit
+
+type FileItem = {
+  type: "file"
+  path: string
+  selection?: {
+    startLine: number
+    startChar: number
+    endLine: number
+    endChar: number
+  }
+  comment?: string
+  commentID?: string
+  commentOrigin?: "review" | "file"
+  preview?: string
+  key?: string
+}
+
+type MessageItem = {
+  type: "message"
+  annotationID: string
+  messageID: string
+  role: Message["role"]
+  quote: string
+  comment?: string
+  preview?: string
+  key?: string
+}
+
+type Item = FileItem | MessageItem
+type Entry = (FileItem | MessageItem) & { key: string }
+
+type PromptCall = {
+  directory: string
+  input: {
+    sessionID: string
+    agent: string
+    model: { providerID: string; modelID: string }
+    messageID: string
+    variant?: string
+    parts: Array<{
+      id?: string
+      type: "text" | "file" | "agent"
+      text?: string
+      synthetic?: boolean
+      metadata?: { opencodeComment?: { comment?: string } }
+      url?: string
+      filename?: string
+      name?: string
+    }>
+  }
+}
+
+type CommandCall = {
+  directory: string
+  input: {
+    sessionID: string
+    command: string
+  }
+}
 
 const createdClients: string[] = []
 const createdSessions: string[] = []
@@ -20,12 +81,114 @@ const storedSessions: Record<string, Array<{ id: string; title?: string }>> = {}
 const promoted: Array<{ directory: string; sessionID: string }> = []
 const sentShell: string[] = []
 const syncedDirectories: string[] = []
+const prompts: PromptCall[] = []
+const commands: CommandCall[] = []
 
 let params: { id?: string } = {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
+let model: { id: string; provider: { id: string } } | undefined
+let agent: { name: string } | undefined
 
 const promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
+
+const join = (prompt: Prompt) => prompt.map((part) => ("content" in part ? part.content : "")).join("")
+const len = (prompt: Prompt) => prompt.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0)
+const event = () => ({ preventDefault: () => undefined }) as unknown as Event
+const tick = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+const frame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+const clonePrompt = (prompt: Prompt): Prompt =>
+  prompt.map((part) => {
+    if (part.type === "text") return { ...part }
+    if (part.type === "image") return { ...part }
+    if (part.type === "agent") return { ...part }
+    return {
+      ...part,
+      selection: part.selection ? { ...part.selection } : undefined,
+    }
+  })
+
+const cloneItem = (item: Entry): Entry => {
+  if (item.type === "message") return { ...item }
+  return {
+    ...item,
+    selection: item.selection ? { ...item.selection } : undefined,
+  }
+}
+
+const key = (item: Item, i: number) => {
+  if (item.type === "message") return `message:${item.annotationID}`
+  return `file:${item.path}:${item.commentID ?? i}`
+}
+
+const withKey = (item: Item, i: number): Entry => {
+  if (item.type === "message") return { ...item, key: item.key ?? key(item, i) }
+  return {
+    ...item,
+    key: item.key ?? key(item, i),
+    selection: item.selection ? { ...item.selection } : undefined,
+  }
+}
+
+function createPromptState(input: { prompt?: Prompt; items?: Item[] } = {}) {
+  let prompt = clonePrompt(input.prompt ?? promptValue)
+  let items = (input.items ?? []).map(withKey)
+
+  return {
+    current: () => clonePrompt(prompt),
+    reset: () => {
+      prompt = [{ type: "text", content: "", start: 0, end: 0 }]
+    },
+    set: (next: Prompt) => {
+      prompt = clonePrompt(next)
+    },
+    context: {
+      add: (item: Item) => {
+        const entry = withKey(item, items.length)
+        if (items.find((x) => x.key === entry.key)) return
+        items = [...items, entry]
+      },
+      remove: (value: string) => {
+        items = items.filter((item) => item.key !== value)
+      },
+      replaceMessages: (next: MessageItem[]) => {
+        items = [...items.filter((item) => item.type !== "message"), ...next.map(withKey)]
+      },
+      items: () => items.map(cloneItem),
+    },
+  }
+}
+
+let prompt = createPromptState()
+
+const setupPrompt = (input: { prompt?: Prompt; items?: Item[] } = {}) => {
+  prompt = createPromptState(input)
+}
+
+const countComments = () => prompt.context.items().filter((item) => !!item.comment?.trim()).length
+
+const createSubmit = (input: Partial<Parameters<typeof createPromptSubmit>[0]> = {}) =>
+  createPromptSubmit({
+    info: () => ({ id: "session-1" }),
+    imageAttachments: () => [],
+    commentCount: countComments,
+    autoAccept: () => false,
+    mode: () => "normal",
+    working: () => false,
+    editor: () => undefined,
+    queueScroll: () => undefined,
+    promptLength: len,
+    addToHistory: () => undefined,
+    resetHistoryNavigation: () => undefined,
+    setMode: () => undefined,
+    setPopover: () => undefined,
+    onSubmit: () => undefined,
+    ...input,
+  })
 
 const clientFor = (directory: string) => {
   createdClients.push(directory)
@@ -45,8 +208,14 @@ const clientFor = (directory: string) => {
         return { data: undefined }
       },
       prompt: async () => ({ data: undefined }),
-      promptAsync: async () => ({ data: undefined }),
-      command: async () => ({ data: undefined }),
+      promptAsync: async (input: PromptCall["input"]) => {
+        prompts.push({ directory, input })
+        return { data: undefined }
+      },
+      command: async (input: CommandCall["input"]) => {
+        commands.push({ directory, input })
+        return { data: undefined }
+      },
       abort: async () => ({ data: undefined }),
     },
     worktree: {
@@ -81,11 +250,11 @@ beforeAll(async () => {
   mock.module("@/context/local", () => ({
     useLocal: () => ({
       model: {
-        current: () => ({ id: "model", provider: { id: "provider" } }),
+        current: () => model,
         variant: { current: () => variant },
       },
       agent: {
-        current: () => ({ name: "agent" }),
+        current: () => agent,
       },
       session: {
         promote(directory: string, sessionID: string) {
@@ -104,16 +273,7 @@ beforeAll(async () => {
   }))
 
   mock.module("@/context/prompt", () => ({
-    usePrompt: () => ({
-      current: () => promptValue,
-      reset: () => undefined,
-      set: () => undefined,
-      context: {
-        add: () => undefined,
-        remove: () => undefined,
-        items: () => [],
-      },
-    }),
+    usePrompt: () => prompt,
   }))
 
   mock.module("@/context/layout", () => ({
@@ -125,17 +285,14 @@ beforeAll(async () => {
   }))
 
   mock.module("@/context/sdk", () => ({
-    useSDK: () => {
-      const sdk = {
-        directory: "/repo/main",
-        client: rootClient,
-        url: "http://localhost:4096",
-        createClient(opts: any) {
-          return clientFor(opts.directory)
-        },
-      }
-      return sdk
-    },
+    useSDK: () => ({
+      directory: "/repo/main",
+      client: rootClient,
+      url: "http://localhost:4096",
+      createClient(opts: { directory: string }) {
+        return clientFor(opts.directory)
+      },
+    }),
   }))
 
   mock.module("@/context/sync", () => ({
@@ -185,15 +342,9 @@ beforeAll(async () => {
     }),
   }))
 
-  mock.module("@/context/platform", () => ({
-    usePlatform: () => ({
-      fetch: fetch,
-    }),
-  }))
-
   mock.module("@/context/language", () => ({
     useLanguage: () => ({
-      t: (key: string) => key,
+      t: (value: string) => value,
     }),
   }))
 
@@ -211,23 +362,31 @@ beforeEach(() => {
   params = {}
   sentShell.length = 0
   syncedDirectories.length = 0
+  prompts.length = 0
+  commands.length = 0
   selected = "/repo/worktree-a"
   variant = undefined
-  for (const key of Object.keys(storedSessions)) delete storedSessions[key]
+  model = { id: "model", provider: { id: "provider" } }
+  agent = { name: "agent" }
+  document.body.innerHTML = ""
+  setupPrompt()
+  for (const value of Object.keys(storedSessions)) delete storedSessions[value]
 })
 
 describe("prompt submit worktree selection", () => {
   test("reads the latest worktree accessor value per submit", async () => {
+    setupPrompt()
+
     const submit = createPromptSubmit({
       info: () => undefined,
       imageAttachments: () => [],
-      commentCount: () => 0,
+      commentCount: countComments,
       autoAccept: () => false,
       mode: () => "shell",
       working: () => false,
       editor: () => undefined,
       queueScroll: () => undefined,
-      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      promptLength: len,
       addToHistory: () => undefined,
       resetHistoryNavigation: () => undefined,
       setMode: () => undefined,
@@ -237,11 +396,10 @@ describe("prompt submit worktree selection", () => {
       onSubmit: () => undefined,
     })
 
-    const event = { preventDefault: () => undefined } as unknown as Event
-
-    await submit.handleSubmit(event)
+    await submit.handleSubmit(event())
     selected = "/repo/worktree-b"
-    await submit.handleSubmit(event)
+    prompt.set(promptValue)
+    await submit.handleSubmit(event())
 
     expect(createdClients).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
     expect(createdSessions).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
@@ -251,20 +409,21 @@ describe("prompt submit worktree selection", () => {
       { directory: "/repo/worktree-a", sessionID: "session-1" },
       { directory: "/repo/worktree-b", sessionID: "session-2" },
     ])
-    expect(syncedDirectories).toEqual(["/repo/worktree-a", "/repo/worktree-a", "/repo/worktree-b", "/repo/worktree-b"])
   })
 
   test("applies auto-accept to newly created sessions", async () => {
+    setupPrompt()
+
     const submit = createPromptSubmit({
       info: () => undefined,
       imageAttachments: () => [],
-      commentCount: () => 0,
+      commentCount: countComments,
       autoAccept: () => true,
       mode: () => "shell",
       working: () => false,
       editor: () => undefined,
       queueScroll: () => undefined,
-      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      promptLength: len,
       addToHistory: () => undefined,
       resetHistoryNavigation: () => undefined,
       setMode: () => undefined,
@@ -274,9 +433,7 @@ describe("prompt submit worktree selection", () => {
       onSubmit: () => undefined,
     })
 
-    const event = { preventDefault: () => undefined } as unknown as Event
-
-    await submit.handleSubmit(event)
+    await submit.handleSubmit(event())
 
     expect(enabledAutoAccept).toEqual([{ sessionID: "session-1", directory: "/repo/worktree-a" }])
   })
@@ -284,27 +441,12 @@ describe("prompt submit worktree selection", () => {
   test("includes the selected variant on optimistic prompts", async () => {
     params = { id: "session-1" }
     variant = "high"
+    setupPrompt()
 
-    const submit = createPromptSubmit({
-      info: () => ({ id: "session-1" }),
-      imageAttachments: () => [],
-      commentCount: () => 0,
-      autoAccept: () => false,
-      mode: () => "normal",
-      working: () => false,
-      editor: () => undefined,
-      queueScroll: () => undefined,
-      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
-      addToHistory: () => undefined,
-      resetHistoryNavigation: () => undefined,
-      setMode: () => undefined,
-      setPopover: () => undefined,
-      onSubmit: () => undefined,
-    })
+    const submit = createSubmit()
 
-    const event = { preventDefault: () => undefined } as unknown as Event
-
-    await submit.handleSubmit(event)
+    await submit.handleSubmit(event())
+    await tick()
 
     expect(optimistic).toHaveLength(1)
     expect(optimistic[0]).toMatchObject({
@@ -317,16 +459,18 @@ describe("prompt submit worktree selection", () => {
   })
 
   test("seeds new sessions before optimistic prompts are added", async () => {
+    setupPrompt()
+
     const submit = createPromptSubmit({
       info: () => undefined,
       imageAttachments: () => [],
-      commentCount: () => 0,
+      commentCount: countComments,
       autoAccept: () => false,
       mode: () => "normal",
       working: () => false,
       editor: () => undefined,
       queueScroll: () => undefined,
-      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      promptLength: len,
       addToHistory: () => undefined,
       resetHistoryNavigation: () => undefined,
       setMode: () => undefined,
@@ -336,11 +480,223 @@ describe("prompt submit worktree selection", () => {
       onSubmit: () => undefined,
     })
 
-    const event = { preventDefault: () => undefined } as unknown as Event
-
-    await submit.handleSubmit(event)
+    await submit.handleSubmit(event())
 
     expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
     expect(optimisticSeeded).toEqual([true])
+  })
+})
+
+describe("message annotation export", () => {
+  test("sends file-comment-only drafts even when the text prompt is blank", async () => {
+    params = { id: "session-1" }
+    setupPrompt({
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      items: [
+        {
+          type: "file",
+          path: "src/app.ts",
+          comment: "Check this file too",
+          commentID: "comment-1",
+          commentOrigin: "review",
+          selection: { startLine: 7, startChar: 0, endLine: 9, endChar: 0 },
+          preview: "src/app.ts:7-9",
+        },
+      ],
+    })
+
+    const onSubmit = mock(() => undefined)
+    const submit = createSubmit({ onSubmit })
+
+    await submit.handleSubmit(event())
+    await tick()
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(prompts).toHaveLength(1)
+    expect(commands).toHaveLength(0)
+    expect(prompt.current()).toEqual([{ type: "text", content: "", start: 0, end: 0 }])
+
+    const sent = prompts[0].input.parts
+    expect(sent[0]).toMatchObject({ type: "text", text: "" })
+    expect(sent.find((part) => part.type === "text" && !!part.synthetic)?.metadata?.opencodeComment?.comment).toBe(
+      "Check this file too",
+    )
+    expect(sent.some((part) => part.type === "file" && part.url?.startsWith("file:///repo/main/src/app.ts"))).toBe(true)
+  })
+
+  test("sends image-only drafts even when the text prompt is blank", async () => {
+    params = { id: "session-1" }
+    const image = {
+      type: "image" as const,
+      id: "img-1",
+      filename: "shot.png",
+      mime: "image/png",
+      dataUrl: "data:image/png;base64,abc",
+    }
+    setupPrompt({
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }, image],
+    })
+
+    const onSubmit = mock(() => undefined)
+    const submit = createSubmit({
+      imageAttachments: () => [image],
+      onSubmit,
+    })
+
+    await submit.handleSubmit(event())
+    await tick()
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(prompts).toHaveLength(1)
+    expect(commands).toHaveLength(0)
+    expect(prompt.current()).toEqual([{ type: "text", content: "", start: 0, end: 0 }])
+
+    const sent = prompts[0].input.parts
+    expect(sent[0]).toMatchObject({ type: "text", text: "" })
+    expect(sent.some((part) => part.type === "file" && part.url === "data:image/png;base64,abc")).toBe(true)
+  })
+
+  test("exports pending message annotations into the draft on first click only", async () => {
+    params = { id: "session-1" }
+    setupPrompt({
+      prompt: [{ type: "text", content: "Draft", start: 0, end: 5 }],
+      items: [
+        {
+          type: "message",
+          annotationID: "ann-1",
+          messageID: "msg-1",
+          role: "assistant",
+          quote: "Look here",
+          comment: "Use this detail",
+          preview: "Look here",
+        },
+        {
+          type: "file",
+          path: "src/app.ts",
+          comment: "Keep this file note",
+          commentID: "comment-1",
+          commentOrigin: "file",
+          selection: { startLine: 2, startChar: 0, endLine: 4, endChar: 0 },
+        },
+      ],
+    })
+
+    const addToHistory = mock(() => undefined)
+    const onSubmit = mock(() => undefined)
+    const queueScroll = mock(() => undefined)
+    const editor = document.createElement("div")
+    editor.contentEditable = "true"
+    editor.textContent = "Draft"
+    document.body.append(editor)
+
+    const submit = createSubmit({
+      addToHistory,
+      onSubmit,
+      editor: () => editor,
+      queueScroll,
+    })
+
+    await submit.handleSubmit(event())
+    await frame()
+
+    const md = exportMessageFeedback([
+      {
+        role: "assistant",
+        quote: "Look here",
+        comment: "Use this detail",
+      },
+    ])
+
+    expect(join(prompt.current())).toBe(`Draft\n\n${md}`)
+    expect(prompt.current()[0]).toMatchObject({ type: "text", content: "Draft" })
+    expect(prompt.current().at(-1)).toMatchObject({ type: "text", content: `\n\n${md}` })
+    expect(prompt.context.items().filter((item) => item.type === "message")).toHaveLength(0)
+    expect(prompt.context.items()).toEqual([
+      expect.objectContaining({
+        type: "file",
+        path: "src/app.ts",
+        comment: "Keep this file note",
+        commentID: "comment-1",
+        commentOrigin: "file",
+        selection: { startLine: 2, startChar: 0, endLine: 4, endChar: 0 },
+      }),
+    ])
+    expect(addToHistory).toHaveBeenCalledTimes(0)
+    expect(onSubmit).toHaveBeenCalledTimes(0)
+    expect(queueScroll).toHaveBeenCalledTimes(1)
+    expect(document.activeElement).toBe(editor)
+    expect(prompts).toHaveLength(0)
+    expect(commands).toHaveLength(0)
+    expect(createdSessions).toHaveLength(0)
+    expect(optimistic).toHaveLength(0)
+  })
+
+  test("sends on the second click and keeps file comments on the synthetic path", async () => {
+    params = { id: "session-1" }
+    setupPrompt({
+      prompt: [{ type: "text", content: "Draft", start: 0, end: 5 }],
+      items: [
+        {
+          type: "message",
+          annotationID: "ann-1",
+          messageID: "msg-1",
+          role: "user",
+          quote: "Please fix this",
+          comment: "Address this first",
+          preview: "Please fix this",
+        },
+        {
+          type: "file",
+          path: "src/app.ts",
+          comment: "Check this file too",
+          commentID: "comment-1",
+          commentOrigin: "review",
+          selection: { startLine: 7, startChar: 0, endLine: 9, endChar: 0 },
+          preview: "src/app.ts:7-9",
+        },
+      ],
+    })
+
+    const addToHistory = mock(() => undefined)
+    const onSubmit = mock(() => undefined)
+    const submit = createSubmit({ addToHistory, onSubmit })
+
+    await submit.handleSubmit(event())
+    await tick()
+
+    expect(prompts).toHaveLength(0)
+    expect(prompt.context.items()).toEqual([
+      expect.objectContaining({
+        type: "file",
+        path: "src/app.ts",
+        comment: "Check this file too",
+        commentID: "comment-1",
+        commentOrigin: "review",
+        selection: { startLine: 7, startChar: 0, endLine: 9, endChar: 0 },
+      }),
+    ])
+
+    const expanded = join(prompt.current())
+    expect(expanded).toContain("# Conversation Feedback")
+
+    await submit.handleSubmit(event())
+    await tick()
+
+    expect(addToHistory).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(prompts).toHaveLength(1)
+    expect(commands).toHaveLength(0)
+
+    const sent = prompts[0].input.parts
+    const head = sent[0]
+    expect(head?.type).toBe("text")
+    if (head?.type === "text") {
+      expect(head.text).toBe(expanded)
+    }
+
+    const note = sent.find((part) => part.type === "text" && !!part.synthetic)
+    expect(note).toBeDefined()
+    expect(note?.metadata?.opencodeComment?.comment).toBe("Check this file too")
+    expect(sent.some((part) => part.type === "file" && part.url?.startsWith("file:///repo/main/src/app.ts"))).toBe(true)
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -19,11 +19,15 @@ import { Worktree as WorktreeState } from "@/utils/worktree"
 import { buildRequestParts } from "./build-request-parts"
 import { setCursorPosition } from "./editor-dom"
 import { formatServerError } from "@/utils/server-errors"
+import { appendMessageFeedback, exportMessageFeedback } from "@/utils/message-feedback"
 
 type PendingPrompt = {
   abort: AbortController
   cleanup: VoidFunction
 }
+
+type FileEntry = ContextItem & { type: "file"; key: string }
+type MessageEntry = ContextItem & { type: "message"; key: string }
 
 const pending = new Map<string, PendingPrompt>()
 
@@ -105,9 +109,10 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
   }
 
   const messageID = input.messageID ?? Identifier.ascending("message")
+  const ctx: FileEntry[] = input.draft.context.filter((item): item is FileEntry => item.type === "file")
   const { requestParts, optimisticParts } = buildRequestParts({
     prompt: input.draft.prompt,
-    context: input.draft.context,
+    context: ctx,
     images,
     text,
     sessionID: input.draft.sessionID,
@@ -289,9 +294,36 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()
     const mode = input.mode()
+    const items = prompt.context.items().slice()
+    const ctx = items.filter((item): item is FileEntry => item.type === "file")
+    const msgs = items.filter((item): item is MessageEntry => item.type === "message")
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
       if (input.working()) abort()
+      return
+    }
+
+    if (mode === "normal" && msgs.length > 0) {
+      const md = exportMessageFeedback(
+        msgs.map((item) => ({
+          role: item.role,
+          quote: item.quote,
+          comment: item.comment ?? "",
+        })),
+      )
+      const next = appendMessageFeedback(currentPrompt, md)
+      const pos = input.promptLength(next)
+
+      prompt.set(next, pos)
+      prompt.context.replaceMessages([])
+
+      requestAnimationFrame(() => {
+        const editor = input.editor()
+        if (!editor) return
+        editor.focus()
+        setCursorPosition(editor, pos)
+        input.queueScroll()
+      })
       return
     }
 
@@ -391,12 +423,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       providerID: currentModel.provider.id,
     }
     const agent = currentAgent.name
-    const context = prompt.context.items().slice()
     const draft: FollowupDraft = {
       sessionID: session.id,
       sessionDirectory,
       prompt: currentPrompt,
-      context,
+      context: ctx,
       agent,
       model,
       variant,
@@ -483,7 +514,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       }
     }
 
-    const commentItems = context.filter((item) => item.type === "file" && !!item.comment?.trim())
+    const commentItems = ctx.filter((item) => !!item.comment?.trim())
     const messageID = Identifier.ascending("message")
 
     const removeOptimisticMessage = () => {

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -1,0 +1,205 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { createRoot } from "solid-js"
+import type { FileContextItem, MessageContextItem } from "./prompt"
+
+let createPromptSessionForTest: typeof import("./prompt").createPromptSessionForTest
+
+beforeAll(async () => {
+  mock.module("@solidjs/router", () => ({
+    useParams: () => ({}),
+  }))
+  mock.module("@opencode-ai/ui/context", () => ({
+    createSimpleContext: () => ({
+      use: () => undefined,
+      provider: () => undefined,
+    }),
+  }))
+  const mod = await import("./prompt")
+  createPromptSessionForTest = mod.createPromptSessionForTest
+})
+
+const file = (id: string, comment = id): FileContextItem => ({
+  type: "file",
+  path: `src/${id}.ts`,
+  selection: { startLine: 1, startChar: 0, endLine: 2, endChar: 0 },
+  comment,
+  commentID: id,
+  commentOrigin: "review",
+  preview: `file ${id}`,
+})
+
+const msg = (id: string, comment = id): MessageContextItem => ({
+  type: "message",
+  annotationID: id,
+  messageID: `msg_${id}`,
+  role: "assistant",
+  quote: `quote ${id}`,
+  comment,
+  preview: `preview ${id}`,
+})
+
+describe("prompt context messages", () => {
+  test("context.add deduplicates message annotations by annotationID", () => {
+    createRoot((dispose) => {
+      const prompt = createPromptSessionForTest()
+
+      prompt.context.add(msg("a1", "first"))
+      prompt.context.add({
+        ...msg("a1", "second"),
+        messageID: "msg_other",
+        quote: "other quote",
+      })
+
+      expect(prompt.context.items()).toHaveLength(1)
+      expect(prompt.context.items()[0]).toMatchObject({
+        type: "message",
+        annotationID: "a1",
+        messageID: "msg_a1",
+        comment: "first",
+        key: "message:a1",
+      })
+
+      dispose()
+    })
+  })
+
+  test("updateMessage changes only the targeted annotation", () => {
+    createRoot((dispose) => {
+      const prompt = createPromptSessionForTest({
+        items: [msg("a1", "first"), msg("a2", "second"), file("c1", "file")],
+      })
+
+      prompt.context.updateMessage("a2", {
+        messageID: "msg_next",
+        role: "user",
+        quote: "updated quote",
+        comment: "updated comment",
+        preview: "updated preview",
+      })
+
+      expect(prompt.context.items()).toMatchObject([
+        {
+          type: "message",
+          annotationID: "a1",
+          messageID: "msg_a1",
+          role: "assistant",
+          quote: "quote a1",
+          comment: "first",
+          preview: "preview a1",
+          key: "message:a1",
+        },
+        {
+          type: "message",
+          annotationID: "a2",
+          messageID: "msg_next",
+          role: "user",
+          quote: "updated quote",
+          comment: "updated comment",
+          preview: "updated preview",
+          key: "message:a2",
+        },
+        {
+          type: "file",
+          path: "src/c1.ts",
+          comment: "file",
+          commentID: "c1",
+        },
+      ])
+
+      dispose()
+    })
+  })
+
+  test("removeMessage removes only the targeted annotation", () => {
+    createRoot((dispose) => {
+      const prompt = createPromptSessionForTest({
+        items: [msg("a1"), msg("a2"), file("c1")],
+      })
+
+      prompt.context.removeMessage("a1")
+
+      expect(prompt.context.items()).toMatchObject([
+        {
+          type: "message",
+          annotationID: "a2",
+          key: "message:a2",
+        },
+        {
+          type: "file",
+          path: "src/c1.ts",
+          commentID: "c1",
+        },
+      ])
+
+      dispose()
+    })
+  })
+
+  test("replaceMessages swaps message annotations and keeps file comments", () => {
+    createRoot((dispose) => {
+      const prompt = createPromptSessionForTest({
+        items: [msg("a1"), file("c1"), msg("a2"), file("c2", "other")],
+      })
+
+      prompt.context.replaceMessages([msg("b1"), msg("b2", "fresh")])
+
+      expect(prompt.context.items()).toMatchObject([
+        {
+          type: "file",
+          path: "src/c1.ts",
+          commentID: "c1",
+        },
+        {
+          type: "file",
+          path: "src/c2.ts",
+          commentID: "c2",
+          comment: "other",
+        },
+        {
+          type: "message",
+          annotationID: "b1",
+          key: "message:b1",
+        },
+        {
+          type: "message",
+          annotationID: "b2",
+          comment: "fresh",
+          key: "message:b2",
+        },
+      ])
+
+      dispose()
+    })
+  })
+
+  test("replaceComments keeps message annotations in place", () => {
+    createRoot((dispose) => {
+      const prompt = createPromptSessionForTest({
+        items: [msg("a1"), file("c1"), msg("a2")],
+      })
+
+      prompt.context.replaceComments([file("c2", "next")])
+
+      expect(prompt.context.items()).toMatchObject([
+        {
+          type: "message",
+          annotationID: "a1",
+          key: "message:a1",
+        },
+        {
+          type: "message",
+          annotationID: "a2",
+          key: "message:a2",
+        },
+        {
+          type: "file",
+          path: "src/c2.ts",
+          commentID: "c2",
+          comment: "next",
+        },
+      ])
+
+      dispose()
+    })
+  })
+})

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -2,7 +2,8 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { checksum } from "@opencode-ai/util/encode"
 import { useParams } from "@solidjs/router"
 import { batch, createMemo, createRoot, getOwner, onCleanup } from "solid-js"
-import { createStore, type SetStoreFunction } from "solid-js/store"
+import { createStore, type SetStoreFunction, type Store } from "solid-js/store"
+import type { Message } from "@opencode-ai/sdk/v2/client"
 import type { FileSelection } from "@/context/file"
 import { Persist, persisted } from "@/utils/persist"
 
@@ -38,17 +39,52 @@ export interface ImageAttachmentPart {
 export type ContentPart = TextPart | FileAttachmentPart | AgentPart | ImageAttachmentPart
 export type Prompt = ContentPart[]
 
-export type FileContextItem = {
-  type: "file"
-  path: string
-  selection?: FileSelection
+type ContextBase = {
   comment?: string
-  commentID?: string
-  commentOrigin?: "review" | "file"
   preview?: string
 }
 
-export type ContextItem = FileContextItem
+export type FileContextItem = ContextBase & {
+  type: "file"
+  path: string
+  selection?: FileSelection
+  commentID?: string
+  commentOrigin?: "review" | "file"
+}
+
+export type MessageContextItem = ContextBase & {
+  type: "message"
+  annotationID: string
+  messageID: string
+  role: Message["role"]
+  quote: string
+}
+
+type MessageValue = MessageContextItem & {
+  path: never
+  selection?: never
+  commentID?: never
+  commentOrigin?: never
+}
+
+export type ContextItem =
+  | (FileContextItem & {
+      annotationID?: never
+      messageID?: never
+      role?: never
+      quote?: never
+    })
+  | MessageValue
+
+type ContextInput = FileContextItem | MessageContextItem
+type ContextEntry = ContextItem & { key: string }
+type PromptStore = {
+  prompt: Prompt
+  cursor?: number
+  context: {
+    items: ContextEntry[]
+  }
+}
 
 export const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
@@ -100,8 +136,27 @@ function clonePrompt(prompt: Prompt): Prompt {
   return prompt.map(clonePart)
 }
 
-function contextItemKey(item: ContextItem) {
-  if (item.type !== "file") return item.type
+function asContext(item: ContextInput): ContextItem {
+  return item as ContextItem
+}
+
+function withKey(item: ContextInput): ContextEntry {
+  const value = asContext(item)
+  return { ...value, key: contextItemKey(value) }
+}
+
+function isFileItem(item: ContextInput | ContextEntry): item is FileContextItem | (FileContextItem & { key: string }) {
+  return item.type === "file"
+}
+
+function isMessageItem(
+  item: ContextInput | ContextEntry,
+): item is MessageContextItem | (MessageContextItem & { key: string }) {
+  return item.type === "message"
+}
+
+function contextItemKey(item: ContextInput | ContextEntry) {
+  if (isMessageItem(item)) return `message:${item.annotationID}`
   const start = item.selection?.startLine
   const end = item.selection?.endLine
   const key = `${item.type}:${item.path}:${start}:${end}`
@@ -117,18 +172,14 @@ function contextItemKey(item: ContextItem) {
 }
 
 function isCommentItem(item: ContextItem | (ContextItem & { key: string })) {
-  return item.type === "file" && !!item.comment?.trim()
+  return !!item.comment?.trim()
 }
 
-function createPromptActions(
-  setStore: SetStoreFunction<{
-    prompt: Prompt
-    cursor?: number
-    context: {
-      items: (ContextItem & { key: string })[]
-    }
-  }>,
-) {
+function isFileCommentItem(item: ContextInput | ContextEntry) {
+  return isFileItem(item) && isCommentItem(item)
+}
+
+function createPromptActions(setStore: SetStoreFunction<PromptStore>) {
   return {
     set(prompt: Prompt, cursorPosition?: number) {
       const next = clonePrompt(prompt)
@@ -144,6 +195,87 @@ function createPromptActions(
       })
     },
   }
+}
+
+function createPromptSessionState(store: Store<PromptStore>, setStore: SetStoreFunction<PromptStore>) {
+  const actions = createPromptActions(setStore)
+
+  return {
+    current: () => store.prompt,
+    cursor: () => store.cursor,
+    dirty: () => !isPromptEqual(store.prompt, DEFAULT_PROMPT),
+    context: {
+      items: () => store.context.items,
+      add(item: ContextInput) {
+        const key = contextItemKey(item)
+        if (store.context.items.find((x) => x.key === key)) return
+        setStore("context", "items", (items) => [...items, withKey(item)])
+      },
+      remove(key: string) {
+        setStore("context", "items", (items) => items.filter((x) => x.key !== key))
+      },
+      removeComment(path: string, commentID: string) {
+        setStore("context", "items", (items) =>
+          items.filter((item) => !(item.type === "file" && item.path === path && item.commentID === commentID)),
+        )
+      },
+      updateComment(path: string, commentID: string, next: Partial<FileContextItem> & { comment?: string }) {
+        setStore("context", "items", (items) =>
+          items.map((item) => {
+            if (item.type !== "file" || item.path !== path || item.commentID !== commentID) return item
+            const value = { ...item, ...next }
+            return { ...value, key: contextItemKey(value) }
+          }),
+        )
+      },
+      removeMessage(annotationID: string) {
+        setStore("context", "items", (items) =>
+          items.filter((item) => !(item.type === "message" && item.annotationID === annotationID)),
+        )
+      },
+      updateMessage(annotationID: string, next: Omit<Partial<MessageContextItem>, "annotationID" | "type">) {
+        setStore("context", "items", (items) =>
+          items.map((item) => {
+            if (item.type !== "message" || item.annotationID !== annotationID) return item
+            const value = { ...item, ...next }
+            return { ...value, key: contextItemKey(value) }
+          }),
+        )
+      },
+      replaceComments(items: FileContextItem[]) {
+        setStore("context", "items", (current) => [
+          ...current.filter((item) => !isFileCommentItem(item)),
+          ...items.map(withKey),
+        ])
+      },
+      replaceMessages(items: MessageContextItem[]) {
+        setStore("context", "items", (current) => [
+          ...current.filter((item) => !isMessageItem(item)),
+          ...items.map(withKey),
+        ])
+      },
+    },
+    set: actions.set,
+    reset: actions.reset,
+  }
+}
+
+export function createPromptSessionForTest(
+  input: {
+    prompt?: Prompt
+    cursor?: number
+    items?: (FileContextItem | MessageContextItem)[]
+  } = {},
+) {
+  const [store, setStore] = createStore<PromptStore>({
+    prompt: clonePrompt(input.prompt ?? DEFAULT_PROMPT),
+    cursor: input.cursor,
+    context: {
+      items: (input.items ?? []).map(withKey),
+    },
+  })
+
+  return createPromptSessionState(store, setStore)
 }
 
 const WORKSPACE_KEY = "__workspace__"
@@ -166,13 +298,7 @@ function createPromptSession(dir: string, id: string | undefined) {
 
   const [store, setStore, _, ready] = persisted(
     Persist.scoped(dir, id, "prompt", [legacy]),
-    createStore<{
-      prompt: Prompt
-      cursor?: number
-      context: {
-        items: (ContextItem & { key: string })[]
-      }
-    }>({
+    createStore<PromptStore>({
       prompt: clonePrompt(DEFAULT_PROMPT),
       cursor: undefined,
       context: {
@@ -180,47 +306,16 @@ function createPromptSession(dir: string, id: string | undefined) {
       },
     }),
   )
-
-  const actions = createPromptActions(setStore)
+  const session = createPromptSessionState(store, setStore)
 
   return {
     ready,
-    current: createMemo(() => store.prompt),
-    cursor: createMemo(() => store.cursor),
-    dirty: createMemo(() => !isPromptEqual(store.prompt, DEFAULT_PROMPT)),
-    context: {
-      items: createMemo(() => store.context.items),
-      add(item: ContextItem) {
-        const key = contextItemKey(item)
-        if (store.context.items.find((x) => x.key === key)) return
-        setStore("context", "items", (items) => [...items, { key, ...item }])
-      },
-      remove(key: string) {
-        setStore("context", "items", (items) => items.filter((x) => x.key !== key))
-      },
-      removeComment(path: string, commentID: string) {
-        setStore("context", "items", (items) =>
-          items.filter((item) => !(item.type === "file" && item.path === path && item.commentID === commentID)),
-        )
-      },
-      updateComment(path: string, commentID: string, next: Partial<FileContextItem> & { comment?: string }) {
-        setStore("context", "items", (items) =>
-          items.map((item) => {
-            if (item.type !== "file" || item.path !== path || item.commentID !== commentID) return item
-            const value = { ...item, ...next }
-            return { ...value, key: contextItemKey(value) }
-          }),
-        )
-      },
-      replaceComments(items: FileContextItem[]) {
-        setStore("context", "items", (current) => [
-          ...current.filter((item) => !isCommentItem(item)),
-          ...items.map((item) => ({ ...item, key: contextItemKey(item) })),
-        ])
-      },
-    },
-    set: actions.set,
-    reset: actions.reset,
+    current: session.current,
+    cursor: session.cursor,
+    dirty: session.dirty,
+    context: session.context,
+    set: session.set,
+    reset: session.reset,
   }
 }
 
@@ -283,12 +378,16 @@ export const { use: usePrompt, provider: PromptProvider } = createSimpleContext(
       dirty: () => session().dirty(),
       context: {
         items: () => session().context.items(),
-        add: (item: ContextItem) => session().context.add(item),
+        add: (item: ContextInput) => session().context.add(item),
         remove: (key: string) => session().context.remove(key),
         removeComment: (path: string, commentID: string) => session().context.removeComment(path, commentID),
         updateComment: (path: string, commentID: string, next: Partial<FileContextItem> & { comment?: string }) =>
           session().context.updateComment(path, commentID, next),
+        removeMessage: (annotationID: string) => session().context.removeMessage(annotationID),
+        updateMessage: (annotationID: string, next: Omit<Partial<MessageContextItem>, "annotationID" | "type">) =>
+          session().context.updateMessage(annotationID, next),
         replaceComments: (items: FileContextItem[]) => session().context.replaceComments(items),
+        replaceMessages: (items: MessageContextItem[]) => session().context.replaceMessages(items),
       },
       set: (prompt: Prompt, cursorPosition?: number, scope?: Scope) => pick(scope).set(prompt, cursorPosition),
       reset: (scope?: Scope) => pick(scope).reset(),

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -258,6 +258,8 @@ export const dict = {
   "prompt.attachment.remove": "إزالة المرفق",
   "prompt.action.send": "إرسال",
   "prompt.action.stop": "توقف",
+  "prompt.action.addCommentToPrompt": "أضف تعليقًا إلى المطالبة",
+  "prompt.action.addCommentsToPrompt": "أضف تعليقات إلى المطالبة",
   "prompt.toast.pasteUnsupported.title": "مرفق غير مدعوم",
   "prompt.toast.pasteUnsupported.description": "يمكن إرفاق الصور أو ملفات PDF أو الملفات النصية فقط هنا.",
   "prompt.toast.modelAgentRequired.title": "حدد وكيلاً ونموذجاً",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -258,6 +258,8 @@ export const dict = {
   "prompt.attachment.remove": "Remover anexo",
   "prompt.action.send": "Enviar",
   "prompt.action.stop": "Parar",
+  "prompt.action.addCommentToPrompt": "Adicionar comentário ao prompt",
+  "prompt.action.addCommentsToPrompt": "Adicionar comentários ao prompt",
   "prompt.toast.pasteUnsupported.title": "Anexo não suportado",
   "prompt.toast.pasteUnsupported.description": "Apenas imagens, PDFs ou arquivos de texto podem ser anexados aqui.",
   "prompt.toast.modelAgentRequired.title": "Selecione um agente e modelo",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -278,6 +278,8 @@ export const dict = {
   "prompt.attachment.remove": "Ukloni prilog",
   "prompt.action.send": "Pošalji",
   "prompt.action.stop": "Zaustavi",
+  "prompt.action.addCommentToPrompt": "Dodaj komentar u prompt",
+  "prompt.action.addCommentsToPrompt": "Dodaj komentare u prompt",
 
   "prompt.toast.pasteUnsupported.title": "Nepodržan prilog",
   "prompt.toast.pasteUnsupported.description": "Ovdje se mogu priložiti samo slike, PDF-ovi ili tekstualne datoteke.",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -276,6 +276,8 @@ export const dict = {
   "prompt.attachment.remove": "Fjern vedhæftning",
   "prompt.action.send": "Send",
   "prompt.action.stop": "Stop",
+  "prompt.action.addCommentToPrompt": "Tilføj kommentar til prompt",
+  "prompt.action.addCommentsToPrompt": "Tilføj kommentarer til prompt",
 
   "prompt.toast.pasteUnsupported.title": "Ikke understøttet vedhæftning",
   "prompt.toast.pasteUnsupported.description": "Kun billeder, PDF'er eller tekstfiler kan vedhæftes her.",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -263,6 +263,8 @@ export const dict = {
   "prompt.attachment.remove": "Anhang entfernen",
   "prompt.action.send": "Senden",
   "prompt.action.stop": "Stopp",
+  "prompt.action.addCommentToPrompt": "Kommentar zum Prompt hinzufügen",
+  "prompt.action.addCommentsToPrompt": "Kommentare zum Prompt hinzufügen",
   "prompt.toast.pasteUnsupported.title": "Nicht unterstützter Anhang",
   "prompt.toast.pasteUnsupported.description": "Hier können nur Bilder, PDFs oder Textdateien angehängt werden.",
   "prompt.toast.modelAgentRequired.title": "Wählen Sie einen Agenten und ein Modell",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -280,6 +280,8 @@ export const dict = {
   "prompt.attachment.remove": "Remove attachment",
   "prompt.action.send": "Send",
   "prompt.action.stop": "Stop",
+  "prompt.action.addCommentToPrompt": "Add comment to prompt",
+  "prompt.action.addCommentsToPrompt": "Add comments to prompt",
 
   "prompt.toast.pasteUnsupported.title": "Unsupported attachment",
   "prompt.toast.pasteUnsupported.description": "Only images, PDFs, or text files can be attached here.",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -277,6 +277,8 @@ export const dict = {
   "prompt.attachment.remove": "Eliminar adjunto",
   "prompt.action.send": "Enviar",
   "prompt.action.stop": "Detener",
+  "prompt.action.addCommentToPrompt": "Añadir comentario al prompt",
+  "prompt.action.addCommentsToPrompt": "Añadir comentarios al prompt",
 
   "prompt.toast.pasteUnsupported.title": "Adjunto no compatible",
   "prompt.toast.pasteUnsupported.description": "Solo se pueden adjuntar imágenes, PDFs o archivos de texto aquí.",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -258,6 +258,8 @@ export const dict = {
   "prompt.attachment.remove": "Supprimer la pièce jointe",
   "prompt.action.send": "Envoyer",
   "prompt.action.stop": "Arrêter",
+  "prompt.action.addCommentToPrompt": "Ajouter un commentaire au prompt",
+  "prompt.action.addCommentsToPrompt": "Ajouter des commentaires au prompt",
   "prompt.toast.pasteUnsupported.title": "Pièce jointe non prise en charge",
   "prompt.toast.pasteUnsupported.description":
     "Seules les images, les PDF ou les fichiers texte peuvent être joints ici.",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -257,6 +257,8 @@ export const dict = {
   "prompt.attachment.remove": "添付ファイルを削除",
   "prompt.action.send": "送信",
   "prompt.action.stop": "停止",
+  "prompt.action.addCommentToPrompt": "コメントをプロンプトに追加",
+  "prompt.action.addCommentsToPrompt": "コメントをプロンプトに追加",
   "prompt.toast.pasteUnsupported.title": "サポートされていない添付ファイル",
   "prompt.toast.pasteUnsupported.description": "画像、PDF、またはテキストファイルのみ添付できます。",
   "prompt.toast.modelAgentRequired.title": "エージェントとモデルを選択",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -261,6 +261,8 @@ export const dict = {
   "prompt.attachment.remove": "첨부 파일 제거",
   "prompt.action.send": "전송",
   "prompt.action.stop": "중지",
+  "prompt.action.addCommentToPrompt": "프롬프트에 댓글 추가",
+  "prompt.action.addCommentsToPrompt": "프롬프트에 댓글 추가",
   "prompt.toast.pasteUnsupported.title": "지원되지 않는 첨부 파일",
   "prompt.toast.pasteUnsupported.description": "이미지, PDF 또는 텍스트 파일만 첨부할 수 있습니다.",
   "prompt.toast.modelAgentRequired.title": "에이전트 및 모델 선택",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -280,6 +280,8 @@ export const dict = {
   "prompt.attachment.remove": "Fjern vedlegg",
   "prompt.action.send": "Send",
   "prompt.action.stop": "Stopp",
+  "prompt.action.addCommentToPrompt": "Legg til kommentar i prompten",
+  "prompt.action.addCommentsToPrompt": "Legg til kommentarer i prompten",
 
   "prompt.toast.pasteUnsupported.title": "Ikke støttet vedlegg",
   "prompt.toast.pasteUnsupported.description": "Kun bilder, PDF-er eller tekstfiler kan legges ved her.",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -259,6 +259,8 @@ export const dict = {
   "prompt.attachment.remove": "Usuń załącznik",
   "prompt.action.send": "Wyślij",
   "prompt.action.stop": "Zatrzymaj",
+  "prompt.action.addCommentToPrompt": "Dodaj komentarz do promptu",
+  "prompt.action.addCommentsToPrompt": "Dodaj komentarze do promptu",
   "prompt.toast.pasteUnsupported.title": "Nieobsługiwany załącznik",
   "prompt.toast.pasteUnsupported.description": "Można tutaj załączać tylko obrazy, pliki PDF lub pliki tekstowe.",
   "prompt.toast.modelAgentRequired.title": "Wybierz agenta i model",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -277,6 +277,8 @@ export const dict = {
   "prompt.attachment.remove": "Удалить вложение",
   "prompt.action.send": "Отправить",
   "prompt.action.stop": "Остановить",
+  "prompt.action.addCommentToPrompt": "Добавить комментарий в запрос",
+  "prompt.action.addCommentsToPrompt": "Добавить комментарии в запрос",
 
   "prompt.toast.pasteUnsupported.title": "Неподдерживаемое вложение",
   "prompt.toast.pasteUnsupported.description": "Здесь можно прикрепить только изображения, PDF или текстовые файлы.",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -277,6 +277,8 @@ export const dict = {
   "prompt.attachment.remove": "เอาไฟล์แนบออก",
   "prompt.action.send": "ส่ง",
   "prompt.action.stop": "หยุด",
+  "prompt.action.addCommentToPrompt": "เพิ่มความคิดเห็นไปยังพรอมต์",
+  "prompt.action.addCommentsToPrompt": "เพิ่มความคิดเห็นไปยังพรอมต์",
 
   "prompt.toast.pasteUnsupported.title": "ไฟล์แนบที่ไม่รองรับ",
   "prompt.toast.pasteUnsupported.description": "แนบได้เฉพาะรูปภาพ, PDF หรือไฟล์ข้อความเท่านั้น",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -282,6 +282,8 @@ export const dict = {
   "prompt.attachment.remove": "Eki kaldır",
   "prompt.action.send": "Gönder",
   "prompt.action.stop": "Durdur",
+  "prompt.action.addCommentToPrompt": "İsteme yorum ekle",
+  "prompt.action.addCommentsToPrompt": "İsteme yorumları ekle",
 
   "prompt.toast.pasteUnsupported.title": "Desteklenmeyen ek",
   "prompt.toast.pasteUnsupported.description": "Buraya yalnızca resimler, PDF'ler veya metin dosyaları eklenebilir.",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -297,6 +297,8 @@ export const dict = {
   "prompt.attachment.remove": "移除附件",
   "prompt.action.send": "发送",
   "prompt.action.stop": "停止",
+  "prompt.action.addCommentToPrompt": "将评论添加到提示词",
+  "prompt.action.addCommentsToPrompt": "将评论添加到提示词",
   "prompt.toast.pasteUnsupported.title": "不支持的附件",
   "prompt.toast.pasteUnsupported.description": "此处仅能附加图片、PDF 或文本文件。",
   "prompt.toast.modelAgentRequired.title": "请选择智能体和模型",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -277,6 +277,8 @@ export const dict = {
   "prompt.attachment.remove": "移除附件",
   "prompt.action.send": "傳送",
   "prompt.action.stop": "停止",
+  "prompt.action.addCommentToPrompt": "將評論加入提示詞",
+  "prompt.action.addCommentsToPrompt": "將評論加入提示詞",
 
   "prompt.toast.pasteUnsupported.title": "不支援的附件",
   "prompt.toast.pasteUnsupported.description": "此處僅能附加圖片、PDF 或文字檔案。",

--- a/packages/app/src/pages/session/message-annotation-popover.cases.tsx
+++ b/packages/app/src/pages/session/message-annotation-popover.cases.tsx
@@ -1,0 +1,510 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { createComponent as CreateComponent, createRoot as CreateRoot } from "solid-js"
+import type { createStore as CreateStore, SetStoreFunction } from "solid-js/store"
+import type { MessageContextItem } from "../../context/prompt"
+import type { MessageSelection } from "./message-selection"
+
+let createComponent: typeof CreateComponent
+let createRoot: typeof CreateRoot
+let createStore: typeof CreateStore
+let render: typeof import("solid-js/web").render
+let MessageAnnotationPopover: typeof import("./message-annotation-popover").MessageAnnotationPopover
+let dir = ""
+const cwd = new URL("../../../", import.meta.url).pathname
+
+const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto")
+const secureDescriptor = Object.getOwnPropertyDescriptor(globalThis, "isSecureContext")
+const focusDescriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "focus")
+
+let focused: HTMLTextAreaElement | undefined
+
+const clean = new Set<VoidFunction>()
+
+const hold = (fn: VoidFunction) => {
+  let live = true
+
+  const drop = () => {
+    if (!live) return
+    live = false
+    clean.delete(drop)
+    fn()
+  }
+
+  clean.add(drop)
+  return drop
+}
+
+const setCrypto = (value: Partial<Crypto>) => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: value as Crypto,
+  })
+}
+
+const setSecure = (value: boolean) => {
+  Object.defineProperty(globalThis, "isSecureContext", {
+    configurable: true,
+    value,
+  })
+}
+
+const box = {
+  x: 24,
+  y: 48,
+  width: 120,
+  height: 18,
+  top: 48,
+  right: 144,
+  bottom: 66,
+  left: 24,
+}
+
+const nextBox = {
+  x: 220,
+  y: 160,
+  width: 80,
+  height: 20,
+  top: 160,
+  right: 300,
+  bottom: 180,
+  left: 220,
+}
+
+const createPrompt = () => {
+  const [state, setState] = createStore({ items: [] as MessageContextItem[] })
+
+  return {
+    context: {
+      items: () => state.items,
+      add: (item: MessageContextItem) => setState("items", (list) => [...list, item]),
+    },
+  }
+}
+
+const tick = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const rect = (value = box) =>
+  ({
+    ...value,
+    toJSON: () => value,
+  }) as DOMRect
+
+const setRect = (range: Range, value = box) => {
+  Object.defineProperty(range, "getBoundingClientRect", {
+    configurable: true,
+    value: () => rect(value),
+  })
+}
+
+const pick = (quote: string, value = box) => {
+  const span = document.querySelector("#quote")
+  if (!(span instanceof HTMLSpanElement)) throw new Error("Missing quote span")
+
+  span.textContent = quote
+  const text = span.firstChild
+  if (!(text instanceof Text)) throw new Error("Missing quote text node")
+
+  const range = document.createRange()
+  range.setStart(text, 0)
+  range.setEnd(text, quote.length)
+  setRect(range, value)
+
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+
+  return {
+    messageID: "msg-1",
+    role: "assistant",
+    quote,
+    rect: value,
+  } satisfies MessageSelection
+}
+
+const pop = () => document.querySelector('[data-component="message-annotation-popover"]') as HTMLDivElement | null
+const head = () => document.querySelector('[data-slot="message-annotation-head"]') as HTMLDivElement | null
+const input = () => document.querySelector('[data-component="message-annotation-input"]') as HTMLTextAreaElement | null
+const save = () => document.querySelector('[data-action="message-annotation-save"]') as HTMLButtonElement | null
+const cancel = () => document.querySelector('[data-action="message-annotation-cancel"]') as HTMLButtonElement | null
+const plain = (value: unknown) => JSON.parse(JSON.stringify(value))
+
+const change = (value: string) => {
+  const el = input()
+  if (!el) throw new Error("Missing annotation input")
+  el.value = value
+  el.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+const seed = (quote = "assistant reply") => {
+  document.body.innerHTML = ""
+
+  const scope = document.createElement("div")
+  const span = document.createElement("span")
+  span.id = "quote"
+  span.textContent = quote
+  scope.append(span)
+
+  const outside = document.createElement("button")
+  outside.id = "outside"
+  outside.type = "button"
+  outside.textContent = "outside"
+
+  const mount = document.createElement("div")
+  mount.id = "mount"
+
+  document.body.append(scope, outside, mount)
+
+  return {
+    mount,
+    outside,
+    selection: pick(quote, box),
+  }
+}
+
+const open = (quote?: string) => {
+  const dom = seed(quote)
+  const prompt = createRoot((dispose) => ({ value: createPrompt(), dispose }))
+  let setStore: SetStoreFunction<{ selection: MessageSelection | undefined }>
+
+  const off = render(() => {
+    const [state, setState] = createStore({ selection: dom.selection as MessageSelection | undefined })
+    setStore = setState
+
+    return createComponent(MessageAnnotationPopover, {
+      get selection() {
+        return state.selection
+      },
+      add: prompt.value.context.add,
+      onClose: () => setState("selection", undefined),
+      placeholderLabel: "Add comment",
+      saveLabel: "Comment",
+      cancelLabel: "Cancel",
+      portal: false,
+    })
+  }, dom.mount)
+
+  const dispose = hold(() => {
+    off()
+    prompt.dispose()
+  })
+
+  return {
+    prompt: prompt.value,
+    outside: dom.outside,
+    close: () => setStore("selection", undefined),
+    select: (quote: string, value = nextBox) => setStore("selection", pick(quote, value)),
+    dispose,
+  }
+}
+
+beforeAll(async () => {
+  const entry = "../message-annotation-popover.tsx"
+  dir = new URL(`./.tmp-message-annotation-popover-${Date.now()}/`, import.meta.url).pathname
+  const fs = await import("node:fs/promises")
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(
+    `${dir}/entry.ts`,
+    [
+      'export { createComponent, createRoot } from "solid-js"',
+      'export { createStore } from "solid-js/store"',
+      'export { render } from "solid-js/web"',
+      `export { MessageAnnotationPopover } from ${JSON.stringify(entry)}`,
+      "",
+    ].join("\n"),
+  )
+  const build = Bun.spawnSync(
+    ["bun", "build", `${dir}/entry.ts`, "--outdir", dir, "--target", "browser", "--format", "esm"],
+    {
+      cwd,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+  if (build.exitCode !== 0)
+    throw new Error(new TextDecoder().decode(build.stderr) || "Failed to build message annotation popover test bundle")
+
+  const mod = await import(`${dir}/entry.js`)
+  createComponent = mod.createComponent
+  createRoot = mod.createRoot
+  createStore = mod.createStore
+  render = mod.render
+  MessageAnnotationPopover = mod.MessageAnnotationPopover
+})
+
+afterAll(async () => {
+  if (!dir) return
+  const fs = await import("node:fs/promises")
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  setCrypto({ randomUUID: () => "11111111-1111-4111-8111-111111111111" })
+  setSecure(true)
+  Object.defineProperty(HTMLTextAreaElement.prototype, "focus", {
+    configurable: true,
+    value: function () {
+      focused = this as HTMLTextAreaElement
+      return focusDescriptor?.value?.call(this)
+    },
+  })
+  focused = undefined
+  document.body.innerHTML = ""
+  window.getSelection()?.removeAllRanges()
+})
+
+afterEach(() => {
+  for (const drop of [...clean]) {
+    drop()
+  }
+
+  document.body.innerHTML = ""
+  window.getSelection()?.removeAllRanges()
+
+  if (cryptoDescriptor) {
+    Object.defineProperty(globalThis, "crypto", cryptoDescriptor)
+  }
+
+  if (secureDescriptor) {
+    Object.defineProperty(globalThis, "isSecureContext", secureDescriptor)
+  } else {
+    delete (globalThis as { isSecureContext?: boolean }).isSecureContext
+  }
+
+  if (focusDescriptor) {
+    Object.defineProperty(HTMLTextAreaElement.prototype, "focus", focusDescriptor)
+    return
+  }
+
+  delete (HTMLTextAreaElement.prototype as { focus?: unknown }).focus
+})
+
+describe("MessageAnnotationPopover", () => {
+  test("saving a comment creates a message annotation item", async () => {
+    const view = open("assistant reply\nwith extra   space")
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    expect(input()).toBeTruthy()
+    expect(save()).toBeTruthy()
+    expect(cancel()).toBeTruthy()
+    expect(focused).toBeTruthy()
+    expect(input()?.getAttribute("placeholder")).toBe("Add comment")
+    expect(save()?.textContent).toBe("Comment")
+    expect(cancel()?.textContent).toBe("Cancel")
+    expect(save()?.disabled).toBe(true)
+
+    change("Needs more detail")
+    expect(save()?.disabled).toBe(false)
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    })
+    input()!.dispatchEvent(event)
+    await tick()
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(plain(view.prompt.context.items())).toEqual([
+      {
+        type: "message",
+        annotationID: "11111111-1111-4111-8111-111111111111",
+        messageID: "msg-1",
+        role: "assistant",
+        quote: "assistant reply\nwith extra   space",
+        preview: "assistant reply with extra space",
+        comment: "Needs more detail",
+      },
+    ])
+    expect(pop()).toBeNull()
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0)
+
+    view.dispose()
+  })
+
+  test("Shift+Enter keeps the popover open for multiline comments", async () => {
+    const view = open()
+    await tick()
+
+    change("Line 1")
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    input()!.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeTruthy()
+
+    change("Line 1\nLine 2")
+    save()!.click()
+
+    expect(plain(view.prompt.context.items())).toEqual([
+      {
+        type: "message",
+        annotationID: "11111111-1111-4111-8111-111111111111",
+        messageID: "msg-1",
+        role: "assistant",
+        quote: "assistant reply",
+        preview: "assistant reply",
+        comment: "Line 1\nLine 2",
+      },
+    ])
+
+    view.dispose()
+  })
+
+  test("blank Enter is a no-op and blank primary stays disabled", async () => {
+    const view = open()
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    expect(save()?.disabled).toBe(true)
+    change("   ")
+    expect(save()?.disabled).toBe(true)
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    })
+    input()!.dispatchEvent(event)
+    await tick()
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeTruthy()
+    expect(input()?.value).toBe("   ")
+    expect(save()?.disabled).toBe(true)
+
+    view.dispose()
+  })
+
+  test("Escape closes the popover without saving", async () => {
+    const view = open()
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    change("discard")
+    input()!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    await tick()
+
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeNull()
+
+    view.dispose()
+  })
+
+  test("cancel closes the popover without saving", async () => {
+    const view = open()
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    change("discard")
+    cancel()!.click()
+    await tick()
+
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeNull()
+
+    view.dispose()
+  })
+
+  test("reselecting a valid quote resets preview, position, and focus", async () => {
+    const view = open("assistant reply")
+    await tick()
+
+    expect(head()?.textContent).toBe("assistant reply")
+    expect(pop()?.style.left).toBe("84px")
+    expect(pop()?.style.top).toBe("36px")
+
+    change("draft")
+    focused = undefined
+
+    view.select("assistant reply\nwith extra   detail", nextBox)
+    await tick()
+
+    const field = input()
+    if (!field) throw new Error("Missing annotation input")
+
+    expect(head()?.textContent).toBe("assistant reply with extra detail")
+    expect(field.value).toBe("")
+    expect(save()?.disabled).toBe(true)
+    expect(pop()?.style.left).toBe("260px")
+    expect(pop()?.style.top).toBe("148px")
+    expect(focused === field).toBe(true)
+    expect(field.selectionStart).toBe(0)
+    expect(field.selectionEnd).toBe(0)
+
+    view.dispose()
+  })
+
+  test("outside click closes the popover", async () => {
+    const view = open()
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    view.outside.dispatchEvent(new Event("pointerdown", { bubbles: true }))
+    await tick()
+
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeNull()
+
+    view.dispose()
+  })
+
+  test("scroll closes the popover", async () => {
+    const view = open()
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    window.dispatchEvent(new Event("scroll"))
+    await tick()
+
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeNull()
+
+    view.dispose()
+  })
+
+  test("resize closes the popover", async () => {
+    const view = open()
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    window.dispatchEvent(new Event("resize"))
+    await tick()
+
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeNull()
+
+    view.dispose()
+  })
+
+  test("selection collapse closes the popover", async () => {
+    const view = open()
+    await tick()
+
+    expect(pop()).toBeTruthy()
+    view.outside.focus()
+    window.getSelection()?.removeAllRanges()
+    document.dispatchEvent(new Event("selectionchange"))
+    await tick()
+
+    expect(view.prompt.context.items()).toHaveLength(0)
+    expect(pop()).toBeNull()
+
+    view.dispose()
+  })
+})

--- a/packages/app/src/pages/session/message-annotation-popover.test.tsx
+++ b/packages/app/src/pages/session/message-annotation-popover.test.tsx
@@ -1,0 +1,24 @@
+import { describe, test } from "bun:test"
+
+const cwd = new URL("../../../", import.meta.url).pathname
+
+const run = () =>
+  Bun.spawnSync(
+    ["bun", "test", "--preload", "./happydom.ts", "./src/pages/session/message-annotation-popover.cases.tsx"],
+    {
+      cwd,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+
+const text = (buf: Uint8Array<ArrayBufferLike>) => new TextDecoder().decode(buf)
+
+describe("MessageAnnotationPopover", () => {
+  test("runs isolated browser bundle coverage", () => {
+    const out = run()
+    if (out.exitCode === 0) return
+
+    throw new Error(`${text(out.stdout)}\n${text(out.stderr)}`.trim())
+  })
+})

--- a/packages/app/src/pages/session/message-annotation-popover.tsx
+++ b/packages/app/src/pages/session/message-annotation-popover.tsx
@@ -1,0 +1,310 @@
+import h from "solid-js/h"
+import { createEffect, onCleanup, type Component, type JSXElement } from "solid-js"
+import { Portal } from "solid-js/web"
+import type { MessageContextItem } from "@/context/prompt"
+import { uuid } from "@/utils/uuid"
+import type { MessageSelection } from "./message-selection"
+
+const gap = 12
+const limit = 96
+
+const clear = () => window.getSelection()?.removeAllRanges()
+
+const preview = (quote: string) => {
+  const text = quote.replace(/\s+/g, " ").trim()
+  if (text.length <= limit) return text
+  return `${text.slice(0, limit - 1).trimEnd()}…`
+}
+
+const rangeRect = () => {
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return
+  return sel.getRangeAt(0).getBoundingClientRect()
+}
+
+const size = (el?: HTMLTextAreaElement) => {
+  if (!el) return
+  el.style.height = "0px"
+  el.style.height = `${Math.min(el.scrollHeight, 160)}px`
+}
+
+export const MessageAnnotationPopover: Component<{
+  selection?: MessageSelection
+  add: (item: MessageContextItem) => void
+  onClose: () => void
+  placeholderLabel: string
+  saveLabel: string
+  cancelLabel: string
+  portal?: boolean
+}> = (props) => {
+  let item: MessageSelection | undefined
+  let top = 0
+  let left = 0
+  let ready = false
+  let id: number | undefined
+  let live = false
+  const root = () => document.querySelector('[data-slot="message-annotation-root"]') as HTMLDivElement | null
+  const head = () => document.querySelector('[data-slot="message-annotation-head"]') as HTMLDivElement | null
+  const input = () => document.querySelector('[data-slot="message-annotation-input"]') as HTMLTextAreaElement | null
+  const save = () => document.querySelector('[data-slot="message-annotation-save"]') as HTMLButtonElement | null
+  const cancel = () => document.querySelector('[data-slot="message-annotation-cancel"]') as HTMLButtonElement | null
+
+  const sync = () => {
+    const box = root()
+    if (box) {
+      if (item) {
+        box.dataset.component = "message-annotation-popover"
+        box.style.display = ""
+      } else {
+        box.removeAttribute("data-component")
+        box.style.display = "none"
+      }
+
+      box.style.top = `${top}px`
+      box.style.left = `${left}px`
+      box.style.opacity = ready ? "1" : "0"
+      box.style.pointerEvents = ready ? "auto" : "none"
+      box.style.transform = `translate(-50%, ${ready ? "0px" : "4px"})`
+    }
+
+    const title = head()
+    if (title) {
+      title.textContent = item ? preview(item.quote) : ""
+    }
+
+    const field = input()
+    if (field) {
+      if (item) field.dataset.component = "message-annotation-input"
+      else field.removeAttribute("data-component")
+    }
+
+    const submit = save()
+    if (submit) {
+      if (item) submit.dataset.action = "message-annotation-save"
+      else submit.removeAttribute("data-action")
+      submit.disabled = !item || (field?.value.trim().length ?? 0) === 0
+    }
+
+    const dismiss = cancel()
+    if (dismiss) {
+      if (item) dismiss.dataset.action = "message-annotation-cancel"
+      else dismiss.removeAttribute("data-action")
+    }
+  }
+
+  const bind = () => {
+    if (live) return
+    live = true
+    document.addEventListener("pointerdown", down, true)
+    document.addEventListener("selectionchange", collapse)
+    window.addEventListener("scroll", close, true)
+    window.addEventListener("resize", close)
+  }
+
+  const drop = () => {
+    if (!live) return
+    live = false
+    document.removeEventListener("pointerdown", down, true)
+    document.removeEventListener("selectionchange", collapse)
+    window.removeEventListener("scroll", close, true)
+    window.removeEventListener("resize", close)
+  }
+
+  const reset = () => {
+    const field = input()
+    if (!field) return
+    field.value = ""
+    size(field)
+  }
+
+  const hide = () => {
+    item = undefined
+    ready = false
+    if (id !== undefined) {
+      window.clearTimeout(id)
+      id = undefined
+    }
+    reset()
+    sync()
+    drop()
+  }
+
+  const close = () => {
+    if (!item) return
+    clear()
+    hide()
+    props.onClose()
+  }
+
+  const place = (selection: MessageSelection) => {
+    const box = rangeRect() ?? selection.rect
+    const pop = root()
+    if (!pop) return
+
+    const rect = pop.getBoundingClientRect()
+    const half = rect.width / 2
+    const center = box.left + box.width / 2
+    left = Math.min(Math.max(center, gap + half), window.innerWidth - gap - half)
+    top =
+      box.top >= rect.height + gap
+        ? Math.max(gap, box.top - rect.height - gap)
+        : Math.max(gap, Math.min(window.innerHeight - rect.height - gap, box.bottom + gap))
+    sync()
+  }
+
+  const focus = () => {
+    const field = input()
+    size(field ?? undefined)
+    field?.focus()
+    const end = field?.value.length ?? 0
+    field?.setSelectionRange(end, end)
+  }
+
+  const submit = () => {
+    if (!item) return
+
+    const comment = input()?.value.trim()
+    if (!comment) return
+
+    props.add({
+      type: "message",
+      annotationID: uuid(),
+      messageID: item.messageID,
+      role: item.role,
+      quote: item.quote,
+      preview: preview(item.quote),
+      comment,
+    })
+    close()
+  }
+
+  const down = (event: PointerEvent) => {
+    const target = event.target
+    if (target instanceof Node && root()?.contains(target)) return
+    close()
+  }
+
+  const collapse = () => {
+    if (!ready) return
+    if (document.activeElement instanceof Node && root()?.contains(document.activeElement)) return
+    const sel = window.getSelection()
+    if (sel && !sel.isCollapsed && sel.rangeCount > 0) return
+    close()
+  }
+
+  const queue = () => {
+    if (id !== undefined) window.clearTimeout(id)
+    id = window.setTimeout(() => {
+      id = undefined
+      if (!item) {
+        hide()
+        return
+      }
+
+      place(item)
+      focus()
+      ready = true
+      sync()
+      bind()
+    }, 0)
+  }
+
+  createEffect(() => {
+    item = props.selection
+    if (!item) {
+      hide()
+      return
+    }
+
+    ready = false
+    reset()
+    sync()
+    queue()
+  })
+
+  onCleanup(() => {
+    if (id !== undefined) window.clearTimeout(id)
+    drop()
+  })
+
+  const body: JSXElement = h(
+    "div",
+    {
+      "data-slot": "message-annotation-root",
+      role: "dialog",
+      "aria-modal": "false",
+      "data-message-selection-ignore": "true",
+      class:
+        "fixed z-[70] w-[min(320px,calc(100vw-24px))] overflow-hidden rounded-[12px] border border-border-weak-base bg-surface-raised-stronger-non-alpha text-text-strong shadow-[var(--shadow-lg-border-base)] transition-[opacity,transform] duration-150 ease-out",
+      style: {
+        display: "none",
+        opacity: "0",
+        left: "0px",
+        top: "0px",
+        transform: "translate(-50%, 4px)",
+        "pointer-events": "none",
+      },
+    },
+    h("div", {
+      "data-slot": "message-annotation-head",
+      class: "border-b border-border-weaker-base px-3 py-2 text-11-medium text-text-weak truncate",
+    }),
+    h(
+      "div",
+      { class: "flex flex-col gap-2 p-2" },
+      h("textarea", {
+        "data-slot": "message-annotation-input",
+        rows: 3,
+        placeholder: props.placeholderLabel,
+        class:
+          "min-h-16 max-h-40 w-full resize-y rounded-md border border-border-base bg-background-base px-2 py-2 text-13-regular text-text-strong outline-none placeholder:text-text-weaker focus:shadow-[var(--shadow-xs-border-select)]",
+        onInput: (event: Event & { currentTarget: HTMLTextAreaElement }) => {
+          size(event.currentTarget)
+          sync()
+        },
+        onKeyDown: (event: KeyboardEvent) => {
+          if (event.key === "Escape") {
+            event.preventDefault()
+            close()
+            return
+          }
+
+          if (event.key !== "Enter" || event.shiftKey) return
+          event.preventDefault()
+          submit()
+        },
+      }),
+      h(
+        "div",
+        { class: "flex items-center justify-end gap-2 pl-2" },
+        h(
+          "button",
+          {
+            "data-slot": "message-annotation-cancel",
+            type: "button",
+            "data-variant": "ghost",
+            class:
+              "h-7 rounded-md border border-border-base bg-transparent px-2.5 text-12-medium text-text-strong transition-colors hover:bg-surface-raised-base-hover",
+            onClick: close,
+          },
+          props.cancelLabel,
+        ),
+        h(
+          "button",
+          {
+            "data-slot": "message-annotation-save",
+            type: "button",
+            "data-variant": "primary",
+            disabled: true,
+            class:
+              "h-7 rounded-md border border-text-strong bg-text-strong px-2.5 text-12-medium text-background-base transition-opacity disabled:pointer-events-none disabled:opacity-50",
+            onClick: submit,
+          },
+          props.saveLabel,
+        ),
+      ),
+    ),
+  ) as unknown as JSXElement
+
+  return (props.portal === false ? body : h(Portal, null, body)) as unknown as JSXElement
+}

--- a/packages/app/src/pages/session/message-annotation-trigger.cases.tsx
+++ b/packages/app/src/pages/session/message-annotation-trigger.cases.tsx
@@ -1,0 +1,566 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import type { createComponent as CreateComponent } from "solid-js"
+import type { createStore as CreateStore, SetStoreFunction } from "solid-js/store"
+import type { MessageSelection } from "./message-selection"
+import type { MessageAnnotationTriggerVariant } from "./message-annotation-trigger"
+
+let createComponent: typeof CreateComponent
+let createStore: typeof CreateStore
+let render: typeof import("solid-js/web").render
+let MessageAnnotationTrigger: typeof import("./message-annotation-trigger").MessageAnnotationTrigger
+let dir = ""
+let focusCount = 0
+const cwd = new URL("../../../", import.meta.url).pathname
+const label = "Add comment"
+const limit = 96
+const vars = ["icon", "toolbar", "mini"] as const satisfies MessageAnnotationTriggerVariant[]
+
+const widthDescriptor = Object.getOwnPropertyDescriptor(window, "innerWidth")
+const heightDescriptor = Object.getOwnPropertyDescriptor(window, "innerHeight")
+const focusDescriptor = Object.getOwnPropertyDescriptor(HTMLButtonElement.prototype, "focus")
+
+const lead = {
+  x: 24,
+  y: 48,
+  width: 120,
+  height: 18,
+  top: 48,
+  right: 144,
+  bottom: 66,
+  left: 24,
+}
+
+const tail = {
+  x: 180,
+  y: 72,
+  width: 40,
+  height: 18,
+  top: 72,
+  right: 220,
+  bottom: 90,
+  left: 180,
+}
+
+const preview = (quote: string) => {
+  const text = quote.replace(/\s+/g, " ").trim()
+  if (text.length <= limit) return text
+  return `${text.slice(0, limit - 1).trimEnd()}…`
+}
+
+const shift = (variant: MessageAnnotationTriggerVariant) =>
+  variant === "icon" ? "translate(0, -50%)" : "translate(calc(28px - 100%), -50%)"
+
+const tick = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const rect = (value = lead) =>
+  ({
+    ...value,
+    toJSON: () => value,
+  }) as DOMRect
+
+const setRect = (range: Range, value = lead) => {
+  Object.defineProperty(range, "getBoundingClientRect", {
+    configurable: true,
+    value: () => rect(value),
+  })
+  Object.defineProperty(range, "getClientRects", {
+    configurable: true,
+    value: () => {
+      return {
+        length: 1,
+        item: (i: number) => (i === 0 ? rect(value) : null),
+        0: rect(value),
+      } as unknown as DOMRectList
+    },
+  })
+}
+
+const pick = (quote: string, input: { rect?: typeof lead; anchor?: typeof tail } = {}) => {
+  const span = document.querySelector("#quote")
+  if (!(span instanceof HTMLSpanElement)) throw new Error("Missing quote span")
+
+  span.textContent = quote
+  const text = span.firstChild
+  if (!(text instanceof Text)) throw new Error("Missing quote text node")
+
+  const range = document.createRange()
+  range.setStart(text, 0)
+  range.setEnd(text, quote.length)
+  setRect(range, input.rect ?? lead)
+
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+
+  return {
+    messageID: "msg-1",
+    role: "assistant",
+    quote,
+    rect: input.rect ?? lead,
+    anchor: input.anchor ?? tail,
+  } satisfies MessageSelection
+}
+
+const seed = (input: { quote?: string; rect?: typeof lead; anchor?: typeof tail } = {}) => {
+  const quote = input.quote ?? "assistant reply"
+  document.body.innerHTML = ""
+
+  const scope = document.createElement("div")
+  const span = document.createElement("span")
+  span.id = "quote"
+  span.textContent = quote
+  scope.append(span)
+
+  const outside = document.createElement("button")
+  outside.id = "outside"
+  outside.type = "button"
+  outside.textContent = "outside"
+
+  const mount = document.createElement("div")
+  mount.id = "mount"
+
+  document.body.append(scope, outside, mount)
+
+  return {
+    mount,
+    outside,
+    selection: pick(quote, { rect: input.rect, anchor: input.anchor }),
+  }
+}
+
+const trigger = () => document.querySelector('[data-component="message-annotation-trigger"]') as HTMLButtonElement | null
+const action = () => document.querySelector('[data-action="message-annotation-trigger-open"]') as HTMLButtonElement | null
+const lab = () => document.querySelector('[data-slot="message-annotation-trigger-label"]') as HTMLSpanElement | null
+const text = () => document.querySelector('[data-slot="message-annotation-trigger-quote"]') as HTMLSpanElement | null
+const plain = (value: unknown) => JSON.parse(JSON.stringify(value))
+
+const open = (input: {
+  quote?: string
+  variant?: MessageAnnotationTriggerVariant
+  rect?: typeof lead
+  anchor?: typeof tail
+  label?: string
+} = {}) => {
+  const dom = seed({ quote: input.quote, rect: input.rect, anchor: input.anchor })
+  let setStore: SetStoreFunction<{
+    selection: MessageSelection | undefined
+    variant: MessageAnnotationTriggerVariant | undefined
+  }>
+  const calls = {
+    open: [] as MessageSelection[],
+    close: 0,
+  }
+
+  const off = render(() => {
+    const [state, setState] = createStore({
+      selection: dom.selection as MessageSelection | undefined,
+      variant: input.variant,
+    })
+    setStore = setState
+
+    return createComponent(MessageAnnotationTrigger, {
+      get selection() {
+        return state.selection
+      },
+      get variant() {
+        return state.variant
+      },
+      label: input.label ?? label,
+      onOpen: (selection) => calls.open.push(selection),
+      onClose: () => {
+        calls.close += 1
+        setState("selection", undefined)
+      },
+    })
+  }, dom.mount)
+
+  return {
+    calls,
+    label: input.label ?? label,
+    outside: dom.outside,
+    selection: dom.selection,
+    clear: () => setStore("selection", undefined),
+    setVariant: (variant?: MessageAnnotationTriggerVariant) => setStore("variant", variant),
+    dispose: off,
+  }
+}
+
+beforeAll(async () => {
+  const entry = "../message-annotation-trigger.tsx"
+  dir = new URL(`./.tmp-message-annotation-trigger-${Date.now()}/`, import.meta.url).pathname
+  const fs = await import("node:fs/promises")
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(
+    `${dir}/entry.ts`,
+    [
+      'import h from "solid-js/h"',
+      'globalThis.React = { createElement: h }',
+      'export { createComponent } from "solid-js"',
+      'export { createStore } from "solid-js/store"',
+      'export { render } from "solid-js/web"',
+      `export { MessageAnnotationTrigger } from ${JSON.stringify(entry)}`,
+      "",
+    ].join("\n"),
+  )
+  const build = Bun.spawnSync(["bun", "build", `${dir}/entry.ts`, "--outdir", dir, "--target", "browser", "--format", "esm"], {
+    cwd,
+    stderr: "pipe",
+    stdout: "pipe",
+  })
+  if (build.exitCode !== 0)
+    throw new Error(new TextDecoder().decode(build.stderr) || "Failed to build message annotation trigger test bundle")
+
+  const mod = await import(`${dir}/entry.js`)
+  createComponent = mod.createComponent
+  createStore = mod.createStore
+  render = mod.render
+  MessageAnnotationTrigger = mod.MessageAnnotationTrigger
+})
+
+afterAll(async () => {
+  if (!dir) return
+  const fs = await import("node:fs/promises")
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: 640,
+  })
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: 480,
+  })
+  Object.defineProperty(HTMLButtonElement.prototype, "focus", {
+    configurable: true,
+    value: function () {
+      focusCount += 1
+      return focusDescriptor?.value?.call(this)
+    },
+  })
+  focusCount = 0
+  document.body.innerHTML = ""
+  window.getSelection()?.removeAllRanges()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ""
+  window.getSelection()?.removeAllRanges()
+
+  if (widthDescriptor) Object.defineProperty(window, "innerWidth", widthDescriptor)
+  if (heightDescriptor) Object.defineProperty(window, "innerHeight", heightDescriptor)
+
+  if (focusDescriptor) {
+    Object.defineProperty(HTMLButtonElement.prototype, "focus", focusDescriptor)
+    return
+  }
+
+  delete (HTMLButtonElement.prototype as { focus?: unknown }).focus
+})
+
+describe("MessageAnnotationTrigger", () => {
+  test("renders icon, toolbar, and mini trigger shells without mounting editor UI", async () => {
+    const quote = `  ${"assistant\n\nreply   ".repeat(12)} `
+
+    for (const variant of vars) {
+      const view = open({ quote, variant })
+      await tick()
+
+      const el = trigger()
+      if (!el) throw new Error(`Missing trigger for ${variant}`)
+
+      expect(action()).toBe(el)
+      expect(el.dataset.variant).toBe(variant)
+      expect(el.getAttribute("aria-label")).toBe(view.label)
+      expect(el.querySelector('[data-component="icon"][data-size="small"]')).toBeTruthy()
+      expect(el.style.left).toBe(variant === "mini" ? "264px" : "228px")
+      expect(el.style.top).toBe("81px")
+      expect(el.style.transform).toBe(shift(variant))
+      expect(document.querySelector('[data-slot="message-annotation-input"]')).toBeNull()
+      expect(document.querySelector('[data-action="message-annotation-save"]')).toBeNull()
+      expect(document.querySelector('[data-component="message-annotation-popover"]')).toBeNull()
+
+      if (variant === "icon") {
+        expect(lab()?.textContent).toBe("")
+        expect(lab()?.style.display).toBe("none")
+        expect(text()?.textContent).toBe("")
+        expect(text()?.style.display).toBe("none")
+        expect(el.textContent?.trim()).toBe("")
+      }
+
+      if (variant === "toolbar") {
+        expect(lab()?.textContent).toBe(view.label)
+        expect(lab()?.style.display).toBe("block")
+        expect(text()?.textContent).toBe("")
+        expect(text()?.style.display).toBe("none")
+        expect(el.textContent?.trim()).toBe(view.label)
+      }
+
+      if (variant === "mini") {
+        expect(lab()?.textContent).toBe("")
+        expect(lab()?.style.display).toBe("none")
+        expect(text()?.textContent).toBe(preview(quote))
+        expect(text()?.style.display).toBe("block")
+        expect(text()?.title).toBe(preview(quote))
+        expect(el.textContent?.trim()).toBe(preview(quote))
+      }
+
+      view.clear()
+      await tick()
+
+      expect(trigger()).toBeNull()
+      expect(action()).toBeNull()
+      expect(view.calls.close).toBe(0)
+
+      view.dispose()
+    }
+  })
+
+  test("defaults to the icon contract when variant is omitted", async () => {
+    const view = open()
+    await tick()
+
+    expect(trigger()?.dataset.variant).toBe("icon")
+    expect(lab()?.style.display).toBe("none")
+    expect(text()?.style.display).toBe("none")
+    expect(action()).toBeTruthy()
+
+    view.dispose()
+  })
+
+  test("switches visible variants without changing the shared selection contract", async () => {
+    const quote = "  assistant\n\nreply   with    space  "
+    const view = open({ quote, variant: "icon" })
+    await tick()
+
+    expect(trigger()?.dataset.variant).toBe("icon")
+    expect(window.getSelection()?.rangeCount).toBe(1)
+    expect(view.calls.open).toHaveLength(0)
+    expect(view.calls.close).toBe(0)
+
+    view.setVariant("toolbar")
+    await tick()
+
+    expect(trigger()?.dataset.variant).toBe("toolbar")
+    expect(lab()?.textContent).toBe(view.label)
+    expect(lab()?.style.display).toBe("block")
+    expect(text()?.textContent).toBe("")
+    expect(text()?.style.display).toBe("none")
+    expect(window.getSelection()?.rangeCount).toBe(1)
+    expect(view.calls.open).toHaveLength(0)
+    expect(view.calls.close).toBe(0)
+
+    view.setVariant("mini")
+    await tick()
+
+    expect(trigger()?.dataset.variant).toBe("mini")
+    expect(lab()?.textContent).toBe("")
+    expect(lab()?.style.display).toBe("none")
+    expect(text()?.textContent).toBe(preview(quote))
+    expect(text()?.style.display).toBe("block")
+    expect(window.getSelection()?.rangeCount).toBe(1)
+    expect(view.calls.open).toHaveLength(0)
+    expect(view.calls.close).toBe(0)
+
+    view.setVariant("icon")
+    await tick()
+
+    expect(trigger()?.dataset.variant).toBe("icon")
+    expect(lab()?.textContent).toBe("")
+    expect(lab()?.style.display).toBe("none")
+    expect(text()?.textContent).toBe("")
+    expect(text()?.style.display).toBe("none")
+    expect(window.getSelection()?.rangeCount).toBe(1)
+    expect(view.calls.open).toHaveLength(0)
+    expect(view.calls.close).toBe(0)
+
+    view.dispose()
+  })
+
+  test("keeps every trigger variant inside the viewport near the top-right edge", async () => {
+    for (const variant of vars) {
+      const view = open({
+        variant,
+        anchor: {
+          x: 628,
+          y: 0,
+          width: 8,
+          height: 20,
+          top: 0,
+          right: 636,
+          bottom: 20,
+          left: 628,
+        },
+      })
+      await tick()
+
+      expect(trigger()).toBeTruthy()
+      expect(trigger()?.style.left).toBe("600px")
+      expect(trigger()?.style.top).toBe("26px")
+      expect(trigger()?.style.transform).toBe(shift(variant))
+
+      view.dispose()
+    }
+  })
+
+  test("keeps every trigger variant inside the viewport near the bottom edge", async () => {
+    for (const variant of vars) {
+      const view = open({
+        variant,
+        anchor: {
+          x: 180,
+          y: 468,
+          width: 40,
+          height: 24,
+          top: 468,
+          right: 220,
+          bottom: 492,
+          left: 180,
+        },
+      })
+      await tick()
+
+      expect(trigger()).toBeTruthy()
+      expect(trigger()?.style.left).toBe("228px")
+      expect(trigger()?.style.top).toBe("454px")
+      expect(trigger()?.style.transform).toBe(shift(variant))
+
+      view.dispose()
+    }
+  })
+
+  test("keeps wide variants inside the viewport near the left edge", async () => {
+    const quote = `  ${"assistant\n\nreply   ".repeat(12)} `
+    const anchor = {
+      x: 12,
+      y: 72,
+      width: 8,
+      height: 18,
+      top: 72,
+      right: 20,
+      bottom: 90,
+      left: 12,
+    }
+
+    const toolbar = open({ quote, variant: "toolbar", anchor })
+    await tick()
+
+    expect(trigger()?.style.left).toBe("90px")
+    expect(trigger()?.dataset.variant).toBe("toolbar")
+    expect(lab()?.style.display).toBe("block")
+    toolbar.dispose()
+
+    const mini = open({ quote, variant: "mini", anchor })
+    await tick()
+
+    expect(trigger()?.style.left).toBe("264px")
+    expect(trigger()?.dataset.variant).toBe("mini")
+    expect(text()?.style.display).toBe("block")
+    mini.dispose()
+  })
+
+  test("activation preserves selection and opens the same trigger contract across variants", async () => {
+    for (const variant of vars) {
+      const view = open({ variant })
+      await tick()
+
+      const el = trigger()
+      if (!el) throw new Error(`Missing trigger for ${variant}`)
+
+      const point = new Event("pointerdown", { bubbles: true, cancelable: true })
+      el.dispatchEvent(point)
+      expect(point.defaultPrevented).toBe(true)
+      expect(view.calls.close).toBe(0)
+      expect(window.getSelection()?.rangeCount).toBe(1)
+
+      const down = new MouseEvent("mousedown", { bubbles: true, cancelable: true })
+      el.dispatchEvent(down)
+      expect(down.defaultPrevented).toBe(true)
+      expect(window.getSelection()?.rangeCount).toBe(1)
+
+      const click = new MouseEvent("click", { bubbles: true, cancelable: true })
+      el.dispatchEvent(click)
+      expect(click.defaultPrevented).toBe(true)
+      expect(action()).toBe(el)
+      expect(el.dataset.variant).toBe(variant)
+      expect(plain(view.calls.open)).toEqual([plain(view.selection)])
+      expect(view.calls.close).toBe(0)
+      expect(window.getSelection()?.rangeCount).toBe(1)
+      expect(focusCount).toBe(0)
+
+      view.dispose()
+    }
+  })
+
+  test("outside pointerdown closes every variant without clearing selection", async () => {
+    for (const variant of vars) {
+      const view = open({ variant })
+      await tick()
+
+      expect(trigger()).toBeTruthy()
+      view.outside.dispatchEvent(new Event("pointerdown", { bubbles: true }))
+      await tick()
+
+      expect(view.calls.open).toHaveLength(0)
+      expect(view.calls.close).toBe(1)
+      expect(trigger()).toBeNull()
+      expect(window.getSelection()?.rangeCount).toBe(1)
+
+      view.dispose()
+    }
+  })
+
+  test("selection collapse closes every trigger variant", async () => {
+    for (const variant of vars) {
+      const view = open({ variant })
+      await tick()
+
+      expect(trigger()).toBeTruthy()
+      window.getSelection()?.removeAllRanges()
+      document.dispatchEvent(new Event("selectionchange"))
+      await tick()
+
+      expect(view.calls.close).toBe(1)
+      expect(trigger()).toBeNull()
+
+      view.dispose()
+    }
+  })
+
+  test("scroll closes every variant without clearing selection", async () => {
+    for (const variant of vars) {
+      const view = open({ variant })
+      await tick()
+
+      expect(trigger()).toBeTruthy()
+      window.dispatchEvent(new Event("scroll"))
+      await tick()
+
+      expect(view.calls.close).toBe(1)
+      expect(trigger()).toBeNull()
+      expect(window.getSelection()?.rangeCount).toBe(1)
+
+      view.dispose()
+    }
+  })
+
+  test("resize closes every variant without clearing selection", async () => {
+    for (const variant of vars) {
+      const view = open({ variant })
+      await tick()
+
+      expect(trigger()).toBeTruthy()
+      window.dispatchEvent(new Event("resize"))
+      await tick()
+
+      expect(view.calls.close).toBe(1)
+      expect(trigger()).toBeNull()
+      expect(window.getSelection()?.rangeCount).toBe(1)
+
+      view.dispose()
+    }
+  })
+})

--- a/packages/app/src/pages/session/message-annotation-trigger.test.tsx
+++ b/packages/app/src/pages/session/message-annotation-trigger.test.tsx
@@ -1,0 +1,24 @@
+import { describe, test } from "bun:test"
+
+const cwd = new URL("../../../", import.meta.url).pathname
+
+const run = () =>
+  Bun.spawnSync(
+    ["bun", "test", "--preload", "./happydom.ts", "./src/pages/session/message-annotation-trigger.cases.tsx"],
+    {
+      cwd,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+
+const text = (buf: Uint8Array<ArrayBufferLike>) => new TextDecoder().decode(buf)
+
+describe("MessageAnnotationTrigger", () => {
+  test("runs isolated browser coverage for the icon, toolbar, and mini trigger contracts", () => {
+    const out = run()
+    if (out.exitCode === 0) return
+
+    throw new Error(`${text(out.stdout)}\n${text(out.stderr)}`.trim())
+  })
+})

--- a/packages/app/src/pages/session/message-annotation-trigger.tsx
+++ b/packages/app/src/pages/session/message-annotation-trigger.tsx
@@ -1,0 +1,278 @@
+import h from "solid-js/h"
+import { createEffect, onCleanup, type Component, type JSXElement } from "solid-js"
+import { Icon } from "@opencode-ai/ui/icon"
+import type { MessageSelection } from "./message-selection"
+
+const gap = 12
+const offset = 8
+const limit = 96
+const max = 240
+const size = 28
+const half = size / 2
+
+type State = "hidden" | "visible"
+
+export type MessageAnnotationTriggerVariant = "icon" | "toolbar" | "mini"
+
+const pick = (selection: MessageSelection) => selection.anchor ?? selection.rect
+const kind = (variant?: MessageAnnotationTriggerVariant) => variant ?? "icon"
+const wide = (variant: MessageAnnotationTriggerVariant) => variant !== "icon"
+const preview = (quote: string) => {
+  const text = quote.replace(/\s+/g, " ").trim()
+  if (text.length <= limit) return text
+  return `${text.slice(0, limit - 1).trimEnd()}…`
+}
+const shift = (variant: MessageAnnotationTriggerVariant) =>
+  variant === "icon" ? "translate(0, -50%)" : "translate(calc(28px - 100%), -50%)"
+const shell = (variant: MessageAnnotationTriggerVariant) => {
+  const base =
+    "fixed z-[70] flex h-7 items-center rounded-full border border-border-weak-base bg-surface-raised-stronger-non-alpha shadow-[var(--shadow-lg-border-base)]"
+  if (variant === "icon") return `${base} w-7 justify-center text-13-medium text-text-strong`
+  return `${base} min-w-0 max-w-[min(320px,calc(100vw-24px))] gap-1 pl-2 pr-1 text-text-strong`
+}
+const span = (value: string) => Math.min(max, value.length * 6)
+
+export const MessageAnnotationTrigger: Component<{
+  selection?: MessageSelection
+  variant?: MessageAnnotationTriggerVariant
+  label: string
+  onOpen: (selection: MessageSelection) => void
+  onClose: () => void
+}> = (props) => {
+  let el: HTMLButtonElement | undefined
+  let lab: HTMLSpanElement | undefined
+  let text: HTMLSpanElement | undefined
+  let item: MessageSelection | undefined
+  let state: State = "hidden"
+  let live = false
+  let left = 0
+  let top = 0
+
+  const copy = (variant: MessageAnnotationTriggerVariant) => {
+    if (variant === "toolbar") return props.label
+    if (variant === "mini" && item) return preview(item.quote)
+    return ""
+  }
+
+  const paint = (variant: MessageAnnotationTriggerVariant) => {
+    const value = copy(variant)
+
+    if (lab) {
+      lab.style.display = variant === "toolbar" ? "block" : "none"
+      lab.textContent = variant === "toolbar" ? value : ""
+    }
+
+    if (text) {
+      text.style.display = variant === "mini" ? "block" : "none"
+      text.textContent = variant === "mini" ? value : ""
+      if (variant === "mini" && value) text.title = value
+      else text.removeAttribute("title")
+    }
+  }
+
+  const width = (variant: MessageAnnotationTriggerVariant) => {
+    if (!wide(variant)) return size
+    if (!el) return Math.min(window.innerWidth - gap * 2, size + 12 + span(copy(variant)))
+
+    const left = el.style.left
+    const top = el.style.top
+    const display = el.style.display
+    const pointer = el.style.pointerEvents
+    const visibility = el.style.visibility
+    const transform = el.style.transform
+    const cls = el.className
+
+    el.className = shell(variant)
+    el.style.left = "0px"
+    el.style.top = "0px"
+    el.style.display = ""
+    el.style.pointerEvents = "none"
+    el.style.visibility = "hidden"
+    el.style.transform = shift(variant)
+    paint(variant)
+
+    const value = el.getBoundingClientRect().width || el.scrollWidth || size + 12 + span(copy(variant))
+
+    el.className = cls
+    el.style.left = left
+    el.style.top = top
+    el.style.display = display
+    el.style.pointerEvents = pointer
+    el.style.visibility = visibility
+    el.style.transform = transform
+
+    return Math.min(Math.max(value, size), window.innerWidth - gap * 2)
+  }
+
+  const sync = () => {
+    if (!el) return
+
+    const mode = kind(props.variant)
+
+    el.style.left = `${left}px`
+    el.style.top = `${top}px`
+    el.style.transform = shift(mode)
+    el.className = shell(mode)
+    el.setAttribute("aria-label", props.label)
+    paint(mode)
+
+    if (state === "visible") {
+      el.dataset.component = "message-annotation-trigger"
+      el.dataset.action = "message-annotation-trigger-open"
+      el.dataset.variant = mode
+      el.style.display = ""
+      el.style.pointerEvents = "auto"
+      return
+    }
+
+    el.removeAttribute("data-component")
+    el.removeAttribute("data-action")
+    el.removeAttribute("data-variant")
+    if (lab) lab.textContent = ""
+    if (text) {
+      text.textContent = ""
+      text.removeAttribute("title")
+    }
+    el.style.display = "none"
+    el.style.pointerEvents = "none"
+  }
+
+  const down = (event: PointerEvent) => {
+    const target = event.target
+    if (target instanceof Node && el?.contains(target)) return
+    close()
+  }
+
+  const collapse = () => {
+    if (state !== "visible") return
+    const sel = window.getSelection()
+    if (sel && !sel.isCollapsed && sel.rangeCount > 0) return
+    close()
+  }
+
+  const bind = () => {
+    if (live || state !== "visible") return
+    live = true
+    document.addEventListener("pointerdown", down, true)
+    document.addEventListener("selectionchange", collapse)
+    window.addEventListener("scroll", close, true)
+    window.addEventListener("resize", close)
+  }
+
+  const drop = () => {
+    if (!live) return
+    live = false
+    document.removeEventListener("pointerdown", down, true)
+    document.removeEventListener("selectionchange", collapse)
+    window.removeEventListener("scroll", close, true)
+    window.removeEventListener("resize", close)
+  }
+
+  const hide = () => {
+    state = "hidden"
+    sync()
+    drop()
+  }
+
+  const close = () => {
+    if (state !== "visible") return
+    hide()
+    props.onClose()
+  }
+
+  const place = (selection: MessageSelection) => {
+    const mode = kind(props.variant)
+    const box = pick(selection)
+    const next = width(mode)
+    const x = Math.max(gap + next - size, window.innerWidth - gap - size)
+    const y = Math.max(gap + half, window.innerHeight - gap - half)
+    left = Math.min(Math.max(box.right + offset, gap + next - size), x)
+    top = Math.min(Math.max(box.top + box.height / 2, gap + half), y)
+    sync()
+  }
+
+  const open = () => {
+    if (!item) return
+    props.onOpen(item)
+  }
+
+  createEffect(() => {
+    item = props.selection
+    if (!item) {
+      hide()
+      return
+    }
+
+    state = "visible"
+    place(item)
+    bind()
+  })
+
+  onCleanup(drop)
+
+  return h(
+    "button",
+    {
+      ref: (node: HTMLButtonElement) => {
+        el = node
+        sync()
+      },
+      type: "button",
+      "aria-label": props.label,
+      "data-message-selection-ignore": "true",
+      class:
+        shell(kind(props.variant)),
+      style: {
+        display: "none",
+        left: "0px",
+        top: "0px",
+        transform: shift(kind(props.variant)),
+        "pointer-events": "none",
+      },
+      onPointerDown: (event: PointerEvent) => {
+        event.preventDefault()
+        event.stopPropagation()
+      },
+      onMouseDown: (event: MouseEvent) => {
+        event.preventDefault()
+        event.stopPropagation()
+      },
+      onClick: (event: MouseEvent) => {
+        event.preventDefault()
+        event.stopPropagation()
+        open()
+      },
+    },
+    h(
+      "span",
+      {
+        class: "flex min-w-0 items-center gap-1",
+      },
+      h("span", {
+        ref: (node: HTMLSpanElement) => {
+          text = node
+        },
+        "data-slot": "message-annotation-trigger-quote",
+        class: "min-w-0 max-w-[240px] truncate text-11-medium text-text-weak",
+        style: {
+          display: "none",
+        },
+      }),
+      h("span", {
+        ref: (node: HTMLSpanElement) => {
+          lab = node
+        },
+        "data-slot": "message-annotation-trigger-label",
+        class: "min-w-0 max-w-[240px] truncate whitespace-nowrap text-12-medium",
+        style: {
+          display: "none",
+        },
+      }),
+      h(Icon, {
+        name: "bubble-5",
+        size: "small",
+        class: "shrink-0",
+      }),
+    ),
+  ) as unknown as JSXElement
+}

--- a/packages/app/src/pages/session/message-selection.test.ts
+++ b/packages/app/src/pages/session/message-selection.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { readMessageSelection } from "./message-selection"
+
+const base = {
+  x: 24,
+  y: 48,
+  width: 120,
+  height: 18,
+  top: 48,
+  right: 144,
+  bottom: 66,
+  left: 24,
+}
+
+const makeRect = (input = {}) => {
+  const box = { ...base, ...input }
+  return {
+    ...box,
+    toJSON: () => box,
+  } as DOMRect
+}
+
+const setRect = (range: Range, input: { box?: DOMRect; list?: DOMRect[] } = {}) => {
+  const box = input.box ?? makeRect()
+  const list = input.list ?? [box]
+  Object.defineProperty(range, "getBoundingClientRect", {
+    configurable: true,
+    value: () => box,
+  })
+  Object.defineProperty(range, "getClientRects", {
+    configurable: true,
+    value: () => {
+      return {
+        length: list.length,
+        item: (i: number) => list[i] ?? null,
+        ...Object.fromEntries(list.map((box, i) => [i, box])),
+      } as DOMRectList
+    },
+  })
+}
+
+const text = (id: string) => {
+  const node = document.getElementById(id)?.firstChild
+  if (node) return node
+  throw new Error(`Missing text node for ${id}`)
+}
+
+const select = (input: {
+  startID: string
+  start: number
+  endID?: string
+  end: number
+  box?: DOMRect
+  list?: DOMRect[]
+}) => {
+  const range = document.createRange()
+  range.setStart(text(input.startID), input.start)
+  range.setEnd(text(input.endID ?? input.startID), input.end)
+  setRect(range, { box: input.box, list: input.list })
+
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+  window.getSelection()?.removeAllRanges()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ""
+  window.getSelection()?.removeAllRanges()
+})
+
+describe("readMessageSelection", () => {
+  test("accepts a trimmed selection within one assistant message", () => {
+    document.body.innerHTML = `
+      <div data-message-id="turn-1">
+        <div data-message-selection="true" data-message-selection-id="msg-a1" data-message-role="assistant">
+          <span id="a1">assistant reply text</span>
+        </div>
+      </div>
+    `
+
+    select({ startID: "a1", start: 0, end: 9 })
+
+    expect(readMessageSelection({ root: document.body })).toEqual({
+      messageID: "msg-a1",
+      role: "assistant",
+      quote: "assistant",
+      rect: base,
+      anchor: base,
+    })
+  })
+
+  test("accepts assistant selection in a multi-assistant turn", () => {
+    document.body.innerHTML = `
+      <div data-message-id="turn-1">
+        <div data-message-selection="true" data-message-selection-id="msg-u1" data-message-role="user">
+          <span id="u1">user prompt</span>
+        </div>
+        <div data-message-selection="true" data-message-selection-id="msg-a1" data-message-role="assistant">
+          <span id="a1">first assistant reply</span>
+        </div>
+        <div data-message-selection="true" data-message-selection-id="msg-a2" data-message-role="assistant">
+          <span id="a2">second assistant reply</span>
+        </div>
+      </div>
+    `
+
+    select({ startID: "a2", start: 7, end: 16 })
+
+    expect(readMessageSelection({ root: document.body })).toEqual({
+      messageID: "msg-a2",
+      role: "assistant",
+      quote: "assistant",
+      rect: base,
+      anchor: base,
+    })
+  })
+
+  test("falls back to the range bounding box when client rects are empty", () => {
+    const back = {
+      x: 60,
+      y: 80,
+      width: 44,
+      height: 16,
+      top: 80,
+      right: 104,
+      bottom: 96,
+      left: 60,
+    }
+
+    document.body.innerHTML = `
+      <div data-message-id="turn-1">
+        <div data-message-selection="true" data-message-selection-id="msg-a1" data-message-role="assistant">
+          <span id="a1">assistant reply text</span>
+        </div>
+      </div>
+    `
+
+    select({
+      startID: "a1",
+      start: 0,
+      end: 9,
+      box: makeRect(back),
+      list: [],
+    })
+
+    expect(readMessageSelection({ root: document.body })).toEqual({
+      messageID: "msg-a1",
+      role: "assistant",
+      quote: "assistant",
+      rect: back,
+      anchor: back,
+    })
+  })
+
+  test("returns the first rect and last rect for a multi-line selection", () => {
+    const first = {
+      x: 24,
+      y: 48,
+      width: 96,
+      height: 18,
+      top: 48,
+      right: 120,
+      bottom: 66,
+      left: 24,
+    }
+    const last = {
+      x: 148,
+      y: 72,
+      width: 32,
+      height: 18,
+      top: 72,
+      right: 180,
+      bottom: 90,
+      left: 148,
+    }
+
+    document.body.innerHTML = `
+      <div data-message-id="turn-1">
+        <div data-message-selection="true" data-message-selection-id="msg-a1" data-message-role="assistant">
+          <span id="a1">assistant reply text</span>
+        </div>
+      </div>
+    `
+
+    select({
+      startID: "a1",
+      start: 0,
+      end: 20,
+      list: [makeRect(first), makeRect(last)],
+    })
+
+    expect(readMessageSelection({ root: document.body })).toEqual({
+      messageID: "msg-a1",
+      role: "assistant",
+      quote: "assistant reply text",
+      rect: first,
+      anchor: last,
+    })
+  })
+
+  test("rejects a selection spanning two assistant messages in one turn", () => {
+    document.body.innerHTML = `
+      <div data-message-id="turn-1">
+        <div data-message-selection="true" data-message-selection-id="msg-u1" data-message-role="user">
+          <span id="u1">user prompt</span>
+        </div>
+        <div data-message-selection="true" data-message-selection-id="msg-a1" data-message-role="assistant">
+          <span id="a1">first assistant reply</span>
+        </div>
+        <div data-message-selection="true" data-message-selection-id="msg-a2" data-message-role="assistant">
+          <span id="a2">second assistant reply</span>
+        </div>
+      </div>
+    `
+
+    select({ startID: "a1", start: 6, endID: "a2", end: 6 })
+
+    expect(readMessageSelection({ root: document.body })).toBeUndefined()
+  })
+
+  test("rejects a selection spanning two message wrappers", () => {
+    document.body.innerHTML = `
+      <div data-message-id="turn-1">
+        <div data-message-selection="true" data-message-selection-id="msg-u1" data-message-role="user">
+          <span id="u1">hello world</span>
+        </div>
+      </div>
+      <div data-message-id="turn-2">
+        <div data-message-selection="true" data-message-selection-id="msg-a2" data-message-role="assistant">
+          <span id="a2">assistant reply</span>
+        </div>
+      </div>
+    `
+
+    select({ startID: "u1", start: 6, endID: "a2", end: 5 })
+
+    expect(readMessageSelection({ root: document.body })).toBeUndefined()
+  })
+
+  test("rejects a whitespace-only selection", () => {
+    document.body.innerHTML = `
+      <div data-message-id="turn-1">
+        <div data-message-selection="true" data-message-selection-id="msg-u1" data-message-role="user">
+          <span id="blank">   </span>
+        </div>
+      </div>
+    `
+
+    select({ startID: "blank", start: 0, end: 3 })
+
+    expect(readMessageSelection({ root: document.body })).toBeUndefined()
+  })
+})

--- a/packages/app/src/pages/session/message-selection.ts
+++ b/packages/app/src/pages/session/message-selection.ts
@@ -1,0 +1,143 @@
+import { createSignal, type Accessor } from "solid-js"
+
+export type MessageRole = "assistant" | "user"
+
+export type MessageSelectionRect = {
+  x: number
+  y: number
+  width: number
+  height: number
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+export type MessageSelection = {
+  messageID: string
+  role: MessageRole
+  quote: string
+  rect: MessageSelectionRect
+  anchor?: MessageSelectionRect
+}
+
+type Input = {
+  blocked?: string
+  root?: ParentNode | null
+  selection?: Selection | null
+}
+
+const turnSel = "[data-message-id]"
+const scopeSel = '[data-message-selection="true"][data-message-selection-id][data-message-role]'
+
+const blockedSel = [
+  '[data-component="prompt-input"]',
+  '[data-component="message-annotation-basket"]',
+  "[data-session-title]",
+  '[data-message-selection-ignore="true"]',
+].join(", ")
+
+const parent = (node: Node | null) => {
+  if (node instanceof Element) return node
+  return node?.parentElement ?? undefined
+}
+
+const turn = (node: Node | null) => parent(node)?.closest<HTMLElement>(turnSel)
+
+const scope = (node: Node | null) => parent(node)?.closest<HTMLElement>(scopeSel)
+
+const blocked = (node: Node | null, sel: string) => !!parent(node)?.closest(sel)
+
+const within = (root: ParentNode | null | undefined, node: Node | null) => {
+  if (!(root instanceof Node)) return true
+  return root.contains(node)
+}
+
+const role = (value: string | undefined) => {
+  if (value === "assistant" || value === "user") return value
+}
+
+const box = (rect: DOMRect | DOMRectReadOnly): MessageSelectionRect => {
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    left: rect.left,
+  }
+}
+
+const geometry = (range: Range) => {
+  const list = range.getClientRects()
+  const back = range.getBoundingClientRect()
+  const first = list.item(0) ?? back
+  const last = list.length === 0 ? back : list.item(list.length - 1) ?? back
+  return {
+    rect: box(first),
+    anchor: box(last),
+  }
+}
+
+export function readMessageSelection(input: Input = {}) {
+  const selection = input.selection ?? (typeof window === "undefined" ? undefined : window.getSelection())
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return
+
+  const range = selection.getRangeAt(0)
+  if (!within(input.root, range.startContainer) || !within(input.root, range.endContainer)) return
+
+  const sel = input.blocked ?? blockedSel
+  if (blocked(range.startContainer, sel) || blocked(range.endContainer, sel)) return
+
+  const startTurn = turn(range.startContainer)
+  if (!startTurn) return
+
+  const endTurn = turn(range.endContainer)
+  if (!endTurn || endTurn !== startTurn) return
+
+  const start = scope(range.startContainer)
+  if (!start) return
+
+  const end = scope(range.endContainer)
+  if (!end) return
+
+  const messageID = start.dataset.messageSelectionId
+  if (!messageID || end.dataset.messageSelectionId !== messageID) return
+
+  const kind = role(start.dataset.messageRole)
+  if (!kind || role(end.dataset.messageRole) !== kind) return
+
+  const quote = range.toString().trim()
+  if (!quote) return
+
+  return {
+    messageID,
+    role: kind,
+    quote,
+    ...geometry(range),
+  } satisfies MessageSelection
+}
+
+export function createMessageSelectionController(input: { root: Accessor<ParentNode | undefined>; blocked?: string }) {
+  const [state, setState] = createSignal<MessageSelection>()
+
+  const sync = (selection?: Selection | null) => {
+    const next = readMessageSelection({
+      root: input.root(),
+      selection,
+      blocked: input.blocked,
+    })
+    setState(next)
+    return next
+  }
+
+  const clear = () => setState()
+
+  return {
+    current: state,
+    sync,
+    clear,
+  }
+}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -11,6 +11,7 @@ import { Dialog } from "@opencode-ai/ui/dialog"
 import { InlineInput } from "@opencode-ai/ui/inline-input"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { SessionTurn } from "@opencode-ai/ui/session-turn"
+import { PART_MAPPING } from "@opencode-ai/ui/message-part"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import { TextField } from "@opencode-ai/ui/text-field"
 import type { AssistantMessage, Message as MessageType, Part, TextPart, UserMessage } from "@opencode-ai/sdk/v2"
@@ -22,16 +23,21 @@ import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
+import { usePrompt } from "@/context/prompt"
 import { useSessionKey } from "@/pages/session/session-layout"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
+import { MessageAnnotationPopover } from "@/pages/session/message-annotation-popover"
+import { MessageAnnotationTrigger } from "@/pages/session/message-annotation-trigger"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionTitle } from "@/utils/session-title"
 import { parseCommentNote, readCommentMetadata } from "@/utils/comment-note"
 import { makeTimer } from "@solid-primitives/timer"
+import { createMessageSelectionController, type MessageSelection } from "@/pages/session/message-selection"
+import { messageAnnotationVariant } from "@/testing/message-annotation"
 
 type MessageComment = {
   path: string
@@ -43,7 +49,12 @@ type MessageComment = {
 }
 
 const emptyMessages: MessageType[] = []
+const emptyAssistants: AssistantMessage[] = []
+const hidden = new Set(["todowrite", "todoread"])
+const ctx = new Set(["read", "glob", "grep", "list"])
 const idle = { type: "idle" as const }
+const noteVariant = "icon" as const
+
 type UserActions = {
   fork?: (input: { sessionID: string; messageID: string }) => Promise<void> | void
   revert?: (input: { sessionID: string; messageID: string }) => Promise<void> | void
@@ -97,6 +108,71 @@ const markBoundaryGesture = (input: {
   ) {
     input.onMarkScrollGesture(input.root)
   }
+}
+
+const tag = (el: Element | null, input?: { id: string; role: "assistant" | "user" }) => {
+  if (!(el instanceof HTMLElement)) return
+
+  if (!input) {
+    el.removeAttribute("data-message-selection")
+    el.removeAttribute("data-message-selection-id")
+    el.removeAttribute("data-message-role")
+    return
+  }
+
+  el.dataset.messageSelection = "true"
+  el.dataset.messageSelectionId = input.id
+  el.dataset.messageRole = input.role
+}
+
+const turnAssistants = (messages: MessageType[], id: string) => {
+  const result = Binary.search(messages, id, (message) => message.id)
+  const index = result.found ? result.index : messages.findIndex((message) => message.id === id)
+  if (index < 0) return emptyAssistants
+
+  const rest = messages.slice(index + 1)
+  const stop = rest.findIndex((message) => message.role === "user")
+  const list = stop === -1 ? rest : rest.slice(0, stop)
+  return list.filter((message): message is AssistantMessage => message.role === "assistant" && message.parentID === id)
+}
+
+const visible = (part: Part, show: boolean) => {
+  if (part.type === "tool") {
+    if (hidden.has(part.tool)) return false
+    if (part.tool === "question") return part.state.status !== "pending" && part.state.status !== "running"
+    return true
+  }
+
+  if (part.type === "text") return !!part.text?.trim()
+  if (part.type === "reasoning") return show && !!part.text?.trim()
+  return !!PART_MAPPING[part.type]
+}
+
+const assistantScopes = (messages: AssistantMessage[], parts: Record<string, Part[] | undefined>, show: boolean) => {
+  const list = messages.flatMap((message) =>
+    (parts[message.id] ?? []).filter((part) => visible(part, show)).map((part) => ({ messageID: message.id, part })),
+  )
+  const result: (string | undefined)[] = []
+  let refs: string[] = []
+
+  const flush = () => {
+    if (!refs.length) return
+    result.push(refs.every((id) => id === refs[0]) ? refs[0] : undefined)
+    refs = []
+  }
+
+  list.forEach((item) => {
+    if (item.part.type === "tool" && ctx.has(item.part.tool)) {
+      refs.push(item.messageID)
+      return
+    }
+
+    flush()
+    result.push(item.messageID)
+  })
+
+  flush()
+  return result
 }
 
 type StageConfig = {
@@ -220,11 +296,13 @@ export function MessageTimeline(props: {
   anchor: (id: string) => string
 }) {
   let touchGesture: number | undefined
+  let content: HTMLDivElement | undefined
 
   const navigate = useNavigate()
   const globalSDK = useGlobalSDK()
   const sdk = useSDK()
   const sync = useSync()
+  const prompt = usePrompt()
   const settings = useSettings()
   const dialog = useDialog()
   const language = useLanguage()
@@ -303,6 +381,33 @@ export function MessageTimeline(props: {
     messages: () => props.renderedUserMessages,
     config: stageCfg,
   })
+  const selection = createMessageSelectionController({ root: () => content })
+  const variant = () => messageAnnotationVariant(noteVariant)
+  const [annotation, setAnnotation] = createStore({
+    trigger: undefined as MessageSelection | undefined,
+    popover: undefined as MessageSelection | undefined,
+  })
+  const closeTrigger = () => {
+    selection.clear()
+    setAnnotation("trigger", undefined)
+  }
+  const closePopover = () => {
+    selection.clear()
+    setAnnotation({ trigger: undefined, popover: undefined })
+  }
+  const openPopover = (item: MessageSelection) => {
+    selection.clear()
+    setAnnotation({ trigger: undefined, popover: item })
+  }
+  const syncAnnotation = () => {
+    const next = selection.sync()
+    if (!next) {
+      setAnnotation("trigger", undefined)
+      return
+    }
+
+    setAnnotation({ trigger: next, popover: undefined })
+  }
 
   const [title, setTitle] = createStore({
     draft: "",
@@ -577,6 +682,7 @@ export function MessageTimeline(props: {
           }}
         >
           <button
+            type="button"
             class="pointer-events-auto size-8 flex items-center justify-center rounded-full bg-background-base border border-border-base shadow-sm text-text-base hover:bg-background-stronger transition-colors"
             onClick={props.onResumeScroll}
           >
@@ -585,6 +691,12 @@ export function MessageTimeline(props: {
         </div>
         <ScrollView
           viewportRef={props.setScrollRef}
+          onMouseUp={() => {
+            syncAnnotation()
+          }}
+          onKeyUp={() => {
+            syncAnnotation()
+          }}
           onWheel={(e) => {
             const root = e.currentTarget
             const delta = normalizeWheelDelta({
@@ -612,6 +724,7 @@ export function MessageTimeline(props: {
           }}
           onTouchEnd={() => {
             touchGesture = undefined
+            syncAnnotation()
           }}
           onTouchCancel={() => {
             touchGesture = undefined
@@ -635,10 +748,17 @@ export function MessageTimeline(props: {
             "--sticky-accordion-top": showHeader() ? "48px" : "0px",
           }}
         >
-          <div ref={props.setContentRef} class="min-w-0 w-full">
+          <div
+            ref={(el) => {
+              content = el
+              props.setContentRef(el)
+            }}
+            class="min-w-0 w-full"
+          >
             <Show when={showHeader()}>
               <div
                 data-session-title
+                data-message-selection-ignore="true"
                 classList={{
                   "sticky top-0 z-30 bg-[linear-gradient(to_bottom,var(--background-stronger)_48px,transparent)]": true,
                   "w-full": true,
@@ -744,6 +864,7 @@ export function MessageTimeline(props: {
                           />
                           <DropdownMenu.Portal>
                             <DropdownMenu.Content
+                              data-message-selection-ignore="true"
                               style={{ "min-width": "104px" }}
                               onCloseAutoFocus={(event) => {
                                 if (title.pendingRename) {
@@ -806,6 +927,7 @@ export function MessageTimeline(props: {
                         >
                           <KobaltePopover.Portal>
                             <KobaltePopover.Content
+                              data-message-selection-ignore="true"
                               data-component="popover-content"
                               style={{ "min-width": "320px" }}
                               onEscapeKeyDown={(event) => {
@@ -924,7 +1046,16 @@ export function MessageTimeline(props: {
               </Show>
               <For each={rendered()}>
                 {(messageID) => {
+                  let root: HTMLDivElement | undefined
                   const active = createMemo(() => activeMessageID() === messageID)
+                  const assistants = createMemo(() => turnAssistants(sessionMessages(), messageID), emptyAssistants, {
+                    equals: (a, b) => a.length === b.length && a.every((item, i) => item.id === b[i]?.id),
+                  })
+                  const scopes = createMemo(
+                    () => assistantScopes(assistants(), sync.data.part, settings.general.showReasoningSummaries()),
+                    [],
+                    { equals: (a, b) => a.length === b.length && a.every((item, i) => item === b[i]) },
+                  )
                   const comments = createMemo(() => messageComments(sync.data.part[messageID] ?? []), [], {
                     equals: (a, b) =>
                       a.length === b.length &&
@@ -937,10 +1068,35 @@ export function MessageTimeline(props: {
                       ),
                   })
                   const commentCount = createMemo(() => comments().length)
+
+                  createEffect(() => {
+                    const el = root
+                    if (!el) return
+
+                    tag(el.querySelector('[data-slot="session-turn-message-content"]'), {
+                      id: messageID,
+                      role: "user",
+                    })
+
+                    const box = el.querySelector('[data-slot="session-turn-assistant-content"]')
+                    if (!(box instanceof HTMLElement)) return
+
+                    tag(box, undefined)
+                    const list = scopes()
+                    Array.from(box.children).forEach((child, i) => {
+                      const id = list[i]
+                      tag(child, id ? { id, role: "assistant" } : undefined)
+                    })
+                  })
+
                   return (
                     <div
+                      ref={(el) => {
+                        root = el
+                      }}
                       id={props.anchor(messageID)}
                       data-message-id={messageID}
+                      data-message-role="user"
                       classList={{
                         "min-w-0 w-full max-w-full": true,
                         "md:max-w-200 2xl:max-w-[1000px]": props.centered,
@@ -1013,6 +1169,25 @@ export function MessageTimeline(props: {
             </div>
           </div>
         </ScrollView>
+        <MessageAnnotationTrigger
+          selection={annotation.trigger}
+          variant={variant()}
+          label={language.t("ui.lineComment.placeholder")}
+          onOpen={openPopover}
+          onClose={closeTrigger}
+        />
+        <Show when={annotation.popover}>
+          {(current) => (
+            <MessageAnnotationPopover
+              selection={current()}
+              add={prompt.context.add}
+              onClose={closePopover}
+              placeholderLabel={language.t("ui.lineComment.placeholder")}
+              saveLabel={language.t("ui.lineComment.submit")}
+              cancelLabel={language.t("common.cancel")}
+            />
+          )}
+        </Show>
       </div>
     </Show>
   )

--- a/packages/app/src/testing/message-annotation.ts
+++ b/packages/app/src/testing/message-annotation.ts
@@ -1,0 +1,35 @@
+import type { MessageAnnotationTriggerVariant } from "@/pages/session/message-annotation-trigger"
+
+export type MessageAnnotationWindow = Window & {
+  __opencode_e2e?: {
+    messageAnnotation?: {
+      enabled?: boolean
+      variant?: MessageAnnotationTriggerVariant
+    }
+  }
+}
+
+const valid = (value: unknown): value is MessageAnnotationTriggerVariant =>
+  value === "icon" || value === "toolbar" || value === "mini"
+
+export const messageAnnotationEnabled = () => {
+  if (typeof window === "undefined") return false
+  return (window as MessageAnnotationWindow).__opencode_e2e?.messageAnnotation?.enabled === true
+}
+
+const root = () => {
+  if (!messageAnnotationEnabled()) return
+  return (window as MessageAnnotationWindow).__opencode_e2e?.messageAnnotation
+}
+
+export const messageAnnotationVariant = (fallback: MessageAnnotationTriggerVariant) => {
+  const state = root()
+  if (!state) return fallback
+  return valid(state.variant) ? state.variant : fallback
+}
+
+export const setMessageAnnotationVariant = (variant: MessageAnnotationTriggerVariant | undefined) => {
+  const state = root()
+  if (!state) return
+  state.variant = variant
+}

--- a/packages/app/src/utils/message-feedback.test.ts
+++ b/packages/app/src/utils/message-feedback.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import type { Prompt } from "@/context/prompt"
+import { appendMessageFeedback, exportMessageFeedback } from "./message-feedback"
+
+type Item = Parameters<typeof exportMessageFeedback>[0][number]
+
+const item = (role: Item["role"], id: string, comment = `comment ${id}`): Item => ({
+  role,
+  quote: `quote ${id}`,
+  comment,
+})
+
+describe("message feedback", () => {
+  test("exportMessageFeedback preserves input order and role labels", () => {
+    expect(exportMessageFeedback([item("user", "a"), item("assistant", "b")])).toBe(`# Conversation Feedback
+
+Please use the following annotated excerpts from the conversation when generating the next reply.
+
+## 1. user message
+
+**Selected text**
+\`\`\`
+quote a
+\`\`\`
+
+**Comment**
+> comment a
+
+## 2. assistant message
+
+**Selected text**
+\`\`\`
+quote b
+\`\`\`
+
+**Comment**
+> comment b`)
+  })
+
+  test("exportMessageFeedback blockquotes multi-line comments", () => {
+    expect(exportMessageFeedback([item("assistant", "a", "first\nsecond")])).toContain("**Comment**\n> first\n> second")
+  })
+
+  test("appendMessageFeedback appends a trailing text part without mutating prompt", () => {
+    const prompt: Prompt = [
+      { type: "text", content: "Draft", start: 0, end: 5 },
+      { type: "agent", content: "@helper", start: 5, end: 12, name: "helper" },
+    ]
+    const next = appendMessageFeedback(prompt, "# Conversation Feedback")
+
+    expect(next).toEqual([
+      { type: "text", content: "Draft", start: 0, end: 5 },
+      { type: "agent", content: "@helper", start: 5, end: 12, name: "helper" },
+      { type: "text", content: "\n\n# Conversation Feedback", start: 0, end: 25 },
+    ])
+    expect(next).not.toBe(prompt)
+    expect(next[0]).not.toBe(prompt[0])
+    expect(next[1]).not.toBe(prompt[1])
+    expect(prompt).toEqual([
+      { type: "text", content: "Draft", start: 0, end: 5 },
+      { type: "agent", content: "@helper", start: 5, end: 12, name: "helper" },
+    ])
+  })
+
+  test("appendMessageFeedback appends markdown directly when prompt text is empty", () => {
+    const prompt: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
+
+    expect(appendMessageFeedback(prompt, "# Conversation Feedback")).toEqual([
+      { type: "text", content: "", start: 0, end: 0 },
+      { type: "text", content: "# Conversation Feedback", start: 0, end: 23 },
+    ])
+  })
+})

--- a/packages/app/src/utils/message-feedback.ts
+++ b/packages/app/src/utils/message-feedback.ts
@@ -1,0 +1,74 @@
+import type { Message } from "@opencode-ai/sdk/v2/client"
+import type { Prompt } from "@/context/prompt"
+
+type Item = {
+  role: Message["role"]
+  quote: string
+  comment: string
+}
+
+const TITLE = "# Conversation Feedback"
+const INTRO = "Please use the following annotated excerpts from the conversation when generating the next reply."
+
+const block = (text: string) =>
+  text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n")
+
+export function exportMessageFeedback(items: Item[]) {
+  if (items.length === 0) return ""
+
+  return [
+    TITLE,
+    "",
+    INTRO,
+    "",
+    ...items.flatMap((item, i) => [
+      `## ${i + 1}. ${item.role} message`,
+      "",
+      "**Selected text**",
+      "```",
+      item.quote,
+      "```",
+      "",
+      "**Comment**",
+      block(item.comment),
+      ...(i === items.length - 1 ? [] : [""]),
+    ]),
+  ].join("\n")
+}
+
+export function appendMessageFeedback(prompt: Prompt, markdown: string): Prompt {
+  if (!markdown) {
+    return prompt.map((part) => {
+      if (part.type === "text") return { ...part }
+      if (part.type === "image") return { ...part }
+      if (part.type === "agent") return { ...part }
+      return {
+        ...part,
+        selection: part.selection ? { ...part.selection } : undefined,
+      }
+    })
+  }
+
+  const content = prompt.some((part) => part.type === "text" && part.content.length > 0) ? `\n\n${markdown}` : markdown
+
+  return [
+    ...prompt.map((part) => {
+      if (part.type === "text") return { ...part }
+      if (part.type === "image") return { ...part }
+      if (part.type === "agent") return { ...part }
+      return {
+        ...part,
+        selection: part.selection ? { ...part.selection } : undefined,
+      }
+    }),
+    {
+      type: "text",
+      content,
+      start: 0,
+      end: content.length,
+    },
+  ]
+}


### PR DESCRIPTION
### Issue for this PR

Closes #23677

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds message annotations for session replies. Users can select text in a user or assistant message, see a small floating annotation trigger, click it to open the existing comment editor, and save the note into the prompt context basket.

The trigger is intentional: selecting text no longer opens the editor immediately, so users can still copy the selection first. The implementation also keeps invalid selections rejected, adds a test-only variant probe for icon / toolbar / mini trigger previews, and preserves the prompt basket/export flow when comments are sent.

### How did you verify your code works?

- `bun typecheck`
- `bun test --preload ./happydom.ts ./src/pages/session/message-selection.test.ts ./src/pages/session/message-annotation-popover.test.tsx ./src/pages/session/message-annotation-trigger.test.tsx`
- `OPENCODE_SERVER_PASSWORD= OPENCODE_SERVER_USERNAME= bun run test:e2e:local -- --grep "message annotation"`

### Screenshots / recordings

UI behavior was verified locally and by the Playwright message annotation e2e flow. The e2e flow captures the icon, toolbar, and mini trigger variants during the test run.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR