### PR TITLE
docs: add opencode-claude-code-plugin to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -52,6 +52,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
+| [opencode-claude-code-plugin](https://github.com/khalilgharbaoui/opencode-claude-code-plugin)      | Use your Claude Code CLI auth (Pro/Max, Bedrock, Vertex, API key) with opencode's UI, agents, and MCP |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — adding a community plugin to the ecosystem list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-claude-code-plugin](https://github.com/khalilgharbaoui/opencode-claude-code-plugin) to the ecosystem plugins list.

An opencode plugin that wraps the Claude Code CLI and routes model traffic through it instead of the Anthropic HTTP API. Users keep opencode's UI, agents, MCP, and permission system while authenticating through whichever method `claude` is logged into (Pro/Max plan, Bedrock, Vertex, or API key). Auto-registers all current Claude models with reasoning variants, tool proxying, and MCP bridging.

- [npm package](https://www.npmjs.com/package/@khalilgharbaoui/opencode-claude-code-plugin)
- [GitHub repo](https://github.com/khalilgharbaoui/opencode-claude-code-plugin)

### How did you verify your code works?

Documentation-only change. Verified the markdown table row renders correctly and the links resolve.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR