### PR TITLE
docs(it): fix duplicated word in CLI env var table

### DIFF
--- a/packages/web/src/content/docs/it/cli.mdx
+++ b/packages/web/src/content/docs/it/cli.mdx
@@ -598,6 +598,6 @@ Queste variabili d'ambiente abilitano funzionalità sperimentali che potrebbero 
 | `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Abilita strumento LSP sperimentale         |
 | `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disabilita file watcher                    |
 | `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Abilita funzionalità Exa sperimentali      |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Abilita Abilita TY LSP per i file python   |
+| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Abilita TY LSP per i file python   |
 | `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Abilita markdown sperimentale              |
 | `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Abilita plan mode                          |


### PR DESCRIPTION
## Summary
Fixes a duplicated word in the Italian CLI docs environment variable table:

- from: `Abilita Abilita TY LSP per i file python`
- to:   `Abilita TY LSP per i file python`

## Why
Small documentation quality fix to improve readability and translation correctness.