### PR TITLE
fix(app): persist project edit metadata

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -390,8 +390,11 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       const metadata = projectID
         ? globalSync.data.project.find((x) => x.id === projectID)
         : globalSync.data.project.find((x) => x.worktree === project.worktree)
+      const local = !metadata || metadata.id === "global" ? childStore.projectMeta : undefined
+      const icon = local?.icon ? { ...metadata?.icon, ...local.icon } : metadata?.icon
+      const commands = local?.commands ? { ...metadata?.commands, ...local.commands } : metadata?.commands
 
-      return { ...metadata, ...project }
+      return { ...metadata, ...local, ...project, icon, commands }
     }
 
     const roots = createMemo(() => {

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -30,24 +30,23 @@ export function Avatar(props: AvatarProps) {
     "classList",
     "style",
   ])
-  const src = split.src // did this so i can zero it out to test fallback
   return (
     <div
       {...rest}
       data-component="avatar"
       data-size={split.size || "normal"}
-      data-has-image={src ? "" : undefined}
+      data-has-image={split.src ? "" : undefined}
       classList={{
         ...split.classList,
         [split.class ?? ""]: !!split.class,
       }}
       style={{
         ...(typeof split.style === "object" ? split.style : {}),
-        ...(!src && split.background ? { "--avatar-bg": split.background } : {}),
-        ...(!src && split.foreground ? { "--avatar-fg": split.foreground } : {}),
+        ...(!split.src && split.background ? { "--avatar-bg": split.background } : {}),
+        ...(!split.src && split.foreground ? { "--avatar-fg": split.foreground } : {}),
       }}
     >
-      <Show when={src} fallback={first(split.fallback)}>
+      <Show when={split.src} fallback={first(split.fallback)}>
         {(src) => <img src={src()} draggable={false} data-slot="avatar-image" />}
       </Show>
     </div>


### PR DESCRIPTION
### Issue for this PR

Closes #24744

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
 - [ ] Documentation

### What does this PR do?

fixes an issue where project edits weren’t showing up in the sidebar for local and global projects.

the edit dialog was already saving local project metadata via globalSync.project.meta, but the sidebar was only pulling in metadata from the server. so for projects tied to the global project record, the locally saved changes (like name or icon) were basically ignored, and the old values kept showing even after saving.

this change makes sure childStore.projectMeta is merged into the displayed project when there’s no server metadata, or when the project is global.

also updates avatar to read src reactively instead of grabbing it once during render, so it can properly switch from fallback initials to an uploaded image.

### How did you verify your code works?

Tested locally with:

- `bun run dev:web` before and after the change
- local embedded binary built with `bun run script/build.ts --single --skip-install`

Also ran:

- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/ui`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR