### PR TITLE
fix(provider): auto-enable interleaved reasoning for Kimi K2.6 models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1201,7 +1201,7 @@ const layer: Layer.Layer<
                 interleaved:
                   model.interleaved ??
                   existingModel?.capabilities.interleaved ??
-                  (!existingModel && apiNpm === "@ai-sdk/openai-compatible" && apiID.includes("deepseek")
+                  (!existingModel && apiNpm === "@ai-sdk/openai-compatible" && (apiID.includes("deepseek") || apiID.includes("kimi-k2"))
                     ? { field: "reasoning_content" }
                     : false),
               },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -312,6 +312,46 @@ test("custom provider with npm package", async () => {
   })
 })
 
+test("custom Kimi openai-compatible model defaults interleaved reasoning field", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-provider": {
+              name: "Custom Provider",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://api.custom.com/v1",
+              models: {
+                "kimi-k2.6": {
+                  name: "Kimi K2.6",
+                },
+                "kimi-k2.5": {
+                  name: "Kimi K2.5",
+                },
+              },
+              options: {
+                apiKey: "custom-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const provider = providers[ProviderID.make("custom-provider")]
+      expect(provider.models["kimi-k2.6"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
+      expect(provider.models["kimi-k2.5"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
+    },
+  })
+})
+
 test("custom DeepSeek openai-compatible model defaults interleaved reasoning field", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -11544,6 +11544,23 @@
         "cost": { "input": 0.6, "output": 3, "cache_read": 0.08 },
         "limit": { "context": 262144, "output": 65536 }
       },
+      "kimi-k2.6": {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "family": "kimi",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": { "field": "reasoning_content" },
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-03-15",
+        "last_updated": "2026-03-15",
+        "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+        "open_weights": true,
+        "cost": { "input": 0.32, "output": 1.34, "cache_read": 0.054 },
+        "limit": { "context": 262144, "output": 65536 }
+      },
       "mimo-v2-omni-free": {
         "id": "mimo-v2-omni-free",
         "name": "MiMo V2 Omni Free",
@@ -64090,6 +64107,23 @@
         "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
         "open_weights": true,
         "cost": { "input": 0.6, "output": 3, "cache_read": 0.1 },
+        "limit": { "context": 262144, "output": 65536 }
+      },
+      "kimi-k2.6": {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "family": "kimi",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": { "field": "reasoning_content" },
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-03-15",
+        "last_updated": "2026-03-15",
+        "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+        "open_weights": true,
+        "cost": { "input": 0.32, "output": 1.34, "cache_read": 0.054 },
         "limit": { "context": 262144, "output": 65536 }
       },
       "minimax-m2.7": {


### PR DESCRIPTION
### Issue for this PR

Closes #20427
Closes #24722
Closes #23646

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When using Kimi K2.6 (and other kimi-k2 models) through OpenCode's Zen or Go providers, the model configuration was missing the `interleaved` capability that tells OpenCode to preserve `reasoning_content` in conversation history.

Without this, multi-turn tool-use conversations fail with Moonshot returning:
> "thinking is enabled but reasoning_content is missing in assistant tool call message at index N"

This PR:
1. Auto-detects interleaved reasoning for Kimi models using `@ai-sdk/openai-compatible` (same pattern as DeepSeek)
2. Adds missing `kimi-k2.6` entries to `models-api.json` for `opencode` (Zen) and `opencode-go` providers

### How did you verify your code works?

- Added test in `provider.test.ts` verifying custom Kimi models get `interleaved: { field: "reasoning_content" }` automatically
- Manually verified model configuration structure matches existing `kimi-k2.5` entries
- Inspected `ProviderTransform.message()` logic confirms interleaved field triggers `reasoning_content` preservation on assistant messages

### Screenshots / recordings

N/A - This is a backend/provider fix, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR