### PR TITLE
fix(mcp): truncate tool names exceeding 64-char provider limit

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -127,7 +127,7 @@ const buildToolName = (clientName: string, toolName: string): string => {
   if (combined.length <= MAX_TOOL_NAME) return combined
   const hash = Hash.fast(combined).slice(0, 8)
   const truncated = combined.slice(0, MAX_TOOL_NAME - hash.length - 1) + "_" + hash
-  log.warn("MCP tool name exceeds 64 chars, truncating with hash suffix", {
+  log.warn(`MCP tool name exceeds ${MAX_TOOL_NAME} chars, truncating with hash suffix`, {
     server: clientName,
     tool: toolName,
     truncated,

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -13,6 +13,7 @@ import { Config } from "@/config/config"
 import { ConfigMCP } from "../config/mcp"
 import * as Log from "@opencode-ai/core/util/log"
 import { NamedError } from "@opencode-ai/core/util/error"
+import { Hash } from "@opencode-ai/core/util/hash"
 import z from "zod/v4"
 import { Installation } from "../installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
@@ -113,6 +114,26 @@ function isMcpConfigured(entry: McpEntry): entry is ConfigMCP.Info {
 }
 
 const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_")
+
+// OpenAI's tool-use API rejects tools[].function.name strings longer than
+// 64 chars. When `<server>_<tool>` exceeds the limit, opencode silently
+// dies because the provider returns 400 and the error never reaches the
+// TUI. Truncate to 64 with a content-derived suffix so colliding prefixes
+// stay distinct (issue #3523).
+const MAX_TOOL_NAME = 64
+
+const buildToolName = (clientName: string, toolName: string): string => {
+  const combined = sanitize(clientName) + "_" + sanitize(toolName)
+  if (combined.length <= MAX_TOOL_NAME) return combined
+  const hash = Hash.fast(combined).slice(0, 8)
+  const truncated = combined.slice(0, MAX_TOOL_NAME - hash.length - 1) + "_" + hash
+  log.warn("MCP tool name exceeds 64 chars, truncating with hash suffix", {
+    server: clientName,
+    tool: toolName,
+    truncated,
+  })
+  return truncated
+}
 
 // Convert MCP tool definition to AI SDK Tool type
 function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Tool {
@@ -642,7 +663,7 @@ export const layer = Layer.effect(
 
             const timeout = entry?.timeout ?? defaultTimeout
             for (const mcpTool of listed) {
-              result[sanitize(clientName) + "_" + sanitize(mcpTool.name)] = convertMcpTool(mcpTool, client, timeout)
+              result[buildToolName(clientName, mcpTool.name)] = convertMcpTool(mcpTool, client, timeout)
             }
           }),
         { concurrency: "unbounded" },

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -784,3 +784,79 @@ test(
     }),
   ),
 )
+
+// ========================================================================
+// Test: tool name length cap (issue #3523)
+// ========================================================================
+// When the combined `<server>_<tool>` exceeds 64 chars OpenAI rejects the
+// request and opencode silently dies. Truncate to 64 with a content-derived
+// suffix so collisions on the prefix still produce distinct keys.
+
+test(
+  "tools() truncates names exceeding 64 chars and preserves uniqueness",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      // Server name from the issue's reported reproducer (35 chars).
+      const longServer = "chrome-devtools-aaaaaaaaaaaaaaaaaaa"
+      lastCreatedClientName = longServer
+      const serverState = getOrCreateClientState(longServer)
+      // Two tool names that share the first 55 chars after the
+      // "<server>_" prefix — these would collide under blind truncation.
+      serverState.tools = [
+        {
+          name: "perform_extremely_specific_workflow_step_alpha",
+          description: "first long-named tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        {
+          name: "perform_extremely_specific_workflow_step_beta",
+          description: "second long-named tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]
+
+      yield* mcp.add(longServer, {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const tools = yield* mcp.tools()
+      const keys = Object.keys(tools)
+
+      // Both tools registered — neither got dropped.
+      expect(keys.length).toBe(2)
+
+      // Every key fits the 64-char provider limit.
+      for (const key of keys) {
+        expect(key.length).toBeLessThanOrEqual(64)
+      }
+
+      // Both keys are present and distinct (collision avoidance).
+      expect(new Set(keys).size).toBe(2)
+
+      // Truncated names end with an 8-char hex hash suffix.
+      for (const key of keys) {
+        expect(key).toMatch(/_[0-9a-f]{8}$/)
+      }
+    }),
+  ),
+)
+
+test(
+  "tools() leaves short names untouched",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "short"
+      const serverState = getOrCreateClientState("short")
+      serverState.tools = [{ name: "ping", description: "ping", inputSchema: { type: "object", properties: {} } }]
+
+      yield* mcp.add("short", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const tools = yield* mcp.tools()
+      expect(Object.keys(tools)).toContain("short_ping")
+    }),
+  ),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #3523

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI's tool-use API rejects `tools[].function.name` strings longer than 64 characters. When an MCP server's combined `<sanitized-server>_<sanitized-tool>` overflows, the provider returns 400 and opencode silently stops processing because the error is logged at DEBUG but never surfaces to the TUI — exactly the symptom in the issue.

`buildToolName()` (new helper next to `sanitize` in `packages/opencode/src/mcp/index.ts`) returns combined names ≤64 chars unchanged. Overflows truncate to `prefix(55) + "_" + hash(8)` where `hash` is `Hash.fast(combined).slice(0, 8)`. That preserves 55 chars of readable prefix while keeping keys distinct when two tools' first 64 chars would otherwise collide. Every truncation logs a `log.warn`.

Applied at `tools()` only — the call site feeding `function.name` to the provider. The `:`-separated keys in `fetchFromClient()` (prompts/resources) aren't subject to the 64-char limit, so I left them alone.

PR #15595 attempted this but was opened against the pre-Effect `namespace MCP` code, so that diff is rebase-incompatible regardless of approach. It also uses blind `.slice(0, 64)`, which silently drops one of any two tools whose first 64 chars match — the hash suffix here prevents that.

### How did you verify your code works?

Two new tests in `packages/opencode/test/mcp/lifecycle.test.ts`:

1. Registers `chrome-devtools-aaaaaaaaaaaaaaaaaaa` (the issue's reproducer) with two tools whose combined names share a 55-char prefix. Asserts both end up in the registry, both ≤64 chars, both end with `_[0-9a-f]{8}`, and the keys are distinct.
2. Short-name case asserts the key is unchanged `<server>_<tool>`.

Demonstrating the bug catch with the source change reverted (tests kept):

| Run | Combined name length | Test result |
|---|---|---|
| Without this fix | 82 chars | `expect(<= 64), got 82` — fail |
| With this fix | 64 chars w/ `_<8hex>` suffix | pass |

Full run: `bun test test/mcp/lifecycle.test.ts` → 21 pass, 0 fail (19 existing + 2 new). `bun run typecheck` → clean.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR