### PR TITLE
fix(opencode): avoid PowerShell for zip extraction

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -8,7 +8,7 @@ import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner
 
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Global } from "@opencode-ai/core/global"
-import { Log } from "@/util"
+import { Archive, Log } from "@/util"
 import { sanitizedProcessEnv } from "@opencode-ai/core/util/opencode-process"
 import { which } from "@/util/which"
 import { zod } from "@/util/effect-zod"
@@ -253,16 +253,10 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | ChildPro
         const dir = yield* fs.makeTempDirectoryScoped({ directory: Global.Path.bin, prefix: "ripgrep-" })
 
         if (config.extension === "zip") {
-          const shell = (yield* Effect.sync(() => which("powershell.exe") ?? which("pwsh.exe"))) ?? "powershell.exe"
-          const result = yield* run(shell, [
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath '${archive.replaceAll("'", "''")}' -DestinationPath '${dir.replaceAll("'", "''")}' -Force`,
-          ])
-          if (result.code !== 0) {
-            return yield* Effect.fail(error(result.stderr || result.stdout, result.code))
-          }
+          yield* Effect.tryPromise({
+            try: () => Archive.extractZip(archive, dir),
+            catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+          })
         }
 
         if (config.extension === "tar.gz") {

--- a/packages/opencode/src/util/archive.ts
+++ b/packages/opencode/src/util/archive.ts
@@ -1,15 +1,33 @@
 import path from "path"
-import * as Process from "./process"
+import fs from "fs/promises"
+import { BlobReader, Uint8ArrayWriter, ZipReader } from "@zip.js/zip.js"
+
+function destination(root: string, filename: string) {
+  const normalized = filename.replace(/\\/g, "/")
+  const target = path.resolve(root, normalized)
+  const relative = path.relative(root, target)
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`zip entry escapes destination: ${filename}`)
+  }
+  return target
+}
 
 export async function extractZip(zipPath: string, destDir: string) {
-  if (process.platform === "win32") {
-    const winZipPath = path.resolve(zipPath)
-    const winDestDir = path.resolve(destDir)
-    // $global:ProgressPreference suppresses PowerShell's blue progress bar popup
-    const cmd = `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path '${winZipPath}' -DestinationPath '${winDestDir}' -Force`
-    await Process.run(["powershell", "-NoProfile", "-NonInteractive", "-Command", cmd])
-    return
+  const root = path.resolve(destDir)
+  const reader = new ZipReader(new BlobReader(Bun.file(zipPath)), { useWebWorkers: false })
+  try {
+    for (const entry of await reader.getEntries()) {
+      const target = destination(root, entry.filename)
+      if (entry.directory) {
+        await fs.mkdir(target, { recursive: true })
+        continue
+      }
+      if (!entry.getData) throw new Error(`zip entry cannot be extracted: ${entry.filename}`)
+      await fs.mkdir(path.dirname(target), { recursive: true })
+      await Bun.write(target, await entry.getData(new Uint8ArrayWriter(), { useWebWorkers: false }))
+      if (entry.executable && process.platform !== "win32") await fs.chmod(target, 0o755)
+    }
+  } finally {
+    await reader.close()
   }
-
-  await Process.run(["unzip", "-o", "-q", zipPath, "-d", destDir])
 }

--- a/packages/opencode/test/util/archive.test.ts
+++ b/packages/opencode/test/util/archive.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { BlobWriter, TextReader, ZipWriter } from "@zip.js/zip.js"
+import { tmpdir } from "../fixture/fixture"
+import { Archive } from "../../src/util"
+
+async function writeZip(zipPath: string, entries: Array<{ path: string; text?: string; directory?: boolean }>) {
+  const writer = new ZipWriter(new BlobWriter("application/zip"))
+  for (const entry of entries) {
+    await writer.add(entry.path, entry.directory ? undefined : new TextReader(entry.text ?? ""), {
+      directory: entry.directory,
+      useWebWorkers: false,
+    })
+  }
+  await Bun.write(zipPath, await writer.close())
+}
+
+describe("util.archive", () => {
+  test("extractZip extracts nested files", async () => {
+    await using tmp = await tmpdir()
+    const zipPath = path.join(tmp.path, "archive.zip")
+    const destDir = path.join(tmp.path, "dest")
+
+    await writeZip(zipPath, [
+      { path: "top.txt", text: "top" },
+      { path: "nested/deep/file.txt", text: "deep" },
+      { path: "empty/", directory: true },
+    ])
+
+    await Archive.extractZip(zipPath, destDir)
+
+    expect(await Bun.file(path.join(destDir, "top.txt")).text()).toBe("top")
+    expect(await Bun.file(path.join(destDir, "nested", "deep", "file.txt")).text()).toBe("deep")
+    expect((await fs.stat(path.join(destDir, "empty"))).isDirectory()).toBe(true)
+  })
+
+  test("extractZip rejects path traversal entries", async () => {
+    await using tmp = await tmpdir()
+    const zipPath = path.join(tmp.path, "archive.zip")
+    const destDir = path.join(tmp.path, "dest")
+    const outside = path.join(tmp.path, "outside.txt")
+
+    await writeZip(zipPath, [{ path: "../outside.txt", text: "escaped" }])
+
+    await expect(Archive.extractZip(zipPath, destDir)).rejects.toThrow("escapes destination")
+    expect(await Bun.file(outside).exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #24489

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Windows skill loading could fail while bootstrapping ripgrep because ZIP extraction used PowerShell `Expand-Archive`, which depends on `Microsoft.PowerShell.Archive` autoloading correctly.

This changes ZIP extraction to use the existing `@zip.js/zip.js` dependency in-process and routes ripgrep ZIP extraction through the shared archive helper. It also rejects ZIP entries that escape the destination directory.

### How did you verify your code works?

- `bun test test/util/archive.test.ts`
- `bun test test/file/ripgrep.test.ts`
- `bun test test/tool/skill.test.ts`
- `bun typecheck`
- Built a Windows x64 exe and confirmed `Skill "context7"` loads on Windows after deleting cached `rg.exe`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR