### PR TITLE
fix(app): keep question dock buttons visible on mobile when options have long descriptions

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -122,13 +122,14 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     if (!root) return
 
     const scroller = document.querySelector(".scroll-view__viewport")
-    const head = scroller instanceof HTMLElement ? scroller.firstElementChild : undefined
-    const top =
-      head instanceof HTMLElement && head.classList.contains("sticky") ? head.getBoundingClientRect().bottom : 0
-    if (!top) {
+    if (!(scroller instanceof HTMLElement)) {
       root.style.removeProperty("--question-prompt-max-height")
       return
     }
+
+    const sticky = scroller.querySelector("[data-session-title]")
+    const top =
+      sticky instanceof HTMLElement ? sticky.getBoundingClientRect().bottom : scroller.getBoundingClientRect().top
 
     const dock = root.closest('[data-component="session-prompt-dock"]')
     if (!(dock instanceof HTMLElement)) return


### PR DESCRIPTION
Fixes #23730

The question dock's `measure()` looks for the sticky session title at `scroller.firstElementChild`, but a refactor wrapped the title inside a `setContentRef` div, so the sticky check never matches. The `--question-prompt-max-height` CSS variable is therefore never set, the dock falls back to `100dvh`, and on mobile (where descriptions wrap into more lines) the dock overflows the viewport, hiding the Dismiss/Submit buttons.

Use `[data-session-title]` to find the sticky title, and fall back to the scroller's top when the title isn't present (untitled sessions).

## How I verified

- iPhone 14 viewport (390x844) in Chromium
- Triggered a 4-option question with long descriptions
- Confirmed Dismiss/Submit buttons stay visible and the option list scrolls internally
- Re-tested with the fix reverted to confirm the bug reproduces

## Screenshots

Before — Dismiss/Submit clipped below viewport:

<img width="390" alt="before" src="https://github.com/ysm-dev/opencode/releases/download/assets-pr-23730/before.png" />

After — buttons visible, option list scrolls internally:

<img width="390" alt="after" src="https://github.com/ysm-dev/opencode/releases/download/assets-pr-23730/after.png" />

After (options scrolled to bottom) — header and footer stay pinned:

<img width="390" alt="after-scrolled" src="https://github.com/ysm-dev/opencode/releases/download/assets-pr-23730/after-scrolled.png" />
