### PR TITLE
docs: add opencode-byterover to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -17,6 +17,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 | Name                                                                                               | Description                                                                                       |
 | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [opencode-byterover](https://github.com/ian-pascoe/opencode-byterover)                             | Persist and recall ByteRover memory context across OpenCode sessions                              |
 | [opencode-daytona](https://github.com/daytonaio/daytona/tree/main/libs/opencode-plugin)            | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                                |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |


### PR DESCRIPTION
### Issue for this PR

Closes #24464

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-byterover` to the ecosystem docs plugin table so users can discover the ByteRover memory integration for OpenCode.

### How did you verify your code works?

Ran `bunx prettier --check packages/web/src/content/docs/ecosystem.mdx`.

### Screenshots / recordings

N/A - documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR