### PR TITLE
fix(app): hide synthetic global project on home

### DIFF
--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -25,6 +25,7 @@ export default function Home() {
   const homedir = createMemo(() => sync.data.path.home)
   const recent = createMemo(() => {
     return sync.data.project
+      .filter((project) => project.id !== "global" || project.worktree !== "/")
       .slice()
       .sort((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
       .slice(0, 5)
@@ -86,7 +87,7 @@ export default function Home() {
         {server.name}
       </Button>
       <Switch>
-        <Match when={sync.data.project.length > 0}>
+        <Match when={recent().length > 0}>
           <div class="mt-20 w-full flex flex-col gap-4">
             <div class="flex gap-2 items-center justify-between pl-3">
               <div class="text-14-medium text-text-strong">{language.t("home.recentProjects")}</div>


### PR DESCRIPTION
### Issue for this PR

Closes #24438

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The home page treated the synthetic headless-serve project (`id: "global"`, `worktree: "/"`) as a recent project. That made the recent-projects branch render even when there was no real project to open.

This change filters that synthetic project out of the Home recent-projects list and uses the filtered list to decide whether to show recent projects or the empty state. With that change, a fresh headless server now shows the expected empty-state UI instead of a nearly invisible `/` entry.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app`
- Ran `bun test --preload ./happydom.ts ./src` in `packages/app`
- Ran `bun run build` in `packages/app`
- Verified the repo pre-push hook passed `bun turbo typecheck`
- Reproduced `/project` returning only `{"id":"global","worktree":"/"}` and confirmed the patched Home page shows the empty state

### Screenshots / recordings

I verified the UI locally against a fresh headless server. I can add a screenshot in a follow-up if maintainers want one attached directly in the PR conversation.

Before-
<img width="835" height="586" alt="Screenshot 2026-04-27 at 3 31 42 AM" src="https://github.com/user-attachments/assets/8a2ed9f7-68f5-49a3-9243-7455643d9cb5" />

After the patch-
<img width="835" height="586" alt="Screenshot 2026-04-27 at 3 31 47 AM" src="https://github.com/user-attachments/assets/7df4da66-6c6b-4bd0-b73c-515784a2abad" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
