### PR TITLE
fix: guard against undefined MCP tool output causing output.split crash

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -318,6 +318,7 @@ export const ToolStateCompleted = Schema.Struct({
 export type ToolStateCompleted = Types.DeepMutable<Schema.Schema.Type<typeof ToolStateCompleted>>
 
 function truncateToolOutput(text: string, maxChars?: number) {
+  if (!text) return ""
   if (!maxChars || text.length <= maxChars) return text
   const omitted = text.length - maxChars
   return `${text.slice(0, maxChars)}\n[Tool output truncated for compaction: omitted ${omitted} chars]`
@@ -853,7 +854,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           if (part.state.status === "completed") {
             const outputText = part.state.time.compacted
               ? "[Old tool result content cleared]"
-              : truncateToolOutput(part.state.output, options?.toolOutputMaxChars)
+              : truncateToolOutput(part.state.output ?? "", options?.toolOutputMaxChars)
             const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
 
             // For providers that don't support media in tool results, extract media files

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -84,6 +84,7 @@ export const layer = Layer.effect(
     })
 
     const output = Effect.fn("Truncate.output")(function* (text: string, options: Options = {}, agent?: Agent.Info) {
+      if (text == null) return { content: "", truncated: false } as const
       const resolved = yield* limits()
       const maxLines = options.maxLines ?? resolved.maxLines
       const maxBytes = options.maxBytes ?? resolved.maxBytes


### PR DESCRIPTION
Fixes #24402

## Summary

Fixes a crash that occurs when MCP tools return results with no text content (e.g., only images, empty content array, or unexpected response format).

**Error:** `TypeError: undefined is not an object (evaluating 'output.split')`

## Root Cause

When an MCP tool result has no text content, `part.state.output` is stored as `undefined`. This undefined value flows into:

1. `truncateToolOutput()` in `message-v2.ts:320` — calls `.length` on undefined
2. `Truncate.output()` in `truncate.ts:91` — calls `.split("\n")` on undefined

The undefined propagates into the AI SDK's `convertToModelMessages()`, which then crashes.

## Changes

- **`packages/opencode/src/session/message-v2.ts`**:
  - Added `if (!text) return ""` guard in `truncateToolOutput()` (line 321)
  - Added `?? ""` fallback at call site in `toModelMessagesEffect()` (line 856)

- **`packages/opencode/src/tool/truncate.ts`**:
  - Added `if (text == null)` early return in `Truncate.output()` (line 87)

## Reproduction

1. Configure any MCP server that returns tool results with no text content (e.g., image generation tools)
2. Call the MCP tool
3. Observe `undefined is not an object (evaluating 'output.split')` crash

## Testing

- Confirmed MCP server returns valid JSON-RPC responses via direct stdin/stdout testing
- The bug is in opencode's response parsing, not in the MCP servers themselves