### PR TITLE
feat(provider): add apiKeyCommand for dynamic API key refresh

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1449,11 +1449,42 @@ const layer: Layer.Layer<
 
         const customFetch = options["fetch"]
         const chunkTimeout = options["chunkTimeout"]
+        const apiKeyCommand = options["apiKeyCommand"]
         delete options["chunkTimeout"]
+        delete options["apiKeyCommand"]
+
+        // apiKeyCommand: run a shell command to get a fresh API key, cached with 5-min TTL.
+        // Same pattern as Claude Code's apiKeyHelper.
+        let cachedKey: { value: string; expires: number } | undefined
+        function resolveApiKey(): string | undefined {
+          if (!apiKeyCommand) return undefined
+          if (cachedKey && Date.now() < cachedKey.expires) return cachedKey.value
+          try {
+            const result = Bun.spawnSync(["sh", "-c", apiKeyCommand], { timeout: 10_000 })
+            const value = result.stdout.toString().trim()
+            if (value) {
+              cachedKey = { value, expires: Date.now() + 5 * 60 * 1000 }
+              return value
+            }
+          } catch {}
+          return cachedKey?.value
+        }
 
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const fetchFn = customFetch ?? fetch
           const opts = init ?? {}
+
+          // Refresh API key if apiKeyCommand is configured
+          if (apiKeyCommand) {
+            const freshKey = resolveApiKey()
+            if (freshKey) {
+              const headers = new Headers(opts.headers)
+              headers.set("authorization", `Bearer ${freshKey}`)
+              headers.set("x-api-key", freshKey)
+              opts.headers = headers
+            }
+          }
+
           const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
           const signals: AbortSignal[] = []
 


### PR DESCRIPTION
### Issue for this PR

Enterprise users with short-lived tokens (IAM, STS, SSO) face frequent 401 errors mid-session because API keys are resolved once at startup and never refreshed.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an `apiKeyCommand` provider option that runs a shell command to obtain a fresh API key on each request, with a 5-minute TTL cache. This matches Claude Code's `apiKeyHelper` pattern.

When `apiKeyCommand` is set in provider options, the custom fetch wrapper:
1. Checks if the cached key has expired (5-min TTL)
2. If expired, runs the command via `Bun.spawnSync(["sh", "-c", command])` with a 10s timeout
3. Injects the fresh token as both `Authorization: Bearer` and `x-api-key` headers
4. Falls back to the last known good token if the command fails

This is useful for enterprise gateways that issue short-lived tokens (e.g. AWS STS credentials, Azure AD tokens, corporate SSO tokens).

```json
{
  "provider": {
    "my-gateway": {
      "options": {
        "baseURL": "https://my-gateway.example.com/v1",
        "apiKeyCommand": "my-cli auth:get-token"
      }
    }
  }
}
```

### How did you verify your code works?

1. Tested with a token-issuing CLI command — verified fresh token is obtained and cached
2. Verified TTL: second call within 5 min uses cache (no subprocess spawn)
3. Verified fallback: if command returns empty, last known good token is used
4. All 80 provider tests pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR