### PR TITLE
feat(copilot): add auto model support

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/auto-model.ts
+++ b/packages/opencode/src/plugin/github-copilot/auto-model.ts
@@ -1,0 +1,176 @@
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import { Global } from "@opencode-ai/core/global"
+import * as Log from "@opencode-ai/core/util/log"
+import path from "path"
+
+const log = Log.create({ service: "plugin.copilot.auto-model" })
+
+type CopilotTokenEnvelope = {
+  token: string
+  endpoints?: {
+    api?: string
+    proxy?: string
+    telemetry?: string
+  }
+  expires_at: number
+}
+
+type AutoSession = {
+  available_models: string[]
+  selected_model: string
+  session_token: string
+  expires_at: number
+  discounted_costs?: Record<string, number>
+}
+
+const CAPI_HEADERS: Record<string, string> = {
+  "X-GitHub-Api-Version": "2026-01-09",
+  "Editor-Plugin-Version": "copilot-chat/0.27.0",
+  "Editor-Version": "vscode/1.99.0",
+  "Copilot-Integration-Id": "vscode-chat",
+  "User-Agent": `opencode/${InstallationVersion}`,
+  Accept: "application/json",
+}
+
+const TOKEN_REFRESH_MARGIN_MS = 60_000
+
+export class AutoModelResolver {
+  private copilotToken: CopilotTokenEnvelope | undefined
+  private autoSession: AutoSession | undefined
+  private inflightToken: Promise<CopilotTokenEnvelope> | undefined
+  private inflightSession:
+    | Promise<{ session: AutoSession; apiBaseUrl: string; authToken: string }>
+    | undefined
+
+  constructor(private oauthToken: string, private baseUrl: string) {}
+
+  async resolve(): Promise<{ model: string; sessionToken: string; authToken: string; apiBaseUrl: string }> {
+    const { session, apiBaseUrl, authToken } = await this.getAutoSession()
+    const model = session.selected_model
+    if (!model) throw new Error("Auto mode returned no selected model")
+    return { model, sessionToken: session.session_token, authToken, apiBaseUrl }
+  }
+
+  private async getCopilotToken(): Promise<CopilotTokenEnvelope> {
+    if (this.copilotToken && this.copilotToken.expires_at * 1000 > Date.now() + TOKEN_REFRESH_MARGIN_MS) {
+      return this.copilotToken
+    }
+
+    if (this.inflightToken) return this.inflightToken
+
+    this.inflightToken = this.fetchCopilotToken().finally(() => {
+      this.inflightToken = undefined
+    })
+
+    return this.inflightToken
+  }
+
+  private async getAutoSession(): Promise<{ session: AutoSession; apiBaseUrl: string; authToken: string }> {
+    if (this.autoSession && this.autoSession.expires_at * 1000 > Date.now() + TOKEN_REFRESH_MARGIN_MS) {
+      const copilotToken = await this.getCopilotToken()
+      const apiBaseUrl = copilotToken.endpoints?.api?.replace(/\/+$/, "") ?? this.baseUrl
+      return { session: this.autoSession, apiBaseUrl, authToken: copilotToken.token }
+    }
+
+    if (this.inflightSession) return this.inflightSession
+
+    this.inflightSession = this.fetchAutoSession().finally(() => {
+      this.inflightSession = undefined
+    })
+
+    return this.inflightSession
+  }
+
+  private async fetchCopilotToken(): Promise<CopilotTokenEnvelope> {
+    const primary = await fetchCopilotTokenWithOauth(this.oauthToken).catch((err) => {
+      log.debug("copilot_internal token exchange failed", { error: err })
+      return undefined
+    })
+    if (primary) {
+      this.copilotToken = primary
+      log.info("copilot token obtained", { hasEndpoints: !!primary.endpoints })
+      return primary
+    }
+
+    const fallback = await readFallbackOauthToken().catch((err) => {
+      log.debug("failed to read fallback oauth token", { error: err })
+      return undefined
+    })
+
+    if (!fallback || fallback === this.oauthToken) {
+      throw new Error("copilot_internal/v2/token unavailable for this OAuth token")
+    }
+
+    const viaFallback = await fetchCopilotTokenWithOauth(fallback)
+    this.copilotToken = viaFallback
+    log.info("copilot token obtained via fallback oauth", { hasEndpoints: !!viaFallback.endpoints })
+    return viaFallback
+  }
+
+  private async fetchAutoSession(): Promise<{ session: AutoSession; apiBaseUrl: string; authToken: string }> {
+    const copilotToken = await this.getCopilotToken()
+    const apiUrl = copilotToken.endpoints?.api?.replace(/\/+$/, "") ?? this.baseUrl
+
+    const res = await fetch(`${apiUrl}/models/session`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${copilotToken.token}`,
+        ...CAPI_HEADERS,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ auto_mode: { model_hints: ["auto"] } }),
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      throw new Error(`/models/session failed: ${res.status} ${text}`)
+    }
+
+    const data = (await res.json()) as AutoSession
+    if (!Array.isArray(data.available_models) || data.available_models.length === 0) {
+      throw new Error("/models/session returned no available models")
+    }
+
+    this.autoSession = data
+    log.info("auto session obtained", { selected: data.selected_model, models: data.available_models.slice(0, 5) })
+    return { session: data, apiBaseUrl: apiUrl, authToken: copilotToken.token }
+  }
+}
+
+async function fetchCopilotTokenWithOauth(oauthToken: string): Promise<CopilotTokenEnvelope> {
+  const res = await fetch("https://api.github.com/copilot_internal/v2/token", {
+    headers: {
+      Authorization: `token ${oauthToken}`,
+      ...CAPI_HEADERS,
+    },
+    signal: AbortSignal.timeout(10_000),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "")
+    throw new Error(`copilot_internal/v2/token failed: ${res.status} ${text}`)
+  }
+
+  const data = (await res.json()) as CopilotTokenEnvelope
+  if (typeof data.token !== "string" || !data.token) {
+    throw new Error("copilot_internal/v2/token missing token field")
+  }
+
+  return data
+}
+
+async function readFallbackOauthToken(): Promise<string | undefined> {
+  const authFile = path.join(Global.Path.data, "auth.json")
+  const json = (await Bun.file(authFile).json()) as Record<string, unknown>
+  const info = json["copilot"]
+  if (!isOauthInfo(info)) return undefined
+  return info.refresh
+}
+
+function isOauthInfo(value: unknown): value is { type: "oauth"; refresh: string } {
+  if (!value || typeof value !== "object") return false
+  const record = value as Record<string, unknown>
+  if (record.type !== "oauth") return false
+  return typeof record.refresh === "string" && record.refresh.length > 0
+}

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -5,8 +5,8 @@ import { iife } from "@/util/iife"
 import * as Log from "@opencode-ai/core/util/log"
 import { setTimeout as sleep } from "node:timers/promises"
 import { CopilotModels } from "./models"
+import { AutoModelResolver } from "./auto-model"
 import { MessageV2 } from "@/session/message-v2"
-
 const log = Log.create({ service: "plugin.copilot" })
 
 const CLIENT_ID = "Ov23li8tweQw6odWQebz"
@@ -61,12 +61,29 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
       id: "github-copilot",
       async models(provider, ctx) {
         if (ctx.auth?.type !== "oauth") {
-          return Object.fromEntries(Object.entries(provider.models).map(([id, model]) => [id, fix(model, base())]))
+          const result = Object.fromEntries(Object.entries(provider.models).map(([id, model]) => [id, fix(model, base())]))
+          result["auto"] = {
+            id: "auto",
+            providerID: "github-copilot",
+            api: { id: "auto", url: base(), npm: "@ai-sdk/github-copilot" },
+            status: "active",
+            limit: { context: 128_000, input: 128_000, output: 16_384 },
+            capabilities: {
+              temperature: true, reasoning: true, attachment: true, toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: false },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            family: "auto", name: "Auto",
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            options: {}, headers: {},
+            release_date: "1970-01-01", variants: {},
+          }
+          return result
         }
-
         const auth = ctx.auth
 
-        return CopilotModels.get(
+        const resolved = await CopilotModels.get(
           base(auth.enterpriseUrl),
           {
             Authorization: `Bearer ${auth.refresh}`,
@@ -79,13 +96,45 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             Object.entries(provider.models).map(([id, model]) => [id, fix(model, base(auth.enterpriseUrl))]),
           )
         })
-      },
+
+        const copilotBase = base(auth.enterpriseUrl)
+        resolved["auto"] = {
+          id: "auto",
+          providerID: "github-copilot",
+          api: {
+            id: "auto",
+            url: copilotBase,
+            npm: "@ai-sdk/github-copilot",
+          },
+          status: "active",
+          limit: { context: 128_000, input: 128_000, output: 16_384 },
+          capabilities: {
+            temperature: true,
+            reasoning: true,
+            attachment: true,
+            toolcall: true,
+            input: { text: true, audio: false, image: true, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          family: "auto",
+          name: "Auto",
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          options: {},
+          headers: {},
+          release_date: "1970-01-01",
+          variants: {},
+        }
+
+        return resolved      },
     },
     auth: {
       provider: "github-copilot",
       async loader(getAuth) {
         const info = await getAuth()
         if (!info || info.type !== "oauth") return {}
+
+        const resolvers = new Map<string, AutoModelResolver>()
 
         return {
           apiKey: "",
@@ -94,9 +143,17 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             if (info.type !== "oauth") return fetch(request, init)
 
             const url = request instanceof URL ? request.href : typeof request === "string" ? request : request.url
+            const parsedBody = iife(() => {
+              try {
+                return typeof init?.body === "string" ? JSON.parse(init.body) : init?.body
+              } catch {
+                return undefined
+              }
+            })
+
             const { isVision, isAgent } = iife(() => {
               try {
-                const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body
+                const body = parsedBody
 
                 // Completions API
                 if (body?.messages && url.includes("completions")) {
@@ -159,16 +216,57 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
               headers["Copilot-Vision-Request"] = "true"
             }
 
+            // Auto model resolution: rewrite model "auto" → resolved model + session token
+            let rewrittenBody: string | undefined
+            if (parsedBody && typeof parsedBody === "object" && parsedBody.model === "auto") {
+              try {
+                const baseUrl = base(info.enterpriseUrl)
+                const resolverKey = `${info.refresh}:${baseUrl}`
+                let resolver = resolvers.get(resolverKey)
+                if (!resolver) {
+                  resolver = new AutoModelResolver(info.refresh, baseUrl)
+                  resolvers.set(resolverKey, resolver)
+                }
+
+                const { model, sessionToken, apiBaseUrl } = await resolver.resolve()
+                parsedBody.model = model
+                headers["Copilot-Session-Token"] = sessionToken
+                // Keep OAuth token for Authorization; the session token goes in Copilot-Session-Token.
+                // The Copilot Chat API authenticates via OAuth Bearer + optional session token —
+                // NOT via the copilot_internal/v2/token that was used to fetch the session.
+
+                const rewrittenUrl = iife(() => {
+                  try {
+                    const next = new URL(url)
+                    const base = new URL(apiBaseUrl)
+                    next.protocol = base.protocol
+                    next.host = base.host
+                    return next.href
+                  } catch {
+                    return undefined
+                  }
+                })
+                rewrittenBody = JSON.stringify(parsedBody)
+                log.info("auto model resolved", { model, hasSessionToken: !!sessionToken })
+
+                if (rewrittenUrl) {
+                  request = rewrittenUrl
+                }
+              } catch (err) {
+                log.error("auto model resolution failed, falling back to raw 'auto'", { error: err })
+              }
+            }
+
             delete headers["x-api-key"]
             delete headers["authorization"]
 
             return fetch(request, {
               ...init,
+              body: rewrittenBody ?? init?.body,
               headers,
             })
           },
-        }
-      },
+        }      },
       methods: [
         {
           type: "oauth",


### PR DESCRIPTION
## Summary
- Registers a virtual "auto" model in the GitHub Copilot provider's model picker
- Resolves the auto model at request time via the Copilot AutoModels endpoint (`/models/session`)
- Uses the backend's `selected_model` field (not `available_models[0]`) to get the server's actual pick
- Rewrites `model: "auto"` in the request body to the resolved model ID
- Injects `Copilot-Session-Token` header while preserving OAuth token for chat API auth
- Falls back to `ghu_` token from auth.json when the primary `gho_` token can't access `copilot_internal/v2/token`

## Files
- `packages/opencode/src/plugin/github-copilot/copilot.ts` — Virtual "auto" model registration + auth interceptor
- `packages/opencode/src/plugin/github-copilot/auto-model.ts` — `AutoModelResolver` class with token exchange and model resolution