### PR TITLE
test: use testEffect for plugin workspace adaptor

### DIFF
--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -1,8 +1,10 @@
-import { afterAll, afterEach, describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { afterAll, afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import path from "path"
 import { pathToFileURL } from "url"
-import { tmpdir } from "../fixture/fixture"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
 const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
 process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
@@ -11,6 +13,7 @@ const { Flag } = await import("@opencode-ai/core/flag/flag")
 const { Plugin } = await import("../../src/plugin/index")
 const { Workspace } = await import("../../src/control-plane/workspace")
 const { Instance } = await import("../../src/project/instance")
+const it = testEffect(Layer.mergeAll(Plugin.defaultLayer, CrossSpawnSpawner.defaultLayer))
 
 const experimental = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
 
@@ -31,79 +34,77 @@ afterAll(() => {
 })
 
 describe("plugin.workspace", () => {
-  test("plugin can install a workspace adaptor", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
+  it.live("plugin can install a workspace adaptor", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
         const type = `plug-${Math.random().toString(36).slice(2)}`
         const file = path.join(dir, "plugin.ts")
         const mark = path.join(dir, "created.json")
         const space = path.join(dir, "space")
-        await Bun.write(
-          file,
-          [
-            "export default async ({ experimental_workspace }) => {",
-            `  experimental_workspace.register(${JSON.stringify(type)}, {`,
-            '    name: "plug",',
-            '    description: "plugin workspace adaptor",',
-            "    configure(input) {",
-            `      return { ...input, name: "plug", branch: "plug/main", directory: ${JSON.stringify(space)} }`,
-            "    },",
-            "    async create(input) {",
-            `      await Bun.write(${JSON.stringify(mark)}, JSON.stringify(input))`,
-            "    },",
-            "    async remove() {},",
-            "    target(input) {",
-            '      return { type: "local", directory: input.directory }',
-            "    },",
-            "  })",
-            "  return {}",
-            "}",
-            "",
-          ].join("\n"),
-        )
-
-        await Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify(
-            {
-              $schema: "https://opencode.ai/config.json",
-              plugin: [pathToFileURL(file).href],
-            },
-            null,
-            2,
+        yield* Effect.promise(() =>
+          Bun.write(
+            file,
+            [
+              "export default async ({ experimental_workspace }) => {",
+              `  experimental_workspace.register(${JSON.stringify(type)}, {`,
+              '    name: "plug",',
+              '    description: "plugin workspace adaptor",',
+              "    configure(input) {",
+              `      return { ...input, name: "plug", branch: "plug/main", directory: ${JSON.stringify(space)} }`,
+              "    },",
+              "    async create(input) {",
+              `      await Bun.write(${JSON.stringify(mark)}, JSON.stringify(input))`,
+              "    },",
+              "    async remove() {},",
+              "    target(input) {",
+              '      return { type: "local", directory: input.directory }',
+              "    },",
+              "  })",
+              "  return {}",
+              "}",
+              "",
+            ].join("\n"),
           ),
         )
 
-        return { mark, space, type }
-      },
-    })
+        yield* Effect.promise(() =>
+          Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify(
+              {
+                $schema: "https://opencode.ai/config.json",
+                plugin: [pathToFileURL(file).href],
+              },
+              null,
+              2,
+            ),
+          ),
+        )
 
-    const info = await Instance.provide({
-      directory: tmp.path,
-      fn: async () =>
-        Effect.gen(function* () {
-          const plugin = yield* Plugin.Service
-          yield* plugin.init()
-          return Workspace.create({
-            type: tmp.extra.type,
+        const plugin = yield* Plugin.Service
+        yield* plugin.init()
+        const info = yield* Effect.promise(() =>
+          Workspace.create({
+            type,
             branch: null,
             extra: { key: "value" },
             projectID: Instance.project.id,
-          })
-        }).pipe(Effect.provide(Plugin.defaultLayer), Effect.runPromise),
-    })
+          }),
+        )
 
-    expect(info.type).toBe(tmp.extra.type)
-    expect(info.name).toBe("plug")
-    expect(info.branch).toBe("plug/main")
-    expect(info.directory).toBe(tmp.extra.space)
-    expect(info.extra).toEqual({ key: "value" })
-    expect(JSON.parse(await Bun.file(tmp.extra.mark).text())).toMatchObject({
-      type: tmp.extra.type,
-      name: "plug",
-      branch: "plug/main",
-      directory: tmp.extra.space,
-      extra: { key: "value" },
-    })
-  })
+        expect(info.type).toBe(type)
+        expect(info.name).toBe("plug")
+        expect(info.branch).toBe("plug/main")
+        expect(info.directory).toBe(space)
+        expect(info.extra).toEqual({ key: "value" })
+        expect(JSON.parse(yield* Effect.promise(() => Bun.file(mark).text()))).toMatchObject({
+          type,
+          name: "plug",
+          branch: "plug/main",
+          directory: space,
+          extra: { key: "value" },
+        })
+      }),
+    ),
+  )
 })


### PR DESCRIPTION
## Summary
- Convert the plugin workspace adaptor test to `it.live`
- Use scoped temp directories and the test Effect runtime instead of `Instance.provide` plus `Effect.runPromise`

## Tests
- `bunx prettier --write test/plugin/workspace-adaptor.test.ts`
- `bunx oxlint packages/opencode/test/plugin/workspace-adaptor.test.ts`
- `bun typecheck`
- `bun run test -- test/plugin/workspace-adaptor.test.ts`