### PR TITLE
fix(app): ignore watchman cookie files

### DIFF
--- a/packages/opencode/src/file/ignore.ts
+++ b/packages/opencode/src/file/ignore.ts
@@ -40,6 +40,7 @@ const FILES = [
   // OS
   "**/.DS_Store",
   "**/Thumbs.db",
+  "**/.watchman-cookie-*",
 
   // Logs & temp
   "**/logs/**",

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -139,7 +139,7 @@ export const layer = Layer.effect(
               const ignore = (yield* Effect.promise(() => readdir(vcsDir).catch(() => []))).filter(
                 (entry) => entry !== "HEAD",
               )
-              yield* subscribe(vcsDir, ignore)
+              yield* subscribe(vcsDir, [...ignore, ...FileIgnore.PATTERNS, ...cfgIgnores])
             }
           }
         },

--- a/packages/opencode/test/file/ignore.test.ts
+++ b/packages/opencode/test/file/ignore.test.ts
@@ -7,4 +7,6 @@ test("match nested and non-nested", () => {
   expect(FileIgnore.match("node_modules/")).toBe(true)
   expect(FileIgnore.match("node_modules/bar")).toBe(true)
   expect(FileIgnore.match("node_modules/bar/")).toBe(true)
+  expect(FileIgnore.match(".watchman-cookie-123")).toBe(true)
+  expect(FileIgnore.match("nested/.watchman-cookie-123")).toBe(true)
 })

--- a/packages/opencode/test/file/watcher.test.ts
+++ b/packages/opencode/test/file/watcher.test.ts
@@ -224,6 +224,31 @@ describeWatcher("FileWatcher", () => {
     )
   })
 
+  test("ignores Watchman cookie files", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const projectCookie = path.join(tmp.path, ".watchman-cookie-project")
+    const gitCookie = path.join(tmp.path, ".git", ".watchman-cookie-git")
+
+    await withWatcher(
+      tmp.path,
+      Effect.all(
+        [
+          noUpdate(
+            tmp.path,
+            (e) => e.file === projectCookie,
+            Effect.promise(() => fs.writeFile(projectCookie, "cookie")),
+          ),
+          noUpdate(
+            tmp.path,
+            (e) => e.file === gitCookie,
+            Effect.promise(() => fs.writeFile(gitCookie, "cookie")),
+          ),
+        ],
+        { concurrency: 1 },
+      ).pipe(Effect.asVoid),
+    )
+  })
+
   test("publishes .git/HEAD events", async () => {
     await using tmp = await tmpdir({ git: true })
     const head = path.join(tmp.path, ".git", "HEAD")


### PR DESCRIPTION
### Issue for this PR

Closes #24357

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

opencode app is reacting to temporary Watchman files ( like .watchman-cookie-123456). This pr makes sure that the temporary watchman files are ignored

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
I have a test included in pr that verifies it 

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
