### PR TITLE
fix(app): sync session sidebar loading and title generation across project context

### DIFF
--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -374,6 +374,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
         })
       if (created) {
         seed(sessionDirectory, created)
+        void globalSync.project.loadSessions(sessionDirectory)
         session = created
         if (shouldAutoAccept) permission.enableAutoAccept(session.id, sessionDirectory)
         local.session.promote(sessionDirectory, session.id)

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -472,17 +472,23 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
                     if (!tracked(directory, sessionID)) return
                     const data = session.data
                     if (!data) return
-                    setStore(
-                      "session",
-                      produce((draft) => {
-                        const match = Binary.search(draft, sessionID, (s) => s.id)
-                        if (match.found) {
-                          draft[match.index] = data
-                          return
-                        }
-                        draft.splice(match.index, 0, data)
-                      }),
-                    )
+                    const upsertSession = (setter: Setter) =>
+                      setter(
+                        "session",
+                        produce((draft) => {
+                          const match = Binary.search(draft, sessionID, (s) => s.id)
+                          if (match.found) {
+                            draft[match.index] = data
+                            return
+                          }
+                          draft.splice(match.index, 0, data)
+                        }),
+                      )
+                    upsertSession(setStore)
+                    if (data.directory !== directory) {
+                      const [, targetSetStore] = globalSync.child(data.directory)
+                      upsertSession(targetSetStore)
+                    }
                   })
 
             const messagesReq =

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -566,7 +566,7 @@ export default function Layout(props: ParentProps) {
     const direct = projects.find((p) => workspaceKey(p.worktree) === key)
     if (direct) return direct
 
-    const [child] = globalSync.child(directory, { bootstrap: false })
+    const [child] = globalSync.child(directory, { bootstrap: true })
     const id = child.project
     if (!id) return
 
@@ -1839,6 +1839,17 @@ export default function Layout(props: ParentProps) {
     ),
   )
 
+  createEffect(
+    on(
+      () => [route().slug, params.id, currentDir()] as const,
+      ([slug, _id, dir]) => {
+        if (!slug || !dir) return
+        void globalSync.project.loadSessions(dir)
+      },
+      { defer: true },
+    ),
+  )
+
   function handleDragStart(event: unknown) {
     const id = getDraggableId(event)
     if (!id) return
@@ -2329,6 +2340,17 @@ export default function Layout(props: ParentProps) {
   }
 
   const projects = () => layout.projects.list()
+  const panelProject = createMemo(() => {
+    const current = currentProject()
+    if (current) return current
+    const directory = currentDir()
+    if (directory) {
+      const root = projectRoot(directory)
+      const fromRoot = projects().find((project) => workspaceKey(project.worktree) === workspaceKey(root))
+      if (fromRoot) return fromRoot
+    }
+    return projects()[0]
+  })
   const projectOverlay = () => <ProjectDragOverlay projects={projects} activeProject={() => store.activeProject} />
   const sidebarContent = (mobile?: boolean) => (
     <SidebarContent
@@ -2352,7 +2374,7 @@ export default function Layout(props: ParentProps) {
       helpLabel={() => language.t("sidebar.help")}
       onOpenHelp={() => platform.openLink("https://opencode.ai/desktop-feedback")}
       renderPanel={() =>
-        mobile ? <SidebarPanel project={currentProject} mobile /> : <SidebarPanel project={currentProject} merged />
+        mobile ? <SidebarPanel project={panelProject} mobile /> : <SidebarPanel project={panelProject} merged />
       }
     />
   )

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -3,6 +3,7 @@ import { type Session } from "@opencode-ai/sdk/v2/client"
 
 type SessionStore = {
   session?: Session[]
+  project?: string
   path: { directory: string }
 }
 
@@ -28,11 +29,14 @@ function sortSessions(now: number) {
   }
 }
 
-const isRootVisibleSession = (session: Session, directory: string) =>
-  workspaceKey(session.directory) === workspaceKey(directory) && !session.parentID && !session.time?.archived
+const isRootVisibleSession = (session: Session, store: SessionStore) => {
+  if (session.parentID || session.time?.archived) return false
+  if (store.project && session.projectID && store.project === session.projectID) return true
+  return workspaceKey(session.directory) === workspaceKey(store.path.directory)
+}
 
 export const roots = (store: SessionStore) =>
-  (store.session ?? []).filter((session) => isRootVisibleSession(session, store.path.directory))
+  (store.session ?? []).filter((session) => isRootVisibleSession(session, store))
 
 export const sortedRootSessions = (store: SessionStore, now: number) => roots(store).sort(sortSessions(now))
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -170,8 +170,6 @@ export const layer = Layer.effect(
         m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic)
       const idx = input.history.findIndex(real)
       if (idx === -1) return
-      if (input.history.filter(real).length !== 1) return
-
       const context = input.history.slice(0, idx + 1)
       const firstUser = context[idx]
       if (!firstUser || firstUser.info.role !== "user") return

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -750,11 +750,8 @@ export function* list(input?: {
   if (input?.workspaceID) {
     conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
   }
-  if (!Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
-    if (input?.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
-    }
-  }
+  // Keep session list stable across cwd changes within the same project.
+  // Project scoping is already enforced via project_id above.
   if (input?.roots) {
     conditions.push(isNull(SessionTable.parent_id))
   }


### PR DESCRIPTION
### Issue for this PR

Closes #23607
Closes #18943
Related to #21441
Related to #19348
Related to #20269

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Reloads project session list immediately after creating a new session.
- Syncs session upserts across directory/project context so sidebar stays in sync.
- Improves layout/sidebar project resolution and root-session visibility checks.
- Removes an over-restrictive title generation guard so new sessions can be titled reliably.
- Keeps session listing stable by relying on project scoping rather than strict directory equality.

### How did you verify your code works?

- Ran bun typecheck in packages/app.
- Ran bun typecheck in packages/opencode.
- Verified new-session creation and sidebar/session-title updates in desktop app flow.

### Screenshots / recordings

Will attach UI screenshots for session list/title behavior in this PR.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


### Verification Environment

- macOS (Apple Silicon)
- OpenCode Desktop (dev build)
- Verified: new session creation, sidebar session list refresh, session title generation/update
- Note: Windows behavior was not validated in this PR.
