### PR TITLE
test: use Effect test helper for app runtime logger

### DIFF
--- a/packages/opencode/test/effect/app-runtime-logger.test.ts
+++ b/packages/opencode/test/effect/app-runtime-logger.test.ts
@@ -1,12 +1,15 @@
-import { expect, test } from "bun:test"
+import { expect } from "bun:test"
 import { Context, Effect, Layer, Logger } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
 import { makeRuntime } from "../../src/effect/run-service"
-import { Instance } from "../../src/project/instance"
-import { tmpdir } from "../fixture/fixture"
+import { provideInstance, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(CrossSpawnSpawner.defaultLayer)
 
 function check(loggers: ReadonlySet<Logger.Logger<unknown, any>>) {
   return {
@@ -17,56 +20,58 @@ function check(loggers: ReadonlySet<Logger.Logger<unknown, any>>) {
   }
 }
 
-test("makeRuntime installs EffectLogger through Observability.layer", async () => {
-  class Dummy extends Context.Service<Dummy, { readonly current: () => Effect.Effect<ReturnType<typeof check>> }>()(
-    "@test/Dummy",
-  ) {}
+it.live("makeRuntime installs EffectLogger through Observability.layer", () =>
+  Effect.gen(function* () {
+    class Dummy extends Context.Service<Dummy, { readonly current: () => Effect.Effect<ReturnType<typeof check>> }>()(
+      "@test/Dummy",
+    ) {}
 
-  const layer = Layer.effect(
-    Dummy,
-    Effect.gen(function* () {
-      return Dummy.of({
-        current: () => Effect.map(Effect.service(Logger.CurrentLoggers), check),
-      })
-    }),
-  )
+    const layer = Layer.effect(
+      Dummy,
+      Effect.gen(function* () {
+        return Dummy.of({
+          current: () => Effect.map(Effect.service(Logger.CurrentLoggers), check),
+        })
+      }),
+    )
 
-  const rt = makeRuntime(Dummy, layer)
-  const current = await rt.runPromise((svc) => svc.current())
+    const current = yield* Effect.promise(() => makeRuntime(Dummy, layer).runPromise((svc) => svc.current()))
 
-  expect(current.effectLogger).toBe(true)
-  expect(current.defaultLogger).toBe(false)
-})
+    expect(current.effectLogger).toBe(true)
+    expect(current.defaultLogger).toBe(false)
+  }),
+)
 
-test("AppRuntime also installs EffectLogger through Observability.layer", async () => {
-  const current = await AppRuntime.runPromise(Effect.map(Effect.service(Logger.CurrentLoggers), check))
+it.live("AppRuntime also installs EffectLogger through Observability.layer", () =>
+  Effect.gen(function* () {
+    const current = yield* Effect.promise(() =>
+      AppRuntime.runPromise(Effect.map(Effect.service(Logger.CurrentLoggers), check)),
+    )
 
-  expect(current.effectLogger).toBe(true)
-  expect(current.defaultLogger).toBe(false)
-})
+    expect(current.effectLogger).toBe(true)
+    expect(current.defaultLogger).toBe(false)
+  }),
+)
 
-test("AppRuntime attaches InstanceRef from ALS", async () => {
-  await using tmp = await tmpdir({ git: true })
-
-  const dir = await Instance.provide({
-    directory: tmp.path,
-    fn: () =>
+it.live("AppRuntime attaches InstanceRef from ALS", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const current = yield* Effect.promise(() =>
       AppRuntime.runPromise(
         Effect.gen(function* () {
           return (yield* InstanceRef)?.directory
         }),
       ),
-  })
+    ).pipe(provideInstance(dir))
 
-  expect(dir).toBe(tmp.path)
-})
+    expect(current).toBe(dir)
+  }),
+)
 
-test("EffectBridge preserves logger and instance context across async boundaries", async () => {
-  await using tmp = await tmpdir({ git: true })
-
-  const result = await Instance.provide({
-    directory: tmp.path,
-    fn: () =>
+it.live("EffectBridge preserves logger and instance context across async boundaries", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const result = yield* Effect.promise(() =>
       AppRuntime.runPromise(
         Effect.gen(function* () {
           const bridge = yield* EffectBridge.make()
@@ -84,9 +89,10 @@ test("EffectBridge preserves logger and instance context across async boundaries
           )
         }),
       ),
-  })
+    ).pipe(provideInstance(dir))
 
-  expect(result.directory).toBe(tmp.path)
-  expect(result.effectLogger).toBe(true)
-  expect(result.defaultLogger).toBe(false)
-})
+    expect(result.directory).toBe(dir)
+    expect(result.effectLogger).toBe(true)
+    expect(result.defaultLogger).toBe(false)
+  }),
+)


### PR DESCRIPTION
## Summary
- Convert app runtime logger tests to `it.live`
- Use scoped temp directories and `provideInstance` for InstanceRef/bridge coverage

## Tests
- `bunx prettier --write test/effect/app-runtime-logger.test.ts`
- `bunx oxlint packages/opencode/test/effect/app-runtime-logger.test.ts`
- `bun typecheck`
- `bun run test -- test/effect/app-runtime-logger.test.ts`