### PR TITLE
feat(provider): convert reasoning_effort to thinking_config for Gemini

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1537,6 +1537,7 @@ const layer: Layer.Layer<
           // When apiMode is "chat", fix request body for gateway/proxy compatibility:
           // 1. Rename max_tokens → max_completion_tokens (GPT-5.x rejects max_tokens)
           // 2. Resolve $ref in tool parameter schemas (Bedrock/proxies don't support $ref)
+          // 3. Convert reasoning_effort → thinking_config for Gemini models
           if (options["apiMode"] === "chat" && opts.body && opts.method === "POST") {
             const body = JSON.parse(opts.body as string)
             let changed = false
@@ -1544,6 +1545,15 @@ const layer: Layer.Layer<
             if ("max_tokens" in body && !("max_completion_tokens" in body)) {
               body.max_completion_tokens = body.max_tokens
               delete body.max_tokens
+              changed = true
+            }
+
+            // Gemini uses thinking_config instead of reasoning_effort
+            if ("reasoning_effort" in body && typeof body.model === "string" && body.model.includes("gemini")) {
+              const levelMap: Record<string, string> = { none: "THINKING_LEVEL_UNSPECIFIED", low: "LOW", medium: "LOW", high: "HIGH" }
+              const level = levelMap[body.reasoning_effort] ?? "LOW"
+              body.thinking_config = { thinking_level: level }
+              delete body.reasoning_effort
               changed = true
             }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -138,6 +138,47 @@ function useLanguageModel(sdk: any) {
   return sdk.responses === undefined && sdk.chat === undefined
 }
 
+/**
+ * Resolve a language model from the SDK using the configured API mode.
+ *
+ * When a provider config sets `"api": "chat"`, this calls `sdk.chat(modelID)`
+ * which forces the Chat Completions API endpoint (`/chat/completions`) and
+ * correct parameter naming (`max_completion_tokens`) for GPT-5.x models.
+ *
+ * When `"api": "responses"`, uses the Responses API explicitly.
+ * Otherwise, falls back to `sdk.languageModel()` (default SDK behavior).
+ */
+function resolveLanguageModel(sdk: any, modelID: string, apiMode?: string) {
+  if (apiMode === "chat" && typeof sdk.chat === "function") {
+    return sdk.chat(modelID)
+  }
+  if (apiMode === "responses" && typeof sdk.responses === "function") {
+    return sdk.responses(modelID)
+  }
+  return sdk.languageModel(modelID)
+}
+
+/**
+ * Inline JSON Schema `$ref` references so that tool parameter schemas are
+ * self-contained. Some providers (e.g. GPT-5.x via Bedrock) crash on `$ref`.
+ */
+function resolveRefs(obj: any, defs: Record<string, any>): void {
+  if (!obj || typeof obj !== "object") return
+  for (const key of Object.keys(obj)) {
+    const val = obj[key]
+    if (key === "$ref" && typeof val === "string") {
+      const name = val.replace(/^#\/\$defs\//, "")
+      const resolved = defs[name]
+      if (resolved) {
+        delete obj["$ref"]
+        Object.assign(obj, JSON.parse(JSON.stringify(resolved)))
+      }
+    } else if (typeof val === "object" && val !== null) {
+      resolveRefs(val, defs)
+    }
+  }
+}
+
 function custom(dep: CustomDep): Record<string, CustomLoader> {
   return {
     anthropic: () =>
@@ -1124,11 +1165,19 @@ const layer: Layer.Layer<
         // extend database from config
         for (const [providerID, provider] of configProviders) {
           const existing = database[providerID]
+          const configOptions = mergeDeep(existing?.options ?? {}, provider.options ?? {})
+          // When provider.api is a known SDK method name (e.g. "chat", "responses"),
+          // store it as apiMode so getLanguage can call sdk.chat() / sdk.responses()
+          // instead of the default sdk.languageModel().
+          const API_MODES = ["chat", "responses"]
+          if (provider.api && API_MODES.includes(provider.api)) {
+            configOptions["apiMode"] = provider.api
+          }
           const parsed: Info = {
             id: ProviderID.make(providerID),
             name: provider.name ?? existing?.name ?? providerID,
             env: provider.env ?? existing?.env ?? [],
-            options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
+            options: configOptions,
             source: "config",
             models: existing?.models ?? {},
           }
@@ -1152,7 +1201,12 @@ const layer: Layer.Layer<
               api: {
                 id: apiID,
                 npm: apiNpm,
-                url: model.provider?.api ?? provider?.api ?? existingModel?.api.url ?? modelsDev[providerID]?.api ?? "",
+                url: iife(() => {
+                  // Skip provider.api if it's a mode selector (e.g. "chat", "responses")
+                  // rather than a URL — the mode is already captured in options.apiMode.
+                  const providerApiUrl = provider?.api && !API_MODES.includes(provider.api) ? provider.api : undefined
+                  return model.provider?.api ?? providerApiUrl ?? existingModel?.api.url ?? modelsDev[providerID]?.api ?? ""
+                }),
               },
               status: model.status ?? existingModel?.status ?? "active",
               name,
@@ -1480,6 +1534,34 @@ const layer: Layer.Layer<
             }
           }
 
+          // When apiMode is "chat", fix request body for gateway/proxy compatibility:
+          // 1. Rename max_tokens → max_completion_tokens (GPT-5.x rejects max_tokens)
+          // 2. Resolve $ref in tool parameter schemas (Bedrock/proxies don't support $ref)
+          if (options["apiMode"] === "chat" && opts.body && opts.method === "POST") {
+            const body = JSON.parse(opts.body as string)
+            let changed = false
+
+            if ("max_tokens" in body && !("max_completion_tokens" in body)) {
+              body.max_completion_tokens = body.max_tokens
+              delete body.max_tokens
+              changed = true
+            }
+
+            if (Array.isArray(body.tools)) {
+              for (const tool of body.tools) {
+                const params = tool?.function?.parameters
+                if (params && params["$defs"]) {
+                  resolveRefs(params, params["$defs"])
+                  delete params["$defs"]
+                  delete params["defs"]
+                  changed = true
+                }
+              }
+            }
+
+            if (changed) opts.body = JSON.stringify(body)
+          }
+
           const res = await fetchFn(input, {
             ...opts,
             // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
@@ -1570,7 +1652,7 @@ const layer: Layer.Layer<
                 ...provider.options,
                 ...model.options,
               })
-            : sdk.languageModel(model.api.id)
+            : resolveLanguageModel(sdk, model.api.id, provider.options?.["apiMode"])
           s.models.set(key, language)
           return language
         } catch (e) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2712,3 +2712,133 @@ test("opencode loader keeps paid models when auth exists", async () => {
     }
   }
 })
+
+test("api: 'chat' sets apiMode in provider options and does not corrupt model URL", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "my-gateway": {
+              name: "My Gateway",
+              npm: "@ai-sdk/openai",
+              api: "chat",
+              env: [],
+              models: {
+                "gpt-5": {
+                  name: "GPT-5",
+                  tool_call: true,
+                  limit: { context: 128000, output: 16000 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://my-gateway.example.com/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("my-gateway")]
+      expect(provider).toBeDefined()
+      // apiMode should be stored in provider options
+      expect(provider.options.apiMode).toBe("chat")
+      // model api.url should NOT be "chat" — it should fall back to empty string
+      const model = provider.models["gpt-5"]
+      expect(model.api.url).not.toBe("chat")
+      // baseURL in options should be preserved
+      expect(provider.options.baseURL).toBe("https://my-gateway.example.com/v1")
+    },
+  })
+})
+
+test("api: 'responses' sets apiMode in provider options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "my-openai": {
+              name: "My OpenAI",
+              npm: "@ai-sdk/openai",
+              api: "responses",
+              env: [],
+              models: {
+                "gpt-5": {
+                  name: "GPT-5",
+                  tool_call: true,
+                  limit: { context: 128000, output: 16000 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("my-openai")]
+      expect(provider).toBeDefined()
+      expect(provider.options.apiMode).toBe("responses")
+    },
+  })
+})
+
+test("api URL string (not a mode) still flows into model.api.url normally", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "url-api": {
+              name: "URL API",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://api.custom-gateway.com/v1",
+              env: [],
+              models: {
+                "model-1": {
+                  name: "Model 1",
+                  tool_call: true,
+                  limit: { context: 8000, output: 2000 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("url-api")]
+      expect(provider).toBeDefined()
+      // api field with a URL should NOT set apiMode
+      expect(provider.options.apiMode).toBeUndefined()
+      // URL should flow into model.api.url as before
+      expect(provider.models["model-1"].api.url).toBe("https://api.custom-gateway.com/v1")
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Builds on #24914 (Chat Completions API mode)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a Gemini model is used through the `api: "chat"` provider mode, the fetch interceptor now converts `reasoning_effort` to Gemini's native `thinking_config` parameter with `thinking_level`.

**Why:** Gemini models don't support OpenAI's `reasoning_effort` parameter (gateway returns 422: "no Google equivalent"). Instead they use `thinking_config: { thinking_level: "LOW" | "HIGH" }`. This conversion happens in the fetch interceptor so the same variant UI works for both GPT and Gemini models.

**Mapping:**
| Variant | GPT-5.x (unchanged) | Gemini (converted) |
|---------|---------------------|---------------------|
| low | `reasoning_effort: "low"` | `thinking_config: { thinking_level: "LOW" }` |
| medium | `reasoning_effort: "medium"` | `thinking_config: { thinking_level: "LOW" }` |
| high | `reasoning_effort: "high"` | `thinking_config: { thinking_level: "HIGH" }` |

Gemini 3.x only supports LOW/HIGH thinking levels (not a continuous budget). The model ID is detected via `body.model.includes("gemini")`.

Note: `include_thoughts: true` was tested but the OpenAI-compatible endpoint does not expose thinking content — reasoning tokens are consumed internally. Only the final answer is returned regardless.

### How did you verify your code works?

1. Tested `thinking_config` with `thinking_level: "LOW"` and `"HIGH"` against an OpenAI-compatible gateway — both return 200 with reasoning tokens consumed
2. Verified `reasoning_effort` alone returns 422 for Gemini ("no Google equivalent")
3. All 80 provider tests pass
4. Confirmed `include_thoughts: true` has no observable effect on the OpenAI-compat endpoint (reasoning content not exposed)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR