### PR TITLE
Use workspace service in HTTP routes

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
@@ -1,58 +1,53 @@
 import { listAdaptors } from "@/control-plane/adaptors"
 import { Workspace } from "@/control-plane/workspace"
 import * as InstanceState from "@/effect/instance-state"
-import { Instance } from "@/project/instance"
 import { Effect } from "effect"
-import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { CreatePayload, SessionRestorePayload } from "../groups/workspace"
 
 export const workspaceHandlers = HttpApiBuilder.group(InstanceHttpApi, "workspace", (handlers) =>
   Effect.gen(function* () {
+    const workspace = yield* Workspace.Service
+
     const adaptors = Effect.fn("WorkspaceHttpApi.adaptors")(function* () {
       const instance = yield* InstanceState.context
       return yield* Effect.promise(() => listAdaptors(instance.project.id))
     })
 
     const list = Effect.fn("WorkspaceHttpApi.list")(function* () {
-      return Workspace.list((yield* InstanceState.context).project)
+      return yield* workspace.list((yield* InstanceState.context).project)
     })
 
     const create = Effect.fn("WorkspaceHttpApi.create")(function* (ctx: { payload: typeof CreatePayload.Type }) {
       const instance = yield* InstanceState.context
-      return yield* Effect.promise(() =>
-        Instance.restore(instance, () =>
-          Workspace.create({
-            ...ctx.payload,
-            projectID: instance.project.id,
-          }),
-        ),
-      )
+      return yield* workspace
+        .create({
+          ...ctx.payload,
+          projectID: instance.project.id,
+        })
+        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
     })
 
     const status = Effect.fn("WorkspaceHttpApi.status")(function* () {
-      const ids = new Set(Workspace.list((yield* InstanceState.context).project).map((item) => item.id))
-      return Workspace.status().filter((item) => ids.has(item.workspaceID))
+      const ids = new Set((yield* workspace.list((yield* InstanceState.context).project)).map((item) => item.id))
+      return (yield* workspace.status()).filter((item) => ids.has(item.workspaceID))
     })
 
     const remove = Effect.fn("WorkspaceHttpApi.remove")(function* (ctx: { params: { id: Workspace.Info["id"] } }) {
-      const instance = yield* InstanceState.context
-      return yield* Effect.promise(() => Instance.restore(instance, () => Workspace.remove(ctx.params.id)))
+      return yield* workspace.remove(ctx.params.id)
     })
 
     const sessionRestore = Effect.fn("WorkspaceHttpApi.sessionRestore")(function* (ctx: {
       params: { id: Workspace.Info["id"] }
       payload: typeof SessionRestorePayload.Type
     }) {
-      const instance = yield* InstanceState.context
-      return yield* Effect.promise(() =>
-        Instance.restore(instance, () =>
-          Workspace.sessionRestore({
-            workspaceID: ctx.params.id,
-            sessionID: ctx.payload.sessionID,
-          }),
-        ),
-      )
+      return yield* workspace
+        .sessionRestore({
+          workspaceID: ctx.params.id,
+          sessionID: ctx.payload.sessionID,
+        })
+        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
     })
 
     return handlers

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -31,6 +31,7 @@ import { ToolRegistry } from "@/tool/registry"
 import { lazy } from "@/util/lazy"
 import { Vcs } from "@/project/vcs"
 import { Worktree } from "@/worktree"
+import { Workspace } from "@/control-plane/workspace"
 import { isAllowedCorsOrigin } from "@/server/cors"
 import { InstanceHttpApi, RootHttpApi } from "./api"
 import { ServerAuthConfig, authorizationLayer } from "./middleware/authorization"
@@ -141,6 +142,7 @@ export const routes = Layer.mergeAll(rootApiRoutes, instanceRoutes).pipe(
     Todo.defaultLayer,
     ToolRegistry.defaultLayer,
     Vcs.defaultLayer,
+    Workspace.defaultLayer,
     Worktree.defaultLayer,
     Bus.layer,
     HttpServer.layerServices,


### PR DESCRIPTION
## Summary
- Replace workspace HttpApi handler calls to exported runtime wrappers with the yielded `Workspace.Service`.
- Provide `Workspace.defaultLayer` from the HttpApi server route composition.
- Keep adaptor listing as the remaining plain async registry boundary.

## Verification
- `bun typecheck` from `packages/opencode`
- `bun run test -- test/server/httpapi-workspace.test.ts test/server/httpapi-workspace-routing.test.ts` from `packages/opencode`
- `bunx oxlint packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts packages/opencode/src/server/routes/instance/httpapi/server.ts`
- pre-push `bun turbo typecheck`