### PR TITLE
fix(desktop): disable in-app updater for non-AppImage Linux installs

### DIFF
--- a/packages/desktop-electron/src/main/constants.ts
+++ b/packages/desktop-electron/src/main/constants.ts
@@ -1,4 +1,5 @@
 import { app } from "electron"
+import { isUpdaterEnabled } from "./updater-support"
 
 type Channel = "dev" | "beta" | "prod"
 const raw = import.meta.env.OPENCODE_CHANNEL
@@ -7,4 +8,9 @@ export const CHANNEL: Channel = raw === "dev" || raw === "beta" || raw === "prod
 export const SETTINGS_STORE = "opencode.settings"
 export const DEFAULT_SERVER_URL_KEY = "defaultServerUrl"
 export const WSL_ENABLED_KEY = "wslEnabled"
-export const UPDATER_ENABLED = app.isPackaged && CHANNEL !== "dev"
+export const UPDATER_ENABLED = isUpdaterEnabled({
+  isPackaged: app.isPackaged,
+  channel: CHANNEL,
+  platform: process.platform,
+  appImage: process.env.APPIMAGE,
+})

--- a/packages/desktop-electron/src/main/updater-support.test.ts
+++ b/packages/desktop-electron/src/main/updater-support.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import { isUpdaterEnabled } from "./updater-support"
+
+describe("updater support", () => {
+  test("disables updater for unpackaged or dev builds", () => {
+    expect(
+      isUpdaterEnabled({
+        isPackaged: false,
+        channel: "prod",
+        platform: "darwin",
+        appImage: undefined,
+      }),
+    ).toBe(false)
+
+    expect(
+      isUpdaterEnabled({
+        isPackaged: true,
+        channel: "dev",
+        platform: "darwin",
+        appImage: undefined,
+      }),
+    ).toBe(false)
+  })
+
+  test("enables updater on packaged non-linux builds", () => {
+    expect(
+      isUpdaterEnabled({
+        isPackaged: true,
+        channel: "prod",
+        platform: "win32",
+        appImage: undefined,
+      }),
+    ).toBe(true)
+  })
+
+  test("enables linux updater only for AppImage", () => {
+    expect(
+      isUpdaterEnabled({
+        isPackaged: true,
+        channel: "prod",
+        platform: "linux",
+        appImage: undefined,
+      }),
+    ).toBe(false)
+
+    expect(
+      isUpdaterEnabled({
+        isPackaged: true,
+        channel: "prod",
+        platform: "linux",
+        appImage: "/tmp/OpenCode.AppImage",
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/desktop-electron/src/main/updater-support.ts
+++ b/packages/desktop-electron/src/main/updater-support.ts
@@ -1,0 +1,13 @@
+export type UpdaterSupportInput = {
+  isPackaged: boolean
+  channel: "dev" | "beta" | "prod"
+  platform: NodeJS.Platform
+  appImage: string | undefined
+}
+
+export function isUpdaterEnabled(input: UpdaterSupportInput) {
+  if (!input.isPackaged) return false
+  if (input.channel === "dev") return false
+  if (input.platform !== "linux") return true
+  return Boolean(input.appImage)
+}


### PR DESCRIPTION
### Issue for this PR

Closes #23538

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Linux package-manager installs (RPM/DEB), Electron's in-app updater flow can restart without actually applying the update, which causes repeated "install and restart" prompts for the same version.

This gates desktop updater support on Linux to AppImage builds only (`APPIMAGE` present), while keeping existing updater behavior for packaged macOS/Windows builds.

### How did you verify your code works?

From `packages/desktop-electron`:
- `bun test src/main/updater-support.test.ts`
- `bun typecheck`

(Pre-push also ran workspace `turbo typecheck`.)

### Screenshots / recordings

_Not a UI layout change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR