### PR TITLE
tui: ignore invalid custom themes to prevent startup crashes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -500,7 +500,8 @@ async function getCustomThemes() {
       symlink: true,
     })) {
       const name = path.basename(item, ".json")
-      result[name] = await Filesystem.readJson(item)
+      const theme = await Filesystem.readJson(item)
+      if (isTheme(theme)) result[name] = theme
     }
   }
   return result


### PR DESCRIPTION
## Summary
- Skip custom theme JSON files that do not contain a valid theme object so malformed local themes cannot crash TUI startup.

## Testing
- bun typecheck (packages/opencode)
- pre-push turbo typecheck