### PR TITLE
fix(bash): memory leak - release parsed syntax trees

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -252,7 +252,7 @@ function tail(text: string, maxLines: number, maxBytes: number) {
 const parse = Effect.fn("BashTool.parse")(function* (command: string, ps: boolean) {
   const tree = yield* Effect.promise(() => parser().then((p) => (ps ? p.ps : p.bash).parse(command)))
   if (!tree) throw new Error("Failed to parse command")
-  return tree.rootNode
+  return tree
 })
 
 const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) {
@@ -596,10 +596,17 @@ export const BashTool = Tool.define(
               }
               const timeout = params.timeout ?? DEFAULT_TIMEOUT
               const ps = Shell.ps(shell)
-              const root = yield* parse(params.command, ps)
-              const scan = yield* collect(root, cwd, ps, shell)
-              if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
-              yield* ask(ctx, scan)
+              yield* Effect.scoped(
+                Effect.gen(function* () {
+                  const tree = yield* Effect.acquireRelease(
+                    parse(params.command, ps),
+                    (tree) => Effect.sync(() => tree.delete()),
+                  )
+                  const scan = yield* collect(tree.rootNode, cwd, ps, shell)
+                  if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
+                  yield* ask(ctx, scan)
+                }),
+              )
 
               return yield* run(
                 {


### PR DESCRIPTION
closes #21319

## Summary
- Releases each `web-tree-sitter` parse tree after bash permission scanning finishes.
- Keeps the tree alive through `collect` and `ask`, then lets `run` execute without retaining parser nodes.
- Uses `Effect.acquireRelease` inside `Effect.scoped` so cleanup runs on failures or interruption.

## Reference
- Original PR: https://github.com/anomalyco/opencode/pull/21321. That PR identified the same leak, but it is now out of date and conflicts with current `dev`; this PR ports the fix to the current Effect-based bash tool implementation.

## Repro
I reproduced the leak with a temporary local Bun script using the same parser stack as `packages/opencode/src/tool/bash.ts`: `web-tree-sitter@0.25.10` plus `tree-sitter-bash`.

The script looped over 50,000 parses, forced `Bun.gc(true)` every 5,000 parses, and compared dropping the returned `Tree` versus calling `tree.delete()` after reading `tree.rootNode`.

```ts
const tree = parser.parse(command)
if (!tree) throw new Error("failed to parse")
total += tree.rootNode.descendantsOfType("command").length
if (mode === "delete") tree.delete()
```

## Data
| mode | external start | external end | result |
| --- | ---: | ---: | --- |
| no `tree.delete()` | ~69 MB | ~3.7 GB | leaks |
| with `tree.delete()` | ~69 MB | ~66 MB | stable |

RSS also climbed in the no-delete run, while the delete run stayed stable after initial parser setup.

## Why This Fixes It
`web-tree-sitter` exposes `Tree.delete()` and its JS implementation calls `_ts_tree_delete`; it does not rely on a visible JS finalizer. The old code returned only `tree.rootNode`, so the `Tree` handle was dropped without releasing the underlying WASM/native tree allocation.

This change returns the `Tree`, uses `tree.rootNode` while scanning permissions, and releases the tree before running the shell command.

## Verification
- `bun typecheck` from `packages/opencode`
- pre-push hook: `bun turbo typecheck`