### PR TITLE
fix(acp): accept https:// URIs in image content blocks

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1391,7 +1391,7 @@ export class Agent implements ACPAgent {
               filename,
               mime: part.mimeType,
             })
-          } else if (part.uri && part.uri.startsWith("http:")) {
+          } else if (part.uri && (part.uri.startsWith("http://") || part.uri.startsWith("https://"))) {
             parts.push({
               type: "file",
               url: part.uri,


### PR DESCRIPTION
## Problem

`packages/opencode/src/acp/agent.ts:1394` reads:

```ts
} else if (part.uri && part.uri.startsWith("http:")) {
```

This prefix check matches `http://...` URLs but **not** `https://...` URLs (`"http:"` is a literal 5-character prefix; `"https://..."` does not start with that exact substring because position 4 is `s` not `:`).

Every other URL check in the same codebase uses both prefixes:

| File | Pattern |
|------|---------|
| `packages/opencode/src/session/instruction.ts:146,168` | `startsWith("https://") \|\| startsWith("http://")` |
| `packages/opencode/src/cli/cmd/import.ts:98` | `startsWith("http://") \|\| startsWith("https://")` |
| `packages/opencode/src/tool/webfetch.ts:23` | `!startsWith("http://") && !startsWith("https://")` |
| `packages/opencode/src/config/config.ts:1270` | `startsWith("http://") \|\| startsWith("https://")` |

Only `acp/agent.ts:1394` is missing `https://`. It looks like a typo (probably meant to write `"http://"` but the second `/` was dropped).

## Reproducer

Send an ACP `session/prompt` request with an image content block whose `uri` is `https://`:

```json
{
  "type": "image",
  "uri": "https://storage.googleapis.com/bucket/img.png",
  "mimeType": "image/png"
}
```

**Expected**: image part is forwarded to the LLM provider as a `file` part.
**Actual**: the case falls through (no `parts.push`), and the image is silently dropped from the prompt — no error, no warning.

This is the most likely path for any ACP client doing two-stage uploads (e.g. signing a GCS or S3 URL and sending the URL rather than inlining base64), because cloud-storage signed URLs are always `https://`.

## Fix

One-line: align with the other 5 URL checks in this codebase by accepting both `http://` and `https://` prefixes explicitly.

```diff
-          } else if (part.uri && part.uri.startsWith("http:")) {
+          } else if (part.uri && (part.uri.startsWith("http://") || part.uri.startsWith("https://"))) {
```

## Tests

I haven't added a unit test in this PR because I couldn't find an existing test for the surrounding `case "image"` block that I could extend. Happy to add one if you'd like — point me at the right test file pattern.

## Out of scope

This is a typo fix — no behavior change for `http://` URIs or for inline-`data` blocks. No new dependencies.