### PR TITLE
fix(prompt): avoid long-running servers via bash

### DIFF
--- a/packages/opencode/src/session/prompt/anthropic.txt
+++ b/packages/opencode/src/session/prompt/anthropic.txt
@@ -84,6 +84,17 @@ The user will primarily request you perform software engineering tasks. This inc
 - If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks. For example, if you need to launch multiple agents in parallel, send a single message with multiple Task tool calls.
 - Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit for editing instead of sed/awk, and Write for creating files instead of cat with heredoc or echo redirection. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.
 - VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool instead of running search commands directly.
+
+## Long-running processes
+Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+Instead:
+1. Tell the user the exact command to run.
+2. Ask them to run it in their own terminal.
+3. Wait for them to confirm it is running before continuing.
+
+Exception:
+If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
 <example>
 user: Where are errors from the client handled?
 assistant: [Uses the Task tool to find the files that handle client errors instead of using Glob or Grep directly]

--- a/packages/opencode/src/session/prompt/beast.txt
+++ b/packages/opencode/src/session/prompt/beast.txt
@@ -19,6 +19,17 @@ understanding of third party packages and dependencies is up to date. You must u
 
 Always tell the user what you are going to do before making a tool call with a single concise sentence. This will help them understand what you are doing and why.
 
+## Long-running processes
+Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+Instead:
+1. Tell the user the exact command to run.
+2. Ask them to run it in their own terminal.
+3. Wait for them to confirm it is running before continuing.
+
+Exception:
+If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
+
 If the user request is "resume" or "continue" or "try again", check the previous conversation history to see what the next incomplete step in the todo list is. Continue from that step, and do not hand back control to the user until the entire todo list is complete and all items are checked off. Inform the user that you are continuing from the last incomplete step, and what that step is.
 
 Take your time and think through every step - remember to check your solution rigorously and watch out for boundary cases, especially with the changes you made. Use the sequential thinking tool if available. Your solution must be perfect. If not, continue working on it. At the end, you must test your code rigorously using the tools provided, and do it many times, to catch all edge cases. If it is not robust, iterate more and make it perfect. Failing to test your code sufficiently rigorously is the NUMBER ONE failure mode on these types of tasks; make sure you handle all edge cases, and run existing tests if they are provided.

--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -14,6 +14,17 @@ You are an interactive CLI tool that helps users with software engineering tasks
 - Use Bash for terminal operations (git, bun, builds, tests, running scripts).
 - Run tool calls in parallel when neither call needs the other’s output; otherwise run sequentially.
 
+## Long-running processes
+Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+Instead:
+1. Tell the user the exact command to run.
+2. Ask them to run it in their own terminal.
+3. Wait for them to confirm it is running before continuing.
+
+Exception:
+If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
+
 ## Git and workspace hygiene
 - You may be in a dirty git worktree.
     * NEVER revert existing changes you did not make unless explicitly requested, since these changes were made by the user.

--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -91,6 +91,17 @@ NEVER commit changes unless the user explicitly asks you to. It is VERY IMPORTAN
 - When doing file search, prefer to use the Task tool in order to reduce context usage.
 - You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. When making multiple bash tool calls, you MUST send a single message with multiple tools calls to run the calls in parallel. For example, if you need to run "git status" and "git diff", send a single message with two tool calls to run the calls in parallel.
 
+## Long-running processes
+Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+Instead:
+1. Tell the user the exact command to run.
+2. Ask them to run it in their own terminal.
+3. Wait for them to confirm it is running before continuing.
+
+Exception:
+If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
+
 You MUST answer concisely with fewer than 4 lines of text (not including tool use or code generation), unless user asks for detail.
 
 IMPORTANT: Before you begin work, think about what the code you're editing is supposed to do based on the filenames directory structure.

--- a/packages/opencode/src/session/prompt/gemini.txt
+++ b/packages/opencode/src/session/prompt/gemini.txt
@@ -53,7 +53,14 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read' or 'write'. Relative paths are not supported. You must provide an absolute path.
 - **Parallelism:** Execute multiple independent tool calls in parallel when feasible (i.e. searching the codebase).
 - **Command Execution:** Use the 'bash' tool for running shell commands, remembering the safety rule to explain modifying commands first.
-- **Background Processes:** Use background processes (via \`&\`) for commands that are unlikely to stop on their own, e.g. \`node server.js &\`. If unsure, ask the user.
+- **Long-running processes:** Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+  Instead:
+  1. Tell the user the exact command to run.
+  2. Ask them to run it in their own terminal.
+  3. Wait for them to confirm it is running before continuing.
+
+  Exception: If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
 - **Interactive Commands:** Try to avoid shell commands that are likely to require user interaction (e.g. \`git rebase -i\`). Use non-interactive versions of commands (e.g. \`npm init -y\` instead of \`npm init\`) when available, and otherwise remind the user that interactive shell commands are not supported and may cause hangs until canceled by the user.
 - **Respect User Confirmations:** Most tool calls (also denoted as 'function calls') will first require confirmation from the user, where they will either approve or cancel the function call. If a user cancels a function call, respect their choice and do _not_ try to make the function call again. It is okay to request the tool call again _only_ if the user requests that same tool call on a subsequent prompt. When a user cancels a function call, assume best intentions from the user and consider inquiring if they prefer any alternative paths forward.
 
@@ -79,7 +86,7 @@ model: [tool_call: ls for path '/path/to/project']
 
 <example>
 user: start the server implemented in server.js
-model: [tool_call: bash for 'node server.js &' because it must run in the background]
+model: node server.js
 </example>
 
 <example>

--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -5,6 +5,18 @@ You are a deeply pragmatic, effective software engineer. You take engineering qu
 - When searching for text or files, prefer using Glob and Grep tools (they are powered by `rg`)
 - Parallelize tool calls whenever possible - especially file reads. Use `multi_tool_use.parallel` to parallelize tool calls and only this. Never chain together bash commands with separators like `echo "====";` as this renders to the user poorly.
 
+## Long-running processes
+
+Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+Instead:
+1. Tell the user the exact command to run.
+2. Ask them to run it in their own terminal.
+3. Wait for them to confirm it is running before continuing.
+
+Exception:
+If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
+
 ## Editing Approach
 
 - The best changes are often the smallest correct changes.

--- a/packages/opencode/src/session/prompt/kimi.txt
+++ b/packages/opencode/src/session/prompt/kimi.txt
@@ -31,6 +31,17 @@ Always use tools to implement your code changes:
 
 - Use `write`/`edit` to create or modify source files. Code that only appears in your text response is NOT saved to the file system and will not take effect.
 - Use `bash` to run and test your code after writing it.
+
+## Long-running processes
+Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+Instead:
+1. Tell the user the exact command to run.
+2. Ask them to run it in their own terminal.
+3. Wait for them to confirm it is running before continuing.
+
+Exception:
+If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
 - Iterate: if tests fail, read the error, fix the code with `write`/`edit`, and re-test with `bash`.
 
 When working on an existing codebase, you should:

--- a/packages/opencode/src/session/prompt/trinity.txt
+++ b/packages/opencode/src/session/prompt/trinity.txt
@@ -85,6 +85,17 @@ NEVER commit changes unless the user explicitly asks you to. It is VERY IMPORTAN
 - When the user's request is vague, use the question tool to clarify before reading files or making changes.
 - Avoid repeating the same tool with the same parameters once you have useful results. Use the result to take the next step (e.g. pick one match, read that file, then act); do not search again in a loop.
 
+## Long-running processes
+Do not use the bash tool to start foreground long-running processes such as dev servers, file watchers, build daemons, database servers, or any command that does not exit on its own within seconds. The bash tool has a hard timeout and runs synchronously inside the assistant turn; any process that keeps running inside the tool call will be killed when the tool call ends, and there is no UI for the user to manage it.
+
+Instead:
+1. Tell the user the exact command to run.
+2. Ask them to run it in their own terminal.
+3. Wait for them to confirm it is running before continuing.
+
+Exception:
+If a command starts a managed background service and then exits quickly (for example `docker compose up -d`, `brew services start ...`, `systemctl start ...`), it is OK to run via bash. Prefer to follow it with a status/health check command, and tell the user how to stop it.
+
 You MUST answer concisely with fewer than 4 lines of text (not including tool use or code generation), unless user asks for detail.
 
 # Code References

--- a/packages/opencode/test/session/system-prompt.test.ts
+++ b/packages/opencode/test/session/system-prompt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+
+import PROMPT_DEFAULT from "../../src/session/prompt/default.txt"
+import PROMPT_GPT from "../../src/session/prompt/gpt.txt"
+import PROMPT_BEAST from "../../src/session/prompt/beast.txt"
+import PROMPT_CODEX from "../../src/session/prompt/codex.txt"
+import PROMPT_ANTHROPIC from "../../src/session/prompt/anthropic.txt"
+import PROMPT_GEMINI from "../../src/session/prompt/gemini.txt"
+import PROMPT_KIMI from "../../src/session/prompt/kimi.txt"
+import PROMPT_TRINITY from "../../src/session/prompt/trinity.txt"
+
+describe("system prompt", () => {
+  test("includes long-running process bash steering", () => {
+    const prompts = [
+      PROMPT_DEFAULT,
+      PROMPT_GPT,
+      PROMPT_BEAST,
+      PROMPT_CODEX,
+      PROMPT_ANTHROPIC,
+      PROMPT_GEMINI,
+      PROMPT_KIMI,
+      PROMPT_TRINITY,
+    ]
+
+    for (const prompt of prompts) {
+      expect(prompt).toContain("Do not use the bash tool to start foreground long-running processes")
+      expect(prompt).toContain("Ask them to run it in their own terminal")
+      expect(prompt).toContain("confirm it is running")
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Add system-prompt steering to avoid starting foreground long-running servers/watchers via the `bash` tool (process will be killed on tool timeout / end-of-turn).
- Allow an explicit exception for commands that start a managed background service and exit quickly (e.g. `docker compose up -d`, `brew services start`, `systemctl start`), with guidance to run a status check and explain how to stop.
- Remove Gemini prompt guidance recommending `&` for background servers.

## Testing
- `bun test --timeout 30000` (packages/opencode)
- `bun run typecheck` (packages/opencode)
- `bun run build -- --skip-install --single` (packages/opencode)