### PR TITLE
fix: invert *_ready getters to fix server status indicator

### DIFF
--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -187,7 +187,7 @@ export function createChildStoreManager(input: {
             projectMeta: initialMeta,
             icon: initialIcon,
             get provider_ready() {
-              return providerQuery.isLoading
+              return !providerQuery.isLoading
             },
             provider: { all: [], connected: [], default: {} },
             config: {},
@@ -207,13 +207,13 @@ export function createChildStoreManager(input: {
             permission: {},
             question: {},
             get mcp_ready() {
-              return mcpQuery.isLoading
+              return !mcpQuery.isLoading
             },
             get mcp() {
               return mcpQuery.isLoading ? {} : (mcpQuery.data ?? {})
             },
             get lsp_ready() {
-              return lspQuery.isLoading
+              return !lspQuery.isLoading
             },
             get lsp() {
               return lspQuery.isLoading ? [] : (lspQuery.data ?? [])


### PR DESCRIPTION
## Summary
The server status indicator dot in the top bar was always grey instead of green because the `*_ready` getters (`mcp_ready`, `provider_ready`, `lsp_ready`) in `child-store.ts` were returning `query.isLoading` instead of `!query.isLoading`.

Since TanStack Query's `isLoading` is `true` during fetching and `false` once data is available, these getters were semantically inverted — "ready" was `true` only while loading and `false` after data arrived.

## Changes
- Invert `provider_ready`, `mcp_ready`, and `lsp_ready` getters to return `!query.isLoading`