### PR TITLE
fix(editor): reject lock files with no workspace match for cwd

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -278,12 +278,16 @@ function resolveEditorLockFile() {
   }
 
   const cwd = process.cwd()
+  // longest workspace folder that contains cwd; 0 if none match
+  const bestMatchLength = (lock: EditorLockFile) =>
+    Math.max(0, ...lock.workspaceFolders.map((folder) => pathContainsLength(folder, cwd)))
   const locks = entries
     .filter((entry) => entry.endsWith(".lock"))
     .map((entry) => readEditorLockFile(path.join(directory, entry)))
     .filter((entry): entry is EditorLockFile => Boolean(entry))
-    .sort((left, right) => scoreEditorLock(right, cwd) - scoreEditorLock(left, cwd))
-
+    .filter((entry) => bestMatchLength(entry) > 0)
+    // prefer locks with longer matching workspace folders, then more recent ones
+    .sort((left, right) => bestMatchLength(right) - bestMatchLength(left) || right.mtimeMs - left.mtimeMs)
   return locks[0]
 }
 
@@ -310,11 +314,6 @@ function readEditorLockFile(filePath: string): EditorLockFile | undefined {
   }
 }
 
-function scoreEditorLock(lock: EditorLockFile, cwd: string) {
-  const workspaceMatch = lock.workspaceFolders.some((folder) => pathContains(folder, cwd)) ? 1 : 0
-  return workspaceMatch * 1_000_000_000_000 + lock.mtimeMs
-}
-
 function editorSelectionKey(selection: EditorSelection | undefined) {
   if (!selection) return ""
   return [
@@ -327,9 +326,10 @@ function editorSelectionKey(selection: EditorSelection | undefined) {
   ].join("\0")
 }
 
-function pathContains(parent: string, child: string) {
-  const relative = path.relative(path.resolve(parent), path.resolve(child))
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+function pathContainsLength(parent: string, child: string) {
+  const resolved = path.resolve(parent)
+  const relative = path.relative(resolved, path.resolve(child))
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative)) ? resolved.length : 0
 }
 
 function openEditorSocket(connection: EditorConnection) {


### PR DESCRIPTION
without a minimum score threshold, opencode would connect to any VSCode lock file in ~/.claude/ide/ even when the workspace folders had no relation to the current working directory. This caused cross-directory IDE context injection
-  e.g. a WezTerm session in an unrelated dir receiving file-open events from a VSCode window

### Issue for this PR

Closes #24295

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- instead of just accepting any of lockfiles, regardless of if the paths matched my cwd
- filter lock files to only those whose workspaceFolders contain cwd before sorting. 
- Replace the binary pathContains check with `pathContainsLength` so the sort can prefer the most specific (deepest) workspace match, falling back to mtime for ties.

### How did you verify your code works?
- ran bun dev from the opencode repo with VSCode open in the same workspace
	- confirmed `selection_changed` events are still received for files within the workspace
- ran from another workspace with the vscode ide still open, and verified that a lock file from an unrelated VSCode workspace is rejected by the filter. 

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR