### PR TITLE
docs: bump GitHub stars count to 150K

### DIFF
--- a/packages/console/app/src/config.ts
+++ b/packages/console/app/src/config.ts
@@ -9,8 +9,8 @@ export const config = {
   github: {
     repoUrl: "https://github.com/anomalyco/opencode",
     starsFormatted: {
-      compact: "140K",
-      full: "140,000",
+      compact: "150K",
+      full: "150,000",
     },
   },
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The GitHub stars count displayed in the website nav was showing 140K but the repo has now crossed 150K stars. This PR updates the hardcoded compact and full stars values in `packages/console/app/src/config.ts` so the nav reflects the current milestone.

### How did you verify your code works?

Visually confirmed the nav now displays `GitHub [150K]` instead of `[140K]`.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR