### PR TITLE
fix(session): use transcript position instead of lexical ID compare in prompt loop

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1324,12 +1324,27 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           let lastUser: MessageV2.User | undefined
           let lastAssistant: MessageV2.Assistant | undefined
           let lastFinished: MessageV2.Assistant | undefined
+          // Track transcript positions instead of relying on lexical ID ordering.
+          // Callers may supply custom messageIDs via the API, so MessageID order
+          // is not guaranteed to match transcript order — use array indices.
+          let lastUserIndex = -1
+          let lastAssistantIndex = -1
+          let lastFinishedIndex = -1
           let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
           for (let i = msgs.length - 1; i >= 0; i--) {
             const msg = msgs[i]
-            if (!lastUser && msg.info.role === "user") lastUser = msg.info
-            if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info
-            if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
+            if (!lastUser && msg.info.role === "user") {
+              lastUser = msg.info
+              lastUserIndex = i
+            }
+            if (!lastAssistant && msg.info.role === "assistant") {
+              lastAssistant = msg.info
+              lastAssistantIndex = i
+            }
+            if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) {
+              lastFinished = msg.info
+              lastFinishedIndex = i
+            }
             if (lastUser && lastFinished) break
             const task = msg.parts.filter((part) => part.type === "compaction" || part.type === "subtask")
             if (task && !lastFinished) tasks.push(...task)
@@ -1351,7 +1366,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastUserIndex < lastAssistantIndex
           ) {
             yield* slog.info("exiting loop")
             break
@@ -1456,8 +1471,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               yield* summary.summarize({ sessionID, messageID: lastUser.id }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             if (step > 1 && lastFinished) {
-              for (const m of msgs) {
-                if (m.info.role !== "user" || m.info.id <= lastFinished.id) continue
+              for (let i = lastFinishedIndex + 1; i < msgs.length; i++) {
+                const m = msgs[i]
+                if (m.info.role !== "user") continue
                 for (const p of m.parts) {
                   if (p.type !== "text" || p.ignored || p.synthetic) continue
                   if (!p.text.trim()) continue

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -342,6 +342,66 @@ it.live("loop exits immediately when last assistant has stop finish", () =>
   ),
 )
 
+// Regression: #23490. The HTTP API accepts caller-supplied messageIDs, but the
+// loop-exit decision used to compare lexical IDs (`lastUser.id < lastAssistant.id`).
+// A custom user ID that lex-sorts AFTER the assistant's auto-generated ID would
+// cause the loop to keep running after assistant `finish: "stop"`, sending a
+// transcript ending in an assistant turn — which providers reject with
+// "last message must be a user message". Ordering must use transcript position,
+// not opaque ID compare.
+it.live("loop exits when caller-supplied user messageID lex-sorts after assistant id", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Custom IDs" })
+      const session = yield* Session.Service
+
+      // Custom user ID that lex-sorts greater than any MessageID.ascending()
+      // output (which uses hex 0-9a-f for the timestamp prefix).
+      const userTime = Date.now()
+      const userMsg = yield* session.updateMessage({
+        id: MessageID.make("msg_zzzzzzzzzzzzzzzzzzzzzzzz"),
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: userTime },
+      })
+      yield* session.updatePart({
+        id: PartID.ascending(),
+        messageID: userMsg.id,
+        sessionID: chat.id,
+        type: "text",
+        text: "hello",
+      })
+      yield* session.updateMessage({
+        id: MessageID.ascending(),
+        role: "assistant",
+        parentID: userMsg.id,
+        sessionID: chat.id,
+        mode: "build",
+        agent: "build",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        // Strictly greater than userTime so transcript ordering by time_created
+        // is unambiguous regardless of ID lex order.
+        time: { created: userTime + 1 },
+        finish: "stop",
+      })
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+      if (result.info.role === "assistant") expect(result.info.finish).toBe("stop")
+      expect(yield* llm.calls).toBe(0)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop calls LLM and returns assistant message", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {


### PR DESCRIPTION
### Issue for this PR

Closes #23490

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionPrompt.run` decided transcript ordering by comparing opaque message IDs:

```ts
lastUser.id < lastAssistant.id        // loop-exit check
m.info.id <= lastFinished.id          // post-finish reminder check
```

The HTTP API explicitly accepts caller-supplied `messageID` on prompt input, but those checks assume IDs always preserve OpenCode's internal monotonic ordering. When a caller supplies a `messageID` that lexically sorts greater than `MessageID.ascending()` output (e.g. `msg_zzzzzzzz...`), the comparison reverses and:

1. Loop-exit at `finish="stop"` no longer fires → loop runs an extra iteration after the assistant turn already completed.
2. The next request OpenCode sends ends with an assistant message → providers like Anthropic via OpenRouter reject it with "last message must be a user message".

The fix tracks `lastUser`/`lastAssistant`/`lastFinished` array indices during the same backward walk that already collects those messages, then uses array position (the canonical transcript order produced by `MessageV2.filterCompactedEffect` → `page()` → `ORDER BY time_created, id`) for both decisions. No new traversals; behavior is unchanged for OpenCode-generated monotonic IDs.

Two sites updated:
- Loop-exit check at the top of `runLoop`.
- Post-finish system-reminder loop after the user has sent additional messages.

### How did you verify your code works?

Added a regression test in `packages/opencode/test/session/prompt.test.ts`:

```ts
it.live("loop exits when caller-supplied user messageID lex-sorts after assistant id", ...)
```

It seeds a session with:
- A user message whose ID is `msg_zzzzzzzzzzzzzzzzzzzzzzzz` (lex-greater than any hex-prefixed `MessageID.ascending()`),
- An auto-ID assistant message with `finish: "stop"` and `time.created` strictly greater so transcript ordering is unambiguous.

Then asserts `prompt.loop` returns the assistant message and the LLM mock receives **0 calls**.

Verification:
- New test fails on `dev` (loop times out re-calling LLM with no replies queued — exactly the reporter's symptom).
- New test passes with the fix applied.
- Full session test suite green: `bun test test/session/` → 315 pass / 0 fail.
- `bun typecheck` clean in `packages/opencode`.
- `bun turbo typecheck` clean repo-wide (13/13).

### Screenshots / recordings

N/A — non-UI fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
