### PR TITLE
fix(core): remap tail_start_id for compaction parts when forking sessions

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -608,6 +608,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
             id: PartID.ascending(),
             messageID: cloned.id,
             sessionID: session.id,
+            ...(part.type === "compaction" && part.tail_start_id && { tail_start_id: idMap.get(part.tail_start_id) }),
           })
         }
       }


### PR DESCRIPTION
### Issue for this PR

Closes #24700

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

What does this PR do?

Fixes Session.fork not remapping `CompactionPart.tail_start_id`, which caused forked sessions to include all pre‑compaction messages in context and inflating session length.

**Problem**
Session.fork copies messages and remaps messageID and parentID via idMap, but tail_start_id inside CompactionPart parts was spread raw (...part) and kept its old (original‑session) message ID.

filterCompacted (message‑v2.ts:1058) uses tail_start_id as the retention boundary. it retains messages until it finds one matching that ID. 
Since the forked session has new message IDs, the old tail_start_id never matches → the break never fires → all pre‑compaction messages leak through into context.

**Fix**
One line: remap tail_start_id via the same idMap already used for parentID:

`...(part.type === "compaction" && part.tail_start_id && { tail_start_id: idMap.get(part.tail_start_id) })`

Placed after ...part so it overrides the old value. If tail_start_id is undefined or the message wasn't in the map, nothing is spread (leaves the old value as fallback).

### How did you verify your code works?

Reproducing my issue #24700 failed. Context length of forked session stayed at ~300k (no longer jumped to ~800k)

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
