### PR TITLE
fix(desktop): recover from renderer reload white screen

### DIFF
--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -9,16 +9,25 @@ export type HealthCheck = { wait: Promise<void> }
 
 export function getDefaultServerUrl(): string | null {
   const value = getStore().get(DEFAULT_SERVER_URL_KEY)
-  return typeof value === "string" ? value : null
+  return typeof value === "string" && isHttpUrl(value) ? value : null
 }
 
 export function setDefaultServerUrl(url: string | null) {
-  if (url) {
+  if (url && isHttpUrl(url)) {
     getStore().set(DEFAULT_SERVER_URL_KEY, url)
     return
   }
 
   getStore().delete(DEFAULT_SERVER_URL_KEY)
+}
+
+function isHttpUrl(value: string) {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 export function getWslConfig(): WslConfig {

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -20,7 +20,7 @@ protocol.registerSchemesAsPrivileged([
   },
 ])
 
-let backgroundColor: string | undefined
+let backgroundColor: string | undefined = "#101010"
 
 export function setBackgroundColor(color: string) {
   backgroundColor = color
@@ -164,7 +164,8 @@ export function registerRendererProtocol() {
       return new Response("Not found", { status: 404 })
     }
 
-    const file = resolve(rendererRoot, `.${decodeURIComponent(url.pathname)}`)
+    const pathname = decodeURIComponent(url.pathname)
+    const file = resolve(rendererRoot, pathname === "/" ? "index.html" : `.${pathname}`)
     const rel = relative(rendererRoot, file)
     if (rel.startsWith("..") || isAbsolute(rel)) {
       return new Response("Not found", { status: 404 })


### PR DESCRIPTION
﻿## Summary

Fixes a desktop white-screen failure mode after renderer reloads and after stale desktop state stores a renderer-protocol URL as the server URL.

## Changes

- Ignore saved default server URLs unless they are `http:` or `https:` before using them as the desktop API base.
- Store only valid `http(s)` server URLs; invalid values clear the saved entry.
- Serve `index.html` for `oc://renderer/` root reloads instead of returning 404.
- Set a dark initial background so a failed paint does not appear as a blank white window.

## Validation

- `git diff --check origin/dev..HEAD`
- `packages/desktop-electron`: `bun run typecheck`
- Full pre-push typecheck hook passed while publishing the public mirror branch.
