### PR TITLE
feat(opencode): show model provider quota in prompt metrics

### DIFF
--- a/packages/console/resource/resource.node.ts
+++ b/packages/console/resource/resource.node.ts
@@ -34,7 +34,9 @@ export const Resource = new Proxy(
                   keys: Array.isArray(k) ? k : [k],
                   account_id: accountId,
                 })
-                .then((result) => (isMulti ? new Map(Object.entries(result?.values ?? {})) : result?.values?.[k]))
+                .then((result: Awaited<ReturnType<typeof client.kv.namespaces.bulkGet>>) =>
+                  isMulti ? new Map(Object.entries(result?.values ?? {})) : result?.values?.[k],
+                )
             },
             put: (k: string, v: string, opts?: KVNamespacePutOptions) =>
               client.kv.namespaces.values.update(namespaceId, k, {
@@ -54,7 +56,7 @@ export const Resource = new Proxy(
                   account_id: accountId,
                   prefix: opts?.prefix ?? undefined,
                 })
-                .then((result) => {
+                .then((result: Awaited<ReturnType<typeof client.kv.namespaces.keys.list>>) => {
                   return {
                     keys: result.result,
                     list_complete: true,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -20,7 +20,7 @@ import { usePromptStash } from "./stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
 import { useCommandDialog } from "../dialog-command"
-import { useRenderer, type JSX } from "@opentui/solid"
+import { useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
@@ -37,6 +37,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { formatCodexQuotaMetrics } from "./metrics"
 
 export type PromptProps = {
   sessionID?: string
@@ -91,6 +92,7 @@ export function Prompt(props: PromptProps) {
   const stash = usePromptStash()
   const command = useCommandDialog()
   const renderer = useRenderer()
+  const terminal = useTerminalDimensions()
   const { theme, syntax } = useTheme()
   const kv = useKV()
   const list = createMemo(() => props.placeholders?.normal ?? [])
@@ -159,6 +161,14 @@ export function Prompt(props: PromptProps) {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
       cost: cost > 0 ? money.format(cost) : undefined,
     }
+  })
+  const quota = createMemo(() => {
+    return formatCodexQuotaMetrics(sync.data.console_state.codexQuota, terminal().width)
+  })
+  const metrics = createMemo(() => {
+    const parts = [usage()?.context, quota(), usage()?.cost].filter((part): part is string => Boolean(part))
+    if (parts.length === 0) return
+    return parts.join(" · ")
   })
 
   const [store, setStore] = createStore<{
@@ -1231,10 +1241,10 @@ export function Prompt(props: PromptProps) {
               <Switch>
                 <Match when={store.mode === "normal"}>
                   <Switch>
-                    <Match when={usage()}>
+                    <Match when={metrics()}>
                       {(item) => (
                         <text fg={theme.textMuted} wrapMode="none">
-                          {[item().context, item().cost].filter(Boolean).join(" · ")}
+                          {item()}
                         </text>
                       )}
                     </Match>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/metrics.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/metrics.ts
@@ -3,22 +3,24 @@ import type { ConsoleState } from "@/config/console-state"
 type CodexQuotaSnapshot = NonNullable<ConsoleState["codexQuota"]>
 type CodexQuotaWindow = NonNullable<CodexQuotaSnapshot["fiveHour"]>
 
-type CodexQuotaTimestampMode = "full" | "short"
-
 type CodexQuotaLayout = {
   barWidth?: number
-  timestamp?: CodexQuotaTimestampMode
+  timestamp?: boolean
 }
 
-export function formatCodexQuotaFetchedAt(timestamp: number, mode: CodexQuotaTimestampMode = "full") {
+export function formatCodexQuotaFetchedAt(timestamp: number, now = Date.now()) {
   const date = new Date(timestamp)
   if (Number.isNaN(date.valueOf())) return
 
   const pad = (value: number) => value.toString().padStart(2, "0")
   const time = `${pad(date.getHours())}h${pad(date.getMinutes())}m${pad(date.getSeconds())}s`
-  if (mode === "short") return time
+  const dateStart = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+  const nowDate = new Date(now)
+  const nowStart = new Date(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate()).getTime()
+  const daysAgo = Math.max(0, Math.floor((nowStart - dateStart) / 86_400_000))
+  const day = daysAgo === 0 ? "today" : daysAgo === 1 ? "yesterday" : `${daysAgo}d ago`
 
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${time}`
+  return `${day}@${time}`
 }
 
 export function clampPercent(value: number) {
@@ -39,20 +41,21 @@ function formatQuotaWindow(label: "5h" | "wk", item: CodexQuotaWindow, barWidth?
 }
 
 function codexQuotaLayout(width: number): CodexQuotaLayout {
-  if (width >= 200) return { barWidth: 10, timestamp: "full" }
-  if (width >= 120) return { barWidth: 5, timestamp: "short" }
-  if (width >= 90) return { timestamp: "short" }
+  if (width >= 200) return { barWidth: 10, timestamp: true }
+  if (width >= 120) return { barWidth: 5, timestamp: true }
+  if (width >= 90) return { timestamp: true }
   return {}
 }
 
-export function formatCodexQuotaMetrics(item: CodexQuotaSnapshot | undefined, terminalWidth: number) {
+export function formatCodexQuotaMetrics(item: CodexQuotaSnapshot | undefined, terminalWidth: number, now = Date.now()) {
   if (!item?.fiveHour && !item?.weekly) return
 
   const layout = codexQuotaLayout(terminalWidth)
+  const fetchedAt = item.fetchedAt !== undefined && layout.timestamp ? formatCodexQuotaFetchedAt(item.fetchedAt, now) : undefined
   const parts = [
     item.fiveHour ? formatQuotaWindow("5h", item.fiveHour, layout.barWidth) : undefined,
     item.weekly ? formatQuotaWindow("wk", item.weekly, layout.barWidth) : undefined,
-    item.fetchedAt && layout.timestamp ? `⟳${formatCodexQuotaFetchedAt(item.fetchedAt, layout.timestamp)}` : undefined,
+    fetchedAt ? `⟳ ${fetchedAt}` : undefined,
   ].filter((part): part is string => Boolean(part))
 
   if (parts.length === 0) return

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/metrics.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/metrics.ts
@@ -1,0 +1,60 @@
+import type { ConsoleState } from "@/config/console-state"
+
+type CodexQuotaSnapshot = NonNullable<ConsoleState["codexQuota"]>
+type CodexQuotaWindow = NonNullable<CodexQuotaSnapshot["fiveHour"]>
+
+type CodexQuotaTimestampMode = "full" | "short"
+
+type CodexQuotaLayout = {
+  barWidth?: number
+  timestamp?: CodexQuotaTimestampMode
+}
+
+export function formatCodexQuotaFetchedAt(timestamp: number, mode: CodexQuotaTimestampMode = "full") {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.valueOf())) return
+
+  const pad = (value: number) => value.toString().padStart(2, "0")
+  const time = `${pad(date.getHours())}h${pad(date.getMinutes())}m${pad(date.getSeconds())}s`
+  if (mode === "short") return time
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${time}`
+}
+
+export function clampPercent(value: number) {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+export function formatQuotaBar(percent: number, width: number) {
+  const columns = Math.max(0, Math.floor(width))
+  const filled = Math.round((clampPercent(percent) / 100) * columns)
+  return `${"█".repeat(filled)}${"░".repeat(columns - filled)}`
+}
+
+function formatQuotaWindow(label: "5h" | "wk", item: CodexQuotaWindow, barWidth?: number) {
+  const percent = clampPercent(item.remainingPercent)
+  if (barWidth === undefined) return `${label} ${percent}%`
+  return `${label} ${formatQuotaBar(percent, barWidth)} ${percent}%`
+}
+
+function codexQuotaLayout(width: number): CodexQuotaLayout {
+  if (width >= 200) return { barWidth: 10, timestamp: "full" }
+  if (width >= 120) return { barWidth: 5, timestamp: "short" }
+  if (width >= 90) return { timestamp: "short" }
+  return {}
+}
+
+export function formatCodexQuotaMetrics(item: CodexQuotaSnapshot | undefined, terminalWidth: number) {
+  if (!item?.fiveHour && !item?.weekly) return
+
+  const layout = codexQuotaLayout(terminalWidth)
+  const parts = [
+    item.fiveHour ? formatQuotaWindow("5h", item.fiveHour, layout.barWidth) : undefined,
+    item.weekly ? formatQuotaWindow("wk", item.weekly, layout.barWidth) : undefined,
+    item.fetchedAt && layout.timestamp ? `⟳${formatCodexQuotaFetchedAt(item.fetchedAt, layout.timestamp)}` : undefined,
+  ].filter((part): part is string => Boolean(part))
+
+  if (parts.length === 0) return
+  return `codex ${parts.join(" · ")}`
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -28,9 +28,11 @@ import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
-import { batch, createEffect, on } from "solid-js"
+import { batch, createEffect, on, onCleanup } from "solid-js"
 import { Log } from "@/util/log"
 import { ConsoleState, emptyConsoleState, type ConsoleState as ConsoleStateType } from "@/config/console-state"
+
+const CODEX_QUOTA_REFRESH_INTERVAL = 60 * 1000
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -110,6 +112,21 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const event = useEvent()
     const project = useProject()
     const sdk = useSDK()
+    let codexQuotaSyncWorkspace: string | null | undefined
+
+    async function syncCodexQuota(workspace = project.workspace.current()) {
+      const syncWorkspace = workspace ?? null
+      if (codexQuotaSyncWorkspace === syncWorkspace) return
+      codexQuotaSyncWorkspace = syncWorkspace
+      try {
+        const result = await sdk.client.experimental.console.codexQuota({ workspace })
+        if (!result.data) return
+        if (workspace !== project.workspace.current()) return
+        setStore("console_state", "codexQuota", reconcile(result.data))
+      } finally {
+        if (codexQuotaSyncWorkspace === syncWorkspace) codexQuotaSyncWorkspace = undefined
+      }
+    }
 
     async function syncWorkspaces() {
       const workspace = project.workspace.current()
@@ -427,6 +444,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         })
         .then(() => {
           if (store.status !== "complete") setStore("status", "partial")
+          void syncCodexQuota(workspace).catch(() => undefined)
           // non-blocking
           Promise.all([
             ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
@@ -465,6 +483,17 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         () => {
           fullSyncedSessions.clear()
           void bootstrap()
+        },
+      ),
+    )
+    createEffect(
+      on(
+        () => project.workspace.current(),
+        (workspace) => {
+          const interval = setInterval(() => {
+            void syncCodexQuota(workspace).catch(() => undefined)
+          }, CODEX_QUOTA_REFRESH_INTERVAL)
+          onCleanup(() => clearInterval(interval))
         },
       ),
     )

--- a/packages/opencode/src/config/console-state.ts
+++ b/packages/opencode/src/config/console-state.ts
@@ -1,9 +1,22 @@
 import z from "zod"
 
+export const ConsoleQuotaWindow = z.object({
+  remainingPercent: z.number().min(0).max(100),
+  resetSeconds: z.number().int().nonnegative().optional(),
+  resetAt: z.number().int().nonnegative().optional(),
+})
+
+export const CodexQuotaSnapshot = z.object({
+  fiveHour: ConsoleQuotaWindow.optional(),
+  weekly: ConsoleQuotaWindow.optional(),
+  fetchedAt: z.number().int().nonnegative().optional(),
+})
+
 export const ConsoleState = z.object({
   consoleManagedProviders: z.array(z.string()),
   activeOrgName: z.string().optional(),
   switchableOrgCount: z.number().int().nonnegative(),
+  codexQuota: CodexQuotaSnapshot.optional(),
 })
 
 export type ConsoleState = z.infer<typeof ConsoleState>
@@ -12,4 +25,5 @@ export const emptyConsoleState: ConsoleState = {
   consoleManagedProviders: [],
   activeOrgName: undefined,
   switchableOrgCount: 0,
+  codexQuota: undefined,
 }

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -1,20 +1,61 @@
 import type { Hooks, PluginInput } from "@opencode-ai/plugin"
-import { Log } from "../util/log"
+import z from "zod"
+import type { Auth } from "../auth"
+import { OAUTH_DUMMY_KEY } from "../auth"
 import { Installation } from "../installation"
-import { Auth, OAUTH_DUMMY_KEY } from "../auth"
-import os from "os"
-import { ProviderTransform } from "@/provider/transform"
-import { ModelID, ProviderID } from "@/provider/schema"
+import { Log } from "../util/log"
+import { createServer } from "node:http"
+import os from "node:os"
 import { setTimeout as sleep } from "node:timers/promises"
-import { createServer } from "http"
 
 const log = Log.create({ service: "plugin.codex" })
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+const CODEX_USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+
+const CodexUsageWindow = z.object({
+  used_percent: z.coerce.number().finite(),
+  reset_at: z.coerce.number().int().nonnegative().nullish(),
+  reset_after_seconds: z.coerce.number().int().nonnegative().nullish(),
+})
+
+const CodexUsageRateLimit = z.object({
+  primary_window: CodexUsageWindow.nullish(),
+  secondary_window: CodexUsageWindow.nullish(),
+})
+
+const CodexUsageResponse = z.object({
+  rate_limit: CodexUsageRateLimit.nullish(),
+  rate_limits: CodexUsageRateLimit.nullish(),
+})
+
+export interface CodexQuotaWindowSnapshot {
+  remainingPercent: number
+  resetSeconds?: number
+  resetAt?: number
+}
+
+export interface CodexQuotaSnapshot {
+  fiveHour?: CodexQuotaWindowSnapshot
+  weekly?: CodexQuotaWindowSnapshot
+}
+
+type CodexOauthAuth = Extract<Auth.Info, { type: "oauth" }>
+
+interface CodexAuthStore {
+  getAuth: () => Promise<Auth.Info | undefined>
+  setAuth: (auth: CodexOauthAuth) => Promise<void>
+  fetchImpl?: typeof fetch
+}
+
+interface CodexOauthSession {
+  accessToken: string
+  accountId?: string
+}
 
 interface PkceCodes {
   verifier: string
@@ -104,12 +145,14 @@ function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string):
   return `${ISSUER}/oauth/authorize?${params.toString()}`
 }
 
-interface TokenResponse {
-  id_token: string
-  access_token: string
-  refresh_token: string
-  expires_in?: number
-}
+const TokenResponseSchema = z.object({
+  access_token: z.string(),
+  id_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number().optional(),
+})
+
+type TokenResponse = z.infer<typeof TokenResponseSchema>
 
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
@@ -126,11 +169,11 @@ async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: Pk
   if (!response.ok) {
     throw new Error(`Token exchange failed: ${response.status}`)
   }
-  return response.json()
+  return TokenResponseSchema.parse(await response.json())
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
-  const response = await fetch(`${ISSUER}/oauth/token`, {
+async function refreshAccessToken(refreshToken: string, fetchImpl: typeof fetch = fetch): Promise<TokenResponse> {
+  const response = await fetchImpl(`${ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -142,7 +185,91 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> 
   if (!response.ok) {
     throw new Error(`Token refresh failed: ${response.status}`)
   }
-  return response.json()
+  return TokenResponseSchema.parse(await response.json())
+}
+
+function createCodexHeaders(session: CodexOauthSession, headersInit?: HeadersInit): Headers {
+  const headers = new Headers(headersInit)
+  headers.set("authorization", `Bearer ${session.accessToken}`)
+  headers.set("originator", "opencode")
+  headers.set("User-Agent", `opencode/${Installation.VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`)
+  if (session.accountId) {
+    headers.set("ChatGPT-Account-Id", session.accountId)
+  }
+  return headers
+}
+
+export async function resolveCodexOauthSession(input: CodexAuthStore): Promise<CodexOauthSession | undefined> {
+  const auth = await input.getAuth()
+  if (!auth || auth.type !== "oauth") return undefined
+
+  let currentAuth: CodexOauthAuth = auth
+  if (!currentAuth.access || currentAuth.expires < Date.now()) {
+    log.info("refreshing codex access token")
+    const tokens = await refreshAccessToken(currentAuth.refresh, input.fetchImpl)
+    const accountId = extractAccountId(tokens) || currentAuth.accountId
+    currentAuth = {
+      type: "oauth",
+      refresh: tokens.refresh_token ?? currentAuth.refresh,
+      access: tokens.access_token,
+      expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+      ...(accountId ? { accountId } : {}),
+      ...(currentAuth.enterpriseUrl ? { enterpriseUrl: currentAuth.enterpriseUrl } : {}),
+    }
+    await input.setAuth(currentAuth)
+  }
+
+  return {
+    accessToken: currentAuth.access,
+    accountId: currentAuth.accountId,
+  }
+}
+
+function toRemainingPercent(usedPercent: number) {
+  return Math.max(0, Math.min(100, 100 - usedPercent))
+}
+
+function mapQuotaWindow(window: z.infer<typeof CodexUsageWindow> | null | undefined): CodexQuotaWindowSnapshot | undefined {
+  if (!window) return undefined
+  return {
+    remainingPercent: toRemainingPercent(window.used_percent),
+    ...(window.reset_after_seconds != null ? { resetSeconds: window.reset_after_seconds } : {}),
+    ...(window.reset_at != null ? { resetAt: window.reset_at } : {}),
+  }
+}
+
+export async function getCodexQuotaSnapshot(input: CodexAuthStore): Promise<CodexQuotaSnapshot | undefined> {
+  try {
+    const session = await resolveCodexOauthSession(input)
+    if (!session) return undefined
+
+    const fetchImpl = input.fetchImpl ?? fetch
+    const response = await fetchImpl(CODEX_USAGE_ENDPOINT, {
+      method: "GET",
+      headers: createCodexHeaders(session, {
+        accept: "application/json",
+      }),
+    })
+    if (!response.ok) return undefined
+
+    const parsed = CodexUsageResponse.safeParse(await response.json())
+    if (!parsed.success) return undefined
+
+    const rateLimit = parsed.data.rate_limit ?? parsed.data.rate_limits
+    if (!rateLimit) return undefined
+
+    const quota: CodexQuotaSnapshot = {
+      fiveHour: mapQuotaWindow(rateLimit.primary_window ?? undefined),
+      weekly: mapQuotaWindow(rateLimit.secondary_window ?? undefined),
+    }
+    if (!quota.fiveHour && !quota.weekly) return undefined
+    return quota
+  } catch (error) {
+    log.warn("failed to fetch codex quota snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
 }
 
 const HTML_SUCCESS = `<!doctype html>
@@ -373,6 +500,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           "gpt-5.2",
           "gpt-5.2-codex",
           "gpt-5.3-codex",
+          "gpt-5.5",
           "gpt-5.4",
           "gpt-5.4-mini",
         ])
@@ -407,54 +535,19 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
               }
             }
 
-            const currentAuth = await getAuth()
-            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
-
-            // Cast to include accountId field
-            const authWithAccount = currentAuth as typeof currentAuth & { accountId?: string }
-
-            // Check if token needs refresh
-            if (!currentAuth.access || currentAuth.expires < Date.now()) {
-              log.info("refreshing codex access token")
-              const tokens = await refreshAccessToken(currentAuth.refresh)
-              const newAccountId = extractAccountId(tokens) || authWithAccount.accountId
-              await input.client.auth.set({
-                path: { id: "openai" },
-                body: {
-                  type: "oauth",
-                  refresh: tokens.refresh_token,
-                  access: tokens.access_token,
-                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                  ...(newAccountId && { accountId: newAccountId }),
-                },
-              })
-              currentAuth.access = tokens.access_token
-              authWithAccount.accountId = newAccountId
-            }
+            const session = await resolveCodexOauthSession({
+              getAuth,
+              setAuth: async (auth) => {
+                await input.client.auth.set({
+                  path: { id: "openai" },
+                  body: auth,
+                })
+              },
+            })
+            if (!session) return fetch(requestInput, init)
 
             // Build headers
-            const headers = new Headers()
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                init.headers.forEach((value, key) => headers.set(key, value))
-              } else if (Array.isArray(init.headers)) {
-                for (const [key, value] of init.headers) {
-                  if (value !== undefined) headers.set(key, String(value))
-                }
-              } else {
-                for (const [key, value] of Object.entries(init.headers)) {
-                  if (value !== undefined) headers.set(key, String(value))
-                }
-              }
-            }
-
-            // Set authorization header with access token
-            headers.set("authorization", `Bearer ${currentAuth.access}`)
-
-            // Set ChatGPT-Account-Id header for organization subscriptions
-            if (authWithAccount.accountId) {
-              headers.set("ChatGPT-Account-Id", authWithAccount.accountId)
-            }
+            const headers = createCodexHeaders(session, init?.headers)
 
             // Rewrite URL to Codex endpoint
             const parsed =
@@ -492,6 +585,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
               callback: async () => {
                 const tokens = await callbackPromise
                 stopOAuthServer()
+                if (!tokens.refresh_token) return { type: "failed" as const }
                 const accountId = extractAccountId(tokens)
                 return {
                   type: "success" as const,
@@ -566,7 +660,8 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                       throw new Error(`Token exchange failed: ${tokenResponse.status}`)
                     }
 
-                    const tokens: TokenResponse = await tokenResponse.json()
+                    const tokens = TokenResponseSchema.parse(await tokenResponse.json())
+                    if (!tokens.refresh_token) return { type: "failed" as const }
 
                     return {
                       type: "success" as const,

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -9,8 +9,10 @@ import { Project } from "../../project/project"
 import { MCP } from "../../mcp"
 import { Session } from "../../session"
 import { Config } from "../../config/config"
-import { ConsoleState } from "../../config/console-state"
+import { CodexQuotaSnapshot, ConsoleState } from "../../config/console-state"
 import { Account, AccountID, OrgID } from "../../account"
+import { Auth } from "../../auth"
+import { getCodexQuotaSnapshot } from "../../plugin/codex"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
@@ -60,6 +62,31 @@ export const ExperimentalRoutes = lazy(() =>
           ...consoleState,
           switchableOrgCount: groups.reduce((count, group) => count + group.orgs.length, 0),
         })
+      },
+    )
+    .get(
+      "/console/codex-quota",
+      describeRoute({
+        summary: "Get Codex quota snapshot",
+        description: "Get the current Codex quota snapshot for the active OpenAI OAuth account.",
+        operationId: "experimental.console.codexQuota",
+        responses: {
+          200: {
+            description: "Codex quota snapshot",
+            content: {
+              "application/json": {
+                schema: resolver(CodexQuotaSnapshot),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const quota = await getCodexQuotaSnapshot({
+          getAuth: () => Auth.get("openai"),
+          setAuth: (auth) => Auth.set("openai", auth),
+        })
+        return c.json(quota ? { ...quota, fetchedAt: Date.now() } : {})
       },
     )
     .get(

--- a/packages/opencode/test/cli/cmd/tui/prompt-metrics.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-metrics.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import {
+  formatCodexQuotaFetchedAt,
+  formatCodexQuotaMetrics,
+  formatQuotaBar,
+} from "../../../../src/cli/cmd/tui/component/prompt/metrics"
+
+const fetchedAt = new Date(2026, 3, 28, 17, 38, 30).getTime()
+
+describe("prompt metrics", () => {
+  test("formats codex quota with full bars on wide terminals", () => {
+    expect(
+      formatCodexQuotaMetrics(
+        {
+          fiveHour: { remainingPercent: 90 },
+          weekly: { remainingPercent: 95 },
+          fetchedAt,
+        },
+        200,
+      ),
+    ).toBe("codex 5h █████████░ 90% · wk ██████████ 95% · ⟳2026-04-28T17h38m30s")
+  })
+
+  test("formats codex quota with compact bars on medium terminals", () => {
+    expect(
+      formatCodexQuotaMetrics(
+        {
+          fiveHour: { remainingPercent: 90 },
+          weekly: { remainingPercent: 95 },
+          fetchedAt,
+        },
+        120,
+      ),
+    ).toBe("codex 5h █████ 90% · wk █████ 95% · ⟳17h38m30s")
+  })
+
+  test("falls back to percentages as terminal width tightens", () => {
+    const quota = {
+      fiveHour: { remainingPercent: 90 },
+      weekly: { remainingPercent: 95 },
+      fetchedAt,
+    }
+
+    expect(formatCodexQuotaMetrics(quota, 90)).toBe("codex 5h 90% · wk 95% · ⟳17h38m30s")
+    expect(formatCodexQuotaMetrics(quota, 89)).toBe("codex 5h 90% · wk 95%")
+  })
+
+  test("rounds and clamps quota bar percentages", () => {
+    expect(formatQuotaBar(87.5, 5)).toBe("████░")
+    expect(formatQuotaBar(-10, 5)).toBe("░░░░░")
+    expect(formatQuotaBar(120, 5)).toBe("█████")
+  })
+
+  test("formats refresh timestamps and drops invalid values", () => {
+    expect(formatCodexQuotaFetchedAt(fetchedAt)).toBe("2026-04-28T17h38m30s")
+    expect(formatCodexQuotaFetchedAt(fetchedAt, "short")).toBe("17h38m30s")
+
+    expect(
+      formatCodexQuotaMetrics(
+        {
+          fiveHour: { remainingPercent: 87.5 },
+          fetchedAt: Number.NaN,
+        },
+        120,
+      ),
+    ).toBe("codex 5h ████░ 88%")
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/prompt-metrics.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-metrics.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../../src/cli/cmd/tui/component/prompt/metrics"
 
 const fetchedAt = new Date(2026, 3, 28, 17, 38, 30).getTime()
+const sameDay = new Date(2026, 3, 28, 20, 0, 0).getTime()
 
 describe("prompt metrics", () => {
   test("formats codex quota with full bars on wide terminals", () => {
@@ -17,8 +18,9 @@ describe("prompt metrics", () => {
           fetchedAt,
         },
         200,
+        sameDay,
       ),
-    ).toBe("codex 5h █████████░ 90% · wk ██████████ 95% · ⟳2026-04-28T17h38m30s")
+    ).toBe("codex 5h █████████░ 90% · wk ██████████ 95% · ⟳ today@17h38m30s")
   })
 
   test("formats codex quota with compact bars on medium terminals", () => {
@@ -30,8 +32,9 @@ describe("prompt metrics", () => {
           fetchedAt,
         },
         120,
+        sameDay,
       ),
-    ).toBe("codex 5h █████ 90% · wk █████ 95% · ⟳17h38m30s")
+    ).toBe("codex 5h █████ 90% · wk █████ 95% · ⟳ today@17h38m30s")
   })
 
   test("falls back to percentages as terminal width tightens", () => {
@@ -41,8 +44,8 @@ describe("prompt metrics", () => {
       fetchedAt,
     }
 
-    expect(formatCodexQuotaMetrics(quota, 90)).toBe("codex 5h 90% · wk 95% · ⟳17h38m30s")
-    expect(formatCodexQuotaMetrics(quota, 89)).toBe("codex 5h 90% · wk 95%")
+    expect(formatCodexQuotaMetrics(quota, 90, sameDay)).toBe("codex 5h 90% · wk 95% · ⟳ today@17h38m30s")
+    expect(formatCodexQuotaMetrics(quota, 89, sameDay)).toBe("codex 5h 90% · wk 95%")
   })
 
   test("rounds and clamps quota bar percentages", () => {
@@ -52,8 +55,15 @@ describe("prompt metrics", () => {
   })
 
   test("formats refresh timestamps and drops invalid values", () => {
-    expect(formatCodexQuotaFetchedAt(fetchedAt)).toBe("2026-04-28T17h38m30s")
-    expect(formatCodexQuotaFetchedAt(fetchedAt, "short")).toBe("17h38m30s")
+    expect(formatCodexQuotaFetchedAt(fetchedAt, new Date(2026, 3, 28, 20, 0, 0).getTime())).toBe(
+      "today@17h38m30s",
+    )
+    expect(formatCodexQuotaFetchedAt(fetchedAt, new Date(2026, 3, 29, 20, 0, 0).getTime())).toBe(
+      "yesterday@17h38m30s",
+    )
+    expect(formatCodexQuotaFetchedAt(fetchedAt, new Date(2026, 3, 30, 20, 0, 0).getTime())).toBe(
+      "2d ago@17h38m30s",
+    )
 
     expect(
       formatCodexQuotaMetrics(
@@ -62,6 +72,7 @@ describe("prompt metrics", () => {
           fetchedAt: Number.NaN,
         },
         120,
+        sameDay,
       ),
     ).toBe("codex 5h ████░ 88%")
   })

--- a/packages/opencode/test/cli/tui/sync-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/sync-provider.test.tsx
@@ -105,7 +105,26 @@ function createFetch(log: Hit[]) {
         return json({ all: [], default: {}, connected: [] })
       }
       if (url.pathname === "/experimental/console") {
-        return json({})
+        return json({
+          consoleManagedProviders: [],
+          switchableOrgCount: 0,
+        })
+      }
+      if (url.pathname === "/experimental/console/codex-quota") {
+        const quotaCalls = log.filter(
+          (item) => item.path === "/experimental/console/codex-quota" && item.workspace === workspace,
+        ).length
+        return json({
+          fiveHour: {
+            remainingPercent: 60 + quotaCalls,
+            resetSeconds: 600,
+          },
+          weekly: {
+            remainingPercent: 14 + quotaCalls,
+            resetAt: 1700086400,
+          },
+          fetchedAt: 1700000000000 + quotaCalls * 1000,
+        })
       }
       if (url.pathname === "/agent") {
         return json([])
@@ -230,6 +249,50 @@ function Probe(props: {
 }
 
 describe("SyncProvider", () => {
+  test("hydrates and periodically refreshes codex quota without blocking console bootstrap", async () => {
+    const log: Hit[] = []
+    const refreshers: Array<() => void> = []
+    const originalSetInterval = globalThis.setInterval
+    globalThis.setInterval = ((handler: (...args: unknown[]) => void, timeout?: number, ...args: unknown[]) => {
+      if (timeout === 60 * 1000) {
+        refreshers.push(() => handler(...args))
+        return 0 as unknown as ReturnType<typeof setInterval>
+      }
+      return originalSetInterval(handler, timeout, ...args)
+    }) as typeof setInterval
+
+    try {
+      const { app, sync } = await mount(log)
+
+      try {
+        await wait(() => sync.status === "complete")
+        expect(log.some((item) => item.path === "/experimental/console")).toBe(true)
+        expect(log.some((item) => item.path === "/experimental/console/codex-quota")).toBe(true)
+        await wait(() => !!sync.data.console_state.codexQuota?.fiveHour)
+
+        expect(sync.data.console_state.codexQuota?.fiveHour).toEqual({
+          remainingPercent: 61,
+          resetSeconds: 600,
+        })
+        expect(sync.data.console_state.codexQuota?.weekly).toEqual({
+          remainingPercent: 15,
+          resetAt: 1700086400,
+        })
+        expect(sync.data.console_state.codexQuota?.fetchedAt).toBe(1700000001000)
+
+        expect(refreshers.length).toBeGreaterThan(0)
+        refreshers[0]()
+        await wait(() => log.filter((item) => item.path === "/experimental/console/codex-quota").length >= 2)
+        await wait(() => sync.data.console_state.codexQuota?.fiveHour?.remainingPercent === 62)
+        expect(sync.data.console_state.codexQuota?.fetchedAt).toBe(1700000002000)
+      } finally {
+        app.renderer.destroy()
+      }
+    } finally {
+      globalThis.setInterval = originalSetInterval
+    }
+  })
+
   test("re-runs bootstrap requests when the active workspace changes", async () => {
     const log: Hit[] = []
     const { app, project } = await mount(log)

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -3,6 +3,8 @@ import {
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
+  getCodexQuotaSnapshot,
+  resolveCodexOauthSession,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
 
@@ -10,6 +12,10 @@ function createTestJwt(payload: object): string {
   const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url")
   return `${header}.${body}.sig`
+}
+
+function createMockFetch(handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): typeof fetch {
+  return Object.assign(handler, { preconnect: fetch.preconnect.bind(fetch) })
 }
 
 describe("plugin.codex", () => {
@@ -118,6 +124,180 @@ describe("plugin.codex", () => {
           refresh_token: "rt",
         }),
       ).toBe("acc-123")
+    })
+  })
+
+  describe("resolveCodexOauthSession", () => {
+    test("refreshes expired oauth tokens and persists the updated account id", async () => {
+      const persisted: Array<unknown> = []
+      const refreshedAccessToken = createTestJwt({ chatgpt_account_id: "acc-refreshed" })
+
+      const session = await resolveCodexOauthSession({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "expired-access",
+          expires: Date.now() - 1_000,
+          accountId: "acc-stale",
+        }),
+        setAuth: async (auth) => {
+          persisted.push(auth)
+        },
+        fetchImpl: createMockFetch(async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+          expect(url).toBe("https://auth.openai.com/oauth/token")
+          return new Response(
+            JSON.stringify({
+              id_token: "",
+              access_token: refreshedAccessToken,
+              refresh_token: "refresh-token-next",
+              expires_in: 7200,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }),
+      })
+
+      expect(session).toEqual({
+        accessToken: refreshedAccessToken,
+        accountId: "acc-refreshed",
+      })
+      expect(persisted).toHaveLength(1)
+      expect(persisted[0]).toMatchObject({
+        type: "oauth",
+        refresh: "refresh-token-next",
+        access: refreshedAccessToken,
+        accountId: "acc-refreshed",
+      })
+    })
+
+    test("keeps the existing refresh token when refresh response omits one", async () => {
+      const persisted: Array<unknown> = []
+      const refreshedAccessToken = createTestJwt({ chatgpt_account_id: "acc-refreshed" })
+
+      await resolveCodexOauthSession({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token-existing",
+          access: "expired-access",
+          expires: Date.now() - 1_000,
+          accountId: "acc-stale",
+        }),
+        setAuth: async (auth) => {
+          persisted.push(auth)
+        },
+        fetchImpl: createMockFetch(async () =>
+          new Response(
+            JSON.stringify({
+              access_token: refreshedAccessToken,
+              expires_in: 7200,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+      })
+
+      expect(persisted[0]).toMatchObject({
+        type: "oauth",
+        refresh: "refresh-token-existing",
+        access: refreshedAccessToken,
+        accountId: "acc-refreshed",
+      })
+    })
+  })
+
+  describe("getCodexQuotaSnapshot", () => {
+    test("maps primary and secondary quota windows to remaining percentages", async () => {
+      const quota = await getCodexQuotaSnapshot({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60_000,
+          accountId: "acc-123",
+        }),
+        setAuth: async () => undefined,
+        fetchImpl: createMockFetch(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+          expect(url).toBe("https://chatgpt.com/backend-api/wham/usage")
+
+          const headers = new Headers(init?.headers)
+          expect(headers.get("authorization")).toBe("Bearer access-token")
+          expect(headers.get("ChatGPT-Account-Id")).toBe("acc-123")
+
+          return new Response(
+            JSON.stringify({
+              rate_limit: {
+                primary_window: {
+                  used_percent: 39,
+                  reset_after_seconds: 600,
+                  reset_at: 1_700_000_000,
+                },
+                secondary_window: {
+                  used_percent: 85,
+                  reset_after_seconds: 86_400,
+                  reset_at: 1_700_086_400,
+                },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }),
+      })
+
+      expect(quota).toEqual({
+        fiveHour: {
+          remainingPercent: 61,
+          resetSeconds: 600,
+          resetAt: 1_700_000_000,
+        },
+        weekly: {
+          remainingPercent: 15,
+          resetSeconds: 86_400,
+          resetAt: 1_700_086_400,
+        },
+      })
+    })
+
+    test("returns undefined when openai oauth is not configured", async () => {
+      const quota = await getCodexQuotaSnapshot({
+        getAuth: async () => undefined,
+        setAuth: async () => undefined,
+      })
+
+      expect(quota).toBeUndefined()
+    })
+
+    test("ignores nullable reset fields without dropping quota windows", async () => {
+      const quota = await getCodexQuotaSnapshot({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60_000,
+        }),
+        setAuth: async () => undefined,
+        fetchImpl: createMockFetch(async () =>
+          new Response(
+            JSON.stringify({
+              rate_limit: {
+                primary_window: {
+                  used_percent: 12.5,
+                  reset_after_seconds: null,
+                  reset_at: null,
+                },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+      })
+
+      expect(quota).toEqual({
+        fiveHour: {
+          remainingPercent: 87.5,
+        },
+      })
     })
   })
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -24,6 +24,7 @@ import type {
   EventTuiPromptAppend,
   EventTuiSessionSelect,
   EventTuiToastShow,
+  ExperimentalConsoleCodexQuotaResponses,
   ExperimentalConsoleGetResponses,
   ExperimentalConsoleListOrgsResponses,
   ExperimentalConsoleSwitchOrgResponses,
@@ -1010,6 +1011,36 @@ export class Console extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<ExperimentalConsoleGetResponses, unknown, ThrowOnError>({
       url: "/experimental/console",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get Codex quota snapshot
+   *
+   * Get the current Codex quota snapshot for the active OpenAI OAuth account.
+   */
+  public codexQuota<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ExperimentalConsoleCodexQuotaResponses, unknown, ThrowOnError>({
+      url: "/experimental/console/codex-quota",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2687,10 +2687,55 @@ export type ExperimentalConsoleGetResponses = {
     consoleManagedProviders: Array<string>
     activeOrgName?: string
     switchableOrgCount: number
+    codexQuota?: {
+      fiveHour?: {
+        remainingPercent: number
+        resetSeconds?: number
+        resetAt?: number
+      }
+      weekly?: {
+        remainingPercent: number
+        resetSeconds?: number
+        resetAt?: number
+      }
+      fetchedAt?: number
+    }
   }
 }
 
 export type ExperimentalConsoleGetResponse = ExperimentalConsoleGetResponses[keyof ExperimentalConsoleGetResponses]
+
+export type ExperimentalConsoleCodexQuotaData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/experimental/console/codex-quota"
+}
+
+export type ExperimentalConsoleCodexQuotaResponses = {
+  /**
+   * Codex quota snapshot
+   */
+  200: {
+    fiveHour?: {
+      remainingPercent: number
+      resetSeconds?: number
+      resetAt?: number
+    }
+    weekly?: {
+      remainingPercent: number
+      resetSeconds?: number
+      resetAt?: number
+    }
+    fetchedAt?: number
+  }
+}
+
+export type ExperimentalConsoleCodexQuotaResponse =
+  ExperimentalConsoleCodexQuotaResponses[keyof ExperimentalConsoleCodexQuotaResponses]
 
 export type ExperimentalConsoleListOrgsData = {
   body?: never


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a prompt-metrics surface for model/provider quota information. This PR wires up Codex quota first: it reads the existing OpenAI OAuth session, fetches a best-effort five-hour/weekly quota snapshot through a non-blocking experimental console endpoint, and renders it below the chat box in the existing prompt metrics row.

This keeps the global footer/status/version area unchanged. The Codex usage source is ChatGPT's private `/backend-api/wham/usage` endpoint, so the quota data is intentionally best-effort and isolated under the experimental console surface.

### How did you verify your code works?

- `bun test test/plugin/codex.test.ts test/cli/tui/sync-provider.test.tsx test/cli/cmd/tui/prompt-metrics.test.ts`
- `bun typecheck`
- `OPENCODE_VERSION=1.14.28 bun run build --single --skip-install --skip-embed-web-ui`
- `bun turbo typecheck`
- tmux visual smoke at 160x42 confirmed the quota row stays below the prompt and does not overwrite the footer/version line.

### Screenshots / recordings

Temporarily removed while screenshots are sanitized.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR