### PR TITLE
feat(tool): add bounded wait tool

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -31,6 +31,7 @@ const AVAILABLE_PERMISSIONS = [
   "codesearch",
   "lsp",
   "skill",
+  "wait",
 ]
 
 const AgentCreateCommand = cmd({

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -46,6 +46,7 @@ import type { ApplyPatchTool } from "@/tool/apply_patch"
 import type { WebFetchTool } from "@/tool/webfetch"
 import type { CodeSearchTool } from "@/tool/codesearch"
 import type { WebSearchTool } from "@/tool/websearch"
+import type { WaitTool } from "@/tool/wait"
 import type { TaskTool } from "@/tool/task"
 import type { QuestionTool } from "@/tool/question"
 import type { SkillTool } from "@/tool/skill"
@@ -1592,6 +1593,9 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
         <Match when={props.part.tool === "skill"}>
           <Skill {...toolprops} />
         </Match>
+        <Match when={props.part.tool === "wait"}>
+          <Wait {...toolprops} />
+        </Match>
         <Match when={true}>
           <GenericTool {...toolprops} />
         </Match>
@@ -2222,6 +2226,31 @@ function Skill(props: ToolProps<typeof SkillTool>) {
   return (
     <InlineTool icon="→" pending="Loading skill..." complete={props.input.name} part={props.part}>
       Skill "{props.input.name}"
+    </InlineTool>
+  )
+}
+
+function Wait(props: ToolProps<typeof WaitTool>) {
+  const isRunning = createMemo(() => props.part.state.status === "running")
+  const seconds = createMemo(() => props.input.seconds ?? props.metadata.seconds)
+  const reason = createMemo(() => props.input.reason ?? props.metadata.reason)
+  const target = createMemo(() => props.input.until_file ?? props.metadata.target)
+  const textTarget = createMemo(() => props.input.until_text)
+  const pattern = createMemo(() => props.input.until_text_pattern ?? props.metadata.pattern)
+  const url = createMemo(() => props.input.until_url ?? props.metadata.url)
+  const pid = createMemo(() => props.input.until_pid_exit ?? props.metadata.pid)
+  const label = createMemo(() => (typeof seconds() === "number" ? `${seconds()}s` : "delay"))
+
+  return (
+    <InlineTool icon="~" pending="Waiting..." spinner={isRunning()} complete={!isRunning()} part={props.part}>
+      Wait {label()}
+      <Show when={reason()}> - {reason()}</Show>
+      <Show when={target()}> ({path.basename(String(target()))})</Show>
+      <Show when={textTarget() && pattern()}>
+        {" "}({path.basename(String(textTarget()))} ~/{String(pattern()).slice(0, 24)}/)
+      </Show>
+      <Show when={url()}> [{String(url())}]</Show>
+      <Show when={pid()}> [pid {String(pid())}]</Show>
     </InlineTool>
   )
 }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -12,6 +12,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { WaitTool } from "./wait"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
 import { type ToolContext as PluginToolContext, type ToolDefinition } from "@opencode-ai/plugin"
@@ -115,6 +116,7 @@ export const layer: Layer.Layer<
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const waittool = yield* WaitTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -204,6 +206,7 @@ export const layer: Layer.Layer<
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          wait: Tool.init(waittool),
         })
 
         return {
@@ -226,6 +229,7 @@ export const layer: Layer.Layer<
             tool.patch,
             ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [tool.lsp] : []),
             ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [tool.plan] : []),
+            tool.wait,
           ],
           task: tool.task,
           read: tool.read,

