### PR TITLE
fix: preserve enterpriseUrl through OAuth/PAT callback for self-hosted GitLab

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -23,6 +23,7 @@ export class Api extends Schema.Class<Api>("ApiAuth")({
   type: Schema.Literal("api"),
   key: Schema.String,
   metadata: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  enterpriseUrl: Schema.optional(Schema.String),
 }) {}
 
 export class WellKnown extends Schema.Class<WellKnown>("WellKnownAuth")({

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -200,16 +200,18 @@ export const layer: Layer.Layer<Service, never, Auth.Service | Plugin.Service> =
         yield* auth.set(input.providerID, {
           type: "api",
           key: result.key,
+          enterpriseUrl: result.provider,
         })
       }
 
       if ("refresh" in result) {
-        const { type: _, provider: __, refresh, access, expires, ...extra } = result
+        const { type: _, provider, refresh, access, expires, enterpriseUrl: directEnterpriseUrl, ...extra } = result
         yield* auth.set(input.providerID, {
           type: "oauth",
           access,
           refresh,
           expires,
+          enterpriseUrl: directEnterpriseUrl ?? provider,
           ...extra,
         })
       }

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1666,6 +1666,7 @@ export type OAuth = {
 export type ApiAuth = {
   type: "api"
   key: string
+  enterpriseUrl?: string
 }
 
 export type WellKnownAuth = {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11970,6 +11970,9 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "enterpriseUrl": {
+            "type": "string"
           }
         },
         "required": ["type", "key"]


### PR DESCRIPTION
## Problem

When authenticating with a self-hosted GitLab instance (GitLab Duo / Claude Pro/Max), users see **"Invalid token"** immediately after auth. The root cause is two bugs in how the enterprise URL is handled after the OAuth/PAT callback.

### Root cause 1 — OAuth flow

`provider/auth.ts` destructured the `provider` field (enterprise URL returned by plugins) as `provider: __`, silently discarding it:

```ts
// BEFORE — provider silently dropped
const { type: _, provider: __, refresh, access, expires, ...extra } = result
```

With no `enterpriseUrl` in `auth.json`, the `opencode-gitlab-auth` loader calls `exchangeRefreshToken` against `gitlab.com` instead of the enterprise host → refresh fails → loader falls back to the expired `access` token → API returns **"Invalid token"**. The `'Failed to refresh token in loader'` debug message in the GitLab plugin is the fingerprint for this path.

### Root cause 2 — PAT flow

`auth/index.ts`'s `Api` schema class lacked an `enterpriseUrl` field. Effect Schema strips unknown fields on decode, so even if the PAT callback returned `provider: enterpriseUrl`, the value was lost on the very first read from disk.

## Fix

**`packages/opencode/src/provider/auth.ts`**
- *OAuth branch*: capture both `provider` and `enterpriseUrl` from the result, store `enterpriseUrl: directEnterpriseUrl ?? provider`. Handles both naming conventions — Copilot sets `enterpriseUrl` directly; GitLab uses `provider`. Explicit `enterpriseUrl` wins via `??`.
- *API/PAT branch*: forward `result.provider` as `enterpriseUrl` in the stored auth object.

**`packages/opencode/src/auth/index.ts`**
- Add `enterpriseUrl: Schema.optional(Schema.String)` to the `Api` class so Effect Schema preserves the field through decode/encode cycles.

**`packages/sdk/openapi.json` + `packages/sdk/js/src/gen/types.gen.ts`**
- Add `enterpriseUrl?: string` to `ApiAuth` (the `OAuth` type already had it; `ApiAuth` was missing it).
