### PR TITLE
fix(ui): remove redundant flex overrides in tool components

### DIFF
--- a/packages/ui/src/components/basic-tool.css
+++ b/packages/ui/src/components/basic-tool.css
@@ -11,17 +11,6 @@
     cursor: pointer;
   }
 
-  &[data-hide-details="true"] {
-    [data-slot="basic-tool-tool-trigger-content"] {
-      flex: 1 1 auto;
-      max-width: 100%;
-    }
-
-    [data-slot="basic-tool-tool-info"] {
-      flex: 1 1 auto;
-    }
-  }
-
   [data-slot="basic-tool-tool-trigger-content"] {
     flex: 0 1 auto;
     width: auto;

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -1207,7 +1207,6 @@
 
   [data-slot="apply-patch-filename"] {
     color: var(--text-strong);
-    flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
Removes redundant `flex` overrides in tool components to simplify layout:

- `basic-tool.css`: Removed `[data-hide-details="true"]` block that applied unnecessary flex rules to tool trigger content and tool info.
- `message-part.css`: Removed `flex: 1 1 auto` from `apply-patch-filename` to avoid unintended stretching.