### PR TITLE
feat: default HTTP API backend to on for dev/beta channels

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -1,4 +1,5 @@
 import { Config } from "effect"
+import { InstallationChannel } from "../installation/version"
 
 function truthy(key: string) {
   const value = process.env[key]?.toLowerCase()
@@ -9,6 +10,10 @@ function falsy(key: string) {
   const value = process.env[key]?.toLowerCase()
   return value === "false" || value === "0"
 }
+
+// Channels that default to the new effect-httpapi server backend. The legacy
+// hono backend remains the default for stable (`prod`/`latest`) installs.
+const HTTPAPI_DEFAULT_ON_CHANNELS = new Set(["dev", "beta", "local"])
 
 function number(key: string) {
   const value = process.env[key]
@@ -81,7 +86,14 @@ export const Flag = {
   OPENCODE_STRICT_CONFIG_DEPS: truthy("OPENCODE_STRICT_CONFIG_DEPS"),
 
   OPENCODE_WORKSPACE_ID: process.env["OPENCODE_WORKSPACE_ID"],
-  OPENCODE_EXPERIMENTAL_HTTPAPI: truthy("OPENCODE_EXPERIMENTAL_HTTPAPI"),
+  // Defaults to true on dev/beta/local channels so internal users exercise the
+  // new effect-httpapi server backend. Stable (`prod`/`latest`) installs stay
+  // on the legacy hono backend until the rollout is complete. An explicit env
+  // var ("true"/"1" or "false"/"0") always wins, providing an opt-in for
+  // stable users and an escape hatch for dev/beta users.
+  OPENCODE_EXPERIMENTAL_HTTPAPI:
+    truthy("OPENCODE_EXPERIMENTAL_HTTPAPI") ||
+    (!falsy("OPENCODE_EXPERIMENTAL_HTTPAPI") && HTTPAPI_DEFAULT_ON_CHANNELS.has(InstallationChannel)),
   OPENCODE_EXPERIMENTAL_WORKSPACES: OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_WORKSPACES"),
 
   // Evaluated at access time (not module load) because tests, the CLI, and


### PR DESCRIPTION
## Summary

Flip `Flag.OPENCODE_EXPERIMENTAL_HTTPAPI` to default-on for `dev`, `beta`, and `local` installation channels so internal users start exercising the new effect-httpapi server backend in the normal course of using opencode. Stable (`prod` / `latest`) installs are unaffected and continue running the legacy hono backend until we're ready to flip them too.

## Behavior

The flag now resolves as:

- `OPENCODE_EXPERIMENTAL_HTTPAPI=true` / `=1` → on (works on every channel, same as before)
- `OPENCODE_EXPERIMENTAL_HTTPAPI=false` / `=0` → off (new escape hatch for dev/beta users if the new backend misbehaves)
- unset on `dev` / `beta` / `local` → on (new default)
- unset on `prod` / `latest` → off (unchanged)

This piggybacks on the existing channel signal that `backend.ts` already reports via OTel attributes, and avoids touching every test that mutates the flag directly.

## Test plan

- `bun typecheck` in `packages/core` and `packages/opencode`
- `bun run test test/server/httpapi-bridge.test.ts` (covers the explicit-false / explicit-true backend selection behavior)
- `bun run test test/server/httpapi-json-parity.test.ts test/server/httpapi-sync.test.ts test/server/httpapi-experimental.test.ts`

The one failing test in `packages/core` (`cross-spawn spawner > cwd option`) is pre-existing on `origin/dev` and unrelated to this change.