### PR TITLE
docs: Add opencode-swarm to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -52,6 +52,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
+| [opencode-swarm](https://github.com/zaxbysauce/opencode-swarm)                                     | Verification-gated swarm with architect, review, test, and security agents and resumable evidence |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-swarm` to the ecosystem Plugins table.

This is a docs-only row for https://github.com/zaxbysauce/opencode-swarm, described as a verification-gated swarm with architect, review, test, security agents, and resumable evidence.

### How did you verify your code works?

Verified the row matches the existing table format and that only `packages/web/src/content/docs/ecosystem.mdx` changed.

No MDX-specific docs lint was found for this prose-only table update.

### Screenshots / recordings

Not applicable. This is a documentation table update.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
