### PR TITLE
provider: Bedrock non-Anthropic message cleanup and xhigh→max

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -215,6 +215,49 @@ function normalizeMessages(
   }
 
   if (
+    model.api.npm === "@ai-sdk/amazon-bedrock" &&
+    !model.api.id.includes("anthropic") &&
+    !model.api.id.includes("mistral")
+  ) {
+    const keys = ["bedrock", model.providerID]
+    const strip = (opts: Record<string, unknown> | undefined): Record<string, unknown> | undefined => {
+      if (!opts) return opts
+      let out = opts
+      for (const k of keys) {
+        const bucket = out[k] as Record<string, unknown> | undefined
+        if (bucket?.cachePoint) {
+          const { cachePoint: _, ...rest } = bucket
+          out = { ...out, [k]: Object.keys(rest).length > 0 ? rest : undefined }
+        }
+      }
+      return out
+    }
+    return msgs.map((msg) => {
+      let content = msg.content
+      if (msg.role === "assistant" && Array.isArray(content)) {
+        content = content.filter(
+          (part) =>
+            (part as { type: string }).type !== "reasoning" &&
+            (part as { type: string }).type !== "redacted-reasoning",
+        ) as typeof content
+        if (content.length === 0)
+          content = [{ type: "text" as const, text: "..." }] as typeof content
+      }
+      if (Array.isArray(content)) {
+        content = content.map((part) => {
+          const p = part as { providerOptions?: Record<string, unknown> }
+          const cleaned = strip(p.providerOptions)
+          return cleaned !== p.providerOptions ? { ...part, providerOptions: cleaned } : part
+        }) as typeof content
+      }
+      const cleaned = strip(msg.providerOptions as Record<string, unknown> | undefined)
+      if (content !== msg.content || cleaned !== msg.providerOptions)
+        return { ...msg, content, providerOptions: cleaned } as typeof msg
+      return msg
+    })
+  }
+
+  if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
     model.api.npm !== "@openrouter/ai-sdk-provider"
@@ -679,7 +722,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             {
               reasoningConfig: {
                 type: "adaptive",
-                maxReasoningEffort: effort,
+                maxReasoningEffort: effort === "xhigh" ? "max" : effort,
                 ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
                   ? { display: "summarized" }
                   : {}),

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3004,7 +3004,7 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
-    test("anthropic opus 4.7 returns adaptive reasoning options with xhigh", () => {
+    test("anthropic opus 4.7 returns adaptive reasoning options with xhigh mapped to max", () => {
       const model = createMockModel({
         id: "bedrock/anthropic-claude-opus-4-7",
         providerID: "bedrock",
@@ -3019,7 +3019,7 @@ describe("ProviderTransform.variants", () => {
       expect(result.xhigh).toEqual({
         reasoningConfig: {
           type: "adaptive",
-          maxReasoningEffort: "xhigh",
+          maxReasoningEffort: "max",
           display: "summarized",
         },
       })


### PR DESCRIPTION
## Summary

Some Amazon Bedrock models are **not** the Anthropic Claude adapter: they use different wire shapes. Sending them Anthropic-style extras—reasoning blocks from another stack, or cache breakpoints their stack does not understand—causes failures or empty turns. Separately, Bedrock’s adaptive “extra high” reasoning knob must map to a value the SDK accepts. This PR tightens Bedrock message shaping and variant config for those cases.

## Problem (plain language)

1. **Wrong shape for the wrong engine:** Assistant messages can still carry reasoning or cache metadata meant for Claude-on-Anthropic. When the active Bedrock model is something else, that metadata should not be forwarded as-is.
2. **Empty assistant turns:** After stripping unsupported parts, a message could end up with no content; providers reject empty assistant messages.
3. **Reasoning effort label mismatch:** The UI may offer **`xhigh`**, but Bedrock’s adaptive config for this path expects **`max`** for that tier—sending **`xhigh`** literally can break or be ignored.

## Technical breakdown

1. **`normalizeMessages`** (Bedrock npm **`@ai-sdk/amazon-bedrock`**, API id **without** `anthropic` or `mistral`):
   - Strip **`cachePoint`** from **`providerOptions`** under **`bedrock`** and **`model.providerID`** buckets.
   - Remove **`reasoning`** / **`redacted-reasoning`** parts from assistant array content; if nothing remains, insert a minimal **text** placeholder.
2. **`variants`** for **`@ai-sdk/amazon-bedrock`** adaptive map: **`maxReasoningEffort: effort === "xhigh" ? "max" : effort`**, while preserving upstream **Opus 4.7** `display: "summarized"` behavior on the **`xhigh`** variant row.

## Solution

- Add a dedicated early branch in **`normalizeMessages`** before interleaved handling for non-Anthropic, non-Mistral Bedrock models.
- Map **`xhigh` → `max`** for adaptive **`reasoningConfig.maxReasoningEffort`** on Bedrock.
- Extend **`transform.test.ts`** so Bedrock Opus 4.7 **`xhigh`** expects **`max`** plus **`display: "summarized"`**.

## Files

- `packages/opencode/src/provider/transform.ts`
- `packages/opencode/test/provider/transform.test.ts`

## How to test

From `packages/opencode`:

```bash
bun typecheck
bun test test/provider/transform.test.ts
```

## Merge order

Best reviewed after [PR #25186](https://github.com/anomalyco/opencode/pull/25186) (catalog **200K / 1M** split), since users pick the **`-1m`** rows this transform complements. Still **compiles independently** if merged out of order.
