### PR TITLE
fix(app): improve sidebar session load more behavior

### DIFF
--- a/packages/app/src/context/global-sync.test.ts
+++ b/packages/app/src/context/global-sync.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import { canDisposeDirectory, pickDirectoriesToEvict } from "./global-sync/eviction"
-import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
+import {
+  canReuseRootSessionCache,
+  estimateRootSessionTotal,
+  loadRootSessionsWithFallback,
+  nextRootSessionLimit,
+} from "./global-sync/session-load"
+import { SESSION_ROOT_PAGE_SIZE } from "./global-sync/types"
 
 describe("pickDirectoriesToEvict", () => {
   test("keeps pinned stores and evicts idle stores", () => {
@@ -74,6 +80,52 @@ describe("estimateRootSessionTotal", () => {
 
   test("keeps exact total when limited fetch is under limit", () => {
     expect(estimateRootSessionTotal({ count: 9, limit: 10, limited: true })).toBe(9)
+  })
+})
+
+describe("sidebar session page sizing", () => {
+  test("starts from a larger bounded root-session page", () => {
+    expect(SESSION_ROOT_PAGE_SIZE).toBe(20)
+  })
+
+  test("loads another full page of root sessions", () => {
+    expect(nextRootSessionLimit(undefined)).toBe(SESSION_ROOT_PAGE_SIZE)
+    expect(nextRootSessionLimit(SESSION_ROOT_PAGE_SIZE)).toBe(SESSION_ROOT_PAGE_SIZE * 2)
+  })
+})
+
+describe("canReuseRootSessionCache", () => {
+  test("reuses cache when it already covers the visible limit", () => {
+    expect(
+      canReuseRootSessionCache({
+        cachedRootCount: 40,
+        fetchedLimit: 70,
+        requestedLimit: 40,
+        total: 71,
+      }),
+    ).toBe(true)
+  })
+
+  test("refetches when trimmed cache cannot satisfy load more", () => {
+    expect(
+      canReuseRootSessionCache({
+        cachedRootCount: 20,
+        fetchedLimit: 70,
+        requestedLimit: 40,
+        total: 71,
+      }),
+    ).toBe(false)
+  })
+
+  test("reuses cache when all available roots are already cached", () => {
+    expect(
+      canReuseRootSessionCache({
+        cachedRootCount: 20,
+        fetchedLimit: 70,
+        requestedLimit: 40,
+        total: 20,
+      }),
+    ).toBe(true)
   })
 })
 

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -26,7 +26,7 @@ import {
 import { createChildStoreManager } from "./global-sync/child-store"
 import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./global-sync/event-reducer"
 import { clearSessionPrefetchDirectory } from "./global-sync/session-prefetch"
-import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
+import { canReuseRootSessionCache, estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
 import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
@@ -209,7 +209,16 @@ function createGlobalSync() {
     children.pin(directory)
     const [store, setStore] = children.child(directory, { bootstrap: false })
     const meta = sessionMeta.get(directory)
-    if (meta && meta.limit >= store.limit) {
+    const cachedRootCount = store.session.filter((s) => !!s?.id && !s.parentID && !s.time?.archived).length
+    if (
+      meta &&
+      canReuseRootSessionCache({
+        cachedRootCount,
+        fetchedLimit: meta.limit,
+        requestedLimit: store.limit,
+        total: store.sessionTotal,
+      })
+    ) {
       const next = trimSessions(store.session, {
         limit: store.limit,
         permission: store.permission,

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -5,6 +5,7 @@ import type { OpencodeClient, VcsInfo } from "@opencode-ai/sdk/v2/client"
 import {
   DIR_IDLE_TTL_MS,
   MAX_DIR_STORES,
+  SESSION_ROOT_PAGE_SIZE,
   type ChildOptions,
   type DirState,
   type IconCache,
@@ -209,7 +210,7 @@ export function createChildStoreManager(input: {
               return lspQuery.isLoading ? [] : (lspQuery.data ?? [])
             },
             vcs: vcsStore.value,
-            limit: 5,
+            limit: SESSION_ROOT_PAGE_SIZE,
             message: {},
             part: {},
           })

--- a/packages/app/src/context/global-sync/session-load.ts
+++ b/packages/app/src/context/global-sync/session-load.ts
@@ -1,4 +1,4 @@
-import type { RootLoadArgs } from "./types"
+import { SESSION_ROOT_PAGE_SIZE, type RootLoadArgs } from "./types"
 
 export async function loadRootSessionsWithFallback(input: RootLoadArgs) {
   try {
@@ -22,4 +22,19 @@ export function estimateRootSessionTotal(input: { count: number; limit: number; 
   if (!input.limited) return input.count
   if (input.count < input.limit) return input.count
   return input.count + 1
+}
+
+export function nextRootSessionLimit(limit: number | undefined) {
+  return (limit ?? 0) + SESSION_ROOT_PAGE_SIZE
+}
+
+export function canReuseRootSessionCache(input: {
+  cachedRootCount: number
+  fetchedLimit: number
+  requestedLimit: number
+  total: number
+}) {
+  if (input.fetchedLimit < input.requestedLimit) return false
+  if (input.cachedRootCount >= input.requestedLimit) return true
+  return input.total <= input.cachedRootCount
 }

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -131,5 +131,6 @@ export type RootLoadResult = {
 
 export const MAX_DIR_STORES = 30
 export const DIR_IDLE_TTL_MS = 20 * 60 * 1000
+export const SESSION_ROOT_PAGE_SIZE = 20
 export const SESSION_RECENT_WINDOW = 4 * 60 * 60 * 1000
 export const SESSION_RECENT_LIMIT = 50

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -15,6 +15,7 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import { type LocalProject } from "@/context/layout"
 import { loadSessionsQuery, useGlobalSync } from "@/context/global-sync"
+import { nextRootSessionLimit } from "@/context/global-sync/session-load"
 import { useLanguage } from "@/context/language"
 import { NewSessionItem, SessionItem, SessionSkeleton } from "./sidebar-items"
 import { sortedRootSessions, workspaceKey } from "./helpers"
@@ -325,7 +326,7 @@ export const SortableWorkspace = (props: {
   const touch = createMediaQuery("(hover: none)")
   const showNew = createMemo(() => !loading() && (touch() || count() === 0 || (active() && !params.id)))
   const loadMore = async () => {
-    setWorkspaceStore("limit", (limit) => (limit ?? 0) + 5)
+    setWorkspaceStore("limit", nextRootSessionLimit)
     await globalSync.project.loadSessions(props.directory)
   }
 
@@ -457,7 +458,7 @@ export const LocalWorkspace = (props: {
   const hasMore = createMemo(() => workspace().store.sessionTotal > count())
   const loading = () => query.isLoading && count() === 0
   const loadMore = async () => {
-    workspace().setStore("limit", (limit) => (limit ?? 0) + 5)
+    workspace().setStore("limit", nextRootSessionLimit)
     await globalSync.project.loadSessions(props.project.worktree)
   }
 


### PR DESCRIPTION
## Summary
- Increase the shared sidebar root-session page size from 5 to 20, including Load More increments, so Web/Desktop users need fewer repeated clicks on taller sidebars.
- Refetch root sessions when the trimmed cache cannot satisfy the newly requested limit, preventing Load More from appearing stuck.
- Add unit coverage for the page-size helpers and cache reuse/refetch boundaries.

## Relationship to #23033
This is intended as a tested, more complete UX alternative to #23033 rather than an uncoordinated duplicate.

#23033 fixes the trimmed-cache refetch bug for #23026. This PR includes that same cache-safety behavior, adds tests around it, and also improves the surrounding sidebar UX by increasing the bounded initial and incremental session page size.

If maintainers prefer the smaller #23033 patch first, I am happy to close, rebase, or split this into a follow-up UX-only PR.

## Issues
- Fixes #23026
- Related to #20614, #23074, #20270, and #23033
- Does not attempt to address archived-session server-side filtering from #24850

## Test plan
- `bun test --preload ./happydom.ts ./src/context/global-sync.test.ts` from `packages/app` — 13 pass
- `bun run test:unit` from `packages/app` — 312 pass
- `bun run typecheck` from `packages/app`
- `bun run build` from `packages/app`
- Push hook: `bun turbo typecheck` — 13 packages successful