### PR TITLE
fix(ripgrep): handle broken symlinks gracefully in files() stream

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -195,7 +195,7 @@ function fail(queue: Queue.Queue<string, PlatformError | Error | Cause.Done>, er
 }
 
 function filesArgs(input: FilesInput) {
-  const args = ["--no-config", "--files", "--glob=!.git/*"]
+  const args = ["--no-config", "--files", "--no-messages", "--glob=!.git/*"]
   if (input.follow) args.push("--follow")
   if (input.hidden !== false) args.push("--hidden")
   if (input.hidden === false) args.push("--glob=!.*")
@@ -360,7 +360,10 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | ChildPro
                 )
                 const code = yield* raceAbort(handle.exitCode, input.signal)
                 yield* Fiber.join(stdout)
-                if (code === 0 || code === 1) {
+                // Exit codes: 0 = files found, 1 = no files found, 2 = soft errors
+                // (e.g. broken symlinks, permission denied) but valid results on stdout.
+                // This matches how searchArgs uses --no-messages and search() treats code 2.
+                if (code === 0 || code === 1 || code === 2) {
                   Queue.endUnsafe(queue)
                   return
                 }

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -169,6 +169,25 @@ describe("file.ripgrep", () => {
     expect(files).toEqual(["keep.ts"])
   })
 
+  test("files returns valid results despite broken symlinks", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "real.txt"), "hello")
+        await fs.symlink(path.join(dir, "nonexistent-target"), path.join(dir, "broken-link"))
+      },
+    })
+
+    const files = await run(
+      Ripgrep.Service.use((rg) =>
+        rg.files({ cwd: tmp.path, follow: true }).pipe(
+          Stream.runCollect,
+          Effect.map((c) => [...c]),
+        ),
+      ),
+    )
+    expect(files).toContain("real.txt")
+  })
+
   test("files dies on nonexistent directory", async () => {
     const exit = await Ripgrep.Service.use((rg) =>
       rg.files({ cwd: "/tmp/nonexistent-dir-12345" }).pipe(Stream.runCollect),


### PR DESCRIPTION
### Issue for this PR

Closes #24972

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The glob tool silently returns zero results when any broken symlink or permission-denied path exists in the search tree. This happens because `Ripgrep.files()` treats ripgrep exit code 2 as fatal — it discards all valid stdout output and fails the stream.

The `search()` function (used by the grep tool) already handles this correctly: it passes `--no-messages` to suppress stderr warnings and treats exit code 2 as non-fatal. `files()` was missed.

This PR brings `files()` in line with `search()`:

1. Adds `--no-messages` to `filesArgs()` so stderr warnings about broken symlinks don't pollute output.
2. Treats exit code 2 as non-fatal in the `files()` stream so valid results already emitted to stdout are kept instead of discarded.

### How did you verify your code works?

- Added a test (`files returns valid results despite broken symlinks`) that creates a directory with a real file and a broken symlink, calls `rg.files()` with `follow: true`, and asserts the real file is returned.
- All existing tests pass: 13 ripgrep tests, 2 glob tests, 4 grep tests.
- Full monorepo typecheck passes (13/13 packages via `bun turbo typecheck`).
- Confirmed the underlying behavior on a system with broken symlinks (pnpm store, paru cache, Firefox/Cider lock files): `rg --files --follow` returns the target file on stdout but exits with code 2, which the unpatched `files()` would treat as fatal.
- Confirmed that running OpenCode locally with this fix finds files using a glob pattern that does not work with the latest release build.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR