### PR TITLE
fix(opencode): project .opencode/ config now overrides global ~/.opencode

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -24,6 +24,11 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
   const afs = yield* AppFileSystem.Service
   return unique([
     Global.Path.config,
+    ...(yield* afs.up({
+      targets: [".opencode"],
+      start: Global.Path.home,
+      stop: Global.Path.home,
+    })),
     ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
       ? yield* afs.up({
           targets: [".opencode"],
@@ -31,11 +36,6 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
           stop: worktree,
         })
       : []),
-    ...(yield* afs.up({
-      targets: [".opencode"],
-      start: Global.Path.home,
-      stop: Global.Path.home,
-    })),
     ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
   ])
 })


### PR DESCRIPTION
### Issue for this PR
Closes #19296
Closes #21307
### Type of change
- [x] Bug fix
### What does this PR do?
ConfigPaths.directories() appended ~/.opencode after the project walk results,
so the global config was always merged last and always won. Swapped the two
afs.up() spreads so ~/.opencode comes first. unique() then deduplicates it
from the walk, leaving the project dir last so it wins.
### How did you verify your code works?
Set model X in ~/.opencode/agent/build.md and model Y in
project/.opencode/agent/build.md. Before: X was always used. After: Y is used.
### Screenshots / recordings
_N/A — no UI changes._
### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR