### PR TITLE
fix(app): keep question dock buttons visible on mobile

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -124,14 +124,14 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     const dock = root.closest('[data-component="session-prompt-dock"]')
     if (!(dock instanceof HTMLElement)) return
 
+    const header = document.querySelector("[data-session-title]")
     const scroller = document.querySelector(".scroll-view__viewport")
-    const head = scroller instanceof HTMLElement ? scroller.firstElementChild : undefined
-    const sticky =
-      head instanceof HTMLElement && head.classList.contains("sticky") ? head.getBoundingClientRect().bottom : 0
-    // Fall back to the scroller's top when no sticky header is present (e.g. on
-    // mobile with no session title) so the dock stays inside the visible content
-    // area instead of overflowing the viewport via the 100dvh CSS fallback.
-    const top = sticky || (scroller instanceof HTMLElement ? scroller.getBoundingClientRect().top : 0)
+    const top =
+      header instanceof HTMLElement
+        ? header.getBoundingClientRect().bottom
+        : scroller instanceof HTMLElement
+          ? scroller.getBoundingClientRect().top
+          : 0
 
     const dockBottom = dock.getBoundingClientRect().bottom
     const below = Math.max(0, dockBottom - root.getBoundingClientRect().bottom)

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -124,8 +124,11 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     const dock = root.closest('[data-component="session-prompt-dock"]')
     if (!(dock instanceof HTMLElement)) return
 
-    const header = document.querySelector("[data-session-title]")
-    const scroller = document.querySelector(".scroll-view__viewport")
+    const panel = dock.parentElement
+    if (!(panel instanceof HTMLElement)) return
+
+    const header = panel.querySelector("[data-session-title]")
+    const scroller = panel.querySelector(".scroll-view__viewport")
     const top =
       header instanceof HTMLElement
         ? header.getBoundingClientRect().bottom
@@ -178,8 +181,16 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     makeEventListener(window, "resize", update)
 
     const dock = root?.closest('[data-component="session-prompt-dock"]')
-    const scroller = document.querySelector(".scroll-view__viewport")
-    createResizeObserver([dock, scroller], update)
+    const panel = dock?.parentElement
+    createResizeObserver(
+      [
+        dock,
+        panel,
+        panel instanceof HTMLElement ? panel.querySelector(".scroll-view__viewport") : undefined,
+        panel instanceof HTMLElement ? panel.querySelector("[data-session-title]") : undefined,
+      ],
+      update,
+    )
 
     onCleanup(() => {
       if (raf !== undefined) cancelAnimationFrame(raf)

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -121,17 +121,17 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   const measure = () => {
     if (!root) return
 
-    const scroller = document.querySelector(".scroll-view__viewport")
-    const head = scroller instanceof HTMLElement ? scroller.firstElementChild : undefined
-    const top =
-      head instanceof HTMLElement && head.classList.contains("sticky") ? head.getBoundingClientRect().bottom : 0
-    if (!top) {
-      root.style.removeProperty("--question-prompt-max-height")
-      return
-    }
-
     const dock = root.closest('[data-component="session-prompt-dock"]')
     if (!(dock instanceof HTMLElement)) return
+
+    const scroller = document.querySelector(".scroll-view__viewport")
+    const head = scroller instanceof HTMLElement ? scroller.firstElementChild : undefined
+    const sticky =
+      head instanceof HTMLElement && head.classList.contains("sticky") ? head.getBoundingClientRect().bottom : 0
+    // Fall back to the scroller's top when no sticky header is present (e.g. on
+    // mobile with no session title) so the dock stays inside the visible content
+    // area instead of overflowing the viewport via the 100dvh CSS fallback.
+    const top = sticky || (scroller instanceof HTMLElement ? scroller.getBoundingClientRect().top : 0)
 
     const dockBottom = dock.getBoundingClientRect().bottom
     const below = Math.max(0, dockBottom - root.getBoundingClientRect().bottom)


### PR DESCRIPTION
### Issue for this PR

Closes #23730
Closes #22439

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On mobile, the question dock's next/dismiss buttons get clipped below the viewport when the dock has long content.

While preparing this fix I traced the DOM and found that `measure()` was already silently broken: it ran `scroller.firstElementChild.classList.contains("sticky")`, but the scroller's first child is the `setContentRef` wrapper `<div class="min-w-0 w-full">` — the sticky title is one level deeper. The check never matched, so `measure()` always hit the `removeProperty` path and the CSS fallback `100dvh` was the only thing setting the height. On desktop the available area is usually large enough to hide that, but on mobile long content overflows and the footer gets clipped.

This PR makes `measure()` do what it was trying to do:

1. Scope lookups to the session panel containing the dock instead of using document-level selectors.
2. Use the semantic `[data-session-title]` selector (already used by `use-session-hash-scroll.ts`) instead of walking through `firstElementChild`.
3. Fall back to the panel's message scroller top when no session title is rendered, so the dock is still bounded by the visible content area.
4. Observe the scoped panel/header/scroller inputs that affect the measurement.

#24022 fixes the same bug with broader scope (CSS `overflow-hidden` on dock containers, `visualViewport.height` for keyboard handling, `paddingBottom` inset). This PR is the smaller measurement fix; happy to defer or compose.

### How did you verify your code works?

- `bun run typecheck` — all 13 packages pass
- `bun run --cwd packages/app test:unit` — 307 pass, 0 fail
- `bun run lint` on the changed file — 0 errors, no new warnings
- Pre-push hook ran full repo typecheck successfully
- Manually traced the DOM (session panel → ScrollView → .scroll-view__viewport → setContentRef wrapper → [data-session-title]) to confirm the original selector mismatch
- Reasoned through desktop / mobile / no-header / no-scroller cases

### Screenshots / recordings

I don't have a phone harness set up to capture before/after; #24022 has video recordings of the same bug.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR