### PR TITLE
feat: `opencode session move` / `session detached`

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -180,6 +180,22 @@ async function resolveProjectId(dir: string): Promise<string | undefined> {
     .toSorted()[0]
 }
 
+async function checkDetached(
+  dir: string,
+  sessions: Session.Info[],
+): Promise<(Session.Info & { detachReason: string })[]> {
+  if (!existsSync(dir)) return sessions.map((s) => ({ ...s, detachReason: "directory does not exist" }))
+  const stat = Filesystem.stat(dir)
+  if (!stat?.isDirectory()) return sessions.map((s) => ({ ...s, detachReason: "path is not a directory" }))
+  const correctId = (await resolveProjectId(dir)) ?? "global"
+  return sessions
+    .filter((s) => s.projectID !== correctId)
+    .map((s) => ({
+      ...s,
+      detachReason: `project_id ${s.projectID} != expected ${correctId}`,
+    }))
+}
+
 export const SessionDetachedCommand = cmd({
   command: "detached",
   describe: "find sessions with missing directories or mismatched project IDs",
@@ -199,36 +215,9 @@ export const SessionDetachedCommand = cmd({
         list.push(s)
         byDir.set(s.directory, list)
       }
-      const detached: (Session.Info & { detachReason: string })[] = []
-      const validDirs = new Map<string, Session.Info[]>()
-      for (const [dir, dirSessions] of byDir) {
-        if (!existsSync(dir)) {
-          for (const s of dirSessions) detached.push({ ...s, detachReason: "directory does not exist" })
-          continue
-        }
-        const stat = Filesystem.stat(dir)
-        if (!stat?.isDirectory()) {
-          for (const s of dirSessions) detached.push({ ...s, detachReason: "path is not a directory" })
-          continue
-        }
-        validDirs.set(dir, dirSessions)
-      }
-      const projectIds = new Map(
-        await Promise.all(
-          [...validDirs.keys()].map(async (dir) => [dir, (await resolveProjectId(dir)) ?? "global"] as const),
-        ),
-      )
-      for (const [dir, dirSessions] of validDirs) {
-        const correctId = projectIds.get(dir)!
-        for (const s of dirSessions) {
-          if (s.projectID !== correctId) {
-            detached.push({
-              ...s,
-              detachReason: `project_id ${s.projectID} != expected ${correctId}`,
-            })
-          }
-        }
-      }
+      const detached = (
+        await Promise.all([...byDir].map(([dir, dirSessions]) => checkDetached(dir, dirSessions)))
+      ).flat()
       if (detached.length === 0) return
       if (args.format === "json") {
         const jsonData = detached.map((s) => ({

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -2,6 +2,7 @@ import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { Session } from "@/session/session"
 import { SessionID } from "../../session/schema"
+import { ProjectID } from "@/project/schema"
 import { bootstrap } from "../bootstrap"
 import { UI } from "../ui"
 import { Locale } from "@/util/locale"
@@ -143,7 +144,7 @@ export const SessionMoveCommand = cmd({
               : eq(SessionTable.directory, Filesystem.resolve(dir))
           })()
         : undefined
-      const fromProject = args.fromProject ? eq(SessionTable.project_id, args.fromProject) : undefined
+      const fromProject = args.fromProject ? eq(SessionTable.project_id, ProjectID.make(args.fromProject)) : undefined
       const where = and(fromId, fromDir, fromProject)
       const set: Record<string, string> = {}
       if (args.toDirectory && args.toDirectory !== "keep") set.directory = Filesystem.resolve(args.toDirectory)
@@ -226,37 +227,26 @@ export const SessionDetachedCommand = cmd({
         (s): s is Session.Info & { detachReason: string } => s !== undefined,
       )
       if (detached.length === 0) return
-      if (args.format === "json") {
-        const jsonData = detached.map((s) => ({
-          id: s.id,
-          title: s.title,
-          updated: s.time.updated,
-          created: s.time.created,
-          projectId: s.projectID,
-          directory: s.directory,
-          detachReason: s.detachReason,
-        }))
-        console.log(JSON.stringify(jsonData, null, 2))
-        return
-      }
-      const maxIdWidth = Math.max(20, ...detached.map((s) => s.id.length))
-      const maxReasonWidth = Math.max(12, ...detached.map((s) => s.detachReason.length))
-      const header = `Session ID${" ".repeat(maxIdWidth - 10)}  Reason${" ".repeat(maxReasonWidth - 6)}  Directory`
-      console.log(header)
-      console.log("─".repeat(header.length))
-      for (const s of detached) {
-        console.log(`${s.id.padEnd(maxIdWidth)}  ${s.detachReason.padEnd(maxReasonWidth)}  ${s.directory}`)
-      }
+      await printSessions(detached, args, [{ header: "Reason", value: (s) => s.detachReason! }])
     })
   },
 })
 
-async function printSessions(sessions: Session.Info[], args: { format?: string; maxCount?: number }) {
+type ExtraColumn = {
+  header: string
+  value: (s: Session.Info & { detachReason?: string }) => string
+}
+
+async function printSessions(
+  sessions: (Session.Info & { detachReason?: string })[],
+  args: { format?: string; maxCount?: number },
+  extras: ExtraColumn[] = [],
+) {
   let output: string
   if (args.format === "json") {
-    output = formatSessionJSON(sessions)
+    output = formatSessionJSON(sessions, extras)
   } else {
-    output = formatSessionTable(sessions)
+    output = formatSessionTable(sessions, extras)
   }
   await paginate(output, { paginate: process.stdout.isTTY && !args.maxCount && args.format === "table" })
 }
@@ -311,33 +301,46 @@ export const SessionListCommand = cmd({
   },
 })
 
-function formatSessionTable(sessions: Session.Info[]): string {
+function formatSessionTable(
+  sessions: (Session.Info & { detachReason?: string })[],
+  extras: ExtraColumn[] = [],
+): string {
   const lines: string[] = []
 
   const maxIdWidth = Math.max(20, ...sessions.map((s) => s.id.length))
   const maxTitleWidth = Math.max(25, ...sessions.map((s) => s.title.length))
+  const extraWidths = extras.map((col) => ({
+    ...col,
+    width: Math.max(col.header.length, ...sessions.map((s) => col.value(s).length)),
+  }))
 
-  const header = `Session ID${" ".repeat(maxIdWidth - 10)}  Title${" ".repeat(maxTitleWidth - 5)}  Updated`
+  let header = `Session ID${" ".repeat(maxIdWidth - 10)}  Title${" ".repeat(maxTitleWidth - 5)}  Updated`
+  for (const col of extraWidths) header += `  ${col.header.padEnd(col.width)}`
   lines.push(header)
   lines.push("─".repeat(header.length))
   for (const session of sessions) {
     const truncatedTitle = Locale.truncate(session.title, maxTitleWidth)
     const timeStr = Locale.todayTimeOrDateTime(session.time.updated)
-    const line = `${session.id.padEnd(maxIdWidth)}  ${truncatedTitle.padEnd(maxTitleWidth)}  ${timeStr}`
+    let line = `${session.id.padEnd(maxIdWidth)}  ${truncatedTitle.padEnd(maxTitleWidth)}  ${timeStr}`
+    for (const col of extraWidths) line += `  ${col.value(session).padEnd(col.width)}`
     lines.push(line)
   }
 
   return lines.join(EOL)
 }
 
-function formatSessionJSON(sessions: Session.Info[]): string {
-  const jsonData = sessions.map((session) => ({
-    id: session.id,
-    title: session.title,
-    updated: session.time.updated,
-    created: session.time.created,
-    projectId: session.projectID,
-    directory: session.directory,
-  }))
+function formatSessionJSON(sessions: (Session.Info & { detachReason?: string })[], extras: ExtraColumn[] = []): string {
+  const jsonData = sessions.map((session) => {
+    const base: Record<string, unknown> = {
+      id: session.id,
+      title: session.title,
+      updated: session.time.updated,
+      created: session.time.created,
+      projectId: session.projectID,
+      directory: session.directory,
+    }
+    for (const col of extras) base[col.header] = col.value(session)
+    return base
+  })
   return JSON.stringify(jsonData, null, 2)
 }

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -8,6 +8,9 @@ import { Locale } from "@/util/locale"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
+import { Database } from "@/storage/db"
+import { SessionTable } from "@/session/session.sql"
+import { eq, and, inArray } from "drizzle-orm"
 import { EOL } from "os"
 import path from "path"
 import { which } from "../../util/which"
@@ -43,7 +46,8 @@ function pagerCmd(): string[] {
 export const SessionCommand = cmd({
   command: "session",
   describe: "manage sessions",
-  builder: (yargs: Argv) => yargs.command(SessionListCommand).command(SessionDeleteCommand).demandCommand(),
+  builder: (yargs: Argv) =>
+    yargs.command(SessionListCommand).command(SessionDeleteCommand).command(SessionMoveCommand).demandCommand(),
   async handler() {},
 })
 
@@ -68,6 +72,52 @@ export const SessionDeleteCommand = cmd({
       }
       await AppRuntime.runPromise(Session.Service.use((svc) => svc.remove(sessionID)))
       UI.println(UI.Style.TEXT_SUCCESS_BOLD + `Session ${args.sessionID} deleted` + UI.Style.TEXT_NORMAL)
+    })
+  },
+})
+
+export const SessionMoveCommand = cmd({
+  command: "move",
+  describe: "move sessions to a different project/directory",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("from-id", {
+        describe: "session ID to move (can be specified multiple times)",
+        type: "string",
+        array: true,
+        demandOption: true,
+      })
+      .option("directory", {
+        describe: "new directory for the sessions",
+        type: "string",
+      })
+      .option("project", {
+        describe: "new project ID for the sessions",
+        type: "string",
+      }),
+  handler: async (args) => {
+    if (!args.directory && !args.project) {
+      UI.error("At least one of --directory or --project is required")
+      process.exit(1)
+    }
+    await bootstrap(process.cwd(), async () => {
+      const ids = args.id.map((id) => SessionID.make(id))
+      const set: Record<string, string> = {}
+      if (args.directory) set.directory = Filesystem.resolve(args.directory)
+      if (args.project) set.project_id = args.project
+      const result = Database.use((db) =>
+        db.update(SessionTable).set(set).where(inArray(SessionTable.id, ids)).returning().all(),
+      )
+      if (result.length === 0) {
+        UI.error("No sessions found matching the given IDs")
+        process.exit(1)
+      }
+      for (const row of result) {
+        const parts: string[] = [`moved ${row.id}`]
+        if (args.directory) parts.push(`directory=${row.directory}`)
+        if (args.project) parts.push(`project=${row.project_id}`)
+        UI.println(UI.Style.TEXT_SUCCESS_BOLD + parts.join(" ") + UI.Style.TEXT_NORMAL)
+      }
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -10,7 +10,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 import { Database } from "@/storage/db"
 import { SessionTable } from "@/session/session.sql"
-import { eq, and, inArray } from "drizzle-orm"
+import { eq, and, inArray, type SQL } from "drizzle-orm"
 import { EOL } from "os"
 import path from "path"
 import { which } from "../../util/which"
@@ -85,7 +85,10 @@ export const SessionMoveCommand = cmd({
         describe: "session ID to move (can be specified multiple times)",
         type: "string",
         array: true,
-        demandOption: true,
+      })
+      .option("from-dir", {
+        describe: "move all sessions matching this directory ('cwd' for current working directory)",
+        type: "string",
       })
       .option("directory", {
         describe: "new directory for the sessions",
@@ -100,16 +103,33 @@ export const SessionMoveCommand = cmd({
       UI.error("At least one of --directory or --project is required")
       process.exit(1)
     }
+    if (!args.id?.length && !args.fromDir) {
+      UI.error("At least one of --id or --from-dir is required")
+      process.exit(1)
+    }
     await bootstrap(process.cwd(), async () => {
-      const ids = args.id.map((id) => SessionID.make(id))
+      const conditions: SQL[] = []
+      if (args.id?.length) {
+        const ids = args.id.map((id) => SessionID.make(id))
+        conditions.push(inArray(SessionTable.id, ids))
+      }
+      if (args.fromDir) {
+        const dir = args.fromDir === "cwd" ? process.cwd() : Filesystem.resolve(args.fromDir)
+        conditions.push(eq(SessionTable.directory, dir))
+      }
       const set: Record<string, string> = {}
       if (args.directory) set.directory = Filesystem.resolve(args.directory)
       if (args.project) set.project_id = args.project
       const result = Database.use((db) =>
-        db.update(SessionTable).set(set).where(inArray(SessionTable.id, ids)).returning().all(),
+        db
+          .update(SessionTable)
+          .set(set)
+          .where(conditions.length === 1 ? conditions[0] : and(...conditions))
+          .returning()
+          .all(),
       )
       if (result.length === 0) {
-        UI.error("No sessions found matching the given IDs")
+        UI.error("No sessions found matching the given criteria")
         process.exit(1)
       }
       for (const row of result) {

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -194,17 +194,6 @@ async function resolveDir(dir: string): Promise<DirResult> {
 
 type DirResult = { reason: string } | { projectID: string }
 
-function createMemo<T, U>(fn: (arg: T) => Promise<U>): (arg: T) => Promise<U> {
-  const cache = new Map<T, Promise<U>>()
-  return (arg: T) => {
-    let promise = cache.get(arg)
-    if (promise) return promise
-    promise = fn(arg)
-    cache.set(arg, promise)
-    return promise
-  }
-}
-
 export const SessionDetachedCommand = cmd({
   command: "detached",
   describe: "find sessions with missing directories or mismatched project IDs",
@@ -218,24 +207,24 @@ export const SessionDetachedCommand = cmd({
   handler: async (args) => {
     await bootstrap(process.cwd(), async () => {
       const sessions = Database.use((db) => db.select().from(SessionTable).all()).map(Session.fromRow)
-      const memoResolve = createMemo(resolveDir)
-      const dirResults = new Map(
-        await Promise.all(
-          [...new Set(sessions.map((s) => s.directory))].map(async (dir) => [dir, await memoResolve(dir)] as const),
-        ),
-      )
-      const detached: (Session.Info & { detachReason: string })[] = []
-      for (const s of sessions) {
-        const result = dirResults.get(s.directory)!
-        if ("reason" in result) {
-          detached.push({ ...s, detachReason: result.reason })
-        } else if (s.projectID !== result.projectID) {
-          detached.push({
-            ...s,
-            detachReason: `project_id ${s.projectID} != expected ${result.projectID}`,
-          })
-        }
+      const cache = new Map<string, Promise<DirResult>>()
+      const resolve = (dir: string) => {
+        let promise = cache.get(dir)
+        if (promise) return promise
+        promise = resolveDir(dir)
+        cache.set(dir, promise)
+        return promise
       }
+      const checks = sessions.map(async (s) => {
+        const result = await resolve(s.directory)
+        if ("reason" in result) return { ...s, detachReason: result.reason }
+        if (s.projectID !== result.projectID)
+          return { ...s, detachReason: `project_id ${s.projectID} != expected ${result.projectID}` }
+        return undefined
+      })
+      const detached = (await Promise.all(checks)).filter(
+        (s): s is Session.Info & { detachReason: string } => s !== undefined,
+      )
       if (detached.length === 0) return
       if (args.format === "json") {
         const jsonData = detached.map((s) => ({

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -174,8 +174,9 @@ async function resolveDir(dir: string): Promise<DirResult> {
   }
   if (!st.isDirectory()) return { reason: "path is not a directory" }
   const gitText = (args: string[]) => Process.text(["git", ...args], { cwd: dir, nothrow: true })
-  const commonDir = (await gitText(["rev-parse", "--git-common-dir"])).text.trim()
-  if (commonDir) {
+  const commonDirRaw = (await gitText(["rev-parse", "--git-common-dir"])).text.trim()
+  const commonDir = path.resolve(dir, commonDirRaw)
+  if (commonDirRaw) {
     const cached = path.join(commonDir, "opencode")
     try {
       return { projectID: (await readFile(cached, "utf-8")).trim() }

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -200,7 +200,7 @@ export const SessionDetachedCommand = cmd({
         byDir.set(s.directory, list)
       }
       const detached: (Session.Info & { detachReason: string })[] = []
-      const projectIdCache = new Map<string, string | undefined>()
+      const validDirs = new Map<string, Session.Info[]>()
       for (const [dir, dirSessions] of byDir) {
         if (!existsSync(dir)) {
           for (const s of dirSessions) detached.push({ ...s, detachReason: "directory does not exist" })
@@ -211,11 +211,15 @@ export const SessionDetachedCommand = cmd({
           for (const s of dirSessions) detached.push({ ...s, detachReason: "path is not a directory" })
           continue
         }
-        let correctId = projectIdCache.get(dir)
-        if (!projectIdCache.has(dir)) {
-          correctId = (await resolveProjectId(dir)) ?? "global"
-          projectIdCache.set(dir, correctId)
-        }
+        validDirs.set(dir, dirSessions)
+      }
+      const projectIds = new Map(
+        await Promise.all(
+          [...validDirs.keys()].map(async (dir) => [dir, (await resolveProjectId(dir)) ?? "global"] as const),
+        ),
+      )
+      for (const [dir, dirSessions] of validDirs) {
+        const correctId = projectIds.get(dir)!
         for (const s of dirSessions) {
           if (s.projectID !== correctId) {
             detached.push({

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -11,6 +11,8 @@ import { Process } from "@/util/process"
 import { Database } from "@/storage/db"
 import { SessionTable } from "@/session/session.sql"
 import { eq, and, inArray, type SQL } from "drizzle-orm"
+import { Instance } from "@/project/instance"
+import * as Log from "@opencode-ai/core/util/log"
 import { EOL } from "os"
 import path from "path"
 import { which } from "../../util/which"
@@ -90,19 +92,15 @@ export const SessionMoveCommand = cmd({
         describe: "move all sessions matching this directory ('cwd' for current working directory)",
         type: "string",
       })
-      .option("directory", {
-        describe: "new directory for the sessions",
+      .option("to-directory", {
+        describe: "new directory for the sessions (default: current project root)",
         type: "string",
       })
-      .option("project", {
-        describe: "new project ID for the sessions",
+      .option("to-project", {
+        describe: "new project ID for the sessions (default: current project ID)",
         type: "string",
       }),
   handler: async (args) => {
-    if (!args.directory && !args.project) {
-      UI.error("At least one of --directory or --project is required")
-      process.exit(1)
-    }
     if (!args.id?.length && !args.fromDir) {
       UI.error("At least one of --id or --from-dir is required")
       process.exit(1)
@@ -118,8 +116,8 @@ export const SessionMoveCommand = cmd({
         conditions.push(eq(SessionTable.directory, dir))
       }
       const set: Record<string, string> = {}
-      if (args.directory) set.directory = Filesystem.resolve(args.directory)
-      if (args.project) set.project_id = args.project
+      set.directory = args.toDirectory ? Filesystem.resolve(args.toDirectory) : Instance.worktree
+      set.project_id = args.toProject ?? Instance.project.id
       const result = Database.use((db) =>
         db
           .update(SessionTable)
@@ -133,10 +131,11 @@ export const SessionMoveCommand = cmd({
         process.exit(1)
       }
       for (const row of result) {
-        const parts: string[] = [`moved ${row.id}`]
-        if (args.directory) parts.push(`directory=${row.directory}`)
-        if (args.project) parts.push(`project=${row.project_id}`)
-        UI.println(UI.Style.TEXT_SUCCESS_BOLD + parts.join(" ") + UI.Style.TEXT_NORMAL)
+        UI.println(
+          UI.Style.TEXT_SUCCESS_BOLD +
+            `moved ${row.id} directory=${row.directory} project=${row.project_id}` +
+            UI.Style.TEXT_NORMAL,
+        )
       }
     })
   },

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -18,6 +18,8 @@ import path from "path"
 import { which } from "../../util/which"
 import { AppRuntime } from "@/effect/app-runtime"
 
+const log = Log.create({ service: "command-session" })
+
 function pagerCmd(): string[] {
   const lessOptions = ["-R", "-S"]
   if (process.platform !== "win32") {
@@ -99,44 +101,38 @@ export const SessionMoveCommand = cmd({
       .option("to-project", {
         describe: "new project ID for the sessions (default: current project ID)",
         type: "string",
+      })
+      .option("dry-run", {
+        describe: "print what would be done without making changes",
+        type: "boolean",
+        default: false,
+      })
+      .option("format", {
+        describe: "output format",
+        type: "string",
+        choices: ["table", "json"],
+        default: "table",
       }),
   handler: async (args) => {
-    if (!args.id?.length && !args.fromDir) {
-      UI.error("At least one of --id or --from-dir is required")
+    if (!args.fromId?.length && !args.fromDir) {
+      UI.error("At least one of --from-id or --from-dir is required")
       process.exit(1)
     }
     await bootstrap(process.cwd(), async () => {
       const conditions: SQL[] = []
-      if (args.id?.length) {
-        const ids = args.id.map((id) => SessionID.make(id))
-        conditions.push(inArray(SessionTable.id, ids))
+      if (args.fromId?.length) conditions.push(inArray(SessionTable.id, args.fromId.map((id) => SessionID.make(id))))
+      if (args.fromDir)
+        conditions.push(eq(SessionTable.directory, args.fromDir === "cwd" ? process.cwd() : Filesystem.resolve(args.fromDir)))
+      const where = conditions.length === 1 ? conditions[0] : and(...conditions)
+      const set: Record<string, string> = {
+        directory: args.toDirectory ? Filesystem.resolve(args.toDirectory) : Instance.worktree,
+        project_id: args.toProject ?? Instance.project.id,
       }
-      if (args.fromDir) {
-        const dir = args.fromDir === "cwd" ? process.cwd() : Filesystem.resolve(args.fromDir)
-        conditions.push(eq(SessionTable.directory, dir))
-      }
-      const set: Record<string, string> = {}
-      set.directory = args.toDirectory ? Filesystem.resolve(args.toDirectory) : Instance.worktree
-      set.project_id = args.toProject ?? Instance.project.id
-      const result = Database.use((db) =>
-        db
-          .update(SessionTable)
-          .set(set)
-          .where(conditions.length === 1 ? conditions[0] : and(...conditions))
-          .returning()
-          .all(),
-      )
-      if (result.length === 0) {
-        UI.error("No sessions found matching the given criteria")
-        process.exit(1)
-      }
-      for (const row of result) {
-        UI.println(
-          UI.Style.TEXT_SUCCESS_BOLD +
-            `moved ${row.id} directory=${row.directory} project=${row.project_id}` +
-            UI.Style.TEXT_NORMAL,
-        )
-      }
+      const before = Database.use((db) => db.select().from(SessionTable).where(where).all()).map(Session.fromRow)
+      if (before.length === 0) return
+      log.debug("session move parameters", { set })
+      if (!args.dryRun) Database.use((db) => db.update(SessionTable).set(set).where(where).run())
+      console.log(args.format === "json" ? formatSessionJSON(before) : formatSessionTable(before))
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -132,10 +132,40 @@ export const SessionMoveCommand = cmd({
       if (before.length === 0) return
       log.debug("session move parameters", { set })
       if (!args.dryRun) Database.use((db) => db.update(SessionTable).set(set).where(where).run())
-      console.log(args.format === "json" ? formatSessionJSON(before) : formatSessionTable(before))
+      await printSessions(before, args)
     })
   },
 })
+
+async function printSessions(sessions: Session.Info[], args: { format?: string; maxCount?: number }) {
+  let output: string
+  if (args.format === "json") {
+    output = formatSessionJSON(sessions)
+  } else {
+    output = formatSessionTable(sessions)
+  }
+  await paginate(output, { paginate: process.stdout.isTTY && !args.maxCount && args.format === "table" })
+}
+
+async function paginate(output: string, input?: { paginate?: boolean }) {
+  const shouldPaginate = input?.paginate ?? (process.stdout.isTTY && false)
+  if (!shouldPaginate) {
+    console.log(output)
+    return
+  }
+  const proc = Process.spawn(pagerCmd(), {
+    stdin: "pipe",
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+  if (!proc.stdin) {
+    console.log(output)
+    return
+  }
+  proc.stdin.write(output)
+  proc.stdin.end()
+  await proc.exited
+}
 
 export const SessionListCommand = cmd({
   command: "list",
@@ -162,33 +192,7 @@ export const SessionListCommand = cmd({
         return
       }
 
-      let output: string
-      if (args.format === "json") {
-        output = formatSessionJSON(sessions)
-      } else {
-        output = formatSessionTable(sessions)
-      }
-
-      const shouldPaginate = process.stdout.isTTY && !args.maxCount && args.format === "table"
-
-      if (shouldPaginate) {
-        const proc = Process.spawn(pagerCmd(), {
-          stdin: "pipe",
-          stdout: "inherit",
-          stderr: "inherit",
-        })
-
-        if (!proc.stdin) {
-          console.log(output)
-          return
-        }
-
-        proc.stdin.write(output)
-        proc.stdin.end()
-        await proc.exited
-      } else {
-        console.log(output)
-      }
+      await printSessions(sessions, args)
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -10,7 +10,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 import { Database } from "@/storage/db"
 import { SessionTable } from "@/session/session.sql"
-import { eq, and, inArray, type SQL } from "drizzle-orm"
+import { eq, and, inArray, like } from "drizzle-orm"
 import { Instance } from "@/project/instance"
 import * as Log from "@opencode-ai/core/util/log"
 import { EOL } from "os"
@@ -94,12 +94,16 @@ export const SessionMoveCommand = cmd({
         describe: "move all sessions matching this directory ('cwd' for current working directory)",
         type: "string",
       })
+      .option("from-project", {
+        describe: "move all sessions matching this project ID",
+        type: "string",
+      })
       .option("to-directory", {
-        describe: "new directory for the sessions (default: current project root)",
+        describe: "new directory for the sessions ('keep' to leave unchanged, default: current project root)",
         type: "string",
       })
       .option("to-project", {
-        describe: "new project ID for the sessions (default: current project ID)",
+        describe: "new project ID for the sessions ('keep' to leave unchanged, default: current project ID)",
         type: "string",
       })
       .option("dry-run", {
@@ -119,15 +123,27 @@ export const SessionMoveCommand = cmd({
       process.exit(1)
     }
     await bootstrap(process.cwd(), async () => {
-      const conditions: SQL[] = []
-      if (args.fromId?.length) conditions.push(inArray(SessionTable.id, args.fromId.map((id) => SessionID.make(id))))
-      if (args.fromDir)
-        conditions.push(eq(SessionTable.directory, args.fromDir === "cwd" ? process.cwd() : Filesystem.resolve(args.fromDir)))
-      const where = conditions.length === 1 ? conditions[0] : and(...conditions)
-      const set: Record<string, string> = {
-        directory: args.toDirectory ? Filesystem.resolve(args.toDirectory) : Instance.worktree,
-        project_id: args.toProject ?? Instance.project.id,
-      }
+      const fromId = args.fromId?.length
+        ? inArray(
+            SessionTable.id,
+            args.fromId.map((id) => SessionID.make(id)),
+          )
+        : undefined
+      const fromDir = args.fromDir
+        ? (() => {
+            const dir = args.fromDir === "cwd" ? process.cwd() : args.fromDir
+            return dir.includes("*") || dir.includes("?")
+              ? like(SessionTable.directory, dir.replace(/\*/g, "%").replace(/\?/g, "_"))
+              : eq(SessionTable.directory, Filesystem.resolve(dir))
+          })()
+        : undefined
+      const fromProject = args.fromProject ? eq(SessionTable.project_id, args.fromProject) : undefined
+      const where = and(fromId, fromDir, fromProject)
+      const set: Record<string, string> = {}
+      if (args.toDirectory && args.toDirectory !== "keep") set.directory = Filesystem.resolve(args.toDirectory)
+      else if (args.toDirectory !== "keep") set.directory = Instance.worktree
+      if (args.toProject && args.toProject !== "keep") set.project_id = args.toProject
+      else if (args.toProject !== "keep") set.project_id = Instance.project.id
       const before = Database.use((db) => db.select().from(SessionTable).where(where).all()).map(Session.fromRow)
       if (before.length === 0) return
       log.debug("session move parameters", { set })

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -17,7 +17,7 @@ import { EOL } from "os"
 import path from "path"
 import { which } from "../../util/which"
 import { AppRuntime } from "@/effect/app-runtime"
-import { existsSync, readFileSync } from "fs"
+import { stat, readFile } from "fs/promises"
 
 const log = Log.create({ service: "command-session" })
 
@@ -159,41 +159,50 @@ export const SessionMoveCommand = cmd({
   },
 })
 
-async function resolveProjectId(dir: string): Promise<string | undefined> {
-  const gitText = async (args: string[]) => {
-    const proc = Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" })
-    const exitCode = await proc.exited
-    if (exitCode !== 0) return undefined
-    return await new Response(proc.stdout).text().then((t) => t.trim())
+async function resolveDir(dir: string): Promise<DirResult> {
+  let st
+  try {
+    st = await stat(dir)
+  } catch (e) {
+    if (e instanceof Error && "code" in e && typeof e.code === "string") {
+      if (e.code === "ENOENT") return { reason: "directory does not exist" }
+      if (e.code === "EACCES") return { reason: "permission denied" }
+      if (e.code === "ENOTDIR") return { reason: "not a directory" }
+    }
+    return { reason: "cannot access directory" }
   }
-  const commonDir = await gitText(["rev-parse", "--git-common-dir"])
+  if (!st.isDirectory()) return { reason: "path is not a directory" }
+  const gitText = (args: string[]) => Process.text(["git", ...args], { cwd: dir, nothrow: true })
+  const commonDir = (await gitText(["rev-parse", "--git-common-dir"])).text.trim()
   if (commonDir) {
     const cached = path.join(commonDir, "opencode")
-    if (existsSync(cached)) return readFileSync(cached, "utf-8").trim()
+    try {
+      return { projectID: (await readFile(cached, "utf-8")).trim() }
+    } catch {}
   }
-  const revList = await gitText(["rev-list", "--max-parents=0", "HEAD"])
-  if (!revList) return undefined
-  return revList
-    .split("\n")
-    .filter(Boolean)
-    .map((x) => x.trim())
-    .toSorted()[0]
+  const revList = (await gitText(["rev-list", "--max-parents=0", "HEAD"])).text.trim()
+  if (!revList) return { projectID: "global" }
+  return {
+    projectID:
+      revList
+        .split("\n")
+        .filter(Boolean)
+        .map((x) => x.trim())
+        .toSorted()[0] ?? "global",
+  }
 }
 
-async function checkDetached(
-  dir: string,
-  sessions: Session.Info[],
-): Promise<(Session.Info & { detachReason: string })[]> {
-  if (!existsSync(dir)) return sessions.map((s) => ({ ...s, detachReason: "directory does not exist" }))
-  const stat = Filesystem.stat(dir)
-  if (!stat?.isDirectory()) return sessions.map((s) => ({ ...s, detachReason: "path is not a directory" }))
-  const correctId = (await resolveProjectId(dir)) ?? "global"
-  return sessions
-    .filter((s) => s.projectID !== correctId)
-    .map((s) => ({
-      ...s,
-      detachReason: `project_id ${s.projectID} != expected ${correctId}`,
-    }))
+type DirResult = { reason: string } | { projectID: string }
+
+function createMemo<T, U>(fn: (arg: T) => Promise<U>): (arg: T) => Promise<U> {
+  const cache = new Map<T, Promise<U>>()
+  return (arg: T) => {
+    let promise = cache.get(arg)
+    if (promise) return promise
+    promise = fn(arg)
+    cache.set(arg, promise)
+    return promise
+  }
 }
 
 export const SessionDetachedCommand = cmd({
@@ -209,15 +218,24 @@ export const SessionDetachedCommand = cmd({
   handler: async (args) => {
     await bootstrap(process.cwd(), async () => {
       const sessions = Database.use((db) => db.select().from(SessionTable).all()).map(Session.fromRow)
-      const byDir = new Map<string, Session.Info[]>()
+      const memoResolve = createMemo(resolveDir)
+      const dirResults = new Map(
+        await Promise.all(
+          [...new Set(sessions.map((s) => s.directory))].map(async (dir) => [dir, await memoResolve(dir)] as const),
+        ),
+      )
+      const detached: (Session.Info & { detachReason: string })[] = []
       for (const s of sessions) {
-        const list = byDir.get(s.directory) ?? []
-        list.push(s)
-        byDir.set(s.directory, list)
+        const result = dirResults.get(s.directory)!
+        if ("reason" in result) {
+          detached.push({ ...s, detachReason: result.reason })
+        } else if (s.projectID !== result.projectID) {
+          detached.push({
+            ...s,
+            detachReason: `project_id ${s.projectID} != expected ${result.projectID}`,
+          })
+        }
       }
-      const detached = (
-        await Promise.all([...byDir].map(([dir, dirSessions]) => checkDetached(dir, dirSessions)))
-      ).flat()
       if (detached.length === 0) return
       if (args.format === "json") {
         const jsonData = detached.map((s) => ({

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -17,6 +17,7 @@ import { EOL } from "os"
 import path from "path"
 import { which } from "../../util/which"
 import { AppRuntime } from "@/effect/app-runtime"
+import { existsSync, readFileSync } from "fs"
 
 const log = Log.create({ service: "command-session" })
 
@@ -51,7 +52,12 @@ export const SessionCommand = cmd({
   command: "session",
   describe: "manage sessions",
   builder: (yargs: Argv) =>
-    yargs.command(SessionListCommand).command(SessionDeleteCommand).command(SessionMoveCommand).demandCommand(),
+    yargs
+      .command(SessionListCommand)
+      .command(SessionDeleteCommand)
+      .command(SessionMoveCommand)
+      .command(SessionDetachedCommand)
+      .demandCommand(),
   async handler() {},
 })
 
@@ -149,6 +155,98 @@ export const SessionMoveCommand = cmd({
       log.debug("session move parameters", { set })
       if (!args.dryRun) Database.use((db) => db.update(SessionTable).set(set).where(where).run())
       await printSessions(before, args)
+    })
+  },
+})
+
+async function resolveProjectId(dir: string): Promise<string | undefined> {
+  const gitText = async (args: string[]) => {
+    const proc = Bun.spawn(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" })
+    const exitCode = await proc.exited
+    if (exitCode !== 0) return undefined
+    return await new Response(proc.stdout).text().then((t) => t.trim())
+  }
+  const commonDir = await gitText(["rev-parse", "--git-common-dir"])
+  if (commonDir) {
+    const cached = path.join(commonDir, "opencode")
+    if (existsSync(cached)) return readFileSync(cached, "utf-8").trim()
+  }
+  const revList = await gitText(["rev-list", "--max-parents=0", "HEAD"])
+  if (!revList) return undefined
+  return revList
+    .split("\n")
+    .filter(Boolean)
+    .map((x) => x.trim())
+    .toSorted()[0]
+}
+
+export const SessionDetachedCommand = cmd({
+  command: "detached",
+  describe: "find sessions with missing directories or mismatched project IDs",
+  builder: (yargs: Argv) =>
+    yargs.option("format", {
+      describe: "output format",
+      type: "string",
+      choices: ["table", "json"],
+      default: "table",
+    }),
+  handler: async (args) => {
+    await bootstrap(process.cwd(), async () => {
+      const sessions = Database.use((db) => db.select().from(SessionTable).all()).map(Session.fromRow)
+      const byDir = new Map<string, Session.Info[]>()
+      for (const s of sessions) {
+        const list = byDir.get(s.directory) ?? []
+        list.push(s)
+        byDir.set(s.directory, list)
+      }
+      const detached: (Session.Info & { detachReason: string })[] = []
+      const projectIdCache = new Map<string, string | undefined>()
+      for (const [dir, dirSessions] of byDir) {
+        if (!existsSync(dir)) {
+          for (const s of dirSessions) detached.push({ ...s, detachReason: "directory does not exist" })
+          continue
+        }
+        const stat = Filesystem.stat(dir)
+        if (!stat?.isDirectory()) {
+          for (const s of dirSessions) detached.push({ ...s, detachReason: "path is not a directory" })
+          continue
+        }
+        let correctId = projectIdCache.get(dir)
+        if (!projectIdCache.has(dir)) {
+          correctId = (await resolveProjectId(dir)) ?? "global"
+          projectIdCache.set(dir, correctId)
+        }
+        for (const s of dirSessions) {
+          if (s.projectID !== correctId) {
+            detached.push({
+              ...s,
+              detachReason: `project_id ${s.projectID} != expected ${correctId}`,
+            })
+          }
+        }
+      }
+      if (detached.length === 0) return
+      if (args.format === "json") {
+        const jsonData = detached.map((s) => ({
+          id: s.id,
+          title: s.title,
+          updated: s.time.updated,
+          created: s.time.created,
+          projectId: s.projectID,
+          directory: s.directory,
+          detachReason: s.detachReason,
+        }))
+        console.log(JSON.stringify(jsonData, null, 2))
+        return
+      }
+      const maxIdWidth = Math.max(20, ...detached.map((s) => s.id.length))
+      const maxReasonWidth = Math.max(12, ...detached.map((s) => s.detachReason.length))
+      const header = `Session ID${" ".repeat(maxIdWidth - 10)}  Reason${" ".repeat(maxReasonWidth - 6)}  Directory`
+      console.log(header)
+      console.log("─".repeat(header.length))
+      for (const s of detached) {
+        console.log(`${s.id.padEnd(maxIdWidth)}  ${s.detachReason.padEnd(maxReasonWidth)}  ${s.directory}`)
+      }
     })
   },
 })


### PR DESCRIPTION
### Issue for this PR

Closes #23249 ~~#24708~~ by way of new `opencode session` commands 

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add `opencode session move` and `opencode session detached` to [`session.ts`]((https://github.com/rektide/opencode-session-move/blob/main/packages/opencode/src/cli/cmd/session.ts), to move sessions, and find sessions which are detached, respectively.

#### `move` notes

 - `--from-id` (multiple), `--from-dir` (supports `cwd`, glob */? wildcards), `--from-project` select sessions to move.
 - `--to-directory` / `--to-project` set new values. Default to current project root/ID, or use special value `keep` to leave untouched.
 - `--dry-run` to print matches without doing any changes
 
#### `detached`

- Resolves each session's directory independently, using src/util/process.ts
- Checks for a project directory, then resolves correct project_id via `.git/opencode` cache or `git rev-list`.

### How did you verify your code works?

I've been trying a variety of `move` flags to fix and rework a variety of my own detached sessions, testing locally for expected output. I've used `detached` to find detached sessions.

### Screenshots / recordings

Sample `detached` output, showing a variety of detached reasons:

```
Session ID                      Title                                                               Updated  Reason                                                                                                    Directory
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
ses_31647510affeyrDt9pbZZiLG3r  Fix autoStartConsumers casing in README.md                          1:01 AM · 3/14/2026  directory does not exist                                                                                  /home/rektide/src/nvim-termichatter
ses_2c962842cffe9WeWPx0PFKyhbP  Research AT Protocol XRPC lexicons (@internet-researcher subagent)  10:43 PM · 3/28/2026  project_id global != expected 6a6e9a29a86380313b983492428e93e0641b60ec                                    /home/rektide/src/atmost-storage                     >
s
ses_2aa46bf84ffedXSNTlydogfPkJ  Moving files to archive preserving VCS history                      12:07 AM · 4/4/2026  project_id 3e7947fa4edcba8122f4f8125e6f21a098fc4fd7 != expected bd8da28042e5e59e21c6f509fac243a584d4210b  /home/rektide/src/doc
```

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
