### PR TITLE
fix(opencode): project .opencode/ config now overrides global ~/.opencode

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -26,6 +26,11 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
   const afs = yield* AppFileSystem.Service
   return unique([
     Global.Path.config,
+    ...(yield* afs.up({
+      targets: [".opencode"],
+      start: Global.Path.home,
+      stop: Global.Path.home,
+    })),
     ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
       ? yield* afs.up({
           targets: [".opencode"],
@@ -33,11 +38,6 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
           stop: worktree,
         })
       : []),
-    ...(yield* afs.up({
-      targets: [".opencode"],
-      start: Global.Path.home,
-      stop: Global.Path.home,
-    })),
     ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
   ])
 })


### PR DESCRIPTION
ConfigPaths.directories() was appending ~/.opencode after the project
walk results, so it was always processed last and always won the merge.
Swapped the two afs.up() spreads so ~/.opencode is placed before project
dirs. unique() then deduplicates it from the walk, leaving project dirs
last — which means project config correctly overrides global.
Verified by running opencode from a project with a local .opencode/agent/
build.md specifying a different model than ~/.opencode/agent/build.md.
Before the fix the global model was used; after, the project model wins.
To reproduce:
1. Set model X in ~/.opencode/agent/build.md
2. Set model Y in <project>/.opencode/agent/build.md
3. Launch opencode from the project dir — before: X, after: Y
Fixes #19296
Fixes #21307