### PR TITLE
fix: prevent sibling instruction path leaks

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,5 +1,5 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { dirname, join, relative, resolve as pathResolve } from "path"
+import { dirname, join, relative, resolve as pathResolve, win32 } from "path"
 import { realpathSync } from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
@@ -224,13 +224,28 @@ export namespace AppFileSystem {
       .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
   }
 
+  function isWindowsAbsolutePath(p: string) {
+    return /^[A-Za-z]:[\\/]/.test(p) || p.startsWith("\\\\")
+  }
+
+  function relativePath(from: string, to: string) {
+    if (isWindowsAbsolutePath(from) || isWindowsAbsolutePath(to)) return win32.relative(from, to)
+    return relative(from, to)
+  }
+
+  function isParentRelativePath(p: string) {
+    return p === ".." || p.startsWith("../") || p.startsWith("..\\")
+  }
+
+  function isContainedRelativePath(p: string) {
+    return !p || (!isParentRelativePath(p) && !win32.isAbsolute(p))
+  }
+
   export function overlaps(a: string, b: string) {
-    const relA = relative(a, b)
-    const relB = relative(b, a)
-    return !relA || !relA.startsWith("..") || !relB || !relB.startsWith("..")
+    return isContainedRelativePath(relativePath(a, b)) || isContainedRelativePath(relativePath(b, a))
   }
 
   export function contains(parent: string, child: string) {
-    return !relative(parent, child).startsWith("..")
+    return isContainedRelativePath(relativePath(parent, child))
   }
 }

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -326,13 +326,20 @@ describe("AppFileSystem", () => {
 
     test("contains checks path containment", () => {
       expect(AppFileSystem.contains("/a/b", "/a/b/c")).toBe(true)
+      expect(AppFileSystem.contains("/a/b", "/a/b/..c")).toBe(true)
       expect(AppFileSystem.contains("/a/b", "/a/c")).toBe(false)
+      expect(AppFileSystem.contains("C:\\a\\b", "C:\\a\\b\\c")).toBe(true)
+      expect(AppFileSystem.contains("C:\\a\\b", "C:\\a\\b\\..c")).toBe(true)
+      expect(AppFileSystem.contains("C:\\a\\b", "C:\\a\\c")).toBe(false)
+      expect(AppFileSystem.contains("C:\\a\\b", "D:\\a\\b\\c")).toBe(false)
     })
 
     test("overlaps detects overlapping paths", () => {
       expect(AppFileSystem.overlaps("/a/b", "/a/b/c")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b/c", "/a/b")).toBe(true)
       expect(AppFileSystem.overlaps("/a", "/b")).toBe(false)
+      expect(AppFileSystem.overlaps("C:\\a\\b", "C:\\a\\b\\c")).toBe(true)
+      expect(AppFileSystem.overlaps("C:\\a\\b", "D:\\a\\b\\c")).toBe(false)
     })
   })
 })

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -198,7 +198,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         let current = path.dirname(target)
 
         // Walk upward from the file being read and attach nearby instruction files once per message.
-        while (current.startsWith(root) && current !== root) {
+        while (current !== root && AppFileSystem.contains(root, current)) {
           const found = yield* find(current)
           if (!found || found === target || sys.has(found) || already.has(found)) {
             current = path.dirname(current)

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -155,14 +155,30 @@ export function windowsPath(p: string): string {
       .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/, (_, drive) => `${drive.toUpperCase()}:/`)
   )
 }
+
+function isWindowsAbsolutePath(p: string) {
+  return /^[A-Za-z]:[\\/]/.test(p) || p.startsWith("\\\\")
+}
+
+function relativePath(from: string, to: string) {
+  if (isWindowsAbsolutePath(from) || isWindowsAbsolutePath(to)) return win32.relative(from, to)
+  return relative(from, to)
+}
+
+function isParentRelativePath(p: string) {
+  return p === ".." || p.startsWith("../") || p.startsWith("..\\")
+}
+
+function isContainedRelativePath(p: string) {
+  return !p || (!isParentRelativePath(p) && !win32.isAbsolute(p))
+}
+
 export function overlaps(a: string, b: string) {
-  const relA = relative(a, b)
-  const relB = relative(b, a)
-  return !relA || !relA.startsWith("..") || !relB || !relB.startsWith("..")
+  return isContainedRelativePath(relativePath(a, b)) || isContainedRelativePath(relativePath(b, a))
 }
 
 export function contains(parent: string, child: string) {
-  return !relative(parent, child).startsWith("..")
+  return isContainedRelativePath(relativePath(parent, child))
 }
 
 export async function findUp(

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -35,6 +35,13 @@ describe("Filesystem.contains", () => {
     expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
     expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
   })
+
+  test("handles Windows drive boundaries", () => {
+    expect(Filesystem.contains("C:\\project", "C:\\project\\src")).toBe(true)
+    expect(Filesystem.contains("C:\\project", "C:\\project\\..config")).toBe(true)
+    expect(Filesystem.contains("C:\\project", "C:\\project-other\\file")).toBe(false)
+    expect(Filesystem.contains("C:\\project", "D:\\project\\src")).toBe(false)
+  })
 })
 
 /*

--- a/packages/opencode/test/filesystem/filesystem.test.ts
+++ b/packages/opencode/test/filesystem/filesystem.test.ts
@@ -307,13 +307,20 @@ describe("AppFileSystem", () => {
 
     test("contains checks path containment", () => {
       expect(AppFileSystem.contains("/a/b", "/a/b/c")).toBe(true)
+      expect(AppFileSystem.contains("/a/b", "/a/b/..c")).toBe(true)
       expect(AppFileSystem.contains("/a/b", "/a/c")).toBe(false)
+      expect(AppFileSystem.contains("C:\\a\\b", "C:\\a\\b\\c")).toBe(true)
+      expect(AppFileSystem.contains("C:\\a\\b", "C:\\a\\b\\..c")).toBe(true)
+      expect(AppFileSystem.contains("C:\\a\\b", "C:\\a\\c")).toBe(false)
+      expect(AppFileSystem.contains("C:\\a\\b", "D:\\a\\b\\c")).toBe(false)
     })
 
     test("overlaps detects overlapping paths", () => {
       expect(AppFileSystem.overlaps("/a/b", "/a/b/c")).toBe(true)
       expect(AppFileSystem.overlaps("/a/b/c", "/a/b")).toBe(true)
       expect(AppFileSystem.overlaps("/a", "/b")).toBe(false)
+      expect(AppFileSystem.overlaps("C:\\a\\b", "C:\\a\\b\\c")).toBe(true)
+      expect(AppFileSystem.overlaps("C:\\a\\b", "D:\\a\\b\\c")).toBe(false)
     })
   })
 })

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -109,6 +109,32 @@ describe("Instruction.resolve", () => {
     })
   })
 
+  test("does not attach instructions from sibling paths with matching prefixes", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "project", "src", "file.ts"), "const x = 1")
+        await Bun.write(path.join(dir, "project-sibling", "AGENTS.md"), "# Sibling Instructions")
+        await Bun.write(path.join(dir, "project-sibling", "nested", "file.ts"), "const x = 2")
+      },
+    })
+    await Instance.provide({
+      directory: path.join(tmp.path, "project"),
+      fn: () =>
+        run(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const results = yield* svc.resolve(
+                [],
+                path.join(tmp.path, "project-sibling", "nested", "file.ts"),
+                MessageID.make("message-test-sibling-prefix"),
+              )
+              expect(results).toEqual([])
+            }),
+          ),
+        ),
+    })
+  })
+
   test("doesn't reload AGENTS.md when reading it directly", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #24862

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes instruction resolution so sibling paths like `/tmp/project-sibling` are not treated as inside `/tmp/project`. The change replaces the string-prefix boundary check with path-aware containment and tightens Windows drive/UNC handling in the shared filesystem helpers.

### How did you verify your code works?

- `bun test test/session/instruction.test.ts test/filesystem/filesystem.test.ts test/file/path-traversal.test.ts --timeout 30000` from `packages/opencode`
- `bun test test/filesystem/filesystem.test.ts --timeout 30000` from `packages/core`
- `bun typecheck` from `packages/opencode`
- `bun typecheck` from `packages/core`
- `codex review --base origin/dev`

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR