### PR TITLE
feat(httpapi): bridge instance dispose endpoint

### DIFF
--- a/packages/opencode/specs/effect/http-api.md
+++ b/packages/opencode/specs/effect/http-api.md
@@ -163,7 +163,7 @@ Use raw Effect HTTP routes where `HttpApi` does not fit. The goal is deleting Ho
 | `file`                   | `bridged` partial | find text/file/symbol, list/content/status                                               |
 | `mcp`                    | `bridged` partial | status only                                                                              |
 | `workspace`              | `bridged`         | list, get, enter                                                                         |
-| top-level instance reads | `bridged`         | path, vcs, command, agent, skill, lsp, formatter                                         |
+| top-level instance routes | `bridged`         | path, vcs, command, agent, skill, lsp, formatter, dispose                                |
 | experimental JSON routes | `bridged` partial | console reads, tool ids, worktree list, resource list; global session list remains later |
 | `session`                | `later/special`   | large stateful surface plus streaming                                                    |
 | `sync`                   | `later`           | process/control side effects                                                             |

--- a/packages/opencode/src/server/routes/instance/httpapi/instance.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/instance.ts
@@ -6,10 +6,10 @@ import { LSP } from "@/lsp"
 import { Vcs } from "@/project"
 import { Skill } from "@/skill"
 import * as InstanceState from "@/effect/instance-state"
-import { Instance } from "@/project/instance"
 import { Effect, Layer, Schema } from "effect"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "./auth"
+import { markInstanceForDisposal } from "./lifecycle"
 
 const PathInfo = Schema.Struct({
   home: Schema.String,
@@ -150,13 +150,7 @@ export const instanceHandlers = Layer.unwrap(
     const vcs = yield* Vcs.Service
 
     const dispose = Effect.fn("InstanceHttpApi.dispose")(function* () {
-      const ctx = yield* InstanceState.context
-      yield* Effect.sync(() => {
-        // Disposing inline would invalidate the active request scope before HttpApi can send the response.
-        setTimeout(() => {
-          void Instance.restore(ctx, () => Instance.dispose())
-        }, 0)
-      })
+      yield* markInstanceForDisposal(yield* InstanceState.context)
       return true
     })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/instance.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/instance.ts
@@ -6,6 +6,7 @@ import { LSP } from "@/lsp"
 import { Vcs } from "@/project"
 import { Skill } from "@/skill"
 import * as InstanceState from "@/effect/instance-state"
+import { Instance } from "@/project/instance"
 import { Effect, Layer, Schema } from "effect"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "./auth"
@@ -23,6 +24,7 @@ const VcsDiffQuery = Schema.Struct({
 })
 
 export const InstancePaths = {
+  dispose: "/instance/dispose",
   path: "/path",
   vcs: "/vcs",
   vcsDiff: "/vcs/diff",
@@ -37,6 +39,15 @@ export const InstanceApi = HttpApi.make("instance")
   .add(
     HttpApiGroup.make("instance")
       .add(
+        HttpApiEndpoint.post("dispose", InstancePaths.dispose, {
+          success: Schema.Boolean,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "instance.dispose",
+            summary: "Dispose instance",
+            description: "Clean up and dispose the current OpenCode instance, releasing all resources.",
+          }),
+        ),
         HttpApiEndpoint.get("path", InstancePaths.path, {
           success: PathInfo,
         }).annotateMerge(
@@ -138,6 +149,17 @@ export const instanceHandlers = Layer.unwrap(
     const skill = yield* Skill.Service
     const vcs = yield* Vcs.Service
 
+    const dispose = Effect.fn("InstanceHttpApi.dispose")(function* () {
+      const ctx = yield* InstanceState.context
+      yield* Effect.sync(() => {
+        // Disposing inline would invalidate the active request scope before HttpApi can send the response.
+        setTimeout(() => {
+          void Instance.restore(ctx, () => Instance.dispose())
+        }, 0)
+      })
+      return true
+    })
+
     const getPath = Effect.fn("InstanceHttpApi.path")(function* () {
       const ctx = yield* InstanceState.context
       return {
@@ -180,6 +202,7 @@ export const instanceHandlers = Layer.unwrap(
 
     return HttpApiBuilder.group(InstanceApi, "instance", (handlers) =>
       handlers
+        .handle("dispose", dispose)
         .handle("path", getPath)
         .handle("vcs", getVcs)
         .handle("vcsDiff", getVcsDiff)

--- a/packages/opencode/src/server/routes/instance/httpapi/lifecycle.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/lifecycle.ts
@@ -1,0 +1,24 @@
+import { Instance, type InstanceContext } from "@/project/instance"
+import { Effect } from "effect"
+import { HttpEffect, HttpMiddleware, HttpServerRequest } from "effect/unstable/http"
+
+const disposeAfterResponse = new WeakMap<object, InstanceContext>()
+
+export const markInstanceForDisposal = (ctx: InstanceContext) =>
+  HttpEffect.appendPreResponseHandler((request, response) =>
+    Effect.sync(() => {
+      disposeAfterResponse.set(request.source, ctx)
+      return response
+    }),
+  )
+
+export const disposeMiddleware: HttpMiddleware.HttpMiddleware = (effect) =>
+  Effect.gen(function* () {
+    const response = yield* effect
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const ctx = disposeAfterResponse.get(request.source)
+    if (!ctx) return response
+    disposeAfterResponse.delete(request.source)
+    yield* Effect.promise(() => Instance.restore(ctx, () => Instance.dispose()))
+    return response
+  })

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -19,6 +19,7 @@ import { ProjectApi, projectHandlers } from "./project"
 import { ProviderApi, providerHandlers } from "./provider"
 import { QuestionApi, questionHandlers } from "./question"
 import { WorkspaceApi, workspaceHandlers } from "./workspace"
+import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 
 const Query = Schema.Struct({
@@ -83,6 +84,7 @@ export const routes = Layer.mergeAll(
 export const webHandler = lazy(() =>
   HttpRouter.toWebHandler(routes, {
     memoMap,
+    middleware: disposeMiddleware,
   }),
 )
 

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -64,6 +64,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
     app.get(FilePaths.content, (c) => handler(c.req.raw, context))
     app.get(FilePaths.status, (c) => handler(c.req.raw, context))
     app.get(InstancePaths.path, (c) => handler(c.req.raw, context))
+    app.post(InstancePaths.dispose, (c) => handler(c.req.raw, context))
     app.get(InstancePaths.vcs, (c) => handler(c.req.raw, context))
     app.get(InstancePaths.vcsDiff, (c) => handler(c.req.raw, context))
     app.get(InstancePaths.command, (c) => handler(c.req.raw, context))

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import type { UpgradeWebSocket } from "hono/ws"
 import path from "path"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { GlobalBus } from "@/bus/global"
 import { Instance } from "../../src/project/instance"
 import { InstanceRoutes } from "../../src/server/routes/instance"
 import { InstancePaths } from "../../src/server/routes/instance/httpapi/instance"
@@ -81,6 +82,15 @@ describe("instance HttpApi", () => {
   test("serves instance dispose through Hono bridge", async () => {
     await using tmp = await tmpdir()
 
+    const disposed = new Promise<string | undefined>((resolve) => {
+      const onEvent = (event: { directory?: string; payload: { type?: string } }) => {
+        if (event.payload.type !== "server.instance.disposed") return
+        GlobalBus.off("event", onEvent)
+        resolve(event.directory)
+      }
+      GlobalBus.on("event", onEvent)
+    })
+
     const response = await app().request(InstancePaths.dispose, {
       method: "POST",
       headers: { "x-opencode-directory": tmp.path },
@@ -88,5 +98,6 @@ describe("instance HttpApi", () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toBe(true)
+    expect(await disposed).toBe(tmp.path)
   })
 })

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -77,4 +77,16 @@ describe("instance HttpApi", () => {
     expect(formatter.status).toBe(200)
     expect(await formatter.json()).toEqual([])
   })
+
+  test("serves instance dispose through Hono bridge", async () => {
+    await using tmp = await tmpdir()
+
+    const response = await app().request(InstancePaths.dispose, {
+      method: "POST",
+      headers: { "x-opencode-directory": tmp.path },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- Bridge `POST /instance/dispose` through the experimental HttpApi path.
- Keep the legacy Hono route for SDK/OpenAPI generation.
- Add bridge coverage for the dispose response and disposal event, and update the HttpApi migration status.

## Notes
- Disposal is handled through Effect HTTP lifecycle hooks: the endpoint marks the request with a pre-response handler, and web-handler middleware performs `Instance.dispose()` after the response has been resolved. This avoids invalidating the active HttpApi request scope inline.

## Tests
- `bun typecheck` from `packages/opencode`
- `bun run test:ci test/server/httpapi-*.test.ts` from `packages/opencode`
- `./packages/sdk/js/script/build.ts`
- `bun turbo typecheck`