### PR TITLE
fix: ignore GitHub Actions changelog contributor

### DIFF
--- a/script/raw-changelog.ts
+++ b/script/raw-changelog.ts
@@ -23,7 +23,7 @@ type Diff = {
 }
 
 const repo = process.env.GH_REPO ?? "anomalyco/opencode"
-const bot = ["actions-user", "opencode", "opencode-agent[bot]"]
+const bot = ["actions-user", "github-actions[bot]", "opencode", "opencode-agent[bot]"]
 const team = [
   ...(await Bun.file(new URL("../.github/TEAM_MEMBERS", import.meta.url))
     .text()


### PR DESCRIPTION
## Summary
- Excludes github-actions[bot] from changelog community contributor attribution.
- Keeps generated contributor lists from thanking GitHub Actions automation.

## Testing
- bun script/raw-changelog.ts --help