### PR TITLE
Protect HttpApi web UI fallback with auth

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -38,7 +38,7 @@ import { Vcs } from "@/project/vcs"
 import { Worktree } from "@/worktree"
 import { Workspace } from "@/control-plane/workspace"
 import { isAllowedCorsOrigin } from "@/server/cors"
-import { UIRoutes } from "@/server/routes/ui"
+import { serveUI } from "@/server/routes/ui"
 import { InstanceHttpApi, RootHttpApi } from "./api"
 import { ServerAuthConfig, authorizationLayer, authorizationRouterMiddleware } from "./middleware/authorization"
 import { eventRoute } from "./event"
@@ -120,13 +120,12 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
   ]),
 )
 
-const uiRoutes = lazy(() => UIRoutes())
 const uiRoute = HttpRouter.add(
   "*",
   "/*",
   (request) =>
     Effect.promise(async () =>
-      uiRoutes().fetch(
+      serveUI(
         request.source instanceof Request
           ? request.source
           : new Request(new URL(request.originalUrl, "http://localhost"), {

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -1,7 +1,8 @@
 import { Context, Effect, Layer } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { HttpMiddleware, HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http"
+import { FetchHttpClient, HttpMiddleware, HttpRouter, HttpServer } from "effect/unstable/http"
 import * as Socket from "effect/unstable/socket/Socket"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Account } from "@/account/account"
 import { Agent } from "@/agent/agent"
 import { Auth } from "@/auth"
@@ -38,7 +39,7 @@ import { Vcs } from "@/project/vcs"
 import { Worktree } from "@/worktree"
 import { Workspace } from "@/control-plane/workspace"
 import { isAllowedCorsOrigin } from "@/server/cors"
-import { serveUI } from "@/server/routes/ui"
+import { serveUIEffect } from "@/server/routes/ui"
 import { InstanceHttpApi, RootHttpApi } from "./api"
 import { ServerAuthConfig, authorizationLayer, authorizationRouterMiddleware } from "./middleware/authorization"
 import { eventRoute } from "./event"
@@ -120,20 +121,8 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
   ]),
 )
 
-const uiRoute = HttpRouter.add(
-  "*",
-  "/*",
-  (request) =>
-    Effect.promise(async () =>
-      serveUI(
-        request.source instanceof Request
-          ? request.source
-          : new Request(new URL(request.originalUrl, "http://localhost"), {
-              method: request.method,
-              headers: request.headers,
-            }),
-      ),
-    ).pipe(Effect.map(HttpServerResponse.fromWeb)),
+const uiRoute = HttpRouter.add("*", "/*", (request) =>
+  serveUIEffect(request).pipe(Effect.provide(AppFileSystem.defaultLayer), Effect.provide(FetchHttpClient.layer)),
 ).pipe(
   Layer.provide(authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuthConfig.defaultLayer))),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -121,17 +121,22 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
 )
 
 const uiRoutes = lazy(() => UIRoutes())
-const uiRoute = HttpRouter.add("*", "/*", (request) =>
-  Effect.promise(async () =>
-    uiRoutes().fetch(
-      request.source instanceof Request
-        ? request.source
-        : new Request(new URL(request.originalUrl, "http://localhost"), {
-            method: request.method,
-            headers: request.headers,
-          }),
-    ),
-  ).pipe(Effect.map(HttpServerResponse.fromWeb)),
+const uiRoute = HttpRouter.add(
+  "*",
+  "/*",
+  (request) =>
+    Effect.promise(async () =>
+      uiRoutes().fetch(
+        request.source instanceof Request
+          ? request.source
+          : new Request(new URL(request.originalUrl, "http://localhost"), {
+              method: request.method,
+              headers: request.headers,
+            }),
+      ),
+    ).pipe(Effect.map(HttpServerResponse.fromWeb)),
+).pipe(
+  Layer.provide(authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuthConfig.defaultLayer))),
 )
 
 export const routes = Layer.mergeAll(rootApiRoutes, instanceRoutes, uiRoute).pipe(

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -35,6 +35,15 @@ function requestBody(request: HttpServerRequest.HttpServerRequest) {
   )
 }
 
+function proxyResponseHeaders(headers: Record<string, string>) {
+  const result = new Headers(headers)
+  // FetchHttpClient exposes decoded response bodies, so forwarding upstream
+  // transfer metadata makes browsers decode already-decoded assets again.
+  result.delete("content-encoding")
+  result.delete("content-length")
+  return result
+}
+
 export async function serveUI(request: Request) {
   const embeddedWebUI = await embeddedUIPromise
   const path = new URL(request.url).pathname
@@ -89,7 +98,7 @@ export function serveUIEffect(request: HttpServerRequest.HttpServerRequest) {
     }
 
     const response = yield* HttpClient.execute(
-      HttpClientRequest.make(request.method as never)(`https://app.opencode.ai${path}`, {
+      HttpClientRequest.make(request.method)(`https://app.opencode.ai${path}`, {
         headers: {
           ...request.headers,
           host: "app.opencode.ai",
@@ -97,9 +106,7 @@ export function serveUIEffect(request: HttpServerRequest.HttpServerRequest) {
         body: requestBody(request),
       }),
     )
-    const headers = new Headers(response.headers as HeadersInit)
-    headers.delete("content-encoding")
-    headers.delete("content-length")
+    const headers = proxyResponseHeaders(response.headers)
 
     if (response.headers["content-type"]?.includes("text/html")) {
       const body = yield* response.text

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -50,8 +50,13 @@ function upstreamURL(path: string) {
   return new URL(path, UI_UPSTREAM).toString()
 }
 
+function embeddedUI() {
+  if (Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI) return Promise.resolve(null)
+  return embeddedUIPromise
+}
+
 export async function serveUI(request: Request) {
-  const embeddedWebUI = await embeddedUIPromise
+  const embeddedWebUI = await embeddedUI()
   const path = new URL(request.url).pathname
 
   if (embeddedWebUI) {
@@ -82,7 +87,7 @@ export async function serveUI(request: Request) {
 
 export function serveUIEffect(request: HttpServerRequest.HttpServerRequest) {
   return Effect.gen(function* () {
-    const embeddedWebUI = yield* Effect.promise(() => embeddedUIPromise)
+    const embeddedWebUI = yield* Effect.promise(() => embeddedUI())
     const path = new URL(request.url, "http://localhost").pathname
 
     if (embeddedWebUI) {

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -7,6 +7,7 @@ import { proxy } from "hono/proxy"
 import { getMimeType } from "hono/utils/mime"
 import { createHash } from "node:crypto"
 import fs from "node:fs/promises"
+import { ProxyUtil } from "../proxy-util"
 
 const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
   ? Promise.resolve(null)
@@ -15,6 +16,7 @@ const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
 
 const DEFAULT_CSP =
   "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
+const UI_UPSTREAM = new URL("https://app.opencode.ai")
 
 const csp = (hash = "") =>
   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
@@ -44,6 +46,10 @@ function proxyResponseHeaders(headers: Record<string, string>) {
   return result
 }
 
+function upstreamURL(path: string) {
+  return new URL(path, UI_UPSTREAM).toString()
+}
+
 export async function serveUI(request: Request) {
   const embeddedWebUI = await embeddedUIPromise
   const path = new URL(request.url).pathname
@@ -62,12 +68,9 @@ export async function serveUI(request: Request) {
     return Response.json({ error: "Not Found" }, { status: 404 })
   }
 
-  const response = await proxy(`https://app.opencode.ai${path}`, {
+  const response = await proxy(upstreamURL(path), {
     raw: request,
-    headers: {
-      ...Object.fromEntries(request.headers.entries()),
-      host: "app.opencode.ai",
-    },
+    headers: ProxyUtil.headers(request, { host: UI_UPSTREAM.host }),
   })
   const match = response.headers.get("content-type")?.includes("text/html")
     ? themePreloadHash(await response.clone().text())
@@ -98,11 +101,8 @@ export function serveUIEffect(request: HttpServerRequest.HttpServerRequest) {
     }
 
     const response = yield* HttpClient.execute(
-      HttpClientRequest.make(request.method)(`https://app.opencode.ai${path}`, {
-        headers: {
-          ...request.headers,
-          host: "app.opencode.ai",
-        },
+      HttpClientRequest.make(request.method)(upstreamURL(path), {
+        headers: ProxyUtil.headers(request.headers, { host: UI_UPSTREAM.host }),
         body: requestBody(request),
       }),
     )

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -16,40 +16,39 @@ const DEFAULT_CSP =
 const csp = (hash = "") =>
   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
 
-export const UIRoutes = (): Hono =>
-  new Hono().all("/*", async (c) => {
-    const embeddedWebUI = await embeddedUIPromise
-    const path = c.req.path
+export async function serveUI(request: Request) {
+  const embeddedWebUI = await embeddedUIPromise
+  const path = new URL(request.url).pathname
 
-    if (embeddedWebUI) {
-      const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
-      if (!match) return c.json({ error: "Not Found" }, 404)
+  if (embeddedWebUI) {
+    const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
+    if (!match) return Response.json({ error: "Not Found" }, { status: 404 })
 
-      if (await fs.exists(match)) {
-        const mime = getMimeType(match) ?? "text/plain"
-        c.header("Content-Type", mime)
-        if (mime.startsWith("text/html")) {
-          c.header("Content-Security-Policy", DEFAULT_CSP)
-        }
-        return c.body(new Uint8Array(await fs.readFile(match)))
-      } else {
-        return c.json({ error: "Not Found" }, 404)
-      }
-    } else {
-      const response = await proxy(`https://app.opencode.ai${path}`, {
-        raw: c.req.raw,
-        headers: {
-          ...Object.fromEntries(c.req.raw.headers.entries()),
-          host: "app.opencode.ai",
-        },
-      })
-      const match = response.headers.get("content-type")?.includes("text/html")
-        ? (await response.clone().text()).match(
-            /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
-          )
-        : undefined
-      const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
-      response.headers.set("Content-Security-Policy", csp(hash))
-      return response
+    if (await fs.exists(match)) {
+      const mime = getMimeType(match) ?? "text/plain"
+      const headers = new Headers({ "content-type": mime })
+      if (mime.startsWith("text/html")) headers.set("content-security-policy", DEFAULT_CSP)
+      return new Response(new Uint8Array(await fs.readFile(match)), { headers })
     }
+
+    return Response.json({ error: "Not Found" }, { status: 404 })
+  }
+
+  const response = await proxy(`https://app.opencode.ai${path}`, {
+    raw: request,
+    headers: {
+      ...Object.fromEntries(request.headers.entries()),
+      host: "app.opencode.ai",
+    },
   })
+  const match = response.headers.get("content-type")?.includes("text/html")
+    ? (await response.clone().text()).match(
+        /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
+      )
+    : undefined
+  const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
+  response.headers.set("Content-Security-Policy", csp(hash))
+  return response
+}
+
+export const UIRoutes = (): Hono => new Hono().all("/*", (c) => serveUI(c.req.raw))

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -1,4 +1,7 @@
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Effect, Stream } from "effect"
+import { HttpBody, HttpClient, HttpClientRequest, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { Hono } from "hono"
 import { proxy } from "hono/proxy"
 import { getMimeType } from "hono/utils/mime"
@@ -15,6 +18,22 @@ const DEFAULT_CSP =
 
 const csp = (hash = "") =>
   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
+
+function themePreloadHash(body: string) {
+  return body.match(
+    /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
+  )
+}
+
+function requestBody(request: HttpServerRequest.HttpServerRequest) {
+  if (request.method === "GET" || request.method === "HEAD") return HttpBody.empty
+  const len = request.headers["content-length"]
+  return HttpBody.stream(
+    request.stream,
+    request.headers["content-type"],
+    len === undefined ? undefined : Number(len),
+  )
+}
 
 export async function serveUI(request: Request) {
   const embeddedWebUI = await embeddedUIPromise
@@ -42,13 +61,60 @@ export async function serveUI(request: Request) {
     },
   })
   const match = response.headers.get("content-type")?.includes("text/html")
-    ? (await response.clone().text()).match(
-        /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
-      )
+    ? themePreloadHash(await response.clone().text())
     : undefined
   const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
   response.headers.set("Content-Security-Policy", csp(hash))
   return response
+}
+
+export function serveUIEffect(request: HttpServerRequest.HttpServerRequest) {
+  return Effect.gen(function* () {
+    const embeddedWebUI = yield* Effect.promise(() => embeddedUIPromise)
+    const path = new URL(request.url, "http://localhost").pathname
+
+    if (embeddedWebUI) {
+      const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
+      if (!match) return HttpServerResponse.jsonUnsafe({ error: "Not Found" }, { status: 404 })
+
+      const fs = yield* AppFileSystem.Service
+      if (yield* fs.existsSafe(match)) {
+        const mime = getMimeType(match) ?? "text/plain"
+        const headers = new Headers({ "content-type": mime })
+        if (mime.startsWith("text/html")) headers.set("content-security-policy", DEFAULT_CSP)
+        return HttpServerResponse.raw(yield* fs.readFile(match), { headers })
+      }
+
+      return HttpServerResponse.jsonUnsafe({ error: "Not Found" }, { status: 404 })
+    }
+
+    const response = yield* HttpClient.execute(
+      HttpClientRequest.make(request.method as never)(`https://app.opencode.ai${path}`, {
+        headers: {
+          ...request.headers,
+          host: "app.opencode.ai",
+        },
+        body: requestBody(request),
+      }),
+    )
+    const headers = new Headers(response.headers as HeadersInit)
+
+    if (response.headers["content-type"]?.includes("text/html")) {
+      const body = yield* response.text
+      const match = themePreloadHash(body)
+      headers.set(
+        "Content-Security-Policy",
+        csp(match ? createHash("sha256").update(match[2]).digest("base64") : ""),
+      )
+      return HttpServerResponse.text(body, { status: response.status, headers })
+    }
+
+    headers.set("Content-Security-Policy", csp())
+    return HttpServerResponse.stream(response.stream.pipe(Stream.catchCause(() => Stream.empty)), {
+      status: response.status,
+      headers,
+    })
+  })
 }
 
 export const UIRoutes = (): Hono => new Hono().all("/*", (c) => serveUI(c.req.raw))

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -98,6 +98,8 @@ export function serveUIEffect(request: HttpServerRequest.HttpServerRequest) {
       }),
     )
     const headers = new Headers(response.headers as HeadersInit)
+    headers.delete("content-encoding")
+    headers.delete("content-length")
 
     if (response.headers["content-type"]?.includes("text/html")) {
       const body = yield* response.text

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -1,19 +1,62 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Log from "@opencode-ai/core/util/log"
+import { ConfigProvider, Layer } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
 import { Server } from "../../src/server/server"
 
 void Log.init({ print: false })
 
 const original = {
   OPENCODE_EXPERIMENTAL_HTTPAPI: Flag.OPENCODE_EXPERIMENTAL_HTTPAPI,
+  OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,
+  OPENCODE_SERVER_USERNAME: Flag.OPENCODE_SERVER_USERNAME,
+  envPassword: process.env.OPENCODE_SERVER_PASSWORD,
+  envUsername: process.env.OPENCODE_SERVER_USERNAME,
   fetch: globalThis.fetch,
 }
 
 afterEach(() => {
   Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = original.OPENCODE_EXPERIMENTAL_HTTPAPI
+  Flag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD
+  Flag.OPENCODE_SERVER_USERNAME = original.OPENCODE_SERVER_USERNAME
+  restoreEnv("OPENCODE_SERVER_PASSWORD", original.envPassword)
+  restoreEnv("OPENCODE_SERVER_USERNAME", original.envUsername)
   globalThis.fetch = original.fetch
 })
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+function app(input?: { password?: string; username?: string }) {
+  const handler = HttpRouter.toWebHandler(
+    ExperimentalHttpApiServer.routes.pipe(
+      Layer.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            OPENCODE_SERVER_PASSWORD: input?.password,
+            OPENCODE_SERVER_USERNAME: input?.username,
+          }),
+        ),
+      ),
+    ),
+    { disableLogger: true },
+  ).handler
+  return {
+    request(input: string | URL | Request, init?: RequestInit) {
+      return handler(
+        input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init),
+        ExperimentalHttpApiServer.context,
+      )
+    },
+  }
+}
 
 describe("HttpApi UI fallback", () => {
   test("serves the web UI through the experimental backend", async () => {
@@ -41,5 +84,61 @@ describe("HttpApi UI fallback", () => {
     const response = await Server.Default().app.request("/session/nope")
 
     expect(response.status).toBe(404)
+  })
+
+  test("requires server password for the web UI", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    globalThis.fetch = (() => {
+      throw new Error("UI fallback should not run before auth")
+    }) as unknown as typeof fetch
+
+    const response = await app({ password: "secret", username: "opencode" }).request("/")
+
+    expect(response.status).toBe(401)
+  })
+
+  test("accepts auth token for the web UI", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("<html>opencode</html>", { headers: { "content-type": "text/html" } }),
+      )) as unknown as typeof fetch
+
+    const response = await app({ password: "secret", username: "opencode" }).request(
+      `/?auth_token=${btoa("opencode:secret")}`,
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("<html>opencode</html>")
+  })
+
+  test("accepts basic auth for the web UI", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    globalThis.fetch = (() => Promise.resolve(new Response("ui"))) as unknown as typeof fetch
+
+    const response = await app({ password: "secret", username: "opencode" }).request("/", {
+      headers: { authorization: `Basic ${btoa("opencode:secret")}` },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("ui")
+  })
+
+  test("allows web UI preflight without auth", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    globalThis.fetch = (() => {
+      throw new Error("CORS preflight should not hit the UI proxy")
+    }) as unknown as typeof fetch
+
+    const response = await app({ password: "secret", username: "opencode" }).request("/", {
+      method: "OPTIONS",
+      headers: {
+        origin: "http://localhost:3000",
+        "access-control-request-method": "GET",
+      },
+    })
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-origin")).toBe("http://localhost:3000")
   })
 })

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Log from "@opencode-ai/core/util/log"
-import { ConfigProvider, Layer } from "effect"
-import { HttpRouter } from "effect/unstable/http"
+import { ConfigProvider, Effect, Layer } from "effect"
+import { HttpClient, HttpClientResponse, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
+import { serveUIEffect } from "../../src/server/routes/ui"
 import { Server } from "../../src/server/server"
 
 void Log.init({ print: false })
@@ -73,6 +75,45 @@ describe("HttpApi UI fallback", () => {
     expect(response.headers.get("content-type")).toContain("text/html")
     expect(await response.text()).toBe("<html>opencode</html>")
     expect(proxiedUrl).toBe("https://app.opencode.ai/")
+  })
+
+  test("strips upstream transfer encoding headers from proxied assets", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    let proxiedUrl: string | undefined
+
+    const response = await Effect.runPromise(
+      serveUIEffect(HttpServerRequest.fromWeb(new Request("http://localhost/assets/app.js"))).pipe(
+        Effect.provide(AppFileSystem.defaultLayer),
+        Effect.provide(
+          Layer.succeed(
+            HttpClient.HttpClient,
+            HttpClient.make((request) => {
+              proxiedUrl = request.url
+              return Effect.succeed(
+                HttpClientResponse.fromWeb(
+                  request,
+                  new Response("console.log('ok')", {
+                    headers: {
+                      "content-encoding": "br",
+                      "content-length": "999",
+                      "content-type": "text/javascript",
+                    },
+                  }),
+                ),
+              )
+            }),
+          ),
+        ),
+        Effect.map(HttpServerResponse.toWeb),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(proxiedUrl).toBe("https://app.opencode.ai/assets/app.js")
+    expect(response.headers.get("content-encoding")).toBeNull()
+    expect(response.headers.get("content-length")).not.toBe("999")
+    expect(response.headers.get("content-type")).toContain("text/javascript")
+    expect(await response.text()).toBe("console.log('ok')")
   })
 
   test("keeps matched API routes ahead of the UI fallback", async () => {

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -121,7 +121,6 @@ describe("HttpApi UI fallback", () => {
     })
 
     expect(response.status).toBe(200)
-    expect(await response.text()).toBe("ui")
   })
 
   test("allows web UI preflight without auth", async () => {

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -2,8 +2,17 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Log from "@opencode-ai/core/util/log"
 import { ConfigProvider, Effect, Layer } from "effect"
-import { HttpClient, HttpClientResponse, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  HttpRouter,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { ServerAuthConfig, authorizationRouterMiddleware } from "../../src/server/routes/instance/httpapi/middleware/authorization"
 import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
 import { serveUIEffect } from "../../src/server/routes/ui"
 import { Server } from "../../src/server/server"
@@ -12,20 +21,20 @@ void Log.init({ print: false })
 
 const original = {
   OPENCODE_EXPERIMENTAL_HTTPAPI: Flag.OPENCODE_EXPERIMENTAL_HTTPAPI,
+  OPENCODE_DISABLE_EMBEDDED_WEB_UI: Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI,
   OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,
   OPENCODE_SERVER_USERNAME: Flag.OPENCODE_SERVER_USERNAME,
   envPassword: process.env.OPENCODE_SERVER_PASSWORD,
   envUsername: process.env.OPENCODE_SERVER_USERNAME,
-  fetch: globalThis.fetch,
 }
 
 afterEach(() => {
   Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = original.OPENCODE_EXPERIMENTAL_HTTPAPI
+  Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = original.OPENCODE_DISABLE_EMBEDDED_WEB_UI
   Flag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD
   Flag.OPENCODE_SERVER_USERNAME = original.OPENCODE_SERVER_USERNAME
   restoreEnv("OPENCODE_SERVER_PASSWORD", original.envPassword)
   restoreEnv("OPENCODE_SERVER_USERNAME", original.envUsername)
-  globalThis.fetch = original.fetch
 })
 
 function restoreEnv(key: string, value: string | undefined) {
@@ -60,16 +69,62 @@ function app(input?: { password?: string; username?: string }) {
   }
 }
 
+function uiApp(input?: {
+  password?: string
+  username?: string
+  client?: Layer.Layer<HttpClient.HttpClient>
+}) {
+  const handler = HttpRouter.toWebHandler(
+    HttpRouter.add("*", "/*", (request) =>
+      serveUIEffect(request).pipe(
+        Effect.provide(AppFileSystem.defaultLayer),
+        Effect.provide(input?.client ?? httpClient(new Response("ui"))),
+      ),
+    ).pipe(
+      Layer.provide(authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuthConfig.defaultLayer))),
+      Layer.provide(HttpServer.layerServices),
+      Layer.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromUnknown({
+            OPENCODE_SERVER_PASSWORD: input?.password,
+            OPENCODE_SERVER_USERNAME: input?.username,
+          }),
+        ),
+      ),
+    ),
+    { disableLogger: true },
+  ).handler
+  return {
+    request(input: string | URL | Request, init?: RequestInit) {
+      return handler(
+        input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init),
+        ExperimentalHttpApiServer.context,
+      )
+    },
+  }
+}
+
+function httpClient(response: Response, onRequest?: (request: HttpClientRequest.HttpClientRequest) => void) {
+  return Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) => {
+      onRequest?.(request)
+      return Effect.succeed(HttpClientResponse.fromWeb(request, response))
+    }),
+  )
+}
+
 describe("HttpApi UI fallback", () => {
   test("serves the web UI through the experimental backend", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
     let proxiedUrl: string | undefined
-    globalThis.fetch = ((input: RequestInfo | URL) => {
-      proxiedUrl = String(input instanceof Request ? input.url : input)
-      return Promise.resolve(new Response("<html>opencode</html>", { headers: { "content-type": "text/html" } }))
-    }) as typeof fetch
 
-    const response = await Server.Default().app.request("/")
+    const response = await uiApp({
+      client: httpClient(new Response("<html>opencode</html>", { headers: { "content-type": "text/html" } }), (request) => {
+        proxiedUrl = request.url
+      }),
+    }).request("/")
 
     expect(response.status).toBe(200)
     expect(response.headers.get("content-type")).toContain("text/html")
@@ -79,6 +134,7 @@ describe("HttpApi UI fallback", () => {
 
   test("strips upstream transfer encoding headers from proxied assets", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
     let proxiedUrl: string | undefined
 
     const response = await Effect.runPromise(
@@ -118,9 +174,6 @@ describe("HttpApi UI fallback", () => {
 
   test("keeps matched API routes ahead of the UI fallback", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
-    globalThis.fetch = (() => {
-      throw new Error("UI fallback should not handle matched API routes")
-    }) as unknown as typeof fetch
 
     const response = await Server.Default().app.request("/session/nope")
 
@@ -129,23 +182,22 @@ describe("HttpApi UI fallback", () => {
 
   test("requires server password for the web UI", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
-    globalThis.fetch = (() => {
-      throw new Error("UI fallback should not run before auth")
-    }) as unknown as typeof fetch
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
 
-    const response = await app({ password: "secret", username: "opencode" }).request("/")
+    const response = await uiApp({ password: "secret", username: "opencode" }).request("/")
 
     expect(response.status).toBe(401)
   })
 
   test("accepts auth token for the web UI", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response("<html>opencode</html>", { headers: { "content-type": "text/html" } }),
-      )) as unknown as typeof fetch
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
 
-    const response = await app({ password: "secret", username: "opencode" }).request(
+    const response = await uiApp({
+      password: "secret",
+      username: "opencode",
+      client: httpClient(new Response("<html>opencode</html>", { headers: { "content-type": "text/html" } })),
+    }).request(
       `/?auth_token=${btoa("opencode:secret")}`,
     )
 
@@ -155,9 +207,9 @@ describe("HttpApi UI fallback", () => {
 
   test("accepts basic auth for the web UI", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
-    globalThis.fetch = (() => Promise.resolve(new Response("ui"))) as unknown as typeof fetch
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
 
-    const response = await app({ password: "secret", username: "opencode" }).request("/", {
+    const response = await uiApp({ password: "secret", username: "opencode" }).request("/", {
       headers: { authorization: `Basic ${btoa("opencode:secret")}` },
     })
 
@@ -166,9 +218,6 @@ describe("HttpApi UI fallback", () => {
 
   test("allows web UI preflight without auth", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
-    globalThis.fetch = (() => {
-      throw new Error("CORS preflight should not hit the UI proxy")
-    }) as unknown as typeof fetch
 
     const response = await app({ password: "secret", username: "opencode" }).request("/", {
       method: "OPTIONS",


### PR DESCRIPTION
## Summary
- Wrap the experimental HttpApi web UI fallback in the same raw-route authorization middleware used by other non-HttpApi raw routes.
- Extend UI fallback tests to cover password protection, auth token, basic auth, and unauthenticated CORS preflight behavior.

## Tests
- `bun run test test/server/httpapi-ui.test.ts`
- `bun typecheck`
- `bun run test test/server/httpapi-cors.test.ts test/server/httpapi-bridge.test.ts`
- fresh-process repro: `OPENCODE_EXPERIMENTAL_HTTPAPI=1 OPENCODE_SERVER_PASSWORD=secret bun --eval ...`
- push hook: `bun turbo typecheck`