### PR TITLE
refactor: use Effect config for HttpApi authorization

### DIFF
--- a/packages/opencode/src/effect/config-service.ts
+++ b/packages/opencode/src/effect/config-service.ts
@@ -19,9 +19,6 @@ export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClas
   readonly defaultLayer: Layer.Layer<Self, Config.ConfigError>
 }
 
-/** Extract the service shape from a config service class. */
-export type ServiceShape<Service extends Context.Service.Any> = Context.Service.Shape<Service>
-
 /**
  * Create a Context service whose implementation is derived from Effect `Config`.
  *

--- a/packages/opencode/src/effect/config-service.ts
+++ b/packages/opencode/src/effect/config-service.ts
@@ -1,0 +1,54 @@
+import { Config, Context, Effect, Layer } from "effect"
+
+type ConfigMap = Record<string, Config.Config<unknown>>
+
+/**
+ * The service shape inferred from an object of Effect `Config` definitions.
+ */
+export type Shape<Fields extends ConfigMap> = {
+  readonly [Key in keyof Fields]: Config.Success<Fields[Key]>
+}
+
+/**
+ * A Context service class with generated layers for config-backed services.
+ */
+export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClass<Self, Id, Service> & {
+  /** Provide already-parsed config, useful in tests. */
+  readonly layer: (input: Service) => Layer.Layer<Self>
+  /** Parse config once from the active Effect ConfigProvider and provide the service. */
+  readonly defaultLayer: Layer.Layer<Self, Config.ConfigError>
+}
+
+/**
+ * Create a Context service whose implementation is derived from Effect `Config`.
+ *
+ * This keeps Effect `Config` as the source of truth for env names, defaults, and
+ * validation while generating a typed service plus convenient production/test
+ * layers.
+ */
+export const Service =
+  <Self>() =>
+  <const Id extends string, const Fields extends ConfigMap>(id: Id, fields: Fields) => {
+    class ConfigTag extends Context.Service<Self, Shape<Fields>>()(id) {
+      static layer(input: Shape<Fields>) {
+        return Layer.succeed(this, this.of(input))
+      }
+
+      static get defaultLayer() {
+        return Layer.effect(
+          this,
+          Config.all(fields)
+            .asEffect()
+            .pipe(
+              // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- Config.all preserves the field shape, but its conditional return type also supports iterable inputs.
+              Effect.map((config) => this.of(config as Shape<Fields>)),
+            ),
+        )
+      }
+    }
+
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- The generated class carries typed static helpers.
+    return ConfigTag as ServiceClass<Self, Id, Shape<Fields>>
+  }
+
+export * as ConfigService from "./config-service"

--- a/packages/opencode/src/effect/config-service.ts
+++ b/packages/opencode/src/effect/config-service.ts
@@ -19,6 +19,9 @@ export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClas
   readonly defaultLayer: Layer.Layer<Self, Config.ConfigError>
 }
 
+/** Extract the service shape from a config service class. */
+export type ServiceShape<Service extends Context.Service.Any> = Context.Service.Shape<Service>
+
 /**
  * Create a Context service whose implementation is derived from Effect `Config`.
  *

--- a/packages/opencode/src/effect/config-service.ts
+++ b/packages/opencode/src/effect/config-service.ts
@@ -25,6 +25,19 @@ export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClas
  * This keeps Effect `Config` as the source of truth for env names, defaults, and
  * validation while generating a typed service plus convenient production/test
  * layers.
+ *
+ * ```ts
+ * class ServerAuthConfig extends ConfigService.Service<ServerAuthConfig>()(
+ *   "@opencode/ServerAuthConfig",
+ *   {
+ *     password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
+ *     username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
+ *   },
+ * ) {}
+ *
+ * const live = ServerAuthConfig.defaultLayer
+ * const test = ServerAuthConfig.layer({ password: Option.some("secret"), username: "kit" })
+ * ```
  */
 export const Service =
   <Self>() =>

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from "@/effect/config-service"
-import { Config, Context, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
+import { Config, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
 import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
 
 class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
@@ -30,7 +30,7 @@ export class ServerAuthConfig extends ConfigService.Service<ServerAuthConfig>()(
 function validateCredential<A, E, R>(
   effect: Effect.Effect<A, E, R>,
   credential: { readonly username: string; readonly password: Redacted.Redacted },
-  config: Context.Service.Shape<typeof ServerAuthConfig>,
+  config: ConfigService.ServiceShape<typeof ServerAuthConfig>,
 ) {
   return Effect.gen(function* () {
     if (Option.isNone(config.password) || config.password.value === "") return yield* effect

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -24,26 +24,24 @@ export class ServerAuthConfig extends Context.Service<
     readonly password: string | undefined
     readonly username: string
   }
->()("@opencode/ExperimentalHttpApiServerAuthConfig") {}
+>()("@opencode/ExperimentalHttpApiServerAuthConfig") {
+  static readonly layer = (input: Context.Service.Shape<typeof ServerAuthConfig>) =>
+    Layer.succeed(ServerAuthConfig, ServerAuthConfig.of(input))
 
-const emptyCredential = {
-  username: "",
-  password: Redacted.make(""),
+  static readonly defaultLayer = Layer.effect(
+    ServerAuthConfig,
+    Effect.gen(function* () {
+      const config = yield* Config.all({
+        password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
+        username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
+      })
+      return ServerAuthConfig.of({
+        password: Option.getOrUndefined(config.password),
+        username: config.username,
+      })
+    }),
+  )
 }
-
-export const serverAuthConfigLayer = Layer.effect(
-  ServerAuthConfig,
-  Effect.gen(function* () {
-    const config = yield* Config.all({
-      password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
-      username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
-    })
-    return ServerAuthConfig.of({
-      password: Option.getOrUndefined(config.password),
-      username: config.username,
-    })
-  }),
-)
 
 function validateCredential<A, E, R>(
   effect: Effect.Effect<A, E, R>,
@@ -64,6 +62,11 @@ function validateCredential<A, E, R>(
 }
 
 function decodeCredential(input: string) {
+  const emptyCredential = {
+    username: "",
+    password: Redacted.make(""),
+  }
+
   return Encoding.decodeBase64String(input)
     .asEffect()
     .pipe(
@@ -88,9 +91,9 @@ export const authorizationLayer = Layer.effect(
     return Authorization.of({
       basic: (effect, { credential }) => validateCredential(effect, credential, config),
       authToken: (effect, { credential }) =>
-        Effect.gen(function* () {
-          return yield* validateCredential(effect, yield* decodeCredential(Redacted.value(credential)), config)
-        }),
+        decodeCredential(Redacted.value(credential)).pipe(
+          Effect.flatMap((decoded) => validateCredential(effect, decoded, config)),
+        ),
     })
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -18,29 +18,26 @@ export class Authorization extends HttpApiMiddleware.Service<Authorization>()(
   },
 ) {}
 
-export interface ServerAuthConfigService {
-  readonly password: string | undefined
-  readonly username: string
-}
-
-export class ServerAuthConfig extends Context.Service<ServerAuthConfig, ServerAuthConfigService>()(
-  "@opencode/ExperimentalHttpApiServerAuthConfig",
-) {}
+export class ServerAuthConfig extends Context.Service<
+  ServerAuthConfig,
+  {
+    readonly password: string | undefined
+    readonly username: string
+  }
+>()("@opencode/ExperimentalHttpApiServerAuthConfig") {}
 
 const emptyCredential = {
   username: "",
   password: Redacted.make(""),
 }
 
-const authConfig = Config.all({
-  password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
-  username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
-})
-
 export const serverAuthConfigLayer = Layer.effect(
   ServerAuthConfig,
   Effect.gen(function* () {
-    const config = yield* authConfig
+    const config = yield* Config.all({
+      password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
+      username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
+    })
     return ServerAuthConfig.of({
       password: Option.getOrUndefined(config.password),
       username: config.username,
@@ -50,8 +47,8 @@ export const serverAuthConfigLayer = Layer.effect(
 
 function validateCredential<A, E, R>(
   effect: Effect.Effect<A, E, R>,
-  credential: { readonly username: string; readonly password: typeof emptyCredential.password },
-  config: ServerAuthConfigService,
+  credential: { readonly username: string; readonly password: Redacted.Redacted },
+  config: Context.Service.Shape<typeof ServerAuthConfig>,
 ) {
   return Effect.gen(function* () {
     if (!config.password) return yield* effect

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -1,4 +1,4 @@
-import { Config, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
+import { Config, Context, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
 import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
 
 class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
@@ -18,6 +18,15 @@ export class Authorization extends HttpApiMiddleware.Service<Authorization>()(
   },
 ) {}
 
+export interface ServerAuthConfigService {
+  readonly password: string | undefined
+  readonly username: string
+}
+
+export class ServerAuthConfig extends Context.Service<ServerAuthConfig, ServerAuthConfigService>()(
+  "@opencode/ExperimentalHttpApiServerAuthConfig",
+) {}
+
 const emptyCredential = {
   username: "",
   password: Redacted.make(""),
@@ -28,18 +37,29 @@ const authConfig = Config.all({
   username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
 })
 
+export const serverAuthConfigLayer = Layer.effect(
+  ServerAuthConfig,
+  Effect.gen(function* () {
+    const config = yield* authConfig
+    return ServerAuthConfig.of({
+      password: Option.getOrUndefined(config.password),
+      username: config.username,
+    })
+  }),
+)
+
 function validateCredential<A, E, R>(
   effect: Effect.Effect<A, E, R>,
   credential: { readonly username: string; readonly password: typeof emptyCredential.password },
-  config: Config.Success<typeof authConfig>,
+  config: ServerAuthConfigService,
 ) {
   return Effect.gen(function* () {
-    if (Option.isNone(config.password) || config.password.value === "") return yield* effect
+    if (!config.password) return yield* effect
 
     if (credential.username !== config.username) {
       return yield* new Unauthorized({ message: "Unauthorized" })
     }
-    if (Redacted.value(credential.password) !== config.password.value) {
+    if (Redacted.value(credential.password) !== config.password) {
       return yield* new Unauthorized({ message: "Unauthorized" })
     }
     return yield* effect
@@ -67,7 +87,7 @@ function decodeCredential(input: string) {
 export const authorizationLayer = Layer.effect(
   Authorization,
   Effect.gen(function* () {
-    const config = yield* authConfig
+    const config = yield* ServerAuthConfig
     return Authorization.of({
       basic: (effect, { credential }) => validateCredential(effect, credential, config),
       authToken: (effect, { credential }) =>

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from "@/effect/config-service"
-import { Config, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
+import { Config, Context, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
 import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
 
 class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
@@ -30,7 +30,7 @@ export class ServerAuthConfig extends ConfigService.Service<ServerAuthConfig>()(
 function validateCredential<A, E, R>(
   effect: Effect.Effect<A, E, R>,
   credential: { readonly username: string; readonly password: Redacted.Redacted },
-  config: ConfigService.ServiceShape<typeof ServerAuthConfig>,
+  config: Context.Service.Shape<typeof ServerAuthConfig>,
 ) {
   return Effect.gen(function* () {
     if (Option.isNone(config.password) || config.password.value === "") return yield* effect

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -1,17 +1,11 @@
 import { ConfigService } from "@/effect/config-service"
-import { Config, Context, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
-import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
-
-class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
-  "Unauthorized",
-  { message: Schema.String },
-  { httpApiStatus: 401 },
-) {}
+import { Config, Context, Effect, Encoding, Layer, Option, Redacted } from "effect"
+import { HttpApiError, HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
 
 export class Authorization extends HttpApiMiddleware.Service<Authorization>()(
   "@opencode/ExperimentalHttpApiAuthorization",
   {
-    error: Unauthorized,
+    error: HttpApiError.UnauthorizedNoContent,
     security: {
       basic: HttpApiSecurity.basic,
       authToken: HttpApiSecurity.apiKey({ in: "query", key: "auth_token" }),
@@ -36,10 +30,10 @@ function validateCredential<A, E, R>(
     if (Option.isNone(config.password) || config.password.value === "") return yield* effect
 
     if (credential.username !== config.username) {
-      return yield* new Unauthorized({ message: "Unauthorized" })
+      return yield* new HttpApiError.Unauthorized({})
     }
     if (Redacted.value(credential.password) !== config.password.value) {
-      return yield* new Unauthorized({ message: "Unauthorized" })
+      return yield* new HttpApiError.Unauthorized({})
     }
     return yield* effect
   })

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -1,6 +1,5 @@
-import { Effect, Encoding, Layer, Redacted, Schema } from "effect"
+import { Config, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
 import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
-import { Flag } from "@opencode-ai/core/flag/flag"
 
 class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
   "Unauthorized",
@@ -24,17 +23,23 @@ const emptyCredential = {
   password: Redacted.make(""),
 }
 
+const authConfig = Config.all({
+  password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
+  username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
+})
+
 function validateCredential<A, E, R>(
   effect: Effect.Effect<A, E, R>,
   credential: { readonly username: string; readonly password: typeof emptyCredential.password },
+  config: Config.Success<typeof authConfig>,
 ) {
   return Effect.gen(function* () {
-    if (!Flag.OPENCODE_SERVER_PASSWORD) return yield* effect
+    if (Option.isNone(config.password) || config.password.value === "") return yield* effect
 
-    if (credential.username !== (Flag.OPENCODE_SERVER_USERNAME ?? "opencode")) {
+    if (credential.username !== config.username) {
       return yield* new Unauthorized({ message: "Unauthorized" })
     }
-    if (Redacted.value(credential.password) !== Flag.OPENCODE_SERVER_PASSWORD) {
+    if (Redacted.value(credential.password) !== config.password.value) {
       return yield* new Unauthorized({ message: "Unauthorized" })
     }
     return yield* effect
@@ -59,13 +64,16 @@ function decodeCredential(input: string) {
     )
 }
 
-export const authorizationLayer = Layer.succeed(
+export const authorizationLayer = Layer.effect(
   Authorization,
-  Authorization.of({
-    basic: (effect, { credential }) => validateCredential(effect, credential),
-    authToken: (effect, { credential }) =>
-      Effect.gen(function* () {
-        return yield* validateCredential(effect, yield* decodeCredential(Redacted.value(credential)))
-      }),
+  Effect.gen(function* () {
+    const config = yield* authConfig
+    return Authorization.of({
+      basic: (effect, { credential }) => validateCredential(effect, credential, config),
+      authToken: (effect, { credential }) =>
+        Effect.gen(function* () {
+          return yield* validateCredential(effect, yield* decodeCredential(Redacted.value(credential)), config)
+        }),
+    })
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from "@/effect/config-service"
 import { Config, Context, Effect, Encoding, Layer, Option, Redacted, Schema } from "effect"
 import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
 
@@ -18,30 +19,13 @@ export class Authorization extends HttpApiMiddleware.Service<Authorization>()(
   },
 ) {}
 
-export class ServerAuthConfig extends Context.Service<
-  ServerAuthConfig,
+export class ServerAuthConfig extends ConfigService.Service<ServerAuthConfig>()(
+  "@opencode/ExperimentalHttpApiServerAuthConfig",
   {
-    readonly password: string | undefined
-    readonly username: string
-  }
->()("@opencode/ExperimentalHttpApiServerAuthConfig") {
-  static readonly layer = (input: Context.Service.Shape<typeof ServerAuthConfig>) =>
-    Layer.succeed(ServerAuthConfig, ServerAuthConfig.of(input))
-
-  static readonly defaultLayer = Layer.effect(
-    ServerAuthConfig,
-    Effect.gen(function* () {
-      const config = yield* Config.all({
-        password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
-        username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
-      })
-      return ServerAuthConfig.of({
-        password: Option.getOrUndefined(config.password),
-        username: config.username,
-      })
-    }),
-  )
-}
+    password: Config.string("OPENCODE_SERVER_PASSWORD").pipe(Config.option),
+    username: Config.string("OPENCODE_SERVER_USERNAME").pipe(Config.withDefault("opencode")),
+  },
+) {}
 
 function validateCredential<A, E, R>(
   effect: Effect.Effect<A, E, R>,
@@ -49,12 +33,12 @@ function validateCredential<A, E, R>(
   config: Context.Service.Shape<typeof ServerAuthConfig>,
 ) {
   return Effect.gen(function* () {
-    if (!config.password) return yield* effect
+    if (Option.isNone(config.password) || config.password.value === "") return yield* effect
 
     if (credential.username !== config.username) {
       return yield* new Unauthorized({ message: "Unauthorized" })
     }
-    if (Redacted.value(credential.password) !== config.password) {
+    if (Redacted.value(credential.password) !== config.password.value) {
       return yield* new Unauthorized({ message: "Unauthorized" })
     }
     return yield* effect

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -32,7 +32,7 @@ import { lazy } from "@/util/lazy"
 import { Vcs } from "@/project/vcs"
 import { Worktree } from "@/worktree"
 import { InstanceHttpApi, RootHttpApi } from "./api"
-import { authorizationLayer } from "./middleware/authorization"
+import { authorizationLayer, serverAuthConfigLayer } from "./middleware/authorization"
 import { eventRoute } from "./event"
 import { configHandlers } from "./handlers/config"
 import { controlHandlers } from "./handlers/control"
@@ -97,7 +97,7 @@ const rawInstanceRoutes = Layer.mergeAll(eventRoute, ptyConnectRoute).pipe(
 )
 const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe(
   Layer.provide([
-    authorizationLayer,
+    authorizationLayer.pipe(Layer.provide(serverAuthConfigLayer)),
     workspaceRoutingLayer.pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal)),
     instanceContextLayer,
   ]),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -32,7 +32,7 @@ import { lazy } from "@/util/lazy"
 import { Vcs } from "@/project/vcs"
 import { Worktree } from "@/worktree"
 import { InstanceHttpApi, RootHttpApi } from "./api"
-import { authorizationLayer, serverAuthConfigLayer } from "./middleware/authorization"
+import { ServerAuthConfig, authorizationLayer } from "./middleware/authorization"
 import { eventRoute } from "./event"
 import { configHandlers } from "./handlers/config"
 import { controlHandlers } from "./handlers/control"
@@ -97,7 +97,7 @@ const rawInstanceRoutes = Layer.mergeAll(eventRoute, ptyConnectRoute).pipe(
 )
 const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe(
   Layer.provide([
-    authorizationLayer.pipe(Layer.provide(serverAuthConfigLayer)),
+    authorizationLayer.pipe(Layer.provide(ServerAuthConfig.defaultLayer)),
     workspaceRoutingLayer.pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal)),
     instanceContextLayer,
   ]),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -56,7 +56,7 @@ import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import * as ServerBackend from "@/server/backend"
 
-export const context = Context.empty() as Context.Context<unknown>
+export const context = Context.makeUnsafe<unknown>(new Map())
 
 const runtime = HttpRouter.middleware()(
   Effect.succeed((effect) =>

--- a/packages/opencode/test/server/httpapi-authorization.test.ts
+++ b/packages/opencode/test/server/httpapi-authorization.test.ts
@@ -27,18 +27,13 @@ const apiLayer = HttpRouter.serve(
   { disableListenLog: true, disableLogger: true },
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
-const authConfigLayer = (input: { password?: string; username?: string } = {}) =>
-  ServerAuthConfig.layer({
-    password: input.password === undefined ? Option.none() : Option.some(input.password),
-    username: input.username ?? "opencode",
-  })
+const noAuthLayer = ServerAuthConfig.layer({ password: Option.none(), username: "opencode" })
+const secretLayer = ServerAuthConfig.layer({ password: Option.some("secret"), username: "opencode" })
+const kitSecretLayer = ServerAuthConfig.layer({ password: Option.some("secret"), username: "kit" })
 
-const itWithAuth = (input: { password?: string; username?: string } = {}) =>
-  testEffect(apiLayer.pipe(Layer.provide(authConfigLayer(input))))
-
-const it = itWithAuth()
-const itSecret = itWithAuth({ password: "secret" })
-const itKitSecret = itWithAuth({ username: "kit", password: "secret" })
+const it = testEffect(apiLayer.pipe(Layer.provide(noAuthLayer)))
+const itSecret = testEffect(apiLayer.pipe(Layer.provide(secretLayer)))
+const itKitSecret = testEffect(apiLayer.pipe(Layer.provide(kitSecretLayer)))
 
 const basic = (username: string, password: string) =>
   `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`

--- a/packages/opencode/test/server/httpapi-authorization.test.ts
+++ b/packages/opencode/test/server/httpapi-authorization.test.ts
@@ -1,9 +1,13 @@
 import { NodeHttpServer } from "@effect/platform-node"
 import { describe, expect } from "bun:test"
-import { ConfigProvider, Effect, Layer, Schema } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
-import { Authorization, authorizationLayer } from "../../src/server/routes/instance/httpapi/middleware/authorization"
+import {
+  Authorization,
+  ServerAuthConfig,
+  authorizationLayer,
+} from "../../src/server/routes/instance/httpapi/middleware/authorization"
 import { testEffect } from "../lib/effect"
 
 const Api = HttpApi.make("test-authorization").add(
@@ -23,19 +27,17 @@ const apiLayer = HttpRouter.serve(
   { disableListenLog: true, disableLogger: true },
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
-const itWithAuth = (input: { password?: string; username?: string } = {}) =>
-  testEffect(
-    apiLayer.pipe(
-      Layer.provide(
-        ConfigProvider.layer(
-          ConfigProvider.fromUnknown({
-            ...(input.password === undefined ? {} : { OPENCODE_SERVER_PASSWORD: input.password }),
-            ...(input.username === undefined ? {} : { OPENCODE_SERVER_USERNAME: input.username }),
-          }),
-        ),
-      ),
-    ),
+const authConfigLayer = (input: { password?: string; username?: string } = {}) =>
+  Layer.succeed(
+    ServerAuthConfig,
+    ServerAuthConfig.of({
+      password: input.password,
+      username: input.username ?? "opencode",
+    }),
   )
+
+const itWithAuth = (input: { password?: string; username?: string } = {}) =>
+  testEffect(apiLayer.pipe(Layer.provide(authConfigLayer(input))))
 
 const it = itWithAuth()
 const itSecret = itWithAuth({ password: "secret" })

--- a/packages/opencode/test/server/httpapi-authorization.test.ts
+++ b/packages/opencode/test/server/httpapi-authorization.test.ts
@@ -1,7 +1,6 @@
 import { NodeHttpServer } from "@effect/platform-node"
-import { Flag } from "@opencode-ai/core/flag/flag"
 import { describe, expect } from "bun:test"
-import { Effect, Layer, Schema } from "effect"
+import { ConfigProvider, Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 import { Authorization, authorizationLayer } from "../../src/server/routes/instance/httpapi/middleware/authorization"
@@ -24,47 +23,28 @@ const apiLayer = HttpRouter.serve(
   { disableListenLog: true, disableLogger: true },
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
-const testStateLayer = Layer.effectDiscard(
-  Effect.gen(function* () {
-    const original = {
-      OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,
-      OPENCODE_SERVER_USERNAME: Flag.OPENCODE_SERVER_USERNAME,
-    }
-    Flag.OPENCODE_SERVER_PASSWORD = undefined
-    Flag.OPENCODE_SERVER_USERNAME = undefined
-    yield* Effect.addFinalizer(() =>
-      Effect.sync(() => {
-        Flag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD
-        Flag.OPENCODE_SERVER_USERNAME = original.OPENCODE_SERVER_USERNAME
-      }),
-    )
-  }),
-)
+const itWithAuth = (input: { password?: string; username?: string } = {}) =>
+  testEffect(
+    apiLayer.pipe(
+      Layer.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            ...(input.password === undefined ? {} : { OPENCODE_SERVER_PASSWORD: input.password }),
+            ...(input.username === undefined ? {} : { OPENCODE_SERVER_USERNAME: input.username }),
+          }),
+        ),
+      ),
+    ),
+  )
 
-const it = testEffect(apiLayer.pipe(Layer.provideMerge(testStateLayer)))
+const it = itWithAuth()
+const itSecret = itWithAuth({ password: "secret" })
+const itKitSecret = itWithAuth({ username: "kit", password: "secret" })
 
 const basic = (username: string, password: string) =>
   `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
 
 const token = (username: string, password: string) => Buffer.from(`${username}:${password}`).toString("base64")
-
-const useAuth = (input: { password: string; username?: string }) =>
-  Effect.acquireRelease(
-    Effect.sync(() => {
-      const original = {
-        OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,
-        OPENCODE_SERVER_USERNAME: Flag.OPENCODE_SERVER_USERNAME,
-      }
-      Flag.OPENCODE_SERVER_PASSWORD = input.password
-      Flag.OPENCODE_SERVER_USERNAME = input.username
-      return original
-    }),
-    (original) =>
-      Effect.sync(() => {
-        Flag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD
-        Flag.OPENCODE_SERVER_USERNAME = original.OPENCODE_SERVER_USERNAME
-      }),
-  )
 
 const getProbe = (headers?: Record<string, string>) =>
   HttpClientRequest.get("/probe").pipe(
@@ -82,10 +62,8 @@ describe("HttpApi authorization middleware", () => {
     }),
   )
 
-  it.live("requires configured password for basic auth", () =>
+  itSecret.live("requires configured password for basic auth", () =>
     Effect.gen(function* () {
-      yield* useAuth({ password: "secret" })
-
       const [missing, badPassword, good] = yield* Effect.all(
         [
           getProbe(),
@@ -101,10 +79,8 @@ describe("HttpApi authorization middleware", () => {
     }),
   )
 
-  it.live("respects configured basic auth username", () =>
+  itKitSecret.live("respects configured basic auth username", () =>
     Effect.gen(function* () {
-      yield* useAuth({ username: "kit", password: "secret" })
-
       const [defaultUser, configuredUser] = yield* Effect.all(
         [getProbe({ authorization: basic("opencode", "secret") }), getProbe({ authorization: basic("kit", "secret") })],
         { concurrency: "unbounded" },
@@ -115,20 +91,16 @@ describe("HttpApi authorization middleware", () => {
     }),
   )
 
-  it.live("accepts auth token query credentials", () =>
+  itSecret.live("accepts auth token query credentials", () =>
     Effect.gen(function* () {
-      yield* useAuth({ password: "secret" })
-
       const response = yield* HttpClient.get(`/probe?auth_token=${encodeURIComponent(token("opencode", "secret"))}`)
 
       expect(response.status).toBe(200)
     }),
   )
 
-  it.live("rejects malformed auth token query credentials", () =>
+  itSecret.live("rejects malformed auth token query credentials", () =>
     Effect.gen(function* () {
-      yield* useAuth({ password: "secret" })
-
       const response = yield* HttpClient.get("/probe?auth_token=not-base64")
 
       expect(response.status).toBe(401)

--- a/packages/opencode/test/server/httpapi-authorization.test.ts
+++ b/packages/opencode/test/server/httpapi-authorization.test.ts
@@ -28,13 +28,10 @@ const apiLayer = HttpRouter.serve(
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
 const authConfigLayer = (input: { password?: string; username?: string } = {}) =>
-  Layer.succeed(
-    ServerAuthConfig,
-    ServerAuthConfig.of({
-      password: input.password,
-      username: input.username ?? "opencode",
-    }),
-  )
+  ServerAuthConfig.layer({
+    password: input.password,
+    username: input.username ?? "opencode",
+  })
 
 const itWithAuth = (input: { password?: string; username?: string } = {}) =>
   testEffect(apiLayer.pipe(Layer.provide(authConfigLayer(input))))

--- a/packages/opencode/test/server/httpapi-authorization.test.ts
+++ b/packages/opencode/test/server/httpapi-authorization.test.ts
@@ -1,6 +1,6 @@
 import { NodeHttpServer } from "@effect/platform-node"
 import { describe, expect } from "bun:test"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Layer, Option, Schema } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 import {
@@ -29,7 +29,7 @@ const apiLayer = HttpRouter.serve(
 
 const authConfigLayer = (input: { password?: string; username?: string } = {}) =>
   ServerAuthConfig.layer({
-    password: input.password,
+    password: input.password === undefined ? Option.none() : Option.some(input.password),
     username: input.username ?? "opencode",
   })
 

--- a/packages/opencode/test/server/httpapi-bridge.test.ts
+++ b/packages/opencode/test/server/httpapi-bridge.test.ts
@@ -2,11 +2,14 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Instance } from "../../src/project/instance"
 import { ControlPaths } from "../../src/server/routes/instance/httpapi/groups/control"
-import { FileApi, FilePaths } from "../../src/server/routes/instance/httpapi/groups/file"
+import { FilePaths } from "../../src/server/routes/instance/httpapi/groups/file"
 import { GlobalPaths } from "../../src/server/routes/instance/httpapi/groups/global"
 import { PublicApi } from "../../src/server/routes/instance/httpapi/public"
+import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
 import { Server } from "../../src/server/server"
 import * as Log from "@opencode-ai/core/util/log"
+import { ConfigProvider, Layer } from "effect"
+import { HttpRouter } from "effect/unstable/http"
 import { OpenApi } from "effect/unstable/httpapi"
 import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
@@ -30,7 +33,26 @@ function app(input?: { password?: string; username?: string }) {
   Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
   Flag.OPENCODE_SERVER_PASSWORD = input?.password
   Flag.OPENCODE_SERVER_USERNAME = input?.username
-  return Server.Default().app
+
+  const handler = HttpRouter.toWebHandler(
+    ExperimentalHttpApiServer.routes.pipe(
+      Layer.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            OPENCODE_SERVER_PASSWORD: input?.password,
+            OPENCODE_SERVER_USERNAME: input?.username,
+          }),
+        ),
+      ),
+    ),
+    { disableLogger: true },
+  ).handler
+  return {
+    fetch: (request: Request) => handler(request, ExperimentalHttpApiServer.context),
+    request(input: string | URL | Request, init?: RequestInit) {
+      return this.fetch(input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init))
+    },
+  }
 }
 
 function openApiRouteKeys(spec: { paths: Record<string, Partial<Record<(typeof methods)[number], unknown>>> }) {
@@ -94,9 +116,9 @@ type RequestBody = {
   required?: boolean
 }
 
-function parameterKey(param: unknown) {
-  if (!param || typeof param !== "object" || !("in" in param) || !("name" in param)) return
-  if (typeof param.in !== "string" || typeof param.name !== "string") return
+function parameterKey(param: unknown): string | undefined {
+  if (!param || typeof param !== "object" || !("in" in param) || !("name" in param)) return undefined
+  if (typeof param.in !== "string" || typeof param.name !== "string") return undefined
   return `${param.in}:${param.name}:${"required" in param && param.required === true}`
 }
 
@@ -105,27 +127,29 @@ function parameterSchema(input: {
   path: string
   method: (typeof methods)[number]
   name: string
-}) {
+}): unknown {
   const param = input.spec.paths[input.path]?.[input.method]?.parameters?.find(
     (param) => !!param && typeof param === "object" && "name" in param && param.name === input.name,
   )
-  if (!param || typeof param !== "object" || !("schema" in param)) return
+  if (!param || typeof param !== "object" || !("schema" in param)) return undefined
   return param.schema
 }
 
 function requestBodyKey(spec: OpenApiSpec, body: unknown) {
   if (!body || typeof body !== "object" || !("content" in body)) return ""
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- Guarded above; test helper only needs this OpenAPI subset.
   const requestBody = body as RequestBody
   return JSON.stringify({
     required: requestBody.required === true,
     content: Object.entries(requestBody.content ?? {})
-      .map(([type, value]) => [type, requestBodySchemaKind(spec, value.schema)])
-      .sort(),
+      .map(([type, value]) => [type, requestBodySchemaKind(spec, value.schema)] as const)
+      .sort(([left], [right]) => left.localeCompare(right)),
   })
 }
 
 function requestBodySchemaKind(spec: OpenApiSpec, schema: OpenApiSchema | undefined) {
   if (!schema) return ""
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- `$ref` lookup is constrained to OpenAPI schema components in this test helper.
   const resolved = (
     schema.$ref ? spec.components?.schemas?.[schema.$ref.replace("#/components/schemas/", "")] : schema
   ) as OpenApiSchema | undefined
@@ -142,6 +166,7 @@ function responseContentTypes(input: {
 }) {
   const responses = input.spec.paths[input.path]?.[input.method]?.responses
   if (!responses || typeof responses !== "object" || !(input.status in responses)) return []
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- Guarded dynamic OpenAPI response lookup.
   const response = (responses as Record<string, unknown>)[input.status]
   if (!response || typeof response !== "object" || !("content" in response)) return []
   const content = (response as { content?: unknown }).content

--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect } from "bun:test"
-import { Effect } from "effect"
+import { ConfigProvider, Effect, Layer } from "effect"
 import type * as Scope from "effect/Scope"
+import { HttpRouter } from "effect/unstable/http"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { Instance } from "../../src/project/instance"
+import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
 import { Server } from "../../src/server/server"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -33,7 +35,27 @@ function app(backend: Backend, input?: { password?: string; username?: string })
   Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = backend === "httpapi"
   Flag.OPENCODE_SERVER_PASSWORD = input?.password
   Flag.OPENCODE_SERVER_USERNAME = input?.username
-  return backend === "httpapi" ? Server.Default().app : Server.Legacy().app
+  if (backend === "legacy") return Server.Legacy().app
+
+  const handler = HttpRouter.toWebHandler(
+    ExperimentalHttpApiServer.routes.pipe(
+      Layer.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            OPENCODE_SERVER_PASSWORD: input?.password,
+            OPENCODE_SERVER_USERNAME: input?.username,
+          }),
+        ),
+      ),
+    ),
+    { disableLogger: true },
+  ).handler
+  return {
+    fetch: (request: Request) => handler(request, ExperimentalHttpApiServer.context),
+    request(input: string | URL | Request, init?: RequestInit) {
+      return this.fetch(input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init))
+    },
+  }
 }
 
 function client(
@@ -123,7 +145,7 @@ function firstEvent(open: () => Promise<{ stream: AsyncIterator<unknown> }>) {
 }
 
 function record(value: unknown) {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+  return value && typeof value === "object" && !Array.isArray(value) ? Object.fromEntries(Object.entries(value)) : {}
 }
 
 function array(value: unknown) {


### PR DESCRIPTION
## Summary
- Add a reusable `ConfigService.Service` helper that turns Effect `Config` definitions into a typed Context service with generated `defaultLayer` and test `layer(...)` helpers.
- Define `ServerAuthConfig` with the new helper so env var names/defaults live in one Effect Config definition.
- Update authorization tests to provide typed auth config directly instead of mutating `Flag` or constructing env-shaped config providers.

## Tests
- `bunx prettier --write packages/opencode/src/effect/config-service.ts packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts packages/opencode/src/server/routes/instance/httpapi/server.ts packages/opencode/test/server/httpapi-authorization.test.ts`
- `bunx oxlint packages/opencode/src/effect/config-service.ts packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts packages/opencode/src/server/routes/instance/httpapi/server.ts packages/opencode/test/server/httpapi-authorization.test.ts`
- `bun typecheck` from `packages/opencode`
- `bun run test -- test/server/httpapi-authorization.test.ts`
- `bun run test -- test/server/httpapi-authorization.test.ts test/server/httpapi-instance-context.test.ts test/server/httpapi-workspace-routing.test.ts test/server/workspace-proxy.test.ts`
- push hook: `bun turbo typecheck`