### PR TITLE
fix(session): exclude archived sessions from Session.list() query

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -771,9 +771,14 @@ export function* list(input?: {
   start?: number
   search?: string
   limit?: number
+  archived?: boolean
 }) {
   const project = Instance.project
   const conditions = [eq(SessionTable.project_id, project.id)]
+
+  if (!input?.archived) {
+    conditions.push(isNull(SessionTable.time_archived))
+  }
 
   if (input?.workspaceID) {
     conditions.push(eq(SessionTable.workspace_id, input.workspaceID))

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -226,4 +226,71 @@ describe("session.list", () => {
       },
     })
   })
+
+  test("excludes archived sessions by default", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const active = await svc.create({ title: "active-session" })
+        const archived = await svc.create({ title: "archived-session" })
+
+        Database.use((db) =>
+          db.update(SessionTable).set({ time_archived: Date.now() }).where(eq(SessionTable.id, archived.id)).run(),
+        )
+
+        const sessions = [...svc.list()]
+        const ids = sessions.map((s) => s.id)
+        expect(ids).toContain(active.id)
+        expect(ids).not.toContain(archived.id)
+      },
+    })
+  })
+
+  test("archived sessions do not consume limit slots", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const s1 = await svc.create({ title: "session-1" })
+        const s2 = await svc.create({ title: "session-2" })
+        const archived = await svc.create({ title: "archived-session" })
+
+        Database.use((db) =>
+          db
+            .update(SessionTable)
+            .set({ time_archived: Date.now(), time_updated: Date.now() + 1000 })
+            .where(eq(SessionTable.id, archived.id))
+            .run(),
+        )
+
+        const sessions = [...svc.list({ limit: 2 })]
+        const ids = sessions.map((s) => s.id)
+        expect(sessions.length).toBe(2)
+        expect(ids).toContain(s1.id)
+        expect(ids).toContain(s2.id)
+        expect(ids).not.toContain(archived.id)
+      },
+    })
+  })
+
+  test("includes archived sessions when archived option is true", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const active = await svc.create({ title: "active-session" })
+        const archived = await svc.create({ title: "archived-session" })
+
+        Database.use((db) =>
+          db.update(SessionTable).set({ time_archived: Date.now() }).where(eq(SessionTable.id, archived.id)).run(),
+        )
+
+        const sessions = [...svc.list({ archived: true })]
+        const ids = sessions.map((s) => s.id)
+        expect(ids).toContain(active.id)
+        expect(ids).toContain(archived.id)
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #24850

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Session.list()` did not filter out archived sessions server-side, while `listGlobal()` already did via `isNull(SessionTable.time_archived)`. This caused archived sessions (which have bumped `time_updated` on archive) to consume `LIMIT` slots in the query result. The client-side `trimSessions()` then stripped them, leaving fewer visible unarchived sessions than expected — sessions silently disappeared from the sidebar after bulk archiving.

The fix adds `isNull(SessionTable.time_archived)` as a default condition to `Session.list()`, matching `listGlobal()`'s existing behavior. An opt-in `archived?: boolean` parameter is also added for callers that need to include archived sessions.

**Changes:**
- `packages/opencode/src/session/session.ts`: Added `archived?: boolean` input field and `isNull(time_archived)` condition (applied unless `archived` is explicitly `true`)
- `packages/opencode/test/server/session-list.test.ts`: Added 3 tests — default exclusion, LIMIT slot preservation, and opt-in inclusion

### How did you verify your code works?

All 11 session-list tests pass (8 existing + 3 new), and related session tests also pass with no regressions:

```
bun test test/server/session-list.test.ts     → 11 pass, 0 fail
bun test test/server/global-session-list.test.ts → 3 pass, 0 fail
bun test test/session/session.test.ts         → 4 pass, 0 fail
```

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR