### PR TITLE
feat(plugin): add model.before hook

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -83,6 +83,32 @@ const live: Layer.Layer<
         providerID: input.model.providerID,
       })
 
+      // Allow plugins to rewrite the selected model before it's committed
+      // for this request. The output is pre-filled with the original model's
+      // IDs; plugins that do not override them produce a no-op. Use cases
+      // include hybrid local/cloud routing, cascade fallbacks, A/B testing.
+      const rewrite = yield* plugin.trigger(
+        "model.before",
+        {
+          sessionID: input.sessionID,
+          agent: input.agent.name,
+          model: input.model,
+          message: input.user,
+        },
+        {
+          providerID: input.model.providerID,
+          modelID: input.model.id,
+        },
+      )
+      if (rewrite.providerID !== input.model.providerID || rewrite.modelID !== input.model.id) {
+        const replaced = yield* provider.getModel(rewrite.providerID as any, rewrite.modelID as any)
+        l.info("model.before rewrite", {
+          from: `${input.model.providerID}/${input.model.id}`,
+          to: `${replaced.providerID}/${replaced.id}`,
+        })
+        input.model = replaced
+      }
+
       const [language, cfg, item, info] = yield* Effect.all(
         [
           provider.getLanguage(input.model),

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -241,6 +241,23 @@ export interface Hooks {
     output: { message: UserMessage; parts: Part[] },
   ) => Promise<void>
   /**
+   * Called before the model is locked in for a chat-completion request.
+   * Plugins may rewrite `output.providerID` and `output.modelID` to route
+   * the request to a different model — useful for hybrid local/cloud
+   * routing, cascade fallbacks, A/B testing, and similar dispatch
+   * decisions. The output is pre-filled with the IDs of the originally
+   * selected model, so plugins that do not need to rewrite anything can
+   * leave it untouched (no-op).
+   *
+   * If `providerID` or `modelID` is changed, the new pair is resolved via
+   * `Provider.getModel()`; an unresolvable pair surfaces as an error from
+   * the LLM stream.
+   */
+  "model.before"?: (
+    input: { sessionID: string; agent: string; model: Model; message: UserMessage },
+    output: { providerID: string; modelID: string },
+  ) => Promise<void>
+  /**
    * Modify parameters sent to LLM
    */
   "chat.params"?: (


### PR DESCRIPTION
Lets a plugin rewrite the selected (providerID, modelID) before a chat completion is dispatched. Same (input, output) shape as chat.params. Dispatched in LLM.run; if a plugin does not change the IDs nothing happens, otherwise the new model is resolved via Provider.getModel().

Useful for routing setups (e.g. local-vs-cloud hybrid) without needing a proxy in front of opencode.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `model.before` plugin hook that fires right before a chat completion is dispatched. It receives the originally-selected model and lets a plugin override `providerID` / `modelID`. If a plugin doesn't change them, nothing changes.

When the IDs change, the new model is resolved via `Provider.getModel()` and the rest of the request (system prompts, `chat.params`, `chat.headers`, `streamText`) uses the new one.

Same `(input, output)` shape as `chat.params` / `chat.headers`. Dispatched in `LLM.run` right after the existing `l.info("stream", …)` call.

I want this for a hybrid local/cloud routing plugin — small local model for trivial prompts, cloud for the hard ones. Today that needs a proxy sitting in front of opencode; this hook lets the routing live as a normal plugin.

One question for reviewers: `Provider.getModel(rewrite.providerID as any, rewrite.modelID as any)` casts because the plugin output is plain `string` and `getModel` wants the branded `ProviderID` / `ModelID`. What's the right way to construct those from a string here? Happy to switch.

### How did you verify your code works?

- Read through the diff: hook fires in `LLM.run` between the initial `l.info("stream", …)` log line and the `Provider.getLanguage` / `Provider.getProvider` resolution, so the rewritten model is what the rest of the request sees. Same dispatch shape as the existing `chat.params` and `chat.headers` triggers in the same function.
- No-op semantics: `output` is pre-filled with the originally-selected IDs. A plugin that registers the hook but leaves output untouched is a no-op, and a plugin that doesn't register it at all is also a no-op (the loop in `Plugin.trigger` skips undefined hooks).
- Haven't been able to run `bun turbo typecheck` locally yet — will rely on CI to flag any type fallout. Happy to add a unit test for the dispatcher if useful.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR