### PR TITLE
fix(tui): startup rejection handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -117,11 +117,15 @@ export function tui(input: {
   headers?: RequestInit["headers"]
   events?: EventSource
 }) {
-  // promise to prevent immediate exit
-  // oxlint-disable-next-line no-async-promise-executor -- intentional: async executor used for sequential setup before resolve
-  return new Promise<void>(async (resolve) => {
+  return new Promise<void>((resolve, reject) => {
     const unguard = win32InstallCtrlCGuard()
-    win32DisableProcessedInput()
+    let renderer: Awaited<ReturnType<typeof createCliRenderer>> | undefined
+    const fail = (error: unknown) => {
+      renderer?.destroy()
+      renderer = undefined
+      unguard?.()
+      reject(error)
+    }
 
     const onExit = async () => {
       unguard?.()
@@ -132,73 +136,77 @@ export function tui(input: {
       await TuiPluginRuntime.dispose()
     }
 
-    const renderer = await createCliRenderer(rendererConfig(input.config))
-    const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
+    void (async () => {
+      win32DisableProcessedInput()
 
-    await render(() => {
-      return (
-        <ErrorBoundary
-          fallback={(error, reset) => (
-            <ErrorComponent error={error} reset={reset} onBeforeExit={onBeforeExit} onExit={onExit} mode={mode} />
-          )}
-        >
-          <ArgsProvider {...input.args}>
-            <ExitProvider onBeforeExit={onBeforeExit} onExit={onExit}>
-              <KVProvider>
-                <ToastProvider>
-                  <RouteProvider
-                    initialRoute={
-                      input.args.continue
-                        ? {
-                            type: "session",
-                            sessionID: "dummy",
-                          }
-                        : undefined
-                    }
-                  >
-                    <TuiConfigProvider config={input.config}>
-                      <SDKProvider
-                        url={input.url}
-                        directory={input.directory}
-                        fetch={input.fetch}
-                        headers={input.headers}
-                        events={input.events}
-                      >
-                        <ProjectProvider>
-                          <SyncProvider>
-                            <ThemeProvider mode={mode}>
-                              <LocalProvider>
-                                <KeybindProvider>
-                                  <PromptStashProvider>
-                                    <DialogProvider>
-                                      <CommandProvider>
-                                        <FrecencyProvider>
-                                          <PromptHistoryProvider>
-                                            <PromptRefProvider>
-                                              <EditorContextProvider>
-                                                <App onSnapshot={input.onSnapshot} />
-                                              </EditorContextProvider>
-                                            </PromptRefProvider>
-                                          </PromptHistoryProvider>
-                                        </FrecencyProvider>
-                                      </CommandProvider>
-                                    </DialogProvider>
-                                  </PromptStashProvider>
-                                </KeybindProvider>
-                              </LocalProvider>
-                            </ThemeProvider>
-                          </SyncProvider>
-                        </ProjectProvider>
-                      </SDKProvider>
-                    </TuiConfigProvider>
-                  </RouteProvider>
-                </ToastProvider>
-              </KVProvider>
-            </ExitProvider>
-          </ArgsProvider>
-        </ErrorBoundary>
-      )
-    }, renderer)
+      renderer = await createCliRenderer(rendererConfig(input.config))
+      const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
+
+      await render(() => {
+        return (
+          <ErrorBoundary
+            fallback={(error, reset) => (
+              <ErrorComponent error={error} reset={reset} onBeforeExit={onBeforeExit} onExit={onExit} mode={mode} />
+            )}
+          >
+            <ArgsProvider {...input.args}>
+              <ExitProvider onBeforeExit={onBeforeExit} onExit={onExit}>
+                <KVProvider>
+                  <ToastProvider>
+                    <RouteProvider
+                      initialRoute={
+                        input.args.continue
+                          ? {
+                              type: "session",
+                              sessionID: "dummy",
+                            }
+                          : undefined
+                      }
+                    >
+                      <TuiConfigProvider config={input.config}>
+                        <SDKProvider
+                          url={input.url}
+                          directory={input.directory}
+                          fetch={input.fetch}
+                          headers={input.headers}
+                          events={input.events}
+                        >
+                          <ProjectProvider>
+                            <SyncProvider>
+                              <ThemeProvider mode={mode}>
+                                <LocalProvider>
+                                  <KeybindProvider>
+                                    <PromptStashProvider>
+                                      <DialogProvider>
+                                        <CommandProvider>
+                                          <FrecencyProvider>
+                                            <PromptHistoryProvider>
+                                              <PromptRefProvider>
+                                                <EditorContextProvider>
+                                                  <App onSnapshot={input.onSnapshot} />
+                                                </EditorContextProvider>
+                                              </PromptRefProvider>
+                                            </PromptHistoryProvider>
+                                          </FrecencyProvider>
+                                        </CommandProvider>
+                                      </DialogProvider>
+                                    </PromptStashProvider>
+                                  </KeybindProvider>
+                                </LocalProvider>
+                              </ThemeProvider>
+                            </SyncProvider>
+                          </ProjectProvider>
+                        </SDKProvider>
+                      </TuiConfigProvider>
+                    </RouteProvider>
+                  </ToastProvider>
+                </KVProvider>
+              </ExitProvider>
+            </ArgsProvider>
+          </ErrorBoundary>
+        )
+      }, renderer)
+    })().catch(fail)
   })
 }
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -119,13 +119,6 @@ export function tui(input: {
 }) {
   return new Promise<void>((resolve, reject) => {
     const unguard = win32InstallCtrlCGuard()
-    let renderer: Awaited<ReturnType<typeof createCliRenderer>> | undefined
-    const fail = (error: unknown) => {
-      renderer?.destroy()
-      renderer = undefined
-      unguard?.()
-      reject(error)
-    }
 
     const onExit = async () => {
       unguard?.()
@@ -139,7 +132,7 @@ export function tui(input: {
     void (async () => {
       win32DisableProcessedInput()
 
-      renderer = await createCliRenderer(rendererConfig(input.config))
+      const renderer = await createCliRenderer(rendererConfig(input.config))
       const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
 
       await render(() => {
@@ -206,7 +199,7 @@ export function tui(input: {
           </ErrorBoundary>
         )
       }, renderer)
-    })().catch(fail)
+    })().catch(reject)
   })
 }
 

--- a/packages/opencode/test/cli/tui/app.test.ts
+++ b/packages/opencode/test/cli/tui/app.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
+import * as Core from "@opentui/core"
+
+afterEach(() => {
+  mock.restore()
+})
+
+test("tui rejects when renderer startup fails", async () => {
+  const err = new Error("setRawMode failed with errno: 9")
+  spyOn(Core, "createCliRenderer").mockRejectedValue(err)
+
+  const { tui } = await import("../../../src/cli/cmd/tui/app")
+  const result = await Promise.race([
+    tui({
+      url: "http://opencode.internal",
+      config: {},
+      args: {
+        continue: false,
+        fork: false,
+      },
+    }).then(
+      () => "resolved",
+      (error) => error,
+    ),
+    Bun.sleep(100).then(() => "timeout"),
+  ])
+
+  expect(result).toBe(err)
+})


### PR DESCRIPTION
Propagate renderer startup failures from the TUI promise instead of leaving opencode hanging, and destroy any partially initialized renderer before rejecting to restore terminal state.
