### PR TITLE
fix(tui): preserve terminal selection when copy-on-select is disabled

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -293,6 +293,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   // Wire up console copy-to-clipboard via opentui's onCopySelection callback
   renderer.console.onCopySelection = async (text: string) => {
     if (!text || text.length === 0) return
+    if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
 
     await Clipboard.copy(text)
       .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))


### PR DESCRIPTION
### Issue for this PR

Closes #5046

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT=1` is enabled, selection should remain under terminal control so users can copy normally (for example Ctrl+C in tmux/Windows Terminal workflows).

This stops OpenCode's `onCopySelection` callback from auto-copying and clearing the selection in that mode.

### How did you verify your code works?

From `packages/opencode`:
- `bun typecheck`

### Screenshots / recordings

_Not a visual layout change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR