### PR TITLE
fix(web): enable file watcher in web/serve mode

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -8,10 +8,9 @@ export const ServeCommand = effectCmd({
   command: "serve",
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "starts a headless opencode server",
-  // Server loads instances per-request via x-opencode-directory header — no
-  // need for an ambient project InstanceContext at startup.
   instance: false,
   handler: Effect.fn("Cli.serve")(function* (args) {
+    process.env.OPENCODE_EXPERIMENTAL_FILEWATCHER = "true"
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -33,10 +33,9 @@ export const WebCommand = effectCmd({
   command: "web",
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
-  // Server loads instances per-request via x-opencode-directory header — no
-  // ambient project InstanceContext needed at startup.
   instance: false,
   handler: Effect.fn("Cli.web")(function* (args) {
+    process.env.OPENCODE_EXPERIMENTAL_FILEWATCHER = "true"
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }


### PR DESCRIPTION
### Issue for this PR

Closes #19182

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In web/serve mode, the native file watcher (`FileWatcher`) only subscribes to `.git/HEAD` for branch change detection but does **not** monitor the working directory for file changes. This is because `OPENCODE_EXPERIMENTAL_FILEWATCHER` defaults to `false`, and neither the `web` nor `serve` command sets it — unlike the desktop mode which explicitly sets `OPENCODE_EXPERIMENTAL_FILEWATCHER: "true"` in `desktop-electron/src/main/server.ts` line 68.

Without this flag, when files are modified externally (e.g. via VSCode), no `file.watcher.updated` event is produced, so the SSE stream doesn't push updates to the frontend, and the changes tab / review panel don't refresh.

The fix adds `process.env.OPENCODE_EXPERIMENTAL_FILEWATCHER = "true"` at the start of both `web.ts` and `serve.ts` handlers, matching the desktop mode behavior.

### How did you verify your code works?

Started the opencode web server with `OPENCODE_EXPERIMENTAL_FILEWATCHER=true`, opened the web UI, then modified a file externally. Confirmed that the changes tab and review panel updated in real time.

### Screenshots / recordings

_N/A — no UI change, only a backend behavior fix._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR