### PR TITLE
fix(httpapi): accept empty session create body

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/session.ts
@@ -203,7 +203,7 @@ export const SessionApi = HttpApi.make("session")
           }),
         ),
         HttpApiEndpoint.post("create", SessionPaths.create, {
-          payload: Schema.optional(Session.CreateInput),
+          payload: [HttpApiSchema.NoContent, Session.CreateInput],
           success: Session.Info,
         }).annotateMerge(
           OpenApi.annotations({

--- a/packages/opencode/src/server/routes/instance/httpapi/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/session.ts
@@ -203,7 +203,7 @@ export const SessionApi = HttpApi.make("session")
           }),
         ),
         HttpApiEndpoint.post("create", SessionPaths.create, {
-          payload: Session.CreateInput,
+          payload: Schema.optional(Session.CreateInput),
           success: Session.Info,
         }).annotateMerge(
           OpenApi.annotations({
@@ -513,7 +513,7 @@ export const sessionHandlers = Layer.unwrap(
       )
     })
 
-    const create = Effect.fn("SessionHttpApi.create")(function* (ctx: { payload: Session.CreateInput }) {
+    const create = Effect.fn("SessionHttpApi.create")(function* (ctx: { payload?: Session.CreateInput }) {
       const instance = yield* InstanceState.context
       return yield* Effect.promise(() =>
         Instance.restore(instance, () =>
@@ -522,6 +522,22 @@ export const sessionHandlers = Layer.unwrap(
           ),
         ),
       )
+    })
+
+    const createRaw = Effect.fn("SessionHttpApi.createRaw")(function* (ctx: {
+      request: HttpServerRequest.HttpServerRequest
+    }) {
+      const body = yield* Effect.orDie(ctx.request.text)
+      if (body.trim().length === 0) return yield* create({})
+
+      const json = yield* Effect.try({
+        try: () => JSON.parse(body) as unknown,
+        catch: () => new HttpApiError.BadRequest({}),
+      })
+      const payload = yield* Schema.decodeUnknownEffect(Session.CreateInput)(json).pipe(
+        Effect.mapError(() => new HttpApiError.BadRequest({})),
+      )
+      return yield* create({ payload })
     })
 
     const remove = Effect.fn("SessionHttpApi.remove")(function* (ctx: { params: { sessionID: SessionID } }) {
@@ -894,7 +910,7 @@ export const sessionHandlers = Layer.unwrap(
         .handle("diff", diff)
         .handle("messages", messages)
         .handle("message", message)
-        .handle("create", create)
+        .handleRaw("create", createRaw)
         .handle("remove", remove)
         .handle("update", update)
         .handle("fork", fork)

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -151,6 +151,14 @@ describe("session HttpApi", () => {
     await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false, share: "disabled" } })
     const headers = { "x-opencode-directory": tmp.path, "content-type": "application/json" }
 
+    const createdEmpty = await json<Session.Info>(
+      await app().request(SessionPaths.create, {
+        method: "POST",
+        headers,
+      }),
+    )
+    expect(createdEmpty.id).toBeTruthy()
+
     const created = await json<Session.Info>(
       await app().request(SessionPaths.create, {
         method: "POST",


### PR DESCRIPTION
## Summary
- Allow experimental HttpApi session creation to handle empty request bodies like the legacy Hono route.
- Keep non-empty payloads JSON/schema validated and add regression coverage for no-body `POST /session`.

## Testing
- `bun typecheck`
- `bun run test:ci test/server/httpapi-session.test.ts`