### PR TITLE
fix: make scrollbar visible in Monokai theme

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1064,8 +1064,8 @@ export function Session() {
                 paddingLeft: 1,
                 visible: showScrollbar(),
                 trackOptions: {
-                  backgroundColor: theme.backgroundElement,
-                  foregroundColor: theme.border,
+                  backgroundColor: theme.background,
+                  foregroundColor: theme.borderActive,
                 },
               }}
               stickyScroll={true}


### PR DESCRIPTION
### Issue for this PR

Fixes #24425

### Type of change

- [x] Bug fix

### What does this PR do?

In the session view, the scrollbar track used `theme.backgroundElement` and the thumb used `theme.border`. In the Monokai theme, both of these resolve to `#3e3d32`, making the scrollbar completely invisible against the background.

Changed the session scrollbar colors to match the pattern already used in `sidebar.tsx` and `permission.tsx`:
- Track: `theme.backgroundElement` -> `theme.background`
- Thumb: `theme.border` -> `theme.borderActive`

This ensures the thumb is drawn with the active border color (cyan in Monokai), which is clearly visible against the darker track and background.

### How did you verify your code works?

- Verified that `theme.borderActive` resolves to a contrasting color in Monokai
- The pattern is already established in other components (sidebar, permission)
- No logic changes — purely visual

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
- [x] I have read the CONTRIBUTING.md guidelines