### PR TITLE
feat(agent): add orchestrate subagent for task decomposition

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -13,6 +13,7 @@ import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
+import PROMPT_ORCHESTRATE from "./prompt/orchestrate.txt"
 import { Permission } from "@/permission"
 import { mergeDeep, pipe, sortBy, values } from "remeda"
 import { Global } from "@/global"
@@ -181,6 +182,23 @@ export namespace Agent {
               ),
               description: `Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase (eg. "how do API endpoints work?"). When calling this agent, specify the desired thoroughness level: "quick" for basic searches, "medium" for moderate exploration, or "very thorough" for comprehensive analysis across multiple locations and naming conventions.`,
               prompt: PROMPT_EXPLORE,
+              options: {},
+              mode: "subagent",
+              native: true,
+            },
+            orchestrate: {
+              name: "orchestrate",
+              permission: Permission.merge(
+                defaults,
+                Permission.fromConfig({
+                  question: "allow",
+                  task: "allow",
+                  todowrite: "allow",
+                }),
+                user,
+              ),
+              description: `Task decomposition specialist. Breaks down complex multi-step tasks into smaller subtasks and executes them in parallel using specialized agents. Use this when a task involves multiple independent components, can be parallelized for speed, or is too large for a single agent. This agent will analyze the task, create a plan of subtasks, launch parallel Task tool calls, and synthesize results.`,
+              prompt: PROMPT_ORCHESTRATE,
               options: {},
               mode: "subagent",
               native: true,

--- a/packages/opencode/src/agent/prompt/orchestrate.txt
+++ b/packages/opencode/src/agent/prompt/orchestrate.txt
@@ -1,0 +1,66 @@
+# Orchestrator Agent - Task Decomposition Specialist
+
+You are a task decomposition specialist. Your job is to break down complex, multi-step tasks into smaller, manageable subtasks that can be executed in parallel by specialized agents.
+
+## Your Workflow
+
+When given a complex task:
+
+1. **Analyze the Task**
+   - Identify distinct components that can work independently
+   - Determine dependencies between components
+   - Identify which agents are best suited for each subtask
+
+2. **Create Subtask Plan**
+   - Break the task into 2-5 focused subtasks
+   - Each subtask should have a clear, actionable description
+   - Specify the appropriate agent type for each subtask
+
+3. **Execute Subtasks in Parallel**
+   - Launch multiple agents concurrently using the Task tool
+   - Each Task call should include:
+     - `description`: Short name for the subtask
+     - `prompt`: Detailed instructions for what to do
+     - `subagent_type`: The appropriate agent type
+
+4. **Collect and Synthesize Results**
+   - Wait for all subagents to complete
+   - Synthesize the results into a cohesive solution
+   - Report back to the primary agent
+
+## When to Use the Orchestrator
+
+Use the orchestrator when:
+- Task involves multiple independent components
+- Task can be parallelized for speed
+- Task requires different expertise areas
+- Task is too large for a single agent to handle effectively
+
+## Agent Types Reference
+
+| Agent | Best For |
+|-------|----------|
+| `explore` | File searching, codebase research, finding patterns |
+| `general` | Multi-step research tasks, writing code |
+| `build` | Main implementation, executing tools |
+| `plan` | Planning, read-only analysis |
+
+## Example
+
+**User Task:** "Migrate the authentication system to OAuth2"
+
+**Your Decomposition:**
+1. Subtask: Research current auth implementation → `explore`
+2. Subtask: Design OAuth2 flow → `plan`  
+3. Subtask: Implement OAuth2 server → `general`
+4. Subtask: Update client integration → `general`
+
+**Then execute all 4 in parallel and synthesize results.**
+
+## Important Guidelines
+
+- Be specific in subtask descriptions - vague tasks produce vague results
+- Set clear success criteria for each subtask
+- Handle dependencies: if Task B needs output from Task A, execute sequentially
+- Trust subagent outputs
+- Provide clear final summary to the calling agent

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -4,6 +4,7 @@ When using the Task tool, you must specify a subagent_type parameter to select w
 
 When to use the Task tool:
 - When you are instructed to execute custom slash commands. Use the Task tool with the slash command invocation as the entire prompt. The slash command can take arguments. For example: Task(description="Check the file", prompt="/check-file path/to/file.py")
+- When you need to break down a complex task into parallel subtasks using the `orchestrate` agent. The orchestrate agent analyzes the task, creates a plan, and launches parallel Task calls for maximum efficiency.
 
 When NOT to use the Task tool:
 - If you want to read a specific file path, use the Read or Glob tool instead of the Task tool, to find the match more quickly
@@ -23,6 +24,7 @@ Usage notes:
 Example usage (NOTE: The agents below are fictional examples for illustration only - use the actual agents listed above):
 
 <example_agent_descriptions>
+"orchestrate": use this agent to break down complex multi-step tasks into parallel subtasks that can be executed concurrently
 "code-reviewer": use this agent after you are done writing a significant piece of code
 "greeting-responder": use this agent when to respond to user greetings with a friendly joke
 </example_agent_description>


### PR DESCRIPTION
### Issue for this PR

Closes #24447 (partially - addresses need for better task decomposition)

### Type of change

- [x] New feature

### What does this PR do?

Add a new `orchestrate` subagent that breaks down complex multi-step tasks into parallel subtasks executed by specialized agents.

**Problem:** Large tasks require manual decomposition and coordination of multiple Task calls.

**Solution:** Automate task breakdown with an orchestrator that:
1. Analyzes complex tasks
2. Creates focused subtasks (2-5 items)
3. Executes subtasks in parallel via Task tool
4. Synthesizes results

### Files Changed

| File | Change |
|------|--------|
| `packages/opencode/src/agent/prompt/orchestrate.txt` | New orchestrator prompt |
| `packages/opencode/src/agent/agent.ts` | Register orchestrate agent |
| `packages/opencode/src/tool/task.txt` | Document orchestrate usage |

### How did you verify your code works?

- [ ] Code follows existing agent patterns (explore, general, plan)
- [ ] Import added to agent.ts
- [ ] Orchestrator has appropriate permissions (task, todowrite, question)
- [ ] Task tool docs updated with orchestrate example

### Checklist

- [x] I have not included unrelated changes in this PR
- [x] Follows existing agent registration patterns