### PR TITLE
feat: add model-level system_prompt override

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -55,6 +55,10 @@ export const Model = Schema.Struct({
   ),
   options: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
   headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  system_prompt: Schema.optional(Schema.String).annotate({
+    description:
+      "Override the default system prompt for this model with content from a file path or URL. Supports: absolute paths ('/home/user/prompt.md'), home-relative paths ('~/prompt.md'), relative paths ('./prompt.md' - resolved from current working directory where opencode is run), and remote URLs ('https://example.com/prompt.md'). When set, this completely replaces the default system prompt.",
+  }),
   variants: Schema.optional(
     Schema.Record(
       Schema.String,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -884,6 +884,7 @@ export const Model = Schema.Struct({
   options: Schema.Record(Schema.String, Schema.Any),
   headers: Schema.Record(Schema.String, Schema.String),
   release_date: Schema.String,
+  system_prompt: Schema.optional(Schema.String),
   variants: Schema.optional(Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.Any))),
 })
   .annotate({ identifier: "Model" })
@@ -1196,6 +1197,7 @@ const layer: Layer.Layer<
               headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
               family: model.family ?? existingModel?.family ?? "",
               release_date: model.release_date ?? existingModel?.release_date ?? "",
+              system_prompt: model.system_prompt ?? existingModel?.system_prompt,
               variants: {},
             }
             const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -59,7 +59,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/LL
 const live: Layer.Layer<
   Service,
   never,
-  Auth.Service | Config.Service | Provider.Service | Plugin.Service | Permission.Service
+  Auth.Service | Config.Service | Provider.Service | Plugin.Service | Permission.Service | SystemPrompt.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -68,6 +68,7 @@ const live: Layer.Layer<
     const provider = yield* Provider.Service
     const plugin = yield* Plugin.Service
     const perm = yield* Permission.Service
+    const sys = yield* SystemPrompt.Service
 
     const run = Effect.fn("LLM.run")(function* (input: StreamRequest) {
       const l = log
@@ -97,10 +98,13 @@ const live: Layer.Layer<
       const isOpenaiOauth = item.id === "openai" && info?.type === "oauth"
 
       const system: string[] = []
+      const providerPrompt = input.agent.prompt
+        ? [input.agent.prompt]
+        : yield* sys.provider(input.model)
       system.push(
         [
           // use agent prompt otherwise provider prompt
-          ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
+          ...providerPrompt,
           // any custom prompt passed into this call
           ...input.system,
           // any custom prompt from last user message
@@ -440,6 +444,7 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(Config.defaultLayer),
     Layer.provide(Provider.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
+    Layer.provide(SystemPrompt.defaultLayer),
   ),
 )
 

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, Layer } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 
 import { Instance } from "../project/instance"
 
@@ -15,8 +16,12 @@ import type { Provider } from "@/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { withTransientReadRetry } from "@/util/effect-http-client"
+import path from "path"
+import os from "os"
 
-export function provider(model: Provider.Model) {
+function defaultProvider(model: Provider.Model): string[] {
   if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
     return [PROMPT_BEAST]
   if (model.api.id.includes("gpt")) {
@@ -35,14 +40,49 @@ export function provider(model: Provider.Model) {
 export interface Interface {
   readonly environment: (model: Provider.Model) => string[]
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
+  readonly provider: (model: Provider.Model) => Effect.Effect<string[]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SystemPrompt") {}
 
-export const layer = Layer.effect(
+export const layer: Layer.Layer<
+  Service,
+  never,
+  Skill.Service | AppFileSystem.Service | HttpClient.HttpClient
+> = Layer.effect(
   Service,
   Effect.gen(function* () {
     const skill = yield* Skill.Service
+    const fs = yield* AppFileSystem.Service
+    const http = HttpClient.filterStatusOk(withTransientReadRetry(yield* HttpClient.HttpClient))
+
+    const loadSystemPrompt = Effect.fn("SystemPrompt.loadSystemPrompt")(function* (promptPath: string) {
+      if (promptPath.startsWith("https://") || promptPath.startsWith("http://")) {
+        const res = yield* http
+          .execute(HttpClientRequest.get(promptPath))
+          .pipe(Effect.timeout(10000), Effect.catch(() => Effect.succeed(null)))
+        if (!res) return ""
+        const body = yield* res.arrayBuffer.pipe(Effect.catch(() => Effect.succeed(new ArrayBuffer(0))))
+        return new TextDecoder().decode(body)
+      }
+
+      let resolvedPath = promptPath
+      if (promptPath.startsWith("~/")) {
+        resolvedPath = path.join(os.homedir(), promptPath.slice(2))
+      } else if (!path.isAbsolute(promptPath)) {
+        resolvedPath = path.resolve(Instance.directory, promptPath)
+      }
+
+      return yield* fs.readFileString(resolvedPath).pipe(Effect.catch(() => Effect.succeed("")))
+    })
+
+    const provider = Effect.fn("SystemPrompt.provider")(function* (model: Provider.Model) {
+      if (model.system_prompt) {
+        const content = yield* loadSystemPrompt(model.system_prompt)
+        if (content) return [content]
+      }
+      return defaultProvider(model)
+    })
 
     return Service.of({
       environment(model) {
@@ -75,10 +115,16 @@ export const layer = Layer.effect(
           Skill.fmt(list, { verbose: true }),
         ].join("\n")
       }),
+
+      provider,
     })
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(Skill.defaultLayer))
+export const defaultLayer = layer.pipe(
+  Layer.provide(Skill.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(FetchHttpClient.layer),
+)
 
 export * as SystemPrompt from "./system"


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add a new `system_prompt` field to model configuration that allows completely replacing the core system prompt with content from a local file or remote URL.

- Added `system_prompt` field to Model schema in `config/provider.ts`
- Refactored `SystemPrompt.provider()` to be an Effect that loads overrides
- Updated LLM layer to use the new Effect-based provider() function
- Supports relative paths, absolute paths, ~/ paths, and HTTP(S) URLs

It works similarly to skills and instruction overrides, in that the data is fetched on every query.

When set, the `system_prompt` completely replaces the default system prompt (`default.txt`, `gpt.txt`, `anthropic.txt`, etc.) for that specific model.

Example usage in `opencode.json`:
```json
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "llama.cpp": {
      "npm": "@ai-sdk/openai-compatible",
      "name": "llama-server (local)",
      "options": {
        "baseURL": "http://127.0.0.1:8001/v1"
      },
      "models": {
        "Qwen3.5-27B-GGUF": {
          "name": "Qwen3.5-27B-GGUF (local)",
          "modalities": { "input": ["image", "text"], "output": ["text"] },
          "system_prompt": "~/.config/opencode/system-prompt-alt.md",
          "limit": {
            "context": 262144,
            "output": 65536
          }
        }
      }
    }
  }
}
```

### How did you verify your code works?

I checked that it works without adding the `system_prompt` field and that the behavior is still the same. I also provided a custom system prompt with instructions to respond `SYSTEM_PROMPT_TEST_RESPONSE` to `SYSTEM_PROMPT_TEST_REQUEST` to verify that the override works. And it worked.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
