### PR TITLE
feat: editable allow all

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -157,40 +157,20 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
   return (
     <Switch>
       <Match when={store.stage === "always"}>
-        <Prompt
-          title="Always allow"
-          body={
-            <Switch>
-              <Match when={props.request.always.length === 1 && props.request.always[0] === "*"}>
-                <TextBody title={"This will allow " + props.request.permission + " until OpenCode is restarted."} />
-              </Match>
-              <Match when={true}>
-                <box paddingLeft={1} gap={1}>
-                  <text fg={theme.textMuted}>This will allow the following patterns until OpenCode is restarted</text>
-                  <box>
-                    <For each={props.request.always}>
-                      {(pattern) => (
-                        <text fg={theme.text}>
-                          {"- "}
-                          {pattern}
-                        </text>
-                      )}
-                    </For>
-                  </box>
-                </box>
-              </Match>
-            </Switch>
-          }
-          options={{ confirm: "Confirm", cancel: "Cancel" }}
-          escapeKey="cancel"
-          onSelect={(option) => {
+        <AlwaysEditPrompt
+          initial={Array.from(props.request.always)}
+          permission={props.request.permission}
+          onConfirm={(patterns) => {
             setStore("stage", "permission")
-            if (option === "cancel") return
             void sdk.client.permission.reply({
               reply: "always",
               requestID: props.request.id,
               workspace: project.workspace.current(),
+              patterns: patterns.length > 0 ? patterns : undefined,
             })
+          }}
+          onCancel={() => {
+            setStore("stage", "permission")
           }}
         />
       </Match>
@@ -456,6 +436,97 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
         })()}
       </Match>
     </Switch>
+  )
+}
+
+function AlwaysEditPrompt(props: {
+  initial: string[]
+  permission: string
+  onConfirm: (patterns: string[]) => void
+  onCancel: () => void
+}) {
+  let input: TextareaRenderable
+  const { theme } = useTheme()
+  const keybind = useKeybind()
+  const textareaKeybindings = useTextareaKeybindings()
+  const dimensions = useTerminalDimensions()
+  const narrow = createMemo(() => dimensions().width < 80)
+  const dialog = useDialog()
+  const initialText = props.initial.join("\n")
+
+  useKeyboard((evt) => {
+    if (dialog.stack.length > 0) return
+
+    if (evt.name === "escape" || keybind.match("app_exit", evt)) {
+      evt.preventDefault()
+      props.onCancel()
+      return
+    }
+    if (evt.name === "return" && !evt.meta && !evt.shift) {
+      evt.preventDefault()
+      const patterns = input.plainText
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+      props.onConfirm(patterns)
+    }
+  })
+
+  return (
+    <box
+      backgroundColor={theme.backgroundPanel}
+      border={["left"]}
+      borderColor={theme.warning}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
+        <box flexDirection="row" gap={1} paddingLeft={1}>
+          <text fg={theme.warning}>{"△"}</text>
+          <text fg={theme.text}>Always allow</text>
+        </box>
+        <box paddingLeft={1}>
+          <text fg={theme.textMuted}>
+            {"Edit pattern(s) to allow for " + props.permission + " until OpenCode is restarted."}
+          </text>
+        </box>
+        <box paddingLeft={1}>
+          <text fg={theme.textMuted}>One pattern per line. Alt+Enter inserts a newline.</text>
+        </box>
+      </box>
+      <box
+        flexDirection={narrow() ? "column" : "row"}
+        flexShrink={0}
+        paddingTop={1}
+        paddingLeft={2}
+        paddingRight={3}
+        paddingBottom={1}
+        backgroundColor={theme.backgroundElement}
+        justifyContent={narrow() ? "flex-start" : "space-between"}
+        alignItems={narrow() ? "flex-start" : "center"}
+        gap={1}
+      >
+        <textarea
+          ref={(val: TextareaRenderable) => {
+            input = val
+            val.traits = { status: "ALWAYS" }
+          }}
+          initialValue={initialText}
+          focused
+          textColor={theme.text}
+          focusedTextColor={theme.text}
+          cursorColor={theme.primary}
+          keyBindings={textareaKeybindings()}
+        />
+        <box flexDirection="row" gap={2} flexShrink={0}>
+          <text fg={theme.text}>
+            enter <span style={{ fg: theme.textMuted }}>confirm</span>
+          </text>
+          <text fg={theme.text}>
+            esc <span style={{ fg: theme.textMuted }}>cancel</span>
+          </text>
+        </box>
+      </box>
+    </box>
   )
 }
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -60,6 +60,7 @@ export type Reply = Schema.Schema.Type<typeof Reply>
 const reply = {
   reply: Reply,
   message: Schema.optional(Schema.String),
+  patterns: Schema.optional(Schema.Array(Schema.String)),
 }
 
 export const ReplyBody = Schema.Struct(reply)
@@ -248,7 +249,10 @@ export const layer = Layer.effect(
       yield* Deferred.succeed(existing.deferred, undefined)
       if (input.reply === "once") return
 
-      for (const pattern of existing.info.always) {
+      const patternsToAllow =
+        input.patterns && input.patterns.length > 0 ? input.patterns : existing.info.always
+
+      for (const pattern of patternsToAllow) {
         approved.push({
           permission: existing.info.permission,
           pattern,

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
@@ -11,6 +11,7 @@ const root = "/permission"
 const ReplyPayload = Schema.Struct({
   reply: Permission.Reply,
   message: Schema.optional(Schema.String),
+  patterns: Schema.optional(Schema.Array(Schema.String)),
 })
 
 export const PermissionApi = HttpApi.make("permission")

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
@@ -20,6 +20,7 @@ export const permissionHandlers = HttpApiBuilder.group(InstanceHttpApi, "permiss
         requestID: ctx.params.requestID,
         reply: ctx.payload.reply,
         message: ctx.payload.message,
+        patterns: ctx.payload.patterns,
       })
       return true
     })

--- a/packages/opencode/src/server/routes/instance/permission.ts
+++ b/packages/opencode/src/server/routes/instance/permission.ts
@@ -33,7 +33,14 @@ export const PermissionRoutes = lazy(() =>
           requestID: PermissionID.zod,
         }),
       ),
-      validator("json", z.object({ reply: Permission.Reply.zod, message: z.string().optional() })),
+      validator(
+        "json",
+        z.object({
+          reply: Permission.Reply.zod,
+          message: z.string().optional(),
+          patterns: z.array(z.string()).optional(),
+        }),
+      ),
       async (c) =>
         jsonRequest("PermissionRoutes.reply", c, function* () {
           const params = c.req.valid("param")
@@ -43,6 +50,7 @@ export const PermissionRoutes = lazy(() =>
             requestID: params.requestID,
             reply: json.reply,
             message: json.message,
+            patterns: json.patterns,
           })
           return true
         }),

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -1122,3 +1122,85 @@ it.live("ask - abort should clear pending request", () =>
     if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Permission.RejectedError)
   }),
 )
+
+it.live("reply - always with custom patterns overrides server-suggested patterns", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const run = withProvided(dir)
+    const fiber = yield* ask({
+      id: PermissionID.make("per_custom1"),
+      sessionID: SessionID.make("session_custom"),
+      permission: "bash",
+      patterns: ["docker exec -it app_foo cat /etc/hosts"],
+      metadata: {},
+      always: ["docker *"],
+      ruleset: [],
+    }).pipe(run, Effect.forkScoped)
+
+    yield* waitForPending(1).pipe(run)
+    yield* reply({
+      requestID: PermissionID.make("per_custom1"),
+      reply: "always",
+      patterns: ["docker exec -it app_* cat *"],
+    }).pipe(run)
+    yield* Fiber.join(fiber)
+
+    const ok = yield* ask({
+      sessionID: SessionID.make("session_custom2"),
+      permission: "bash",
+      patterns: ["docker exec -it app_bar cat /etc/passwd"],
+      metadata: {},
+      always: [],
+      ruleset: [],
+    }).pipe(run)
+    expect(ok).toBeUndefined()
+
+    const fiber2 = yield* ask({
+      id: PermissionID.make("per_custom2"),
+      sessionID: SessionID.make("session_custom3"),
+      permission: "bash",
+      patterns: ["docker ps"],
+      metadata: {},
+      always: ["docker *"],
+      ruleset: [],
+    }).pipe(run, Effect.forkScoped)
+
+    yield* waitForPending(1).pipe(run)
+    yield* reply({ requestID: PermissionID.make("per_custom2"), reply: "reject" }).pipe(run)
+    yield* Fiber.await(fiber2)
+  }),
+)
+
+it.live("reply - always with empty custom patterns falls back to server-suggested", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const run = withProvided(dir)
+    const fiber = yield* ask({
+      id: PermissionID.make("per_custom3"),
+      sessionID: SessionID.make("session_fallback"),
+      permission: "bash",
+      patterns: ["ls"],
+      metadata: {},
+      always: ["ls"],
+      ruleset: [],
+    }).pipe(run, Effect.forkScoped)
+
+    yield* waitForPending(1).pipe(run)
+    yield* reply({
+      requestID: PermissionID.make("per_custom3"),
+      reply: "always",
+      patterns: [],
+    }).pipe(run)
+    yield* Fiber.join(fiber)
+
+    const ok = yield* ask({
+      sessionID: SessionID.make("session_fallback2"),
+      permission: "bash",
+      patterns: ["ls"],
+      metadata: {},
+      always: [],
+      ruleset: [],
+    }).pipe(run)
+    expect(ok).toBeUndefined()
+  }),
+)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2722,6 +2722,7 @@ export class Permission extends HeyApiClient {
       workspace?: string
       reply?: "once" | "always" | "reject"
       message?: string
+      patterns?: Array<string>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2735,6 +2736,7 @@ export class Permission extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "body", key: "reply" },
             { in: "body", key: "message" },
+            { in: "body", key: "patterns" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4290,6 +4290,7 @@ export type PermissionReplyData = {
   body?: {
     reply: "once" | "always" | "reject"
     message?: string
+    patterns?: Array<string>
   }
   path: {
     requestID: string


### PR DESCRIPTION
### Issue for this PR

Closes #25089

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a permission request is approved with **Allow always**, the TUI currently only lets you confirm the server-suggested patterns. That makes cases like `devcontainer exec ls` awkward, because the suggested rule is often much broader than what you actually want to allow.

This change makes the **Allow always** step editable. The prompt now opens a textarea pre-filled with the suggested patterns, and the user can replace them with narrower rules before confirming.

On the backend, the permission reply payload now accepts optional `patterns`. If custom patterns are provided, those are stored for the session. If the textarea is left empty, the existing behavior is preserved and OpenCode falls back to the server-suggested patterns.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Ran `bun test test/permission/next.test.ts` in `packages/opencode`
- Added coverage for:
  - custom patterns overriding the suggested `always` patterns
  - empty custom patterns falling back to the existing behavior
- Manually checked the TUI flow:
  - **Allow always** opens an editable textarea
  - `Enter` confirms
  - `Esc` cancels
  - `Alt+Enter` inserts a newline

### Screenshots / recordings

<img width="1060" height="385" alt="изображение" src="https://github.com/user-attachments/assets/72e1afac-9cb9-4cda-83de-9efb5389ff03" />

[Запись экрана_20260504_125050.webm](https://github.com/user-attachments/assets/8a6fb446-2bc5-4a0f-9f88-06534b88114b)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
