### PR TITLE
feat(httpapi): add CORS middleware to instance routes

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -55,6 +55,7 @@ import { workspaceRouterMiddleware, workspaceRoutingLayer } from "./middleware/w
 import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import * as ServerBackend from "@/server/backend"
+import type { Predicate } from "effect/Predicate"
 
 export const context = Context.makeUnsafe<unknown>(new Map())
 
@@ -104,6 +105,23 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
 )
 
 export const routes = Layer.mergeAll(rootApiRoutes, instanceRoutes).pipe(
+  Layer.provide(
+    HttpRouter.cors({
+      maxAge: 86_400,
+      allowedOrigins: ((input) => {
+        return (
+          !input ||
+          input.startsWith("http://localhost:") ||
+          input.startsWith("http://127.0.0.1:") ||
+          input.startsWith("oc://renderer") ||
+          input === "tauri://localhost" ||
+          input === "http://tauri.localhost" ||
+          input === "https://tauri.localhost" ||
+          /^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(input)
+        )
+      }) as Predicate<string> as any,
+    }),
+  ),
   Layer.provide([
     runtime,
     Account.defaultLayer,


### PR DESCRIPTION
Adds CORS middleware to HTTP API instance routes with support for:
- Localhost origins (http://localhost:*, http://127.0.0.1:*)
- Tauri origins (oc://renderer, tauri://localhost, http://tauri.localhost, https://tauri.localhost)
- opencode.ai subdomains