### PR TITLE
test: cover ConfigService helper

### DIFF
--- a/packages/opencode/test/effect/config-service.test.ts
+++ b/packages/opencode/test/effect/config-service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import { Config, ConfigProvider, Context, Effect, Layer, Option } from "effect"
+import { ConfigService } from "../../src/effect/config-service"
+
+class TestConfig extends ConfigService.Service<TestConfig>()("@test/ConfigService", {
+  name: Config.string("NAME"),
+  token: Config.string("TOKEN").pipe(Config.option),
+  port: Config.number("PORT").pipe(Config.withDefault(3000)),
+}) {}
+
+const fromConfig = (input: Record<string, unknown>) =>
+  TestConfig.defaultLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(input))))
+
+const readConfig = TestConfig.useSync((config) => config)
+
+describe("ConfigService", () => {
+  test("defaultLayer parses values from the active ConfigProvider", async () => {
+    const config = await Effect.runPromise(
+      readConfig.pipe(
+        Effect.provide(
+          fromConfig({
+            NAME: "kit",
+            TOKEN: "secret",
+            PORT: "4096",
+          }),
+        ),
+      ),
+    )
+
+    expect(config.name).toBe("kit")
+    expect(config.token).toEqual(Option.some("secret"))
+    expect(config.port).toBe(4096)
+  })
+
+  test("defaultLayer applies Effect Config defaults", async () => {
+    const config = await Effect.runPromise(readConfig.pipe(Effect.provide(fromConfig({ NAME: "kit" }))))
+
+    expect(config.name).toBe("kit")
+    expect(config.token).toEqual(Option.none())
+    expect(config.port).toBe(3000)
+  })
+
+  test("layer provides an already parsed service value", async () => {
+    const config = await Effect.runPromise(
+      readConfig.pipe(
+        Effect.provide(
+          TestConfig.layer({
+            name: "direct",
+            token: Option.some("parsed"),
+            port: 9000,
+          }),
+        ),
+      ),
+    )
+
+    expect(config).toEqual({
+      name: "direct",
+      token: Option.some("parsed"),
+      port: 9000,
+    } satisfies Context.Service.Shape<typeof TestConfig>)
+  })
+})

--- a/packages/opencode/test/effect/config-service.test.ts
+++ b/packages/opencode/test/effect/config-service.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect } from "bun:test"
 import { Config, ConfigProvider, Context, Effect, Layer, Option } from "effect"
 import { ConfigService } from "../../src/effect/config-service"
+import { it } from "../lib/effect"
 
 class TestConfig extends ConfigService.Service<TestConfig>()("@test/ConfigService", {
   name: Config.string("NAME"),
@@ -14,9 +15,9 @@ const fromConfig = (input: Record<string, unknown>) =>
 const readConfig = TestConfig.useSync((config) => config)
 
 describe("ConfigService", () => {
-  test("defaultLayer parses values from the active ConfigProvider", async () => {
-    const config = await Effect.runPromise(
-      readConfig.pipe(
+  it.effect("defaultLayer parses values from the active ConfigProvider", () =>
+    Effect.gen(function* () {
+      const config = yield* readConfig.pipe(
         Effect.provide(
           fromConfig({
             NAME: "kit",
@@ -24,25 +25,27 @@ describe("ConfigService", () => {
             PORT: "4096",
           }),
         ),
-      ),
-    )
+      )
 
-    expect(config.name).toBe("kit")
-    expect(config.token).toEqual(Option.some("secret"))
-    expect(config.port).toBe(4096)
-  })
+      expect(config.name).toBe("kit")
+      expect(config.token).toEqual(Option.some("secret"))
+      expect(config.port).toBe(4096)
+    }),
+  )
 
-  test("defaultLayer applies Effect Config defaults", async () => {
-    const config = await Effect.runPromise(readConfig.pipe(Effect.provide(fromConfig({ NAME: "kit" }))))
+  it.effect("defaultLayer applies Effect Config defaults", () =>
+    Effect.gen(function* () {
+      const config = yield* readConfig.pipe(Effect.provide(fromConfig({ NAME: "kit" })))
 
-    expect(config.name).toBe("kit")
-    expect(config.token).toEqual(Option.none())
-    expect(config.port).toBe(3000)
-  })
+      expect(config.name).toBe("kit")
+      expect(config.token).toEqual(Option.none())
+      expect(config.port).toBe(3000)
+    }),
+  )
 
-  test("layer provides an already parsed service value", async () => {
-    const config = await Effect.runPromise(
-      readConfig.pipe(
+  it.effect("layer provides an already parsed service value", () =>
+    Effect.gen(function* () {
+      const config = yield* readConfig.pipe(
         Effect.provide(
           TestConfig.layer({
             name: "direct",
@@ -50,13 +53,13 @@ describe("ConfigService", () => {
             port: 9000,
           }),
         ),
-      ),
-    )
+      )
 
-    expect(config).toEqual({
-      name: "direct",
-      token: Option.some("parsed"),
-      port: 9000,
-    } satisfies Context.Service.Shape<typeof TestConfig>)
-  })
+      expect(config).toEqual({
+        name: "direct",
+        token: Option.some("parsed"),
+        port: 9000,
+      } satisfies Context.Service.Shape<typeof TestConfig>)
+    }),
+  )
 })


### PR DESCRIPTION
## Summary
- Add focused tests for `ConfigService.Service` default config parsing and direct test-layer provisioning.
- Verify Effect `Config` defaults apply and `Config.option` remains an `Option` in the generated service shape.

## Tests
- `bunx prettier --write packages/opencode/test/effect/config-service.test.ts`
- `bunx oxlint packages/opencode/test/effect/config-service.test.ts`
- `bun typecheck` from `packages/opencode`
- `bun run test -- test/effect/config-service.test.ts`
- push hook: `bun turbo typecheck`

## Follow-up Candidates
- `server/backend.ts`: small `OPENCODE_EXPERIMENTAL_HTTPAPI` boolean config service for backend selection tests.
- `server/workspace.ts` / HttpApi workspace routing: centralize `OPENCODE_WORKSPACE_ID` as typed config.
- `tool/bash.ts`: move bash timeout/env-related flags into a typed config service where runtime/test overrides are useful.