### PR TITLE
fix(tui): prevent question option submission on drag-to-select copy

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 import { createMemo, createSignal, For, Show } from "solid-js"
-import { useKeyboard } from "@opentui/solid"
+import { useKeyboard, useRenderer } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
@@ -121,6 +121,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
   }
 
   const dialog = useDialog()
+  const renderer = useRenderer()
 
   useKeyboard((evt) => {
     // Skip processing if a dialog (e.g., command palette) is open
@@ -279,7 +280,10 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                     }
                     onMouseOver={() => setTabHover(index())}
                     onMouseOut={() => setTabHover(null)}
-                    onMouseUp={() => selectTab(index())}
+                    onMouseUp={() => {
+                      if (renderer.getSelection()?.getSelectedText()) return
+                      selectTab(index())
+                    }}
                   >
                     <text
                       fg={
@@ -304,7 +308,10 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               }
               onMouseOver={() => setTabHover("confirm")}
               onMouseOut={() => setTabHover(null)}
-              onMouseUp={() => selectTab(questions().length)}
+              onMouseUp={() => {
+                if (renderer.getSelection()?.getSelectedText()) return
+                selectTab(questions().length)
+              }}
             >
               <text fg={confirm() ? selectedForeground(theme, theme.accent) : theme.textMuted}>Confirm</text>
             </box>
@@ -328,7 +335,10 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                     <box
                       onMouseOver={() => moveTo(i())}
                       onMouseDown={() => moveTo(i())}
-                      onMouseUp={() => selectOption()}
+                      onMouseUp={() => {
+                        if (renderer.getSelection()?.getSelectedText()) return
+                        selectOption()
+                      }}
                     >
                       <box flexDirection="row">
                         <box backgroundColor={active() ? theme.backgroundElement : undefined} paddingRight={1}>
@@ -357,7 +367,10 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                 <box
                   onMouseOver={() => moveTo(options().length)}
                   onMouseDown={() => moveTo(options().length)}
-                  onMouseUp={() => selectOption()}
+                  onMouseUp={() => {
+                    if (renderer.getSelection()?.getSelectedText()) return
+                    selectOption()
+                  }}
                 >
                   <box flexDirection="row">
                     <box backgroundColor={other() ? theme.backgroundElement : undefined} paddingRight={1}>


### PR DESCRIPTION
## Summary

In the TUI question prompt, dragging to select text on a question option (or tab) submits the option instead of copying the selected text to the clipboard. This is especially common in **plan mode** where the agent asks multiple-choice questions.

## Root cause

The app root handles copy-on-select via `onMouseUp` → `Selection.copy(renderer, toast)`, but the question component's `onMouseUp` handlers don't guard against it. Other clickable surfaces in the TUI already use:

```ts
if (renderer.getSelection()?.getSelectedText()) return
```

The question prompt was missing this guard on its four `onMouseUp` handlers.

## Fix

Add the existing guard idiom to all four `onMouseUp` handlers in `packages/opencode/src/cli/cmd/tui/routes/session/question.tsx`:

1. Question tabs
2. Confirm tab
3. Option rows
4. "Type your own answer" row

## Behavior after fix

- Click (no drag) → option/tab is selected as before
- Drag to select → text is copied to clipboard, option is **not** submitted

## Test plan

- [ ] Enter plan mode (or any flow with the `question` tool)
- [ ] Click an option → should select/submit as before
- [ ] Drag to select text on an option → should copy text and **not** submit
- [ ] Same behavior for tabs and the custom answer row

Fixes #24986