### PR TITLE
fix: Buffer stdin before prompt UI appears

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -63,6 +63,7 @@ import { FormatError, FormatUnknownError } from "@/cli/error"
 
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
+import { createStartupInputBuffer } from "./startup-input-buffer"
 
 function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   const mouseEnabled = !Flag.OPENCODE_DISABLE_MOUSE && (_config.mouse ?? true)
@@ -119,6 +120,7 @@ export function tui(input: {
   return new Promise<void>(async (resolve) => {
     const unguard = win32InstallCtrlCGuard()
     win32DisableProcessedInput()
+    const startupInputBuffer = createStartupInputBuffer()
 
     const onExit = async () => {
       unguard?.()
@@ -126,6 +128,7 @@ export function tui(input: {
     }
 
     const onBeforeExit = async () => {
+      startupInputBuffer.dispose()
       await TuiPluginRuntime.dispose()
     }
 
@@ -171,7 +174,7 @@ export function tui(input: {
                                       <CommandProvider>
                                         <FrecencyProvider>
                                           <PromptHistoryProvider>
-                                            <PromptRefProvider>
+                                            <PromptRefProvider startupInputBuffer={startupInputBuffer}>
                                               <EditorContextProvider>
                                                 <App onSnapshot={input.onSnapshot} />
                                               </EditorContextProvider>

--- a/packages/opencode/src/cli/cmd/tui/context/prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/prompt.tsx
@@ -1,10 +1,12 @@
 import { createSimpleContext } from "./helper"
 import type { PromptRef } from "../component/prompt"
+import type { StartupInputBuffer } from "../startup-input-buffer"
 
 export const { use: usePromptRef, provider: PromptRefProvider } = createSimpleContext({
   name: "PromptRef",
-  init: () => {
+  init: (props: { startupInputBuffer: StartupInputBuffer }) => {
     let current: PromptRef | undefined
+    let startupDrained = false
 
     return {
       get current() {
@@ -12,6 +14,15 @@ export const { use: usePromptRef, provider: PromptRefProvider } = createSimpleCo
       },
       set(ref: PromptRef | undefined) {
         current = ref
+      },
+      drainStartupInputBuffer(ref = current) {
+        if (startupDrained || !ref) return false
+        startupDrained = true
+        const input = props.startupInputBuffer.drain()
+        props.startupInputBuffer.dispose()
+        if (!input || ref.current.input) return false
+        ref.set({ input, parts: [] })
+        return true
       },
     }
   },

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -29,15 +29,21 @@ export function Home() {
   const bind = (r: PromptRef | undefined) => {
     setRef(r)
     promptRef.set(r)
-    if (once || !r) return
-    if (route.prompt) {
-      r.set(route.prompt)
-      once = true
-      return
+    if (!r) return
+
+    // Seed explicit prompt state first.
+    if (!once) {
+      if (route.prompt) {
+        r.set(route.prompt)
+        once = true
+      } else if (args.prompt) {
+        r.set({ input: args.prompt, parts: [] })
+        once = true
+      }
     }
-    if (!args.prompt) return
-    r.set({ input: args.prompt, parts: [] })
-    once = true
+
+    // Fill with startup typing only if still empty.
+    promptRef.drainStartupInputBuffer(r)
   }
 
   // Wait for sync and model store to be ready before auto-submitting --prompt

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -243,9 +243,16 @@ export function Session() {
   const bind = (r: PromptRef | undefined) => {
     prompt = r
     promptRef.set(r)
-    if (seeded || !route.prompt || !r) return
-    seeded = true
-    r.set(route.prompt)
+    if (!r) return
+
+    // Seed explicit prompt state first.
+    if (!seeded && route.prompt) {
+      seeded = true
+      r.set(route.prompt)
+    }
+
+    // Fill with startup typing only if still empty.
+    promptRef.drainStartupInputBuffer(r)
   }
   const keybind = useKeybind()
   const dialog = useDialog()

--- a/packages/opencode/src/cli/cmd/tui/startup-input-buffer.ts
+++ b/packages/opencode/src/cli/cmd/tui/startup-input-buffer.ts
@@ -1,0 +1,80 @@
+import { decodePasteBytes, StdinParser } from "@opentui/core"
+
+/**
+ * Captures input typed before the prompt UI appears so users can start typing immediately.
+ */
+export type StartupInputBuffer = ReturnType<typeof createStartupInputBuffer>
+export type StartupInputBufferState = ReturnType<typeof createStartupInputBufferState>
+
+const encoder = new TextEncoder()
+
+export function createStartupInputBufferState() {
+  return {
+    input: "",
+    // Keep parsing synchronous; startup capture should not own timers.
+    parser: new StdinParser({ armTimeouts: false }),
+  }
+}
+
+export function appendStartupInputBufferChunk(state: StartupInputBufferState, chunk: string | Uint8Array) {
+  state.parser.push(typeof chunk === "string" ? encoder.encode(chunk) : chunk)
+  state.parser.drain((event) => {
+    if (event.type === "response") return
+    if (event.type === "paste") {
+      state.input += decodePasteBytes(event.bytes)
+      return
+    }
+    if (event.type !== "key") return
+
+    // Backspace/delete edit buffered startup text.
+    if (event.key.name === "backspace" || event.key.name === "delete") {
+      state.input = dropLast(state.input)
+      return
+    }
+
+    // Ctrl+U clears the startup buffer.
+    if (event.key.ctrl && event.key.name === "u") {
+      state.input = ""
+      return
+    }
+
+    // Enter before the prompt appears should not submit anything.
+    if (event.key.name === "return") return
+
+    // Preserve pasted newlines and append normal typed characters.
+    if (event.key.name === "linefeed" || (!event.key.ctrl && !event.key.meta && Array.from(event.raw).length === 1)) {
+      state.input += event.raw
+    }
+  })
+
+  return state
+}
+
+export function createStartupInputBuffer() {
+  const state = createStartupInputBufferState()
+  let disposed = false
+
+  const onData = (data: Buffer | string) => {
+    appendStartupInputBufferChunk(state, data)
+  }
+
+  if (process.stdin.isTTY) process.stdin.on("data", onData)
+
+  return {
+    drain() {
+      const result = state.input
+      state.input = ""
+      return result
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
+      process.stdin.off("data", onData)
+      state.parser.destroy()
+    },
+  }
+}
+
+function dropLast(input: string) {
+  return Array.from(input).slice(0, -1).join("")
+}

--- a/packages/opencode/test/cli/cmd/tui/startup-input-buffer.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/startup-input-buffer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import {
+  appendStartupInputBufferChunk,
+  createStartupInputBufferState,
+} from "../../../../src/cli/cmd/tui/startup-input-buffer"
+
+function append(chunks: string[]) {
+  return chunks.reduce(appendStartupInputBufferChunk, createStartupInputBufferState()).input
+}
+
+describe("startup input buffer", () => {
+  test("keeps printable text", () => {
+    expect(append(["hello world"])).toBe("hello world")
+  })
+
+  test("handles simple editing controls", () => {
+    expect(append(["hello", "\x7f!\x15again"])).toBe("again")
+  })
+
+  test("drops terminal escape responses", () => {
+    expect(append(["\x1b]11;rgb:ffff/ffff/ffff\x07hello\x1b[?2026;1$y\x1bPignored\x1b\\"])).toBe("hello")
+  })
+
+  test("keeps bracketed paste content", () => {
+    expect(append(["\x1b[200~one\ntwo\x1b[201~"])).toBe("one\ntwo")
+  })
+
+  test("drops terminal responses split across chunks", () => {
+    expect(append(["\x1b]11;rgb:", "0000/afaf/ffff\x07hello"])).toBe("hello")
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/startup-prompt-precedence.test.tsx
+++ b/packages/opencode/test/cli/cmd/tui/startup-prompt-precedence.test.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { onMount } from "solid-js"
+import { PromptRefProvider, usePromptRef } from "../../../../src/cli/cmd/tui/context/prompt"
+import type { PromptRef } from "../../../../src/cli/cmd/tui/component/prompt"
+import type { PromptInfo } from "../../../../src/cli/cmd/tui/component/prompt/history"
+
+function createPromptRef(input: string) {
+  const prompt: PromptInfo = { input, parts: [] }
+
+  return {
+    get focused() {
+      return true
+    },
+    get current() {
+      return prompt
+    },
+    set(next) {
+      prompt.input = next.input
+      prompt.parts = next.parts
+    },
+    reset() {},
+    blur() {},
+    focus() {},
+    submit() {},
+  } satisfies PromptRef
+}
+
+function Probe(props: { ref: PromptRef; onDrain: (value: boolean) => void }) {
+  const promptRef = usePromptRef()
+
+  onMount(() => {
+    promptRef.set(props.ref)
+    props.onDrain(promptRef.drainStartupInputBuffer(props.ref))
+  })
+
+  return <box />
+}
+
+describe("startup input buffer precedence", () => {
+  test("does not overwrite an explicitly seeded prompt with startup input", async () => {
+    let drained = false
+    let disposed = false
+    let applied = true
+    const ref = createPromptRef("seeded")
+
+    const app = await testRender(() => (
+      <PromptRefProvider
+        startupInputBuffer={{
+          drain() {
+            drained = true
+            return "typed during startup"
+          },
+          dispose() {
+            disposed = true
+          },
+        }}
+      >
+        <Probe ref={ref} onDrain={(value) => (applied = value)} />
+      </PromptRefProvider>
+    ))
+
+    try {
+      expect(applied).toBe(false)
+      expect(drained).toBe(true)
+      expect(disposed).toBe(true)
+      expect(ref.current.input).toBe("seeded")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14415

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This addresses chars being dropped while typing between launching opencode and the prompt UI being rendered, by buffering stdin and seeding the prompt state with it later.
This takes a different approach to https://github.com/anomalyco/opencode/pull/20934, leveraging OpenTUI's StdinParser rather than parsing the input ourselves.

I attempted to address @TZubiri's concern, but couldn't find a subtractive solution that worked. That said, I'm not well versed in OpenTUI. It seems to take stdin ownership and set it to raw mode immediately in `createCliRenderer()`. I tried in a small repro project that delays before rendering a text box, and input was swallowed there too.

### How did you verify your code works?

Manual testing on macOS 26's stock Terminal.app.

### Screenshots / recordings

| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/27bf694c-9330-4173-bc2a-9d0ed0794153"/> |  <video src="https://github.com/user-attachments/assets/f7486992-5341-4d50-b6cf-d4871a374a38"/>  |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR