### PR TITLE
feat: added ability to load dynamically the model list from LM Studio

### DIFF
--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -1,0 +1,86 @@
+import { Log } from "../util"
+
+const log = Log.create({ service: "model-cache" })
+
+export namespace ModelCache {
+  const cache: Record<string, Record<string, any>> = {}
+
+  export async function fetch(providerID: string, options: { baseURL?: string; apiKey?: string } = {}): Promise<Record<string, any>> {
+    if (cache[providerID]) return cache[providerID]
+
+    if (providerID === "apertis") {
+      return fetchApertisModels(options)
+    }
+
+    if (providerID === "lmstudio") {
+      return fetchOpenAICompatibleModels(options)
+    }
+
+    return {}
+  }
+
+  export async function refresh(providerID: string, options: { baseURL?: string; apiKey?: string } = {}): Promise<Record<string, any>> {
+    const result = await fetch(providerID, options)
+    if (Object.keys(result).length > 0) {
+      cache[providerID] = result
+    }
+    return result
+  }
+
+  const APERTIS_BASE_URL = "https://api.apertis.ai/v1"
+
+  async function fetchOpenAICompatibleModels(options: { baseURL?: string; apiKey?: string }): Promise<Record<string, any>> {
+    const baseURL = options.baseURL ?? "http://127.0.0.1:1234/v1"
+    const apiKey = options.apiKey
+
+    const url = `${baseURL.replace(/\/+$/, "")}/models`
+
+    try {
+      const response = await Bun.fetch(url, {
+        method: "GET",
+        headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+        signal: AbortSignal.timeout(10_000),
+      })
+
+      if (!response.ok) {
+        log.error("openai-compatible model fetch failed", { url, status: response.status })
+        return {}
+      }
+
+      const json = await response.json() as { data?: Array<{ id: string; owned_by?: string }> }
+
+      const models: Record<string, any> = {}
+      for (const model of json.data ?? []) {
+        models[model.id] = {
+          id: model.id,
+          name: model.id,
+          family: model.owned_by ?? "",
+          release_date: "",
+          attachment: true,
+          reasoning: false,
+          temperature: true,
+          tool_call: true,
+          cost: { input: 0, output: 0 },
+          limit: { context: 128000, output: 4096 },
+          options: {},
+          modalities: {
+            input: ["text", "image"],
+            output: ["text"],
+          },
+        }
+      }
+
+      return models
+    } catch (error) {
+      log.error("openai-compatible model fetch error", { url, error })
+      return {}
+    }
+  }
+
+  async function fetchApertisModels(options: { baseURL?: string; apiKey?: string }): Promise<Record<string, any>> {
+    return fetchOpenAICompatibleModels({
+      baseURL: options.baseURL ?? APERTIS_BASE_URL,
+      apiKey: options.apiKey,
+    })
+  }
+}

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -8,6 +8,7 @@ import { lazy } from "@/util/lazy"
 import { Filesystem } from "../util"
 import { Flock } from "@opencode-ai/core/util/flock"
 import { Hash } from "@opencode-ai/core/util/hash"
+import { ModelCache } from "./model-cache"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
@@ -145,7 +146,55 @@ export const Data = lazy(async () => {
 
 export async function get() {
   const result = await Data()
-  return result as Record<string, Provider>
+  const providers = result as Record<string, Provider>
+
+  const config = await Filesystem.readJson(path.join(Global.Path.config, "config.json")).catch(() => undefined) as {
+    disabled_providers?: string[]
+    enabled_providers?: string[]
+    provider?: Record<string, { options?: Record<string, unknown> }>
+  } | undefined
+
+  const disabled = new Set(config?.disabled_providers ?? [])
+  const enabled = config?.enabled_providers ? new Set(config.enabled_providers) : null
+  const lmstudioDisabled = disabled.has("lmstudio")
+  const lmstudioEnabled = enabled ? enabled.has("lmstudio") : true
+  const lmstudioAllowed = lmstudioEnabled && !lmstudioDisabled
+
+  if (lmstudioAllowed) {
+    const lmstudioConfig = config?.provider?.lmstudio?.options
+    const lmstudioBaseURL = (lmstudioConfig?.baseURL as string) ?? "http://127.0.0.1:1234/v1"
+    const lmstudioFetchOptions = {
+      ...(lmstudioConfig?.baseURL ? { baseURL: lmstudioConfig.baseURL as string } : {}),
+      ...(lmstudioConfig?.apiKey ? { apiKey: lmstudioConfig.apiKey as string } : {}),
+    }
+
+    try {
+      const lmstudioModels = await ModelCache.fetch("lmstudio", lmstudioFetchOptions).catch(() => ({}))
+      if (Object.keys(lmstudioModels).length > 0) {
+        if (!providers["lmstudio"]) {
+          providers["lmstudio"] = {
+            id: "lmstudio",
+            name: "LMStudio",
+            env: ["LMSTUDIO_API_KEY"],
+            api: lmstudioBaseURL,
+            npm: "@ai-sdk/openai-compatible",
+            models: lmstudioModels,
+          }
+        } else {
+          const existing = providers["lmstudio"]
+          providers["lmstudio"] = {
+            ...existing,
+            models: lmstudioModels,
+            api: lmstudioConfig?.baseURL ? lmstudioBaseURL : existing.api,
+          }
+        }
+      }
+    } catch (err) {
+      log.debug("lmstudio model fetch failed, using snapshot fallback", { error: err })
+    }
+  }
+
+  return providers
 }
 
 export async function refresh(force = false) {


### PR DESCRIPTION
### Issue for this PR

Closes none.

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Today opencode displays a static list from models.dev of 3 models in lmstudio. Since LM Studio is intended to be self-hosted, it made no sense for the list to be static. Even though there is the possibility to add models manually via config files, still, it's too much hassle for something that should come out of the box.
This PR adds the ability to load the model list from LM Studio dynamically.

### How did you verify your code works?

1. Run the project once in branch `dev` to assert everything works and I don't chase unrelated changes later.
2. Did my changes
3. Build it
4. Run the newly built version
5. Assert that the list of models that appears on the provider LM Studio is truthful with the ones provided by LM Studio's API endpoint

### Screenshots / recordings
| Before | After |
| ------ | ----- |
| <img width="641" height="318" alt="image" src="https://github.com/user-attachments/assets/ca447eb6-66b2-4e73-8c04-2cd6c42160bb" /> | <img width="637" height="382" alt="image" src="https://github.com/user-attachments/assets/c0aadcb8-37f3-4b8a-810d-43a0bec87065" /> |

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR