### PR TITLE
fix: disable tools when MAX_STEPS limit is reached

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1492,7 +1492,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               parentSessionID: session.parentID,
               system,
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
-              tools,
+              tools: isLastStep ? {} : tools,
               model,
               toolChoice: format.type === "json_schema" ? "required" : undefined,
             })


### PR DESCRIPTION
### Issue for this PR

Fixes #24505

### Type of change

- [x] Bug fix

### What does this PR do?

When `isLastStep` is true, the prefilled assistant message claims tools are disabled, but the full `tools` object was still passed to `handle.process()`. This change passes an empty object instead, preventing the model from making further tool calls when the step limit has been reached.

### How did you verify your code works?

- The change is a single-line conditional: `tools: isLastStep ? {} : tools`
- This makes the code consistent with the prefilled message that claims tools are disabled
- No behavioral change except that the model can no longer ignore the message and call tools anyway

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
- [x] I have read the CONTRIBUTING.md guidelines