### PR TITLE
fix(tui): restore slash command text when jumping back to command messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
@@ -6,8 +6,7 @@ import { Locale } from "@/util/locale"
 import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { useDialog, type DialogContext } from "../../ui/dialog"
-import type { PromptInfo } from "@tui/component/prompt/history"
-import { strip } from "@tui/component/prompt/part"
+import { createPromptInfoFromParts } from "./prompt-info"
 
 export function DialogForkFromTimeline(props: { sessionID: string; onMove: (messageID?: string) => void }) {
   const sync = useSync()
@@ -36,12 +35,10 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
     const result = [] as DialogSelectOption<string | undefined>[]
     for (const message of messages) {
       if (message.role !== "user") continue
-      const part = (sync.data.part[message.id] ?? []).find(
-        (x) => x.type === "text" && !x.synthetic && !x.ignored,
-      ) as TextPart
-      if (!part) continue
+      const prompt = createPromptInfoFromParts(sync.data.part[message.id] ?? [])
+      if (!prompt.input) continue
       result.push({
-        title: part.text.replace(/\n/g, " "),
+        title: prompt.input.replace(/\n/g, " "),
         value: message.id,
         footer: Locale.time(message.time.created),
         onSelect: async (dialog) => {
@@ -49,17 +46,6 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
             sessionID: props.sessionID,
             messageID: message.id,
           })
-          const parts = sync.data.part[message.id] ?? []
-          const prompt = parts.reduce(
-            (agg, part) => {
-              if (part.type === "text") {
-                if (!part.synthetic) agg.input += part.text
-              }
-              if (part.type === "file") agg.parts.push(strip(part))
-              return agg
-            },
-            { input: "", parts: [] as PromptInfo["parts"] },
-          )
           route.navigate({
             sessionID: forked.data!.id,
             type: "session",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -5,7 +5,7 @@ import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import * as Clipboard from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
-import { strip } from "@tui/component/prompt/part"
+import { createPromptInfoFromParts } from "./prompt-info"
 
 export function DialogMessage(props: {
   messageID: string
@@ -35,18 +35,8 @@ export function DialogMessage(props: {
             })
 
             if (props.setPrompt) {
-              const parts = sync.data.part[msg.id]
-              const promptInfo = parts.reduce(
-                (agg, part) => {
-                  if (part.type === "text") {
-                    if (!part.synthetic) agg.input += part.text
-                  }
-                  if (part.type === "file") agg.parts.push(strip(part))
-                  return agg
-                },
-                { input: "", parts: [] as PromptInfo["parts"] },
-              )
-              props.setPrompt(promptInfo)
+              const parts = sync.data.part[msg.id] ?? []
+              props.setPrompt(createPromptInfoFromParts(parts))
             }
 
             dialog.clear()
@@ -82,18 +72,7 @@ export function DialogMessage(props: {
               messageID: props.messageID,
             })
             const msg = message()
-            const prompt = msg
-              ? sync.data.part[msg.id].reduce(
-                  (agg, part) => {
-                    if (part.type === "text") {
-                      if (!part.synthetic) agg.input += part.text
-                    }
-                    if (part.type === "file") agg.parts.push(part)
-                    return agg
-                  },
-                  { input: "", parts: [] as PromptInfo["parts"] },
-                )
-              : undefined
+            const prompt = msg ? createPromptInfoFromParts(sync.data.part[msg.id] ?? []) : undefined
             route.navigate({
               sessionID: result.data!.id,
               type: "session",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
@@ -6,6 +6,7 @@ import { Locale } from "@/util/locale"
 import { DialogMessage } from "./dialog-message"
 import { useDialog } from "../../ui/dialog"
 import type { PromptInfo } from "../../component/prompt/history"
+import { createPromptInfoFromParts } from "./prompt-info"
 
 export function DialogTimeline(props: {
   sessionID: string
@@ -24,12 +25,10 @@ export function DialogTimeline(props: {
     const result = [] as DialogSelectOption<string>[]
     for (const message of messages) {
       if (message.role !== "user") continue
-      const part = (sync.data.part[message.id] ?? []).find(
-        (x) => x.type === "text" && !x.synthetic && !x.ignored,
-      ) as TextPart
-      if (!part) continue
+      const prompt = createPromptInfoFromParts(sync.data.part[message.id] ?? [])
+      if (!prompt.input) continue
       result.push({
-        title: part.text.replace(/\n/g, " "),
+        title: prompt.input.replace(/\n/g, " "),
         value: message.id,
         footer: Locale.time(message.time.created),
         onSelect: (dialog) => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/prompt-info.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/prompt-info.ts
@@ -1,0 +1,33 @@
+import type { Part } from "@opencode-ai/sdk/v2"
+import type { PromptInfo } from "@tui/component/prompt/history"
+import { strip } from "@tui/component/prompt/part"
+
+function invocation(part: Part): string | undefined {
+  if (part.type !== "text") return
+  const metadata = part.metadata
+  if (!metadata || typeof metadata !== "object") return
+  const command = (metadata as Record<string, unknown>)["command"]
+  if (!command || typeof command !== "object") return
+
+  const invocation = (command as Record<string, unknown>)["invocation"]
+  if (typeof invocation === "string" && invocation.length > 0) return invocation
+
+  const name = (command as Record<string, unknown>)["name"]
+  if (typeof name !== "string" || name.length === 0) return
+
+  const args = (command as Record<string, unknown>)["arguments"]
+  if (typeof args !== "string" || args.length === 0) return `/${name}`
+  return `/${name} ${args}`
+}
+
+export function createPromptInfoFromParts(parts: Part[]): PromptInfo {
+  const command = parts.reduce<string | undefined>((result, part) => result ?? invocation(part), undefined)
+  return parts.reduce(
+    (agg, part) => {
+      if (part.type === "text" && !part.synthetic && !command) agg.input += part.text
+      if (part.type === "file") agg.parts.push(strip(part))
+      return agg
+    },
+    { input: command ?? "", parts: [] as PromptInfo["parts"] },
+  )
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1588,6 +1588,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
       const templateParts = yield* resolvePromptParts(template)
       const isSubtask = (agent.mode === "subagent" && cmd.subtask !== false) || cmd.subtask === true
+      const invocation = input.arguments ? `/${input.command} ${input.arguments}` : `/${input.command}`
+      const commandParts = [...templateParts, ...(input.parts ?? [])]
+      const firstText = commandParts.findIndex((part) => part.type === "text")
       const parts = isSubtask
         ? [
             {
@@ -1599,7 +1602,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
             },
           ]
-        : [...templateParts, ...(input.parts ?? [])]
+        : commandParts.map((part, index) => {
+            if (part.type !== "text" || index !== firstText) return part
+            return {
+              ...part,
+              metadata: {
+                ...part.metadata,
+                command: {
+                  name: input.command,
+                  arguments: input.arguments,
+                  source: cmd.source ?? "command",
+                  invocation,
+                },
+              },
+            }
+          })
 
       const userAgent = isSubtask ? (input.agent ?? (yield* agents.defaultAgent())) : agentName
       const userModel = isSubtask

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1882,6 +1882,44 @@ it.live("applies agent variant only when using agent model", () =>
 // Agent / command resolution errors
 
 it.live(
+  "command prompts tag first text part with slash invocation metadata",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Pinned" })
+        yield* llm.text("done")
+
+        yield* prompt.command({
+          sessionID: chat.id,
+          command: "init",
+          arguments: "alpha beta",
+        })
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const user = messages.find((message) => message.info.role === "user")
+        expect(user).toBeDefined()
+        if (!user) return
+
+        const text = user.parts.find((part) => part.type === "text" && !part.synthetic)
+        expect(text?.type).toBe("text")
+        if (!text || text.type !== "text") return
+
+        const command = (text.metadata as Record<string, unknown> | undefined)?.["command"] as
+          | Record<string, unknown>
+          | undefined
+        expect(command?.["name"]).toBe("init")
+        expect(command?.["arguments"]).toBe("alpha beta")
+        expect(command?.["source"]).toBe("command")
+        expect(command?.["invocation"]).toBe("/init alpha beta")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  30_000,
+)
+
+it.live(
   "unknown agent throws typed error",
   () =>
     provideTmpdirInstance(


### PR DESCRIPTION
### Issue for this PR

Closes #22349

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When jumping back to a user message that was created via slash command/skill, the prompt input currently gets the fully expanded template body, which is hard to edit.

This persists slash invocation metadata on command-generated prompt text parts and updates timeline/message prompt reconstruction to prefer that invocation (for example `/myskill ...`) instead of the expanded content.

### How did you verify your code works?

From `packages/opencode`:
- `bun typecheck`
- `bun test test/session/prompt.test.ts -t "command prompts tag first text part with slash invocation metadata"`

### Screenshots / recordings

_Not a UI screenshot change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR