### PR TITLE
feat(agent): add order field for configurable agent cycling order

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -33,6 +33,7 @@ export const Info = Schema.Struct({
   hidden: Schema.optional(Schema.Boolean),
   topP: Schema.optional(Schema.Number),
   temperature: Schema.optional(Schema.Number),
+  order: Schema.optional(Schema.Number),
   color: Schema.optional(Schema.String),
   permission: Permission.Ruleset,
   model: Schema.optional(
@@ -256,6 +257,7 @@ export const layer = Layer.effect(
           item.color = value.color ?? item.color
           item.hidden = value.hidden ?? item.hidden
           item.name = value.name ?? item.name
+          item.order = value.order ?? item.order
           item.steps = value.steps ?? item.steps
           item.options = mergeDeep(item.options, value.options ?? {})
           item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
@@ -288,6 +290,7 @@ export const layer = Layer.effect(
             values(),
             sortBy(
               [(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "build"), "desc"],
+              [(x) => x.order ?? Infinity, "asc"],
               [(x) => x.name, "asc"],
             ),
           )

--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -35,6 +35,10 @@ const AgentSchema = Schema.StructWithRest(
     disable: Schema.optional(Schema.Boolean),
     description: Schema.optional(Schema.String).annotate({ description: "Description of when to use the agent" }),
     mode: Schema.optional(Schema.Literals(["subagent", "primary", "all"])),
+    order: Schema.optional(PositiveInt).annotate({
+      description:
+        "Sorting order for agent cycling (Tab). Lower values appear first. Agents without order are sorted alphabetically after ordered agents.",
+    }),
     hidden: Schema.optional(Schema.Boolean).annotate({
       description: "Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)",
     }),
@@ -60,6 +64,7 @@ const KNOWN_KEYS = new Set([
   "temperature",
   "top_p",
   "mode",
+  "order",
   "hidden",
   "color",
   "steps",

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -391,7 +391,7 @@ test("multiple custom agents can be defined", async () => {
   })
 })
 
-test("Agent.list keeps the default agent first and sorts the rest by name", async () => {
+test("Agent.list keeps the default agent first and sorts the rest by name when no order is set", async () => {
   await using tmp = await tmpdir({
     config: {
       default_agent: "plan",
@@ -413,6 +413,80 @@ test("Agent.list keeps the default agent first and sorts the rest by name", asyn
       const names = (await load(tmp.path, (svc) => svc.list())).map((a) => a.name)
       expect(names[0]).toBe("plan")
       expect(names.slice(1)).toEqual(names.slice(1).toSorted((a, b) => a.localeCompare(b)))
+    },
+  })
+})
+
+test("Agent.list respects order field for sorting", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      default_agent: "build",
+      agent: {
+        build: {
+          description: "Build agent",
+          mode: "primary",
+          order: 2,
+        },
+        alpha: {
+          description: "Alpha",
+          mode: "primary",
+          order: 1,
+        },
+        zebra: {
+          description: "Zebra",
+          mode: "primary",
+          order: 3,
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const names = (await load(tmp.path, (svc) => svc.list())).map((a) => a.name)
+      // Default agent ("build") always first regardless of order
+      expect(names[0]).toBe("build")
+      // Remaining sorted by order ascending: alpha (1) → zebra (3)
+      expect(names[1]).toBe("alpha")
+      expect(names[2]).toBe("zebra")
+    },
+  })
+})
+
+test("Agent.list sorts agents without order after ordered agents", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        zebra: {
+          description: "Zebra",
+          mode: "primary",
+        },
+        alpha: {
+          description: "Alpha",
+          mode: "primary",
+          order: 1,
+        },
+        beta: {
+          description: "Beta",
+          mode: "primary",
+          order: 2,
+        },
+        gamma: {
+          description: "Gamma",
+          mode: "primary",
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const names = (await load(tmp.path, (svc) => svc.list())).map((a) => a.name)
+      // Sorted: by order (alpha:1, beta:2), then alphabetical (gamma, zebra)
+      expect(names[0]).toBe("alpha")
+      expect(names[1]).toBe("beta")
+      expect(names[2]).toBe("gamma")
+      expect(names[3]).toBe("zebra")
     },
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #7372

### Type of change

- [x] New feature

### What does this PR do?

Adds an optional `order` field (PositiveInt) to agent config so users and plugins can control Tab cycling order instead of being forced into alphabetical sort.

Currently `Agent.list()` sorts agents alphabetically by name (after the default agent). This breaks plugins that define multiple agents with a specific intended order. For example, oh-my-opencode defines Sisyphus → Hephaestus → Prometheus → Atlas, but alphabetical sort produces Atlas → Hephaestus → Prometheus → Sisyphus.

Sorting becomes:
1. Default agent first (unchanged)
2. By `order` ascending (new) — agents without `order` get `Infinity`
3. By name ascending (unchanged fallback)

Fully backward compatible — configs without `order` behave exactly as before.

**Changes:**
- `packages/opencode/src/config/agent.ts`: Add `order` to AgentSchema + KNOWN_KEYS
- `packages/opencode/src/agent/agent.ts`: Add `order` to Info schema, merge logic, and `sortBy`
- `packages/opencode/test/agent/agent.test.ts`: Add 2 tests for `order` field sorting

### How did you verify your code works?

Two new unit tests cover the behavior:
1. **Order field sorting** — agents with `order: 1, 2, 3` appear in that sequence after the default agent
2. **Mixed ordered/unordered** — agents with `order` appear before those without, fall back to alphabetical

The existing alphabetical sort test was renamed for clarity and still passes. Backward compatibility is verified: agents without `order` sort alphabetically as before.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR