### PR TITLE
fix(desktop): Prevent Model response Interruption when opening settings dialog

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -329,6 +329,7 @@ export const SettingsGeneral: Component = () => {
             label={(o) => o.label}
             onSelect={(option) => {
               if (!option) return
+              if (option.value === currentShell()) return
               globalSync.updateConfig({ shell: option.value })
             }}
             variant="secondary"

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -759,18 +759,23 @@ export const layer = Layer.effect(
       const patch = writableGlobal(config)
 
       let next: Info
+      let changed: boolean
       if (!file.endsWith(".jsonc")) {
         const existing = ConfigParse.effectSchema(Info, ConfigParse.jsonc(before, file), file)
         const merged = mergeDeep(writable(existing), patch)
-        yield* fs.writeFileString(file, JSON.stringify(merged, null, 2)).pipe(Effect.orDie)
+        const serialized = JSON.stringify(merged, null, 2)
+        changed = serialized !== before
+        if (changed) yield* fs.writeFileString(file, serialized).pipe(Effect.orDie)
         next = merged
       } else {
         const updated = patchJsonc(before, patch)
         next = ConfigParse.effectSchema(Info, ConfigParse.jsonc(updated, file), file)
-        yield* fs.writeFileString(file, updated).pipe(Effect.orDie)
+        changed = updated !== before
+        if (changed) yield* fs.writeFileString(file, updated).pipe(Effect.orDie)
       }
 
-      yield* invalidate()
+      // Only tear down running instances if the config actually changed.
+      if (changed) yield* invalidate()
       return next
     })
 


### PR DESCRIPTION
### Issue for this PR

Closes #24859

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the Settings dialog opens, `<SettingsGeneral />` mounts and kicks off `createResource(() => globalSdk.client.pty.shells())` (settings-general.tsx:181). When that resolves, shellOptions() rebuilds. Kobalte's `<Select>` sees a new current reference and fires onChange with the auto option (value: ""). That calls globalSync.updateConfig({ shell: "" }) → PATCH /global/config → Config.invalidate() → Instance.disposeAll(), which interrupts every running agent fiber with MessageAbortedError (no /session/abort involved).


**Added in fixes on the Desktop side and OpenCode Server side**

1. `Client (packages/app/src/components/settings-general.tsx:332)`: Bail out of onSelect if the chosen value equals currentShell(). Prevents the spurious write on mount.

2. `Server (packages/opencode/src/config/config.ts:756)`: Config.updateGlobal now diffs the serialized config against what's on disk and only writes / invalidates when it actually changed. Defensive — protects against any other client (TUI, future UI controls, third-party SDK users) doing the same no-op write.

### How did you verify your code works?

Tested on the electron build locally with the update

### Screenshots / recordings

**BEFORE**

https://github.com/user-attachments/assets/d14c41d3-d0fe-402d-982c-e01bae3a2afb

**AFTER**

https://github.com/user-attachments/assets/a11567c0-e6db-486e-b465-9c116f6786e2

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR