### PR TITLE
fix: preserve Anthropic thinking block signatures when switching Claude models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -93,6 +93,33 @@ function normalizeMessages(
       .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
   }
 
+  // For Anthropic-family providers (both direct and via Bedrock), strip any
+  // reasoning/thinking parts whose providerMetadata is missing the signature.
+  // The Anthropic API requires the signature field on every thinking block in
+  // subsequent turns.  A missing signature means the block was produced by a
+  // different provider, the metadata was lost, or the session predates
+  // signature capture — in all cases the safest action is to drop the block.
+  // A reasoning block without a signature cannot be echoed back and causes:
+  //   "messages.N.content.0.thinking.signature: Field required"
+  if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/amazon-bedrock") {
+    msgs = msgs.map((msg) => {
+      if (!Array.isArray(msg.content)) return msg
+      const filtered = msg.content.filter((part) => {
+        if (part.type !== "reasoning") return true
+        // Keep the block only if providerMetadata contains a non-empty signature.
+        const sig = (part as any).providerMetadata?.anthropic?.signature
+        if (sig && typeof sig === "string" && sig.length > 0) return true
+        // No valid signature — drop the block to prevent API rejection.
+        return false
+      })
+      // If we dropped all content blocks, replace with an empty text block
+      // so the message remains structurally valid (empty array → API error).
+      if (filtered.length === 0 && Array.isArray(msg.content) && msg.content.length > 0)
+        return { ...msg, content: [{ type: "text" as const, text: "" }] }
+      return { ...msg, content: filtered }
+    })
+  }
+
   if (model.api.id.includes("claude")) {
     const scrub = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
     msgs = msgs.map((msg) => {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -838,6 +838,25 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 
     if (msg.info.role === "assistant") {
       const differentModel = `${model.providerID}/${model.id}` !== `${msg.info.providerID}/${msg.info.modelID}`
+
+      // When switching between Anthropic-family models (e.g. Sonnet → Opus,
+      // or amazon-bedrock/claude-* → anthropic/claude-*), reasoning blocks
+      // MUST still carry their providerMetadata so the signature field is
+      // echoed back to the API.  Without the signature Anthropic rejects the
+      // request with:
+      //   "messages.N.content.0.thinking.signature: Field required"
+      //
+      // The signature is a cryptographic token that is valid across all
+      // Claude models; it only needs to be dropped when switching to a
+      // non-Anthropic provider that doesn't understand the thinking format.
+      const isAnthropicFamily = (providerID: string, modelID: string) =>
+        providerID === "anthropic" ||
+        providerID === "amazon-bedrock" ||
+        modelID.includes("claude")
+      const keepReasoningMetadata =
+        !differentModel ||
+        (isAnthropicFamily(model.providerID, model.id) &&
+          isAnthropicFamily(msg.info.providerID ?? "", msg.info.modelID ?? ""))
       const media: Array<{ mime: string; url: string }> = []
 
       if (
@@ -941,7 +960,11 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           assistantMessage.parts.push({
             type: "reasoning",
             text: part.text,
-            ...(differentModel ? {} : { providerMetadata: part.metadata }),
+            // Use keepReasoningMetadata (not differentModel) so the Anthropic
+            // signature is preserved when switching between Claude models.
+            // The signature is required by the API on every subsequent turn;
+            // dropping it causes "thinking.signature: Field required".
+            ...(keepReasoningMetadata ? { providerMetadata: part.metadata } : {}),
           })
         }
       }


### PR DESCRIPTION
### Issue for this PR

Closes #25005

Also related to #23104 which has a similar fix — see note below.

### Type of change

- [x] Bug fix

### What does this PR do?

`message-v2.ts` computes `differentModel = true` whenever the current model ID differs from the one that produced a historical message. For reasoning/thinking parts this is wrong: it strips `providerMetadata`, which is where the Anthropic SDK stores the cryptographic `signature` field required on every subsequent turn.

Without the signature, Anthropic rejects the request:
```
messages.N.content.0.thinking.signature: Field required
```

**Changes:**

1. **`message-v2.ts`**: Introduce `keepReasoningMetadata` — true when both old and new model are Anthropic-family (providerID is `anthropic`, `amazon-bedrock`, or modelID contains `claude`). Use this for reasoning parts instead of `!differentModel`, so signatures survive intra-Anthropic model switches. Non-Anthropic providers still have metadata dropped as before.

2. **`transform.ts`**: Add a safety filter in `normalizeMessages` for Anthropic-family providers that strips reasoning blocks with a missing/empty signature before the API call. This handles old sessions created before signature capture and any edge case where metadata is unavailable. Dropping such a block is safer than crashing the entire conversation.

**Note on #23104**: That PR uses a simpler one-line fix (unconditionally pass `providerMetadata` for all reasoning parts regardless of model). This PR takes a slightly more conservative approach (preserve metadata only for Anthropic-family switches) and adds the transform.ts safety filter. Both fix the same root cause. Happy to close this in favour of #23104 if maintainers prefer the simpler approach.

### How did you verify your code works?

- `bun test test/session/message-v2.test.ts` — 27/27 pass
- `bun typecheck` — no errors
- Manually reproduced: started session with Opus (extended thinking), sent messages, switched to Sonnet, sent another message. Before fix: crash. After fix: works.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR