### PR TITLE
fix(npm): resolve cached package name from install dir for non-registry specs

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -186,16 +186,32 @@ export const layer = Layer.effect(
 
     const add = Effect.fn("Npm.add")(function* (pkg: string) {
       const dir = directory(pkg)
-      const name = (() => {
+      const npaName = (() => {
         try {
-          return npa(pkg).name ?? pkg
+          return npa(pkg).name ?? undefined
         } catch {
-          return pkg
+          return undefined
         }
       })()
 
       if (yield* afs.existsSafe(dir)) {
-        return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        // For non-registry specs (remote tarball URLs, git+https://, github:
+        // shorthand, file: paths), npa(pkg).name returns undefined — only
+        // registry packages have inferable names from the spec alone. Read
+        // the install-root package.json (written by Arborist on the initial
+        // install) to recover the actual installed package name from its
+        // first dependency entry, matching what the fresh-install path
+        // computes from the arborist tree below.
+        const cachedPkg = yield* afs.readJson(path.join(dir, "package.json")).pipe(Effect.option)
+        const installedName = (() => {
+          if (Option.isSome(cachedPkg)) {
+            const deps = (cachedPkg.value as { dependencies?: Record<string, unknown> })?.dependencies
+            const first = deps && Object.keys(deps)[0]
+            if (first) return first
+          }
+          return npaName ?? pkg
+        })()
+        return resolveEntryPoint(installedName, path.join(dir, "node_modules", installedName))
       }
 
       const tree = yield* reify({ dir, add: [pkg] })

--- a/packages/opencode/test/npm.test.ts
+++ b/packages/opencode/test/npm.test.ts
@@ -9,6 +9,7 @@ import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { Npm } from "@opencode-ai/core/npm"
 import { tmpdir } from "./fixture/fixture"
+import os from "os"
 
 const win = process.platform === "win32"
 const encoder = new TextEncoder()
@@ -139,5 +140,118 @@ describe("Npm.outdated", () => {
     expect(result).toBe(true)
     expect(calls).toContainEqual(["npm", "view", "example", "dist-tags.latest", "--json"])
     expect(calls).toContainEqual(["pnpm", "view", "example", "dist-tags.latest", "--json"])
+  })
+})
+
+describe("Npm.add cache fast-path", () => {
+  // Helper: build a layer where Global.cache points at the given dir.
+  // Other Global fields aren't read by Npm.add but Service.of requires them.
+  function cacheLayer(cacheDir: string) {
+    const tmp = os.tmpdir()
+    return Npm.layer.pipe(
+      Layer.provide(mockSpawner()),
+      Layer.provide(EffectFlock.layer),
+      Layer.provide(AppFileSystem.layer),
+      Layer.provide(
+        Layer.succeed(
+          Global.Service,
+          Global.Service.of({
+            home: tmp,
+            data: tmp,
+            cache: cacheDir,
+            config: tmp,
+            state: tmp,
+            bin: tmp,
+            log: tmp,
+          }),
+        ),
+      ),
+      Layer.provide(NodeFileSystem.layer),
+    )
+  }
+
+  // Helper: simulate a populated cache install for `pkg` whose actual
+  // installed name is `installedName`. Mirrors what Arborist produces:
+  //   <cache>/packages/<sanitize(pkg)>/package.json     (declares dep)
+  //   <cache>/packages/<sanitize(pkg)>/node_modules/<installedName>/package.json
+  async function seedCache(cacheDir: string, pkg: string, installedName: string) {
+    const installRoot = path.join(cacheDir, "packages", Npm.sanitize(pkg))
+    const pkgDir = path.join(installRoot, "node_modules", installedName)
+    await fs.mkdir(pkgDir, { recursive: true })
+    await Bun.write(
+      path.join(installRoot, "package.json"),
+      JSON.stringify({ dependencies: { [installedName]: pkg } }),
+    )
+    await Bun.write(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: installedName, version: "1.0.0", main: "index.js" }),
+    )
+    await Bun.write(path.join(pkgDir, "index.js"), "module.exports = {}")
+    return { installRoot, pkgDir }
+  }
+
+  test("resolves remote tarball URL to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const url =
+      "https://github.com/sjawhar/opencode-anthropic-auth/releases/download/v0.4.2/sjawhar-opencode-anthropic-auth-0.4.2.tgz"
+    const installed = "@sjawhar/opencode-anthropic-auth"
+    const { pkgDir } = await seedCache(tmp.path, url, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(url)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves git+https spec to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "git+https://github.com/example/some-repo.git"
+    const installed = "@example/some-repo"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves github: shorthand to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "github:example/another-repo"
+    const installed = "another-repo"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves local tarball file: spec to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "file:/some/local/path/example-1.0.0.tgz"
+    const installed = "@example/local-pkg"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("still resolves registry packages correctly", async () => {
+    await using tmp = await tmpdir()
+    const spec = "prettier"
+    const { pkgDir } = await seedCache(tmp.path, spec, spec)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
   })
 })


### PR DESCRIPTION
## Summary

`Npm.add`'s cache fast-path fails to load any non-registry plugin/package on the second and subsequent runs. The fresh-install path works correctly; only the cached path is broken.

## Root cause

`packages/core/src/npm.ts:187-199` (current `dev`):

```ts
const add = Effect.fn("Npm.add")(function* (pkg: string) {
  const dir = directory(pkg)
  const name = (() => {
    try { return npa(pkg).name ?? pkg } catch { return pkg }
  })()

  if (yield* afs.existsSafe(dir)) {
    return resolveEntryPoint(name, path.join(dir, "node_modules", name))
  }

  const tree = yield* reify({ dir, add: [pkg] })
  const first = tree.edgesOut.values().next().value?.to
  if (!first) return yield* new InstallFailedError({ add: [pkg], dir })
  return resolveEntryPoint(first.name, first.path)
}, Effect.scoped)
```

For non-registry specs, `npa(pkg).name` returns `undefined`, so `name` falls back to the spec string itself:

| Spec | `npa(pkg).name` |
|---|---|
| `prettier` | `"prettier"` ✅ |
| `@scope/pkg@1.0.0` | `"@scope/pkg"` ✅ |
| `https://example.com/foo.tgz` | `undefined` ❌ |
| `git+https://github.com/x/y.git` | `undefined` ❌ |
| `github:owner/repo` | `undefined` ❌ |
| `file:./local.tgz` | `undefined` ❌ |

The cache fast-path then resolves `node_modules/<spec-string>/` which doesn't exist — the package is actually installed at `node_modules/<actualName>/` (e.g. `@sjawhar/opencode-anthropic-auth`).

The fresh-install path doesn't have this issue because it uses `tree.edgesOut.values().next().value.to.{name,path}`, which Arborist provides correctly.

## Reproduction

```bash
# Configure opencode with a remote tarball plugin URL
echo '{"plugin": ["https://github.com/sjawhar/opencode-anthropic-auth/releases/download/v0.4.2/sjawhar-opencode-anthropic-auth-0.4.2.tgz"]}' > ~/.config/opencode/opencode.json

# First run installs cleanly via fresh-install path
opencode run --model anthropic/claude-haiku-4-5 'OK'  # ✅ works

# Second run hits cache fast-path, fails
opencode run --model anthropic/claude-haiku-4-5 'OK'
# ERROR service=plugin error=ENOENT: no such file or directory, open
#   '<cache>/node_modules/https:/github.com/sjawhar/.../v0.4.2/package.json'
#   failed to resolve plugin server entry
```

## Fix

Read the install-root `package.json` (written by Arborist on the initial install) to recover the actual installed package name from its first `dependencies` entry. Same source `Npm.install` already reads on lines 247-275 to detect dirty installs.

Fallback chain: install-root `package.json` first dep → `npa(pkg).name` → spec string (preserves backward compat for the unforeseen case where `package.json` is missing or has no deps).

The fresh-install path is unchanged.

## Tests

`packages/opencode/test/npm.test.ts` gains a new `describe("Npm.add cache fast-path", ...)` block with 5 tests covering each non-registry spec type plus a registry-package regression check:

- ✅ `https://` remote tarball URL
- ✅ `git+https://` git URL  
- ✅ `github:owner/repo` shorthand
- ✅ `file:` local tarball path
- ✅ registry package (regression test)

Each test seeds a synthetic populated cache (mimicking what Arborist writes after a successful install) and asserts `Npm.add(spec).directory` resolves to `<cache>/<sanitized>/node_modules/<actualPkgName>/` rather than the broken `<cache>/<sanitized>/node_modules/<spec>/`.

Without the fix, 4/5 new tests fail (the 4 non-registry cases). With the fix, all 5 pass plus all 6 pre-existing tests in the file.

```
$ bun test packages/opencode/test/npm.test.ts
 11 pass
 0 fail
 17 expect() calls
```

Typecheck clean. Full `packages/core` test suite (72 tests) green.

## Why now

This bug is latent in main but only surfaces for non-registry specs. With the recent push toward more flexible plugin sources (remote tarballs, git URLs), users hitting the cache fast-path on a second run see silent plugin-load failures.