### PR TITLE
fix(opencode): synthesize reasoning-start for incomplete streams

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -397,6 +397,24 @@ const live: Layer.Layer<
                 }
                 return args.params
               },
+              async wrapStream({ doStream }) {
+                const result = await doStream()
+                const started = new Set<string>()
+                const fix = new TransformStream({
+                  transform(chunk, controller) {
+                    if (chunk.type === "reasoning-start") started.add(chunk.id)
+                    if (
+                      (chunk.type === "reasoning-delta" || chunk.type === "reasoning-end") &&
+                      !started.has(chunk.id)
+                    ) {
+                      started.add(chunk.id)
+                      controller.enqueue({ type: "reasoning-start", id: chunk.id })
+                    }
+                    controller.enqueue(chunk)
+                  },
+                })
+                return { ...result, stream: result.stream.pipeThrough(fix) }
+              },
             },
           ],
         }),


### PR DESCRIPTION
### Issue for this PR

Closes #25191

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a model stream emits reasoning deltas without a preceding `reasoning-start` event, the LLM wrapper injects a synthetic start so downstream session/UI logic always sees a well-formed reasoning span.

### How did you verify your code works?

From `packages/opencode`: `bun typecheck` and stream/session tests touching `wrapStream` / LLM pipeline where applicable.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
