### PR TITLE
fix(app): preserve per-workspace icon override from localStorage

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -391,7 +391,14 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         ? globalSync.data.project.find((x) => x.id === projectID)
         : globalSync.data.project.find((x) => x.worktree === project.worktree)
 
-      return { ...metadata, ...project }
+      // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
+      // Without this, different subdirectories of the same git repo would share the same
+      // icon from the database instead of using their individual overrides.
+      const base = { ...metadata, ...project }
+      if (childStore.icon) {
+        return { ...base, icon: { ...base.icon, override: childStore.icon } }
+      }
+      return base
     }
 
     const roots = createMemo(() => {


### PR DESCRIPTION
Commit 6002500bc accidentally removed local icon override fallback from childStore.icon
when enriching project metadata. This caused different subdirectories of the same
git repo to share the same icon from the database instead of using their
individual overrides stored in per-workspace localStorage.