### PR TITLE
docs: add BRHP to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -44,6 +44,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |
 | [opencode-conductor](https://github.com/derekbar90/opencode-conductor)                             | Protocol-Driven Workflow: Automation of the Context -> Spec -> Plan -> Implement lifecycle.       |
+| [BRHP](https://github.com/ZanzyTHEbar/brhp)                                                         | Structured, persistent planning with local session state, `/brhp` commands, and a TUI sidebar     |
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                         |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                             |
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)              | Claude Code-style background agents with async delegation and context persistence                 |


### PR DESCRIPTION
### Issue for this PR

Closes #24970

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds BRHP to the ecosystem plugin table with its GitHub link and a short description.

### How did you verify your code works?

Reviewed the docs-only diff. It only adds one Markdown table row in `packages/web/src/content/docs/ecosystem.mdx`.

### Screenshots / recordings

Not applicable; docs table entry only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR