### PR TITLE
fix(opencode): allow oc://renderer origin in cors middleware

### DIFF
--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -74,6 +74,7 @@ export function CorsMiddleware(opts?: { cors?: string[] }): MiddlewareHandler {
 
       if (input.startsWith("http://localhost:")) return input
       if (input.startsWith("http://127.0.0.1:")) return input
+      if (input.startsWith("oc://renderer")) return input
       if (input === "tauri://localhost" || input === "http://tauri.localhost" || input === "https://tauri.localhost")
         return input
 


### PR DESCRIPTION
### Issue for this PR

Closes #25075

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Packaged Electron desktop loads the renderer from the privileged `oc://renderer` scheme, but CORS preflights to the sidecar were returning 404 because the origin wasn't in the hardcoded allowlist.
- Add `oc://renderer` next to the existing `localhost` / `tauri://` entries in `CorsMiddleware`, matching how the effect-httpapi backend already handles it (`routes/instance/httpapi/server.ts:116`).

Follows the style of the new EFFECT httpapi cors allowlist https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/server/routes/instance/httpapi/server.ts#L116

### How did you verify your code works?

- `bun typecheck` in `packages/opencode`

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR