### PR TITLE
docs: regenerate go and zen tables from models.dev

### DIFF
--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -63,18 +63,18 @@ Only one member per workspace can subscribe to OpenCode Go.
 
 The current list of models includes:
 
-- **GLM-5**
 - **GLM-5.1**
+- **GLM-5**
 - **Kimi K2.5**
 - **Kimi K2.6**
-- **MiMo-V2-Pro**
-- **MiMo-V2-Omni**
-- **MiMo-V2.5-Pro**
-- **MiMo-V2.5**
-- **MiniMax M2.5**
+- **MiMo V2 Pro**
+- **MiMo V2 Omni**
+- **MiMo V2.5 Pro**
+- **MiMo V2.5**
 - **MiniMax M2.7**
-- **Qwen3.5 Plus**
+- **MiniMax M2.5**
 - **Qwen3.6 Plus**
+- **Qwen3.5 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
 
@@ -94,22 +94,22 @@ Limits are defined in dollar value. This means your actual request count depends
 
 The table below provides an estimated request count based on typical Go usage patterns:
 
-| Model              | requests per 5 hour | requests per week | requests per month |
-| ------------------ | ------------------- | ----------------- | ------------------ |
-| GLM-5.1            | 880                 | 2,150             | 4,300              |
-| GLM-5              | 1,150               | 2,880             | 5,750              |
-| Kimi K2.5          | 1,850               | 4,630             | 9,250              |
-| Kimi K2.6          | 1,150               | 2,880             | 5,750              |
-| MiMo-V2-Pro        | 1,290               | 3,225             | 6,450              |
-| MiMo-V2-Omni       | 2,150               | 5,450             | 10,900             |
-| MiMo-V2.5-Pro      | 1,290               | 3,225             | 6,450              |
-| MiMo-V2.5 (≤ 256K) | 2,150               | 5,450             | 10,900             |
-| MiniMax M2.7       | 3,400               | 8,500             | 17,000             |
-| MiniMax M2.5       | 6,300               | 15,900            | 31,800             |
-| Qwen3.6 Plus       | 3,300               | 8,200             | 16,300             |
-| Qwen3.5 Plus       | 10,200              | 25,200            | 50,500             |
-| DeepSeek V4 Pro    | 3,450               | 8,550             | 17,150             |
-| DeepSeek V4 Flash  | 31,650              | 79,050            | 158,150            |
+| Model             | requests per 5 hour | requests per week | requests per month |
+| ----------------- | ------------------- | ----------------- | ------------------ |
+| GLM-5.1           |                 791 |             1,978 |              3,957 |
+| GLM-5             |               1,036 |             2,590 |              5,181 |
+| Kimi K2.5         |               1,812 |             4,530 |              9,060 |
+| Kimi K2.6         |               3,412 |             8,531 |             17,062 |
+| MiMo V2 Pro       |               1,290 |             3,225 |              6,451 |
+| MiMo V2 Omni      |               2,189 |             5,474 |             10,948 |
+| MiMo V2.5 Pro     |               1,290 |             3,225 |              6,451 |
+| MiMo V2.5         |               2,189 |             5,474 |             10,948 |
+| MiniMax M2.7      |               3,389 |             8,474 |             16,949 |
+| MiniMax M2.5      |               6,349 |            15,873 |             31,746 |
+| Qwen3.6 Plus      |               3,269 |             8,174 |             16,348 |
+| Qwen3.5 Plus      |              10,084 |            25,210 |             50,420 |
+| DeepSeek V4 Pro   |               3,425 |             8,563 |             17,127 |
+| DeepSeek V4 Flash |              31,628 |            79,072 |            158,144 |
 
 Estimates are based on observed average request patterns:
 
@@ -118,10 +118,10 @@ Estimates are based on observed average request patterns:
 - DeepSeek V4 Pro — 750 input, 82,000 cached, 290 output tokens per request
 - DeepSeek V4 Flash — 790 input, 68,000 cached, 280 output tokens per request
 - MiniMax M2.7/M2.5 — 300 input, 55,000 cached, 125 output tokens per request
-- MiMo-V2-Pro — 350 input, 41,000 cached, 250 output tokens per request
-- MiMo-V2-Omni — 1000 input, 60,000 cached, 140 output tokens per request
-- MiMo-V2.5-Pro — 350 input, 41,000 cached, 250 output tokens per request
-- MiMo-V2.5 — 1000 input, 60,000 cached, 140 output tokens per request
+- MiMo V2 Pro — 350 input, 41,000 cached, 250 output tokens per request
+- MiMo V2 Omni — 1000 input, 60,000 cached, 140 output tokens per request
+- MiMo V2.5 Pro — 350 input, 41,000 cached, 250 output tokens per request
+- MiMo V2.5 — 1000 input, 60,000 cached, 140 output tokens per request
 - Qwen3.5 Plus — 410 input, 47,000 cached, 140 output tokens per request
 - Qwen3.6 Plus — 500 input, 57,000 cached, 190 output tokens per request
 
@@ -153,16 +153,16 @@ You can also access Go models through the following API endpoints.
 | GLM-5             | glm-5             | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.5         | kimi-k2.5         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiMo V2 Pro       | mimo-v2-pro       | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiMo V2 Omni      | mimo-v2-omni      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiMo V2.5 Pro     | mimo-v2.5-pro     | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiMo V2.5         | mimo-v2.5         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Qwen3.5 Plus      | qwen3.5-plus      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro   | deepseek-v4-pro   | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash | deepseek-v4-flash | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
-| MiMo-V2-Pro       | mimo-v2-pro       | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
-| MiMo-V2-Omni      | mimo-v2-omni      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
-| MiMo-V2.5-Pro     | mimo-v2.5-pro     | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
-| MiMo-V2.5         | mimo-v2.5         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
-| MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
-| MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
-| Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/alibaba`           |
-| Qwen3.5 Plus      | qwen3.5-plus      | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/alibaba`           |
 
 The [model id](/docs/config/#models) in your OpenCode config
 uses the format `opencode-go/<model-id>`. For example, for Kimi K2.6, you would

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -62,49 +62,49 @@ You are charged per request and you can add credits to your account.
 
 You can also access our models through the following API endpoints.
 
-| Model                 | Model ID              | Endpoint                                           | AI SDK Package              |
-| --------------------- | --------------------- | -------------------------------------------------- | --------------------------- |
-| GPT 5.5               | gpt-5.5               | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.5 Pro           | gpt-5.5-pro           | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.4               | gpt-5.4               | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.4 Pro           | gpt-5.4-pro           | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.4 Mini          | gpt-5.4-mini          | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.4 Nano          | gpt-5.4-nano          | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.3 Codex         | gpt-5.3-codex         | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.3 Codex Spark   | gpt-5.3-codex-spark   | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.2               | gpt-5.2               | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.2 Codex         | gpt-5.2-codex         | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.1               | gpt-5.1               | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.1 Codex         | gpt-5.1-codex         | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.1 Codex Max     | gpt-5.1-codex-max     | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5.1 Codex Mini    | gpt-5.1-codex-mini    | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5                 | gpt-5                 | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5 Codex           | gpt-5-codex           | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| GPT 5 Nano            | gpt-5-nano            | `https://opencode.ai/zen/v1/responses`             | `@ai-sdk/openai`            |
-| Claude Opus 4.7       | claude-opus-4-7       | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Opus 4.6       | claude-opus-4-6       | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Opus 4.5       | claude-opus-4-5       | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Opus 4.1       | claude-opus-4-1       | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Sonnet 4.6     | claude-sonnet-4-6     | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Sonnet 4.5     | claude-sonnet-4-5     | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Sonnet 4       | claude-sonnet-4       | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Haiku 4.5      | claude-haiku-4-5      | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Claude Haiku 3.5      | claude-3-5-haiku      | `https://opencode.ai/zen/v1/messages`              | `@ai-sdk/anthropic`         |
-| Gemini 3.1 Pro        | gemini-3.1-pro        | `https://opencode.ai/zen/v1/models/gemini-3.1-pro` | `@ai-sdk/google`            |
-| Gemini 3 Flash        | gemini-3-flash        | `https://opencode.ai/zen/v1/models/gemini-3-flash` | `@ai-sdk/google`            |
-| Qwen3.6 Plus          | qwen3.6-plus          | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.5 Plus          | qwen3.5-plus          | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| MiniMax M2.7          | minimax-m2.7          | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| MiniMax M2.5          | minimax-m2.5          | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| MiniMax M2.5 Free     | minimax-m2.5-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| GLM 5.1               | glm-5.1               | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| GLM 5                 | glm-5                 | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Kimi K2.5             | kimi-k2.5             | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Kimi K2.6             | kimi-k2.6             | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Ling 2.6 Flash        | ling-2.6-flash        | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Hy3 Preview Free      | hy3-preview-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
+| Model                  | Model ID                   | Endpoint                                      | AI SDK Package              |
+| ---------------------- | -------------------------- | --------------------------------------------- | --------------------------- |
+| GPT-5.5 Pro            | gpt-5.5-pro                | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.5                | gpt-5.5                    | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.4 Pro            | gpt-5.4-pro                | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.4                | gpt-5.4                    | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.4 Mini           | gpt-5.4-mini               | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.4 Nano           | gpt-5.4-nano               | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.3 Codex Spark    | gpt-5.3-codex-spark        | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.3 Codex          | gpt-5.3-codex              | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.2 Codex          | gpt-5.2-codex              | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.2                | gpt-5.2                    | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.1 Codex Max      | gpt-5.1-codex-max          | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.1 Codex Mini     | gpt-5.1-codex-mini         | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.1 Codex          | gpt-5.1-codex              | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5.1                | gpt-5.1                    | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5 Codex            | gpt-5-codex                | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5 Nano             | gpt-5-nano                 | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GPT-5                  | gpt-5                      | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Opus 4.7        | claude-opus-4-7            | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Opus 4.6        | claude-opus-4-6            | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Opus 4.5        | claude-opus-4-5            | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Opus 4.1        | claude-opus-4-1            | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Sonnet 4.6      | claude-sonnet-4-6          | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Sonnet 4.5      | claude-sonnet-4-5          | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Sonnet 4        | claude-sonnet-4            | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Claude Haiku 4.5       | claude-haiku-4-5           | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.1 Pro Preview | gemini-3.1-pro             | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3 Flash         | gemini-3-flash             | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Qwen3.6 Plus           | qwen3.6-plus               | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Qwen3.5 Plus           | qwen3.5-plus               | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiniMax M2.7           | minimax-m2.7               | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiniMax M2.5           | minimax-m2.5               | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| MiniMax M2.5 Free      | minimax-m2.5-free          | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GLM-5.1                | glm-5.1                    | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| GLM-5                  | glm-5                      | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Kimi K2.6              | kimi-k2.6                  | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Kimi K2.5              | kimi-k2.5                  | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Big Pickle             | big-pickle                 | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Trinity Large Preview  | trinity-large-preview-free | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Hy3 preview Free       | hy3-preview-free           | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Ling 2.6 Flash Free    | ling-2.6-flash-free        | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Nemotron 3 Super Free  | nemotron-3-super-free      | `https://opencode.ai/zen/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 
 The [model id](/docs/config/#models) in your OpenCode config
 uses the format `opencode/<model-id>`. For example, for GPT 5.5, you would
@@ -126,53 +126,54 @@ https://opencode.ai/zen/v1/models
 
 We support a pay-as-you-go model. Below are the prices **per 1M tokens**.
 
-| Model                             | Input  | Output  | Cached Read | Cached Write |
-| --------------------------------- | ------ | ------- | ----------- | ------------ |
-| Big Pickle                        | Free   | Free    | Free        | -            |
-| MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
-| Ling 2.6 Flash Free               | Free   | Free    | Free        | -            |
-| Hy3 Preview Free                  | Free   | Free    | Free        | -            |
-| Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
-| MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | $0.375       |
-| MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
-| GLM 5.1                           | $1.40  | $4.40   | $0.26       | -            |
-| GLM 5                             | $1.00  | $3.20   | $0.20       | -            |
-| Kimi K2.5                         | $0.60  | $3.00   | $0.10       | -            |
-| Kimi K2.6                         | $0.95  | $4.00   | $0.16       | -            |
-| Qwen3.6 Plus                      | $0.50  | $3.00   | $0.05       | $0.625       |
-| Qwen3.5 Plus                      | $0.20  | $1.20   | $0.02       | $0.25        |
-| Claude Opus 4.7                   | $5.00  | $25.00  | $0.50       | $6.25        |
-| Claude Opus 4.6                   | $5.00  | $25.00  | $0.50       | $6.25        |
-| Claude Opus 4.5                   | $5.00  | $25.00  | $0.50       | $6.25        |
-| Claude Opus 4.1                   | $15.00 | $75.00  | $1.50       | $18.75       |
-| Claude Sonnet 4.6                 | $3.00  | $15.00  | $0.30       | $3.75        |
-| Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
-| Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
-| Claude Sonnet 4 (≤ 200K tokens)   | $3.00  | $15.00  | $0.30       | $3.75        |
-| Claude Sonnet 4 (> 200K tokens)   | $6.00  | $22.50  | $0.60       | $7.50        |
-| Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
-| Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |
-| Gemini 3.1 Pro (> 200K tokens)    | $4.00  | $18.00  | $0.40       | -            |
-| Gemini 3 Flash                    | $0.50  | $3.00   | $0.05       | -            |
-| GPT 5.5 (≤ 272K tokens)           | $5.00  | $30.00  | $0.50       | -            |
-| GPT 5.5 (> 272K tokens)           | $10.00 | $45.00  | $1.00       | -            |
-| GPT 5.5 Pro                       | $30.00 | $180.00 | $30.00      | -            |
-| GPT 5.4 (≤ 272K tokens)           | $2.50  | $15.00  | $0.25       | -            |
-| GPT 5.4 (> 272K tokens)           | $5.00  | $22.50  | $0.50       | -            |
-| GPT 5.4 Pro                       | $30.00 | $180.00 | $30.00      | -            |
-| GPT 5.4 Mini                      | $0.75  | $4.50   | $0.075      | -            |
-| GPT 5.4 Nano                      | $0.20  | $1.25   | $0.02       | -            |
-| GPT 5.3 Codex Spark               | $1.75  | $14.00  | $0.175      | -            |
-| GPT 5.3 Codex                     | $1.75  | $14.00  | $0.175      | -            |
-| GPT 5.2                           | $1.75  | $14.00  | $0.175      | -            |
-| GPT 5.2 Codex                     | $1.75  | $14.00  | $0.175      | -            |
-| GPT 5.1                           | $1.07  | $8.50   | $0.107      | -            |
-| GPT 5.1 Codex                     | $1.07  | $8.50   | $0.107      | -            |
-| GPT 5.1 Codex Max                 | $1.25  | $10.00  | $0.125      | -            |
-| GPT 5.1 Codex Mini                | $0.25  | $2.00   | $0.025      | -            |
-| GPT 5                             | $1.07  | $8.50   | $0.107      | -            |
-| GPT 5 Codex                       | $1.07  | $8.50   | $0.107      | -            |
-| GPT 5 Nano                        | Free   | Free    | Free        | -            |
+| Model                                  |  Input |  Output | Cached Read | Cached Write |
+| -------------------------------------- | ------ | ------- | ----------- | ------------ |
+| GPT-5.5 Pro                            | $30.00 | $180.00 |      $30.00 |            - |
+| GPT-5.5                                |  $5.00 |  $30.00 |       $0.50 |            - |
+| GPT-5.5 (> 200K tokens)                | $10.00 |  $45.00 |       $1.00 |            - |
+| GPT-5.4 Pro                            | $30.00 | $180.00 |      $30.00 |            - |
+| GPT-5.4                                |  $2.50 |  $15.00 |       $0.25 |            - |
+| GPT-5.4 (> 200K tokens)                |  $5.00 |  $22.50 |       $0.50 |            - |
+| GPT-5.4 Mini                           |  $0.75 |   $4.50 |       $0.07 |            - |
+| GPT-5.4 Nano                           |  $0.20 |   $1.25 |       $0.02 |            - |
+| GPT-5.3 Codex Spark                    |  $1.75 |  $14.00 |       $0.17 |            - |
+| GPT-5.3 Codex                          |  $1.75 |  $14.00 |       $0.17 |            - |
+| GPT-5.2 Codex                          |  $1.75 |  $14.00 |       $0.17 |            - |
+| GPT-5.2                                |  $1.75 |  $14.00 |       $0.17 |            - |
+| GPT-5.1 Codex Max                      |  $1.25 |  $10.00 |       $0.12 |            - |
+| GPT-5.1 Codex Mini                     |  $0.25 |   $2.00 |       $0.03 |            - |
+| GPT-5.1 Codex                          |  $1.07 |   $8.50 |       $0.11 |            - |
+| GPT-5.1                                |  $1.07 |   $8.50 |       $0.11 |            - |
+| GPT-5 Codex                            |  $1.07 |   $8.50 |       $0.11 |            - |
+| GPT-5 Nano                             |   Free |    Free |        Free |            - |
+| GPT-5                                  |  $1.07 |   $8.50 |       $0.11 |            - |
+| Claude Opus 4.7                        |  $5.00 |  $25.00 |       $0.50 |        $6.25 |
+| Claude Opus 4.6                        |  $5.00 |  $25.00 |       $0.50 |        $6.25 |
+| Claude Opus 4.5                        |  $5.00 |  $25.00 |       $0.50 |        $6.25 |
+| Claude Opus 4.1                        | $15.00 |  $75.00 |       $1.50 |       $18.75 |
+| Claude Sonnet 4.6                      |  $3.00 |  $15.00 |       $0.30 |        $3.75 |
+| Claude Sonnet 4.5                      |  $3.00 |  $15.00 |       $0.30 |        $3.75 |
+| Claude Sonnet 4.5 (> 200K tokens)      |  $6.00 |  $22.50 |       $0.60 |        $7.50 |
+| Claude Sonnet 4                        |  $3.00 |  $15.00 |       $0.30 |        $3.75 |
+| Claude Sonnet 4 (> 200K tokens)        |  $6.00 |  $22.50 |       $0.60 |        $7.50 |
+| Claude Haiku 4.5                       |  $1.00 |   $5.00 |       $0.10 |        $1.25 |
+| Gemini 3.1 Pro Preview                 |  $2.00 |  $12.00 |       $0.20 |            - |
+| Gemini 3.1 Pro Preview (> 200K tokens) |  $4.00 |  $18.00 |       $0.40 |            - |
+| Gemini 3 Flash                         |  $0.50 |   $3.00 |       $0.05 |            - |
+| Qwen3.6 Plus                           |  $0.50 |   $3.00 |       $0.05 |        $0.62 |
+| Qwen3.5 Plus                           |  $0.20 |   $1.20 |       $0.02 |        $0.25 |
+| MiniMax M2.7                           |  $0.30 |   $1.20 |       $0.06 |            - |
+| MiniMax M2.5                           |  $0.30 |   $1.20 |       $0.06 |            - |
+| MiniMax M2.5 Free                      |   Free |    Free |        Free |            - |
+| GLM-5.1                                |  $1.40 |   $4.40 |       $0.26 |            - |
+| GLM-5                                  |  $1.00 |   $3.20 |       $0.20 |            - |
+| Kimi K2.6                              |  $0.95 |   $4.00 |       $0.16 |            - |
+| Kimi K2.5                              |  $0.60 |   $3.00 |       $0.08 |            - |
+| Big Pickle                             |   Free |    Free |        Free |         Free |
+| Trinity Large Preview                  |   Free |    Free |           - |            - |
+| Hy3 preview Free                       |   Free |    Free |        Free |            - |
+| Ling 2.6 Flash Free                    |   Free |    Free |           - |            - |
+| Nemotron 3 Super Free                  |   Free |    Free |        Free |            - |
 
 You might notice _Claude Haiku 3.5_ in your usage history. This is a [low cost model](/docs/config/#models) that's used to generate the titles of your sessions.
 
@@ -182,11 +183,12 @@ Credit card fees are passed along at cost (4.4% + $0.30 per transaction); we don
 
 The free models:
 
+- Big Pickle is a stealth model that's free on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - MiniMax M2.5 Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Ling 2.6 Flash Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
-- Hy3 Preview Flash Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
+- Hy3 Preview Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Nemotron 3 Super Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
-- Big Pickle is a stealth model that's free on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
+- Trinity Large Preview is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 
 <a href={email}>Contact us</a> if you have any questions.
 
@@ -242,6 +244,7 @@ All our models are hosted in the US. Our providers follow a zero-retention polic
 - Ling 2.6 Flash Free: During its free period, collected data may be used to improve the model.
 - Hy3 Preview Free: During its free period, collected data may be used to improve the model.
 - Nemotron 3 Super Free (NVIDIA free endpoints): Provided under the [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Trial use only — not for production or sensitive data. Prompts and outputs are logged by NVIDIA to improve its models and services. Do not submit personal or confidential data.
+- Trinity Large Preview: During its free period, collected data may be used to improve the model.
 - OpenAI APIs: Requests are retained for 30 days in accordance with [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Requests are retained for 30 days in accordance with [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
 


### PR DESCRIPTION
### Issue for this PR

Closes #24723

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

https://opencode.ai/docs/go/#usage-limits and https://opencode.ai/docs/zen/#pricing are not up to date with models.dev data; values for Kimi K2.6 are currently especially wrong (not updated after https://github.com/anomalyco/models.dev/commit/aa30ce3ef23512d1c7642d55a565302a37337295)

This PR regenerates those tables based off of latest prices

It also updates some of the notices for correctness

### How did you verify your code works?

N/A, docs not code

### Screenshots / recordings

N/A, docs not ui

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
