### PR TITLE
fix(session): remap compaction tail_start_id when forking

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -616,15 +616,16 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
         })
 
         for (const part of msg.parts) {
-          yield* updatePart({
+          const p: MessageV2.Part = {
             ...part,
             id: PartID.ascending(),
             messageID: cloned.id,
             sessionID: session.id,
-            ...(part.type === "compaction" && part.tail_start_id
-              ? { tail_start_id: idMap.get(part.tail_start_id) }
-              : {}),
-          })
+          }
+          if (p.type === "compaction" && p.tail_start_id) {
+            p.tail_start_id = idMap.get(p.tail_start_id)
+          }
+          yield* updatePart(p)
         }
       }
       return session

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -621,6 +621,9 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
             id: PartID.ascending(),
             messageID: cloned.id,
             sessionID: session.id,
+            ...(part.type === "compaction" && part.tail_start_id
+              ? { tail_start_id: idMap.get(part.tail_start_id) }
+              : {}),
           })
         }
       }

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -896,6 +896,7 @@ describe("MessageV2.filterCompacted", () => {
 
         const tailPart = childFiltered.flatMap((m) => m.parts).find((p) => p.type === "compaction")
         expect(tailPart?.type).toBe("compaction")
+        if (!tailPart || tailPart.type !== "compaction") throw new Error("Expected forked compaction part")
         expect(tailPart.tail_start_id).toBeDefined()
         expect(childFiltered.some((m) => m.info.id === tailPart.tail_start_id)).toBe(true)
 

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -29,6 +29,9 @@ const svc = {
   updatePart<T extends MessageV2.Part>(part: T) {
     return run(SessionNs.Service.use((svc) => svc.updatePart(part)))
   },
+  fork(input: { sessionID: SessionID; messageID?: MessageID }) {
+    return run(SessionNs.Service.use((svc) => svc.fork(input)))
+  },
 }
 
 async function fill(sessionID: SessionID, count: number, time = (i: number) => Date.now() + i) {
@@ -832,6 +835,71 @@ describe("MessageV2.filterCompacted", () => {
 
         expect(result.map((item) => item.info.id)).toEqual([u2, a2, c1, s1, u3, a3])
 
+        await svc.remove(session.id)
+      },
+    })
+  })
+
+  test("fork remaps compaction tail_start_id for filterCompacted", async () => {
+    await Instance.provide({
+      directory: root,
+      fn: async () => {
+        const session = await svc.create({})
+
+        const u1 = await addUser(session.id, "first")
+        const a1 = await addAssistant(session.id, u1, { finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: a1,
+          type: "text",
+          text: "first reply",
+        })
+
+        const u2 = await addUser(session.id, "second")
+        const a2 = await addAssistant(session.id, u2, { finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: a2,
+          type: "text",
+          text: "second reply",
+        })
+
+        const c1 = await addUser(session.id)
+        await addCompactionPart(session.id, c1, u2)
+        const s1 = await addAssistant(session.id, c1, { summary: true, finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: s1,
+          type: "text",
+          text: "summary",
+        })
+
+        const u3 = await addUser(session.id, "third")
+        const a3 = await addAssistant(session.id, u3, { finish: "end_turn" })
+        await svc.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: a3,
+          type: "text",
+          text: "third reply",
+        })
+
+        const parentFiltered = MessageV2.filterCompacted(MessageV2.stream(session.id))
+        expect(parentFiltered.map((item) => item.info.id)).toEqual([u2, a2, c1, s1, u3, a3])
+
+        const forked = await svc.fork({ sessionID: session.id })
+        const childFiltered = MessageV2.filterCompacted(MessageV2.stream(forked.id))
+        expect(childFiltered).toHaveLength(parentFiltered.length)
+
+        const tailPart = childFiltered.flatMap((m) => m.parts).find((p) => p.type === "compaction")
+        expect(tailPart?.type).toBe("compaction")
+        expect(tailPart.tail_start_id).toBeDefined()
+        expect(childFiltered.some((m) => m.info.id === tailPart.tail_start_id)).toBe(true)
+
+        await svc.remove(forked.id)
         await svc.remove(session.id)
       },
     })


### PR DESCRIPTION
### Issue for this PR

Closes #24700

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes `Session.fork` not remapping `CompactionPart.tail_start_id`, which caused forked sessions to include all pre-compaction messages in context and inflate session length.

**Problem**

`Session.fork` copies messages and remaps each message’s id and assistant `parentID` via `idMap`, but `tail_start_id` on compaction parts was left as the **parent session’s** message id.

`filterCompacted` (`message-v2.ts`) uses `tail_start_id` as the retention boundary: it walks older messages until it finds one whose id equals `tail_start_id`. In a fork, every message id is new, so the old `tail_start_id` never matches; the loop does not stop where compaction intended, and pre-compaction history leaks into the prompt (observed as much larger context / `context_length_exceeded` on the next request).

**Regression**

Introduced when `tail_start_id` and the corresponding `filterCompacted` behavior were added in commit **`6f5a3d30f`** (“keep recent turns during session compaction”, 2026-04-10). `Session.fork` was not updated to remap that field alongside `parentID`.

**Fix**

When cloning parts, after `...part`, override `tail_start_id` for compaction parts using the same `idMap`:

```ts
...(part.type === "compaction" && part.tail_start_id
  ? { tail_start_id: idMap.get(part.tail_start_id) }
  : {}),
```

If the tail message was not copied (e.g. partial fork), `idMap.get` returns `undefined`, clearing the stale reference instead of pointing at a non-existent id.

### How did you verify your code works?

- **Automated:** from `packages/opencode`, run  
  `bun test test/session/messages-pagination.test.ts -t "fork remaps compaction"`  
  (adds test `fork remaps compaction tail_start_id for filterCompacted`).
- **Manual:** reproducing #24700 — forked session context no longer balloons (e.g. stays ~300k instead of jumping toward ~800k).

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
