### PR TITLE
fix: use continuous scroll layout for share page on desktop

### DIFF
--- a/packages/enterprise/src/routes/share/[shareID].tsx
+++ b/packages/enterprise/src/routes/share/[shareID].tsx
@@ -18,7 +18,7 @@ import { createStore } from "solid-js/store"
 import z from "zod"
 import NotFound from "../[...404]"
 import { Tabs } from "@opencode-ai/ui/tabs"
-import { MessageNav } from "@opencode-ai/ui/message-nav"
+
 import { FileSSR } from "@opencode-ai/ui/file-ssr"
 import { clientOnly } from "@solidjs/start"
 import { Meta, Title } from "@solidjs/meta"
@@ -282,68 +282,9 @@ export default function () {
                             </div>
                           </header>
                           <div class="select-text flex flex-col flex-1 min-h-0">
-                            <div
-                              classList={{
-                                "hidden w-full flex-1 min-h-0": true,
-                                "md:flex": wide(),
-                                "lg:flex": !wide(),
-                              }}
-                            >
-                              <div
-                                classList={{
-                                  "@container relative shrink-0 pt-14 flex flex-col gap-10 min-h-0 w-full": true,
-                                }}
-                              >
-                                <div
-                                  classList={{
-                                    "w-full flex justify-start items-start min-w-0 px-6": true,
-                                  }}
-                                >
-                                  {title()}
-                                </div>
-                                <div class="flex items-start justify-start h-full min-h-0">
-                                  <Show when={messages().length > 1}>
-                                    <MessageNav
-                                      class="sticky top-0 shrink-0 py-2 pl-4"
-                                      messages={messages()}
-                                      current={activeMessage()}
-                                      size="compact"
-                                      onMessageSelect={setActiveMessage}
-                                    />
-                                  </Show>
-                                  <SessionTurn
-                                    sessionID={data().sessionID}
-                                    messageID={store.messageId ?? firstUserMessage()!.id!}
-                                    classes={{
-                                      root: "grow",
-                                      content: "flex flex-col justify-between",
-                                      container: "w-full pb-20 px-6",
-                                    }}
-                                  >
-                                    <div classList={{ "w-full flex items-center justify-center pb-8 shrink-0": true }}>
-                                      <Logo class="w-58.5 opacity-12" />
-                                    </div>
-                                  </SessionTurn>
-                                </div>
-                              </div>
-                              <Show when={diffs().length > 0}>
-                                <div class="@container relative grow pt-14 flex-1 min-h-0 border-l border-border-weak-base">
-                                  <SessionReview
-                                    diffs={diffs()}
-                                    diffStyle={diffStyle()}
-                                    onDiffStyleChange={setDiffStyle}
-                                    classes={{
-                                      root: "pb-20",
-                                      header: "px-6",
-                                      container: "px-6",
-                                    }}
-                                  />
-                                </div>
-                              </Show>
-                            </div>
                             <Switch>
                               <Match when={diffs().length > 0}>
-                                <Tabs classList={{ "md:hidden": wide(), "lg:hidden": !wide() }}>
+                                <Tabs>
                                   <Tabs.List>
                                     <Tabs.Trigger value="session" class="w-1/2" classes={{ button: "w-full" }}>
                                       Session
@@ -374,9 +315,7 @@ export default function () {
                                 </Tabs>
                               </Match>
                               <Match when={true}>
-                                <div
-                                  classList={{ "!overflow-hidden": true, "md:hidden": wide(), "lg:hidden": !wide() }}
-                                >
+                                <div class="!overflow-hidden">
                                   {turns()}
                                 </div>
                               </Match>


### PR DESCRIPTION
### Issue for this PR

Closes #18567

### Type of change

- [x] Bug fix

### What does this PR do?

The share page at opncd.ai/share/* on desktop uses a MessageNav sidebar with compact tick marks to navigate between messages, showing only one message at a time. Every sidebar item shows the same generic label "New Message", making it impossible to tell which message is which. Users must click individual ticks to switch messages, and the hover tooltip disappears when the mouse moves toward it.

The mobile layout already uses a continuous scroll view (turns()) that shows all messages in a single scrollable view. This PR removes the desktop-only sidebar layout and makes the continuous scroll layout active for all screen sizes.

Related issues: #6576, #20916.

Changes:
- Removed the desktop MessageNav sidebar + single SessionTurn layout block (64 lines deleted)
- Removed CSS classList conditions that hid the continuous scroll on desktop
- Removed unused MessageNav import

### How did you verify your code works?

- TypeScript typecheck passes on the changed file with zero errors
- The turns() function is unchanged -- it is the same function already working in production for mobile viewports

### Screenshots / recordings

Screenshots of the problem are available in the linked issue #18567.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
