### PR TITLE
fix(project): stop calling git for linked worktree discovery during startup

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -17,7 +17,6 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { zod } from "@/util/effect-zod"
 import { NonNegativeInt, withStatics } from "@/util/schema"
-
 const log = Log.create({ service: "project" })
 
 const ProjectVcs = Schema.Literal("git")
@@ -173,6 +172,29 @@ export const layer: Layer.Layer<
       return pathSvc.resolve(cwd, name)
     }
 
+    const readLinkedWorktree = Effect.fnUntraced(function* (dotgit: string, sandbox: string) {
+      const text = yield* fs.readFileString(dotgit).pipe(Effect.catch(() => Effect.void))
+      const match = text?.match(/^gitdir:\s*(.+)$/m)
+      if (!match) return
+
+      const admin = resolveGitPath(sandbox, match[1]!.trim())
+      const [commonDirText, gitdirText] = yield* Effect.all(
+        [
+          fs.readFileString(pathSvc.join(admin, "commondir")).pipe(Effect.catch(() => Effect.void)),
+          fs.readFileString(pathSvc.join(admin, "gitdir")).pipe(Effect.catch(() => Effect.void)),
+        ],
+        { concurrency: 2 },
+      )
+      if (!commonDirText || !gitdirText) return
+
+      const linkedGitFile = resolveGitPath(admin, gitdirText.trim())
+      if (pathSvc.normalize(linkedGitFile) !== pathSvc.normalize(dotgit)) return
+
+      const common = resolveGitPath(admin, commonDirText.trim())
+      const worktree = pathSvc.basename(common) === ".git" ? pathSvc.dirname(common) : common
+      return { common, worktree, sandbox }
+    })
+
     const scope = yield* Scope.Scope
 
     const readCachedProjectId = Effect.fnUntraced(function* (dir: string) {
@@ -205,6 +227,8 @@ export const layer: Layer.Layer<
         let sandbox = pathSvc.dirname(dotgit)
         const gitBinary = yield* Effect.sync(() => which("git"))
         let id = yield* readCachedProjectId(dotgit)
+        const dotgitInfo = yield* fs.stat(dotgit).pipe(Effect.catch(() => Effect.void))
+        const directRepo = dotgitInfo?.type === "Directory"
 
         if (!gitBinary) {
           return {
@@ -212,6 +236,67 @@ export const layer: Layer.Layer<
             worktree: sandbox,
             sandbox,
             vcs: fakeVcs,
+          }
+        }
+
+        if (directRepo) {
+          // Standard repos already expose their real root via the discovered `.git` directory,
+          // so avoid extra git subprocesses that are only needed for linked worktrees/bare repos.
+          if (!id) {
+            const revList = yield* git(["rev-list", "--max-parents=0", "HEAD"], { cwd: sandbox })
+            const roots = revList.text
+              .split("\n")
+              .filter(Boolean)
+              .map((x) => x.trim())
+              .toSorted()
+
+            id = roots[0] ? ProjectID.make(roots[0]) : undefined
+            if (id) {
+              yield* fs.writeFileString(pathSvc.join(dotgit, "opencode"), id).pipe(Effect.ignore)
+            }
+          }
+
+          if (!id) {
+            return { id: ProjectID.global, worktree: sandbox, sandbox, vcs: "git" as const }
+          }
+
+          return { id, sandbox, worktree: sandbox, vcs: "git" as const }
+        }
+
+        const linkedWorktree = yield* readLinkedWorktree(dotgit, sandbox)
+        if (linkedWorktree) {
+          if (id == null) {
+            id = yield* readCachedProjectId(linkedWorktree.common)
+          }
+
+          if (!id) {
+            const revList = yield* git(["rev-list", "--max-parents=0", "HEAD"], { cwd: sandbox })
+            const roots = revList.text
+              .split("\n")
+              .filter(Boolean)
+              .map((x) => x.trim())
+              .toSorted()
+
+            id = roots[0] ? ProjectID.make(roots[0]) : undefined
+            if (id) {
+              yield* fs.writeFileString(pathSvc.join(linkedWorktree.common, "opencode"), id).pipe(Effect.ignore)
+            }
+          }
+
+          if (!id) {
+            return {
+              id: ProjectID.global,
+              worktree: linkedWorktree.worktree,
+              sandbox,
+              vcs: "git" as const,
+            }
+          }
+
+          return {
+            id,
+            sandbox,
+            worktree: linkedWorktree.worktree,
+            vcs: "git" as const,
           }
         }
 

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -30,7 +30,8 @@ function run<A>(fn: (svc: Project.Interface) => Effect.Effect<A>, layer = Projec
  * matching `failArg` and returns exit code 128, while delegating everything
  * else to the real CrossSpawnSpawner.
  */
-function mockGitFailure(failArg: string) {
+function mockGitFailure(failArg: string | string[]) {
+  const failArgs = new Set(Array.isArray(failArg) ? failArg : [failArg])
   return Layer.effect(
     ChildProcessSpawner.ChildProcessSpawner,
     Effect.gen(function* () {
@@ -38,7 +39,7 @@ function mockGitFailure(failArg: string) {
       return ChildProcessSpawner.make(
         Effect.fnUntraced(function* (command) {
           const std = ChildProcess.isStandardCommand(command) ? command : undefined
-          if (std?.command === "git" && std.args.some((a) => a === failArg)) {
+          if (std?.command === "git" && std.args.some((a) => failArgs.has(a))) {
             return ChildProcessSpawner.makeHandle({
               pid: ChildProcessSpawner.ProcessId(0),
               exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(128)),
@@ -60,7 +61,7 @@ function mockGitFailure(failArg: string) {
   ).pipe(Layer.provide(CrossSpawnSpawner.defaultLayer))
 }
 
-function projectLayerWithFailure(failArg: string) {
+function projectLayerWithFailure(failArg: string | string[]) {
   return Project.layer.pipe(
     Layer.provide(mockGitFailure(failArg)),
     Layer.provide(AppFileSystem.defaultLayer),
@@ -192,6 +193,27 @@ describe("Project.fromDirectory with worktrees", () => {
       const cache = path.join(tmp.path, ".git", "opencode")
       const exists = await Bun.file(cache).exists()
       expect(exists).toBe(true)
+    } finally {
+      await $`git worktree remove ${worktreePath}`
+        .cwd(tmp.path)
+        .quiet()
+        .catch(() => {})
+    }
+  })
+
+  test("worktree resolves from gitdir metadata without git topology subprocesses", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const worktreePath = path.join(tmp.path, "..", path.basename(tmp.path) + "-wt-metadata")
+    const layer = projectLayerWithFailure(["--git-common-dir", "--show-toplevel", "core.bare"])
+    try {
+      await $`git worktree add ${worktreePath} -b metadata-${Date.now()}`.cwd(tmp.path).quiet()
+
+      const { project, sandbox } = await run((svc) => svc.fromDirectory(worktreePath), layer)
+
+      expect(project.worktree).toBe(tmp.path)
+      expect(sandbox).toBe(worktreePath)
+      expect(project.sandboxes).toContain(worktreePath)
     } finally {
       await $`git worktree remove ${worktreePath}`
         .cwd(tmp.path)


### PR DESCRIPTION
### Issue for this PR

Closes #25022

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a Windows startup hang I was hitting in linked worktrees.

The UI would sit on `Loading plugins...`, but the actual blocker was earlier in startup. In `Project.fromDirectory()`, linked worktree discovery was shelling out to Git for topology info with:

- `git rev-parse --git-common-dir`
- `git config --bool core.bare`
- `git rev-parse --show-toplevel`

In the bad case, this was not just slow. It hung and never reached the prompt.

For linked worktrees, that topology data is already on disk:
- the worktree `.git` file points at the admin dir
- the admin dir contains `gitdir`
- the admin dir contains `commondir`

This change resolves linked worktree topology from that metadata first instead of calling Git on the startup path. If the metadata does not parse cleanly, the existing Git fallback stays in place.

### How did you verify your code works?

- `bun test test/project/project.test.ts`
- `bun test test/project/migrate-global.test.ts`
- repeated Windows startup runs against a linked worktree
- checked the process tree before and after the patch to confirm the linked-worktree path stopped spawning `git rev-parse --git-common-dir`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
