### PR TITLE
Remove covered workspace websocket todo

### DIFF
--- a/packages/opencode/test/server/httpapi-workspace.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test"
+import { afterEach, describe, expect, mock } from "bun:test"
 import { NodeServices } from "@effect/platform-node"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
@@ -133,8 +133,6 @@ afterEach(async () => {
 })
 
 describe("workspace HttpApi", () => {
-  test.todo("proxies remote workspace websocket through real Effect listener", () => {})
-
   it.live("serves read endpoints", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })


### PR DESCRIPTION
## Summary
- Remove a stale workspace HttpApi websocket proxy `test.todo`.
- The coverage already exists in `httpapi-workspace-routing.test.ts` using an Effect listener and `Socket.makeWebSocket`.

## Tests
- `bun typecheck` from `packages/opencode`
- `bun run test -- test/server/httpapi-workspace.test.ts test/server/httpapi-workspace-routing.test.ts` from `packages/opencode`
- pre-push `bun turbo typecheck`