### PR TITLE
fix(download): update beta asset names from electron to desktop

### DIFF
--- a/packages/console/app/src/routes/download/[channel]/[platform].ts
+++ b/packages/console/app/src/routes/download/[channel]/[platform].ts
@@ -11,12 +11,12 @@ const prodAssetNames: Record<string, string> = {
 } satisfies Record<DownloadPlatform, string>
 
 const betaAssetNames: Record<string, string> = {
-  "darwin-aarch64-dmg": "opencode-electron-mac-arm64.dmg",
-  "darwin-x64-dmg": "opencode-electron-mac-x64.dmg",
-  "windows-x64-nsis": "opencode-electron-win-x64.exe",
-  "linux-x64-deb": "opencode-electron-linux-amd64.deb",
-  "linux-x64-appimage": "opencode-electron-linux-x86_64.AppImage",
-  "linux-x64-rpm": "opencode-electron-linux-x86_64.rpm",
+  "darwin-aarch64-dmg": "opencode-desktop-mac-arm64.dmg",
+  "darwin-x64-dmg": "opencode-desktop-mac-x64.dmg",
+  "windows-x64-nsis": "opencode-desktop-win-x64.exe",
+  "linux-x64-deb": "opencode-desktop-linux-amd64.deb",
+  "linux-x64-appimage": "opencode-desktop-linux-x86_64.AppImage",
+  "linux-x64-rpm": "opencode-desktop-linux-x86_64.rpm",
 } satisfies Record<DownloadPlatform, string>
 
 // Doing this on the server lets us preserve the original name for platforms we don't care to rename for


### PR DESCRIPTION
## Summary
- Updated beta download asset names from `opencode-electron-*` to `opencode-desktop-*` to match the correct naming convention.

## Changes
- Renamed all beta asset entries in `packages/console/app/src/routes/download/[channel]/[platform].ts`:
  - `opencode-electron-mac-arm64.dmg` → `opencode-desktop-mac-arm64.dmg`
  - `opencode-electron-mac-x64.dmg` → `opencode-desktop-mac-x64.dmg`
  - `opencode-electron-win-x64.exe` → `opencode-desktop-win-x64.exe`
  - `opencode-electron-linux-amd64.deb` → `opencode-desktop-linux-amd64.deb`
  - `opencode-electron-linux-x86_64.AppImage` → `opencode-desktop-linux-x86_64.AppImage`
  - `opencode-electron-linux-x86_64.rpm` → `opencode-desktop-linux-x86_64.rpm`