### PR TITLE
fix app crash restoring messages without model

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -382,7 +382,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           setSaved("session", session, {
             agent: msg.agent,
             model: msg.model,
-            variant: msg.model.variant ?? null,
+            variant: msg.model?.variant ?? null,
           })
         },
       },


### PR DESCRIPTION
## Summary
- Avoid crashing when restoring session model state from old user messages that do not include a model field.
- Preserve the existing default/no-variant behavior by storing `null` for the variant when the model is missing.

## Verification
- `bun typecheck` from `packages/app`
- `bun test --preload ./happydom.ts ./src/context/model-variant.test.ts ./src/pages/session/session-model-helpers.test.ts ./src/components/prompt-input/submit.test.ts` from `packages/app`