### PR TITLE
fix(provider): show opus 4.7 thinking chunks

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -427,8 +427,13 @@ export function topK(model: Provider.Model) {
 const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 
+function isAnthropicOpus47(apiId: string) {
+  const id = apiId.toLowerCase()
+  return ["opus-4-7", "opus-4.7"].some((v) => id.includes(v))
+}
+
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
-  if (["opus-4-7", "opus-4.7"].some((v) => apiId.includes(v))) {
+  if (isAnthropicOpus47(apiId)) {
     return ["low", "medium", "high", "xhigh", "max"]
   }
   if (["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) => apiId.includes(v))) {
@@ -485,6 +490,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
               {
                 thinking: {
                   type: "adaptive",
+                  ...(isAnthropicOpus47(model.api.id) ? { display: "summarized" } : {}),
                 },
                 effort,
               },
@@ -645,9 +651,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             {
               thinking: {
                 type: "adaptive",
-                ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
-                  ? { display: "summarized" }
-                  : {}),
+                ...(isAnthropicOpus47(model.api.id) ? { display: "summarized" } : {}),
               },
               effort,
             },
@@ -680,9 +684,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
               reasoningConfig: {
                 type: "adaptive",
                 maxReasoningEffort: effort,
-                ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
-                  ? { display: "summarized" }
-                  : {}),
+                ...(isAnthropicOpus47(model.api.id) ? { display: "summarized" } : {}),
               },
             },
           ]),
@@ -910,8 +912,25 @@ export function options(input: {
     }
   }
 
-  // Enable thinking by default for kimi models using anthropic SDK
   const modelId = input.model.api.id.toLowerCase()
+  // Opus 4.7 omits thinking text unless display is explicitly summarized.
+  if (
+    isAnthropicOpus47(modelId) &&
+    ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic", "@ai-sdk/gateway"].includes(input.model.api.npm)
+  ) {
+    result["thinking"] = {
+      type: "adaptive",
+      display: "summarized",
+    }
+  }
+  if (isAnthropicOpus47(modelId) && input.model.api.npm === "@ai-sdk/amazon-bedrock") {
+    result["reasoningConfig"] = {
+      type: "adaptive",
+      display: "summarized",
+    }
+  }
+
+  // Enable thinking by default for kimi models using anthropic SDK
   if (
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
     (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -356,6 +356,82 @@ describe("ProviderTransform.options - gateway", () => {
       },
     })
   })
+
+  test("enables summarized thinking for opus 4.7", () => {
+    const model = createModel("anthropic/claude-opus-4.7")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result).toEqual({
+      thinking: {
+        type: "adaptive",
+        display: "summarized",
+      },
+      gateway: {
+        caching: "auto",
+      },
+    })
+  })
+})
+
+describe("ProviderTransform.options - opus 4.7 thinking", () => {
+  const sessionID = "test-session-123"
+
+  const createModel = (npm: string, apiId = "claude-opus-4-7") =>
+    ({
+      id: `anthropic/${apiId}`,
+      providerID: "anthropic",
+      api: {
+        id: apiId,
+        url: "https://api.anthropic.com",
+        npm,
+      },
+      name: apiId,
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: true },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: {
+        input: 0.001,
+        output: 0.002,
+        cache: { read: 0.0001, write: 0.0002 },
+      },
+      limit: {
+        context: 200_000,
+        output: 64_000,
+      },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2026-04-16",
+    }) as any
+
+  test("enables summarized thinking for anthropic", () => {
+    const result = ProviderTransform.options({
+      model: createModel("@ai-sdk/anthropic"),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.thinking).toEqual({
+      type: "adaptive",
+      display: "summarized",
+    })
+  })
+
+  test("enables summarized reasoning config for bedrock", () => {
+    const result = ProviderTransform.options({
+      model: createModel("@ai-sdk/amazon-bedrock", "anthropic.claude-opus-4-7"),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.reasoningConfig).toEqual({
+      type: "adaptive",
+      display: "summarized",
+    })
+  })
 })
 
 describe("ProviderTransform.providerOptions", () => {
@@ -2456,12 +2532,14 @@ describe("ProviderTransform.variants", () => {
       expect(result.xhigh).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
         },
         effort: "xhigh",
       })
       expect(result.max).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
         },
         effort: "max",
       })


### PR DESCRIPTION
### Issue for this PR

Fixes #25106

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opus 4.7 omits thinking text by default unless summarized thinking display is requested. This sets summarized thinking display by default for Opus 4.7 provider options so reasoning chunks can be emitted without requiring a reasoning variant.

The change covers Anthropic, Gateway, Vertex Anthropic, and Bedrock option shapes, while keeping explicit Opus 4.7 reasoning variants such as xhigh using summarized display.

### How did you verify your code works?

- bun test test/provider/transform.test.ts --timeout 30000
- bun typecheck

### Screenshots / recordings

N/A, non-UI provider option change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR