### PR TITLE
feat(tui): read Zed editor context from state db

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -116,7 +116,6 @@ export function Prompt(props: PromptProps) {
   const editorSelectionLabel = createMemo(() => {
     const selection = editor.selection()?.selection
     if (!selection) return
-    if (selection.start.line === selection.end.line && selection.start.character === selection.end.character) return
     if (selection.start.line === selection.end.line) return `#${selection.start.line}`
     return `#${selection.start.line}-${selection.end.line}`
   })
@@ -756,7 +755,7 @@ export function Prompt(props: PromptProps) {
               const start = editorSelection.selection.start
               const end = editorSelection.selection.end
               if (start.line === end.line && start.character === end.character) {
-                return `Note: The user opened the file "${editorSelection.filePath}".`
+                return `Note: The user's cursor is on line ${start.line} in "${editorSelection.filePath}".`
               }
               if (start.line === end.line) {
                 return `Note: The user selected line ${start.line} from  "${editorSelection.filePath}": ${editorSelection.text}`

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -116,6 +116,7 @@ export function Prompt(props: PromptProps) {
   const editorSelectionLabel = createMemo(() => {
     const selection = editor.selection()?.selection
     if (!selection) return
+    if (selection.start.line === selection.end.line && selection.start.character === selection.end.character) return
     if (selection.start.line === selection.end.line) return `#${selection.start.line}`
     return `#${selection.start.line}-${selection.end.line}`
   })
@@ -755,7 +756,7 @@ export function Prompt(props: PromptProps) {
               const start = editorSelection.selection.start
               const end = editorSelection.selection.end
               if (start.line === end.line && start.character === end.character) {
-                return `Note: The user's cursor is on line ${start.line} in "${editorSelection.filePath}".`
+                return `Note: The user opened the file "${editorSelection.filePath}".`
               }
               if (start.line === end.line) {
                 return `Note: The user selected line ${start.line} from  "${editorSelection.filePath}": ${editorSelection.text}`

--- a/packages/opencode/src/cli/cmd/tui/context/editor-zed.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor-zed.ts
@@ -1,0 +1,172 @@
+import { Database } from "bun:sqlite"
+import os from "node:os"
+import path from "node:path"
+import z from "zod"
+import { Filesystem } from "@/util"
+import type { EditorSelection } from "./editor"
+
+const ZedEditorRowSchema = z.object({
+  editor_id: z.number(),
+  workspace_id: z.number(),
+  workspace_paths: z.string().nullable(),
+  timestamp: z.string(),
+  buffer_path: z.string().nullable(),
+  selection_start: z.number().nullable(),
+  selection_end: z.number().nullable(),
+})
+
+const ZedEditorContentsSchema = z.object({
+  contents: z.string().nullable(),
+})
+
+type ZedEditorRow = z.infer<typeof ZedEditorRowSchema>
+
+export async function resolveZedSelection(dbPath: string): Promise<EditorSelection | undefined> {
+  const row = queryZedActiveEditor(dbPath, process.cwd())
+  if (!row?.buffer_path || row.selection_start == null || row.selection_end == null) return
+
+  const text =
+    queryZedEditorContents(dbPath, row) ??
+    (await Bun.file(row.buffer_path)
+      .text()
+      .catch(() => undefined))
+  if (text == null) return
+
+  const startOffset = Math.min(row.selection_start, row.selection_end)
+  const endOffset = Math.max(row.selection_start, row.selection_end)
+
+  return {
+    text: text.slice(startOffset, endOffset),
+    filePath: row.buffer_path,
+    selection: offsetsToSelection(text, startOffset, endOffset),
+  }
+}
+
+function queryZedActiveEditor(dbPath: string, cwd: string) {
+  let db: Database | undefined
+  try {
+    db = new Database(dbPath, { readonly: true })
+    return db
+      .query(
+        `select
+          e.item_id as editor_id,
+          e.workspace_id as workspace_id,
+          w.paths as workspace_paths,
+          w.timestamp as timestamp,
+          e.buffer_path as buffer_path,
+          s.start as selection_start,
+          s.end as selection_end
+        from items i
+        join panes p on p.pane_id = i.pane_id and p.workspace_id = i.workspace_id
+        join workspaces w on w.workspace_id = i.workspace_id
+        join editors e on e.item_id = i.item_id and e.workspace_id = i.workspace_id
+        left join editor_selections s on s.editor_id = e.item_id and s.workspace_id = e.workspace_id
+        where i.active = 1 and p.active = 1 and i.kind = 'Editor' and e.buffer_path is not null
+        order by w.timestamp desc`,
+      )
+      .all()
+      .flatMap((row) => {
+        const parsed = ZedEditorRowSchema.safeParse(row)
+        return parsed.success ? [parsed.data] : []
+      })
+      .map((row) => ({ row, score: scoreZedWorkspace(row.workspace_paths, cwd) }))
+      .filter((entry) => entry.score > 0)
+      .sort((left, right) => right.score - left.score || right.row.timestamp.localeCompare(left.row.timestamp))[0]?.row
+  } catch {
+    return
+  } finally {
+    db?.close()
+  }
+}
+
+function queryZedEditorContents(dbPath: string, row: ZedEditorRow) {
+  let db: Database | undefined
+  try {
+    db = new Database(dbPath, { readonly: true })
+    return ZedEditorContentsSchema.safeParse(
+      db
+        .query(
+          `select contents
+        from editors
+        where item_id = $editorID and workspace_id = $workspaceID`,
+        )
+        .get({ $editorID: row.editor_id, $workspaceID: row.workspace_id }),
+    ).data?.contents
+  } catch {
+    return
+  } finally {
+    db?.close()
+  }
+}
+
+export function resolveZedDbPath() {
+  const candidates = [
+    process.env.OPENCODE_ZED_DB,
+    path.join(os.homedir(), "Library", "Application Support", "Zed", "db", "0-stable", "db.sqlite"),
+    path.join(os.homedir(), ".local", "share", "zed", "db", "0-stable", "db.sqlite"),
+  ].filter((item): item is string => Boolean(item))
+
+  return candidates.find((item) => Filesystem.stat(item)?.isFile())
+}
+
+function scoreZedWorkspace(workspacePaths: string | null, cwd: string) {
+  return zedWorkspacePaths(workspacePaths).reduce((score, item) => {
+    if (pathContains(item, cwd)) return Math.max(score, 2)
+    if (pathContains(cwd, item)) return Math.max(score, 1)
+    return score
+  }, 0)
+}
+
+function zedWorkspacePaths(value: string | null) {
+  if (!value) return []
+  const parsed = parseJson(value)
+  if (Array.isArray(parsed)) return parsed.filter((item): item is string => typeof item === "string")
+  return value.split(/\r?\n/).filter(Boolean)
+}
+
+export function offsetToPosition(text: string, offset: number) {
+  return offsetsToSelection(text, offset, offset).start
+}
+
+function offsetsToSelection(text: string, startOffset: number, endOffset: number) {
+  const start = Math.max(0, Math.min(startOffset, text.length))
+  const end = Math.max(0, Math.min(endOffset, text.length))
+  let line = 1
+  let lineStart = 0
+  let startPosition = position(line, lineStart, start)
+  let endPosition = position(line, lineStart, end)
+
+  for (let index = 0; index <= end; index++) {
+    if (index === start) startPosition = position(line, lineStart, index)
+    if (index === end) {
+      endPosition = position(line, lineStart, index)
+      break
+    }
+    if (text[index] === "\n") {
+      line += 1
+      lineStart = index + 1
+    }
+  }
+
+  return { start: startPosition, end: endPosition }
+}
+
+function position(line: number, lineStart: number, offset: number) {
+  return {
+    line,
+    character: offset - lineStart + 1,
+  }
+}
+
+function pathContains(parent: string, child: string) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child))
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+function parseJson(value: string) {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -1,4 +1,5 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
+import { Database } from "bun:sqlite"
 import os from "node:os"
 import path from "node:path"
 import { onCleanup, onMount } from "solid-js"
@@ -70,6 +71,15 @@ type EditorLockFile = {
   mtimeMs: number
 }
 
+type ZedEditorRow = {
+  workspace_paths: string | null
+  timestamp: string
+  buffer_path: string | null
+  contents: string | null
+  selection_start: number | null
+  selection_end: number | null
+}
+
 export const { use: useEditorContext, provider: EditorContextProvider } = createSimpleContext({
   name: "EditorContext",
   init: () => {
@@ -114,7 +124,21 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
 
         const connection = resolveEditorConnection()
         if (!connection) {
-          setStore("status", "disabled")
+          if (!resolveZedDbPath()) {
+            setStore("status", "disabled")
+            scheduleReconnect(1000)
+            return
+          }
+          void resolveZedSelection()
+            .then((selection) => {
+              if (closed || socket) return
+              setStore("selection", selection)
+              setStore("status", selection ? "connected" : "disabled")
+            })
+            .catch(() => {
+              if (closed || socket) return
+              setStore("status", "disabled")
+            })
           scheduleReconnect(1000)
           return
         }
@@ -196,7 +220,7 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
 
     return {
       enabled() {
-        return Boolean(resolveEditorConnection())
+        return Boolean(resolveEditorConnection() || resolveZedDbPath())
       },
       connected() {
         return store.status === "connected"
@@ -238,6 +262,100 @@ function resolveEditorConnection(): EditorConnection | undefined {
   return {
     url: `ws://127.0.0.1:${port}`,
     source: `env:${port}`,
+  }
+}
+
+async function resolveZedSelection() {
+  const dbPath = resolveZedDbPath()
+  if (!dbPath) return
+
+  const row = queryZedActiveEditor(dbPath, process.cwd())
+  if (!row?.buffer_path || row.selection_start == null || row.selection_end == null) return
+
+  const text =
+    row.contents ??
+    (await Bun.file(row.buffer_path)
+      .text()
+      .catch(() => undefined))
+  if (text == null) return
+
+  const start = offsetToPosition(text, Math.min(row.selection_start, row.selection_end))
+  const end = offsetToPosition(text, Math.max(row.selection_start, row.selection_end))
+
+  return {
+    text: text.slice(
+      Math.min(row.selection_start, row.selection_end),
+      Math.max(row.selection_start, row.selection_end),
+    ),
+    filePath: row.buffer_path,
+    selection: { start, end },
+  }
+}
+
+function queryZedActiveEditor(dbPath: string, cwd: string) {
+  let db: Database | undefined
+  try {
+    db = new Database(dbPath, { readonly: true })
+    return db
+      .query(
+        `select
+          w.paths as workspace_paths,
+          w.timestamp as timestamp,
+          e.buffer_path as buffer_path,
+          e.contents as contents,
+          s.start as selection_start,
+          s.end as selection_end
+        from items i
+        join panes p on p.pane_id = i.pane_id and p.workspace_id = i.workspace_id
+        join workspaces w on w.workspace_id = i.workspace_id
+        join editors e on e.item_id = i.item_id and e.workspace_id = i.workspace_id
+        left join editor_selections s on s.editor_id = e.item_id and s.workspace_id = e.workspace_id
+        where i.active = 1 and p.active = 1 and i.kind = 'Editor' and e.buffer_path is not null
+        order by w.timestamp desc`,
+      )
+      .all()
+      .filter(isZedEditorRow)
+      .map((row) => ({ row, score: scoreZedWorkspace(row.workspace_paths, cwd) }))
+      .filter((entry) => entry.score > 0)
+      .sort((left, right) => right.score - left.score || right.row.timestamp.localeCompare(left.row.timestamp))[0]?.row
+  } catch {
+    return
+  } finally {
+    db?.close()
+  }
+}
+
+function resolveZedDbPath() {
+  const candidates = [
+    process.env.OPENCODE_ZED_DB,
+    path.join(os.homedir(), "Library", "Application Support", "Zed", "db", "0-stable", "db.sqlite"),
+    path.join(os.homedir(), ".local", "share", "zed", "db", "0-stable", "db.sqlite"),
+  ].filter((item): item is string => Boolean(item))
+
+  return candidates.find((item) => statSafe(item)?.isFile())
+}
+
+function scoreZedWorkspace(workspacePaths: string | null, cwd: string) {
+  return zedWorkspacePaths(workspacePaths).reduce((score, item) => {
+    if (pathContains(item, cwd)) return Math.max(score, 2)
+    if (pathContains(cwd, item)) return Math.max(score, 1)
+    return score
+  }, 0)
+}
+
+function zedWorkspacePaths(value: string | null) {
+  if (!value) return []
+  const parsed = parseJson(value)
+  if (Array.isArray(parsed)) return parsed.filter((item): item is string => typeof item === "string")
+  return value.split(/\r?\n/).filter(Boolean)
+}
+
+export function offsetToPosition(text: string, offset: number) {
+  const before = text.slice(0, Math.max(0, Math.min(offset, text.length)))
+  const lineStart = before.lastIndexOf("\n")
+  return {
+    line: before.split("\n").length,
+    character: lineStart === -1 ? before.length + 1 : before.length - lineStart,
   }
 }
 
@@ -284,6 +402,14 @@ function readEditorLockFile(filePath: string): EditorLockFile | undefined {
   }
 }
 
+function statSafe(filePath: string) {
+  try {
+    return statSync(filePath)
+  } catch {
+    return
+  }
+}
+
 function scoreEditorLock(lock: EditorLockFile, cwd: string) {
   const workspaceMatch = lock.workspaceFolders.some((folder) => pathContains(folder, cwd)) ? 1 : 0
   return workspaceMatch * 1_000_000_000_000 + lock.mtimeMs
@@ -312,6 +438,26 @@ function parseMessage(value: unknown) {
   } catch {
     return
   }
+}
+
+function parseJson(value: string) {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return
+  }
+}
+
+function isZedEditorRow(value: unknown): value is ZedEditorRow {
+  if (!isRecord(value)) return false
+  return (
+    (typeof value.workspace_paths === "string" || value.workspace_paths === null) &&
+    typeof value.timestamp === "string" &&
+    (typeof value.buffer_path === "string" || value.buffer_path === null) &&
+    (typeof value.contents === "string" || value.contents === null) &&
+    (typeof value.selection_start === "number" || value.selection_start === null) &&
+    (typeof value.selection_end === "number" || value.selection_end === null)
+  )
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -5,6 +5,8 @@ import path from "node:path"
 import { onCleanup, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import z from "zod"
+import { Filesystem } from "@/util"
+import { isRecord } from "@/util/record"
 import { createSimpleContext } from "./helper"
 
 const MCP_PROTOCOL_VERSION = "2025-11-25"
@@ -52,6 +54,20 @@ const EditorServerInfoSchema = z.object({
     .optional(),
 })
 
+const ZedEditorRowSchema = z.object({
+  editor_id: z.number(),
+  workspace_id: z.number(),
+  workspace_paths: z.string().nullable(),
+  timestamp: z.string(),
+  buffer_path: z.string().nullable(),
+  selection_start: z.number().nullable(),
+  selection_end: z.number().nullable(),
+})
+
+const ZedEditorContentsSchema = z.object({
+  contents: z.string().nullable(),
+})
+
 type JsonRpcMessage = z.infer<typeof JsonRpcMessageSchema>
 export type EditorSelection = z.infer<typeof EditorSelectionSchema>
 export type EditorMention = z.infer<typeof EditorMentionSchema>
@@ -71,14 +87,7 @@ type EditorLockFile = {
   mtimeMs: number
 }
 
-type ZedEditorRow = {
-  workspace_paths: string | null
-  timestamp: string
-  buffer_path: string | null
-  contents: string | null
-  selection_start: number | null
-  selection_end: number | null
-}
+type ZedEditorRow = z.infer<typeof ZedEditorRowSchema>
 
 export const { use: useEditorContext, provider: EditorContextProvider } = createSimpleContext({
   name: "EditorContext",
@@ -100,6 +109,8 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
       let reconnect: ReturnType<typeof setTimeout> | undefined
       let attempt = 0
       let requestID = 0
+      let zedSelection: Promise<void> | undefined
+      let lastZedSelectionKey: string | undefined
       const pending = new Map<number, string>()
 
       const send = (payload: JsonRpcMessage) => {
@@ -124,20 +135,28 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
 
         const connection = resolveEditorConnection()
         if (!connection) {
-          if (!resolveZedDbPath()) {
+          const dbPath = resolveZedDbPath()
+          if (!dbPath) {
             setStore("status", "disabled")
             scheduleReconnect(1000)
             return
           }
-          void resolveZedSelection()
+          zedSelection ??= resolveZedSelection(dbPath)
             .then((selection) => {
               if (closed || socket) return
-              setStore("selection", selection)
-              setStore("status", selection ? "connected" : "disabled")
+              const key = editorSelectionKey(selection)
+              if (key !== lastZedSelectionKey) {
+                lastZedSelectionKey = key
+                setStore("selection", selection)
+                setStore("status", selection ? "connected" : "disabled")
+              }
             })
             .catch(() => {
               if (closed || socket) return
               setStore("status", "disabled")
+            })
+            .finally(() => {
+              zedSelection = undefined
             })
           scheduleReconnect(1000)
           return
@@ -265,30 +284,24 @@ function resolveEditorConnection(): EditorConnection | undefined {
   }
 }
 
-async function resolveZedSelection() {
-  const dbPath = resolveZedDbPath()
-  if (!dbPath) return
-
+async function resolveZedSelection(dbPath: string) {
   const row = queryZedActiveEditor(dbPath, process.cwd())
   if (!row?.buffer_path || row.selection_start == null || row.selection_end == null) return
 
   const text =
-    row.contents ??
+    queryZedEditorContents(dbPath, row) ??
     (await Bun.file(row.buffer_path)
       .text()
       .catch(() => undefined))
   if (text == null) return
 
-  const start = offsetToPosition(text, Math.min(row.selection_start, row.selection_end))
-  const end = offsetToPosition(text, Math.max(row.selection_start, row.selection_end))
+  const startOffset = Math.min(row.selection_start, row.selection_end)
+  const endOffset = Math.max(row.selection_start, row.selection_end)
 
   return {
-    text: text.slice(
-      Math.min(row.selection_start, row.selection_end),
-      Math.max(row.selection_start, row.selection_end),
-    ),
+    text: text.slice(startOffset, endOffset),
     filePath: row.buffer_path,
-    selection: { start, end },
+    selection: offsetsToSelection(text, startOffset, endOffset),
   }
 }
 
@@ -299,10 +312,11 @@ function queryZedActiveEditor(dbPath: string, cwd: string) {
     return db
       .query(
         `select
+          e.item_id as editor_id,
+          e.workspace_id as workspace_id,
           w.paths as workspace_paths,
           w.timestamp as timestamp,
           e.buffer_path as buffer_path,
-          e.contents as contents,
           s.start as selection_start,
           s.end as selection_end
         from items i
@@ -314,10 +328,33 @@ function queryZedActiveEditor(dbPath: string, cwd: string) {
         order by w.timestamp desc`,
       )
       .all()
-      .filter(isZedEditorRow)
+      .flatMap((row) => {
+        const parsed = ZedEditorRowSchema.safeParse(row)
+        return parsed.success ? [parsed.data] : []
+      })
       .map((row) => ({ row, score: scoreZedWorkspace(row.workspace_paths, cwd) }))
       .filter((entry) => entry.score > 0)
       .sort((left, right) => right.score - left.score || right.row.timestamp.localeCompare(left.row.timestamp))[0]?.row
+  } catch {
+    return
+  } finally {
+    db?.close()
+  }
+}
+
+function queryZedEditorContents(dbPath: string, row: ZedEditorRow) {
+  let db: Database | undefined
+  try {
+    db = new Database(dbPath, { readonly: true })
+    return ZedEditorContentsSchema.safeParse(
+      db
+        .query(
+          `select contents
+        from editors
+        where item_id = $editorID and workspace_id = $workspaceID`,
+        )
+        .get({ $editorID: row.editor_id, $workspaceID: row.workspace_id }),
+    ).data?.contents
   } catch {
     return
   } finally {
@@ -332,7 +369,7 @@ function resolveZedDbPath() {
     path.join(os.homedir(), ".local", "share", "zed", "db", "0-stable", "db.sqlite"),
   ].filter((item): item is string => Boolean(item))
 
-  return candidates.find((item) => statSafe(item)?.isFile())
+  return candidates.find((item) => Filesystem.stat(item)?.isFile())
 }
 
 function scoreZedWorkspace(workspacePaths: string | null, cwd: string) {
@@ -351,11 +388,36 @@ function zedWorkspacePaths(value: string | null) {
 }
 
 export function offsetToPosition(text: string, offset: number) {
-  const before = text.slice(0, Math.max(0, Math.min(offset, text.length)))
-  const lineStart = before.lastIndexOf("\n")
+  return offsetsToSelection(text, offset, offset).start
+}
+
+function offsetsToSelection(text: string, startOffset: number, endOffset: number) {
+  const start = Math.max(0, Math.min(startOffset, text.length))
+  const end = Math.max(0, Math.min(endOffset, text.length))
+  let line = 1
+  let lineStart = 0
+  let startPosition = position(line, lineStart, start)
+  let endPosition = position(line, lineStart, end)
+
+  for (let index = 0; index <= end; index++) {
+    if (index === start) startPosition = position(line, lineStart, index)
+    if (index === end) {
+      endPosition = position(line, lineStart, index)
+      break
+    }
+    if (text[index] === "\n") {
+      line += 1
+      lineStart = index + 1
+    }
+  }
+
+  return { start: startPosition, end: endPosition }
+}
+
+function position(line: number, lineStart: number, offset: number) {
   return {
-    line: before.split("\n").length,
-    character: lineStart === -1 ? before.length + 1 : before.length - lineStart,
+    line,
+    character: offset - lineStart + 1,
   }
 }
 
@@ -402,17 +464,21 @@ function readEditorLockFile(filePath: string): EditorLockFile | undefined {
   }
 }
 
-function statSafe(filePath: string) {
-  try {
-    return statSync(filePath)
-  } catch {
-    return
-  }
-}
-
 function scoreEditorLock(lock: EditorLockFile, cwd: string) {
   const workspaceMatch = lock.workspaceFolders.some((folder) => pathContains(folder, cwd)) ? 1 : 0
   return workspaceMatch * 1_000_000_000_000 + lock.mtimeMs
+}
+
+function editorSelectionKey(selection: EditorSelection | undefined) {
+  if (!selection) return ""
+  return [
+    selection.filePath,
+    selection.selection.start.line,
+    selection.selection.start.character,
+    selection.selection.end.line,
+    selection.selection.end.character,
+    selection.text,
+  ].join("\0")
 }
 
 function pathContains(parent: string, child: string) {
@@ -446,20 +512,4 @@ function parseJson(value: string) {
   } catch {
     return
   }
-}
-
-function isZedEditorRow(value: unknown): value is ZedEditorRow {
-  if (!isRecord(value)) return false
-  return (
-    (typeof value.workspace_paths === "string" || value.workspace_paths === null) &&
-    typeof value.timestamp === "string" &&
-    (typeof value.buffer_path === "string" || value.buffer_path === null) &&
-    (typeof value.contents === "string" || value.contents === null) &&
-    (typeof value.selection_start === "number" || value.selection_start === null) &&
-    (typeof value.selection_end === "number" || value.selection_end === null)
-  )
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }

--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -1,13 +1,12 @@
 import { readdirSync, readFileSync, statSync } from "node:fs"
-import { Database } from "bun:sqlite"
 import os from "node:os"
 import path from "node:path"
 import { onCleanup, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import z from "zod"
-import { Filesystem } from "@/util"
 import { isRecord } from "@/util/record"
 import { createSimpleContext } from "./helper"
+import { resolveZedDbPath, resolveZedSelection } from "./editor-zed"
 
 const MCP_PROTOCOL_VERSION = "2025-11-25"
 
@@ -54,20 +53,6 @@ const EditorServerInfoSchema = z.object({
     .optional(),
 })
 
-const ZedEditorRowSchema = z.object({
-  editor_id: z.number(),
-  workspace_id: z.number(),
-  workspace_paths: z.string().nullable(),
-  timestamp: z.string(),
-  buffer_path: z.string().nullable(),
-  selection_start: z.number().nullable(),
-  selection_end: z.number().nullable(),
-})
-
-const ZedEditorContentsSchema = z.object({
-  contents: z.string().nullable(),
-})
-
 type JsonRpcMessage = z.infer<typeof JsonRpcMessageSchema>
 export type EditorSelection = z.infer<typeof EditorSelectionSchema>
 export type EditorMention = z.infer<typeof EditorMentionSchema>
@@ -86,8 +71,6 @@ type EditorLockFile = {
   workspaceFolders: string[]
   mtimeMs: number
 }
-
-type ZedEditorRow = z.infer<typeof ZedEditorRowSchema>
 
 export const { use: useEditorContext, provider: EditorContextProvider } = createSimpleContext({
   name: "EditorContext",
@@ -284,143 +267,6 @@ function resolveEditorConnection(): EditorConnection | undefined {
   }
 }
 
-async function resolveZedSelection(dbPath: string) {
-  const row = queryZedActiveEditor(dbPath, process.cwd())
-  if (!row?.buffer_path || row.selection_start == null || row.selection_end == null) return
-
-  const text =
-    queryZedEditorContents(dbPath, row) ??
-    (await Bun.file(row.buffer_path)
-      .text()
-      .catch(() => undefined))
-  if (text == null) return
-
-  const startOffset = Math.min(row.selection_start, row.selection_end)
-  const endOffset = Math.max(row.selection_start, row.selection_end)
-
-  return {
-    text: text.slice(startOffset, endOffset),
-    filePath: row.buffer_path,
-    selection: offsetsToSelection(text, startOffset, endOffset),
-  }
-}
-
-function queryZedActiveEditor(dbPath: string, cwd: string) {
-  let db: Database | undefined
-  try {
-    db = new Database(dbPath, { readonly: true })
-    return db
-      .query(
-        `select
-          e.item_id as editor_id,
-          e.workspace_id as workspace_id,
-          w.paths as workspace_paths,
-          w.timestamp as timestamp,
-          e.buffer_path as buffer_path,
-          s.start as selection_start,
-          s.end as selection_end
-        from items i
-        join panes p on p.pane_id = i.pane_id and p.workspace_id = i.workspace_id
-        join workspaces w on w.workspace_id = i.workspace_id
-        join editors e on e.item_id = i.item_id and e.workspace_id = i.workspace_id
-        left join editor_selections s on s.editor_id = e.item_id and s.workspace_id = e.workspace_id
-        where i.active = 1 and p.active = 1 and i.kind = 'Editor' and e.buffer_path is not null
-        order by w.timestamp desc`,
-      )
-      .all()
-      .flatMap((row) => {
-        const parsed = ZedEditorRowSchema.safeParse(row)
-        return parsed.success ? [parsed.data] : []
-      })
-      .map((row) => ({ row, score: scoreZedWorkspace(row.workspace_paths, cwd) }))
-      .filter((entry) => entry.score > 0)
-      .sort((left, right) => right.score - left.score || right.row.timestamp.localeCompare(left.row.timestamp))[0]?.row
-  } catch {
-    return
-  } finally {
-    db?.close()
-  }
-}
-
-function queryZedEditorContents(dbPath: string, row: ZedEditorRow) {
-  let db: Database | undefined
-  try {
-    db = new Database(dbPath, { readonly: true })
-    return ZedEditorContentsSchema.safeParse(
-      db
-        .query(
-          `select contents
-        from editors
-        where item_id = $editorID and workspace_id = $workspaceID`,
-        )
-        .get({ $editorID: row.editor_id, $workspaceID: row.workspace_id }),
-    ).data?.contents
-  } catch {
-    return
-  } finally {
-    db?.close()
-  }
-}
-
-function resolveZedDbPath() {
-  const candidates = [
-    process.env.OPENCODE_ZED_DB,
-    path.join(os.homedir(), "Library", "Application Support", "Zed", "db", "0-stable", "db.sqlite"),
-    path.join(os.homedir(), ".local", "share", "zed", "db", "0-stable", "db.sqlite"),
-  ].filter((item): item is string => Boolean(item))
-
-  return candidates.find((item) => Filesystem.stat(item)?.isFile())
-}
-
-function scoreZedWorkspace(workspacePaths: string | null, cwd: string) {
-  return zedWorkspacePaths(workspacePaths).reduce((score, item) => {
-    if (pathContains(item, cwd)) return Math.max(score, 2)
-    if (pathContains(cwd, item)) return Math.max(score, 1)
-    return score
-  }, 0)
-}
-
-function zedWorkspacePaths(value: string | null) {
-  if (!value) return []
-  const parsed = parseJson(value)
-  if (Array.isArray(parsed)) return parsed.filter((item): item is string => typeof item === "string")
-  return value.split(/\r?\n/).filter(Boolean)
-}
-
-export function offsetToPosition(text: string, offset: number) {
-  return offsetsToSelection(text, offset, offset).start
-}
-
-function offsetsToSelection(text: string, startOffset: number, endOffset: number) {
-  const start = Math.max(0, Math.min(startOffset, text.length))
-  const end = Math.max(0, Math.min(endOffset, text.length))
-  let line = 1
-  let lineStart = 0
-  let startPosition = position(line, lineStart, start)
-  let endPosition = position(line, lineStart, end)
-
-  for (let index = 0; index <= end; index++) {
-    if (index === start) startPosition = position(line, lineStart, index)
-    if (index === end) {
-      endPosition = position(line, lineStart, index)
-      break
-    }
-    if (text[index] === "\n") {
-      line += 1
-      lineStart = index + 1
-    }
-  }
-
-  return { start: startPosition, end: endPosition }
-}
-
-function position(line: number, lineStart: number, offset: number) {
-  return {
-    line,
-    character: offset - lineStart + 1,
-  }
-}
-
 function resolveEditorLockFile() {
   const directory = path.join(os.homedir(), ".claude", "ide")
   let entries: string[]
@@ -501,14 +347,6 @@ function parseMessage(value: unknown) {
 
   try {
     return JsonRpcMessageSchema.parse(JSON.parse(value))
-  } catch {
-    return
-  }
-}
-
-function parseJson(value: string) {
-  try {
-    return JSON.parse(value) as unknown
   } catch {
     return
   }

--- a/packages/opencode/test/cli/tui/editor-context.test.ts
+++ b/packages/opencode/test/cli/tui/editor-context.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { offsetToPosition } from "../../../src/cli/cmd/tui/context/editor"
+import { offsetToPosition } from "../../../src/cli/cmd/tui/context/editor-zed"
 
 test("offsetToPosition converts Zed offsets to 1-based editor positions", () => {
   expect(offsetToPosition("one\ntwo\nthree", 0)).toEqual({ line: 1, character: 1 })

--- a/packages/opencode/test/cli/tui/editor-context.test.ts
+++ b/packages/opencode/test/cli/tui/editor-context.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test"
+import { offsetToPosition } from "../../../src/cli/cmd/tui/context/editor"
+
+test("offsetToPosition converts Zed offsets to 1-based editor positions", () => {
+  expect(offsetToPosition("one\ntwo\nthree", 0)).toEqual({ line: 1, character: 1 })
+  expect(offsetToPosition("one\ntwo\nthree", 4)).toEqual({ line: 2, character: 1 })
+  expect(offsetToPosition("one\ntwo\nthree", 6)).toEqual({ line: 2, character: 3 })
+  expect(offsetToPosition("one\ntwo\nthree", 100)).toEqual({ line: 3, character: 6 })
+})


### PR DESCRIPTION
## Summary
- Adds a Zed SQLite state fallback for the TUI editor context when the websocket editor bridge is unavailable.
- Reuses the existing editor selection store so current Zed file/line context flows through James's prompt footer and synthetic context path.
- Converts Zed character offsets to 1-based editor positions and scopes polling to matching Zed workspaces.

## Testing
- `bun typecheck` from `packages/opencode`
- `bun run test:ci test/cli/tui/editor-context.test.ts` from `packages/opencode`