### PR TITLE
fix: include PR URL in GitHub Action comments (more-pr-tracking)

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -197,13 +197,13 @@ try {
     if (await branchIsDirty()) {
       const summary = await summarize(response)
       await pushToNewBranch(summary, branch)
-      const pr = await createPR(
+      const prUrl = await createPR(
         repoData.data.default_branch,
         branch,
         summary,
         `${response}\n\nCloses #${useIssueId()}${footer({ image: true })}`,
       )
-      await updateComment(`Created PR #${pr}${footer({ image: true })}`)
+      await updateComment(`[Created PR](${prUrl})${footer({ image: true })}`)
     } else {
       await updateComment(`${response}${footer({ image: true })}`)
     }
@@ -808,7 +808,8 @@ async function createPR(base: string, branch: string, title: string, body: strin
     title: truncatedTitle,
     body,
   })
-  return pr.data.number
+  console.log(`Created PR #${pr.data.number}: ${pr.data.html_url}`)
+  return pr.data.html_url
 }
 
 function footer(opts?: { image?: boolean }) {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -604,7 +604,7 @@ export const GithubRunCommand = cmd({
               `${response}\n\nTriggered by ${triggerType}${footer({ image: true })}`,
             )
             if (pr) {
-              console.log(`Created PR #${pr}`)
+              console.log(`Created PR #${pr.number}: ${pr.url}`)
             } else {
               console.log("Skipped PR creation (no new commits)")
             }
@@ -676,7 +676,8 @@ export const GithubRunCommand = cmd({
               `${response}\n\nCloses #${issueId}${footer({ image: true })}`,
             )
             if (pr) {
-              await createComment(`Created PR #${pr}${footer({ image: true })}`)
+              console.log(`Created PR #${pr.number}: ${pr.url}`)
+              await createComment(`Created PR [#${pr.number}](${pr.url})${footer({ image: true })}`)
             } else {
               await createComment(`${response}${footer({ image: true })}`)
             }
@@ -1327,7 +1328,7 @@ export const GithubRunCommand = cmd({
         })
       }
 
-      async function createPR(base: string, branch: string, title: string, body: string): Promise<number | null> {
+      async function createPR(base: string, branch: string, title: string, body: string): Promise<{ number: number; url: string } | null> {
         console.log("Creating pull request...")
 
         // Check if an open PR already exists for this head→base combination
@@ -1344,8 +1345,9 @@ export const GithubRunCommand = cmd({
           )
 
           if (existing.data.length > 0) {
-            console.log(`PR #${existing.data[0].number} already exists for branch ${branch}`)
-            return existing.data[0].number
+            const pr = existing.data[0]
+            console.log(`PR #${pr.number} already exists for branch ${branch}: ${pr.html_url}`)
+            return { number: pr.number, url: pr.html_url }
           }
         } catch (e) {
           // If the check fails, proceed to create - we'll get a clear error if a PR already exists
@@ -1371,7 +1373,8 @@ export const GithubRunCommand = cmd({
               body,
             }),
           )
-          return pr.data.number
+          console.log(`Created PR #${pr.data.number}: ${pr.data.html_url}`)
+          return { number: pr.data.number, url: pr.data.html_url }
         } catch (e: unknown) {
           // Handle "No commits between X and Y" validation error from GitHub.
           // This can happen when the branch was pushed but has no new commits


### PR DESCRIPTION
## Summary

When the GitHub Action creates a PR from an issue, the bot comment says "Created PR #42" with **no link to the actual PR**. Users are told to "follow the thread for updates" but the thread never gets updated — the action posts once and exits.

This PR fixes that by including the actual PR URL in the comments.

## Changes

**`github/index.ts`** (GitHub Actions workflow entry point):
- `createPR()` now returns `html_url` instead of `pr.data.number`
- Comment updated to `[Created PR](${prUrl})` — a clickable link

**`packages/opencode/src/cli/cmd/github.ts`** (CLI github run command):
- `createPR()` now returns `{ number, url }` instead of `number | null`
- Issue→PR comment flow: `Created PR [#${number}](${url})`
- Existing PR detection (agent-created via `gh pr create`) also returns URL
- All `console.log` calls include PR URL for easier log debugging

## Before / After

**Before:** `Created PR #42` (plain text, no link)
**After:** `Created PR [#42](https://github.com/owner/repo/pull/42)` (clickable link)
