### PR TITLE
feat(desktop): support remote electron server

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs"
 import { createServer } from "node:net"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { parseArgs } from "node:util"
 import type { Event } from "electron"
 import { app, BrowserWindow, dialog } from "electron"
 import pkg from "electron-updater"
@@ -63,6 +64,7 @@ const pendingDeepLinks: string[] = []
 
 const serverReady = defer<ServerReadyData>()
 const logger = initLogging()
+const remoteServerUrl = getRemoteServerUrl()
 
 logger.log("app starting", {
   version: app.getVersion(),
@@ -138,6 +140,25 @@ function setInitStep(step: InitStep) {
 }
 
 async function initialize() {
+  const overlay = remoteServerUrl ? initializeRemoteServer(remoteServerUrl) : await initializeSidecarServer()
+  mainWindow = createMainWindow()
+  wireMenu()
+  overlay?.close()
+}
+
+function initializeRemoteServer(url: string) {
+  logger.log("using remote server", { url })
+  serverReady.resolve({
+    url,
+    username: null,
+    password: null,
+    source: "remote",
+  })
+  setInitStep({ phase: "done" })
+  return null
+}
+
+async function initializeSidecarServer() {
   const needsMigration = !sqliteFileExists()
   const sqliteDone = needsMigration ? defer<void>() : undefined
   let overlay: BrowserWindow | null = null
@@ -181,6 +202,7 @@ async function initialize() {
       url,
       username: "opencode",
       password,
+      source: "sidecar",
     })
 
     await Promise.race([
@@ -210,10 +232,7 @@ async function initialize() {
     await loadingComplete.promise
   }
 
-  mainWindow = createMainWindow()
-  wireMenu()
-
-  overlay?.close()
+  return overlay
 }
 
 function wireMenu() {
@@ -290,6 +309,34 @@ function ensureLoopbackNoProxy() {
 
   upsert("NO_PROXY")
   upsert("no_proxy")
+}
+
+function getRemoteServerUrl() {
+  const parsed = parseLaunchArgs().values["server-url"]
+  const value = typeof parsed === "string" ? parsed : process.env.OPENCODE_DESKTOP_SERVER_URL
+  if (!value) return
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return
+    url.pathname = url.pathname.replace(/\/+$/, "")
+    return url.toString().replace(/\/$/, "")
+  } catch {
+    logger.warn("ignoring invalid --server-url", { value })
+  }
+}
+
+function parseLaunchArgs() {
+  return parseArgs({
+    args: process.argv.slice(1),
+    options: {
+      "server-url": {
+        type: "string",
+      },
+    },
+    strict: false,
+    allowPositionals: true,
+  })
 }
 
 async function getSidecarPort() {

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -110,6 +110,7 @@ export function createMainWindow() {
     const { responseHeaders = {} } = details
     upsertKeyValue(responseHeaders, "Access-Control-Allow-Origin", ["*"])
     upsertKeyValue(responseHeaders, "Access-Control-Allow-Headers", ["*"])
+    upsertKeyValue(responseHeaders, "Access-Control-Allow-Methods", ["GET, POST, PUT, PATCH, DELETE, OPTIONS"])
     callback({ responseHeaders })
   })
 

--- a/packages/desktop-electron/src/preload/types.ts
+++ b/packages/desktop-electron/src/preload/types.ts
@@ -4,6 +4,7 @@ export type ServerReadyData = {
   url: string
   username: string | null
   password: string | null
+  source: "sidecar" | "remote"
 }
 
 export type SqliteMigrationProgress = { type: "InProgress"; value: number } | { type: "Done" }

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -268,8 +268,7 @@ render(() => {
 
   const [windowCount] = createResource(() => window.api.getWindowCount())
 
-  // Fetch sidecar credentials (available immediately, before health check)
-  const [sidecar] = createResource(() => window.api.awaitInitialization(() => undefined))
+  const [launchServer] = createResource(() => window.api.awaitInitialization(() => undefined))
 
   const [defaultServer] = createResource(() =>
     platform.getDefaultServer?.().then((url) => {
@@ -279,8 +278,18 @@ render(() => {
   const [locale] = createResource(loadLocale)
 
   const servers = () => {
-    const data = sidecar()
+    const data = launchServer()
     if (!data) return []
+    if (data.source === "remote") {
+      return [
+        {
+          type: "http",
+          http: {
+            url: data.url,
+          },
+        },
+      ] as ServerConnection.Any[]
+    }
     const server: ServerConnection.Sidecar = {
       displayName: "Local Server",
       type: "sidecar",
@@ -333,7 +342,7 @@ render(() => {
         <Show
           when={
             !defaultServer.loading &&
-            !sidecar.loading &&
+            !launchServer.loading &&
             !windowConfig.loading &&
             !windowCount.loading &&
             !locale.loading
@@ -342,7 +351,11 @@ render(() => {
           {(_) => {
             return (
               <AppInterface
-                defaultServer={defaultServer.latest ?? ServerConnection.Key.make("sidecar")}
+                defaultServer={
+                  launchServer.latest?.source === "remote"
+                    ? ServerConnection.Key.make(launchServer.latest.url)
+                    : (defaultServer.latest ?? ServerConnection.Key.make("sidecar"))
+                }
                 servers={servers()}
                 router={MemoryRouter}
               >


### PR DESCRIPTION
## Summary
- Add a minimal Electron desktop launch mode for connecting to an existing opencode server via `--server-url`.
- Skip local sidecar startup and SQLite migration when a remote server URL is provided.
- Treat the launch server as a normal HTTP server in the renderer so local-only desktop actions stay disabled.

## Related
- Related to #8890
- Builds on the existing remote server switching behavior fixed in #17214

## Test plan
- `cd packages/desktop-electron && bun typecheck`
- `OPENCODE_DESKTOP_SERVER_URL=http://mediaserver:4096 bun dev`