### PR TITLE
refactor(tool/read): yield InstanceState.context instead of reading ALS

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -7,7 +7,7 @@ import * as Tool from "./tool"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { LSP } from "@/lsp/lsp"
 import DESCRIPTION from "./read.txt"
-import { Instance } from "../project/instance"
+import { InstanceState } from "@/effect/instance-state"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
 import { isImageAttachment, isPdfAttachment, sniffAttachmentMime } from "@/util/media"
@@ -157,14 +157,15 @@ export const ReadTool = Tool.define(
         return yield* Effect.fail(new Error("offset must be greater than or equal to 1"))
       }
 
+      const instance = yield* InstanceState.context
       let filepath = params.filePath
       if (!path.isAbsolute(filepath)) {
-        filepath = path.resolve(Instance.directory, filepath)
+        filepath = path.resolve(instance.directory, filepath)
       }
       if (process.platform === "win32") {
         filepath = AppFileSystem.normalizePath(filepath)
       }
-      const title = path.relative(Instance.worktree, filepath)
+      const title = path.relative(instance.worktree, filepath)
 
       const stat = yield* fs.stat(filepath).pipe(
         Effect.catchIf(


### PR DESCRIPTION
## Summary

First step in migrating the prompt-path call graph off `Instance.{directory,worktree,project}` ALS reads and onto the Effect-side `InstanceState.context` accessor that already exists.

`InstanceState.context` reads `InstanceRef` first and falls back to the legacy `Instance.current` ALS — so this change is safe in every existing context: HttpApi handlers (which provide `InstanceRef` Effect-side), CLI commands (which set ALS via `Instance.provide`), and Hono routes.

`tool/read.ts` is the smallest possible starting point: 2 reads, both inside an existing `Effect.fn`, no interface change, no callers to update.

```diff
+      const instance = yield* InstanceState.context
       let filepath = params.filePath
       if (!path.isAbsolute(filepath)) {
-        filepath = path.resolve(Instance.directory, filepath)
+        filepath = path.resolve(instance.directory, filepath)
       }
       if (process.platform === "win32") {
         filepath = AppFileSystem.normalizePath(filepath)
       }
-      const title = path.relative(Instance.worktree, filepath)
+      const title = path.relative(instance.worktree, filepath)
```

## Why

The HttpApi session prompt handlers wrap `promptSvc.prompt` in `EffectBridge.run` because the prompt's call graph eventually reaches `Instance.directory` / `Instance.worktree` / `Instance.project` — pure ALS reads in `session.ts`, `llm.ts`, `system.ts`, and the tool layer. The bridge re-establishes ALS via `Instance.restore(ctx, () => runPromise(...))`. Once every read in the prompt graph goes through `InstanceState.context`, the bridge is unnecessary and handlers can call `yield* promptSvc.prompt(input)` directly.

This is one tile in that mosaic. Fourteen more files to convert (tool/lsp, tool/edit, tool/bash, tool/apply_patch, tool/plan, tool/write, session/llm, session/system, session/session.{plan,list}, file/watcher, sync, project/bootstrap), then the bridge usage in session prompt handlers gets deleted in a final payoff PR.

## Test plan

- [x] `bun typecheck` from `packages/opencode` — clean.
- [x] `bun run test:ci test/tool/read.test.ts` — 36/36 pass.