### PR TITLE
fix: add trailing newline to help output

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -63,7 +63,7 @@ function show(out: string) {
     process.stderr.write(text)
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(out.endsWith(EOL) ? out : out + EOL)
 }
 
 const cli = yargs(args)


### PR DESCRIPTION
Fixes #24813

## Description

When `opencode auth` is run without a subcommand, yargs' demandCommand
fires and the help text is printed via the show() callback. yargs hands
the callback help text without a final newline, so the shell prompt ends
up glued to the last help line. Ensure show() writes a trailing EOL.

Fixes #24813

## Issue for this PR

_TODO: fill in if applicable_

## Type of change

_TODO: fill in if applicable_

## What does this PR do?

_TODO: fill in if applicable_

## How did you verify your code works?

_TODO: fill in if applicable_

## Screenshots / recordings

_TODO: fill in if applicable_

## Checklist

_TODO: fill in if applicable_

