### PR TITLE
fix(acp): include tool image attachments in updates

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -344,33 +344,7 @@ export class Agent implements ACPAgent {
               this.toolStarts.delete(part.callID)
               this.bashSnapshots.delete(part.callID)
               const kind = toToolKind(part.tool)
-              const content: ToolCallContent[] = [
-                {
-                  type: "content",
-                  content: {
-                    type: "text",
-                    text: part.state.output,
-                  },
-                },
-              ]
-
-              if (kind === "edit") {
-                const input = part.state.input
-                const filePath = typeof input["filePath"] === "string" ? input["filePath"] : ""
-                const oldText = typeof input["oldString"] === "string" ? input["oldString"] : ""
-                const newText =
-                  typeof input["newString"] === "string"
-                    ? input["newString"]
-                    : typeof input["content"] === "string"
-                      ? input["content"]
-                      : ""
-                content.push({
-                  type: "diff",
-                  path: filePath,
-                  oldText,
-                  newText,
-                })
-              }
+              const content = completedToolContent(part, kind)
 
               if (part.tool === "todowrite") {
                 const parsedTodos = decodeTodos(part.state.output)
@@ -410,10 +384,7 @@ export class Agent implements ACPAgent {
                     content,
                     title: part.state.title,
                     rawInput: part.state.input,
-                    rawOutput: {
-                      output: part.state.output,
-                      metadata: part.state.metadata,
-                    },
+                    rawOutput: completedToolRawOutput(part),
                   },
                 })
                 .catch((error) => {
@@ -873,33 +844,7 @@ export class Agent implements ACPAgent {
             this.toolStarts.delete(part.callID)
             this.bashSnapshots.delete(part.callID)
             const kind = toToolKind(part.tool)
-            const content: ToolCallContent[] = [
-              {
-                type: "content",
-                content: {
-                  type: "text",
-                  text: part.state.output,
-                },
-              },
-            ]
-
-            if (kind === "edit") {
-              const input = part.state.input
-              const filePath = typeof input["filePath"] === "string" ? input["filePath"] : ""
-              const oldText = typeof input["oldString"] === "string" ? input["oldString"] : ""
-              const newText =
-                typeof input["newString"] === "string"
-                  ? input["newString"]
-                  : typeof input["content"] === "string"
-                    ? input["content"]
-                    : ""
-              content.push({
-                type: "diff",
-                path: filePath,
-                oldText,
-                newText,
-              })
-            }
+            const content = completedToolContent(part, kind)
 
             if (part.tool === "todowrite") {
               const parsedTodos = decodeTodos(part.state.output)
@@ -939,10 +884,7 @@ export class Agent implements ACPAgent {
                   content,
                   title: part.state.title,
                   rawInput: part.state.input,
-                  rawOutput: {
-                    output: part.state.output,
-                    metadata: part.state.metadata,
-                  },
+                  rawOutput: completedToolRawOutput(part),
                 },
               })
               .catch((err) => {
@@ -1589,6 +1531,70 @@ function toLocations(toolName: string, input: Record<string, any>): { path: stri
     default:
       return []
   }
+}
+
+function completedToolContent(part: ToolPart, kind: ToolKind): ToolCallContent[] {
+  if (part.state.status !== "completed") return []
+
+  const content: ToolCallContent[] = [
+    {
+      type: "content",
+      content: {
+        type: "text",
+        text: part.state.output,
+      },
+    },
+  ]
+
+  if (kind === "edit") {
+    const input = part.state.input
+    const filePath = typeof input["filePath"] === "string" ? input["filePath"] : ""
+    const oldText = typeof input["oldString"] === "string" ? input["oldString"] : ""
+    const newText =
+      typeof input["newString"] === "string"
+        ? input["newString"]
+        : typeof input["content"] === "string"
+          ? input["content"]
+          : ""
+    content.push({
+      type: "diff",
+      path: filePath,
+      oldText,
+      newText,
+    })
+  }
+
+  content.push(...imageContents(part.state.attachments ?? []))
+  return content
+}
+
+function completedToolRawOutput(part: ToolPart) {
+  if (part.state.status !== "completed") return {}
+  return {
+    output: part.state.output,
+    metadata: part.state.metadata,
+    ...(part.state.attachments?.length ? { attachments: part.state.attachments } : {}),
+  }
+}
+
+function imageContents(attachments: Array<{ mime: string; url: string }>): ToolCallContent[] {
+  return attachments.flatMap((attachment): ToolCallContent[] => {
+    const match = attachment.url.match(/^data:([^;,]+)(?:;[^,]*)*;base64,(.*)$/)
+    const mime = match?.[1] ?? attachment.mime
+    if (!mime.startsWith("image/")) return []
+    const data = match?.[2]
+    if (data === undefined) return []
+    return [
+      {
+        type: "content" as const,
+        content: {
+          type: "image" as const,
+          mimeType: mime,
+          data,
+        },
+      },
+    ]
+  })
 }
 
 async function defaultModel(config: ACPConfig, cwd?: string): Promise<{ providerID: ProviderID; modelID: ModelID }> {

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { ACP } from "../../src/acp/agent"
 import type { AgentSideConnection } from "@agentclientprotocol/sdk"
-import type { Event, EventMessagePartUpdated, ToolStatePending, ToolStateRunning } from "@opencode-ai/sdk/v2"
+import type {
+  Event,
+  EventMessagePartUpdated,
+  ToolStateCompleted,
+  ToolStatePending,
+  ToolStateRunning,
+} from "@opencode-ai/sdk/v2"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
@@ -35,6 +41,14 @@ function isToolCallUpdate(
   return update.sessionUpdate === "tool_call_update"
 }
 
+function completedToolUpdate(sessionUpdates: SessionUpdateParams[], sessionId: string, callID: string) {
+  return sessionUpdates
+    .filter((u) => u.sessionId === sessionId)
+    .map((u) => u.update)
+    .filter(isToolCallUpdate)
+    .find((u) => u.toolCallId === callID && u.status === "completed")
+}
+
 function toolEvent(
   sessionId: string,
   cwd: string,
@@ -57,6 +71,45 @@ function toolEvent(
           input: opts.input,
           raw: opts.raw,
         }
+  const payload: EventMessagePartUpdated = {
+    type: "message.part.updated",
+    properties: {
+      sessionID: sessionId,
+      time: Date.now(),
+      part: {
+        id: `part_${opts.callID}`,
+        sessionID: sessionId,
+        messageID: `msg_${opts.callID}`,
+        type: "tool",
+        callID: opts.callID,
+        tool: opts.tool,
+        state,
+      },
+    },
+  }
+  return { directory: cwd, payload }
+}
+
+function completedToolEvent(
+  sessionId: string,
+  cwd: string,
+  opts: {
+    callID: string
+    tool: string
+    input: Record<string, unknown>
+    output: string
+    attachments?: ToolStateCompleted["attachments"]
+  },
+): GlobalEventEnvelope {
+  const state: ToolStateCompleted = {
+    status: "completed",
+    input: opts.input,
+    output: opts.output,
+    title: opts.tool,
+    metadata: {},
+    time: { start: Date.now() - 1, end: Date.now() },
+    ...(opts.attachments && { attachments: opts.attachments }),
+  }
   const payload: EventMessagePartUpdated = {
     type: "message.part.updated",
     properties: {
@@ -609,6 +662,130 @@ describe("acp.agent event subscription", () => {
         expect(pendings.every((p) => p.update.sessionUpdate === "tool_call" && p.update.status === "pending")).toBe(
           true,
         )
+        stop()
+      },
+    })
+  })
+
+  test("emits image attachments as ACP tool content blocks on live completed tool updates", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const data = Buffer.from("image-data").toString("base64")
+
+        controller.push(
+          completedToolEvent(sessionId, cwd, {
+            callID: "call_image",
+            tool: "read",
+            input: { filePath: "/tmp/image.png" },
+            output: "Image read successfully",
+            attachments: [
+              {
+                id: "part_image",
+                sessionID: sessionId,
+                messageID: "msg_image",
+                type: "file",
+                mime: "image/png",
+                filename: "image.png",
+                url: `data:image/png;base64,${data}`,
+              },
+              {
+                id: "part_text",
+                sessionID: sessionId,
+                messageID: "msg_image",
+                type: "file",
+                mime: "text/plain",
+                filename: "note.txt",
+                url: "data:text/plain;base64,Zm9v",
+              },
+            ],
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const update = completedToolUpdate(sessionUpdates, sessionId, "call_image")
+        expect(update?.content).toContainEqual({
+          type: "content",
+          content: { type: "text", text: "Image read successfully" },
+        })
+        expect(update?.content).toContainEqual({
+          type: "content",
+          content: { type: "image", mimeType: "image/png", data },
+        })
+        expect(update?.content?.some((item) => item.type === "content" && item.content.type === "resource")).toBe(false)
+        expect((update?.rawOutput as { attachments?: unknown[] } | undefined)?.attachments?.length).toBe(2)
+
+        stop()
+      },
+    })
+  })
+
+  test("replays completed tool image attachments as ACP tool content blocks", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, sessionUpdates, stop, sdk } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const data = Buffer.from("replay-image").toString("base64")
+
+        sdk.session.messages = async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                sessionID: sessionId,
+              },
+              parts: [
+                {
+                  id: "part_replay",
+                  sessionID: sessionId,
+                  messageID: "msg_replay",
+                  type: "tool",
+                  callID: "call_replay_image",
+                  tool: "webfetch",
+                  state: {
+                    status: "completed",
+                    input: { url: "https://example.com/image.png" },
+                    output: "Image fetched successfully",
+                    title: "webfetch",
+                    metadata: {},
+                    time: { start: Date.now() - 1, end: Date.now() },
+                    attachments: [
+                      {
+                        id: "part_replay_image",
+                        sessionID: sessionId,
+                        messageID: "msg_replay",
+                        type: "file",
+                        mime: "image/jpeg",
+                        filename: "image.jpg",
+                        url: `data:image/jpeg;base64,${data}`,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        })
+
+        await agent.loadSession({ sessionId, cwd, mcpServers: [] } as any)
+
+        const update = completedToolUpdate(sessionUpdates, sessionId, "call_replay_image")
+        expect(update?.content).toContainEqual({
+          type: "content",
+          content: { type: "text", text: "Image fetched successfully" },
+        })
+        expect(update?.content).toContainEqual({
+          type: "content",
+          content: { type: "image", mimeType: "image/jpeg", data },
+        })
+
         stop()
       },
     })


### PR DESCRIPTION
Closes https://github.com/anomalyco/opencode/issues/25127.

### Issue for this PR

Closes #25127.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Converts image attachments into image blocks in ACP tool responses.

### How did you verify your code works?

I tested this in [Tidewave](https://tidewave.ai/), where we have a screenshot tool that relies on the agent returning the screenshot in the ACP tool result.

<img width="528" height="804" alt="image" src="https://github.com/user-attachments/assets/9f75da53-0250-4890-989b-2b62a3b6ff9d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
