### PR TITLE
docs: fix duplicated word in CLI env var table

### DIFF
--- a/packages/web/src/content/docs/it/cli.mdx
+++ b/packages/web/src/content/docs/it/cli.mdx
@@ -598,6 +598,6 @@ Queste variabili d'ambiente abilitano funzionalità sperimentali che potrebbero 
 | `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Abilita strumento LSP sperimentale         |
 | `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disabilita file watcher                    |
 | `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Abilita funzionalità Exa sperimentali      |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Abilita Abilita TY LSP per i file python   |
+| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Abilita TY LSP per i file python   |
 | `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Abilita markdown sperimentale              |
 | `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Abilita plan mode                          |


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Fixes a duplicated word in the Italian CLI docs environment-variable table.

- from: `Abilita Abilita TY LSP per i file python`
- to:   `Abilita TY LSP per i file python`

This is a minimal docs-only correction (one line) with no behavior change.

### How did you verify your code works?

- Verified the changed line in `packages/web/src/content/docs/it/cli.mdx`
- Confirmed this PR only changes one docs line

### Screenshots / recordings

N/A (docs-only text fix).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
