### PR TITLE
fix: route child session events to parent ACP session (#21802)

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -189,6 +189,19 @@ export class Agent implements ACPAgent {
 
   private async handleEvent(event: Event) {
     switch (event.type) {
+      case "session.created": {
+        const info = event.properties.info
+        if (info.parentID) {
+          this.sessionManager.registerChild(event.properties.sessionID, info.parentID)
+        }
+        return
+      }
+
+      case "session.deleted": {
+        this.sessionManager.unregisterChild(event.properties.sessionID)
+        return
+      }
+
       case "permission.asked": {
         const permission = event.properties
         const session = this.sessionManager.tryGet(permission.sessionID)

--- a/packages/opencode/src/acp/session.ts
+++ b/packages/opencode/src/acp/session.ts
@@ -8,13 +8,32 @@ const log = Log.create({ service: "acp-session-manager" })
 export class ACPSessionManager {
   private sessions = new Map<string, ACPSessionState>()
   private sdk: OpencodeClient
+  private childToRoot = new Map<string, string>()
 
   constructor(sdk: OpencodeClient) {
     this.sdk = sdk
   }
 
   tryGet(sessionId: string): ACPSessionState | undefined {
-    return this.sessions.get(sessionId)
+    const direct = this.sessions.get(sessionId)
+    if (direct) return direct
+    const rootId = this.childToRoot.get(sessionId)
+    if (rootId) return this.sessions.get(rootId)
+    return undefined
+  }
+
+  registerChild(childSessionID: string, parentSessionID: string) {
+    const rootId =
+      this.childToRoot.get(parentSessionID) ??
+      (this.sessions.has(parentSessionID) ? parentSessionID : undefined)
+    if (rootId) {
+      this.childToRoot.set(childSessionID, rootId)
+      log.info("registered child session", { child: childSessionID, root: rootId })
+    }
+  }
+
+  unregisterChild(childSessionID: string) {
+    this.childToRoot.delete(childSessionID)
   }
 
   async create(cwd: string, mcpServers: McpServer[], model?: ACPSessionState["model"]): Promise<ACPSessionState> {


### PR DESCRIPTION
## Summary

- Fixes ACP clients not seeing subagent activity from the Task tool (#21802)
- Adds child-to-root session resolution in ACPSessionManager
- Handles session.created and session.deleted events in agent.ts

## Root Cause

`ACPSessionManager` only tracked sessions created via `session/new` or `session/load`. Child sessions spawned by the Task tool via `Session.create({ parentID: ... })` were never registered, causing `handleEvent()` to silently drop all sub-agent events — tool calls, text streaming, and permission requests.

## Changes

- `packages/opencode/src/acp/session.ts` (+22,-1): Added `childToRoot` map, `registerChild()`, `unregisterChild()`, and updated `tryGet()` to check the child→root mapping
- `packages/opencode/src/acp/agent.ts` (+13): Added `session.created` handler to register child sessions, and `session.deleted` handler for cleanup

## Test Results

- Typecheck: 13/13 packages pass
- ACP tests: 11/11 pass
- Session tests: 319/319 pass (0 fail)

Closes #21802