### PR TITLE
fix(session): remove compaction summary dividers

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -38,7 +38,6 @@ const DEFAULT_TAIL_TURNS = 2
 const MIN_PRESERVE_RECENT_TOKENS = 2_000
 const MAX_PRESERVE_RECENT_TOKENS = 8_000
 const SUMMARY_TEMPLATE = `Output exactly this Markdown structure and keep the section order unchanged:
----
 ## Goal
 - [single-sentence task summary]
 
@@ -66,7 +65,6 @@ const SUMMARY_TEMPLATE = `Output exactly this Markdown structure and keep the se
 
 ## Relevant Files
 - [file or directory path: why it matters, or "(none)"]
----
 
 Rules:
 - Keep every section, even when empty.

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -37,7 +37,8 @@ const PRUNE_PROTECTED_TOOLS = ["skill"]
 const DEFAULT_TAIL_TURNS = 2
 const MIN_PRESERVE_RECENT_TOKENS = 2_000
 const MAX_PRESERVE_RECENT_TOKENS = 8_000
-const SUMMARY_TEMPLATE = `Output exactly this Markdown structure and keep the section order unchanged:
+const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
+<template>
 ## Goal
 - [single-sentence task summary]
 
@@ -65,6 +66,7 @@ const SUMMARY_TEMPLATE = `Output exactly this Markdown structure and keep the se
 
 ## Relevant Files
 - [file or directory path: why it matters, or "(none)"]
+</template>
 
 Rules:
 - Keep every section, even when empty.


### PR DESCRIPTION
## Summary
- Remove the top and bottom `---` lines from the compaction summary template.
- Keep the explicit Markdown section structure and ordering instructions intact.

## Testing
- `bun typecheck` from `packages/opencode`
- `bun run test test/session/compaction.test.ts` from `packages/opencode`