### PR TITLE
fix: pass workspace symbol query to experimental LSP tool

### DIFF
--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -29,6 +29,9 @@ export const Parameters = Schema.Struct({
   character: Schema.Number.check(Schema.isInt())
     .check(Schema.isGreaterThanOrEqualTo(1))
     .annotate({ description: "The character offset (1-based, as shown in editors)" }),
+  query: Schema.optional(Schema.String).annotate({
+    description: "Search query for workspaceSymbol. Empty string requests all symbols.",
+  }),
 })
 
 export const LspTool = Tool.define(
@@ -40,7 +43,7 @@ export const LspTool = Tool.define(
       description: DESCRIPTION,
       parameters: Parameters,
       execute: (
-        args: { operation: (typeof operations)[number]; filePath: string; line: number; character: number },
+        args: Schema.Schema.Type<typeof Parameters>,
         ctx: Tool.Context,
       ) =>
         Effect.gen(function* () {
@@ -89,7 +92,7 @@ export const LspTool = Tool.define(
               case "documentSymbol":
                 return lsp.documentSymbol(uri)
               case "workspaceSymbol":
-                return lsp.workspaceSymbol("")
+                return lsp.workspaceSymbol(args.query ?? "")
               case "goToImplementation":
                 return lsp.implementation(position)
               case "prepareCallHierarchy":

--- a/packages/opencode/src/tool/lsp.txt
+++ b/packages/opencode/src/tool/lsp.txt
@@ -5,7 +5,7 @@ Supported operations:
 - findReferences: Find all references to a symbol
 - hover: Get hover information (documentation, type info) for a symbol
 - documentSymbol: Get all symbols (functions, classes, variables) in a document
-- workspaceSymbol: Search for symbols across the entire workspace
+- workspaceSymbol: List project-wide symbols matching a query string
 - goToImplementation: Find implementations of an interface or abstract method
 - prepareCallHierarchy: Get call hierarchy item at a position (functions/methods)
 - incomingCalls: Find all functions/methods that call the function at a position
@@ -15,5 +15,10 @@ All operations require:
 - filePath: The file to operate on
 - line: The line number (1-based, as shown in editors)
 - character: The character offset (1-based, as shown in editors)
+
+workspaceSymbol also accepts:
+- query: A query string to filter symbols by. Empty string requests all symbols.
+
+For workspaceSymbol, filePath is not sent in the LSP workspace/symbol request. It is used by opencode to select and start the matching LSP server.
 
 Note: LSP servers must be configured for the file type. If no server is available, an error will be returned.

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -209,6 +209,10 @@ exports[`tool parameters JSON Schema (wire shape) lsp 1`] = `
       ],
       "type": "string",
     },
+    "query": {
+      "description": "Search query for workspaceSymbol. Empty string requests all symbols.",
+      "type": "string",
+    },
   },
   "required": [
     "operation",

--- a/packages/opencode/test/tool/lsp.test.ts
+++ b/packages/opencode/test/tool/lsp.test.ts
@@ -28,6 +28,8 @@ const ctx = {
   ask: () => Effect.void,
 }
 
+const workspaceSymbolQueries: string[] = []
+
 const lsp = Layer.succeed(
   LSP.Service,
   LSP.Service.of({
@@ -41,7 +43,11 @@ const lsp = Layer.succeed(
     references: () => Effect.succeed([]),
     implementation: () => Effect.succeed([]),
     documentSymbol: () => Effect.succeed([]),
-    workspaceSymbol: () => Effect.succeed([]),
+    workspaceSymbol: (query) =>
+      Effect.sync(() => {
+        workspaceSymbolQueries.push(query)
+        return []
+      }),
     prepareCallHierarchy: () => Effect.succeed([]),
     incomingCalls: () => Effect.succeed([]),
     outgoingCalls: () => Effect.succeed([]),
@@ -142,6 +148,7 @@ describe("tool.lsp", () => {
       provideTmpdirInstance(
         (dir) =>
           Effect.gen(function* () {
+            workspaceSymbolQueries.length = 0
             const file = path.join(dir, "test.ts")
             yield* put(file)
 
@@ -154,6 +161,23 @@ describe("tool.lsp", () => {
               operation: "workspaceSymbol",
             })
             expect(result.title).toBe("workspaceSymbol")
+          }),
+        { git: true },
+      ),
+    )
+
+    it.live("passes workspaceSymbol query to LSP", () =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            workspaceSymbolQueries.length = 0
+            const file = path.join(dir, "test.ts")
+            yield* put(file)
+
+            yield* run({ operation: "workspaceSymbol", filePath: file, line: 3, character: 7, query: "TestSymbol" })
+            yield* run({ operation: "workspaceSymbol", filePath: file, line: 3, character: 7 })
+
+            expect(workspaceSymbolQueries).toEqual(["TestSymbol", ""])
           }),
         { git: true },
       ),


### PR DESCRIPTION
## Summary
- Add a `query` parameter to the experimental LSP tool and pass it through to `workspace/symbol` instead of always sending an empty query.
- Keep opencode's existing file-based LSP startup/permission flow so `filePath` still selects and starts the matching server, while not being sent as part of the LSP `workspace/symbol` request.
- Update the LSP tool description using the LSP spec wording for `WorkspaceSymbolParams.query`.

## Context
- Fixes https://github.com/anomalyco/opencode/issues/23075.
- This is the focused subset of https://github.com/anomalyco/opencode/pull/23612 after https://github.com/anomalyco/opencode/pull/23771 already handled the diagnostics/sync side.
- LSP 3.17 defines `workspace/symbol` params as `WorkspaceSymbolParams` with `query: string`; empty string is valid and requests all symbols.

## Repro
- Created a tiny clangd project with `compile_flags.txt` and a unique C++ function `unique_workspace_symbol_target`.
- Before this change, invoking the LSP tool's `workspaceSymbol` path returned broad empty-query results because the tool called `lsp.workspaceSymbol(\"\")`.
- After this change, the same tool call with `query: \"unique_workspace_symbol_target\"` returns that symbol.
- Also verified that a fresh `ocl debug lsp symbols unique_workspace_symbol_target` returns `[]` until a file starts clangd, which is why this PR keeps `filePath` for server selection/startup instead of making the tool fully fileless.

## Verification
- `bun typecheck` from `packages/opencode` with a 10s timeout: timed out while running `tsgo --noEmit`.
- Push hook ran `bun turbo typecheck`: passed in 11.093s.