### PR TITLE
fix(app): normalize watcher paths

### DIFF
--- a/packages/app/src/context/file/watcher.test.ts
+++ b/packages/app/src/context/file/watcher.test.ts
@@ -58,6 +58,61 @@ describe("file watcher invalidation", () => {
     expect(loads).toEqual(["src/open.ts"])
   })
 
+  test("normalizes watcher paths before matching open files", () => {
+    const loads: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.updated",
+        properties: {
+          file: "src\\open.ts",
+          event: "change",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => false,
+        isOpen: (path) => path === "src/open.ts",
+        loadFile: (path) => loads.push(path),
+        node: () => ({
+          path: "src/open.ts",
+          type: "file",
+          name: "open.ts",
+          absolute: "/repo/src/open.ts",
+          ignored: false,
+        }),
+        isDirLoaded: () => false,
+        refreshDir: () => {},
+      },
+    )
+
+    expect(loads).toEqual(["src/open.ts"])
+  })
+
+  test("refreshes nearest loaded ancestor on add", () => {
+    const refresh: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.updated",
+        properties: {
+          file: "src/nested/deep/new.ts",
+          event: "add",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => false,
+        loadFile: () => {},
+        node: () => undefined,
+        isDirLoaded: (path) => path === "src",
+        refreshDir: (path) => refresh.push(path),
+      },
+    )
+
+    expect(refresh).toEqual(["src"])
+  })
+
   test("refreshes only changed loaded directory nodes", () => {
     const refresh: string[] = []
 

--- a/packages/app/src/context/file/watcher.ts
+++ b/packages/app/src/context/file/watcher.ts
@@ -15,6 +15,20 @@ type WatcherOps = {
   refreshDir: (path: string) => void
 }
 
+function toWatcherKey(path: string) {
+  return path.replace(/\\/g, "/")
+}
+
+function nearestLoadedParent(path: string, ops: WatcherOps) {
+  const parts = path.split("/").slice(0, -1)
+  while (true) {
+    const dir = parts.join("/")
+    if (ops.isDirLoaded(dir)) return dir
+    if (parts.length === 0) return
+    parts.pop()
+  }
+}
+
 export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   if (event.type !== "file.watcher.updated") return
   const props =
@@ -24,7 +38,7 @@ export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   if (!rawPath) return
   if (!kind) return
 
-  const path = ops.normalize(rawPath)
+  const path = toWatcherKey(ops.normalize(rawPath))
   if (!path) return
   if (path.startsWith(".git/")) return
 
@@ -46,8 +60,8 @@ export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   }
   if (kind !== "add" && kind !== "unlink") return
 
-  const parent = path.split("/").slice(0, -1).join("/")
-  if (!ops.isDirLoaded(parent)) return
+  const parent = nearestLoadedParent(path, ops)
+  if (parent === undefined) return
 
   ops.refreshDir(parent)
 }


### PR DESCRIPTION
### Issue for this PR

Closes #17780

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Watcher events on Windows can arrive with backslash-separated paths while open tabs and cached file tree entries are keyed with forward slashes. This normalizes watcher-side paths before matching open files or loaded file tree nodes. It also refreshes the nearest loaded ancestor for `add`/`unlink` events so changes under unloaded child directories still update the visible tree.

This intentionally keeps the fix scoped to the watcher invalidation path rather than changing general path normalization behavior.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/context/file/watcher.test.ts` from `packages/app`
- `bun test --preload ./happydom.ts ./src/context/file/path.test.ts ./src/context/file/watcher.test.ts` from `packages/app`
- `bun typecheck` from `packages/app`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR