### PR TITLE
fix(provider): preserve Azure API version

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1471,7 +1471,20 @@ const layer: Layer.Layer<
             }
           }
 
-          const res = await fetchFn(input, {
+          const requestInput = (() => {
+            const apiVersion = options["apiVersion"]
+            if (model.api.npm !== "@ai-sdk/azure" || typeof apiVersion !== "string" || apiVersion === "") return input
+
+            const url = input instanceof URL ? new URL(input.href) : typeof input === "string" && URL.canParse(input) ? new URL(input) : undefined
+            if (!url) return input
+            if (url.searchParams.has("api-version")) return input
+
+            // Azure Cognitive Services requires api-version even when the SDK uses a custom baseURL.
+            url.searchParams.set("api-version", apiVersion)
+            return input instanceof URL ? url : url.href
+          })()
+
+          const res = await fetchFn(requestInput, {
             ...opts,
             // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
             timeout: false,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -675,6 +675,108 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("preserves Azure api-version when using custom Responses API baseURL", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const source = await loadFixture("azure-cognitive-services", "gpt-5.4-mini")
+    const model = source.model
+    const chunks = [
+      {
+        type: "response.created",
+        response: {
+          id: "resp-azure",
+          created_at: Math.floor(Date.now() / 1000),
+          model: model.id,
+          service_tier: null,
+        },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "item-azure",
+        delta: "Hello",
+        logprobs: null,
+      },
+      {
+        type: "response.completed",
+        response: {
+          incomplete_details: null,
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: null,
+            output_tokens: 1,
+            output_tokens_details: null,
+          },
+          service_tier: null,
+        },
+      },
+    ]
+    const request = waitRequest("/responses", createEventResponse(chunks, true))
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["azure-cognitive-services"],
+            provider: {
+              "azure-cognitive-services": {
+                options: {
+                  apiKey: "test-azure-key",
+                  apiVersion: "2025-04-01-preview",
+                  baseURL: `${server.url.origin}/openai`,
+                },
+                models: {
+                  [model.id]: model,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make("azure-cognitive-services"), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-azure-responses")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-azure-responses"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("azure-cognitive-services"), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        expect(capture.url.pathname.endsWith("/responses")).toBe(true)
+        expect(capture.url.searchParams.get("api-version")).toBe("2025-04-01-preview")
+      },
+    })
+  })
+
   test("accepts user image attachments as data URLs for OpenAI models", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
### Issue for this PR

Closes #13999

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Azure Cognitive Services endpoints require `api-version` on Responses API requests. When `@ai-sdk/azure` is configured with a custom `baseURL`, the SDK can build `/responses` URLs without that query parameter, causing Azure to return `404 Resource not found`.

This adds a provider fetch guard for Azure models: if `apiVersion` is configured and the request URL does not already include `api-version`, OpenCode appends it before sending the request.

### How did you verify your code works?

- `bun test test/session/llm.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR