### PR TITLE
session: synthesize reasoning-start when stream omits it

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -397,6 +397,24 @@ const live: Layer.Layer<
                 }
                 return args.params
               },
+              async wrapStream({ doStream }) {
+                const result = await doStream()
+                const started = new Set<string>()
+                const fix = new TransformStream({
+                  transform(chunk, controller) {
+                    if (chunk.type === "reasoning-start") started.add(chunk.id)
+                    if (
+                      (chunk.type === "reasoning-delta" || chunk.type === "reasoning-end") &&
+                      !started.has(chunk.id)
+                    ) {
+                      started.add(chunk.id)
+                      controller.enqueue({ type: "reasoning-start", id: chunk.id })
+                    }
+                    controller.enqueue(chunk)
+                  },
+                })
+                return { ...result, stream: result.stream.pipeThrough(fix) }
+              },
             },
           ],
         }),


### PR DESCRIPTION
## Summary

Some model streams send reasoning updates without ever sending a matching “reasoning started” marker first. Downstream code then sees deltas or ends for an id it never opened, which can break ordering or UI assumptions. This adds a small stream normalizer so every reasoning id gets an explicit start before any delta or end.

## Problem (plain language)

Think of reasoning like a paragraph: you expect “paragraph begins,” then sentences, then “paragraph ends.” If the provider skips the “begins” line and only sends middle sentences, anything that tracks open blocks by id gets confused. Users may see glitches or missing reasoning; worse, the stack may mishandle chunks.

## Technical breakdown

1. The AI SDK exposes a **`wrapStream`** hook on language-model middleware.
2. Some providers emit **`reasoning-delta`** / **`reasoning-end`** for an id before a **`reasoning-start`** with that id.
3. We already normalize prompts in **`transformParams`**; this change normalizes the **stream** so each id is self-consistent.

## Solution

- In **`packages/opencode/src/session/llm.ts`**, extend the existing stream middleware with **`wrapStream`**.
- Track ids that have received **`reasoning-start`**.
- On **`reasoning-delta`** or **`reasoning-end`** without a prior start for that id, enqueue a synthetic **`reasoning-start`** first, then the original chunk.

## Files

- `packages/opencode/src/session/llm.ts`

## How to test

From `packages/opencode`:

```bash
bun typecheck
```

## Merge order

This PR does **not** depend on [PR: session stripReasoning / compaction](https://github.com/anomalyco/opencode/pull/25184). It can land before or after that change. If both merge, behavior stacks: compaction strips reasoning from **history**, while this hook fixes **live stream** ordering for reasoning chunks.
