### PR TITLE
chore: add changelog sync workflow and changelog

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -31,91 +31,76 @@ jobs:
 
       - name: Fetch changelog
         run: |
-          cat > fetch-changelog.mjs << 'EOF'
+          cat > fetch-changelog.mjs << 'SCRIPT'
           const res = await fetch("https://opencode.ai/changelog");
           const html = await res.text();
 
-          const versionRegex = /v(\d+\.\d+\.\d+)[^]+?(\w+ \d+, \d+)/g;
+          const changes = [];
+          const versionRegex = /tag:"v([\d.]+)"/g;
 
-          const versions = [];
           let match;
           while ((match = versionRegex.exec(html)) !== null) {
-            versions.push({ version: match[1], date: match[2].trim(), index: match.index });
-          }
-
-          versions.sort((a, b) => b.index - a.index);
-
-          const changes = [];
-
-          for (let i = 0; i < Math.min(versions.length, 5); i++) {
-            const v = versions[i];
-            const nextIndex = i < versions.length - 1 ? versions[i + 1].index : html.length;
-            const section = html.slice(v.index, nextIndex);
-
+            const version = match[1];
+            
+            const dateStart = match.index + html.slice(match.index).indexOf('date:"') + 5;
+            const dateEnd = html.indexOf('",', dateStart);
+            const dateStr = html.slice(dateStart, dateEnd);
+            const date = new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+            
+            const nextMatch = versionRegex.exec(html.slice(match.index + 10));
+            const sectionEnd = nextMatch ? match.index + 10 + nextMatch.index - 10 : html.length;
+            const section = html.slice(match.index, sectionEnd);
+            
             const sections = {};
-            const sectionTitleRegex = /### (\w+)[^]+?- /g;
-            let sMatch;
-            while ((sMatch = sectionTitleRegex.exec(section)) !== null) {
-              const title = sMatch[1].trim();
-              const entryMatch = section.matchAll(/- ([^\n]+)/g);
-              const items = [...entryMatch].map(m => m[1].trim()).filter(Boolean);
-              sections[title] = items;
+            for (const secName of ["Core", "TUI", "Desktop", "SDK", "Extensions"]) {
+              const secIdx = section.indexOf(`title:"${secName}"`);
+              if (secIdx > -1 && secIdx < 500) {
+                const itemsStart = section.indexOf("[", secIdx);
+                const itemsEnd = section.indexOf("]", itemsStart);
+                if (itemsStart > -1 && itemsEnd > -1) {
+                  const items = section.slice(itemsStart + 1, itemsEnd).match(/"([^"]+)"/g)?.map(s => s.replace(/^"|"$/g, "")) || [];
+                  if (items.length) sections[secName] = items;
+                }
+              }
             }
-
-            changes.push({ version: v.version, date: v.date, ...sections });
+            
+            changes.push({ version, date, ...sections });
           }
 
           await Bun.write("changes.json", JSON.stringify(changes, null, 2));
-          EOF
+          console.log("Fetched", changes.length, "versions");
+          SCRIPT
           bun run fetch-changelog.mjs
 
-      - name: Sync changelog
+      - name: Generate changelog
         run: |
-          cat > sync-changelog.mjs << 'EOF'
-          import { readFileSync, writeFileSync, existsSync } from "fs";
+          cat > generate.mjs << 'SCRIPT'
+          import { readFileSync, writeFileSync } from "fs";
 
           const changes = JSON.parse(readFileSync("changes.json", "utf-8"));
 
-          let content = existsSync("changelog.md") 
-            ? readFileSync("changelog.md", "utf-8").trim() 
-            : "# Changelog\n\nNew updates and improvements to OpenCode";
+          const validSections = ["Core", "TUI", "Desktop", "SDK", "Extensions"];
 
-          const existingVersions = content.match(/## \[v(\d+\.\d+\.\d+)\]/g) || [];
-          const existingSet = new Set(existingVersions.map(v => v.match(/v(\d+\.\d+\.\d+)/)?.[1]).filter(Boolean));
-
-          const newEntries = [];
+          let content = "# Changelog\n\nNew updates and improvements to OpenCode\n\n";
 
           for (const change of changes) {
-            if (existingSet.has(change.version)) continue;
-
-            const validSections = ["Core", "TUI", "Desktop", "SDK"];
             const sections = [];
-
-            for (const sec of validSections) {
-              if (change[sec]?.length) {
-                sections.push(`### ${sec}\n\n${change[sec].map(c => `- ${c}`).join("\n")}`);
+            
+            for (const secName of validSections) {
+              if (change[secName]?.length) {
+                sections.push(`### ${secName}\n\n${change[secName].map(c => `- ${c}`).join("\n")}`);
               }
             }
-
-            if (!sections.length) continue;
-
-            const entry = `## [v${change.version}](https://github.com/anomalyco/opencode/releases/tag/v${change.version})\n\n${change.date}\n\n${sections.join("\n\n")}`;
-            newEntries.push(entry);
+            
+            if (sections.length) {
+              content += `## [v${change.version}](https://github.com/anomalyco/opencode/releases/tag/v${change.version})\n\n${change.date}\n\n${sections.join("\n\n")}\n\n`;
+            }
           }
 
-          if (newEntries.length === 0) {
-            console.log("No new entries found");
-            process.exit(0);
-          }
-
-          const header = "# Changelog\n\nNew updates and improvements to OpenCode";
-          const body = content.replace(header, "").trim();
-          const newContent = `${header}\n\n${newEntries.join("\n\n")}${body ? "\n\n" + body : ""}`;
-
-          writeFileSync("changelog.md", newContent.trim() + "\n");
-          console.log(`Updated changelog with ${newEntries.length} new entries`);
-          EOF
-          bun run sync-changelog.mjs
+          writeFileSync("changelog.md", content.trim() + "\n");
+          console.log(`Generated changelog with ${changes.length} versions`);
+          SCRIPT
+          bun run generate.mjs
 
       - name: Commit and push
         run: |
@@ -123,7 +108,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add changelog.md
           if ! git diff --cached --quiet; then
-            git commit -m "chore: sync changelog from opencode.ai/changelog"
+            git commit -m "chore: sync complete changelog from opencode.ai/changelog"
             git push origin dev
           else
             echo "No changes to commit"

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -1,0 +1,130 @@
+name: sync-changelog
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+    types: [changelog_update]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Fetch changelog
+        run: |
+          cat > fetch-changelog.mjs << 'EOF'
+          const res = await fetch("https://opencode.ai/changelog");
+          const html = await res.text();
+
+          const versionRegex = /v(\d+\.\d+\.\d+)[^]+?(\w+ \d+, \d+)/g;
+
+          const versions = [];
+          let match;
+          while ((match = versionRegex.exec(html)) !== null) {
+            versions.push({ version: match[1], date: match[2].trim(), index: match.index });
+          }
+
+          versions.sort((a, b) => b.index - a.index);
+
+          const changes = [];
+
+          for (let i = 0; i < Math.min(versions.length, 5); i++) {
+            const v = versions[i];
+            const nextIndex = i < versions.length - 1 ? versions[i + 1].index : html.length;
+            const section = html.slice(v.index, nextIndex);
+
+            const sections = {};
+            const sectionTitleRegex = /### (\w+)[^]+?- /g;
+            let sMatch;
+            while ((sMatch = sectionTitleRegex.exec(section)) !== null) {
+              const title = sMatch[1].trim();
+              const entryMatch = section.matchAll(/- ([^\n]+)/g);
+              const items = [...entryMatch].map(m => m[1].trim()).filter(Boolean);
+              sections[title] = items;
+            }
+
+            changes.push({ version: v.version, date: v.date, ...sections });
+          }
+
+          await Bun.write("changes.json", JSON.stringify(changes, null, 2));
+          EOF
+          bun run fetch-changelog.mjs
+
+      - name: Sync changelog
+        run: |
+          cat > sync-changelog.mjs << 'EOF'
+          import { readFileSync, writeFileSync, existsSync } from "fs";
+
+          const changes = JSON.parse(readFileSync("changes.json", "utf-8"));
+
+          let content = existsSync("changelog.md") 
+            ? readFileSync("changelog.md", "utf-8").trim() 
+            : "# Changelog\n\nNew updates and improvements to OpenCode";
+
+          const existingVersions = content.match(/## \[v(\d+\.\d+\.\d+)\]/g) || [];
+          const existingSet = new Set(existingVersions.map(v => v.match(/v(\d+\.\d+\.\d+)/)?.[1]).filter(Boolean));
+
+          const newEntries = [];
+
+          for (const change of changes) {
+            if (existingSet.has(change.version)) continue;
+
+            const validSections = ["Core", "TUI", "Desktop", "SDK"];
+            const sections = [];
+
+            for (const sec of validSections) {
+              if (change[sec]?.length) {
+                sections.push(`### ${sec}\n\n${change[sec].map(c => `- ${c}`).join("\n")}`);
+              }
+            }
+
+            if (!sections.length) continue;
+
+            const entry = `## [v${change.version}](https://github.com/anomalyco/opencode/releases/tag/v${change.version})\n\n${change.date}\n\n${sections.join("\n\n")}`;
+            newEntries.push(entry);
+          }
+
+          if (newEntries.length === 0) {
+            console.log("No new entries found");
+            process.exit(0);
+          }
+
+          const header = "# Changelog\n\nNew updates and improvements to OpenCode";
+          const body = content.replace(header, "").trim();
+          const newContent = `${header}\n\n${newEntries.join("\n\n")}${body ? "\n\n" + body : ""}`;
+
+          writeFileSync("changelog.md", newContent.trim() + "\n");
+          console.log(`Updated changelog with ${newEntries.length} new entries`);
+          EOF
+          bun run sync-changelog.mjs
+
+      - name: Commit and push
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add changelog.md
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: sync changelog from opencode.ai/changelog"
+            git push origin dev
+          else
+            echo "No changes to commit"
+          fi

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,76 @@
+# Changelog
+
+New updates and improvements to OpenCode
+
+## [v1.14.25](https://github.com/anomalyco/opencode/releases/tag/v1.14.25)
+
+Apr 25, 2026
+
+### Core
+
+- Fixed permission config preserving rule order and exposes full IntelliSense for tool permission keys
+- LSP permission prompts now include request details like the operation, file, and cursor position
+- Shell commands keep the correct working directory after login shell startup files run
+- Added Roslyn LSP support for Razor, `.cshtml`, and C# script files
+- GPT-5.5 with OpenAI OAuth now uses the correct context limits to avoid compaction issues
+
+## [v1.14.24](https://github.com/anomalyco/opencode/releases/tag/v1.14.24)
+
+Apr 24, 2026
+
+### Core
+
+- Fixed DeepSeek assistant messages so reasoning is always included, avoiding provider formatting failures.
+- Fixed inherited model configs so interleaved-capability models keep working when that field falls back to an existing model.
+- Added an experimental HTTP API endpoint for MCP server status.
+- Added experimental HTTP API endpoints to list files, read file contents, and check project file status.
+
+## [v1.14.23](https://github.com/anomalyco/opencode/releases/tag/v1.14.23)
+
+Apr 24, 2026
+
+### Core
+
+- Respect custom `.npmrc` registry settings when checking package versions and updates.
+
+### TUI
+
+- Render all non-synthetic text in a user message instead of showing only the first text block.
+
+## [v1.14.22](https://github.com/anomalyco/opencode/releases/tag/v1.14.22)
+
+Apr 23, 2026
+
+### Core
+
+- Respect `.npmrc` settings during npm installs.
+- Let projects store a custom icon override so the chosen icon persists correctly.
+
+### Desktop
+
+- Fix session views and nested session items not getting stuck with stale state when switching between sessions.
+
+## [v1.14.21](https://github.com/anomalyco/opencode/releases/tag/v1.14.21)
+
+Apr 23, 2026
+
+### Core
+
+- Support pull diagnostics from LSP servers that use them, including C# and Kotlin.
+- Fix project detection and caching for bare Git repos and worktrees.
+- Improve session compaction so long threads keep more useful context when older history is summarized.
+- Preserve UTF-8 BOMs when files are edited, patched, or rewritten through tools.
+- Use Roslyn Language Server for C# support instead of `csharp-ls`.
+- Add the high reasoning variant for supported Mistral Small models.
+- Hide unsupported variants for Kimi models that do not expose them.
+
+### TUI
+
+- Fail fast when opening an invalid or missing session instead of starting the TUI in a broken state.
+- Skip upgrade checks when auto-update is disabled.
+
+### Desktop
+
+- Keep project avatar previews consistent between the sidebar and edit dialog.
+- Improve project icon overrides so uploaded icons and color fallbacks behave correctly in the edit dialog.
+- Improve Linux desktop metadata for app listings and categorization.

--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ Apr 24, 2026
 ### Core
 
 - Fixed DeepSeek assistant messages so reasoning is always included, avoiding provider formatting failures.
-- Fixed inherited model configs so interleaved-capability models keep working when that field falls back to an existing model.
+- Fixed inherited model configs so interleaved-capability models keep working when that field falls back to an existing model. (@07akioni)
 - Added an experimental HTTP API endpoint for MCP server status.
 - Added experimental HTTP API endpoints to list files, read file contents, and check project file status.
 
@@ -57,20 +57,311 @@ Apr 23, 2026
 ### Core
 
 - Support pull diagnostics from LSP servers that use them, including C# and Kotlin.
-- Fix project detection and caching for bare Git repos and worktrees.
+- Fix project detection and caching for bare Git repos and worktrees. (@StevenTCramer)
 - Improve session compaction so long threads keep more useful context when older history is summarized.
 - Preserve UTF-8 BOMs when files are edited, patched, or rewritten through tools.
-- Use Roslyn Language Server for C# support instead of `csharp-ls`.
-- Add the high reasoning variant for supported Mistral Small models.
+- Use Roslyn Language Server for C# support instead of `csharp-ls`. (@jmbryan4)
+- Add the high reasoning variant for supported Mistral Small models. (@rubdos)
 - Hide unsupported variants for Kimi models that do not expose them.
 
 ### TUI
 
 - Fail fast when opening an invalid or missing session instead of starting the TUI in a broken state.
-- Skip upgrade checks when auto-update is disabled.
+- Skip upgrade checks when auto-update is disabled. (@rahuliyer95)
 
 ### Desktop
 
 - Keep project avatar previews consistent between the sidebar and edit dialog.
 - Improve project icon overrides so uploaded icons and color fallbacks behave correctly in the edit dialog.
-- Improve Linux desktop metadata for app listings and categorization.
+- Improve Linux desktop metadata for app listings and categorization. (@NN708)
+
+## [v1.14.20](https://github.com/anomalyco/opencode/releases/tag/v1.14.20)
+
+Apr 21, 2026
+
+### Core
+
+- Fixed a system theme regression in the TUI.
+- Added `GET /config` to the experimental HTTP API.
+- Fixed local dynamic imports on Windows when running under Node, improving plugin and tool loading.
+
+### TUI
+
+- Fixed permission replies using remote workspaces so they are sent to the correct workspace.
+
+### Desktop
+
+- Stopped prompt controls from replaying their fade-in animation on every render.
+- Added a setting to hide the session progress bar while the agent is working.
+- Fixed the Select Server dialog layout so the server list and actions size correctly. (@OpeOginni)
+- Fixed synced project updates so desktop project state changes apply reliably.
+- Fixed sidebar project avatars to fall back to `icon.url` when no override is set. (@ysm-dev)
+
+### SDK
+
+- Fixed the `WorkspaceAdaptor.create` type to include the `env` parameter. (@jamesmurdza)
+
+## [v1.14.19](https://github.com/anomalyco/opencode/releases/tag/v1.14.19)
+
+Apr 20, 2026
+
+### Core
+
+- Prevented compiled binaries from failing on startup because of a circular session schema dependency.
+- Renamed the compaction setting to `preserve_recent_tokens` for the budget that keeps recent turns verbatim.
+- Preserved concurrent edits to the same file instead of letting parallel edits overwrite each other.
+- Fixed managed installs on Windows and added bundled ripgrep support for Windows ARM64.
+- Added NVIDIA as a built-in provider option, including connection docs and required attribution headers. (@anniesurla)
+- Kept recent conversation turns verbatim during session compaction so follow-up work keeps more local context.
+- Fell back to summarizing the full conversation when preserved recent turns include too much media to fit safely.
+
+### Desktop
+
+- Reduced loading flicker when opening projects and bringing prompt controls online.
+- Added a separate terminal font setting and bundled JetBrainsMono Nerd Font Mono.
+
+## [v1.14.18](https://github.com/anomalyco/opencode/releases/tag/v1.14.18)
+
+Apr 19, 2026
+
+### Core
+
+- Restore the native ripgrep backend so file search and file listing work reliably again.
+
+## [v1.14.17](https://github.com/anomalyco/opencode/releases/tag/v1.14.17)
+
+Apr 19, 2026
+
+### Core
+
+- Preserve executable permissions before Docker builds when artifacts lose their exec bits.
+- Fix plugins reinstalling more often than needed.
+- Use `display: summarized` by default for Anthropic Bedrock Opus 4.7 requests.
+- Detect attachment types from file contents so images and PDFs still work with incorrect or missing extensions.
+- Support `OTEL_RESOURCE_ATTRIBUTES` for custom telemetry resource tags.
+- Fix package installs when `node_modules` is missing.
+- Fix GitHub Copilot Anthropic Haiku requests by disabling unsupported tool streaming.
+
+### TUI
+
+- Add a full-session option when forking from the session dialog.
+- Show the session ID in the sidebar on non-production channels.
+
+## [v1.4.11](https://github.com/anomalyco/opencode/releases/tag/v1.4.11)
+
+Apr 18, 2026
+
+### Core
+
+- Fixed workspace routing so requests reach the correct workspace instance.
+- Stopped share sync attempts for sessions that were never shared.
+
+## [v1.4.10](https://github.com/anomalyco/opencode/releases/tag/v1.4.10)
+
+Apr 17, 2026
+
+### Core
+
+- Restored workspace history on connect so existing sessions catch up before live sync resumes
+- Passed OTEL exporter settings into managed workspaces so telemetry works there too
+- Normalized provider metadata defaults so models still load when catalog data is incomplete
+- Passed `EXA_API_KEY` to the `websearch` tool to reduce rate limits (@rasdani)
+
+### TUI
+
+- Added a restore flow for sessions whose workspace is unavailable, with clearer workspace status indicators
+- Fixed agent cycling when no agent is selected and improved prompt key handling
+
+## [v1.4.9](https://github.com/anomalyco/opencode/releases/tag/v1.4.9)
+
+Apr 17, 2026
+
+### Core
+
+- Added LLM Gateway as a provider, including config support and model usage reporting. (@smakosh)
+- Limited GitHub Copilot Opus 4.7 models to medium reasoning effort to avoid unsupported variants. (@OpeOginni)
+- Improved remote workspace reconnection with exponential backoff and clearer failure handling.
+
+### TUI
+
+- Fixed `--session-id` so it opens the requested session after app startup.
+- Fixed light mode detection in Ghostty.
+
+### Desktop
+
+- Fixed the beta desktop app so the file tree still appears when enabled in settings.
+
+## [v1.4.8](https://github.com/anomalyco/opencode/releases/tag/v1.4.8)
+
+Apr 17, 2026
+
+### Core
+
+- Fixed a crash when experimental mode was enabled.
+- Let plugin tools return metadata in execute results. (@jquense)
+- Show real filenames instead of `/dev/null` in revert diffs.
+- Improved workspace session handling when a workspace no longer exists.
+- Fixed Windows `ctrl+z` terminal suspend and input undo behavior.
+- Enabled Azure prompt caching with a default per-session cache key.
+
+### TUI
+
+- Preserve prompt input when views unmount and remount.
+- Keep session list dialogs ordered more consistently within each day.
+
+### Desktop
+
+- Fixed desktop workspace loading so ready state persists correctly.
+- Fixed desktop session syncing when loading project data from query cache.
+- Added beta desktop settings to hide title bar tools like navigation, search, terminal, status, and file tree.
+- Improved desktop session change loading in the review panel.
+
+## [v1.4.7](https://github.com/anomalyco/opencode/releases/tag/v1.4.7)
+
+Apr 16, 2026
+
+### Core
+
+- GitHub Copilot `gpt-5-mini` now uses low reasoning effort for better request compatibility. (@thakrarsagar)
+- Workspaces now receive your auth context, so provider sign-in carries across workspace sessions.
+- Cloudflare AI Gateway now drops `max_tokens` for OpenAI reasoning models so GPT-5 and o-series requests stop failing. (@kobicovaldev)
+- Azure models now default `store=true`, fixing requests that require stored responses.
+- Claude Opus 4.7 now supports `xhigh` adaptive reasoning. (@GrahamCampbell)
+- Claude Opus 4.7 now shows summarized thinking by default.
+- TUI plugins now load against the correct project when multiple directories are open.
+- The bash tool uses less memory on large command output.
+- Experimental workspaces now wait for sync to finish before returning writes, reducing stale reads and missed updates.
+- Session restore can now replay a session into another workspace in batches.
+- Sessions now retry provider 5xx errors even when the provider SDK does not mark them retryable.
+
+### TUI
+
+- Pasting files or large text no longer inserts content twice.
+- `--agent` on the command line is no longer overwritten by the session's saved agent. (@CarloWood)
+- Empty LSP, MCP, formatter, and session status responses no longer break TUI sync state.
+
+### Desktop
+
+- Desktop builds now show a Beta or Dev badge in the title bar when applicable.
+
+## [v1.4.6](https://github.com/anomalyco/opencode/releases/tag/v1.4.6)
+
+Apr 15, 2026
+
+### Core
+
+- Fixed snapshot staging for very long file lists and improved staging performance.
+- Fixed OTEL header parsing when a header value contains `=`.
+
+### Desktop
+
+- Fixed prompt submission state updates to avoid failed or inconsistent sends.
+- Improved session title input spacing while editing.
+
+## [v1.4.5](https://github.com/anomalyco/opencode/releases/tag/v1.4.5)
+
+Apr 15, 2026
+
+### Core
+
+- Export AI SDK telemetry spans to OTLP trace backends.
+- Expose the experimental question API schema and OpenAPI spec from `@opencode-ai/server`.
+- Expose a reusable question handler factory for custom question API hosts.
+
+### Desktop
+
+- Start desktop shell commands from the home directory.
+- Avoid bootstrap error popups while global sync initializes.
+
+## [v1.4.4](https://github.com/anomalyco/opencode/releases/tag/v1.4.4)
+
+Apr 15, 2026
+
+### Core
+
+- Restored instance and logger context during prompt runs so prompt-time tools and logging behave correctly.
+- Kept GitHub Copilot compaction requests valid.
+- Restored the flat reply shape for question API responses.
+- Persisted MCP OAuth connections that finish immediately, so authenticated servers stay connected.
+- Prevented duplicate user messages in ACP clients.
+- Stopped emitting `user_message_chunk` events during session and prompt turns in ACP clients. (@RAIT-09)
+- Fixed reasoning summary injection for `@ai-sdk/openai-compatible` providers. (@nazarhnatyshen)
+- Added the experimental `compaction.autocontinue` hook to stop auto-continuing after compaction.
+- Added Alibaba provider support with cache support.
+- Snapshots now fully respect `.gitignore`, including previously tracked files.
+- Reading images no longer counts against quota.
+- Sessions can now update project permissions mid-run. (@remorses)
+- Enabled thinking for `zhipuai-coding-plan` and fixed Korean IME truncation. (@claudianus)
+
+### TUI
+
+- Added `opencode export --sanitize` to redact PII and confidential transcript data.
+- Fixed diff line number contrast in built-in themes.
+- Plugin auth login now asks for an API key when a plugin needs authorization. (@goniz)
+- Plugin auth no longer asks for an API key when the plugin has no `authorize` method. (@goniz)
+
+### Desktop
+
+- Fixed the Windows desktop backend hanging before shutdown.
+
+### SDK
+
+- The JavaScript SDK now throws a clear error when an older server responds with HTML instead of the API.
+
+### Extensions
+
+- Plugins can now register custom workspace adaptors that appear in workspace creation.
+
+## [v1.4.3](https://github.com/anomalyco/opencode/releases/tag/v1.4.3)
+
+Apr 10, 2026
+
+### Core
+
+- Fixed `agent create` for OpenAI accounts authenticated with OAuth.
+- Interrupted Bash commands now keep their final output and truncation details instead of ending as aborted.
+- Added fast mode variants for supported Claude and GPT models.
+
+### TUI
+
+- Restored the hidden session scrollbar as the default.
+
+### Extensions
+
+- Added configurable OAuth redirect URIs for remote MCP servers. (@egze)
+
+## [v1.4.2](https://github.com/anomalyco/opencode/releases/tag/v1.4.2)
+
+Apr 9, 2026
+
+### TUI
+
+- Fix subagents not being clickable until finished
+
+### Desktop
+
+- Removed the forced loading delay while the app connects
+
+## [v1.4.1](https://github.com/anomalyco/opencode/releases/tag/v1.4.1)
+
+Apr 9, 2026
+
+### Core
+
+- Fix `clangd` choosing `CMakeLists.txt` or `Makefile` as the project root in C and C++ workspaces. (@nonbanana)
+- Add permission prompts for GitLab Duo Workflow tool calls instead of auto-running them. (@vglafirov)
+- Hide unsupported variants for Big Pickle models.
+
+### TUI
+
+- Show an OpenCode Go subscribe prompt when free usage limits are reached.
+- Simplify provider labels in the model and provider pickers.
+
+### Desktop
+
+- Fix terminal connections in same-origin desktop and web app setups. (@OpeOginni)
+- Fix session review and change lists when diff data arrives in inconsistent shapes.
+
+### SDK
+
+- Fix the generated SDK and OpenAPI types for `/providers` and session shell responses.


### PR DESCRIPTION
### Issue for this PR
(This is a new feature/enhancement, not a bug fix)

### Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Adds a GitHub Actions workflow (`sync-changelog.yml`) that automatically fetches the complete changelog from https://opencode.ai/changelog and generates `changelog.md` with all version entries. Runs hourly or can be triggered manually. This provides a local changelog file that stays in sync with the website.

### How did you verify your code works?
- Tested locally by running the fetch and generate scripts
- Verified the generated `changelog.md` matches the complete changelog from the website (20 versions from v1.4.1 to v1.14.25)
- Workflow pushes to dev branch where it can be tested via GitHub Actions

### Screenshots / recordings
(Not applicable - this is a workflow/documentation change)

### Checklist
- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR