### PR TITLE
refactor(httpapi): preserve typed errors in session prompt handlers

### DIFF
--- a/packages/opencode/src/effect/bridge.ts
+++ b/packages/opencode/src/effect/bridge.ts
@@ -1,4 +1,4 @@
-import { Effect, Fiber } from "effect"
+import { Effect, Exit, Fiber } from "effect"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Instance, type InstanceContext } from "@/project/instance"
 import type { WorkspaceID } from "@/control-plane/schema"
@@ -9,6 +9,7 @@ import { attachWith } from "./run-service"
 export interface Shape {
   readonly promise: <A, E, R>(effect: Effect.Effect<A, E, R>) => Promise<A>
   readonly fork: <A, E, R>(effect: Effect.Effect<A, E, R>) => Fiber.Fiber<A, E>
+  readonly run: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E>
 }
 
 function restore<R>(instance: InstanceContext | undefined, workspace: WorkspaceID | undefined, fn: () => R): R {
@@ -43,6 +44,14 @@ export function make(): Effect.Effect<Shape> {
         restore(instance, workspace, () => Effect.runPromise(wrap(effect))),
       fork: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
         restore(instance, workspace, () => Effect.runFork(wrap(effect))),
+      run: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+        Effect.callback<A, E>((resume) => {
+          restore(instance, workspace, () =>
+            Effect.runPromiseExit(wrap(effect)).then((exit) =>
+              resume(Exit.isSuccess(exit) ? Effect.succeed(exit.value) : Effect.failCause(exit.cause)),
+            ),
+          )
+        }),
     } satisfies Shape
   })
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -18,9 +18,8 @@ import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NotFoundError } from "@/storage/storage"
-import * as Log from "@opencode-ai/core/util/log"
 import { NamedError } from "@opencode-ai/core/util/error"
-import { Effect, Schema } from "effect"
+import { Cause, Effect, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
@@ -39,8 +38,6 @@ import {
   SummarizePayload,
   UpdatePayload,
 } from "../groups/session"
-
-const log = Log.create({ service: "server" })
 
 const mapNotFound = <A, E, R>(self: Effect.Effect<A, E, R>) =>
   self.pipe(
@@ -63,6 +60,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const statusSvc = yield* SessionStatus.Service
     const todoSvc = yield* Todo.Service
     const summary = yield* SessionSummary.Service
+    const bus = yield* Bus.Service
 
     const list = Effect.fn("SessionHttpApi.list")(function* (ctx: { query: typeof ListQuery.Type }) {
       const instance = yield* InstanceState.context
@@ -264,13 +262,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       const bridge = yield* EffectBridge.make()
       return HttpServerResponse.stream(
         Stream.fromEffect(
-          Effect.promise(() =>
-            bridge.promise(
-              promptSvc.prompt({
-                ...ctx.payload,
-                sessionID: ctx.params.sessionID,
-              }),
-            ),
+          bridge.run(
+            promptSvc.prompt({
+              ...ctx.payload,
+              sessionID: ctx.params.sessionID,
+            }),
           ),
         ).pipe(
           Stream.map((message) => JSON.stringify(message)),
@@ -288,12 +284,12 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       yield* Effect.sync(() => {
         bridge.fork(
           promptSvc.prompt({ ...ctx.payload, sessionID: ctx.params.sessionID }).pipe(
-            Effect.catchCause((error) =>
-              Effect.sync(() => {
-                log.error("prompt_async failed", { sessionID: ctx.params.sessionID, error })
-                void Bus.publish(Session.Event.Error, {
+            Effect.catchCause((cause) =>
+              Effect.gen(function* () {
+                yield* Effect.logError("prompt_async failed", { sessionID: ctx.params.sessionID, cause })
+                yield* bus.publish(Session.Event.Error, {
                   sessionID: ctx.params.sessionID,
-                  error: new NamedError.Unknown({ message: String(error) }).toObject(),
+                  error: new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(),
                 })
               }),
             ),


### PR DESCRIPTION
## Summary

Two related cleanups in the HttpApi session prompt handlers, both about losing Effect typing at the bridge boundary.

### `prompt` — typed errors silently became defects

```ts
// before
Effect.promise(() => bridge.promise(promptSvc.prompt(input)))
```

`bridge.promise` runs the inner Effect via `Effect.runPromise(...)`, which rejects with the inner error on failure. `Effect.promise(() => p)` then turns that rejection into a **defect** (500), erasing whatever typed error the prompt service produced.

This PR adds `EffectBridge.run`, an Effect-typed sibling of `bridge.promise`. It uses `Effect.runPromiseExit` + `Effect.callback` to re-enter Effect-land while preserving the full `Cause`. Same ALS restoration path as `bridge.promise` (the legacy `Instance.directory` / `Instance.worktree` reads in `session.ts` / `llm.ts` / `system.ts` still work — that's why the bridge exists at all).

```ts
// after
bridge.run(promptSvc.prompt(input))
```

### `promptAsync` — fire-and-forget bus publish, stringified cause

```ts
// before
Effect.catchCause((error) =>
  Effect.sync(() => {
    log.error("prompt_async failed", { sessionID, error })
    void Bus.publish(Session.Event.Error, {
      sessionID,
      error: new NamedError.Unknown({ message: String(error) }).toObject(),
    })
  })
)
```

Three problems:
1. `Bus.publish` (the module-level export) returns a `Promise<void>`. Wrapped in `Effect.sync` and prefixed with `void`, the publish is detached and unobserved — if it fails, the failure vanishes.
2. `String(error)` of a `Cause` produces \`\"Cause(...)\"\`-style output, not the actual error chain.
3. The error log goes through a hand-rolled `Log.create` instead of Effect's logger.

After:

```ts
Effect.catchCause((cause) =>
  Effect.gen(function* () {
    yield* Effect.logError("prompt_async failed", { sessionID, cause })
    yield* bus.publish(Session.Event.Error, {
      sessionID,
      error: new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(),
    })
  })
)
```

`bus` is now yielded once at the top of the group closure (next to the other services). The local `Log.create` is dead — removed along with its import.

## Notes

- `EffectBridge.run` is additive — `promise` and `fork` are unchanged, so the other consumers across `pty`, `plugin`, `provider`, `bus`, `mcp`, `command` keep working.
- The bridge itself isn't going anywhere yet — it exists because `Instance.project` / `Instance.worktree` / `Instance.directory` ALS reads are baked into the prompt call graph (`session.ts`, `llm.ts`, `system.ts`). Effect-ifying those is a separate, larger change.

## Test plan

- [x] \`bun typecheck\` from \`packages/opencode\` — clean.
- [x] \`bun run test:ci test/session/prompt.test.ts test/server/\` — 209/209 pass.