### PR TITLE
fix(session): compare message positions instead of IDs in SessionPrompt.run

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1322,14 +1322,26 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
 
           let lastUser: MessageV2.User | undefined
+          let lastUserIndex = -1
           let lastAssistant: MessageV2.Assistant | undefined
+          let lastAssistantIndex = -1
           let lastFinished: MessageV2.Assistant | undefined
+          let lastFinishedIndex = -1
           let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
           for (let i = msgs.length - 1; i >= 0; i--) {
             const msg = msgs[i]
-            if (!lastUser && msg.info.role === "user") lastUser = msg.info
-            if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info
-            if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
+            if (!lastUser && msg.info.role === "user") {
+              lastUser = msg.info
+              lastUserIndex = i
+            }
+            if (!lastAssistant && msg.info.role === "assistant") {
+              lastAssistant = msg.info
+              lastAssistantIndex = i
+            }
+            if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) {
+              lastFinished = msg.info
+              lastFinishedIndex = i
+            }
             if (lastUser && lastFinished) break
             const task = msg.parts.filter((part) => part.type === "compaction" || part.type === "subtask")
             if (task && !lastFinished) tasks.push(...task)
@@ -1351,7 +1363,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastUserIndex < lastAssistantIndex
           ) {
             yield* slog.info("exiting loop")
             break
@@ -1456,8 +1468,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               yield* summary.summarize({ sessionID, messageID: lastUser.id }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             if (step > 1 && lastFinished) {
-              for (const m of msgs) {
-                if (m.info.role !== "user" || m.info.id <= lastFinished.id) continue
+              for (let i = lastFinishedIndex + 1; i < msgs.length; i++) {
+                const m = msgs[i]
+                if (m.info.role !== "user") continue
                 for (const p of m.parts) {
                   if (p.type !== "text" || p.ignored || p.synthetic) continue
                   if (!p.text.trim()) continue


### PR DESCRIPTION
Fixes #23490

Replaces lexicographic message ID comparisons with array index comparisons in SessionPrompt.run. Custom message IDs broke loop exit logic because lastUser.id < lastAssistant.id does not reflect actual transcript order.

Changes:
- Track lastUserIndex, lastAssistantIndex, and lastFinishedIndex while scanning msgs from the end.
- Replace lastUser.id < lastAssistant.id with lastUserIndex < lastAssistantIndex.
- Replace the for...of loop that skipped messages via m.info.id <= lastFinished.id with a for loop starting from lastFinishedIndex + 1.