### PR TITLE
fix: make Home/End move caret to line edges in prompt input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1165,6 +1165,21 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       }
     }
 
+    // Home/End move the caret to the line/document edge. contenteditable does
+    // not handle these reliably across the editor's mixed inline content
+    // (text + <br> + non-editable pills), so route them through Selection.modify.
+    if (event.key === "Home" || event.key === "End") {
+      if (event.metaKey || event.altKey) return
+      const selection = window.getSelection()
+      if (!selection) return
+      const direction = event.key === "Home" ? "backward" : "forward"
+      const granularity = event.ctrlKey ? "documentboundary" : "lineboundary"
+      const alter = event.shiftKey ? "extend" : "move"
+      selection.modify(alter, direction, granularity)
+      event.preventDefault()
+      return
+    }
+
     // Handle Shift+Enter BEFORE IME check - Shift+Enter is never used for IME input
     // and should always insert a newline regardless of composition state
     if (event.key === "Enter" && event.shiftKey) {


### PR DESCRIPTION
## Summary
- The prompt input is a `contenteditable` div, not a `<textarea>`. Chromium's default `Home`/`End` handling in a contenteditable is unreliable when the editor mixes text nodes, `<br>` newlines, and `contenteditable="false"` pill elements (file/agent attachments) — see `packages/app/src/components/prompt-input/editor-dom.ts`.
- As a result, `fn+Left`/`fn+Right` on Magic Keyboards (which the firmware emits as `Home`/`End`, on macOS *and* Linux) often did nothing useful in the prompt — no caret motion, just an occasional surrounding-panel scroll.
- Adds explicit handling in `prompt-input.tsx`'s `handleKeyDown` that routes `Home`/`End` through `Selection.modify`, so the caret reliably moves to the line edge (or document edge with `Ctrl`), and `Shift` extends the selection.

## Behavior
- `Home` / `End` → move caret to start / end of the visual line
- `Shift+Home` / `Shift+End` → extend selection to start / end of the visual line
- `Ctrl+Home` / `Ctrl+End` → move caret to start / end of the prompt
- `Ctrl+Shift+Home` / `Ctrl+Shift+End` → extend selection to start / end of the prompt
- `Cmd+Home/End` and `Alt+Home/End` are left to the browser default (unchanged)

## Test plan
- [ ] Type a multi-line prompt (using `Shift+Enter`) and confirm `Home`/`End` jump to the visual line edge, not the document edge
- [ ] Verify `Shift+Home`/`Shift+End` extend the selection to the line edge
- [ ] Verify `Ctrl+Home`/`Ctrl+End` jump to the prompt's start/end
- [ ] Verify Magic Keyboard `fn+Left`/`fn+Right` (Linux + macOS) move the caret to the line edge
- [ ] Insert a `@file` or agent pill, place the caret nearby, and confirm `Home`/`End` still move correctly across the pill
- [ ] Confirm word-jump (`Ctrl+Left/Right`) and arrow-key history navigation are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)