### PR TITLE
fix(provider): split providerOptions key on dot for openai-compatible, openai, and anthropic providers

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1058,7 +1058,20 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
     return result
   }
 
-  const key = sdkKey(model.api.npm) ?? model.providerID
+  // AI SDK packages that resolve providerOptionsName by splitting the
+  // provider name on "." (e.g. "wafer.ai" -> "wafer") need the same
+  // logic here so the key we write matches the key they read.
+  // Other SDKs (xai, mistral, groq, cohere, etc.) use hardcoded keys
+  // like "xai" or "cohere" - applying .split(".")[0] would break those.
+  const usesDotSplitOptions =
+    model.api.npm === "@ai-sdk/openai-compatible" ||
+    model.api.npm === "@ai-sdk/openai" ||
+    model.api.npm === "@ai-sdk/anthropic"
+  const key =
+    sdkKey(model.api.npm) ??
+    (usesDotSplitOptions
+      ? model.providerID.split(".")[0]
+      : model.providerID)
   // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
   // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
   // "azure" first. Pass both so model options work on either code path.


### PR DESCRIPTION
### Issue for this PR

Closes #23622

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Providers with dots in their ID (e.g. `wafer.ai`) that use `@ai-sdk/openai-compatible`, `@ai-sdk/openai`, or `@ai-sdk/anthropic` never have their `providerOptions` sent to the API. This silently breaks features like `reasoningEffort` - reasoning models return no thinking content.

Three AI SDK packages resolve the `providerOptions` key by splitting the provider name on `.`:

```js
// @ai-sdk/openai-compatible, @ai-sdk/openai, @ai-sdk/anthropic
get providerOptionsName() {
    return this.config.provider.split(".")[0].trim();
}
```

So `"wafer.ai"` reads `providerOptions["wafer"]`, but opencode writes `providerOptions["wafer.ai"]` - key mismatch, options silently dropped.

`@ai-sdk/openai` and `@ai-sdk/anthropic` have the same dot-split but are currently protected by `sdkKey()` mappings. Those mappings aren't guaranteed to stay in sync, so the fix covers all three.

Other AI SDK packages (xai, mistral, groq, cohere, togetherai, etc.) use hardcoded keys like `"xai"` - not derived from the provider name. Applying `.split(".")[0]` would break those, so they are excluded.

Fix: apply the same dot-split for the three packages that use the `providerOptionsName` pattern:

```ts
const usesDotSplitOptions =
  model.api.npm === "@ai-sdk/openai-compatible" ||
  model.api.npm === "@ai-sdk/openai" ||
  model.api.npm === "@ai-sdk/anthropic"
const key =
  sdkKey(model.api.npm) ??
  (usesDotSplitOptions
    ? model.providerID.split(".")[0]
    : model.providerID)
```

Regression analysis:
- Only `wafer.ai` has a dot among all models.dev openai-compatible providers - all others unaffected
- `@ai-sdk/openai` and `@ai-sdk/anthropic` are covered but currently protected by `sdkKey()` mappings anyway
- Other AI SDK packages (xai, mistral, groq, etc.) use hardcoded keys and are excluded from the dot-split
- User-defined providers in opencode.json with dots also benefit

### How did you verify your code works?

Manually tested the change on a fork of OpenCode.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
