### PR TITLE
Disable Windows update code signature verification

### DIFF
--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -63,6 +63,7 @@ const getBase = (): Configuration => ({
       sign: signWindows,
     },
     target: ["nsis"],
+    verifyUpdateCodeSignature: false,
   },
   nsis: {
     oneClick: false,


### PR DESCRIPTION
## Summary
Disables Windows update code signature verification in the electron-builder configuration by adding `verifyUpdateCodeSignature: false` to the Windows target settings.

## Changes
- Added `verifyUpdateCodeSignature: false` to Windows configuration in `electron-builder.config.ts`