### PR TITLE
fix(cli): ensure EOL at end of help messages

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -58,12 +58,9 @@ const args = hideBin(process.argv)
 
 function show(out: string) {
   const text = out.trimStart()
-  if (!text.startsWith("opencode ")) {
-    process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text)
-    return
-  }
-  process.stderr.write(out)
+  const output = text.startsWith("opencode ") ? out : UI.logo() + EOL + EOL + text
+  process.stderr.write(output)
+  if (!output.endsWith("\n")) process.stderr.write(EOL)
 }
 
 const cli = yargs(args)


### PR DESCRIPTION
### Issue for this PR

Closes #22115
Closes #24804
Probably also replaces #22125 (which has lots of other unrelated changes)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds EOL to help messages 

### How did you verify your code works?

`bun dev --help`
`bun dev stats --help`

### Screenshots / recordings

Compare these with #24804 screenshots

`bun dev --help`

<img width="2426" height="966" alt="image" src="https://github.com/user-attachments/assets/5bf75e5a-7c2f-450b-b0cf-282981842ef8" />

(includes final `--agent` line)

`bun dev stats --help`

<img width="2441" height="854" alt="image" src="https://github.com/user-attachments/assets/fa2f4434-d0c4-46cd-85d8-b15e8d92c5f4" />

(includes final `--project` line)


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
