### PR TITLE
feat(tui): add content_padding option to control horizontal content margins

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -24,6 +24,13 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
+  content_padding: z
+    .number()
+    .int()
+    .min(0)
+    .max(20)
+    .optional()
+    .describe("Horizontal padding (in columns) for the main content area (default: 2)"),
 })
 
 export const TuiInfo = z

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -174,7 +174,8 @@ export function Session() {
     return false
   })
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const contentPadding = tuiConfig.content_padding ?? 2
+  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - contentPadding * 2)
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
@@ -1055,7 +1056,7 @@ export function Session() {
       }}
     >
       <box flexDirection="row">
-        <box flexGrow={1} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
+        <box flexGrow={1} paddingBottom={1} paddingLeft={contentPadding} paddingRight={contentPadding} gap={1}>
           <Show when={session()}>
             <scrollbox
               ref={(r) => (scroll = r)}


### PR DESCRIPTION
## Summary

- Adds a new `content_padding` option to `tui.json` that lets users configure horizontal padding of the main content area
- Replaces the hardcoded `paddingLeft={2}` / `paddingRight={2}` and the `- 4` in the `contentWidth` calculation with a configurable value
- Default is `2`, preserving current behavior — users can set `0` for full-width content

<img width="750" height="450" alt="pr25146-tui-content-padding" src="https://github.com/user-attachments/assets/e153da59-7e7d-4bcb-bda1-32f88f408077" />


## Usage

```jsonc
// tui.json
{
  "content_padding": 0 // 0 = minimal margins, up to 20
}
```

## Changes

- `tui-schema.ts` — Added `content_padding` to `TuiOptions` (integer, 0-20, optional, default 2)
- `session/index.tsx` — Read `tuiConfig.content_padding` and use it for both the `<box>` padding props and the `contentWidth` memo

## Related

Closes #25142 (feature request for configurable content width)
Related to #838 (previously closed layout width request)