### PR TITLE
session: optional stripReasoning for compaction and cross-model safety

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -405,6 +405,7 @@ export const layer: Layer.Layer<
       const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, {
         stripMedia: true,
         toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
+        stripReasoning: true,
       })
       const ctx = yield* InstanceState.context
       const msg: MessageV2.Assistant = {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -729,7 +729,7 @@ function providerMeta(metadata: Record<string, any> | undefined) {
 export const toModelMessagesEffect = Effect.fnUntraced(function* (
   input: WithParts[],
   model: Provider.Model,
-  options?: { stripMedia?: boolean; toolOutputMaxChars?: number },
+  options?: { stripMedia?: boolean; toolOutputMaxChars?: number; stripReasoning?: boolean },
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
@@ -938,10 +938,11 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             })
         }
         if (part.type === "reasoning") {
+          if (options?.stripReasoning || differentModel) continue
           assistantMessage.parts.push({
             type: "reasoning",
             text: part.text,
-            ...(differentModel ? {} : { providerMetadata: part.metadata }),
+            providerMetadata: part.metadata,
           })
         }
       }
@@ -986,7 +987,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 export function toModelMessages(
   input: WithParts[],
   model: Provider.Model,
-  options?: { stripMedia?: boolean; toolOutputMaxChars?: number },
+  options?: { stripMedia?: boolean; toolOutputMaxChars?: number; stripReasoning?: boolean },
 ): Promise<ModelMessage[]> {
   return Effect.runPromise(toModelMessagesEffect(input, model, options).pipe(Effect.provide(EffectLogger.layer)))
 }


### PR DESCRIPTION
## Summary

When the app summarizes a long chat (compaction) or you switch models mid-session, hidden “reasoning” data from the old model can leak into the next request. Providers then reject the call or behave inconsistently. This change gives the session layer an explicit switch to drop that reasoning for compaction, while keeping normal chat behavior unchanged.

## Problem (plain language)

Long conversations are periodically summarized so they fit the model’s context window. That summary step should read like a normal transcript: goals, decisions, and tool outcomes—not low-level reasoning blobs tied to a specific model. If those blobs are forwarded anyway, the next model may error (for example missing signatures or wrong format) or users see confusing internal content in places it was never meant to go.

Separately, when you change which model is answering, reasoning attached to an earlier model is often not valid for the new one. The UI already treats “different model” as a special case; the conversion path to provider messages should align with that.

## Technical breakdown

1. **`MessageV2.toModelMessagesEffect`** converts stored session parts into the wire format the AI SDK sends to providers. It already supports stripping media and truncating large tool output (`toolOutputMaxChars`). It did not support **omitting reasoning parts** for specific call sites (notably compaction).

2. **Compaction** builds a shorter context for the compaction model. That path should not include assistant **reasoning** parts from the pre-compaction history, because they are not part of the user-visible story and can break or bloat the compaction request.

3. **Cross-model turns**: when the assistant message was produced with a different `providerID`/`modelID` than the target model, we already omit some provider metadata on text tools. Reasoning parts should follow the same rule: **skip** them when the model changed, instead of sending partial or incompatible reasoning metadata.

4. When we **keep** reasoning (same model, normal chat), reasoning parts should carry **`providerMetadata`** consistently so providers that need it still receive it.

## Solution

- Extend `toModelMessagesEffect` / `toModelMessages` options with optional **`stripReasoning?: boolean`** (alongside existing `stripMedia` and `toolOutputMaxChars`).
- In the reasoning branch: if `stripReasoning` **or** `differentModel`, **omit** the reasoning part; otherwise emit reasoning with **`providerMetadata`** from the stored part.
- In **compaction**, call `toModelMessagesEffect` with **`stripReasoning: true`** in addition to existing `stripMedia` and `toolOutputMaxChars`.

## Files

- `packages/opencode/src/session/message-v2.ts`
- `packages/opencode/src/session/compaction.ts`

## How to test

From `packages/opencode`:

```bash
bun typecheck
bun test test/session/message-v2.test.ts
```

## Merge order

None. This PR is safe to merge first. **PR 2–4** in this series do not depend on this branch for compilation (they touch other files), but landing this first keeps the story and review surface clear.

## Notes for reviewers

- No behavior change for default `toModelMessagesEffect` calls: `stripReasoning` is opt-in.
- Compaction is the only call site that sets `stripReasoning: true` in this PR.
