### PR TITLE
fix(skill): require clear skill matches

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -69,7 +69,9 @@ export const layer = Layer.effect(
 
         return [
           "Skills provide specialized instructions and workflows for specific tasks.",
-          "Use the skill tool to load a skill when a task matches its description.",
+          "Use the skill tool when the user explicitly asks for a skill, or when the task clearly matches the skill's named domain and description.",
+          "For repository- or domain-specific skills, the task must be about that repository or domain.",
+          "Do not load a skill based only on generic workflow overlap, command names, or tool names in the skill description.",
           // the agents seem to ingest the information about skills a bit better if we present a more verbose
           // version of them here and a less verbose version in tool description, rather than vice versa.
           Skill.fmt(list, { verbose: true }),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -248,14 +248,16 @@ export const layer: Layer.Layer<
       return [
         "Load a specialized skill that provides domain-specific instructions and workflows.",
         "",
-        "When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.",
+        "Use this tool when the user explicitly asks for a skill, or when the task clearly matches the skill's named domain and description.",
+        "For repository- or domain-specific skills, the task must be about that repository or domain.",
+        "Do not load a skill based only on generic workflow overlap, command names, or tool names in the skill description.",
         "",
         "The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.",
         "",
         'Tool output includes a `<skill_content name="...">` block with the loaded content.',
         "",
         "The following skills provide specialized sets of instructions for particular tasks",
-        "Invoke this tool to load a skill when a task matches one of the available skills listed below:",
+        "Invoke this tool only for a clear skill match from the list below:",
         "",
         Skill.fmt(list, { verbose: false }),
       ].join("\n")

--- a/packages/opencode/src/tool/skill.txt
+++ b/packages/opencode/src/tool/skill.txt
@@ -1,4 +1,8 @@
-Load a specialized skill when the task at hand matches one of the skills listed in the system prompt.
+Load a specialized skill when the user explicitly asks for it, or when the task clearly matches one of the skills listed in the system prompt.
+
+For repository- or domain-specific skills, the task must be about that repository or domain.
+
+Do not load a skill based only on generic workflow overlap, command names, or tool names in the skill description.
 
 Use this tool to inject the skill's instructions and resources into current conversation. The output may contain detailed workflow guidance as well as references to scripts, files, etc in the same directory as the skill.
 


### PR DESCRIPTION
### Issue for this PR

Closes #25043

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Tightens the skill-loading guidance so repo- or domain-specific skills are only loaded when the task is actually about that repository/domain, or when the user explicitly asks for the skill.

This prevents generic workflow terms like `codex review` or `review loops` from being enough to load an unrelated repository-specific skill. The change is intentionally limited to the guidance surfaces used for model skill selection; opencode does not currently have deterministic semantic skill applicability filtering to unit test.

### How did you verify your code works?

```sh
bun test test/session/system.test.ts test/tool/skill.test.ts
bun typecheck
codex review --base origin/dev
```

Manual desktop check: with the OpenClaw dev-loop skill available, the generic `codex review --base origin/dev` prompt no longer loaded that skill.

Pre-push hook also ran `bun turbo typecheck` successfully.

### Screenshots / recordings

N/A. No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
