### PR TITLE
feat(tool): add hash tool for file checksums

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -31,6 +31,7 @@ const AVAILABLE_PERMISSIONS = [
   "codesearch",
   "lsp",
   "skill",
+  "hash",
 ]
 
 const AgentCreateCommand = cmd({

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -46,6 +46,7 @@ import type { ApplyPatchTool } from "@/tool/apply_patch"
 import type { WebFetchTool } from "@/tool/webfetch"
 import type { CodeSearchTool } from "@/tool/codesearch"
 import type { WebSearchTool } from "@/tool/websearch"
+import type { HashTool } from "@/tool/hash"
 import type { TaskTool } from "@/tool/task"
 import type { QuestionTool } from "@/tool/question"
 import type { SkillTool } from "@/tool/skill"
@@ -1592,6 +1593,9 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
         <Match when={props.part.tool === "skill"}>
           <Skill {...toolprops} />
         </Match>
+        <Match when={props.part.tool === "hash"}>
+          <Hash {...toolprops} />
+        </Match>
         <Match when={true}>
           <GenericTool {...toolprops} />
         </Match>
@@ -2222,6 +2226,22 @@ function Skill(props: ToolProps<typeof SkillTool>) {
   return (
     <InlineTool icon="→" pending="Loading skill..." complete={props.input.name} part={props.part}>
       Skill "{props.input.name}"
+    </InlineTool>
+  )
+}
+
+function Hash(props: ToolProps<typeof HashTool>) {
+  const isRunning = createMemo(() => props.part.state.status === "running")
+  const algorithm = createMemo(() => props.input.algorithm ?? props.metadata.algorithm ?? "hash")
+  const filepath = createMemo(() => props.input.filePath)
+  const basename = createMemo(() => (filepath() ? path.basename(String(filepath())) : "file"))
+  const state = createMemo(() =>
+    props.metadata.matches === true ? "verified" : props.metadata.matches === false ? "mismatch" : "digest",
+  )
+
+  return (
+    <InlineTool icon="#" pending="Hashing..." spinner={isRunning()} complete={!isRunning()} part={props.part}>
+      {algorithm()} {state()} {basename()}
     </InlineTool>
   )
 }

--- a/packages/opencode/src/tool/hash.ts
+++ b/packages/opencode/src/tool/hash.ts
@@ -1,0 +1,118 @@
+import { Effect, Schema } from "effect"
+import { createHash } from "node:crypto"
+import { createReadStream } from "node:fs"
+import * as path from "path"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Instance } from "../project/instance"
+import { assertExternalDirectoryEffect } from "./external-directory"
+import DESCRIPTION from "./hash.txt"
+import * as Tool from "./tool"
+
+const ALGORITHMS = ["sha256", "sha512", "sha1", "md5"] as const
+
+export const Parameters = Schema.Struct({
+  filePath: Schema.String.annotate({
+    description: "Path to the file to hash. Absolute preferred; relative paths resolve from the project directory.",
+  }),
+  algorithm: Schema.Literals(ALGORITHMS)
+    .pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed("sha256" as const)))
+    .annotate({
+      description: "Hash algorithm. One of: sha256 (default), sha512, sha1, md5.",
+    }),
+  expected: Schema.optional(Schema.String).annotate({
+    description:
+      "Optional hex digest to verify against. Case-insensitive; non-hex characters (colons, spaces) are stripped. Sets metadata.matches to true/false.",
+  }),
+})
+
+type Params = Schema.Schema.Type<typeof Parameters>
+type Algorithm = (typeof ALGORITHMS)[number]
+
+type Metadata = {
+  algorithm: Algorithm
+  digest: string
+  size_bytes: number
+  elapsed_ms: number
+  expected?: string
+  matches?: boolean
+}
+
+const normalizeHex = (s: string) => s.toLowerCase().replace(/[^a-f0-9]/g, "")
+
+const streamHash = (filePath: string, algorithm: Algorithm, signal: AbortSignal): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const hasher = createHash(algorithm)
+    const stream = createReadStream(filePath, { signal: signal as any })
+    stream.on("data", (chunk) => hasher.update(chunk))
+    stream.on("end", () => resolve(hasher.digest("hex")))
+    stream.on("error", reject)
+  })
+
+const done = (result: Tool.ExecuteResult<Metadata>) => result
+
+export const HashTool = Tool.define(
+  "hash",
+  Effect.gen(function* () {
+    const fs = yield* AppFileSystem.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Params, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          const algorithm = params.algorithm ?? "sha256"
+          const target = path.isAbsolute(params.filePath)
+            ? params.filePath
+            : path.resolve(Instance.directory, params.filePath)
+
+          yield* ctx.ask({
+            permission: "read",
+            patterns: [target],
+            always: ["*"],
+            metadata: { filePath: target, algorithm },
+          })
+
+          yield* assertExternalDirectoryEffect(ctx, target, { kind: "file" })
+
+          const info = yield* fs.stat(target).pipe(Effect.catch(() => Effect.succeed(undefined)))
+          if (!info) {
+            throw new Error(`hash: file not found: ${target}`)
+          }
+          if (info.type !== "File") {
+            throw new Error(`hash: not a regular file: ${target} (type=${info.type})`)
+          }
+
+          const size_bytes = Number(info.size ?? 0)
+          const start = Date.now()
+          const digest = yield* Effect.promise(() => streamHash(target, algorithm, ctx.abort))
+          const elapsed_ms = Date.now() - start
+
+          const expected = params.expected ? normalizeHex(params.expected) : undefined
+          const matches = expected !== undefined ? digest === expected : undefined
+          const sizeMb = (size_bytes / 1024 / 1024).toFixed(1)
+          const verified = matches === true ? " verified" : matches === false ? " mismatch" : ""
+          const title = `${algorithm} ${digest.slice(0, 12)}...${digest.slice(-4)}${verified}`
+
+          const output =
+            matches === false
+              ? `${algorithm} MISMATCH for ${target} (${sizeMb} MB, hashed in ${elapsed_ms}ms)\n  computed: ${digest}\n  expected: ${expected}`
+              : matches === true
+                ? `${algorithm} verified for ${target} (${sizeMb} MB, hashed in ${elapsed_ms}ms)\n  digest:   ${digest}`
+                : `${algorithm} digest of ${target} (${sizeMb} MB, hashed in ${elapsed_ms}ms)\n  digest: ${digest}`
+
+          return done({
+            title,
+            metadata: {
+              algorithm,
+              digest,
+              size_bytes,
+              elapsed_ms,
+              expected,
+              matches,
+            },
+            output,
+          })
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/hash.txt
+++ b/packages/opencode/src/tool/hash.txt
@@ -1,0 +1,23 @@
+Compute a cryptographic hash of a local file, optionally verifying against an expected digest.
+
+Use this when you need to confirm a downloaded file matches a published digest, compare two files for byte-identity, or record a digest for later verification.
+
+Parameters:
+- `filePath` (required): path to the file to hash. Absolute paths preferred. Relative paths resolve from the current project directory.
+- `algorithm` (optional): one of `sha256` (default), `sha512`, `sha1`, `md5`. Use sha256 unless a vendor specifically publishes a different digest.
+- `expected` (optional): hex digest to verify against. Case-insensitive, non-hex characters are stripped (so you can paste with colons/spaces from a checksum manifest). If provided, the tool's metadata will set `matches` to true/false.
+
+Behavior:
+- Streams the file from disk so it works on multi-gigabyte inputs without OOM.
+- Hashing is interruptible via the abort signal.
+- Returns the hex digest in `metadata.digest`, file size in `metadata.size_bytes`, elapsed time in `metadata.elapsed_ms`.
+- If `expected` is provided and the hash does not match, the tool still returns successfully (no thrown error) but with `matches: false` so you can branch on it.
+
+Examples:
+- Verify a downloaded installer: `{ "filePath": "C:\\Users\\me\\Downloads\\driver.exe", "algorithm": "sha256", "expected": "9af3...:b21" }`
+- Just compute a digest: `{ "filePath": "./build/output.tar.gz" }`
+- Compare two files (call twice and compare digests): `{ "filePath": "/tmp/a" }` then `{ "filePath": "/tmp/b" }`
+
+Do NOT use this tool to:
+- Hash strings or in-memory data. That's not what it does. Hash a file on disk.
+- Verify code-signing / Authenticode signatures. That's a separate operation; this tool only computes content hashes.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -12,6 +12,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { HashTool } from "./hash"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
 import { type ToolContext as PluginToolContext, type ToolDefinition } from "@opencode-ai/plugin"
@@ -115,6 +116,7 @@ export const layer: Layer.Layer<
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const hashtool = yield* HashTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -204,6 +206,7 @@ export const layer: Layer.Layer<
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          hash: Tool.init(hashtool),
         })
 
         return {
@@ -226,6 +229,7 @@ export const layer: Layer.Layer<
             tool.patch,
             ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [tool.lsp] : []),
             ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [tool.plan] : []),
+            tool.hash,
           ],
           task: tool.task,
           read: tool.read,

--- a/packages/opencode/test/tool/hash.test.ts
+++ b/packages/opencode/test/tool/hash.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Agent } from "../../src/agent/agent"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { Tool } from "@/tool/tool"
+import { HashTool } from "../../src/tool/hash"
+import { Truncate } from "@/tool/truncate"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  Layer.mergeAll(CrossSpawnSpawner.defaultLayer, AppFileSystem.defaultLayer, Truncate.defaultLayer, Agent.defaultLayer),
+)
+
+const baseCtx: Tool.Context = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+describe("tool.hash", () => {
+  it.live("computes sha256 by default", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const file = path.join(dir, "hello.txt")
+        yield* Effect.promise(() => Bun.write(file, "hello"))
+
+        const toolInfo = yield* HashTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute({ filePath: file }, baseCtx)
+
+        expect(result.metadata.algorithm).toBe("sha256")
+        expect(result.metadata.digest).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        expect(result.output).toContain("sha256 digest")
+      }),
+    ),
+  )
+
+  it.live("verifies an expected digest", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const file = path.join(dir, "hello.txt")
+        yield* Effect.promise(() => Bun.write(file, "hello"))
+
+        const toolInfo = yield* HashTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          {
+            filePath: file,
+            expected: "2cf2 4dba 5fb0 a30e 26e8 3b2a c5b9 e29e 1b16 1e5c 1fa7 425e 7304 3362 938b 9824",
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.matches).toBe(true)
+        expect(result.title).toContain("verified")
+        expect(result.output).toContain("verified")
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
﻿### Issue for this PR

Closes #24886

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a built-in `hash` tool for computing a digest of a local file and optionally verifying it against an expected checksum.

The tool streams the file from disk, so it can handle large downloads or build artifacts without reading the whole file into memory. It defaults to `sha256`, also supports `sha512`, `sha1`, and `md5` for compatibility with vendor-published checksum manifests, and returns structured metadata for the digest, file size, elapsed time, and match/mismatch state.

It uses the existing read permission path and external-directory check before opening the file.

### How did you verify your code works?

- `packages/opencode`: `bun test test/tool/hash.test.ts --timeout 30000`
- `packages/opencode`: `bun run typecheck`
- `git diff --check origin/dev..HEAD`

### Screenshots / recordings

Not a UI-facing change beyond the compact TUI tool display.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
