### PR TITLE
fix(npm): resolve cached package name from install dir for non-registry specs

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -112,22 +112,39 @@ export const layer = Layer.effect(
 
     const add = Effect.fn("Npm.add")(function* (pkg: string) {
       const dir = directory(pkg)
-      const name = (() => {
+      const npaName = (() => {
         try {
-          return npa(pkg).name ?? pkg
+          return npa(pkg).name ?? undefined
         } catch {
-          return pkg
+          return undefined
         }
       })()
 
-      if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
-        return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+      if (yield* afs.existsSafe(dir)) {
+        // For non-registry specs (remote tarball URLs, git+https://, github:
+        // shorthand, file: paths), npa(pkg).name returns undefined — only
+        // registry packages have inferable names from the spec alone. Read
+        // the install-root package.json (written by Arborist on the initial
+        // install) to recover the actual installed package name from its
+        // first dependency entry, matching what the fresh-install path
+        // computes from the arborist tree below.
+        const cachedPkg = yield* afs.readJson(path.join(dir, "package.json")).pipe(Effect.option)
+        const installedName = (() => {
+          if (Option.isSome(cachedPkg)) {
+            const deps = (cachedPkg.value as { dependencies?: Record<string, unknown> })?.dependencies
+            const first = deps && Object.keys(deps)[0]
+            if (first) return first
+          }
+          return npaName ?? pkg
+        })()
+        return resolveEntryPoint(installedName, path.join(dir, "node_modules", installedName))
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
       const first = tree.edgesOut.values().next().value?.to
       if (!first) {
-        const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        const fallbackName = npaName ?? pkg
+        const result = resolveEntryPoint(fallbackName, path.join(dir, "node_modules", fallbackName))
         if (Option.isSome(result.entrypoint)) return result
         return yield* new InstallFailedError({ add: [pkg], dir })
       }

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -1,12 +1,14 @@
 import fs from "fs/promises"
+import os from "os"
 import path from "path"
 import { describe, expect, test } from "bun:test"
-import { NodeFileSystem } from "@effect/platform-node"
 import { Effect, Layer, Option } from "effect"
+import { NodeFileSystem } from "@effect/platform-node"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Global } from "@opencode-ai/core/global"
-import { Npm } from "@opencode-ai/core/npm"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Npm } from "@opencode-ai/core/npm"
 import { tmpdir } from "./fixture/tmpdir"
 
 const win = process.platform === "win32"
@@ -87,5 +89,118 @@ describe("Npm.install", () => {
 
     await expect(fs.stat(path.join(tmp.path, "node_modules", "prod-pkg"))).resolves.toBeDefined()
     await expect(fs.stat(path.join(tmp.path, "node_modules", "dev-pkg"))).rejects.toThrow()
+  })
+})
+
+describe("Npm.add cache fast-path", () => {
+  // Build a layer where Global.cache points at the given dir.
+  // Other Global fields aren't read by Npm.add but Service.of requires them.
+  function cacheLayer(cacheDir: string) {
+    const tmp = os.tmpdir()
+    return Npm.layer.pipe(
+      Layer.provide(EffectFlock.layer),
+      Layer.provide(AppFileSystem.layer),
+      Layer.provide(
+        Layer.succeed(
+          Global.Service,
+          Global.Service.of({
+            home: tmp,
+            data: tmp,
+            cache: cacheDir,
+            config: tmp,
+            state: tmp,
+            bin: tmp,
+            log: tmp,
+            tmp,
+          }),
+        ),
+      ),
+      Layer.provide(NodeFileSystem.layer),
+      Layer.provide(CrossSpawnSpawner.defaultLayer),
+    )
+  }
+
+  // Simulate a populated cache install for `pkg` whose actual installed
+  // package name is `installedName`. Mirrors what Arborist produces:
+  //   <cache>/packages/<sanitize(pkg)>/package.json     (declares dep)
+  //   <cache>/packages/<sanitize(pkg)>/node_modules/<installedName>/package.json
+  async function seedCache(cacheDir: string, pkg: string, installedName: string) {
+    const installRoot = path.join(cacheDir, "packages", Npm.sanitize(pkg))
+    const pkgDir = path.join(installRoot, "node_modules", installedName)
+    await fs.mkdir(pkgDir, { recursive: true })
+    await Bun.write(
+      path.join(installRoot, "package.json"),
+      JSON.stringify({ dependencies: { [installedName]: pkg } }),
+    )
+    await Bun.write(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: installedName, version: "1.0.0", main: "index.js" }),
+    )
+    await Bun.write(path.join(pkgDir, "index.js"), "module.exports = {}")
+    return { installRoot, pkgDir }
+  }
+
+  test("resolves remote tarball URL to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const url = "https://example.com/releases/v1.0.0/example-pkg-1.0.0.tgz"
+    const installed = "@example/scoped-pkg"
+    const { pkgDir } = await seedCache(tmp.path, url, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(url)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves git+https spec to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "git+https://github.com/example/some-repo.git"
+    const installed = "@example/some-repo"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves github: shorthand to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "github:example/another-repo"
+    const installed = "another-repo"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves local tarball file: spec to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "file:/some/local/path/example-1.0.0.tgz"
+    const installed = "@example/local-pkg"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("still resolves registry packages correctly", async () => {
+    await using tmp = await tmpdir()
+    const spec = "prettier"
+    const { pkgDir } = await seedCache(tmp.path, spec, spec)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #24828

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the `Npm.add` cache fast-path so it resolves non-registry specs to their actual installed directory instead of a path derived from the spec string.

The cache fast-path was reading the package name from `npa(pkg).name`. That works for registry specs like `@scope/pkg@1.0.0`, but for `https://`, `git+https://`, `github:owner/repo`, and `file:` specs `npa(pkg).name` returns `undefined`, so `name` falls back to the full spec string and the resulting `<dir>/node_modules/<spec>/` path doesn't exist.

The fix: read the install-root `package.json` (which Arborist writes during the fresh-install path) and recover the actual name from its first `dependencies` entry. This is the same source `Npm.install` already reads on lines 247-275 to detect dirty installs.

Fallback chain: install-root `package.json` first dep → `npa(pkg).name` → spec string. The third level preserves backward compat for the unlikely case where `package.json` is missing or has no deps.

The fresh-install path is unchanged — it's correct and continues to use `tree.edgesOut`.

### How did you verify your code works?

Added 5 tests in `packages/core/test/npm.test.ts` covering each spec type. Each test seeds a synthetic populated cache (mimicking a previous successful install) and asserts `Npm.add(spec).directory` resolves through the install dir to the actual package, not the broken spec-string path.

- https remote tarball
- git+https URL
- github shorthand
- file: local tarball
- registry package (regression check)

Without the fix, the four non-registry tests fail. With the fix, all five pass.

End-to-end tested against a production opencode setup that uses a private GitHub release tarball as a plugin: previously the cache fast-path returned a non-existent path on every run after the first, now it resolves correctly.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR