### PR TITLE
feat(session): persist invoking slash command on user messages

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -391,6 +391,13 @@ export const User = Schema.Struct({
   }),
   system: Schema.optional(Schema.String),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),
+  command: Schema.optional(
+    Schema.Struct({
+      name: Schema.String,
+      arguments: Schema.String,
+      source: Schema.Literals(["command", "mcp", "skill"]),
+    }),
+  ),
 })
   .annotate({ identifier: "UserMessage" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -956,6 +956,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         },
         system: input.system,
         format: input.format,
+        ...(input.command ? { command: input.command } : {}),
       }
 
       yield* Effect.addFinalizer(() => instruction.clear(info.id))
@@ -1655,6 +1656,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: userAgent,
         parts,
         variant: input.variant,
+        command: {
+          name: input.command,
+          arguments: input.arguments,
+          source: cmd.source ?? "command",
+        },
       })
       yield* bus.publish(Command.Event.Executed, {
         name: input.command,
@@ -1724,6 +1730,13 @@ export const PromptInput = Schema.Struct({
   format: Schema.optional(MessageV2.Format),
   system: Schema.optional(Schema.String),
   variant: Schema.optional(Schema.String),
+  command: Schema.optional(
+    Schema.Struct({
+      name: Schema.String,
+      arguments: Schema.String,
+      source: Schema.Literals(["command", "mcp", "skill"]),
+    }),
+  ),
   parts: Schema.Array(
     Schema.Union([
       MessageV2.TextPartInput,


### PR DESCRIPTION
## Summary

When a slash command (built-in, config-defined, MCP prompt, or skill) is invoked, the resulting user message currently stores only the expanded template body — the original \`/name args\` invocation is dropped. This forces clients to render the full expanded prompt in the chat transcript and breaks the inline-edit / jump-back UX raised in #22349.

This PR adds an optional \`command: { name, arguments, source }\` field on \`MessageV2.User\` so the invocation is preserved on the message itself.

- \`name\` — the command/skill name (without leading \`/\`)
- \`arguments\` — the argument string passed by the user
- \`source\` — \`\"command\" | \"mcp\" | \"skill\"\` (matches \`Command.Info.source\`), so clients can render different chips/icons for each kind

The change is fully backwards compatible — the field is optional and only populated when the message originates from the slash-command path.

## Why

- **#22349**: jumping back to a message that invoked a skill currently dumps the full expanded prompt into the input box. Storing the invocation on the message lets the UI restore \`/skill_name\` instead.
- **Chat transcript**: clients (TUI / web / 3rd-party) can collapse the expanded body and render the original \`/name args\` form.
- **Telemetry / replay**: the persisted field lives in the stored message (not just a transient \`command.executed\` SSE event), so historical sessions and REST replays carry the same information.

## Changes

| File | What |
|---|---|
| \`packages/opencode/src/session/message-v2.ts\` | Add optional \`command\` to the \`User\` schema |
| \`packages/opencode/src/session/prompt.ts\` | Add optional \`command\` to \`PromptInput\`; \`createUserMessage\` propagates it onto the user message; the slash-command Effect populates it when calling \`prompt()\` (using \`cmd.source\` from the unified \`commands\` registry) |

20 lines of additions across 2 files. No deletions.

## Compatibility

- Existing user messages without \`command\` continue to work (optional field).
- Non-command \`prompt()\` callers (REST \`promptAsync\`, plugin-driven prompts) don't pass \`command\` and are unchanged.
- The existing \`command.executed\` bus event is untouched.

## Follow-ups (not in this PR)

- SDK regeneration (\`packages/sdk/js/script/build.ts\`) — happy to include in a follow-up commit if maintainers prefer it bundled here.
- Docs for the new field.
- TUI / app rendering changes to consume the field (separate PRs against \`packages/app\`, etc.).

## Notes for review

- I assumed \`cmd.source\` should fall back to \`\"command\"\` when undefined (only happens for default \`init\` / \`review\` which actually do set \`source: \"command\"\` already, but the schema marks it optional).
- I deliberately left \`Command.Event.Executed\` alone since the new field supersedes its use for display purposes but it's still useful for telemetry / external listeners.

Closes #22349 (if maintainers agree this is the right shape).