### PR TITLE
fix(httpapi): align request body openapi shape

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -26,12 +26,30 @@ type OpenApiParameter = {
 
 type OpenApiOperation = {
   parameters?: OpenApiParameter[]
+  requestBody?: {
+    required?: boolean
+    content?: Record<string, { schema?: OpenApiSchema }>
+  }
 }
 
 type OpenApiPathItem = Partial<Record<"get" | "post" | "put" | "delete" | "patch", OpenApiOperation>>
 
 type OpenApiSpec = {
+  components?: {
+    schemas?: Record<string, OpenApiSchema>
+  }
   paths?: Record<string, OpenApiPathItem>
+}
+
+type OpenApiSchema = {
+  $ref?: string
+  additionalProperties?: OpenApiSchema | boolean
+  allOf?: OpenApiSchema[]
+  anyOf?: OpenApiSchema[]
+  items?: OpenApiSchema
+  oneOf?: OpenApiSchema[]
+  properties?: Record<string, OpenApiSchema>
+  type?: string
 }
 
 const InstanceQueryParameters = [
@@ -49,13 +67,28 @@ const InstanceQueryParameters = [
   },
 ] satisfies OpenApiParameter[]
 
-function documentInstanceQueryParameters(input: Record<string, unknown>) {
+const LegacyBodyRefParameters = new Set(["Auth", "Config", "Part", "WorktreeRemoveInput", "WorktreeResetInput"])
+
+function matchLegacyOpenApi(input: Record<string, unknown>) {
   const spec = input as OpenApiSpec
   for (const [path, item] of Object.entries(spec.paths ?? {})) {
-    if (path.startsWith("/global/") || path.startsWith("/auth/")) continue
+    const isInstanceRoute = !path.startsWith("/global/") && !path.startsWith("/auth/")
     for (const method of ["get", "post", "put", "delete", "patch"] as const) {
       const operation = item[method]
       if (!operation) continue
+      if (operation.requestBody) {
+        delete operation.requestBody.required
+        for (const media of Object.values(operation.requestBody.content ?? {})) {
+          const ref = media.schema?.$ref?.replace("#/components/schemas/", "")
+          if (ref && LegacyBodyRefParameters.has(ref)) continue
+          if (ref && spec.components?.schemas?.[ref]) {
+            media.schema = normalizeRequestSchema(structuredClone(spec.components.schemas[ref]))
+            continue
+          }
+          if (media.schema) media.schema = normalizeRequestSchema(media.schema)
+        }
+      }
+      if (!isInstanceRoute) continue
       operation.parameters = [
         ...InstanceQueryParameters,
         ...(operation.parameters ?? []).filter(
@@ -65,6 +98,29 @@ function documentInstanceQueryParameters(input: Record<string, unknown>) {
     }
   }
   return input
+}
+
+function normalizeRequestSchema(schema: OpenApiSchema): OpenApiSchema {
+  const options = schema.anyOf ?? schema.oneOf
+  if (options) {
+    const withoutNull = options.filter((item) => item.type !== "null")
+    const finite = withoutNull.find((item) => item.type === "number")
+    if (finite && withoutNull.every((item) => item.type === "number" || item.type === "string")) return finite
+    if (withoutNull.length === 1) return normalizeRequestSchema(withoutNull[0])
+    if (schema.anyOf) schema.anyOf = withoutNull.map(normalizeRequestSchema)
+    if (schema.oneOf) schema.oneOf = withoutNull.map(normalizeRequestSchema)
+  }
+  if (schema.allOf) schema.allOf = schema.allOf.map(normalizeRequestSchema)
+  if (schema.items) schema.items = normalizeRequestSchema(schema.items)
+  if (schema.properties) {
+    for (const [key, value] of Object.entries(schema.properties)) {
+      schema.properties[key] = normalizeRequestSchema(value)
+    }
+  }
+  if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+    schema.additionalProperties = normalizeRequestSchema(schema.additionalProperties)
+  }
+  return schema
 }
 
 export const PublicApi = HttpApi.make("opencode")
@@ -91,6 +147,6 @@ export const PublicApi = HttpApi.make("opencode")
       title: "opencode",
       version: "1.0.0",
       description: "opencode api",
-      transform: documentInstanceQueryParameters,
+      transform: matchLegacyOpenApi,
     }),
   )

--- a/packages/opencode/test/server/httpapi-bridge.test.ts
+++ b/packages/opencode/test/server/httpapi-bridge.test.ts
@@ -50,14 +50,41 @@ function openApiParameters(spec: { paths: Record<string, Partial<Record<(typeof 
   )
 }
 
+function openApiRequestBodies(spec: { paths: Record<string, Partial<Record<(typeof methods)[number], Operation>>> }) {
+  return Object.fromEntries(
+    Object.entries(spec.paths).flatMap(([path, item]) =>
+      methods
+        .filter((method) => item[method])
+        .map((method) => [`${method.toUpperCase()} ${path}`, requestBodyKey(item[method]?.requestBody)]),
+    ),
+  )
+}
+
 type Operation = {
   parameters?: unknown[]
+  requestBody?: unknown
+}
+
+type RequestBody = {
+  content?: Record<string, { schema?: { $ref?: string; type?: string } }>
+  required?: boolean
 }
 
 function parameterKey(param: unknown) {
   if (!param || typeof param !== "object" || !("in" in param) || !("name" in param)) return
   if (typeof param.in !== "string" || typeof param.name !== "string") return
   return `${param.in}:${param.name}:${"required" in param && param.required === true}`
+}
+
+function requestBodyKey(body: unknown) {
+  if (!body || typeof body !== "object" || !("content" in body)) return ""
+  const requestBody = body as RequestBody
+  return JSON.stringify({
+    required: requestBody.required === true,
+    content: Object.entries(requestBody.content ?? {})
+      .map(([type, value]) => [type, value.schema?.$ref ?? value.schema?.type ?? "inline"])
+      .sort(),
+  })
 }
 
 function authorization(username: string, password: string) {
@@ -96,6 +123,17 @@ describe("HttpApi server", () => {
     expect(
       Object.keys(hono)
         .filter((route) => JSON.stringify(hono[route]) !== JSON.stringify(effect[route]))
+        .map((route) => ({ route, hono: hono[route], effect: effect[route] })),
+    ).toEqual([])
+  })
+
+  test("matches generated OpenAPI request body shape", async () => {
+    const hono = openApiRequestBodies(await Server.openapi())
+    const effect = openApiRequestBodies(OpenApi.fromApi(PublicApi))
+
+    expect(
+      Object.keys(hono)
+        .filter((route) => hono[route] !== effect[route])
         .map((route) => ({ route, hono: hono[route], effect: effect[route] })),
     ).toEqual([])
   })


### PR DESCRIPTION
## Summary
- normalize Effect HttpApi request-body OpenAPI output to match legacy Hono SDK generation shape
- inline request-body refs where legacy flattened body fields, preserve refs where legacy generated named body params
- remove requestBody-level `required` and normalize nullable/finite-number wrappers in request schemas
- add focused OpenAPI request-body parity coverage

## Parity
- OpenAPI request-body required/ref mismatches reduced to `0`
- HttpApi-generated SDK method signature mismatches reduced from `43` to `15`

## Verification
- `bun typecheck`
- `bun run test:ci test/server/httpapi-bridge.test.ts`
- `./packages/sdk/js/script/build.ts` with default Hono source produced no generated diff