### PR TITLE
fix(web): stop credential prompt loop with text/plain 401 + manifest credentials

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -8,7 +8,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon-v3.svg" />
     <link rel="shortcut icon" href="/favicon-v3.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v3.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <!-- crossorigin=use-credentials is required so the manifest fetch carries the page's basic-auth credentials when OPENCODE_SERVER_PASSWORD is set; same-origin so no CORS preflight. Without it, the browser issues a separate auth dialog for the manifest. -->
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <meta name="theme-color" content="#F8F7F7" />
     <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
     <meta property="og:image" content="/social-share.png" />

--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -36,7 +36,7 @@ export const ErrorMiddleware: ErrorHandler = (err, c) => {
   })
 }
 
-export const AuthMiddleware: MiddlewareHandler = (c, next) => {
+export const AuthMiddleware: MiddlewareHandler = async (c, next) => {
   // Allow CORS preflight requests to succeed without auth.
   // Browser clients sending Authorization headers will preflight with OPTIONS.
   if (c.req.method === "OPTIONS") return next()
@@ -46,7 +46,25 @@ export const AuthMiddleware: MiddlewareHandler = (c, next) => {
 
   if (c.req.query("auth_token")) c.req.raw.headers.set("authorization", `Basic ${c.req.query("auth_token")}`)
 
-  return basicAuth({ username, password })(c, next)
+  // hono's basicAuth builds the 401 response without a Content-Type. Bun's
+  // HTTP layer then defaults to `application/octet-stream`, which Chromium
+  // briefly treats as a download attachment before settling on the basic-auth
+  // dialog. The race produces 2-3 dialog flashes before the password field
+  // accepts input, and Playwright surfaces it as `Error: Download is starting`
+  // on the navigation call. Wrap the call so the 401 carries an explicit
+  // text/plain Content-Type. Refs upstream issue anomalyco/opencode#18325.
+  try {
+    return await basicAuth({ username, password })(c, next)
+  } catch (err) {
+    if (err instanceof HTTPException && err.res && err.res.status === 401 && !err.res.headers.get("content-type")) {
+      const headers = new Headers(err.res.headers)
+      headers.set("content-type", "text/plain; charset=utf-8")
+      throw new HTTPException(401, {
+        res: new Response(err.res.body, { status: 401, headers }),
+      })
+    }
+    throw err
+  }
 }
 
 export const LoggerMiddleware: MiddlewareHandler = async (c, next) => {

--- a/packages/opencode/test/server/auth-middleware.test.ts
+++ b/packages/opencode/test/server/auth-middleware.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { AuthMiddleware, ErrorMiddleware } from "../../src/server/middleware"
+import * as Log from "@opencode-ai/core/util/log"
+
+void Log.init({ print: false })
+
+const original = {
+  OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,
+  OPENCODE_SERVER_USERNAME: Flag.OPENCODE_SERVER_USERNAME,
+}
+
+afterEach(() => {
+  Flag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD
+  Flag.OPENCODE_SERVER_USERNAME = original.OPENCODE_SERVER_USERNAME
+})
+
+function app() {
+  return new Hono()
+    .onError(ErrorMiddleware)
+    .use(AuthMiddleware)
+    .get("/probe", (c) => c.text("ok"))
+}
+
+function authorization(username: string, password: string) {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+}
+
+describe("AuthMiddleware", () => {
+  // Regression: hono's basicAuth returns its 401 Response without a
+  // Content-Type. Bun's HTTP serializer then defaults to
+  // `application/octet-stream`, which Chromium briefly treats as a download
+  // attachment before settling on the basic-auth dialog. AuthMiddleware
+  // wraps basicAuth so the 401 carries text/plain and preserves the
+  // WWW-Authenticate header. Refs upstream issue anomalyco/opencode#18325.
+  test("401 carries text/plain Content-Type when credentials are missing", async () => {
+    Flag.OPENCODE_SERVER_PASSWORD = "secret"
+
+    const response = await app().request("/probe")
+
+    expect(response.status).toBe(401)
+    const contentType = response.headers.get("content-type") ?? ""
+    expect(contentType).toContain("text/plain")
+    expect(contentType).not.toContain("octet-stream")
+    expect(response.headers.get("www-authenticate")).toContain("Basic")
+    expect(await response.text()).toBe("Unauthorized")
+  })
+
+  test("401 carries text/plain Content-Type when credentials are wrong", async () => {
+    Flag.OPENCODE_SERVER_PASSWORD = "secret"
+
+    const response = await app().request("/probe", {
+      headers: { authorization: authorization("opencode", "wrong") },
+    })
+
+    expect(response.status).toBe(401)
+    const contentType = response.headers.get("content-type") ?? ""
+    expect(contentType).toContain("text/plain")
+    expect(contentType).not.toContain("octet-stream")
+  })
+
+  test("authenticated requests pass through unchanged", async () => {
+    Flag.OPENCODE_SERVER_PASSWORD = "secret"
+
+    const response = await app().request("/probe", {
+      headers: { authorization: authorization("opencode", "secret") },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("ok")
+  })
+
+  test("requests pass through when no password is set", async () => {
+    Flag.OPENCODE_SERVER_PASSWORD = undefined
+
+    const response = await app().request("/probe")
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("ok")
+  })
+
+  test("CORS preflight bypasses auth", async () => {
+    Flag.OPENCODE_SERVER_PASSWORD = "secret"
+
+    const response = await app().request("/probe", { method: "OPTIONS" })
+
+    // OPTIONS hits next() with no GET handler matching → 404, not 401.
+    // The point is that auth did not block it.
+    expect(response.status).not.toBe(401)
+  })
+
+  test("auth_token query parameter is accepted as credentials", async () => {
+    Flag.OPENCODE_SERVER_PASSWORD = "secret"
+
+    const token = Buffer.from("opencode:secret").toString("base64")
+    const response = await app().request(`/probe?auth_token=${token}`)
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("ok")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #18325

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `OPENCODE_SERVER_PASSWORD` is set, the basic-auth dialog flashes
2-3 times before the password field accepts input. Two independent
causes; both fixed here.

**1. 401 response has no `Content-Type`.** `hono/basic-auth` builds
its 401 with only `WWW-Authenticate` set. Bun fills the missing slot
with `application/octet-stream`, and Chromium briefly treats the
unauth response as a download attachment — that race produces the
flash-and-reset. `AuthMiddleware` now adds `text/plain; charset=utf-8`
to a 401 with no Content-Type before re-throwing.

**2. Webmanifest is fetched without page credentials.** `<link
rel="manifest">` is fetched in a no-CORS mode that does not include
basic-auth credentials. Even after authenticating, the browser issues
a separate dialog for the manifest and logs `Manifest fetch ...
failed, code 401`. Adding `crossorigin="use-credentials"` makes the
fetch carry the page's credentials. Same-origin, so no CORS preflight;
no effect when `OPENCODE_SERVER_PASSWORD` is unset.

### How did you verify your code works?

From `packages/opencode`:

- `bun test test/server/auth-middleware.test.ts` — 6/6 pass. The new
  test mounts `AuthMiddleware` on a minimal Hono app and asserts the
  401 carries `text/plain` (never `octet-stream`) and preserves
  `WWW-Authenticate`, plus authenticated / no-password / OPTIONS /
  `auth_token` paths. Confirmed it fails against pre-fix code.
- `bun typecheck` clean.
- `curl -i http://localhost:<port>/` returns
  `content-type: text/plain; charset=utf-8` on the 401.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
