### PR TITLE
fix: move session roots filter from client-side to SQL layer

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -112,6 +112,7 @@ export function DialogSessionList() {
   const options = createMemo(() => {
     const today = new Date().toDateString()
     return sessions()
+      .filter((x) => x.parentID === undefined)
       .toSorted((a, b) => {
         const updatedDay = new Date(b.time.updated).setHours(0, 0, 0, 0) - new Date(a.time.updated).setHours(0, 0, 0, 0)
         if (updatedDay !== 0) return updatedDay

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -34,7 +34,7 @@ export function DialogSessionList() {
 
   const [searchResults, { refetch }] = createResource(search, async (query) => {
     if (!query) return undefined
-    const result = await sdk.client.session.list({ search: query, limit: 30 })
+    const result = await sdk.client.session.list({ search: query, limit: 30, roots: true })
     return result.data ?? []
   })
 
@@ -112,7 +112,6 @@ export function DialogSessionList() {
   const options = createMemo(() => {
     const today = new Date().toDateString()
     return sessions()
-      .filter((x) => x.parentID === undefined)
       .toSorted((a, b) => {
         const updatedDay = new Date(b.time.updated).setHours(0, 0, 0, 0) - new Date(a.time.updated).setHours(0, 0, 0, 0)
         if (updatedDay !== 0) return updatedDay

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -362,7 +362,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       }
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
-        .list({ start: start })
+        .list({ start: start, roots: true })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
 
       // blocking - include session.list when continuing a session
@@ -482,7 +482,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         async refresh() {
           const start = Date.now() - 30 * 24 * 60 * 60 * 1000
           const list = await sdk.client.session
-            .list({ start })
+            .list({ start, roots: true })
             .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
           setStore("session", reconcile(list))
         },


### PR DESCRIPTION
### Issue for this PR

Closes #16270
Closes #20238

### Type of change

- [x] Bug fix

### What does this PR do?

In TUI /session dialog, `sdk.client.session.list()` was called without `roots: true`, so subagent child sessions filled up the LIMIT 100 before root sessions. The TUI then filtered client-side, leaving almost nothing visible for heavy subagent users.

Fix: pass `roots: true` so the SQL adds `WHERE parent_id IS NULL` before the LIMIT. Remove the now-redundant client-side filter.

It make sense to do the filter at SQL level.

### How did you verify your code works?

- `bun test test/session/session.test.ts` — 4 pass
- `bun test test/project/project.test.ts` — 32 pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
