### PR TITLE
fix(provider): reject unsupported image mime types

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -9,12 +9,18 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
+const SUPPORTED_IMAGE_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"])
+
 function mimeToModality(mime: string): Modality | undefined {
   if (mime.startsWith("image/")) return "image"
   if (mime.startsWith("audio/")) return "audio"
   if (mime.startsWith("video/")) return "video"
   if (mime === "application/pdf") return "pdf"
   return undefined
+}
+
+function unsupportedImageMime(mime: string) {
+  return mime.startsWith("image/") && !SUPPORTED_IMAGE_MIME_TYPES.has(mime.toLowerCase())
 }
 
 export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
@@ -300,6 +306,14 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
 
       const mime = part.type === "image" ? String(part.image).split(";")[0].replace("data:", "") : part.mediaType
       const filename = part.type === "file" ? part.filename : undefined
+      if (unsupportedImageMime(mime)) {
+        const name = filename ? `"${filename}"` : mime
+        return {
+          type: "text" as const,
+          text: `ERROR: Cannot read ${name} (unsupported image format ${mime}). Supported image formats are JPEG, PNG, GIF, and WebP. Inform the user.`,
+        }
+      }
+
       const modality = mimeToModality(mime)
       if (!modality) return part
       if (model.capabilities.input[modality]) return part

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1055,6 +1055,44 @@ describe("ProviderTransform.message - empty image handling", () => {
     expect(result[0].content[1]).toEqual({ type: "image", image: `data:image/png;base64,${validBase64}` })
   })
 
+  test("should replace unsupported image mime types with error text", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Read this image spec" },
+          { type: "image", image: "data:image/avif;base64,Zm9v" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, mockModel, {})
+
+    expect(result[0].content[1]).toEqual({
+      type: "text",
+      text: "ERROR: Cannot read image/avif (unsupported image format image/avif). Supported image formats are JPEG, PNG, GIF, and WebP. Inform the user.",
+    })
+  })
+
+  test("should replace unsupported file image mime types with filename", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Read this file" },
+          { type: "file", filename: "spec.avif", mediaType: "image/avif", data: "Zm9v" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, mockModel, {})
+
+    expect(result[0].content[1]).toEqual({
+      type: "text",
+      text: 'ERROR: Cannot read "spec.avif" (unsupported image format image/avif). Supported image formats are JPEG, PNG, GIF, and WebP. Inform the user.',
+    })
+  })
+
   test("should handle mixed valid and empty images", () => {
     const validBase64 =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="


### PR DESCRIPTION
### Issue for this PR

Closes #23990

Related: #17772 and #15264 describe the same unsupported/invalid image payload class of provider errors.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode filtered attachments by broad modality (`image/*`) only. If a model supported image input, unsupported formats such as `image/avif` or custom image/spec formats were forwarded to providers, which then rejected the request with errors like `Input should be 'image/jpeg', 'image/png', 'image/gif' or 'image/webp'`.

This blocks unsupported image MIME types before provider submission and replaces them with an explicit text error telling the model/user that only JPEG, PNG, GIF, and WebP are supported.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts`
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A, provider message transform change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR