### PR TITLE
fix(httpapi): align sync seq validation

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/sync.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/sync.ts
@@ -10,14 +10,15 @@ import { or } from "drizzle-orm"
 import { SyncEvent } from "@/sync"
 import { EventTable } from "@/sync/event.sql"
 import { Effect, Layer, Schema } from "effect"
-import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "./auth"
 
 const root = "/sync"
+const Seq = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
 const ReplayEvent = Schema.Struct({
   id: Schema.String,
   aggregateID: Schema.String,
-  seq: Schema.Number,
+  seq: Seq,
   type: Schema.String,
   data: Schema.Record(Schema.String, Schema.Unknown),
 }).annotate({ identifier: "SyncReplayEvent" })
@@ -28,7 +29,7 @@ const ReplayPayload = Schema.Struct({
 const ReplayResponse = Schema.Struct({
   sessionID: Schema.String,
 }).annotate({ identifier: "SyncReplayResponse" })
-const HistoryPayload = Schema.Record(Schema.String, Schema.Number)
+const HistoryPayload = Schema.Record(Schema.String, Seq)
 const HistoryEvent = Schema.Struct({
   id: Schema.String,
   aggregate_id: Schema.String,
@@ -59,6 +60,7 @@ export const SyncApi = HttpApi.make("sync")
         HttpApiEndpoint.post("replay", SyncPaths.replay, {
           payload: ReplayPayload,
           success: ReplayResponse,
+          error: HttpApiError.BadRequest,
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "sync.replay",
@@ -69,6 +71,7 @@ export const SyncApi = HttpApi.make("sync")
         HttpApiEndpoint.post("history", SyncPaths.history, {
           payload: HistoryPayload,
           success: Schema.Array(HistoryEvent),
+          error: HttpApiError.BadRequest,
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "sync.history.list",

--- a/packages/opencode/src/server/routes/instance/httpapi/sync.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/sync.ts
@@ -9,16 +9,16 @@ import { not } from "drizzle-orm"
 import { or } from "drizzle-orm"
 import { SyncEvent } from "@/sync"
 import { EventTable } from "@/sync/event.sql"
+import { NonNegativeInt } from "@/util/schema"
 import { Effect, Layer, Schema } from "effect"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "./auth"
 
 const root = "/sync"
-const Seq = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
 const ReplayEvent = Schema.Struct({
   id: Schema.String,
   aggregateID: Schema.String,
-  seq: Seq,
+  seq: NonNegativeInt,
   type: Schema.String,
   data: Schema.Record(Schema.String, Schema.Unknown),
 }).annotate({ identifier: "SyncReplayEvent" })
@@ -29,7 +29,7 @@ const ReplayPayload = Schema.Struct({
 const ReplayResponse = Schema.Struct({
   sessionID: Schema.String,
 }).annotate({ identifier: "SyncReplayResponse" })
-const HistoryPayload = Schema.Record(Schema.String, Seq)
+const HistoryPayload = Schema.Record(Schema.String, NonNegativeInt)
 const HistoryEvent = Schema.Struct({
   id: Schema.String,
   aggregate_id: Schema.String,

--- a/packages/opencode/test/server/httpapi-sync.test.ts
+++ b/packages/opencode/test/server/httpapi-sync.test.ts
@@ -16,8 +16,8 @@ const originalHttpApi = Flag.OPENCODE_EXPERIMENTAL_HTTPAPI
 const originalWorkspaces = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
 const websocket = (() => () => new Response(null, { status: 501 })) as unknown as UpgradeWebSocket
 
-function app() {
-  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+function app(httpapi = true) {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = httpapi
   return InstanceRoutes(websocket)
 }
 
@@ -80,5 +80,49 @@ describe("sync HttpApi", () => {
     })
     expect(replayed.status).toBe(200)
     expect(await replayed.json()).toEqual({ sessionID: session.id })
+  })
+
+  test("matches legacy seq validation", async () => {
+    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+    const headers = { "x-opencode-directory": tmp.path, "content-type": "application/json" }
+    const cases = [
+      {
+        path: SyncPaths.history,
+        body: { aggregate: -1 },
+      },
+      {
+        path: SyncPaths.history,
+        body: { aggregate: 1.5 },
+      },
+      {
+        path: SyncPaths.replay,
+        body: {
+          directory: tmp.path,
+          events: [{ id: "event", aggregateID: "session", seq: -1, type: "session.created", data: {} }],
+        },
+      },
+      {
+        path: SyncPaths.replay,
+        body: {
+          directory: tmp.path,
+          events: [{ id: "event", aggregateID: "session", seq: 1.5, type: "session.created", data: {} }],
+        },
+      },
+    ]
+
+    for (const item of cases) {
+      const legacy = await app(false).request(item.path, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(item.body),
+      })
+      const httpapi = await app(true).request(item.path, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(item.body),
+      })
+      expect(httpapi.status).toBe(legacy.status)
+      expect(httpapi.status).toBe(400)
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Reject negative and fractional sync sequence values in Effect HttpApi schemas to match legacy Zod validation.
- Add parity coverage for invalid `seq` values on `/sync/history` and `/sync/replay`.

## Verification
- `bun run test:ci test/server/httpapi-sync.test.ts test/server/httpapi-tui.test.ts`
- `bun typecheck` from `packages/opencode`
- `bun typecheck` from `packages/sdk/js`

<sub>Stack created with <a href=\"https://github.com/github/gh-stack\">GitHub Stacks CLI</a></sub>