### PR TITLE
fix(httpapi): mount workspace bridge routes

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/config.ts
@@ -67,10 +67,9 @@ export const configHandlers = Layer.unwrap(
     })
 
     const update = Effect.fn("ConfigHttpApi.update")(function* (ctx) {
-      const payload = Config.Info.zod.parse(ctx.payload)
-      yield* configSvc.update(payload, { dispose: false })
+      yield* configSvc.update(ctx.payload, { dispose: false })
       yield* markInstanceForDisposal(yield* InstanceState.context)
-      return payload
+      return ctx.payload
     })
 
     const providers = Effect.fn("ConfigHttpApi.providers")(function* () {

--- a/packages/opencode/src/server/routes/instance/httpapi/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/project.ts
@@ -99,7 +99,7 @@ export const projectHandlers = Layer.unwrap(
       params: { projectID: ProjectID }
       payload: Project.UpdatePayload
     }) {
-      return yield* svc.update({ ...Project.UpdatePayload.zod.parse(ctx.payload), projectID: ctx.params.projectID })
+      return yield* svc.update({ ...ctx.payload, projectID: ctx.params.projectID })
     })
 
     return HttpApiBuilder.group(ProjectApi, "project", (handlers) =>

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -25,6 +25,7 @@ import { McpPaths } from "./httpapi/mcp"
 import { SessionPaths } from "./httpapi/session"
 import { SyncPaths } from "./httpapi/sync"
 import { TuiPaths } from "./httpapi/tui"
+import { WorkspacePaths } from "./httpapi/workspace"
 import { ProjectRoutes } from "./project"
 import { SessionRoutes } from "./session"
 import { PtyRoutes } from "./pty"
@@ -144,6 +145,12 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
     app.post(TuiPaths.selectSession, (c) => handler(c.req.raw, context))
     app.get(TuiPaths.controlNext, (c) => handler(c.req.raw, context))
     app.post(TuiPaths.controlResponse, (c) => handler(c.req.raw, context))
+    app.get(WorkspacePaths.adaptors, (c) => handler(c.req.raw, context))
+    app.post(WorkspacePaths.list, (c) => handler(c.req.raw, context))
+    app.get(WorkspacePaths.list, (c) => handler(c.req.raw, context))
+    app.get(WorkspacePaths.status, (c) => handler(c.req.raw, context))
+    app.delete(WorkspacePaths.remove, (c) => handler(c.req.raw, context))
+    app.post(WorkspacePaths.sessionRestore, (c) => handler(c.req.raw, context))
   }
 
   return app

--- a/packages/opencode/test/server/httpapi-workspace.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
-import { Context, Effect } from "effect"
+import { Effect } from "effect"
+import type { UpgradeWebSocket } from "hono/ws"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { registerAdaptor } from "../../src/control-plane/adaptors"
 import type { WorkspaceAdaptor } from "../../src/control-plane/types"
 import { Workspace } from "../../src/control-plane/workspace"
-import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
 import { WorkspacePaths } from "../../src/server/routes/instance/httpapi/workspace"
+import { InstanceRoutes } from "../../src/server/routes/instance"
 import { Session } from "../../src/session"
 import { Log } from "../../src/util"
 import { resetDatabase } from "../fixture/db"
@@ -16,19 +17,15 @@ import { Instance } from "../../src/project/instance"
 
 void Log.init({ print: false })
 
-const context = Context.empty() as Context.Context<unknown>
 const originalWorkspaces = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
+const originalHttpApi = Flag.OPENCODE_EXPERIMENTAL_HTTPAPI
+const websocket = (() => () => new Response(null, { status: 501 })) as unknown as UpgradeWebSocket
 
 function request(path: string, directory: string, init: RequestInit = {}) {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
   const headers = new Headers(init.headers)
   headers.set("x-opencode-directory", directory)
-  return ExperimentalHttpApiServer.webHandler().handler(
-    new Request(`http://localhost${path}`, {
-      ...init,
-      headers,
-    }),
-    context,
-  )
+  return InstanceRoutes(websocket).request(path, { ...init, headers })
 }
 
 function runSession<A, E>(fx: Effect.Effect<A, E, Session.Service>) {
@@ -61,6 +58,7 @@ function localAdaptor(directory: string): WorkspaceAdaptor {
 
 afterEach(async () => {
   Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = originalWorkspaces
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = originalHttpApi
   await Instance.disposeAll()
   await resetDatabase()
 })


### PR DESCRIPTION
## Summary
- Mount the existing workspace HttpApi paths through the experimental Hono bridge.
- Exercise workspace routes through `InstanceRoutes` instead of only the raw HttpApi handler.
- Remove redundant Zod reparsing for already decoded config/project HttpApi payloads.

## Test
- bun typecheck
- bun run test:ci test/server/httpapi-workspace.test.ts
- bun run test:ci test/server/httpapi-*.test.ts