### PR TITLE
fix(edit): prevent empty oldString from overwriting existing files

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -88,6 +88,11 @@ export const EditTool = Tool.define(
             Effect.gen(function* () {
               if (params.oldString === "") {
                 const existed = yield* afs.existsSafe(filePath)
+                if (existed) {
+                  throw new Error(
+                    "oldString cannot be empty for existing files. Provide exact oldString context for in-place edits.",
+                  )
+                }
                 const source = existed ? yield* Bom.readFile(afs, filePath) : { bom: false, text: "" }
                 const next = Bom.split(params.newString)
                 const desiredBom = source.bom || next.bom

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -96,7 +96,7 @@ describe("tool.edit", () => {
       })
     })
 
-    test("preserves BOM when oldString is empty on existing files", async () => {
+    test("throws when oldString is empty on existing files", async () => {
       await using tmp = await tmpdir()
       const filepath = path.join(tmp.path, "existing.cs")
       const bom = String.fromCharCode(0xfeff)
@@ -106,23 +106,22 @@ describe("tool.edit", () => {
         directory: tmp.path,
         fn: async () => {
           const edit = await resolve()
-          const result = await Effect.runPromise(
-            edit.execute(
-              {
-                filePath: filepath,
-                oldString: "",
-                newString: "using Up;\n",
-              },
-              ctx,
+          await expect(
+            Effect.runPromise(
+              edit.execute(
+                {
+                  filePath: filepath,
+                  oldString: "",
+                  newString: "using Up;\n",
+                },
+                ctx,
+              ),
             ),
-          )
-
-          expect(result.metadata.diff).toContain("-using System;")
-          expect(result.metadata.diff).toContain("+using Up;")
+          ).rejects.toThrow("oldString cannot be empty for existing files")
 
           const content = await fs.readFile(filepath, "utf-8")
           expect(content.charCodeAt(0)).toBe(0xfeff)
-          expect(content.slice(1)).toBe("using Up;\n")
+          expect(content.slice(1)).toBe("using System;\n")
         },
       })
     })


### PR DESCRIPTION
### Issue for this PR

Closes #23517

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`oldString: ""` currently triggers full-file replacement for existing files, which can silently wipe content when a model tries to append via Edit.

This change keeps `oldString: ""` support for creating new files, but rejects it for existing files and requires explicit old-string context for in-place edits.

### How did you verify your code works?

From `packages/opencode`:
- `bun test test/tool/edit.test.ts -t "oldString is empty"`
- `bun typecheck`

### Screenshots / recordings

_Not a UI layout change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR