### PR TITLE
fix(app): auto-add project to sidebar when navigating via direct URL

### DIFF
--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -7,6 +7,8 @@ import { useLanguage } from "@/context/language"
 import { LocalProvider } from "@/context/local"
 import { SDKProvider } from "@/context/sdk"
 import { SyncProvider, useSync } from "@/context/sync"
+import { useLayout } from "@/context/layout"
+import { useServer } from "@/context/server"
 import { decode64 } from "@/utils/base64"
 
 function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
@@ -44,11 +46,20 @@ export default function Layout(props: ParentProps) {
   const params = useParams()
   const language = useLanguage()
   const navigate = useNavigate()
+  const layout = useLayout()
+  const server = useServer()
   let invalid = ""
 
   const resolved = createMemo(() => {
     if (!params.dir) return ""
     return decode64(params.dir) ?? ""
+  })
+
+  createEffect(() => {
+    const dir = resolved()
+    if (!dir) return
+    layout.projects.open(dir)
+    server.projects.touch(dir)
   })
 
   createEffect(() => {

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -2,7 +2,7 @@ import { DataProvider } from "@opencode-ai/ui/context"
 import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
-import { createEffect, createMemo, createResource, type ParentProps, Show } from "solid-js"
+import { createEffect, createMemo, createResource, type ParentProps, Show, untrack } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { LocalProvider } from "@/context/local"
 import { SDKProvider } from "@/context/sdk"
@@ -58,8 +58,10 @@ export default function Layout(props: ParentProps) {
   createEffect(() => {
     const dir = resolved()
     if (!dir) return
-    layout.projects.open(dir)
-    server.projects.touch(dir)
+    untrack(() => {
+      layout.projects.open(dir)
+      server.projects.touch(dir)
+    })
   })
 
   createEffect(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #18943
Closes #16837

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When navigating to the Web UI via a direct `/:dir/session` URL (IDE plugin, deep link, page reload), the sidebar did not show the project because `layout.projects.open()` was never called in the direct-route code path.

The fix adds a `createEffect` in `directory-layout.tsx` that calls `layout.projects.open(dir)` and `server.projects.touch(dir)` when the URL resolves to a valid directory. Both are idempotent — `open()` returns early if the project is already in the list.

### How did you verify your code works?

- Navigated directly to `/{base64(dir)}/session` — project appears in sidebar
- Reloaded the page — project persists in sidebar
- Opened a URL for an already-registered project — no duplicate entry
- Opened a project from the home screen — still works as before

### Screenshots / recordings

N/A — no visual change, the sidebar now correctly shows the project that was already expected to be there.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
