### PR TITLE
feat(provider): add Chat Completions API mode for gateway/proxy providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -138,6 +138,47 @@ function useLanguageModel(sdk: any) {
   return sdk.responses === undefined && sdk.chat === undefined
 }
 
+/**
+ * Resolve a language model from the SDK using the configured API mode.
+ *
+ * When a provider config sets `"api": "chat"`, this calls `sdk.chat(modelID)`
+ * which forces the Chat Completions API endpoint (`/chat/completions`) and
+ * correct parameter naming (`max_completion_tokens`) for GPT-5.x models.
+ *
+ * When `"api": "responses"`, uses the Responses API explicitly.
+ * Otherwise, falls back to `sdk.languageModel()` (default SDK behavior).
+ */
+function resolveLanguageModel(sdk: any, modelID: string, apiMode?: string) {
+  if (apiMode === "chat" && typeof sdk.chat === "function") {
+    return sdk.chat(modelID)
+  }
+  if (apiMode === "responses" && typeof sdk.responses === "function") {
+    return sdk.responses(modelID)
+  }
+  return sdk.languageModel(modelID)
+}
+
+/**
+ * Inline JSON Schema `$ref` references so that tool parameter schemas are
+ * self-contained. Some providers (e.g. GPT-5.x via Bedrock) crash on `$ref`.
+ */
+function resolveRefs(obj: any, defs: Record<string, any>): void {
+  if (!obj || typeof obj !== "object") return
+  for (const key of Object.keys(obj)) {
+    const val = obj[key]
+    if (key === "$ref" && typeof val === "string") {
+      const name = val.replace(/^#\/\$defs\//, "")
+      const resolved = defs[name]
+      if (resolved) {
+        delete obj["$ref"]
+        Object.assign(obj, JSON.parse(JSON.stringify(resolved)))
+      }
+    } else if (typeof val === "object" && val !== null) {
+      resolveRefs(val, defs)
+    }
+  }
+}
+
 function custom(dep: CustomDep): Record<string, CustomLoader> {
   return {
     anthropic: () =>
@@ -1124,11 +1165,19 @@ const layer: Layer.Layer<
         // extend database from config
         for (const [providerID, provider] of configProviders) {
           const existing = database[providerID]
+          const configOptions = mergeDeep(existing?.options ?? {}, provider.options ?? {})
+          // When provider.api is a known SDK method name (e.g. "chat", "responses"),
+          // store it as apiMode so getLanguage can call sdk.chat() / sdk.responses()
+          // instead of the default sdk.languageModel().
+          const API_MODES = ["chat", "responses"]
+          if (provider.api && API_MODES.includes(provider.api)) {
+            configOptions["apiMode"] = provider.api
+          }
           const parsed: Info = {
             id: ProviderID.make(providerID),
             name: provider.name ?? existing?.name ?? providerID,
             env: provider.env ?? existing?.env ?? [],
-            options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
+            options: configOptions,
             source: "config",
             models: existing?.models ?? {},
           }
@@ -1152,7 +1201,12 @@ const layer: Layer.Layer<
               api: {
                 id: apiID,
                 npm: apiNpm,
-                url: model.provider?.api ?? provider?.api ?? existingModel?.api.url ?? modelsDev[providerID]?.api ?? "",
+                url: iife(() => {
+                  // Skip provider.api if it's a mode selector (e.g. "chat", "responses")
+                  // rather than a URL — the mode is already captured in options.apiMode.
+                  const providerApiUrl = provider?.api && !API_MODES.includes(provider.api) ? provider.api : undefined
+                  return model.provider?.api ?? providerApiUrl ?? existingModel?.api.url ?? modelsDev[providerID]?.api ?? ""
+                }),
               },
               status: model.status ?? existingModel?.status ?? "active",
               name,
@@ -1480,6 +1534,34 @@ const layer: Layer.Layer<
             }
           }
 
+          // When apiMode is "chat", fix request body for gateway/proxy compatibility:
+          // 1. Rename max_tokens → max_completion_tokens (GPT-5.x rejects max_tokens)
+          // 2. Resolve $ref in tool parameter schemas (Bedrock/proxies don't support $ref)
+          if (options["apiMode"] === "chat" && opts.body && opts.method === "POST") {
+            const body = JSON.parse(opts.body as string)
+            let changed = false
+
+            if ("max_tokens" in body && !("max_completion_tokens" in body)) {
+              body.max_completion_tokens = body.max_tokens
+              delete body.max_tokens
+              changed = true
+            }
+
+            if (Array.isArray(body.tools)) {
+              for (const tool of body.tools) {
+                const params = tool?.function?.parameters
+                if (params && params["$defs"]) {
+                  resolveRefs(params, params["$defs"])
+                  delete params["$defs"]
+                  delete params["defs"]
+                  changed = true
+                }
+              }
+            }
+
+            if (changed) opts.body = JSON.stringify(body)
+          }
+
           const res = await fetchFn(input, {
             ...opts,
             // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
@@ -1570,7 +1652,7 @@ const layer: Layer.Layer<
                 ...provider.options,
                 ...model.options,
               })
-            : sdk.languageModel(model.api.id)
+            : resolveLanguageModel(sdk, model.api.id, provider.options?.["apiMode"])
           s.models.set(key, language)
           return language
         } catch (e) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2712,3 +2712,133 @@ test("opencode loader keeps paid models when auth exists", async () => {
     }
   }
 })
