### PR TITLE
fix: SSE stream hang causing run --format json to hang indefinitely

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1446,7 +1446,7 @@ const layer: Layer.Layer<
         if (existing) return existing
 
         const customFetch = options["fetch"]
-        const chunkTimeout = options["chunkTimeout"]
+        const chunkTimeout = options["chunkTimeout"] ?? 60_000
         delete options["chunkTimeout"]
 
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1115,6 +1115,15 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case e instanceof Error && e.message === "SSE read timed out":
+      return new APIError(
+        {
+          message: "SSE stream idle timeout",
+          isRetryable: true,
+          metadata: { code: "SSE_TIMEOUT", message: e.message },
+        },
+        { cause: e },
+      ).toObject()
     case (e as SystemError)?.code === "ECONNRESET":
       return new APIError(
         {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -230,6 +230,18 @@ describe("session.retry.retryable", () => {
     expect(retryable).toBeDefined()
     expect(retryable).toBe("Response decompression failed")
   })
+
+  test("retries SSE read timed out errors", () => {
+    const error = new MessageV2.APIError({
+      message: "SSE stream idle timeout",
+      isRetryable: true,
+      metadata: { code: "SSE_TIMEOUT", message: "SSE read timed out" },
+    }).toObject() as MessageV2.APIError
+
+    const retryable = SessionRetry.retryable(error)
+    expect(retryable).toBeDefined()
+    expect(retryable).toBe("SSE stream idle timeout")
+  })
 })
 
 describe("session.message-v2.fromError", () => {
@@ -315,5 +327,14 @@ describe("session.message-v2.fromError", () => {
     expect(MessageV2.APIError.isInstance(result)).toBe(true)
     expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
     expect(SessionRetry.retryable(result)).toBe("An error occurred while processing your request.")
+  })
+
+  test("maps SSE read timed out to retryable APIError", () => {
+    const error = new Error("SSE read timed out")
+    const result = MessageV2.fromError(error, { providerID }) as MessageV2.APIError
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect(result.data.isRetryable).toBe(true)
+    expect(result.data.message).toBe("SSE stream idle timeout")
+    expect(result.data.metadata?.code).toBe("SSE_TIMEOUT")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #8002

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the SSE connection to the LLM provider silently drops (no RST/FIN — common on satellite, mobile, or unstable networks), the `reader.read()` Promise in the fetch response body never resolves. Since no idle timeout was configured, the process hangs forever.

The root cause: `wrapSSE()` in `provider.ts` provides exactly this timeout protection, but it was never activated because `chunkTimeout` defaulted to `undefined` (no provider sets it in options).

Two changes:
1. **provider.ts**: Default `chunkTimeout` to 60s. Every SSE response now gets wrapped with an idle timer that aborts the reader if no data arrives within 60 seconds.
2. **message-v2.ts**: Map the `"SSE read timed out"` error to `APIError(isRetryable: true)` so the existing exponential-backoff retry kicks in (2s→4s→8s→16s→30s cap, retries until network recovers).

### How did you verify your code works?

- 25/25 unit tests pass (2 new test cases for `fromError` mapping and `retryable` classification)
- 35/35 end-to-end tests with `run --format json` executing real build tasks via GLM-5
- Verified retry mechanism by temporarily setting chunkTimeout to 2s: timeout fired in stderr, automatic retry succeeded, process completed normally
- Build tasks (HarmonyOS HAP) completed successfully through the retry-enabled pipeline

### Screenshots / recordings

N/A — backend-only change, no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
