### PR TITLE
fix(desktop): prevent 100% CPU usage caused by infinite reconnects and recursive directory traversals

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -127,6 +127,9 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     const start = () => {
       if (started) return run
       started = true
+      let reconnectDelay = RECONNECT_DELAY_MS
+      const MAX_RECONNECT_DELAY_MS = 10000
+
       run = (async () => {
         // oxlint-disable-next-line no-unmodified-loop-condition -- `started` is set to false by stop() which also aborts; both flags are checked to allow graceful exit
         while (!abort.signal.aborted && started) {
@@ -152,6 +155,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
             })
             let yielded = Date.now()
             resetHeartbeat()
+            reconnectDelay = RECONNECT_DELAY_MS // Reset backoff on successful connection
             for await (const event of events.stream) {
               resetHeartbeat()
               streamErrorLogged = false
@@ -198,7 +202,8 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
           }
 
           if (abort.signal.aborted || !started) return
-          await wait(RECONNECT_DELAY_MS)
+          await wait(reconnectDelay)
+          reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS)
         }
       })().finally(() => {
         run = undefined

--- a/packages/core/src/util/glob.ts
+++ b/packages/core/src/util/glob.ts
@@ -8,6 +8,8 @@ export namespace Glob {
     include?: "file" | "all"
     dot?: boolean
     symlink?: boolean
+    ignore?: string | string[]
+    maxDepth?: number
   }
 
   function toGlobOptions(options: Options): GlobOptions {
@@ -17,6 +19,8 @@ export namespace Glob {
       dot: options.dot,
       follow: options.symlink ?? false,
       nodir: options.include !== "all",
+      ignore: options.ignore,
+      maxDepth: options.maxDepth,
     }
   }
 

--- a/packages/opencode/src/file/ignore.ts
+++ b/packages/opencode/src/file/ignore.ts
@@ -52,7 +52,12 @@ const FILES = [
   "**/.nyc_output/**",
 ]
 
-export const PATTERNS = [...FILES, ...FOLDERS]
+export const PATTERNS = [
+  ...FILES,
+  ...Array.from(FOLDERS),
+  ...Array.from(FOLDERS).map((f) => `**/${f}`),
+  ...Array.from(FOLDERS).map((f) => `**/${f}/**`),
+]
 
 export function match(
   filepath: string,

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -16,6 +16,7 @@ import { Config } from "@/config/config"
 import { FileIgnore } from "./ignore"
 import { Protected } from "./protected"
 import * as Log from "@opencode-ai/core/util/log"
+import * as os from "os"
 
 declare const OPENCODE_LIBC: string | undefined
 
@@ -120,6 +121,13 @@ export const layer = Layer.effect(
 
           const cfg = yield* config.get()
           const cfgIgnores = cfg.watcher?.ignore ?? []
+
+          const isHome = Instance.directory === os.homedir()
+          const isRoot = Instance.directory === "/"
+          if (isHome || isRoot) {
+            log.info("skipping watcher for home/root directory", { directory: Instance.directory })
+            return
+          }
 
           if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
             yield* subscribe(Instance.directory, [

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -356,6 +356,8 @@ export const layer: Layer.Layer<
           cwd: input.worktree,
           absolute: true,
           include: "file",
+          ignore: ["**/node_modules/**", "**/.git/**", "**/.cache/**", "**/dist/**", "**/build/**"],
+          maxDepth: 3,
         })
         .pipe(Effect.orDie)
       const shortest = matches.sort((a, b) => a.length - b.length)[0]


### PR DESCRIPTION
### Issue for this PR

Closes #24719

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Resolves multiple issues causing 100% CPU usage in the `opencode-cli serve` background process, especially noticeable on Linux/Wayland:

1. **Frontend Event Stream Reconnect:** Adds exponential backoff (up to 10s) to `global-sdk.tsx`. Prevents infinite tight reconnect loops (`epoll_pwait2`) when WebKitGTK drops the IPC/socket connection silently due to compositor glitches on KDE Wayland.
2. **File Watcher Home Directory Traversal:** Skips initializing `@parcel/watcher` if the workspace is the user's home or root directory. Prevents the watcher from getting stuck recursively setting up `inotify` watches for hundreds of thousands of files.
3. **Icon Discovery Performance:** Adds `ignore` and `maxDepth` parameters to `fs.glob` and uses them in `IconDiscovery`. Prevents the glob from traversing extremely deep hidden folders like `.cache` or `.mozilla` in the home directory.
4. **Nested Directory Ignores:** Updates `FileIgnore.PATTERNS` with `**/${f}` patterns so `@parcel/watcher` properly ignores nested folders like deeply nested `node_modules` within monorepos.

### How did you verify your code works?

- Monitored `opencode-cli serve` via `strace` and `procs` to confirm `epoll_pwait2` loops are prevented by frontend backoff.
- Verified `IconDiscovery` correctly skips hidden cache directories via `fs.glob` maxDepth and ignores.
- Tested `tauri dev` in the home directory (`/home/`) to confirm CPU stays near 0% by bypassing the recursive `FileWatcher` initialization.
- Verified `node_modules` traversal stops by fixing glob pattern strings passed to `@parcel/watcher`.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR