### PR TITLE
feat(tool): add open tool for files and URLs

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -31,6 +31,7 @@ const AVAILABLE_PERMISSIONS = [
   "codesearch",
   "lsp",
   "skill",
+  "open",
 ]
 
 const AgentCreateCommand = cmd({

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -46,6 +46,7 @@ import type { ApplyPatchTool } from "@/tool/apply_patch"
 import type { WebFetchTool } from "@/tool/webfetch"
 import type { CodeSearchTool } from "@/tool/codesearch"
 import type { WebSearchTool } from "@/tool/websearch"
+import type { OpenTool } from "@/tool/open"
 import type { TaskTool } from "@/tool/task"
 import type { QuestionTool } from "@/tool/question"
 import type { SkillTool } from "@/tool/skill"
@@ -1592,6 +1593,9 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
         <Match when={props.part.tool === "skill"}>
           <Skill {...toolprops} />
         </Match>
+        <Match when={props.part.tool === "open"}>
+          <Open {...toolprops} />
+        </Match>
         <Match when={true}>
           <GenericTool {...toolprops} />
         </Match>
@@ -2222,6 +2226,27 @@ function Skill(props: ToolProps<typeof SkillTool>) {
   return (
     <InlineTool icon="→" pending="Loading skill..." complete={props.input.name} part={props.part}>
       Skill "{props.input.name}"
+    </InlineTool>
+  )
+}
+
+function Open(props: ToolProps<typeof OpenTool>) {
+  const isRunning = createMemo(() => props.part.state.status === "running")
+  const target = createMemo(() => props.input.target ?? "")
+  const kind = createMemo(() => props.metadata.kind ?? "target")
+  const reveal = createMemo(() => props.input.reveal_in_folder ?? props.metadata.reveal_in_folder)
+  const delivered = createMemo(() => props.metadata.delivered)
+  const label = createMemo(() => {
+    const t = String(target())
+    if (kind() === "url") return t.length > 60 ? t.slice(0, 57) + "..." : t
+    return path.basename(t)
+  })
+
+  return (
+    <InlineTool icon="⤢" pending="Opening..." spinner={isRunning()} complete={!isRunning()} part={props.part}>
+      <Show when={delivered() === false} fallback={<>Open {kind()} {label()}{reveal() ? " (reveal)" : ""}</>}>
+        Open {kind()} {label()} (failed)
+      </Show>
     </InlineTool>
   )
 }

--- a/packages/opencode/src/tool/open.ts
+++ b/packages/opencode/src/tool/open.ts
@@ -1,0 +1,243 @@
+import { Effect, Schema } from "effect"
+import { spawn } from "node:child_process"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { InstanceState } from "@/effect/instance-state"
+import DESCRIPTION from "./open.txt"
+import * as Tool from "./tool"
+
+const ALLOWED_SCHEMES = new Set(["http", "https", "file"])
+
+export const Parameters = Schema.Struct({
+  target: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(2048)).annotate({
+    description:
+      "Local file path, folder path, or http(s)/file URL to open in the OS default handler. Relative paths resolve from the project directory.",
+  }),
+  reason: Schema.optional(Schema.String.check(Schema.isMaxLength(400))).annotate({
+    description: "Short reason shown to the user explaining why this is being opened.",
+  }),
+  reveal_in_folder: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "If true and target is an existing local file, open the parent folder with the file selected (Windows explorer /select, macOS open -R, Linux opens parent folder).",
+  }),
+})
+
+type Params = Schema.Schema.Type<typeof Parameters>
+
+type TargetKind = "url" | "file" | "directory"
+
+type Metadata = {
+  platform: NodeJS.Platform
+  backend: string
+  kind?: TargetKind
+  resolved?: string
+  url?: string
+  delivered: boolean
+  reveal_in_folder?: boolean
+  exit_code?: number
+  error?: string
+  reason?: string
+}
+
+const done = (result: Tool.ExecuteResult<Metadata>) => result
+
+function classifyTarget(input: string): { kind: "url"; url: URL } | { kind: "path"; raw: string } {
+  const trimmed = input.trim()
+  // Detect explicit URL schemes (http://, https://, file://). We deliberately
+  // do not treat Windows drive letters (C:\foo) as URLs even though `new URL`
+  // can sometimes coerce them.
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed)
+  if (schemeMatch) {
+    const scheme = schemeMatch[1].toLowerCase()
+    // Single-letter schemes are almost always Windows drive letters, not URLs.
+    if (scheme.length > 1) {
+      try {
+        return { kind: "url", url: new URL(trimmed) }
+      } catch {
+        // Fall through and treat as a path so a useful error gets returned later.
+      }
+    }
+  }
+  return { kind: "path", raw: trimmed }
+}
+
+function runProcess(
+  cmd: string,
+  args: string[],
+  signal: AbortSignal,
+  timeoutMs = 8000,
+): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve) => {
+    let settled = false
+    const child = spawn(cmd, args, { stdio: ["ignore", "ignore", "pipe"], windowsHide: true, detached: false })
+    const timer = setTimeout(() => {
+      if (!settled) {
+        try {
+          child.kill()
+        } catch {}
+        settled = true
+        resolve({ code: null, stderr: "timeout" })
+      }
+    }, timeoutMs)
+    const onAbort = () => {
+      try {
+        child.kill()
+      } catch {}
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+    let stderr = ""
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString()
+    })
+    child.on("error", (err) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      signal.removeEventListener("abort", onAbort)
+      resolve({ code: null, stderr: err.message })
+    })
+    child.on("close", (code) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      signal.removeEventListener("abort", onAbort)
+      resolve({ code, stderr })
+    })
+  })
+}
+
+function platformLauncher(target: string, reveal: boolean, kind: TargetKind, platform: NodeJS.Platform) {
+  if (platform === "win32") {
+    if (reveal && kind === "file") return { cmd: "explorer.exe", args: [`/select,${target}`] }
+    if (kind === "directory") return { cmd: "explorer.exe", args: [target] }
+    return { cmd: "rundll32.exe", args: ["url.dll,FileProtocolHandler", target] }
+  }
+  if (platform === "darwin") {
+    if (reveal && kind === "file") return { cmd: "open", args: ["-R", target] }
+    return { cmd: "open", args: [target] }
+  }
+  // linux + freebsd + others: best-effort xdg-open
+  if (reveal && kind === "file") return { cmd: "xdg-open", args: [path.dirname(target)] }
+  return { cmd: "xdg-open", args: [target] }
+}
+
+export const OpenTool = Tool.define(
+  "open",
+  Effect.gen(function* () {
+    const fsSvc = yield* AppFileSystem.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Params, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          const ins = yield* InstanceState.context
+          const platform = process.platform
+          const reveal = params.reveal_in_folder === true
+          const classified = classifyTarget(params.target)
+
+          let kind: TargetKind
+          let resolved: string
+          let urlString: string | undefined
+
+          if (classified.kind === "url") {
+            const url = classified.url
+            const scheme = url.protocol.replace(/:$/, "").toLowerCase()
+            if (!ALLOWED_SCHEMES.has(scheme)) {
+              throw new Error(
+                `open: refusing to open URL with scheme '${scheme}'. Allowed schemes: ${[...ALLOWED_SCHEMES].join(", ")}.`,
+              )
+            }
+            if (scheme === "file") {
+              try {
+                resolved = fileURLToPath(url)
+              } catch (err: unknown) {
+                throw new Error(`open: invalid file URL '${url.toString()}': ${(err as Error).message}`)
+              }
+              const stat = yield* fsSvc.stat(resolved).pipe(Effect.catch(() => Effect.succeed(undefined)))
+              if (!stat) throw new Error(`open: file URL points to missing path: ${resolved}`)
+              kind = stat.type === "Directory" ? "directory" : "file"
+            } else {
+              urlString = url.toString()
+              resolved = urlString
+              kind = "url"
+            }
+          } else {
+            resolved = path.isAbsolute(classified.raw) ? classified.raw : path.resolve(ins.directory, classified.raw)
+            const stat = yield* fsSvc.stat(resolved).pipe(Effect.catch(() => Effect.succeed(undefined)))
+            if (!stat) throw new Error(`open: target does not exist: ${resolved}`)
+            kind = stat.type === "Directory" ? "directory" : "file"
+          }
+
+          const permissionTarget = kind === "url" ? (urlString ?? resolved) : resolved
+          yield* ctx.ask({
+            permission: "open",
+            patterns: [permissionTarget],
+            always: ["*"],
+            metadata: {
+              target: permissionTarget,
+              kind,
+              reveal_in_folder: reveal,
+              reason: params.reason,
+            },
+          })
+
+          const launcher = platformLauncher(resolved, reveal && kind === "file", kind, platform)
+          yield* ctx.metadata({
+            title: `open: ${kind === "url" ? urlString : path.basename(resolved)}`,
+            metadata: {
+              platform,
+              backend: launcher.cmd,
+              kind,
+              resolved: kind === "url" ? undefined : resolved,
+              url: urlString,
+              delivered: false,
+              reveal_in_folder: reveal,
+              reason: params.reason,
+            },
+          })
+
+          const result = yield* Effect.promise(async () => {
+            try {
+              return await runProcess(launcher.cmd, launcher.args, ctx.abort)
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : String(err)
+              return { code: null as number | null, stderr: msg }
+            }
+          })
+
+          // explorer.exe can exit non-zero even when it successfully hands work
+          // to an existing Explorer process.
+          const delivered =
+            result.code === 0 || (platform === "win32" && launcher.cmd === "explorer.exe" && result.code !== null)
+
+          const errMsg = !delivered ? (result.stderr.trim() || `exit=${result.code}`) : undefined
+
+          return done({
+            title: delivered
+              ? `opened ${kind === "url" ? urlString : path.basename(resolved)}`
+              : `open failed: ${kind === "url" ? urlString : path.basename(resolved)}`,
+            metadata: {
+              platform,
+              backend: launcher.cmd,
+              kind,
+              resolved: kind === "url" ? undefined : resolved,
+              url: urlString,
+              delivered,
+              reveal_in_folder: reveal,
+              exit_code: result.code ?? undefined,
+              error: errMsg,
+              reason: params.reason,
+            },
+            output: delivered
+              ? `Opened ${kind === "url" ? urlString : resolved}${reveal && kind === "file" ? " (revealed in folder)" : ""} via ${launcher.cmd}.${params.reason ? ` Reason: ${params.reason}` : ""}`
+              : `Failed to open ${kind === "url" ? urlString : resolved} via ${launcher.cmd} (${platform}). ${errMsg ?? ""} Continue without retrying.`,
+          })
+        }),
+    }
+  }),
+)
+
+export const __testing = { classifyTarget, platformLauncher }

--- a/packages/opencode/src/tool/open.txt
+++ b/packages/opencode/src/tool/open.txt
@@ -1,0 +1,24 @@
+Open a local file, folder, or http(s) URL in the OS default handler.
+
+Use this when you want to surface a result to the user - for example after an autonomous build/run finishes, opening the rebuilt installer in Explorer, opening a generated HTML report in the browser, or opening a log directory so the user can browse run history.
+
+Parameters:
+- `target` (required): an http(s) URL, a file:// URL, or a local path. Relative paths resolve from the current project directory. Must point to something that already exists (for local paths) or be a syntactically valid URL.
+- `reason` (optional): one short sentence shown to the user explaining why this is being opened. Helps when the agent is running unattended.
+- `reveal_in_folder` (optional, default false): when true and the target is an existing local file, open the parent folder with the file selected (Windows: `explorer /select,`, macOS: `open -R`, Linux: opens parent folder).
+
+Behavior:
+- Cross-platform: Windows uses `rundll32.exe url.dll,FileProtocolHandler` for files/URLs and `explorer.exe` for folders/reveal; macOS uses `open`; Linux uses `xdg-open`.
+- Best-effort and non-blocking: the tool returns as soon as the launcher is started, not when the user closes the opened app. Returns metadata.delivered=false if the launcher exits non-zero.
+- Refuses unsupported URL schemes (anything other than http, https, file) and refuses local paths that do not exist. This is a safety net against accidental command-injection-shaped inputs.
+- Returns quickly (under a few seconds in the typical case).
+
+Examples:
+- Open the installer folder: `{ "target": "C:\\Users\\User\\Downloads\\582.28-desktop-win10-win11-64bit-international-dch-whql.exe", "reveal_in_folder": true, "reason": "show user the downloaded driver" }`
+- Open a built HTML report: `{ "target": "build/report.html", "reason": "render coverage report" }`
+- Open a project URL: `{ "target": "https://opencode.ai", "reason": "open release notes" }`
+
+Do NOT use this tool to:
+- Run executables headlessly. Use the `bash` tool for that.
+- Launch interactive installers or wizards mid-task without telling the user - `open` is for surfacing results to a human.
+- Open arbitrary URLs from untrusted input. Validate the URL is one you constructed or that the user supplied.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -12,6 +12,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { OpenTool } from "./open"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
 import { type ToolContext as PluginToolContext, type ToolDefinition } from "@opencode-ai/plugin"
@@ -115,6 +116,7 @@ export const layer: Layer.Layer<
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const opentool = yield* OpenTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -204,6 +206,7 @@ export const layer: Layer.Layer<
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          open: Tool.init(opentool),
         })
 
         return {
@@ -226,6 +229,7 @@ export const layer: Layer.Layer<
             tool.patch,
             ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [tool.lsp] : []),
             ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [tool.plan] : []),
+            tool.open,
           ],
           task: tool.task,
           read: tool.read,

--- a/packages/opencode/test/tool/open.test.ts
+++ b/packages/opencode/test/tool/open.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Agent } from "../../src/agent/agent"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { Tool } from "@/tool/tool"
+import { OpenTool, __testing } from "../../src/tool/open"
+import { Truncate } from "@/tool/truncate"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const { classifyTarget, platformLauncher } = __testing
+
+const it = testEffect(
+  Layer.mergeAll(CrossSpawnSpawner.defaultLayer, AppFileSystem.defaultLayer, Truncate.defaultLayer, Agent.defaultLayer),
+)
+
+const baseCtx: Tool.Context = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+describe("tool.open helpers", () => {
+  test("classifyTarget recognises http(s)/file URLs", () => {
+    const httpResult = classifyTarget("https://example.com/path")
+    expect(httpResult.kind).toBe("url")
+
+    const fileResult = classifyTarget("file:///C:/foo/bar.txt")
+    expect(fileResult.kind).toBe("url")
+
+    const ftpResult = classifyTarget("ftp://example.com/file.bin")
+    expect(ftpResult.kind).toBe("url")
+  })
+
+  test("classifyTarget treats Windows drive letters as paths", () => {
+    const r = classifyTarget("C:\\Users\\foo\\bar.txt")
+    expect(r.kind).toBe("path")
+  })
+
+  test("classifyTarget treats relative paths as paths", () => {
+    const r = classifyTarget("./build/report.html")
+    expect(r.kind).toBe("path")
+  })
+
+  test("platformLauncher uses direct Windows file protocol handler for URLs", () => {
+    const r = platformLauncher("https://example.com", false, "url", "win32")
+    expect(r.cmd).toBe("rundll32.exe")
+    expect(r.args).toEqual(["url.dll,FileProtocolHandler", "https://example.com"])
+  })
+
+  test("platformLauncher avoids cmd shell for Windows file targets", () => {
+    const target = "C:\\tmp\\report & not-a-command.txt"
+    const r = platformLauncher(target, false, "file", "win32")
+    expect(r.cmd).toBe("rundll32.exe")
+    expect(r.args).toEqual(["url.dll,FileProtocolHandler", target])
+  })
+
+  test("platformLauncher uses explorer for Windows directories", () => {
+    const r = platformLauncher("C:\\tmp\\reports", false, "directory", "win32")
+    expect(r.cmd).toBe("explorer.exe")
+    expect(r.args).toEqual(["C:\\tmp\\reports"])
+  })
+
+  test("platformLauncher uses explorer /select for reveal+file on Windows", () => {
+    const r = platformLauncher("C:\\foo\\bar.txt", true, "file", "win32")
+    expect(r.cmd).toBe("explorer.exe")
+    expect(r.args[0]).toBe("/select,C:\\foo\\bar.txt")
+  })
+
+  test("platformLauncher uses open -R on macOS reveal", () => {
+    const r = platformLauncher("/tmp/file.bin", true, "file", "darwin")
+    expect(r.cmd).toBe("open")
+    expect(r.args).toEqual(["-R", "/tmp/file.bin"])
+  })
+
+  test("platformLauncher uses xdg-open on linux", () => {
+    const r = platformLauncher("/tmp/file.bin", false, "file", "linux")
+    expect(r.cmd).toBe("xdg-open")
+    expect(r.args).toEqual(["/tmp/file.bin"])
+  })
+})
+
+describe("tool.open", () => {
+  it.live("rejects unsupported URL schemes", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const toolInfo = yield* OpenTool
+        const tool = yield* toolInfo.init()
+        const exit = yield* Effect.exit(tool.execute({ target: "javascript:alert(1)" }, baseCtx))
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          expect(Cause.pretty(exit.cause)).toContain("scheme")
+        }
+      }),
+    ),
+  )
+
+  it.live("rejects nonexistent local paths", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const toolInfo = yield* OpenTool
+        const tool = yield* toolInfo.init()
+        const exit = yield* Effect.exit(
+          tool.execute({ target: "definitely-not-a-real-file-xyz.txt" }, baseCtx),
+        )
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          expect(Cause.pretty(exit.cause)).toContain("does not exist")
+        }
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
﻿### Issue for this PR

Closes #24890

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a built-in `open` tool that can surface a local file, folder, `file://` URL, or `http(s)` URL using the operating system default handler.

The tool resolves relative local paths from the project directory, rejects unsupported URL schemes, asks for an `open` permission before launching anything, and returns structured metadata indicating whether the OS launcher accepted the request. On Windows it uses `rundll32.exe url.dll,FileProtocolHandler` for files/URLs and Explorer for folders/reveal, avoiding `cmd /c start` shell parsing.

### How did you verify your code works?

- `packages/opencode`: `bun test test/tool/open.test.ts --timeout 30000`
- `git diff --check`
- Changed files scrubbed for private fork strings/secrets with `git grep`.

### Screenshots / recordings

No screenshot. This is a tool/runtime change; the TUI shows a compact `Open` tool part.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