+
+test("api: 'chat' sets apiMode in provider options and does not corrupt model URL", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "my-gateway": {
+              name: "My Gateway",
+              npm: "@ai-sdk/openai",
+              api: "chat",
+              env: [],
+              models: {
+                "gpt-5": {
+                  name: "GPT-5",
+                  tool_call: true,
+                  limit: { context: 128000, output: 16000 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://my-gateway.example.com/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("my-gateway")]
+      expect(provider).toBeDefined()
+      // apiMode should be stored in provider options
+      expect(provider.options.apiMode).toBe("chat")
+      // model api.url should NOT be "chat" — it should fall back to empty string
+      const model = provider.models["gpt-5"]
+      expect(model.api.url).not.toBe("chat")
+      // baseURL in options should be preserved
+      expect(provider.options.baseURL).toBe("https://my-gateway.example.com/v1")
+    },
+  })
+})
+
+test("api: 'responses' sets apiMode in provider options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "my-openai": {
+              name: "My OpenAI",
+              npm: "@ai-sdk/openai",
+              api: "responses",
+              env: [],
+              models: {
+                "gpt-5": {
+                  name: "GPT-5",
+                  tool_call: true,
+                  limit: { context: 128000, output: 16000 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("my-openai")]
+      expect(provider).toBeDefined()
+      expect(provider.options.apiMode).toBe("responses")
+    },
+  })
+})
+
+test("api URL string (not a mode) still flows into model.api.url normally", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "url-api": {
+              name: "URL API",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://api.custom-gateway.com/v1",
+              env: [],
+              models: {
+                "model-1": {
+                  name: "Model 1",
+                  tool_call: true,
+                  limit: { context: 8000, output: 2000 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("url-api")]
+      expect(provider).toBeDefined()
+      // api field with a URL should NOT set apiMode
+      expect(provider.options.apiMode).toBeUndefined()
+      // URL should flow into model.api.url as before
+      expect(provider.models["model-1"].api.url).toBe("https://api.custom-gateway.com/v1")
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #7793
Related: #22623, #20622

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `"api": "chat"` provider config option that forces Chat Completions API for custom providers using `@ai-sdk/openai` or `@ai-sdk/openai-compatible`.

**The problem:** GPT-5.x models can't be used through OpenAI-compatible gateways/proxies because:
1. `@ai-sdk/openai` v5 defaults to `/responses` — gateways only implement `/chat/completions` → 404
2. `@ai-sdk/openai-compatible` sends `max_tokens` — GPT-5.x rejects it (needs `max_completion_tokens`)
3. MCP tools emit `$ref` in JSON Schema — AWS Bedrock's OpenAI-compat layer crashes on `$ref`

**The fix (3 parts in the fetch interceptor + model resolution):**
1. When `"api": "chat"` is set, call `sdk.chat(modelId)` instead of `sdk.languageModel(modelId)` — uses `/chat/completions`
2. Rename `max_tokens` → `max_completion_tokens` in the request body for providers in chat mode — the SDK only sends the correct name for model IDs it recognizes (standard OpenAI IDs), not custom gateway IDs
3. Inline `$ref` references in tool parameter schemas before sending — Bedrock doesn't support JSON Schema `$ref`/`$defs`

I found the `$ref` issue by binary-searching through 66 tools in the request until isolating the specific MCP tool (`web_search`) whose schema used `$ref`. The `max_tokens` issue was identified from a 400 error message. The `/responses` 404 was confirmed by testing the endpoint directly.

### How did you verify your code works?

1. All 80 existing provider tests pass + 3 new integration tests added
2. Tested streaming + tool calls against an OpenAI-compatible gateway with GPT-5.4
3. Confirmed the exact request body OpenCode sends works end-to-end with the fixes applied
4. Verified backward compat: URL-value `api` fields still flow into `model.api.url` as before

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR