### PR TITLE
fix(session): remap compaction tail_start_id when forking

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -608,6 +608,9 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
             id: PartID.ascending(),
             messageID: cloned.id,
             sessionID: session.id,
+            ...(part.type === "compaction" && part.tail_start_id
+              ? { tail_start_id: idMap.get(part.tail_start_id) }
+              : {}),
           })
         }
       }

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -29,6 +29,9 @@ const svc = {
   updatePart<T extends MessageV2.Part>(part: T) {
     return run(SessionNs.Service.use((svc) => svc.updatePart(part)))
   },
+  fork(input: { sessionID: SessionID; messageID?: MessageID }) {
+    return run(SessionNs.Service.use((svc) => svc.fork(input)))
+  },
 }
 
 async function fill(sessionID: SessionID, count: number, time = (i: number) => Date.now() + i) {
@@ -832,6 +835,71 @@ describe("MessageV2.filterCompacted", () => {
 
         expect(result.map((item) => item.info.id)).toEqual([u2, a2, c1, s1, u3, a3])
 
+        await svc.remove(session.id)
+      },
+    })
+  })
+
+  test("fork remaps compaction tail_start_id so filterCompacted matches parent", async () => {
+    await Instance.provide({
+      directory: root,
+      fn: async () => {
+        const session = await svc.create({})
+
+        const u1 = await addUser(session.id, "first")
+        const a1 = await addAssistant(session.id, u1, { finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: a1,
+          type: "text",
+          text: "first reply",
+        })
+
+        const u2 = await addUser(session.id, "second")
+        const a2 = await addAssistant(session.id, u2, { finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: a2,
+          type: "text",
+          text: "second reply",
+        })
+
+        const c1 = await addUser(session.id)
+        await addCompactionPart(session.id, c1, u2)
+        const s1 = await addAssistant(session.id, c1, { summary: true, finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: s1,
+          type: "text",
+          text: "summary",
+        })
+
+        const u3 = await addUser(session.id, "third")
+        const a3 = await addAssistant(session.id, u3, { finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: a3,
+          type: "text",
+          text: "third reply",
+        })
+
+        const parentFiltered = MessageV2.filterCompacted(MessageV2.stream(session.id))
+        expect(parentFiltered.map((item) => item.info.id)).toEqual([u2, a2, c1, s1, u3, a3])
+
+        const forked = await svc.fork({ sessionID: session.id })
+        const childFiltered = MessageV2.filterCompacted(MessageV2.stream(forked.id))
+        expect(childFiltered).toHaveLength(parentFiltered.length)
+
+        const tailPart = childFiltered.flatMap((m) => m.parts).find((p) => p.type === "compaction")
+        expect(tailPart?.type).toBe("compaction")
+        expect(tailPart.tail_start_id).toBeDefined()
+        expect(childFiltered.some((m) => m.info.id === tailPart.tail_start_id)).toBe(true)
+
+        await svc.remove(forked.id)
         await svc.remove(session.id)
       },
     })


### PR DESCRIPTION
## Problem
ForkSession copied messages and remapped assistant `parentID`, but `CompactionPart.tail_start_id` stayed on parent ids. `filterCompacted` then never hit the tail breakpoint and sent the full history → `context_length_exceeded` / huge prompts.

## Change
Remap `tail_start_id` through the same `idMap` used for `parentID` (undefined from `get` clears stale refs).

## Verification
`bun test packages/opencode/test/session/messages-pagination.test.ts -t "fork remaps"`

Fixes #24781

Made with [Cursor](https://cursor.com)