### PR TITLE
fix(tui): keep Zed context polling responsive

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -116,6 +116,12 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
         reconnect = setTimeout(connect, delay)
       }
 
+      const scheduleZedPoll = () => {
+        if (closed) return
+        if (reconnect) clearTimeout(reconnect)
+        reconnect = setTimeout(connect, 1000)
+      }
+
       const connect = () => {
         if (closed) return
 
@@ -145,7 +151,7 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
             .finally(() => {
               zedSelection = undefined
             })
-          scheduleReconnect()
+          scheduleZedPoll()
           return
         }
 


### PR DESCRIPTION
## Summary
- keep websocket reconnects on exponential backoff
- poll Zed's state DB at a fixed 1s interval so cursor/file context updates promptly

## Tests
- bun run test test/cli/tui/editor-context.test.ts
- bun typecheck