--- a/packages/opencode/src/tool/wait.ts
+++ b/packages/opencode/src/tool/wait.ts
@@ -1,0 +1,779 @@
+import { open as fsOpen } from "node:fs/promises"
+import path from "path"
+import { Duration, Effect, Schema } from "effect"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { InstanceState } from "@/effect/instance-state"
+import DESCRIPTION from "./wait.txt"
+import * as Tool from "./tool"
+
+const MAX_SECONDS = 3600
+const DEFAULT_POLL_INTERVAL_MS = 5_000
+const MIN_POLL_INTERVAL_MS = 100
+const MAX_POLL_INTERVAL_MS = 60_000
+const DEFAULT_STABLE_REQUIRED_MS = 10_000
+const MAX_STABLE_REQUIRED_MS = 600_000
+const DEFAULT_URL_TIMEOUT_MS = 10_000
+const DEFAULT_TEXT_TAIL_BYTES = 32_768
+const MAX_TEXT_TAIL_BYTES = 1_048_576
+
+export const Parameters = Schema.Struct({
+  seconds: Schema.Number.check(Schema.isInt())
+    .check(Schema.isGreaterThanOrEqualTo(1))
+    .check(Schema.isLessThanOrEqualTo(MAX_SECONDS))
+    .annotate({
+      description: `Maximum number of seconds to wait before continuing in this same chat. Range 1-${MAX_SECONDS} (1 hour cap).`,
+    }),
+  reason: Schema.String.annotate({
+    description: "Short reason shown to the user in the UI explaining why the agent is paused.",
+  }),
+  until_file: Schema.optional(Schema.String).annotate({
+    description:
+      "Optional file path. If provided, poll this file and return early once its size has been stable for stable_ms. Relative paths resolve from the current project directory.",
+  }),
+  min_size_bytes: Schema.optional(Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThanOrEqualTo(0))).annotate(
+    {
+      description:
+        "Optional. Used only with until_file. The file must reach at least this many bytes before the stable-size check can succeed.",
+    },
+  ),
+  poll_interval_ms: Schema.optional(
+    Schema.Number.check(Schema.isInt())
+      .check(Schema.isGreaterThanOrEqualTo(MIN_POLL_INTERVAL_MS))
+      .check(Schema.isLessThanOrEqualTo(MAX_POLL_INTERVAL_MS)),
+  ).annotate({
+    description: `Optional polling interval in milliseconds for until_file/until_url/until_pid_exit and cancel_if_file checks. Range ${MIN_POLL_INTERVAL_MS}-${MAX_POLL_INTERVAL_MS}. Default ${DEFAULT_POLL_INTERVAL_MS}.`,
+  }),
+  stable_ms: Schema.optional(
+    Schema.Number.check(Schema.isInt())
+      .check(Schema.isGreaterThanOrEqualTo(0))
+      .check(Schema.isLessThanOrEqualTo(MAX_STABLE_REQUIRED_MS)),
+  ).annotate({
+    description: `Optional stable-size window in milliseconds for until_file. Default ${DEFAULT_STABLE_REQUIRED_MS}. Use 0 to return as soon as the file exists and meets min_size_bytes.`,
+  }),
+  cancel_if_file: Schema.optional(Schema.String).annotate({
+    description:
+      "Optional sentinel file path. If this file appears while waiting, return early with cancelled_by_file=true instead of waiting for the timeout. Relative paths resolve from the current project directory.",
+  }),
+  until_url: Schema.optional(Schema.String).annotate({
+    description:
+      "Optional http(s) URL. If provided, poll the URL with HEAD (then GET as fallback) and return early once the response status matches until_url_status. Useful for waiting on a dev server or service to come up.",
+  }),
+  until_url_status: Schema.optional(
+    Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThanOrEqualTo(100)).check(Schema.isLessThanOrEqualTo(599)),
+  ).annotate({
+    description:
+      "Optional HTTP status code to consider success for until_url. Defaults to 200. A 2xx-class match can be requested as 200, 204, etc. Pass a number such as 401 to wait until an auth-protected endpoint at least responds.",
+  }),
+  until_pid_exit: Schema.optional(Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThanOrEqualTo(1))).annotate({
+    description:
+      "Optional process id. If provided, return early once the process is no longer running. Useful for waiting on a backgrounded shell command to finish.",
+  }),
+  until_text: Schema.optional(Schema.String).annotate({
+    description:
+      "Optional file path to tail. If provided alongside until_text_pattern, the wait returns as soon as that pattern matches the tail of the file. Pairs well with bash backgrounded jobs that write to a log file.",
+  }),
+  until_text_pattern: Schema.optional(Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(2048))).annotate({
+    description:
+      "Optional regex (JavaScript flavour, no surrounding slashes) used with until_text. Matched against the last text_tail_bytes of the file. The match is case-sensitive; prefix with `(?i)` is NOT supported, use `[Aa][Bb]` style instead, or pass text_pattern_flags='i'.",
+  }),
+  text_pattern_flags: Schema.optional(Schema.String.check(Schema.isMaxLength(8))).annotate({
+    description:
+      "Optional regex flags for until_text_pattern, e.g. 'i' (case-insensitive), 'm' (multi-line), 's' (dotall). Defaults to 'm'.",
+  }),
+  text_tail_bytes: Schema.optional(
+    Schema.Number.check(Schema.isInt())
+      .check(Schema.isGreaterThanOrEqualTo(256))
+      .check(Schema.isLessThanOrEqualTo(MAX_TEXT_TAIL_BYTES)),
+  ).annotate({
+    description: `Optional byte size of the file tail to test against until_text_pattern. Range 256-${MAX_TEXT_TAIL_BYTES}. Default ${DEFAULT_TEXT_TAIL_BYTES}.`,
+  }),
+})
+
+type Params = Schema.Schema.Type<typeof Parameters>
+
+type WaitMode = "fixed" | "until_file" | "until_url" | "until_pid_exit" | "until_text"
+
+type Metadata = {
+  mode: WaitMode
+  seconds: number
+  reason: string
+  elapsed_seconds?: number
+  remaining_seconds?: number
+  aborted?: boolean
+  target?: string
+  min_size_bytes?: number
+  poll_interval_ms?: number
+  stable_ms?: number
+  size_bytes?: number
+  polls?: number
+  ready?: boolean
+  timed_out?: boolean
+  reached_min_size?: boolean
+  cancel_if_file?: string
+  cancelled_by_file?: boolean
+  url?: string
+  url_status?: number
+  expected_status?: number
+  pid?: number
+  exited?: boolean
+  pattern?: string
+  pattern_flags?: string
+  text_tail_bytes?: number
+  matched?: boolean
+  match?: string
+}
+
+const abortable = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  signal: AbortSignal,
+): Effect.Effect<A | "__aborted__", E, R> =>
+  Effect.race(
+    effect,
+    Effect.callback<"__aborted__">((resume) => {
+      if (signal.aborted) {
+        resume(Effect.succeed("__aborted__"))
+        return
+      }
+      const handler = () => resume(Effect.succeed("__aborted__"))
+      signal.addEventListener("abort", handler, { once: true })
+      return Effect.sync(() => signal.removeEventListener("abort", handler))
+    }),
+  )
+
+const mb = (bytes: number) => (bytes / 1024 / 1024).toFixed(1)
+const done = (result: Tool.ExecuteResult<Metadata>) => result
+const sleepMs = (ms: number) => Effect.sleep(Duration.millis(Math.max(0, ms)))
+
+function isProcessAlive(pid: number) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err: any) {
+    // EPERM means it exists but we lack permission to signal it - still alive.
+    return err?.code === "EPERM"
+  }
+}
+
+async function readFileTail(filePath: string, maxBytes: number): Promise<string | undefined> {
+  try {
+    const fh = await fsOpen(filePath, "r")
+    try {
+      const stat = await fh.stat()
+      const size = Number(stat.size ?? 0)
+      const readBytes = Math.min(size, maxBytes)
+      if (readBytes <= 0) return ""
+      const buf = Buffer.alloc(readBytes)
+      const start = size - readBytes
+      await fh.read(buf, 0, readBytes, start)
+      return buf.toString("utf8")
+    } finally {
+      await fh.close().catch(() => undefined)
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function compilePattern(pattern: string, flags: string | undefined): RegExp {
+  const safeFlags = (flags ?? "m").replace(/[^gimsuy]/g, "")
+  // Always include 'm' so ^/$ work line-by-line by default.
+  const finalFlags = safeFlags.includes("m") ? safeFlags : safeFlags + "m"
+  return new RegExp(pattern, finalFlags)
+}
+
+async function probeUrl(url: string, signal: AbortSignal, timeoutMs: number) {
+  const ac = new AbortController()
+  const onAbort = () => ac.abort()
+  signal.addEventListener("abort", onAbort, { once: true })
+  const timer = setTimeout(() => ac.abort(), timeoutMs)
+  try {
+    let res: Response | undefined
+    try {
+      res = await fetch(url, { method: "HEAD", signal: ac.signal, redirect: "follow" })
+    } catch {
+      // HEAD often disallowed; fall through to GET.
+    }
+    if (!res || res.status === 405 || res.status === 501) {
+      res = await fetch(url, { method: "GET", signal: ac.signal, redirect: "follow" })
+    }
+    return { status: res.status as number | undefined, error: undefined as string | undefined }
+  } catch (err: any) {
+    return { status: undefined, error: err?.message ?? String(err) }
+  } finally {
+    clearTimeout(timer)
+    signal.removeEventListener("abort", onAbort)
+  }
+}
+
+export const WaitTool = Tool.define(
+  "wait",
+  Effect.gen(function* () {
+    const fs = yield* AppFileSystem.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Params, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          const ins = yield* InstanceState.context
+          const start = Date.now()
+          const deadline = start + params.seconds * 1000
+          const pollIntervalMs = params.poll_interval_ms ?? DEFAULT_POLL_INTERVAL_MS
+          const stableRequiredMs = params.stable_ms ?? DEFAULT_STABLE_REQUIRED_MS
+          const cancelTarget = params.cancel_if_file
+            ? path.isAbsolute(params.cancel_if_file)
+              ? params.cancel_if_file
+              : path.resolve(ins.directory, params.cancel_if_file)
+            : undefined
+
+          const checkCancel = () =>
+            cancelTarget
+              ? fs.stat(cancelTarget).pipe(
+                  Effect.map(() => true),
+                  Effect.catch(() => Effect.succeed(false)),
+                )
+              : Effect.succeed(false)
+
+          if (params.until_text || params.until_text_pattern) {
+            if (!params.until_text || !params.until_text_pattern) {
+              throw new Error(
+                "wait: until_text and until_text_pattern must be provided together. until_text is the file path to tail; until_text_pattern is the regex to match.",
+              )
+            }
+            const tailBytes = params.text_tail_bytes ?? DEFAULT_TEXT_TAIL_BYTES
+            let regex: RegExp
+            try {
+              regex = compilePattern(params.until_text_pattern, params.text_pattern_flags)
+            } catch (err: unknown) {
+              throw new Error(`wait: until_text_pattern is not a valid regex: ${(err as Error).message}`)
+            }
+            const target = path.isAbsolute(params.until_text)
+              ? params.until_text
+              : path.resolve(ins.directory, params.until_text)
+
+            yield* ctx.metadata({
+              title: `wait up to ${params.seconds}s for /${regex.source}/ in ${path.basename(target)}`,
+              metadata: {
+                mode: "until_text",
+                target,
+                pattern: regex.source,
+                pattern_flags: regex.flags,
+                text_tail_bytes: tailBytes,
+                seconds: params.seconds,
+                reason: params.reason,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+              },
+            })
+
+            let aborted = false
+            let cancelledByFile = false
+            let pollCount = 0
+            let matched = false
+            let matchText: string | undefined
+            let lastTitleUpdate = start
+
+            while (Date.now() < deadline) {
+              if (yield* checkCancel()) {
+                cancelledByFile = true
+                break
+              }
+              pollCount++
+
+              const tail = yield* Effect.promise(() => readFileTail(target, tailBytes))
+              if (typeof tail === "string") {
+                const m = regex.exec(tail)
+                if (m) {
+                  matched = true
+                  matchText = m[0].slice(0, 200)
+                  break
+                }
+              }
+
+              const now = Date.now()
+              if (now - lastTitleUpdate >= 1000 && now < deadline) {
+                lastTitleUpdate = now
+                const left = Math.max(0, Math.ceil((deadline - now) / 1000))
+                yield* ctx.metadata({
+                  title: `wait /${regex.source}/ in ${path.basename(target)} (${left}s left)`,
+                  metadata: {
+                    mode: "until_text",
+                    target,
+                    pattern: regex.source,
+                    pattern_flags: regex.flags,
+                    text_tail_bytes: tailBytes,
+                    seconds: params.seconds,
+                    reason: params.reason,
+                    elapsed_seconds: (now - start) / 1000,
+                    remaining_seconds: left,
+                    polls: pollCount,
+                    poll_interval_ms: pollIntervalMs,
+                    cancel_if_file: cancelTarget,
+                  },
+                })
+              }
+
+              const remaining = deadline - Date.now()
+              if (remaining <= 0) break
+              const tick = yield* abortable(sleepMs(Math.min(pollIntervalMs, remaining)), ctx.abort)
+              if (tick === "__aborted__") {
+                aborted = true
+                break
+              }
+            }
+
+            const elapsed = (Date.now() - start) / 1000
+            return done({
+              title: matched
+                ? `${path.basename(target)} matched /${regex.source}/ after ${elapsed.toFixed(1)}s`
+                : cancelledByFile
+                  ? `wait cancelled by file after ${elapsed.toFixed(1)}s`
+                  : aborted
+                    ? `wait cancelled after ${elapsed.toFixed(1)}s`
+                    : `wait timed out after ${elapsed.toFixed(1)}s`,
+              metadata: {
+                mode: "until_text",
+                target,
+                pattern: regex.source,
+                pattern_flags: regex.flags,
+                text_tail_bytes: tailBytes,
+                seconds: params.seconds,
+                elapsed_seconds: elapsed,
+                polls: pollCount,
+                reason: params.reason,
+                matched,
+                match: matchText,
+                timed_out: !matched && !aborted && !cancelledByFile,
+                aborted,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+                cancelled_by_file: cancelledByFile,
+              },
+              output: matched
+                ? `Pattern /${regex.source}/${regex.flags} matched in ${target} after ${elapsed.toFixed(1)}s. First match: ${matchText}. Reason: ${params.reason}`
+                : cancelledByFile
+                  ? `Wait cancelled after ${elapsed.toFixed(1)}s because sentinel file exists: ${cancelTarget}. Reason: ${params.reason}`
+                  : aborted
+                    ? `Wait cancelled after ${elapsed.toFixed(1)}s. Reason: ${params.reason}`
+                    : `Timed out after ${elapsed.toFixed(1)}s waiting for /${regex.source}/${regex.flags} in ${target}. Reason: ${params.reason}`,
+            })
+          }
+
+          if (params.until_url) {
+            const expectedStatus = params.until_url_status ?? 200
+            yield* ctx.metadata({
+              title: `wait up to ${params.seconds}s for ${params.until_url}`,
+              metadata: {
+                mode: "until_url",
+                url: params.until_url,
+                expected_status: expectedStatus,
+                seconds: params.seconds,
+                reason: params.reason,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+              },
+            })
+
+            let aborted = false
+            let cancelledByFile = false
+            let pollCount = 0
+            let lastStatus: number | undefined
+            let lastError: string | undefined
+            let lastTitleUpdate = start
+            let ready = false
+
+            while (Date.now() < deadline) {
+              if (yield* checkCancel()) {
+                cancelledByFile = true
+                break
+              }
+              pollCount++
+
+              const probe = yield* Effect.promise(() =>
+                probeUrl(params.until_url!, ctx.abort, Math.min(DEFAULT_URL_TIMEOUT_MS, pollIntervalMs * 2)),
+              )
+              lastStatus = probe.status
+              lastError = probe.error
+
+              if (lastStatus !== undefined && lastStatus === expectedStatus) {
+                ready = true
+                break
+              }
+
+              const now = Date.now()
+              if (now - lastTitleUpdate >= 1000 && now < deadline) {
+                lastTitleUpdate = now
+                const left = Math.max(0, Math.ceil((deadline - now) / 1000))
+                yield* ctx.metadata({
+                  title: `${params.until_url} ${lastStatus ?? "?"} (${left}s left)`,
+                  metadata: {
+                    mode: "until_url",
+                    url: params.until_url,
+                    expected_status: expectedStatus,
+                    url_status: lastStatus,
+                    seconds: params.seconds,
+                    reason: params.reason,
+                    elapsed_seconds: (now - start) / 1000,
+                    remaining_seconds: left,
+                    polls: pollCount,
+                    poll_interval_ms: pollIntervalMs,
+                    cancel_if_file: cancelTarget,
+                  },
+                })
+              }
+
+              const remaining = deadline - Date.now()
+              if (remaining <= 0) break
+              const tick = yield* abortable(sleepMs(Math.min(pollIntervalMs, remaining)), ctx.abort)
+              if (tick === "__aborted__") {
+                aborted = true
+                break
+              }
+            }
+
+            const elapsed = (Date.now() - start) / 1000
+            const titleSuffix = ready
+              ? `${params.until_url} ${lastStatus} ready`
+              : cancelledByFile
+                ? `wait cancelled by file after ${elapsed.toFixed(1)}s`
+                : aborted
+                  ? `wait cancelled after ${elapsed.toFixed(1)}s`
+                  : `wait timed out after ${elapsed.toFixed(1)}s`
+            return done({
+              title: titleSuffix,
+              metadata: {
+                mode: "until_url",
+                url: params.until_url,
+                expected_status: expectedStatus,
+                url_status: lastStatus,
+                seconds: params.seconds,
+                elapsed_seconds: elapsed,
+                polls: pollCount,
+                reason: params.reason,
+                ready,
+                timed_out: !ready && !aborted && !cancelledByFile,
+                aborted,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+                cancelled_by_file: cancelledByFile,
+              },
+              output: ready
+                ? `URL ${params.until_url} returned ${lastStatus} after ${elapsed.toFixed(1)}s. Reason: ${params.reason}`
+                : cancelledByFile
+                  ? `Wait cancelled after ${elapsed.toFixed(1)}s because sentinel file exists: ${cancelTarget}. Last status: ${lastStatus ?? lastError ?? "no response"}. Reason: ${params.reason}`
+                  : aborted
+                    ? `Wait cancelled after ${elapsed.toFixed(1)}s. Last status: ${lastStatus ?? lastError ?? "no response"}. Reason: ${params.reason}`
+                    : `Timed out after ${elapsed.toFixed(1)}s polling ${params.until_url}. Last status: ${lastStatus ?? lastError ?? "no response"} (expected ${expectedStatus}). Reason: ${params.reason}`,
+            })
+          }
+
+          if (params.until_pid_exit !== undefined) {
+            const pid = params.until_pid_exit
+            yield* ctx.metadata({
+              title: `wait up to ${params.seconds}s for pid ${pid} to exit`,
+              metadata: {
+                mode: "until_pid_exit",
+                pid,
+                seconds: params.seconds,
+                reason: params.reason,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+              },
+            })
+
+            let aborted = false
+            let cancelledByFile = false
+            let pollCount = 0
+            let exited = false
+            let lastTitleUpdate = start
+
+            while (Date.now() < deadline) {
+              if (yield* checkCancel()) {
+                cancelledByFile = true
+                break
+              }
+              pollCount++
+
+              if (!isProcessAlive(pid)) {
+                exited = true
+                break
+              }
+
+              const now = Date.now()
+              if (now - lastTitleUpdate >= 1000 && now < deadline) {
+                lastTitleUpdate = now
+                const left = Math.max(0, Math.ceil((deadline - now) / 1000))
+                yield* ctx.metadata({
+                  title: `pid ${pid} alive (${left}s left)`,
+                  metadata: {
+                    mode: "until_pid_exit",
+                    pid,
+                    seconds: params.seconds,
+                    reason: params.reason,
+                    elapsed_seconds: (now - start) / 1000,
+                    remaining_seconds: left,
+                    polls: pollCount,
+                    poll_interval_ms: pollIntervalMs,
+                    cancel_if_file: cancelTarget,
+                  },
+                })
+              }
+
+              const remaining = deadline - Date.now()
+              if (remaining <= 0) break
+              const tick = yield* abortable(sleepMs(Math.min(pollIntervalMs, remaining)), ctx.abort)
+              if (tick === "__aborted__") {
+                aborted = true
+                break
+              }
+            }
+
+            const elapsed = (Date.now() - start) / 1000
+            return done({
+              title: exited
+                ? `pid ${pid} exited after ${elapsed.toFixed(1)}s`
+                : cancelledByFile
+                  ? `wait cancelled by file after ${elapsed.toFixed(1)}s`
+                  : aborted
+                    ? `wait cancelled after ${elapsed.toFixed(1)}s`
+                    : `pid ${pid} still alive after ${elapsed.toFixed(1)}s (timeout)`,
+              metadata: {
+                mode: "until_pid_exit",
+                pid,
+                seconds: params.seconds,
+                elapsed_seconds: elapsed,
+                polls: pollCount,
+                reason: params.reason,
+                exited,
+                timed_out: !exited && !aborted && !cancelledByFile,
+                aborted,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+                cancelled_by_file: cancelledByFile,
+              },
+              output: exited
+                ? `Process ${pid} exited after ${elapsed.toFixed(1)}s. Reason: ${params.reason}`
+                : cancelledByFile
+                  ? `Wait cancelled after ${elapsed.toFixed(1)}s because sentinel file exists: ${cancelTarget}. Reason: ${params.reason}`
+                  : aborted
+                    ? `Wait cancelled after ${elapsed.toFixed(1)}s. Reason: ${params.reason}`
+                    : `Timed out after ${elapsed.toFixed(1)}s waiting for pid ${pid} to exit. Reason: ${params.reason}`,
+            })
+          }
+
+          if (!params.until_file) {
+            yield* ctx.metadata({
+              title: `wait ${params.seconds}s - ${params.reason}`,
+              metadata: {
+                mode: "fixed",
+                seconds: params.seconds,
+                reason: params.reason,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+              },
+            })
+
+            let aborted = false
+            let cancelledByFile = false
+            let pollCount = 0
+            let lastTitleUpdate = start
+
+            while (Date.now() < deadline) {
+              if (yield* checkCancel()) {
+                cancelledByFile = true
+                break
+              }
+
+              const remaining = deadline - Date.now()
+              if (remaining <= 0) break
+
+              const result = yield* abortable(sleepMs(Math.min(pollIntervalMs, 1000, remaining)), ctx.abort)
+              if (result === "__aborted__") {
+                aborted = true
+                break
+              }
+              pollCount++
+
+              const now = Date.now()
+              if (now - lastTitleUpdate >= 1000 && now < deadline) {
+                lastTitleUpdate = now
+                const left = Math.max(0, Math.ceil((deadline - now) / 1000))
+                yield* ctx.metadata({
+                  title: `wait ${left}s left - ${params.reason}`,
+                  metadata: {
+                    mode: "fixed",
+                    seconds: params.seconds,
+                    reason: params.reason,
+                    elapsed_seconds: (now - start) / 1000,
+                    remaining_seconds: left,
+                    polls: pollCount,
+                    poll_interval_ms: pollIntervalMs,
+                    cancel_if_file: cancelTarget,
+                  },
+                })
+              }
+            }
+
+            const elapsed = (Date.now() - start) / 1000
+            return done({
+              title: cancelledByFile
+                ? `wait cancelled by file after ${elapsed.toFixed(1)}s`
+                : aborted
+                  ? `wait cancelled after ${elapsed.toFixed(1)}s`
+                  : `waited ${elapsed.toFixed(1)}s`,
+              metadata: {
+                mode: "fixed",
+                seconds: params.seconds,
+                elapsed_seconds: elapsed,
+                reason: params.reason,
+                aborted,
+                polls: pollCount,
+                poll_interval_ms: pollIntervalMs,
+                cancel_if_file: cancelTarget,
+                cancelled_by_file: cancelledByFile,
+              },
+              output: cancelledByFile
+                ? `Wait cancelled after ${elapsed.toFixed(1)}s because sentinel file exists: ${cancelTarget}. Reason: ${params.reason}`
+                : aborted
+                  ? `Wait cancelled after ${elapsed.toFixed(1)}s. Reason: ${params.reason}`
+                  : `Waited ${elapsed.toFixed(1)}s. Reason: ${params.reason}`,
+            })
+          }
+
+          const target = path.isAbsolute(params.until_file)
+            ? params.until_file
+            : path.resolve(ins.directory, params.until_file)
+
+          yield* ctx.metadata({
+            title: `wait up to ${params.seconds}s for ${path.basename(target)}`,
+            metadata: {
+              mode: "until_file",
+              target,
+              seconds: params.seconds,
+              reason: params.reason,
+              min_size_bytes: params.min_size_bytes,
+              poll_interval_ms: pollIntervalMs,
+              stable_ms: stableRequiredMs,
+              cancel_if_file: cancelTarget,
+            },
+          })
+
+          let lastSize = -1
+          let lastChanged = Date.now()
+          let pollCount = 0
+          let aborted = false
+          let cancelledByFile = false
+          let lastTitleSize = -1
+
+          while (Date.now() < deadline) {
+            if (yield* checkCancel()) {
+              cancelledByFile = true
+              break
+            }
+            pollCount++
+
+            const info = yield* fs.stat(target).pipe(Effect.catch(() => Effect.succeed(undefined)))
+            if (info && info.type === "File") {
+              const size = Number(info.size ?? 0)
+
+              // Refresh progress when the file grows by at least 1 MB.
+              const sizeDeltaMb = lastTitleSize < 0 ? Infinity : Math.abs(size - lastTitleSize) / 1024 / 1024
+              if (sizeDeltaMb >= 1) {
+                lastTitleSize = size
+                const elapsedNow = (Date.now() - start) / 1000
+                const targetSuffix = params.min_size_bytes ? ` / ${mb(params.min_size_bytes)} MB` : ""
+                yield* ctx.metadata({
+                  title: `${path.basename(target)} ${mb(size)} MB${targetSuffix} (${elapsedNow.toFixed(0)}s)`,
+                  metadata: {
+                    mode: "until_file",
+                    target,
+                    seconds: params.seconds,
+                    elapsed_seconds: elapsedNow,
+                    size_bytes: size,
+                    polls: pollCount,
+                    reason: params.reason,
+                    poll_interval_ms: pollIntervalMs,
+                    stable_ms: stableRequiredMs,
+                    min_size_bytes: params.min_size_bytes,
+                    cancel_if_file: cancelTarget,
+                  },
+                })
+              }
+
+              if (size !== lastSize) {
+                lastSize = size
+                lastChanged = Date.now()
+              }
+
+              const stableFor = Date.now() - lastChanged
+              const meetsSize = params.min_size_bytes === undefined || size >= params.min_size_bytes
+              if (stableFor >= stableRequiredMs && meetsSize) {
+                const elapsed = (Date.now() - start) / 1000
+                return done({
+                  title: `${path.basename(target)} ready (${mb(size)} MB)`,
+                  metadata: {
+                    mode: "until_file",
+                    target,
+                    seconds: params.seconds,
+                    elapsed_seconds: elapsed,
+                    size_bytes: size,
+                    polls: pollCount,
+                    reason: params.reason,
+                    ready: true,
+                    poll_interval_ms: pollIntervalMs,
+                    stable_ms: stableRequiredMs,
+                    min_size_bytes: params.min_size_bytes,
+                    cancel_if_file: cancelTarget,
+                  },
+                  output: `File ready after ${elapsed.toFixed(1)}s: ${target} (${mb(size)} MB, stable ${(stableFor / 1000).toFixed(0)}s). Reason: ${params.reason}`,
+                })
+              }
+            }
+
+            const remaining = deadline - Date.now()
+            if (remaining <= 0) break
+
+            const tick = yield* abortable(sleepMs(Math.min(pollIntervalMs, remaining)), ctx.abort)
+            if (tick === "__aborted__") {
+              aborted = true
+              break
+            }
+          }
+
+          const elapsed = (Date.now() - start) / 1000
+          const lastInfo = yield* fs.stat(target).pipe(Effect.catch(() => Effect.succeed(undefined)))
+          const sizeNow = lastInfo && lastInfo.type === "File" ? Number(lastInfo.size ?? 0) : 0
+          const reachedMin = params.min_size_bytes === undefined || sizeNow >= params.min_size_bytes
+          return done({
+            title: cancelledByFile
+              ? `wait cancelled by file after ${elapsed.toFixed(1)}s`
+              : aborted
+                ? `wait cancelled after ${elapsed.toFixed(1)}s`
+                : `wait timed out after ${elapsed.toFixed(1)}s`,
+            metadata: {
+              mode: "until_file",
+              target,
+              seconds: params.seconds,
+              elapsed_seconds: elapsed,
+              size_bytes: sizeNow,
+              polls: pollCount,
+              reason: params.reason,
+              timed_out: !aborted && !cancelledByFile,
+              aborted,
+              reached_min_size: reachedMin,
+              poll_interval_ms: pollIntervalMs,
+              stable_ms: stableRequiredMs,
+              min_size_bytes: params.min_size_bytes,
+              cancel_if_file: cancelTarget,
+              cancelled_by_file: cancelledByFile,
+            },
+            output: cancelledByFile
+              ? `Wait cancelled after ${elapsed.toFixed(1)}s because sentinel file exists: ${cancelTarget}. Last size: ${mb(sizeNow)} MB. Reason: ${params.reason}`
+              : aborted
+                ? `Wait cancelled after ${elapsed.toFixed(1)}s. Last size: ${mb(sizeNow)} MB. Reason: ${params.reason}`
+                : `Timed out after ${elapsed.toFixed(1)}s waiting for ${target}. Last observed size: ${mb(sizeNow)} MB${params.min_size_bytes ? ` (min required: ${mb(params.min_size_bytes)} MB, reached: ${reachedMin})` : ""}. Reason: ${params.reason}`,
+          })
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/wait.txt
+++ b/packages/opencode/src/tool/wait.txt
@@ -1,0 +1,50 @@
+Pause the current turn for a specified duration, then continue in the same chat. Use this when you need to wait for an external event you cannot directly observe, such as a long download, a build job, a remote process, or a rate-limit cooldown, without burning a bash slot or asking the user to nudge you back.
+
+Modes (mutually exclusive after `seconds`/`reason`):
+
+1. **Fixed delay** - pass `seconds` and `reason`. The tool sleeps that long, then returns. Use this for predictable waits ("rate-limit cooldown", "let the dev server settle", "5 minutes between health-check pings").
+
+2. **Wait until file ready** - pass `seconds` (the maximum wait), `reason`, and `until_file`. The tool polls the file and returns early once its size has been stable long enough. If `min_size_bytes` is also provided, the file must additionally reach that size before the stable-size check can succeed. If `seconds` elapses first, the tool returns with `timed_out: true` so you can decide what to do.
+
+3. **Wait until URL ready** - pass `seconds`, `reason`, and `until_url` (and optionally `until_url_status`, default 200). The tool tries HEAD then GET, and returns early when the status code matches. Use this for waiting on a dev server, a freshly-deployed endpoint, or a webhook receiver to come up.
+
+4. **Wait until process exits** - pass `seconds`, `reason`, and `until_pid_exit` (a numeric PID). The tool returns early once the process is gone. Use this when a backgrounded shell command does not write a sentinel file but you still need to know when it finished.
+
+5. **Wait until pattern in file** - pass `seconds`, `reason`, `until_text` (file path), and `until_text_pattern` (regex string, no surrounding slashes). The tool tails the file and returns as soon as the pattern matches. Optionally pass `text_pattern_flags` (default `m`) and `text_tail_bytes` (default 32768). Pairs well with backgrounded build/test jobs that write progress to a log file - use a pattern like `BUILD SUCCESSFUL` or `\\d+ passed`.
+
+Always provide a short `reason` string. It is shown to the user in the UI so they can see why the agent is paused.
+
+Optional controls (work in every mode):
+- `poll_interval_ms`: polling interval. Default 5000. Range 100-60000.
+- `stable_ms`: stable-size threshold for `until_file`. Default 10000. Use 0 to return as soon as the file exists and meets `min_size_bytes`.
+- `cancel_if_file`: sentinel file path. If this file appears while waiting, return early with `cancelled_by_file: true`. This lets another process, a user action, or a pre-started shell command stop the wait without aborting the whole chat.
+
+The wait is cancellable: if the user aborts, the tool returns immediately. `cancel_if_file` is a softer cancellation path that completes the tool normally and leaves the chat alive.
+
+Live progress in the UI:
+- `until_file`: title updates as the file grows (e.g. "driver.exe 423.4 MB / 800.0 MB (45s)").
+- `until_url`: title shows the most recent status code and seconds left.
+- `until_pid_exit`: title shows the pid and seconds left.
+- `until_text`: title shows the pattern and seconds left.
+- `fixed`: title counts down each second.
+
+This tool **blocks the current turn**. If you instead want to schedule a *new* opencode session to fire later (fire-and-forget, non-blocking), use a scheduler MCP server. This `wait` tool is for waits that should keep the current chat open and resume in the same turn.
+
+Limits:
+- `seconds` is limited to [1, 3600] (1 hour cap to prevent runaway).
+- `poll_interval_ms` is limited to [100, 60000].
+- `stable_ms` is limited to [0, 600000].
+- `until_url_status` is a single HTTP status code in [100, 599].
+- `until_pid_exit` is a positive integer process id.
+
+Example uses:
+- Slow download: `{ "seconds": 900, "reason": "NVIDIA driver download (~12 min)", "until_file": "C:\\Users\\me\\Downloads\\driver.exe", "min_size_bytes": 700000000, "poll_interval_ms": 1000, "stable_ms": 3000 }`
+- Cooldown: `{ "seconds": 30, "reason": "API rate-limit cooldown" }`
+- Dev server: `{ "seconds": 60, "reason": "letting Vite finish first build", "until_url": "http://localhost:5173/", "poll_interval_ms": 500 }`
+- Auth-protected health endpoint: `{ "seconds": 30, "reason": "wait for service", "until_url": "https://api.local/healthz", "until_url_status": 401 }`
+- Backgrounded job: `{ "seconds": 600, "reason": "wait for tar archive", "until_pid_exit": 12345, "poll_interval_ms": 1000 }`
+- External cancel sentinel: `{ "seconds": 600, "reason": "wait for backup unless cancel sentinel appears", "cancel_if_file": ".opencode-cancel-wait" }`
+- Pattern in log: `{ "seconds": 600, "reason": "wait for build to succeed", "until_text": "build.log", "until_text_pattern": "BUILD SUCCESSFUL", "poll_interval_ms": 1000 }`
+- Test runner: `{ "seconds": 300, "reason": "tests done", "until_text": "test.log", "until_text_pattern": "(\\\\d+ pass|\\\\d+ fail)", "text_pattern_flags": "im" }`
+
+Do NOT use this tool to artificially slow down responses, pad time, or wait on something you could check directly with `read`/`glob`/`grep`. Use it only when there is a genuine asynchronous event you need to wait on.

--- a/packages/opencode/test/tool/wait.test.ts
+++ b/packages/opencode/test/tool/wait.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect } from "bun:test"
+import * as fs from "fs/promises"
+import * as nodePath from "path"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Agent } from "../../src/agent/agent"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { Tool } from "@/tool/tool"
+import { WaitTool } from "../../src/tool/wait"
+import { Truncate } from "@/tool/truncate"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  Layer.mergeAll(CrossSpawnSpawner.defaultLayer, AppFileSystem.defaultLayer, Truncate.defaultLayer, Agent.defaultLayer),
+)
+
+const baseCtx: Tool.Context = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+describe("tool.wait", () => {
+  it.live("waits in the same tool execution", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const updates: Array<{ title?: string }> = []
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          { seconds: 1, reason: "test delay" },
+          {
+            ...baseCtx,
+            metadata: (input) =>
+              Effect.sync(() => {
+                updates.push(input)
+              }),
+          },
+        )
+
+        expect(updates[0]?.title).toBe("wait 1s - test delay")
+        expect(result.metadata.mode).toBe("fixed")
+        expect(result.metadata.aborted).toBe(false)
+        expect(result.output).toContain("test delay")
+      }),
+    ),
+  )
+
+  it.live("returns when aborted", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), 20)
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            clearTimeout(timer)
+          }),
+        )
+
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          { seconds: 3600, reason: "test cancel" },
+          { ...baseCtx, abort: controller.signal },
+        )
+
+        expect(result.metadata.mode).toBe("fixed")
+        expect(result.metadata.aborted).toBe(true)
+        expect(result.output).toContain("Wait cancelled")
+      }),
+    ),
+  )
+
+  it.live("respects custom file polling and stability windows", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const target = nodePath.join(dir, "download.bin")
+        yield* Effect.promise(() => fs.writeFile(target, Buffer.alloc(8)))
+
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          {
+            seconds: 1,
+            reason: "fast file check",
+            until_file: "download.bin",
+            poll_interval_ms: 100,
+            stable_ms: 100,
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.mode).toBe("until_file")
+        expect(result.metadata.ready).toBe(true)
+        expect(result.metadata.poll_interval_ms).toBe(100)
+        expect(result.metadata.stable_ms).toBe(100)
+        expect(result.metadata.elapsed_seconds ?? 999).toBeLessThan(1)
+      }),
+    ),
+  )
+
+  it.live("returns early when a cancel sentinel appears", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const cancelPath = nodePath.join(dir, "stop.wait")
+        const timer = setTimeout(() => {
+          void fs.writeFile(cancelPath, "stop")
+        }, 150)
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            clearTimeout(timer)
+          }),
+        )
+
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          {
+            seconds: 3,
+            reason: "sentinel cancel",
+            poll_interval_ms: 100,
+            cancel_if_file: "stop.wait",
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.mode).toBe("fixed")
+        expect(result.metadata.aborted).toBe(false)
+        expect(result.metadata.cancelled_by_file).toBe(true)
+        expect(result.output).toContain("sentinel file")
+      }),
+    ),
+  )
+
+  it.live("returns early when until_url succeeds", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const server = Bun.serve({ port: 0, fetch: () => new Response("ok", { status: 200 }) })
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(async () => {
+            await server.stop(true)
+          }),
+        )
+        const url = `http://127.0.0.1:${server.port}/`
+
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          {
+            seconds: 3,
+            reason: "service health",
+            until_url: url,
+            poll_interval_ms: 100,
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.mode).toBe("until_url")
+        expect(result.metadata.ready).toBe(true)
+        expect(result.metadata.url_status).toBe(200)
+        expect(result.metadata.elapsed_seconds ?? 999).toBeLessThan(2)
+      }),
+    ),
+  )
+
+  it.live("times out when until_url never returns the expected status", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const server = Bun.serve({ port: 0, fetch: () => new Response("nope", { status: 503 }) })
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(async () => {
+            await server.stop(true)
+          }),
+        )
+        const url = `http://127.0.0.1:${server.port}/`
+
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          {
+            seconds: 1,
+            reason: "expect 200",
+            until_url: url,
+            poll_interval_ms: 100,
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.mode).toBe("until_url")
+        expect(result.metadata.ready).toBeFalsy()
+        expect(result.metadata.timed_out).toBe(true)
+        expect(result.metadata.url_status).toBe(503)
+      }),
+    ),
+  )
+
+  it.live("returns early when until_pid_exit process is gone", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        // Pick a pid extremely unlikely to be alive on a test runner.
+        const result = yield* tool.execute(
+          {
+            seconds: 2,
+            reason: "absent pid",
+            until_pid_exit: 2_147_483_640,
+            poll_interval_ms: 100,
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.mode).toBe("until_pid_exit")
+        expect(result.metadata.exited).toBe(true)
+        expect(result.metadata.elapsed_seconds ?? 999).toBeLessThan(1)
+      }),
+    ),
+  )
+
+  it.live("returns early when until_text pattern matches", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const target = nodePath.join(dir, "build.log")
+        yield* Effect.promise(() => fs.writeFile(target, "starting...\n"))
+        const timer = setTimeout(() => {
+          void fs.appendFile(target, "BUILD SUCCESSFUL in 2s\n").catch(() => undefined)
+        }, 200)
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            clearTimeout(timer)
+          }),
+        )
+
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          {
+            seconds: 3,
+            reason: "wait for build success",
+            until_text: "build.log",
+            until_text_pattern: "BUILD SUCCESSFUL",
+            poll_interval_ms: 100,
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.mode).toBe("until_text")
+        expect(result.metadata.matched).toBe(true)
+        expect(result.metadata.match).toContain("BUILD SUCCESSFUL")
+        expect(result.metadata.elapsed_seconds ?? 999).toBeLessThan(2)
+      }),
+    ),
+  )
+
+  it.live("times out when until_text pattern never matches", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const target = nodePath.join(dir, "noisy.log")
+        yield* Effect.promise(() => fs.writeFile(target, "irrelevant chatter\n"))
+
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const result = yield* tool.execute(
+          {
+            seconds: 1,
+            reason: "expect missing pattern",
+            until_text: "noisy.log",
+            until_text_pattern: "BUILD FAILED",
+            poll_interval_ms: 100,
+          },
+          baseCtx,
+        )
+
+        expect(result.metadata.mode).toBe("until_text")
+        expect(result.metadata.matched).toBeFalsy()
+        expect(result.metadata.timed_out).toBe(true)
+      }),
+    ),
+  )
+
+  it.live("rejects until_text without until_text_pattern", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const toolInfo = yield* WaitTool
+        const tool = yield* toolInfo.init()
+        const exit = yield* Effect.exit(
+          tool.execute(
+            {
+              seconds: 2,
+              reason: "incomplete params",
+              until_text: "any.log",
+              poll_interval_ms: 100,
+            },
+            baseCtx,
+          ),
+        )
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          expect(Cause.pretty(exit.cause)).toContain("until_text_pattern")
+        }
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
﻿### Issue for this PR

Closes #24888

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a built-in `wait` tool for bounded asynchronous waits inside the current assistant turn.

The tool supports a fixed delay plus several early-return conditions: file readiness, URL readiness, process exit, and a regex pattern appearing in a log file. It reports progress through tool metadata so the UI can show what the agent is waiting on, and it respects the abort signal so the user can cancel the wait.

This avoids asking users to manually come back later for common long-running workflows such as downloads, dev-server startup, background build/test jobs, and short rate-limit cooldowns.

### How did you verify your code works?

- Focused wait-tool tests were run when the branch was prepared: `bun test test/tool/wait.test.ts --timeout 30000`.
- `git diff --check origin/dev..b928668d5bd6154eb7f20c78b83378b6398a5a3e`.
- Changed files scrubbed for private fork strings/secrets with `git grep`.

This is still a draft PR so project CI remains the authority before it is marked ready.

### Screenshots / recordings

No screenshot. The TUI display renders the wait tool as a compact `Waiting...` tool part with mode-specific progress text.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
