### PR TITLE
fix(cli): save cloudflare account ID and gateway ID during auth login

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -461,6 +461,38 @@ export const ProvidersLoginCommand = cmd({
           prompts.log.info(
             "Cloudflare AI Gateway can be configured with CLOUDFLARE_GATEWAY_ID, CLOUDFLARE_ACCOUNT_ID, and CLOUDFLARE_API_TOKEN environment variables. Read more: https://opencode.ai/docs/providers/#cloudflare-ai-gateway",
           )
+
+          const accountId = await prompts.text({
+            message: "Enter your Cloudflare Account ID",
+            validate: (x) => (x && x.length > 0 ? undefined : "Required"),
+          })
+          if (prompts.isCancel(accountId)) throw new UI.CancelledError()
+
+          let gatewayId: string | symbol | undefined
+          if (provider === "cloudflare-ai-gateway") {
+            gatewayId = await prompts.text({
+              message: "Enter your Cloudflare Gateway ID",
+              validate: (x) => (x && x.length > 0 ? undefined : "Required"),
+            })
+            if (prompts.isCancel(gatewayId)) throw new UI.CancelledError()
+          }
+
+          const key = await prompts.password({
+            message: "Enter your API key",
+            validate: (x) => (x && x.length > 0 ? undefined : "Required"),
+          })
+          if (prompts.isCancel(key)) throw new UI.CancelledError()
+          await put(provider, {
+            type: "api",
+            key,
+            metadata: {
+              accountId,
+              ...(typeof gatewayId === "string" ? { gatewayId } : {}),
+            },
+          })
+
+          prompts.outro("Done")
+          return
         }
 
         const key = await prompts.password({

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -14,6 +14,7 @@ import { Env } from "../../src/env"
 import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { makeRuntime } from "../../src/effect/run-service"
+import { Auth } from "../../src/auth"
 
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
@@ -2440,6 +2441,42 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
         invoked_by: "test",
         project: "opencode",
       })
+    },
+  })
+})
+
+test("cloudflare-ai-gateway loads with auth metadata", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      // Set up auth with metadata (simulating `opencode auth login`)
+      await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const auth = yield* Auth.Service
+          yield* auth.set("cloudflare-ai-gateway", {
+            type: "api",
+            key: "test-api-key",
+            metadata: {
+              accountId: "test-account-id",
+              gatewayId: "test-gateway-id",
+            },
+          })
+        }),
+      )
+
+      // Verify provider loads using auth metadata (no env vars set)
+      const providers = await list()
+      expect(providers[ProviderID.make("cloudflare-ai-gateway")]).toBeDefined()
     },
   })
 })


### PR DESCRIPTION
Fixes #24498
When running opencode auth login and selecting cloudflare-ai-gateway, the CLI was only displaying an info message about environment variables but not actually saving the Account ID and Gateway ID.
Now it prompts for:
- Cloudflare Account ID
- Cloudflare Gateway ID (for cloudflare-ai-gateway provider)
- API key
And saves them to auth.json with metadata: { type: "api", key, metadata: { accountId, gatewayId } }
Test added: cloudflare-ai-gateway loads with auth metadata
Issue for this PR
Closes #24498
Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
What does this PR do?
The opencode auth login command for cloudflare-ai-gateway (and cloudflare) providers was broken - it only showed an info message about environment variables but never actually prompted for or saved the Account ID and Gateway ID to ~/.opencode/auth.json.
The fix adds the missing prompts to collect:
1. Cloudflare Account ID
2. Cloudflare Gateway ID (for cloudflare-ai-gateway)
3. API key
These are now saved with metadata so the provider can load without requiring environment variables.
How did you verify your code works?
Added test cloudflare-ai-gateway loads with auth metadata that verifies:
- Auth metadata (accountId, gatewayId) is properly saved via Auth.Service
- Provider loads successfully using saved auth metadata without environment variables
All tests pass:
bun test test/provider/provider.test.ts -t "cloudflare-ai-gateway"
Screenshots / recordings
N/A - CLI change
Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR