### PR TITLE
docs: add Skills section to ecosystem page

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -13,6 +13,19 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ---
 
+## Skills
+
+OpenCode [Agent Skills](/docs/skills/) are reusable instructions that agents load on-demand. Install by cloning into `~/.claude/skills/`.
+
+| Name                                                                                                 | Description                                                                     |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [opencode-mcp-registry](https://github.com/LDLZM/opencode-mcp-registry)                             | Register new MCP servers in opencode — install, configure auth, and test        |
+| [uv-skill](https://github.com/LDLZM/uv-skill)                                                       | Use uv for ALL Python package management — replaces pip/poetry/pyenv            |
+| [crowdsource-debugger](https://github.com/LDLZM/crowdsource-debugger)                               | Debug stubborn errors via Stack Overflow, GitHub Issues, Reddit, and Discourse  |
+| [sensitive-operations](https://github.com/LDLZM/sensitive-operations-skill)                         | Delegate passwords, sudo, tokens, and destructive commands to the user          |
+
+---
+
 ## Plugins
 
 | Name                                                                                               | Description                                                                                       |


### PR DESCRIPTION
### Issue for this PR

N/A - adding new content section

### Type of change

- [x] Documentation

### What does this PR do?

Adds a new "Skills" section to the ecosystem page showcasing 4 OpenCode agent skills:

- **opencode-mcp-registry** — Register new MCP servers in opencode
- **uv-skill** — Use uv for all Python package management
- **crowdsource-debugger** — Debug stubborn errors via community sources
- **sensitive-operations** — Delegate sensitive operations to the user

Skills are reusable instructions that agents load on-demand via the SKILL.md format.

### How did you verify your code works?

Markdown formatting verified manually. No code changes — docs only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR