### PR TITLE
docs: add missing docs for global config endpoints

### DIFF
--- a/packages/web/src/content/docs/server.mdx
+++ b/packages/web/src/content/docs/server.mdx
@@ -89,10 +89,12 @@ The opencode server exposes the following APIs.
 
 ### Global
 
-| Method | Path             | Description                    | Response                             |
-| ------ | ---------------- | ------------------------------ | ------------------------------------ |
-| `GET`  | `/global/health` | Get server health and version  | `{ healthy: true, version: string }` |
-| `GET`  | `/global/event`  | Get global events (SSE stream) | Event stream                         |
+| Method  | Path             | Description                    | Response                             |
+| ------- | ---------------- | ------------------------------ | ------------------------------------ |
+| `GET`   | `/global/health` | Get server health and version  | `{ healthy: true, version: string }` |
+| `GET`   | `/global/event`  | Get global events (SSE stream) | Event stream                         |
+| `GET`   | `/global/config` | Get global config info         | <a href={typesUrl}><code>Config</code></a> |
+| `PATCH` | `/global/config` | Update global config           | <a href={typesUrl}><code>Config</code></a> |
 
 ---
 
@@ -126,8 +128,8 @@ The opencode server exposes the following APIs.
 
 | Method  | Path                | Description                       | Response                                                                                 |
 | ------- | ------------------- | --------------------------------- | ---------------------------------------------------------------------------------------- |
-| `GET`   | `/config`           | Get config info                   | <a href={typesUrl}><code>Config</code></a>                                               |
-| `PATCH` | `/config`           | Update config                     | <a href={typesUrl}><code>Config</code></a>                                               |
+| `GET`   | `/config`           | Get instance config info          | <a href={typesUrl}><code>Config</code></a>                                               |
+| `PATCH` | `/config`           | Update instance config            | <a href={typesUrl}><code>Config</code></a>                                               |
 | `GET`   | `/config/providers` | List providers and default models | `{ providers: `<a href={typesUrl}>Provider[]</a>`, default: { [key: string]: string } }` |
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #24949

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

I have been using opencode server and controlling it remotely with API based on info on docs. I have pulled the repo and let 5.4 analyze the hono server and found out that /global/config is undocumented. So, I updated the docs with 5.4 and changes in this PR showcase it.

### How did you verify your code works?

It is not code change, only docs. I did PATCH /config and PATCH /global/config to test out my theories before 

### Screenshots / recordings

no ui changes, only docs.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
