### PR TITLE
feat(tui): show provider quota in prompt metrics

### DIFF
--- a/packages/console/resource/resource.node.ts
+++ b/packages/console/resource/resource.node.ts
@@ -34,7 +34,9 @@ export const Resource = new Proxy(
                   keys: Array.isArray(k) ? k : [k],
                   account_id: accountId,
                 })
-                .then((result) => (isMulti ? new Map(Object.entries(result?.values ?? {})) : result?.values?.[k]))
+                .then((result: Awaited<ReturnType<typeof client.kv.namespaces.bulkGet>>) =>
+                  isMulti ? new Map(Object.entries(result?.values ?? {})) : result?.values?.[k],
+                )
             },
             put: (k: string, v: string, opts?: KVNamespacePutOptions) =>
               client.kv.namespaces.values.update(namespaceId, k, {
@@ -54,7 +56,7 @@ export const Resource = new Proxy(
                   account_id: accountId,
                   prefix: opts?.prefix ?? undefined,
                 })
-                .then((result) => {
+                .then((result: Awaited<ReturnType<typeof client.kv.namespaces.keys.list>>) => {
                   return {
                     keys: result.result,
                     list_complete: true,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -43,6 +43,7 @@ import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-workspace-create"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
+import { formatCodexQuotaMetrics, formatProviderQuotaMetrics } from "./metrics"
 
 export type PromptProps = {
   sessionID?: string
@@ -199,6 +200,20 @@ export function Prompt(props: PromptProps) {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
       cost: cost > 0 ? money.format(cost) : undefined,
     }
+  })
+  const quota = createMemo(
+    () =>
+      formatProviderQuotaMetrics(
+        sync.data.console_state.providerQuota,
+        dimensions().width,
+        Date.now(),
+        currentProviderLabel(),
+      ) ?? formatCodexQuotaMetrics(sync.data.console_state.codexQuota, dimensions().width),
+  )
+  const metrics = createMemo(() => {
+    const parts = [usage()?.context, quota(), usage()?.cost].filter((part): part is string => Boolean(part))
+    if (parts.length === 0) return
+    return parts.join(" · ")
   })
 
   const [store, setStore] = createStore<{
@@ -1395,10 +1410,10 @@ export function Prompt(props: PromptProps) {
               <Switch>
                 <Match when={store.mode === "normal"}>
                   <Switch>
-                    <Match when={usage()}>
+                    <Match when={metrics()}>
                       {(item) => (
                         <text fg={theme.textMuted} wrapMode="none">
-                          {[item().context, item().cost].filter(Boolean).join(" · ")}
+                          {item()}
                         </text>
                       )}
                     </Match>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/metrics.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/metrics.ts
@@ -1,0 +1,112 @@
+import type { ConsoleState } from "@/config/console-state"
+
+type CodexQuotaSnapshot = NonNullable<ConsoleState["codexQuota"]>
+type CodexQuotaWindow = NonNullable<CodexQuotaSnapshot["fiveHour"]>
+type ProviderQuotaSnapshot = NonNullable<ConsoleState["providerQuota"]>[number]
+
+type CodexQuotaLayout = {
+  barWidth?: number
+  timestamp?: boolean
+}
+
+export function formatCodexQuotaFetchedAt(timestamp: number, now = Date.now()) {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.valueOf())) return
+
+  const pad = (value: number) => value.toString().padStart(2, "0")
+  const time = `${pad(date.getHours())}h${pad(date.getMinutes())}m${pad(date.getSeconds())}s`
+  const dateStart = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+  const nowDate = new Date(now)
+  const nowStart = new Date(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate()).getTime()
+  const daysAgo = Math.max(0, Math.floor((nowStart - dateStart) / 86_400_000))
+  const day = daysAgo === 0 ? "today" : daysAgo === 1 ? "yesterday" : `${daysAgo}d ago`
+
+  return `${day}@${time}`
+}
+
+export function clampPercent(value: number) {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+export function formatQuotaBar(percent: number, width: number) {
+  const columns = Math.max(0, Math.floor(width))
+  const filled = Math.round((clampPercent(percent) / 100) * columns)
+  return `${"█".repeat(filled)}${"░".repeat(columns - filled)}`
+}
+
+function formatQuotaWindow(label: "5h" | "wk", item: CodexQuotaWindow, barWidth?: number) {
+  const percent = clampPercent(item.remainingPercent)
+  if (barWidth === undefined) return `${label} ${percent}%`
+  return `${label} ${formatQuotaBar(percent, barWidth)} ${percent}%`
+}
+
+function codexQuotaLayout(width: number): CodexQuotaLayout {
+  if (width >= 200) return { barWidth: 10, timestamp: true }
+  if (width >= 120) return { barWidth: 5, timestamp: true }
+  if (width >= 90) return { timestamp: true }
+  return {}
+}
+
+function formatProviderWindow(item: {
+  label: string
+  remainingPercent?: number
+  confidence: "exact" | "reported" | "estimated"
+}) {
+  if (item.confidence !== "exact" && item.confidence !== "reported") return
+  if (item.remainingPercent == null) return
+  const percent = clampPercent(item.remainingPercent)
+  return `${item.label} ${percent}%`
+}
+
+function hasPromptVisibleProviderQuota(item: ProviderQuotaSnapshot) {
+  if (item.status === "unavailable") return false
+  return item.windows.some((window) => window.confidence === "exact" || window.confidence === "reported")
+}
+
+function providerMatchesActive(item: ProviderQuotaSnapshot, activeProvider: string | undefined) {
+  if (!activeProvider) return false
+  const active = activeProvider.toLowerCase()
+  return item.provider.toLowerCase() === active || item.label.toLowerCase() === active
+}
+
+function formatProviderWindows(item: ProviderQuotaSnapshot, width: number, now: number) {
+  const layout = codexQuotaLayout(width)
+  const parts = item.windows
+    .map((window) => formatProviderWindow(window))
+    .filter((part): part is string => Boolean(part))
+
+  if (parts.length === 0) return
+
+  const fetchedAt = layout.timestamp && item.fetchedAt ? formatCodexQuotaFetchedAt(item.fetchedAt, now) : undefined
+  return `${item.label} ${parts.join(" · ")}${fetchedAt ? ` · ⟳ ${fetchedAt}` : ""}`.trim()
+}
+
+export function formatCodexQuotaMetrics(item: CodexQuotaSnapshot | undefined, terminalWidth: number, now = Date.now()) {
+  if (!item?.fiveHour && !item?.weekly) return
+
+  const layout = codexQuotaLayout(terminalWidth)
+  const fetchedAt =
+    item.fetchedAt !== undefined && layout.timestamp ? formatCodexQuotaFetchedAt(item.fetchedAt, now) : undefined
+  const parts = [
+    item.fiveHour ? formatQuotaWindow("5h", item.fiveHour, layout.barWidth) : undefined,
+    item.weekly ? formatQuotaWindow("wk", item.weekly, layout.barWidth) : undefined,
+    fetchedAt ? `⟳ ${fetchedAt}` : undefined,
+  ].filter((part): part is string => Boolean(part))
+
+  if (parts.length === 0) return
+  return `codex ${parts.join(" · ")}`
+}
+
+export function formatProviderQuotaMetrics(
+  item: ConsoleState["providerQuota"],
+  terminalWidth: number,
+  now = Date.now(),
+  activeProvider?: string,
+) {
+  if (!item || item.length === 0) return
+  const visible = item.filter(hasPromptVisibleProviderQuota)
+  const quote = visible.find((entry) => providerMatchesActive(entry, activeProvider)) ?? visible[0]
+  if (!quote) return
+  return formatProviderWindows(quote, terminalWidth, now)
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -27,11 +27,13 @@ import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
-import { batch, onMount } from "solid-js"
+import { batch, onCleanup, onMount } from "solid-js"
 import * as Log from "@opencode-ai/core/util/log"
 import { emptyConsoleState, type ConsoleState } from "@/config/console-state"
 import path from "path"
 import { useKV } from "./kv"
+
+const CODEX_QUOTA_REFRESH_INTERVAL = 60 * 1000
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -110,6 +112,38 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const project = useProject()
     const sdk = useSDK()
     const kv = useKV()
+    let codexQuotaWorkspace: string | null | undefined
+    let providerQuotaWorkspace: string | null | undefined
+
+    async function syncCodexQuota(workspace = project.workspace.current()) {
+      const current = workspace ?? null
+      if (codexQuotaWorkspace === current) return
+      codexQuotaWorkspace = current
+      try {
+        const result = await sdk.client.experimental.console.codexQuota({ workspace })
+        if (!result.data) return
+        if (workspace !== project.workspace.current()) return
+        setStore("console_state", reconcile({ ...store.console_state, codexQuota: result.data }))
+      } finally {
+        if (codexQuotaWorkspace === current) codexQuotaWorkspace = undefined
+      }
+    }
+
+    async function syncProviderQuota(workspace = project.workspace.current()) {
+      const current = workspace ?? null
+      if (providerQuotaWorkspace === current) return
+      providerQuotaWorkspace = current
+      try {
+        const result = await sdk.client.experimental.providerQuota({ workspace })
+        if (!result.data) return
+        if (workspace !== project.workspace.current()) return
+        setStore("console_state", reconcile({ ...store.console_state, providerQuota: result.data.providerQuota }))
+      } catch {
+        return
+      } finally {
+        if (providerQuotaWorkspace === current) providerQuotaWorkspace = undefined
+      }
+    }
 
     const fullSyncedSessions = new Set<string>()
     let syncedWorkspace = project.workspace.current()
@@ -437,10 +471,14 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         })
         .then(() => {
           if (store.status !== "complete") setStore("status", "partial")
+          void syncCodexQuota(workspace).catch(() => undefined)
+          void syncProviderQuota(workspace).catch(() => undefined)
           // non-blocking
           void Promise.all([
             ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
+            syncCodexQuota(workspace),
+            syncProviderQuota(workspace),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
             sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
@@ -474,6 +512,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     onMount(() => {
       void bootstrap()
+      void syncCodexQuota().catch(() => undefined)
+      void syncProviderQuota().catch(() => undefined)
+      const interval = setInterval(() => {
+        void syncCodexQuota().catch(() => undefined)
+        void syncProviderQuota().catch(() => undefined)
+      }, CODEX_QUOTA_REFRESH_INTERVAL)
+      onCleanup(() => clearInterval(interval))
     })
 
     const result = {

--- a/packages/opencode/src/config/console-state.ts
+++ b/packages/opencode/src/config/console-state.ts
@@ -1,10 +1,51 @@
 import { Schema } from "effect"
 import { zod } from "@/util/effect-zod"
 
+export class ConsoleQuotaWindow extends Schema.Class<ConsoleQuotaWindow>("ConsoleQuotaWindow")({
+  remainingPercent: Schema.Number,
+  resetSeconds: Schema.optional(Schema.Number),
+  resetAt: Schema.optional(Schema.Number),
+}) {}
+
+export class CodexQuotaSnapshot extends Schema.Class<CodexQuotaSnapshot>("CodexQuotaSnapshot")({
+  fiveHour: Schema.optional(ConsoleQuotaWindow),
+  weekly: Schema.optional(ConsoleQuotaWindow),
+  fetchedAt: Schema.optional(Schema.Number),
+}) {
+  static readonly zod = zod(this)
+}
+
+export class ProviderQuotaWindow extends Schema.Class<ProviderQuotaWindow>("ProviderQuotaWindow")({
+  label: Schema.String,
+  remainingPercent: Schema.optional(Schema.Number),
+  resetSeconds: Schema.optional(Schema.Number),
+  resetAt: Schema.optional(Schema.Number),
+  confidence: Schema.Literals(["exact", "reported", "estimated"]),
+  source: Schema.Literals(["official_api", "response_headers", "client_state", "heuristic"]),
+}) {}
+
+export class ProviderQuotaSnapshot extends Schema.Class<ProviderQuotaSnapshot>("ProviderQuotaSnapshot")({
+  provider: Schema.String,
+  label: Schema.String,
+  fetchedAt: Schema.Number,
+  status: Schema.Literals(["available", "unavailable"]),
+  windows: Schema.mutable(Schema.Array(ProviderQuotaWindow)),
+  message: Schema.optional(Schema.String),
+}) {}
+
+export class ProviderQuotaResponse extends Schema.Class<ProviderQuotaResponse>("ProviderQuotaResponse")({
+  providerQuota: Schema.mutable(Schema.Array(ProviderQuotaSnapshot)),
+  fetchedAt: Schema.Number,
+}) {
+  static readonly zod = zod(this)
+}
+
 export class ConsoleState extends Schema.Class<ConsoleState>("ConsoleState")({
   consoleManagedProviders: Schema.mutable(Schema.Array(Schema.String)),
   activeOrgName: Schema.optional(Schema.String),
   switchableOrgCount: Schema.Number,
+  providerQuota: Schema.optional(Schema.mutable(Schema.Array(ProviderQuotaSnapshot))),
+  codexQuota: Schema.optional(CodexQuotaSnapshot),
 }) {
   static readonly zod = zod(this)
 }
@@ -13,4 +54,6 @@ export const emptyConsoleState: ConsoleState = ConsoleState.make({
   consoleManagedProviders: [],
   activeOrgName: undefined,
   switchableOrgCount: 0,
+  providerQuota: undefined,
+  codexQuota: undefined,
 })

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -2,8 +2,10 @@ import type { Hooks, PluginInput } from "@opencode-ai/plugin"
 import * as Log from "@opencode-ai/core/util/log"
 import { Installation } from "../installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import type { Auth } from "../auth"
 import { OAUTH_DUMMY_KEY } from "../auth"
 import os from "os"
+import z from "zod"
 import { setTimeout as sleep } from "node:timers/promises"
 import { createServer } from "http"
 
@@ -12,8 +14,49 @@ const log = Log.create({ service: "plugin.codex" })
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+const CODEX_USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+
+const CodexUsageWindow = z.object({
+  used_percent: z.coerce.number().finite(),
+  reset_at: z.coerce.number().int().nonnegative().nullish(),
+  reset_after_seconds: z.coerce.number().int().nonnegative().nullish(),
+})
+
+const CodexUsageRateLimit = z.object({
+  primary_window: CodexUsageWindow.nullish(),
+  secondary_window: CodexUsageWindow.nullish(),
+})
+
+const CodexUsageResponse = z.object({
+  rate_limit: CodexUsageRateLimit.nullish(),
+  rate_limits: CodexUsageRateLimit.nullish(),
+})
+
+export interface CodexQuotaWindowSnapshot {
+  remainingPercent: number
+  resetSeconds?: number
+  resetAt?: number
+}
+
+export interface CodexQuotaSnapshot {
+  fiveHour?: CodexQuotaWindowSnapshot
+  weekly?: CodexQuotaWindowSnapshot
+}
+
+type CodexOauthAuth = Extract<Auth.Info, { type: "oauth" }>
+
+interface CodexAuthStore {
+  getAuth: () => Promise<Auth.Info | undefined>
+  setAuth: (auth: CodexOauthAuth) => Promise<void>
+  fetchImpl?: typeof fetch
+}
+
+interface CodexOauthSession {
+  accessToken: string
+  accountId?: string
+}
 
 interface PkceCodes {
   verifier: string
@@ -103,12 +146,14 @@ function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string):
   return `${ISSUER}/oauth/authorize?${params.toString()}`
 }
 
-interface TokenResponse {
-  id_token: string
-  access_token: string
-  refresh_token: string
-  expires_in?: number
-}
+const TokenResponseSchema = z.object({
+  access_token: z.string(),
+  id_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number().optional(),
+})
+
+type TokenResponse = z.infer<typeof TokenResponseSchema>
 
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
@@ -125,11 +170,11 @@ async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: Pk
   if (!response.ok) {
     throw new Error(`Token exchange failed: ${response.status}`)
   }
-  return response.json()
+  return TokenResponseSchema.parse(await response.json())
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
-  const response = await fetch(`${ISSUER}/oauth/token`, {
+async function refreshAccessToken(refreshToken: string, fetchImpl: typeof fetch = fetch): Promise<TokenResponse> {
+  const response = await fetchImpl(`${ISSUER}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -141,7 +186,93 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> 
   if (!response.ok) {
     throw new Error(`Token refresh failed: ${response.status}`)
   }
-  return response.json()
+  return TokenResponseSchema.parse(await response.json())
+}
+
+function createCodexHeaders(session: CodexOauthSession, headersInit?: HeadersInit): Headers {
+  const headers = new Headers(headersInit)
+  headers.set("authorization", `Bearer ${session.accessToken}`)
+  headers.set("originator", "opencode")
+  headers.set("User-Agent", `opencode/${InstallationVersion} (${os.platform()} ${os.release()}; ${os.arch()})`)
+  if (session.accountId) {
+    headers.set("ChatGPT-Account-Id", session.accountId)
+  }
+  return headers
+}
+
+export async function resolveCodexOauthSession(input: CodexAuthStore): Promise<CodexOauthSession | undefined> {
+  const auth = await input.getAuth()
+  if (!auth || auth.type !== "oauth") return undefined
+
+  let currentAuth: CodexOauthAuth = auth
+  if (!currentAuth.access || currentAuth.expires < Date.now()) {
+    log.info("refreshing codex access token")
+    const tokens = await refreshAccessToken(currentAuth.refresh, input.fetchImpl)
+    const accountId = extractAccountId(tokens) || currentAuth.accountId
+    currentAuth = {
+      type: "oauth",
+      refresh: tokens.refresh_token ?? currentAuth.refresh,
+      access: tokens.access_token,
+      expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+      ...(accountId ? { accountId } : {}),
+      ...(currentAuth.enterpriseUrl ? { enterpriseUrl: currentAuth.enterpriseUrl } : {}),
+    }
+    await input.setAuth(currentAuth)
+  }
+
+  return {
+    accessToken: currentAuth.access,
+    accountId: currentAuth.accountId,
+  }
+}
+
+function toRemainingPercent(usedPercent: number) {
+  return Math.max(0, Math.min(100, 100 - usedPercent))
+}
+
+function mapQuotaWindow(
+  window: z.infer<typeof CodexUsageWindow> | null | undefined,
+): CodexQuotaWindowSnapshot | undefined {
+  if (!window) return undefined
+  return {
+    remainingPercent: toRemainingPercent(window.used_percent),
+    ...(window.reset_after_seconds != null ? { resetSeconds: window.reset_after_seconds } : {}),
+    ...(window.reset_at != null ? { resetAt: window.reset_at } : {}),
+  }
+}
+
+export async function getCodexQuotaSnapshot(input: CodexAuthStore): Promise<CodexQuotaSnapshot | undefined> {
+  try {
+    const session = await resolveCodexOauthSession(input)
+    if (!session) return undefined
+
+    const fetchImpl = input.fetchImpl ?? fetch
+    const response = await fetchImpl(CODEX_USAGE_ENDPOINT, {
+      method: "GET",
+      headers: createCodexHeaders(session, {
+        accept: "application/json",
+      }),
+    })
+    if (!response.ok) return undefined
+
+    const parsed = CodexUsageResponse.safeParse(await response.json())
+    if (!parsed.success) return undefined
+
+    const rateLimit = parsed.data.rate_limit ?? parsed.data.rate_limits
+    if (!rateLimit) return undefined
+
+    const quota: CodexQuotaSnapshot = {
+      fiveHour: mapQuotaWindow(rateLimit.primary_window ?? undefined),
+      weekly: mapQuotaWindow(rateLimit.secondary_window ?? undefined),
+    }
+    if (!quota.fiveHour && !quota.weekly) return undefined
+    return quota
+  } catch (error) {
+    log.warn("failed to fetch codex quota snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
 }
 
 const HTML_SUCCESS = `<!doctype html>
@@ -372,6 +503,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           "gpt-5.2",
           "gpt-5.2-codex",
           "gpt-5.3-codex",
+          "gpt-5.5",
           "gpt-5.4",
           "gpt-5.4-mini",
         ])
@@ -418,54 +550,19 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
               }
             }
 
-            const currentAuth = await getAuth()
-            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
-
-            // Cast to include accountId field
-            const authWithAccount = currentAuth as typeof currentAuth & { accountId?: string }
-
-            // Check if token needs refresh
-            if (!currentAuth.access || currentAuth.expires < Date.now()) {
-              log.info("refreshing codex access token")
-              const tokens = await refreshAccessToken(currentAuth.refresh)
-              const newAccountId = extractAccountId(tokens) || authWithAccount.accountId
-              await input.client.auth.set({
-                path: { id: "openai" },
-                body: {
-                  type: "oauth",
-                  refresh: tokens.refresh_token,
-                  access: tokens.access_token,
-                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                  ...(newAccountId && { accountId: newAccountId }),
-                },
-              })
-              currentAuth.access = tokens.access_token
-              authWithAccount.accountId = newAccountId
-            }
+            const session = await resolveCodexOauthSession({
+              getAuth,
+              setAuth: async (auth) => {
+                await input.client.auth.set({
+                  path: { id: "openai" },
+                  body: auth,
+                })
+              },
+            })
+            if (!session) return fetch(requestInput, init)
 
             // Build headers
-            const headers = new Headers()
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                init.headers.forEach((value, key) => headers.set(key, value))
-              } else if (Array.isArray(init.headers)) {
-                for (const [key, value] of init.headers) {
-                  if (value !== undefined) headers.set(key, String(value))
-                }
-              } else {
-                for (const [key, value] of Object.entries(init.headers)) {
-                  if (value !== undefined) headers.set(key, String(value))
-                }
-              }
-            }
-
-            // Set authorization header with access token
-            headers.set("authorization", `Bearer ${currentAuth.access}`)
-
-            // Set ChatGPT-Account-Id header for organization subscriptions
-            if (authWithAccount.accountId) {
-              headers.set("ChatGPT-Account-Id", authWithAccount.accountId)
-            }
+            const headers = createCodexHeaders(session, init?.headers)
 
             // Rewrite URL to Codex endpoint
             const parsed =
@@ -503,6 +600,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
               callback: async () => {
                 const tokens = await callbackPromise
                 stopOAuthServer()
+                if (!tokens.refresh_token) return { type: "failed" as const }
                 const accountId = extractAccountId(tokens)
                 return {
                   type: "success" as const,
@@ -577,7 +675,8 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                       throw new Error(`Token exchange failed: ${tokenResponse.status}`)
                     }
 
-                    const tokens: TokenResponse = await tokenResponse.json()
+                    const tokens = TokenResponseSchema.parse(await tokenResponse.json())
+                    if (!tokens.refresh_token) return { type: "failed" as const }
 
                     return {
                       type: "success" as const,

--- a/packages/opencode/src/provider/quota.ts
+++ b/packages/opencode/src/provider/quota.ts
@@ -1,0 +1,52 @@
+import type { ProviderQuotaResponse } from "../config/console-state"
+import type { Auth } from "../auth"
+import { getCodexQuotaSnapshot } from "../plugin/codex"
+
+export interface CodexQuotaInput {
+  getAuth: () => Promise<Auth.Info | undefined>
+  setAuth: (auth: Auth.Info) => Promise<void>
+  fetchImpl?: typeof fetch
+}
+
+type CodexQuotaSnapshot = NonNullable<Awaited<ReturnType<typeof getCodexQuotaSnapshot>>>
+type ProviderQuotaWindow = ProviderQuotaResponse["providerQuota"][number]["windows"][number]
+
+function exact(
+  label: string,
+  window: { remainingPercent?: number; resetAt?: number } | undefined,
+): ProviderQuotaWindow | undefined {
+  if (window?.remainingPercent === undefined) return
+  return {
+    label,
+    remainingPercent: window.remainingPercent,
+    ...(window.resetAt !== undefined ? { resetAt: window.resetAt } : {}),
+    confidence: "exact",
+    source: "official_api",
+  }
+}
+
+function codex(now: number, quota: CodexQuotaSnapshot | undefined) {
+  if (!quota) return
+  const windows = [exact("5h", quota.fiveHour), exact("wk", quota.weekly)].filter(
+    (window): window is ProviderQuotaWindow => Boolean(window),
+  )
+  if (windows.length === 0) return
+
+  return {
+    provider: "codex",
+    label: "codex",
+    fetchedAt: now,
+    status: "available" as const,
+    windows,
+  }
+}
+
+export async function getProviderQuotaSnapshots(input: CodexQuotaInput): Promise<ProviderQuotaResponse> {
+  const now = Date.now()
+  const codexQuota = await getCodexQuotaSnapshot(input).catch(() => undefined)
+  const list = [codex(now, codexQuota)].flatMap((value) => (value ? [value] : []))
+  return {
+    providerQuota: list,
+    fetchedAt: now,
+  }
+}

--- a/packages/opencode/src/server/routes/instance/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/experimental.ts
@@ -10,9 +10,12 @@ import { Project } from "@/project/project"
 import { MCP } from "@/mcp"
 import { Session } from "@/session/session"
 import { Config } from "@/config/config"
-import { ConsoleState } from "@/config/console-state"
+import { CodexQuotaSnapshot, ConsoleState, ProviderQuotaResponse } from "@/config/console-state"
 import { Account } from "@/account/account"
 import { AccountID, OrgID } from "@/account/schema"
+import { Auth } from "@/auth"
+import { getCodexQuotaSnapshot } from "@/plugin/codex"
+import { getProviderQuotaSnapshots } from "@/provider/quota"
 import { errors } from "../../error"
 import { lazy } from "@/util/lazy"
 import { Effect, Option } from "effect"
@@ -77,6 +80,64 @@ export const ExperimentalRoutes = lazy(() =>
             ...state,
             switchableOrgCount: groups.reduce((count, group) => count + group.orgs.length, 0),
           }
+        }),
+    )
+    .get(
+      "/provider-quota",
+      describeRoute({
+        summary: "Get provider quota snapshots",
+        description: "Get the latest known provider quota snapshots for the active session providers.",
+        operationId: "experimental.providerQuota",
+        responses: {
+          200: {
+            description: "Provider quota snapshots",
+            content: {
+              "application/json": {
+                schema: resolver(ProviderQuotaResponse.zod),
+              },
+            },
+          },
+        },
+      }),
+      async (c) =>
+        jsonRequest("ExperimentalRoutes.providerQuota", c, function* () {
+          const auth = yield* Auth.Service
+          const quota = yield* Effect.promise(() =>
+            getProviderQuotaSnapshots({
+              getAuth: () => Effect.runPromise(auth.get("openai")),
+              setAuth: (info) => Effect.runPromise(auth.set("openai", info)),
+            }),
+          )
+          return quota
+        }),
+    )
+    .get(
+      "/console/codex-quota",
+      describeRoute({
+        summary: "Get Codex quota snapshot",
+        description: "Get the current Codex quota snapshot for the active OpenAI OAuth account.",
+        operationId: "experimental.console.codexQuota",
+        responses: {
+          200: {
+            description: "Codex quota snapshot",
+            content: {
+              "application/json": {
+                schema: resolver(CodexQuotaSnapshot.zod),
+              },
+            },
+          },
+        },
+      }),
+      async (c) =>
+        jsonRequest("ExperimentalRoutes.console.codexQuota", c, function* () {
+          const auth = yield* Auth.Service
+          const quota = yield* Effect.promise(() =>
+            getCodexQuotaSnapshot({
+              getAuth: () => Effect.runPromise(auth.get("openai")),
+              setAuth: (info) => Effect.runPromise(auth.set("openai", info)),
+            }),
+          )
+          return quota ? { ...quota, fetchedAt: Date.now() } : {}
         }),
     )
     .get(

--- a/packages/opencode/test/cli/cmd/tui/prompt-metrics.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-metrics.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test"
+import {
+  formatCodexQuotaFetchedAt,
+  formatCodexQuotaMetrics,
+  formatProviderQuotaMetrics,
+  formatQuotaBar,
+} from "../../../../src/cli/cmd/tui/component/prompt/metrics"
+
+const fetchedAt = new Date(2026, 3, 28, 17, 38, 30).getTime()
+const sameDay = new Date(2026, 3, 28, 20, 0, 0).getTime()
+
+describe("prompt metrics", () => {
+  test("formats codex quota with full bars on wide terminals", () => {
+    expect(
+      formatCodexQuotaMetrics(
+        {
+          fiveHour: { remainingPercent: 90 },
+          weekly: { remainingPercent: 95 },
+          fetchedAt,
+        },
+        200,
+        sameDay,
+      ),
+    ).toBe("codex 5h █████████░ 90% · wk ██████████ 95% · ⟳ today@17h38m30s")
+  })
+
+  test("formats codex quota with compact bars on medium terminals", () => {
+    expect(
+      formatCodexQuotaMetrics(
+        {
+          fiveHour: { remainingPercent: 90 },
+          weekly: { remainingPercent: 95 },
+          fetchedAt,
+        },
+        120,
+        sameDay,
+      ),
+    ).toBe("codex 5h █████ 90% · wk █████ 95% · ⟳ today@17h38m30s")
+  })
+
+  test("falls back to percentages as terminal width tightens", () => {
+    const quota = {
+      fiveHour: { remainingPercent: 90 },
+      weekly: { remainingPercent: 95 },
+      fetchedAt,
+    }
+
+    expect(formatCodexQuotaMetrics(quota, 90, sameDay)).toBe("codex 5h 90% · wk 95% · ⟳ today@17h38m30s")
+    expect(formatCodexQuotaMetrics(quota, 89, sameDay)).toBe("codex 5h 90% · wk 95%")
+  })
+
+  test("rounds and clamps quota bar percentages", () => {
+    expect(formatQuotaBar(87.5, 5)).toBe("████░")
+    expect(formatQuotaBar(-10, 5)).toBe("░░░░░")
+    expect(formatQuotaBar(120, 5)).toBe("█████")
+  })
+
+  test("formats refresh timestamps and drops invalid values", () => {
+    expect(formatCodexQuotaFetchedAt(fetchedAt, new Date(2026, 3, 28, 20, 0, 0).getTime())).toBe("today@17h38m30s")
+    expect(formatCodexQuotaFetchedAt(fetchedAt, new Date(2026, 3, 29, 20, 0, 0).getTime())).toBe("yesterday@17h38m30s")
+    expect(formatCodexQuotaFetchedAt(fetchedAt, new Date(2026, 3, 30, 20, 0, 0).getTime())).toBe("2d ago@17h38m30s")
+
+    expect(
+      formatCodexQuotaMetrics(
+        {
+          fiveHour: { remainingPercent: 87.5 },
+          fetchedAt: Number.NaN,
+        },
+        120,
+        sameDay,
+      ),
+    ).toBe("codex 5h ████░ 88%")
+  })
+
+  test("formats provider quota snapshots and skips estimated or unavailable windows", () => {
+    expect(
+      formatProviderQuotaMetrics(
+        [
+          {
+            provider: "copilot",
+            label: "copilot",
+            fetchedAt: fetchedAt,
+            status: "available",
+            windows: [
+              {
+                label: "wk",
+                confidence: "estimated",
+                remainingPercent: 58,
+                source: "heuristic",
+              },
+            ],
+          },
+          {
+            provider: "anthropic",
+            label: "anthropic",
+            fetchedAt: fetchedAt,
+            status: "unavailable",
+            windows: [
+              {
+                label: "req",
+                confidence: "reported",
+                remainingPercent: 0,
+                source: "response_headers",
+              },
+            ],
+          },
+          {
+            provider: "codex",
+            label: "codex",
+            fetchedAt: fetchedAt,
+            status: "available",
+            windows: [
+              {
+                label: "5h",
+                confidence: "exact",
+                remainingPercent: 97,
+                source: "official_api",
+              },
+              {
+                label: "wk",
+                confidence: "reported",
+                remainingPercent: 90,
+                source: "response_headers",
+              },
+            ],
+          },
+        ],
+        120,
+        sameDay,
+      ),
+    ).toBe("codex 5h 97% · wk 90% · ⟳ today@17h38m30s")
+  })
+
+  test("prioritizes the active provider quota", () => {
+    expect(
+      formatProviderQuotaMetrics(
+        [
+          {
+            provider: "codex",
+            label: "codex",
+            fetchedAt,
+            status: "available",
+            windows: [
+              {
+                label: "5h",
+                confidence: "exact",
+                remainingPercent: 97,
+                source: "official_api",
+              },
+            ],
+          },
+          {
+            provider: "anthropic",
+            label: "anthropic",
+            fetchedAt,
+            status: "available",
+            windows: [
+              {
+                label: "req",
+                confidence: "reported",
+                remainingPercent: 82,
+                source: "response_headers",
+              },
+            ],
+          },
+        ],
+        80,
+        sameDay,
+        "anthropic",
+      ),
+    ).toBe("anthropic req 82%")
+  })
+})

--- a/packages/opencode/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/opencode/test/cli/cmd/tui/sync.test.tsx
@@ -36,9 +36,11 @@ function eventSource(): EventSource {
 
 function createFetch() {
   const session = [] as URL[]
+  const quota = [] as URL[]
   const fetch = (async (input: RequestInfo | URL) => {
     const url = new URL(input instanceof Request ? input.url : String(input))
     if (url.pathname === "/session") session.push(url)
+    if (url.pathname === "/experimental/console/codex-quota") quota.push(url)
 
     switch (url.pathname) {
       case "/agent":
@@ -58,6 +60,8 @@ function createFetch() {
         return json({ providers: {}, default: {} })
       case "/experimental/console":
         return json({ consoleManagedProviders: [], switchableOrgCount: 0 })
+      case "/experimental/console/codex-quota":
+        return json({ fiveHour: { remainingPercent: 82 }, weekly: { remainingPercent: 87 }, fetchedAt: 123 })
       case "/path":
         return json({ home: "", state: "", config: "", worktree, directory })
       case "/project/current":
@@ -73,7 +77,7 @@ function createFetch() {
     throw new Error(`unexpected request: ${url.pathname}`)
   }) as typeof globalThis.fetch
 
-  return { fetch, session }
+  return { fetch, session, quota }
 }
 
 async function mount() {
@@ -109,7 +113,7 @@ async function mount() {
 
   await ready
   await wait(() => sync.status === "complete")
-  return { app, kv, sync, session: calls.session }
+  return { app, kv, sync, session: calls.session, quota: calls.quota }
 }
 
 function Probe(props: { onReady: (ctx: { kv: ReturnType<typeof useKV>; sync: ReturnType<typeof useSync> }) => void }) {
@@ -141,6 +145,22 @@ describe("tui sync", () => {
 
       expect(session.at(-1)?.searchParams.get("scope")).toBe("project")
       expect(session.at(-1)?.searchParams.get("path")).toBeNull()
+    } finally {
+      app.renderer.destroy()
+      Global.Path.state = previous
+    }
+  })
+  test("syncs Codex quota into console state", async () => {
+    const previous = Global.Path.state
+    await using tmp = await tmpdir()
+    Global.Path.state = tmp.path
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, quota, sync } = await mount()
+
+    try {
+      await wait(() => quota.length > 0)
+      expect(sync.data.console_state.codexQuota?.fiveHour?.remainingPercent).toBe(82)
+      expect(sync.data.console_state.codexQuota?.weekly?.remainingPercent).toBe(87)
     } finally {
       app.renderer.destroy()
       Global.Path.state = previous

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -3,6 +3,8 @@ import {
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
+  getCodexQuotaSnapshot,
+  resolveCodexOauthSession,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
 
@@ -10,6 +12,10 @@ function createTestJwt(payload: object): string {
   const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url")
   return `${header}.${body}.sig`
+}
+
+function createMockFetch(handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): typeof fetch {
+  return Object.assign(handler, { preconnect: fetch.preconnect.bind(fetch) })
 }
 
 describe("plugin.codex", () => {
@@ -118,6 +124,182 @@ describe("plugin.codex", () => {
           refresh_token: "rt",
         }),
       ).toBe("acc-123")
+    })
+  })
+
+  describe("resolveCodexOauthSession", () => {
+    test("refreshes expired oauth tokens and persists the updated account id", async () => {
+      const persisted: Array<unknown> = []
+      const refreshedAccessToken = createTestJwt({ chatgpt_account_id: "acc-refreshed" })
+
+      const session = await resolveCodexOauthSession({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "expired-access",
+          expires: Date.now() - 1_000,
+          accountId: "acc-stale",
+        }),
+        setAuth: async (auth) => {
+          persisted.push(auth)
+        },
+        fetchImpl: createMockFetch(async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+          expect(url).toBe("https://auth.openai.com/oauth/token")
+          return new Response(
+            JSON.stringify({
+              id_token: "",
+              access_token: refreshedAccessToken,
+              refresh_token: "refresh-token-next",
+              expires_in: 7200,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }),
+      })
+
+      expect(session).toEqual({
+        accessToken: refreshedAccessToken,
+        accountId: "acc-refreshed",
+      })
+      expect(persisted).toHaveLength(1)
+      expect(persisted[0]).toMatchObject({
+        type: "oauth",
+        refresh: "refresh-token-next",
+        access: refreshedAccessToken,
+        accountId: "acc-refreshed",
+      })
+    })
+
+    test("keeps the existing refresh token when refresh response omits one", async () => {
+      const persisted: Array<unknown> = []
+      const refreshedAccessToken = createTestJwt({ chatgpt_account_id: "acc-refreshed" })
+
+      await resolveCodexOauthSession({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token-existing",
+          access: "expired-access",
+          expires: Date.now() - 1_000,
+          accountId: "acc-stale",
+        }),
+        setAuth: async (auth) => {
+          persisted.push(auth)
+        },
+        fetchImpl: createMockFetch(
+          async () =>
+            new Response(
+              JSON.stringify({
+                access_token: refreshedAccessToken,
+                expires_in: 7200,
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+        ),
+      })
+
+      expect(persisted[0]).toMatchObject({
+        type: "oauth",
+        refresh: "refresh-token-existing",
+        access: refreshedAccessToken,
+        accountId: "acc-refreshed",
+      })
+    })
+  })
+
+  describe("getCodexQuotaSnapshot", () => {
+    test("maps primary and secondary quota windows to remaining percentages", async () => {
+      const quota = await getCodexQuotaSnapshot({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60_000,
+          accountId: "acc-123",
+        }),
+        setAuth: async () => undefined,
+        fetchImpl: createMockFetch(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+          expect(url).toBe("https://chatgpt.com/backend-api/wham/usage")
+
+          const headers = new Headers(init?.headers)
+          expect(headers.get("authorization")).toBe("Bearer access-token")
+          expect(headers.get("ChatGPT-Account-Id")).toBe("acc-123")
+
+          return new Response(
+            JSON.stringify({
+              rate_limit: {
+                primary_window: {
+                  used_percent: 39,
+                  reset_after_seconds: 600,
+                  reset_at: 1_700_000_000,
+                },
+                secondary_window: {
+                  used_percent: 85,
+                  reset_after_seconds: 86_400,
+                  reset_at: 1_700_086_400,
+                },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }),
+      })
+
+      expect(quota).toEqual({
+        fiveHour: {
+          remainingPercent: 61,
+          resetSeconds: 600,
+          resetAt: 1_700_000_000,
+        },
+        weekly: {
+          remainingPercent: 15,
+          resetSeconds: 86_400,
+          resetAt: 1_700_086_400,
+        },
+      })
+    })
+
+    test("returns undefined when openai oauth is not configured", async () => {
+      const quota = await getCodexQuotaSnapshot({
+        getAuth: async () => undefined,
+        setAuth: async () => undefined,
+      })
+
+      expect(quota).toBeUndefined()
+    })
+
+    test("ignores nullable reset fields without dropping quota windows", async () => {
+      const quota = await getCodexQuotaSnapshot({
+        getAuth: async () => ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60_000,
+        }),
+        setAuth: async () => undefined,
+        fetchImpl: createMockFetch(
+          async () =>
+            new Response(
+              JSON.stringify({
+                rate_limit: {
+                  primary_window: {
+                    used_percent: 12.5,
+                    reset_after_seconds: null,
+                    reset_at: null,
+                  },
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+        ),
+      })
+
+      expect(quota).toEqual({
+        fiveHour: {
+          remainingPercent: 87.5,
+        },
+      })
     })
   })
 })

--- a/packages/opencode/test/provider/quota.test.ts
+++ b/packages/opencode/test/provider/quota.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { getProviderQuotaSnapshots } from "../../src/provider/quota"
+
+function createMockFetch(handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): typeof fetch {
+  return Object.assign(handler, { preconnect: fetch.preconnect.bind(fetch) })
+}
+
+describe("provider quota snapshots", () => {
+  test("maps Codex quota into exact provider quota windows", async () => {
+    const quota = await getProviderQuotaSnapshots({
+      getAuth: async () => ({
+        type: "oauth",
+        refresh: "refresh-token",
+        access: "access-token",
+        expires: Date.now() + 60_000,
+        accountId: "acc-123",
+      }),
+      setAuth: async () => undefined,
+      fetchImpl: createMockFetch(async (input, init) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+        expect(url).toBe("https://chatgpt.com/backend-api/wham/usage")
+
+        const headers = new Headers(init?.headers)
+        expect(headers.get("authorization")).toBe("Bearer access-token")
+        expect(headers.get("ChatGPT-Account-Id")).toBe("acc-123")
+
+        return new Response(
+          JSON.stringify({
+            rate_limit: {
+              primary_window: {
+                used_percent: 3,
+                reset_at: 1_700_000_000,
+              },
+              secondary_window: {
+                used_percent: 10,
+                reset_at: 1_700_086_400,
+              },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }),
+    })
+
+    expect(quota.providerQuota).toEqual([
+      {
+        provider: "codex",
+        label: "codex",
+        fetchedAt: expect.any(Number),
+        status: "available",
+        windows: [
+          {
+            label: "5h",
+            remainingPercent: 97,
+            resetAt: 1_700_000_000,
+            confidence: "exact",
+            source: "official_api",
+          },
+          {
+            label: "wk",
+            remainingPercent: 90,
+            resetAt: 1_700_086_400,
+            confidence: "exact",
+            source: "official_api",
+          },
+        ],
+      },
+    ])
+    expect(quota.fetchedAt).toEqual(expect.any(Number))
+  })
+
+  test("returns an empty provider quota list when Codex auth is missing", async () => {
+    const quota = await getProviderQuotaSnapshots({
+      getAuth: async () => undefined,
+      setAuth: async () => undefined,
+    })
+
+    expect(quota.providerQuota).toEqual([])
+    expect(quota.fetchedAt).toEqual(expect.any(Number))
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -24,9 +24,11 @@ import type {
   EventTuiPromptAppend,
   EventTuiSessionSelect,
   EventTuiToastShow,
+  ExperimentalConsoleCodexQuotaResponses,
   ExperimentalConsoleGetResponses,
   ExperimentalConsoleListOrgsResponses,
   ExperimentalConsoleSwitchOrgResponses,
+  ExperimentalProviderQuotaResponses,
   ExperimentalResourceListResponses,
   ExperimentalSessionListResponses,
   ExperimentalWorkspaceAdaptorListResponses,
@@ -769,6 +771,36 @@ export class Console extends HeyApiClient {
   }
 
   /**
+   * Get Codex quota snapshot
+   *
+   * Get the current Codex quota snapshot for the active OpenAI OAuth account.
+   */
+  public codexQuota<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ExperimentalConsoleCodexQuotaResponses, unknown, ThrowOnError>({
+      url: "/experimental/console/codex-quota",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
    * List switchable Console orgs
    *
    * Get the available Console orgs across logged-in accounts, including the current active org.
@@ -915,6 +947,36 @@ export class Resource extends HeyApiClient {
 }
 
 export class Experimental extends HeyApiClient {
+  /**
+   * Get provider quota snapshots
+   *
+   * Get the latest known provider quota snapshots for the active session providers.
+   */
+  public providerQuota<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ExperimentalProviderQuotaResponses, unknown, ThrowOnError>({
+      url: "/experimental/provider-quota",
+      ...options,
+      ...params,
+    })
+  }
+
   private _workspace?: Workspace
   get workspace(): Workspace {
     return (this._workspace ??= new Workspace({ client: this.client }))

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1834,10 +1834,47 @@ export type Provider = {
   }
 }
 
+export type ProviderQuotaWindow = {
+  label: string
+  remainingPercent?: number
+  resetSeconds?: number
+  resetAt?: number
+  confidence: "exact" | "reported" | "estimated"
+  source: "official_api" | "response_headers" | "client_state" | "heuristic"
+}
+
+export type ProviderQuotaSnapshot = {
+  provider: string
+  label: string
+  fetchedAt: number
+  status: "available" | "unavailable"
+  windows: Array<ProviderQuotaWindow>
+  message?: string
+}
+
+export type ConsoleQuotaWindow = {
+  remainingPercent: number
+  resetSeconds?: number
+  resetAt?: number
+}
+
+export type CodexQuotaSnapshot = {
+  fiveHour?: ConsoleQuotaWindow
+  weekly?: ConsoleQuotaWindow
+  fetchedAt?: number
+}
+
 export type ConsoleState = {
   consoleManagedProviders: Array<string>
   activeOrgName?: string
   switchableOrgCount: number
+  providerQuota?: Array<ProviderQuotaSnapshot>
+  codexQuota?: CodexQuotaSnapshot
+}
+
+export type ProviderQuotaResponse = {
+  providerQuota: Array<ProviderQuotaSnapshot>
+  fetchedAt: number
 }
 
 export type ToolIds = Array<string>
@@ -2998,6 +3035,46 @@ export type ExperimentalConsoleGetResponses = {
 }
 
 export type ExperimentalConsoleGetResponse = ExperimentalConsoleGetResponses[keyof ExperimentalConsoleGetResponses]
+
+export type ExperimentalProviderQuotaData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/experimental/provider-quota"
+}
+
+export type ExperimentalProviderQuotaResponses = {
+  /**
+   * Provider quota snapshots
+   */
+  200: ProviderQuotaResponse
+}
+
+export type ExperimentalProviderQuotaResponse =
+  ExperimentalProviderQuotaResponses[keyof ExperimentalProviderQuotaResponses]
+
+export type ExperimentalConsoleCodexQuotaData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/experimental/console/codex-quota"
+}
+
+export type ExperimentalConsoleCodexQuotaResponses = {
+  /**
+   * Codex quota snapshot
+   */
+  200: CodexQuotaSnapshot
+}
+
+export type ExperimentalConsoleCodexQuotaResponse =
+  ExperimentalConsoleCodexQuotaResponses[keyof ExperimentalConsoleCodexQuotaResponses]
 
 export type ExperimentalConsoleListOrgsData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1677,6 +1677,88 @@
         ]
       }
     },
+    "/experimental/provider-quota": {
+      "get": {
+        "operationId": "experimental.providerQuota",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get provider quota snapshots",
+        "description": "Get the latest known provider quota snapshots for the active session providers.",
+        "responses": {
+          "200": {
+            "description": "Provider quota snapshots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderQuotaResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.experimental.providerQuota({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/experimental/console/codex-quota": {
+      "get": {
+        "operationId": "experimental.console.codexQuota",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get Codex quota snapshot",
+        "description": "Get the current Codex quota snapshot for the active OpenAI OAuth account.",
+        "responses": {
+          "200": {
+            "description": "Codex quota snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodexQuotaSnapshot"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.experimental.console.codexQuota({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/experimental/console/orgs": {
       "get": {
         "operationId": "experimental.console.listOrgs",
@@ -12445,6 +12527,89 @@
         },
         "required": ["id", "name", "source", "env", "options", "models"]
       },
+      "ProviderQuotaWindow": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "remainingPercent": {
+            "type": "number"
+          },
+          "resetSeconds": {
+            "type": "number"
+          },
+          "resetAt": {
+            "type": "number"
+          },
+          "confidence": {
+            "type": "string",
+            "enum": ["exact", "reported", "estimated"]
+          },
+          "source": {
+            "type": "string",
+            "enum": ["official_api", "response_headers", "client_state", "heuristic"]
+          }
+        },
+        "required": ["label", "confidence", "source"]
+      },
+      "ProviderQuotaSnapshot": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "fetchedAt": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["available", "unavailable"]
+          },
+          "windows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProviderQuotaWindow"
+            }
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["provider", "label", "fetchedAt", "status", "windows"]
+      },
+      "ConsoleQuotaWindow": {
+        "type": "object",
+        "properties": {
+          "remainingPercent": {
+            "type": "number"
+          },
+          "resetSeconds": {
+            "type": "number"
+          },
+          "resetAt": {
+            "type": "number"
+          }
+        },
+        "required": ["remainingPercent"]
+      },
+      "CodexQuotaSnapshot": {
+        "type": "object",
+        "properties": {
+          "fiveHour": {
+            "$ref": "#/components/schemas/ConsoleQuotaWindow"
+          },
+          "weekly": {
+            "$ref": "#/components/schemas/ConsoleQuotaWindow"
+          },
+          "fetchedAt": {
+            "type": "number"
+          }
+        }
+      },
       "ConsoleState": {
         "type": "object",
         "properties": {
@@ -12459,9 +12624,33 @@
           },
           "switchableOrgCount": {
             "type": "number"
+          },
+          "providerQuota": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProviderQuotaSnapshot"
+            }
+          },
+          "codexQuota": {
+            "$ref": "#/components/schemas/CodexQuotaSnapshot"
           }
         },
         "required": ["consoleManagedProviders", "switchableOrgCount"]
+      },
+      "ProviderQuotaResponse": {
+        "type": "object",
+        "properties": {
+          "providerQuota": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProviderQuotaSnapshot"
+            }
+          },
+          "fetchedAt": {
+            "type": "number"
+          }
+        },
+        "required": ["providerQuota", "fetchedAt"]
       },
       "ToolIDs": {
         "type": "array",


### PR DESCRIPTION
### Issue for this PR

Closes #24960

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a compact provider quota metric to the TUI prompt metrics row.

- Fetches exact Codex quota through the existing OpenAI OAuth auth path.
- Adds an experimental provider-quota response shape and generated SDK types.
- Syncs quota in the TUI on a bounded refresh interval and prefers the active provider.
- Adds two console KV result type annotations needed by current root typecheck.

### How did you verify your code works?

- `./script/generate.ts`
- `Bun 1.3.13: bun turbo typecheck`
- `Bun 1.3.13: bun --cwd packages/opencode typecheck`
- `Bun 1.3.13: bun --cwd packages/opencode test test/plugin/codex.test.ts test/provider/quota.test.ts test/cli/cmd/tui/prompt-metrics.test.ts test/cli/cmd/tui/sync.test.tsx test/server/httpapi-experimental.test.ts test/server/httpapi-sdk.test.ts` (`35 pass`, `0 fail`)
- `git diff --check origin/dev...HEAD`

### Screenshots / recordings

Compact home quota row:

![Compact home quota row]<img width="2504" height="1281" alt="image" src="https://github.com/user-attachments/assets/9cb8e1a4-626d-4674-bfad-dd5147f941d6" />

Compact session metrics row:

![Compact session metrics row]<img width="2509" height="1442" alt="image" src="https://github.com/user-attachments/assets/d6ce31fd-7761-4ca4-88dd-c7c25e95f006" />

Session dashboard prototype from the standalone plugin:

![Session dashboard dialog]<img width="2484" height="1428" alt="image" src="https://github.com/user-attachments/assets/48a0fe4b-d829-4bcf-b723-77cd2bb72217" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
