### PR TITLE
fix(cli): resolve --agent names case-insensitively

### DIFF
--- a/packages/opencode/src/cli/cmd/agent-match.ts
+++ b/packages/opencode/src/cli/cmd/agent-match.ts
@@ -1,0 +1,12 @@
+export type AgentSummary = {
+  name: string
+}
+
+export function matchAgentName(name: string, agents: AgentSummary[]) {
+  const exact = agents.find((item) => item.name === name)
+  if (exact) return exact.name
+
+  const lowered = name.toLowerCase()
+  const match = agents.find((item) => item.name.toLowerCase() === lowered)
+  return match?.name
+}

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "@/util/locale"
 import { AppRuntime } from "@/effect/app-runtime"
+import { matchAgentName } from "./agent-match"
 
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
@@ -582,8 +583,9 @@ export const RunCommand = cmd({
             return undefined
           }
 
-          const agent = modes.find((a) => a.name === name)
-          if (!agent) {
+          const matched = matchAgentName(name, modes)
+          const agent = matched ? modes.find((a) => a.name === matched) : undefined
+          if (!agent || !matched) {
             UI.println(
               UI.Style.TEXT_WARNING_BOLD + "!",
               UI.Style.TEXT_NORMAL,
@@ -601,11 +603,13 @@ export const RunCommand = cmd({
             return undefined
           }
 
-          return name
+          return matched
         }
 
-        const entry = await AppRuntime.runPromise(Agent.Service.use((svc) => svc.get(name)))
-        if (!entry) {
+        const list = await AppRuntime.runPromise(Agent.Service.use((svc) => svc.list()))
+        const matched = matchAgentName(name, list)
+        const entry = matched ? list.find((item) => item.name === matched) : undefined
+        if (!entry || !matched) {
           UI.println(
             UI.Style.TEXT_WARNING_BOLD + "!",
             UI.Style.TEXT_NORMAL,
@@ -621,7 +625,7 @@ export const RunCommand = cmd({
           )
           return undefined
         }
-        return name
+        return matched
       })()
 
       const sessionID = await session(sdk)

--- a/packages/opencode/test/cli/agent-match.test.ts
+++ b/packages/opencode/test/cli/agent-match.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { matchAgentName } from "../../src/cli/cmd/agent-match"
+
+describe("cli.agent-match", () => {
+  test("matches exact agent names", () => {
+    expect(matchAgentName("build", [{ name: "build" }, { name: "plan" }])).toBe("build")
+  })
+
+  test("matches names case-insensitively", () => {
+    expect(matchAgentName("Build", [{ name: "build" }, { name: "plan" }])).toBe("build")
+    expect(matchAgentName("PLAN", [{ name: "build" }, { name: "plan" }])).toBe("plan")
+  })
+
+  test("returns undefined when no match exists", () => {
+    expect(matchAgentName("unknown", [{ name: "build" }, { name: "plan" }])).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #23180

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --agent <name>` currently requires an exact case match on the internal agent ID. This causes inputs like `--agent Build` to fail even though the `build` agent exists.

This updates CLI agent resolution to match agent names case-insensitively and use the canonical agent name for the request (both local and `--attach` validation paths).

### How did you verify your code works?

From `packages/opencode`:
- `bun test test/cli/agent-match.test.ts`
- `bun typecheck`

(Pre-push also ran workspace `turbo typecheck`.)

### Screenshots / recordings

_Not a UI layout change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR