### PR TITLE
fix: clear timeout after promise rejection

### DIFF
--- a/packages/opencode/src/util/timeout.ts
+++ b/packages/opencode/src/util/timeout.ts
@@ -1,9 +1,8 @@
 export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let timeout: NodeJS.Timeout
   return Promise.race([
-    promise.then((result) => {
+    promise.finally(() => {
       clearTimeout(timeout)
-      return result
     }),
     new Promise<never>((_, reject) => {
       timeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Clear `withTimeout` timers when the wrapped promise rejects, not only when it fulfills.
- Keeps timeout behavior unchanged while avoiding bounded leftover timers on fast failure paths.

## Repro
I reproduced this with 10,000 rejected promises wrapped in `withTimeout(..., 60_000)`.

Before this change, all promises settled quickly, but the process stayed alive because the 60s timers were still pending.

After this change, the same repro exits immediately after the rejected promises settle.

## User-Facing Impact
This does not make successful actions faster. It only matters when a wrapped operation rejects quickly before its timeout.

| Action | If this fails fast | Possible symptom before this fix |
| --- | --- | --- |
| MCP connect/list tools | bad MCP server/config rejects immediately | process may linger up to `30s` after it otherwise finished |
| LSP initialize | language server rejects/crashes during initialize | process may linger up to `45s` if you exit right after |
| LSP diagnostics | diagnostic request rejects | process may linger up to `3s` |
| TUI shutdown worker RPC | worker shutdown RPC rejects immediately | `opencode` exit may hang up to `5s` |

In normal long-running TUI/server usage, users probably will not notice. This is mostly an `opencode` does not exit promptly after a failure cleanup bug, not action latency.

## Scope
This is a bounded timer/process-exit leak, not an unbounded native memory leak. The affected callsites are MCP connect/list-tools, LSP initialize/diagnostics, and TUI worker shutdown.

## Verification
- Focused Bun repro: 10,000 rejected promises wrapped in `withTimeout(..., 60_000)` exits in under 1s
- `bun typecheck` from `packages/opencode`
- pre-push hook: `bun turbo typecheck`