### PR TITLE
feat(ui): Add support for RTL languages in rendered chat content and text box.

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1344,6 +1344,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               aria-multiline="true"
               aria-label={placeholder()}
               contenteditable="true"
+              dir="auto"
               autocapitalize={store.mode === "normal" ? "sentences" : "off"}
               autocorrect={store.mode === "normal" ? "on" : "off"}
               spellcheck={store.mode === "normal"}
@@ -1366,6 +1367,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               style={{ "padding-bottom": space }}
             />
             <div
+              dir="auto"
               class="absolute top-0 inset-x-0 pl-3 pr-2 pt-2 text-14-regular text-text-weak pointer-events-none whitespace-nowrap truncate"
               classList={{ "font-mono!": store.mode === "shell" }}
               style={{ "padding-bottom": space, display: prompt.dirty() ? "none" : undefined }}

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -7,6 +7,7 @@
   font-family: var(--font-family-sans);
   font-size: var(--font-size-base); /* 14px */
   line-height: 160%;
+  text-align: start;
 
   /* Spacing for flow */
   > *:first-child {
@@ -60,8 +61,8 @@
   ol {
     margin-top: 8px;
     margin-bottom: 12px;
-    margin-left: 0;
-    padding-left: 32px;
+    margin-inline-start: 0;
+    padding-inline-start: 32px;
     list-style-position: outside;
   }
 
@@ -71,7 +72,7 @@
 
   ol {
     list-style-type: decimal;
-    padding-left: 2.25rem;
+    padding-inline-start: 2.25rem;
   }
 
   li {
@@ -97,18 +98,18 @@
   li > ol {
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
-    padding-left: 1rem; /* Minimal indent for nesting only */
+    padding-inline-start: 1rem; /* Minimal indent for nesting only */
   }
 
   li > ol {
-    padding-left: 1.75rem;
+    padding-inline-start: 1.75rem;
   }
 
   /* Blockquotes */
   blockquote {
-    border-left: 2px solid var(--border-weak-base);
+    border-inline-start: 2px solid var(--border-weak-base);
     margin: 1.5rem 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
     color: var(--text-weak);
     font-style: normal;
   }
@@ -204,6 +205,8 @@
     margin-top: 12px;
     margin-bottom: 32px;
     overflow: auto;
+    direction: ltr;
+    text-align: left;
 
     scrollbar-width: none;
     &::-webkit-scrollbar {
@@ -240,7 +243,7 @@
     /* Minimal borders for structure, matching TUI "lines" roughly but keeping it web-clean */
     border-bottom: 1px solid var(--border-weaker-base);
     padding: 12px;
-    text-align: left;
+    text-align: start;
     vertical-align: top;
   }
 

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -173,12 +173,23 @@ function markCodeLinks(root: HTMLDivElement) {
   }
 }
 
+const blockDirectionSelector = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "blockquote", "table"]
+  .map((tag) => `:scope > ${tag}`)
+  .join(",")
+
+function markBlockDirection(root: HTMLDivElement) {
+  for (const el of root.querySelectorAll(blockDirectionSelector)) {
+    el.setAttribute("dir", "auto")
+  }
+}
+
 function decorate(root: HTMLDivElement, labels: CopyLabels) {
   const blocks = Array.from(root.querySelectorAll("pre"))
   for (const block of blocks) {
     ensureCodeWrapper(block, labels)
   }
   markCodeLinks(root)
+  markBlockDirection(root)
 }
 
 function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
@@ -337,6 +348,7 @@ export function Markdown(
   return (
     <div
       data-component="markdown"
+      dir="auto"
       classList={{
         ...local.classList,
         [local.class ?? ""]: !!local.class,

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1100,7 +1100,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
       <Show when={text()}>
         <>
           <div data-slot="user-message-body">
-            <div data-slot="user-message-text">
+            <div data-slot="user-message-text" dir="auto">
               <HighlightedText text={text()} references={inlineFiles()} agents={agents()} />
             </div>
           </div>


### PR DESCRIPTION

### Issue for this PR

Closes #14257 

### Type of change

- [x] New feature

### What does this PR do?

Adds support for RTL languages in rendered chat content and text box.
This change makes the app usable in RTL languages from a previously unusable state.

### How did you verify your code works?

Tested for edge cases including quotes, ordered and unordered lists, code blocks (should stay LTR), and language switching mid-response.
If you make changes to this PR, it is valuable to at least get the agent to repeat the contents of the screenshot and seeing the directions look the same, or have a native RTL-language speaker test it.

### Screenshots / recordings

<img width="613" height="912" alt="image" src="https://github.com/user-attachments/assets/4a0d5ce1-d3c8-4ba2-b7c6-c8a73484af48" />
### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

___

you may use this markdown text to test bullets and quotes:

"""# Short Nested Structures

## English Bullets

- App
  - UI
    - Buttons
  - Logic

## עברית - נקודות

- אפליקציה
  - ממשק
    - כפתורים
  - לוגיקה

## English Quotes

> Main quote text.
>
> > Nested level one.
> >
> > > Nested level two.

## עברית - ציטוטים

> טקסט הציטוט הראשי.
>
> > רמה מקוננת ראשונה.
> >
> > > רמה מקוננת שנייה."""
