### PR TITLE
provider: split Bedrock Claude into 200K and 1M catalog entries

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1037,6 +1037,37 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
   }
 }
 
+const BEDROCK_1M_MODELS = ["claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-5", "claude-sonnet-4-6"]
+const BEDROCK_1M_BETA = "context-1m-2025-08-07"
+const BEDROCK_1M_NATIVE = ["claude-opus-4-7"]
+
+function splitBedrock1m(pid: string, models: Record<string, Model>) {
+  if (pid !== "amazon-bedrock") return
+  for (const [id, model] of Object.entries(models)) {
+    if (!BEDROCK_1M_MODELS.some((m) => model.api.id.includes(m))) continue
+    if (id.endsWith("-1m")) continue
+    const native = BEDROCK_1M_NATIVE.some((m) => model.api.id.includes(m))
+    const name = model.name.replace(/\s+\((200K|1M Experimental)\)$/i, "")
+    const opts = { ...model.options }
+    const raw = opts["anthropicBeta"]
+    const existing = (Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : []).filter(
+      (item): item is string => typeof item === "string",
+    )
+    delete opts["anthropicBeta"]
+    model.name = `${name} (200K)`
+    model.options = opts
+    model.limit = { ...model.limit, context: Math.min(model.limit.context, 200_000) }
+    const betas = native ? existing : [...new Set([...existing, BEDROCK_1M_BETA])]
+    models[`${id}-1m`] = {
+      ...model,
+      id: ModelID.make(`${id}-1m`),
+      name: `${name} (1M)`,
+      limit: { ...model.limit, context: 1_000_000 },
+      options: { ...model.options, ...(betas.length > 0 ? { anthropicBeta: betas } : {}) },
+    }
+  }
+}
+
 export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
   const models: Record<string, Model> = {}
   for (const [key, model] of Object.entries(provider.models)) {
@@ -1061,6 +1092,7 @@ export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
       }
     }
   }
+  splitBedrock1m(provider.id, models)
   return {
     id: ProviderID.make(provider.id),
     source: "custom",


### PR DESCRIPTION
## Summary

Amazon Bedrock exposes several Claude models that can use a very large context window, but only when you opt in with the right headers and product choice. Today those models often appear as a single option, which makes it easy to pick the wrong one or miss the beta header entirely. This change splits each supported Bedrock Claude model into a clear **200K** default and a separate **1M** variant so people can choose deliberately.

## Problem (plain language)

Users want either “normal” long context or the experimental million-token mode. When both behaviors share one catalog entry, the app cannot label limits honestly, and the wrong beta flag may be attached—or omitted—so requests fail or behave unexpectedly. Native 1M support on newer models must not be forced through the older beta path.

## Technical breakdown

1. Models.dev / custom provider ingestion builds a flat map of Bedrock models in **`fromModelsDevProvider`**.
2. Specific Claude Opus/Sonnet API ids support a **1M** context with header **`context-1m-2025-08-07`**, while the same logical model should still be available at **200K** without that beta.
3. **Opus 4.7** is treated as **native 1M**: keep existing `anthropicBeta` from upstream data instead of injecting the 1M beta on the 1M row.

## Solution

- Add **`splitBedrock1m`** for provider id **`amazon-bedrock`**: for matching `model.api.id` substrings, clone into a **`-1m`** model id.
- Base row: cap context at **200K**, strip `anthropicBeta` from options, normalize display name to **`(200K)`**.
- **`-1m` row**: **1M** context; merge beta array—native Opus 4.7 keeps existing betas only; others add the 1M beta when missing.

## Files

- `packages/opencode/src/provider/provider.ts`

## How to test

From `packages/opencode`:

```bash
bun typecheck
```

Manual: open model picker for Bedrock and confirm paired **(200K)** / **(1M)** entries for supported Claude ids.

## Merge order

Independent of [PR #25184](https://github.com/anomalyco/opencode/pull/25184) and [PR #25185](https://github.com/anomalyco/opencode/pull/25185). Recommended before or with any Bedrock **transform** follow-up that assumes distinct `-1m` ids.
