### PR TITLE
fix(opencode): prevent Warp Windows tab close on TUI exit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -67,11 +67,18 @@ import { FormatError, FormatUnknownError } from "@/cli/error"
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
 
+function useMainScreenMode() {
+  if (process.platform !== "win32") return false
+  if (process.env.TERM_PROGRAM?.toLowerCase().includes("warp")) return true
+  return process.env.WARP_IS_LOCAL_SHELL_SESSION !== undefined || process.env.WARP_SESSION_ID !== undefined
+}
+
 function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   const mouseEnabled = !Flag.OPENCODE_DISABLE_MOUSE && (_config.mouse ?? true)
 
   return {
     externalOutputMode: "passthrough",
+    screenMode: useMainScreenMode() ? "main-screen" : undefined,
     targetFps: 60,
     gatherStats: false,
     exitOnCtrlC: false,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1093,9 +1093,8 @@ export function Prompt(props: PromptProps) {
                 }
                 if (keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
-                    await exit()
-                    // Don't preventDefault - let textarea potentially handle the event
                     e.preventDefault()
+                    await exit()
                     return
                   }
                 }


### PR DESCRIPTION
### Issue for this PR

Closes #24790

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Warp on Windows closes the tab when the TUI exits from OpenTUI alternate-screen mode. This changes the TUI renderer to use main-screen mode only for Warp on Windows, while keeping the existing renderer behavior for other terminals. It also consumes the app-exit key before tearing down the prompt so Ctrl+D does not leak to the shell after exit.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/opencode`.
- Ran `bun run script/build.ts --single --skip-install --skip-embed-web-ui` from `packages/opencode`.
- Manually tested the built Windows binary in Warp with `/exit` and Ctrl+D.

### Screenshots / recordings

Not included. This is terminal exit behavior; manual verification confirmed the Warp tab now stays open and returns to the shell.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR