### PR TITLE
fix(ui): show tool parameters during pending state

### DIFF
--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -145,41 +145,39 @@ export function BasicTool(props: BasicToolProps) {
                     >
                       <TextShimmer text={title().title} active={pending()} />
                     </span>
-                    <Show when={!pending()}>
-                      <Show when={title().subtitle}>
-                        <span
-                          data-slot="basic-tool-tool-subtitle"
-                          classList={{
-                            [title().subtitleClass ?? ""]: !!title().subtitleClass,
-                            clickable: !!props.onSubtitleClick,
-                          }}
-                          onClick={(e) => {
-                            if (props.onSubtitleClick) {
-                              e.stopPropagation()
-                              props.onSubtitleClick()
-                            }
-                          }}
-                        >
-                          {title().subtitle}
-                        </span>
-                      </Show>
-                      <Show when={title().args?.length}>
-                        <For each={title().args}>
-                          {(arg) => (
-                            <span
-                              data-slot="basic-tool-tool-arg"
-                              classList={{
-                                [title().argsClass ?? ""]: !!title().argsClass,
-                              }}
-                            >
-                              {arg}
-                            </span>
-                          )}
-                        </For>
-                      </Show>
+                    <Show when={title().subtitle}>
+                      <span
+                        data-slot="basic-tool-tool-subtitle"
+                        classList={{
+                          [title().subtitleClass ?? ""]: !!title().subtitleClass,
+                          clickable: !!props.onSubtitleClick,
+                        }}
+                        onClick={(e) => {
+                          if (props.onSubtitleClick) {
+                            e.stopPropagation()
+                            props.onSubtitleClick()
+                          }
+                        }}
+                      >
+                        {title().subtitle}
+                      </span>
+                    </Show>
+                    <Show when={title().args?.length}>
+                      <For each={title().args}>
+                        {(arg) => (
+                          <span
+                            data-slot="basic-tool-tool-arg"
+                            classList={{
+                              [title().argsClass ?? ""]: !!title().argsClass,
+                            }}
+                          >
+                            {arg}
+                          </span>
+                        )}
+                      </For>
                     </Show>
                   </div>
-                  <Show when={!pending() && title().action}>
+                  <Show when={title().action}>
                     <span data-slot="basic-tool-tool-action">{title().action}</span>
                   </Show>
                 </div>
@@ -189,7 +187,7 @@ export function BasicTool(props: BasicToolProps) {
           </Switch>
         </div>
       </div>
-      <Show when={props.children && !props.hideDetails && !props.locked && !pending()}>
+      <Show when={props.children && !props.hideDetails && !props.locked}>
         <Collapsible.Arrow />
       </Show>
     </div>


### PR DESCRIPTION
### Issue for this PR

Fixes #24934

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `.tool-trigger` element in the web UI hides tool call parameters (subtitle, args), action buttons, and collapsible arrows while waiting for user permission/instructions (pending/running states). Users need full visibility of all tool details to make informed approval decisions.

This PR removes the `!pending()` conditions from all three `<Show>` blocks in `basic-tool.tsx`:
1. Lines 148-178: Now shows subtitle and args during pending/running
2. Line 180: Now shows action buttons during pending/running  
3. Line 190: Now shows collapsible arrow during pending/running

The `TextShimmer` animation on the title is preserved during pending/running states.

### How did you verify your code works?

- TypeScript typecheck passes (`bun typecheck` in `packages/ui`)
- Existing test suites pass (11 pass, 2 pre-existing failures unrelated to changes)
- Code review confirmed all three `<Show>` blocks correctly modified
- Verified no regressions: only removed conditional checks, no new logic added

### Screenshots / recordings

_UI change - tool parameters now visible during pending state_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._