### PR TITLE
fix(provider): respect configured output limit

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1035,7 +1035,7 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
 }
 
 export function maxOutputTokens(model: Provider.Model): number {
-  return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+  return model.limit.output > 0 ? model.limit.output : OUTPUT_TOKEN_MAX
 }
 
 export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JSONSchema7): JSONSchema7 {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2,6 +2,44 @@ import { describe, expect, test } from "bun:test"
 import { ProviderTransform } from "../../src/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 
+describe("ProviderTransform.maxOutputTokens", () => {
+  const model = {
+    id: ModelID.make("test-model"),
+    providerID: ProviderID.make("test"),
+    name: "Test Model",
+    api: { id: "test-model", url: "", npm: "@ai-sdk/openai-compatible" },
+    status: "active",
+    headers: {},
+    options: {},
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: {
+      context: 128_000,
+      output: 65_536,
+    },
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    release_date: "",
+    variants: {},
+  } satisfies Parameters<typeof ProviderTransform.maxOutputTokens>[0]
+
+  test("respects configured output limits above the default fallback", () => {
+    expect(ProviderTransform.maxOutputTokens(model)).toBe(65_536)
+  })
+
+  test("uses the default fallback when no output limit is configured", () => {
+    expect(ProviderTransform.maxOutputTokens({ ...model, limit: { ...model.limit, output: 0 } })).toBe(
+      ProviderTransform.OUTPUT_TOKEN_MAX,
+    )
+  })
+})
+
 describe("ProviderTransform.options - setCacheKey", () => {
   const sessionID = "test-session-123"
 


### PR DESCRIPTION
### Issue for this PR

Closes #20078

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ProviderTransform.maxOutputTokens()` capped every configured model output limit at the default fallback of `32000`. That meant custom OpenAI-compatible providers with `limit.output` above `32000` still sent `max_tokens: 32000`.

This keeps the `32000` fallback only for models with no configured output limit, and otherwise sends the configured `limit.output` value as-is.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR