### PR TITLE
test(provider): avoid plugin dependency install timeout

### DIFF
--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -55,6 +55,14 @@ async function defaultModel() {
   return run((provider) => provider.defaultModel())
 }
 
+async function markPluginDependenciesReady(dir: string) {
+  await mkdir(path.join(dir, "node_modules"), { recursive: true })
+  await Bun.write(
+    path.join(dir, "package-lock.json"),
+    JSON.stringify({ packages: { "": { dependencies: { "@opencode-ai/plugin": "0.0.0" } } } }),
+  )
+}
+
 function paid(providers: Awaited<ReturnType<typeof list>>) {
   const item = providers[ProviderID.make("opencode")]
   expect(item).toBeDefined()
@@ -2439,8 +2447,11 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
 test("plugin config providers persist after instance dispose", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      const root = path.join(dir, ".opencode", "plugin")
+      const configDir = path.join(dir, ".opencode")
+      const root = path.join(configDir, "plugin")
       await mkdir(root, { recursive: true })
+      await markPluginDependenciesReady(configDir)
+      await markPluginDependenciesReady(Global.Path.config)
       await Bun.write(
         path.join(root, "demo-provider.ts"),
         [


### PR DESCRIPTION
## Summary
- Avoid real dependency installation in the plugin provider persistence test.
- Mark both project and global config dependency directories as already prepared so the test exercises provider/plugin persistence instead of npm install timing.

## Tests
- `bun test --timeout 30000 test/provider/provider.test.ts -t "plugin config providers persist after instance dispose"` from `packages/opencode`
- `bun typecheck` from `packages/opencode`