### PR TITLE
fix(mcp): detect transport close and update status to failed

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -472,6 +472,15 @@ export const layer = Layer.effect(
       Effect.catch(() => Effect.succeed([] as number[])),
     )
 
+    function dropConnection(s: State, name: string, client: MCPClient, reason: string) {
+      if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
+      log.warn("mcp server disconnected, marking as failed", { server: name, reason })
+      s.status[name] = { status: "failed", error: reason }
+      delete s.clients[name]
+      delete s.defs[name]
+      void client.close()
+    }
+
     function watch(s: State, name: string, client: MCPClient, bridge: EffectBridge.Shape, timeout?: number) {
       client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
         log.info("tools list changed notification received", { server: name })
@@ -484,6 +493,10 @@ export const layer = Layer.effect(
         s.defs[name] = listed
         await bridge.promise(bus.publish(ToolsChanged, { server: name }).pipe(Effect.ignore))
       })
+
+      client.onclose = () => {
+        bridge.fork(Effect.sync(() => dropConnection(s, name, client, "MCP transport closed unexpectedly")))
+      }
     }
 
     const state = yield* InstanceState.make<State>(


### PR DESCRIPTION
Fixes #23997

Detects when an MCP client transport closes unexpectedly (server crash, network drop, process exit) and immediately marks the connection status as "failed" instead of leaving it as "connected".

## Problem

The TUI and API would continue to show MCP servers as online (green/connected) even after the underlying transport had closed. This happened because the client.onclose callback was not being handled, so the connection state in MCPService was never updated when the transport died.

## Solution

1. Added a dropConnection() helper that:
   - Sets s.status[name] = { status: "failed", error: "MCP transport closed unexpectedly" }
   - Removes the client from s.clients
   - Removes cached tool definitions from s.defs

2. Hooked into the client.onclose callback in watch() to call dropConnection() immediately when the transport closes.

## Changes

- packages/opencode/src/mcp/index.ts: added dropConnection() helper and client.onclose handler inside watch()

## Verification

- The fix uses the existing EffectBridge pattern already established in the codebase.
- The change only affects the watch() function and does not alter the public API.
