### PR TITLE
fix(tool): add 30s timeout to glob and grep to prevent filesystem hang

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -8,6 +8,8 @@ import { assertExternalDirectoryEffect } from "./external-directory"
 import DESCRIPTION from "./glob.txt"
 import * as Tool from "./tool"
 
+const SEARCH_TIMEOUT_MS = 30_000
+
 export const Parameters = Schema.Struct({
   pattern: Schema.String.annotate({ description: "The glob pattern to match files against" }),
   path: Schema.optional(Schema.String).annotate({
@@ -45,9 +47,13 @@ export const GlobTool = Tool.define(
           }
           yield* assertExternalDirectoryEffect(ctx, search, { kind: "directory" })
 
+          const timeoutSignal = AbortSignal.timeout(SEARCH_TIMEOUT_MS)
+          const signal = AbortSignal.any([ctx.abort, timeoutSignal])
+
           const limit = 100
           let truncated = false
-          const files = yield* rg.files({ cwd: search, glob: [params.pattern], signal: ctx.abort }).pipe(
+          let timedOut = false
+          const files = yield* rg.files({ cwd: search, glob: [params.pattern], signal }).pipe(
             Stream.mapEffect((file) =>
               Effect.gen(function* () {
                 const full = path.resolve(search, file)
@@ -63,6 +69,13 @@ export const GlobTool = Tool.define(
             Stream.take(limit + 1),
             Stream.runCollect,
             Effect.map((chunk) => [...chunk]),
+            Effect.catchIf(
+              () => timeoutSignal.aborted && !ctx.abort.aborted,
+              () => {
+                timedOut = true
+                return Effect.succeed([] as { path: string; mtime: number }[])
+              },
+            ),
           )
 
           if (files.length > limit) {
@@ -72,7 +85,13 @@ export const GlobTool = Tool.define(
           files.sort((a, b) => b.mtime - a.mtime)
 
           const output = []
-          if (files.length === 0) output.push("No files found")
+          if (timedOut) {
+            output.push(
+              `Search timed out after ${SEARCH_TIMEOUT_MS / 1000}s. The search path "${search}" is too broad. Use a more specific path closer to the target files.`,
+            )
+          } else if (files.length === 0) {
+            output.push("No files found")
+          }
           if (files.length > 0) {
             output.push(...files.map((file) => file.path))
             if (truncated) {

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -9,6 +9,7 @@ import DESCRIPTION from "./grep.txt"
 import * as Tool from "./tool"
 
 const MAX_LINE_LENGTH = 2000
+const SEARCH_TIMEOUT_MS = 30_000
 
 export const Parameters = Schema.Struct({
   pattern: Schema.String.annotate({ description: "The regex pattern to search for in file contents" }),
@@ -64,13 +65,30 @@ export const GrepTool = Tool.define(
             kind: info?.type === "Directory" ? "directory" : "file",
           })
 
-          const result = yield* rg.search({
-            cwd,
-            pattern: params.pattern,
-            glob: params.include ? [params.include] : undefined,
-            file,
-            signal: ctx.abort,
-          })
+          const timeoutSignal = AbortSignal.timeout(SEARCH_TIMEOUT_MS)
+          const signal = AbortSignal.any([ctx.abort, timeoutSignal])
+
+          const result = yield* rg
+            .search({
+              cwd,
+              pattern: params.pattern,
+              glob: params.include ? [params.include] : undefined,
+              file,
+              signal,
+            })
+            .pipe(
+              Effect.catchIf(
+                () => timeoutSignal.aborted && !ctx.abort.aborted,
+                () =>
+                  Effect.succeed({
+                    title: params.pattern,
+                    metadata: { matches: 0, truncated: false },
+                    output: `Search timed out after ${SEARCH_TIMEOUT_MS / 1000}s. The search path "${search}" is too broad. Use a more specific path closer to the target files.`,
+                  }),
+              ),
+            )
+
+          if ("output" in result) return result
           if (result.items.length === 0) return empty
 
           const rows = result.items.map((item) => ({

--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -78,4 +78,23 @@ describe("tool.glob", () => {
       }),
     ),
   )
+
+  it.live("terminates promptly when context abort signal fires", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => Bun.write(path.join(dir, "a.ts"), "export const a = 1\n"))
+        const controller = new AbortController()
+        // Abort immediately
+        controller.abort()
+        const abortCtx = { ...ctx, abort: controller.signal }
+        const info = yield* GlobTool
+        const glob = yield* info.init()
+        const exit = yield* glob
+          .execute({ pattern: "*.ts", path: dir }, abortCtx)
+          .pipe(Effect.exit)
+        // Should fail (defect from abort) rather than hang
+        expect(Exit.isFailure(exit)).toBe(true)
+      }),
+    ),
+  )
 })

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import path from "path"
-import { Effect, Layer } from "effect"
+import { Effect, Exit, Layer } from "effect"
 import { GrepTool } from "../../src/tool/grep"
 import { provideInstance, provideTmpdirInstance } from "../fixture/fixture"
 import { SessionID, MessageID } from "../../src/session/schema"
@@ -108,6 +108,25 @@ describe("tool.grep", () => {
         expect(result.metadata.matches).toBe(1)
         expect(result.output).toContain(file)
         expect(result.output).toContain("Line 2: line2")
+      }),
+    ),
+  )
+
+  it.live("terminates promptly when context abort signal fires", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => Bun.write(path.join(dir, "test.txt"), "hello world"))
+        const controller = new AbortController()
+        // Abort immediately
+        controller.abort()
+        const abortCtx = { ...ctx, abort: controller.signal }
+        const info = yield* GrepTool
+        const grep = yield* info.init()
+        const exit = yield* grep
+          .execute({ pattern: "hello", path: dir }, abortCtx)
+          .pipe(Effect.exit)
+        // Should fail (defect from abort) rather than hang
+        expect(Exit.isFailure(exit)).toBe(true)
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #24830

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When models call glob or grep with broad paths like `path: "/"`, ripgrep tries to scan the entire filesystem and hangs indefinitely. This is especially problematic for automated or background agent loops where the external directory permission may be auto-accepted.

The fix adds a 30-second timeout to both tools. A combined `AbortSignal` is created from `ctx.abort` (session-level) and `AbortSignal.timeout(30_000)`. When the timeout fires, ripgrep is killed via the existing `raceAbort` mechanism, and the error is caught by `Effect.catchIf` — distinguishing internal timeout (`timeoutSignal.aborted && !ctx.abort.aborted`) from user cancellation. The tool then returns a clear message telling the model to use a more specific path.

**Changes:**
- `packages/opencode/src/tool/glob.ts`: Added `SEARCH_TIMEOUT_MS`, combined abort signal, and `Effect.catchIf` for timeout handling
- `packages/opencode/src/tool/grep.ts`: Same timeout mechanism; returns early with timeout message
- `packages/opencode/test/tool/glob.test.ts`: Added abort-termination test
- `packages/opencode/test/tool/grep.test.ts`: Added abort-termination test

### How did you verify your code works?

All glob, grep, and ripgrep tests pass with no regressions:

```
bun test test/tool/glob.test.ts      → 3 pass, 0 fail
bun test test/tool/grep.test.ts      → 5 pass, 0 fail
bun test test/file/ripgrep.test.ts   → 12 pass, 0 fail
```

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR