### PR TITLE
fix(opencode): split Bedrock Claude into 200K and 1M catalog rows

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1037,6 +1037,37 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
   }
 }
 
+const BEDROCK_1M_MODELS = ["claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-5", "claude-sonnet-4-6"]
+const BEDROCK_1M_BETA = "context-1m-2025-08-07"
+const BEDROCK_1M_NATIVE = ["claude-opus-4-7"]
+
+function splitBedrock1m(pid: string, models: Record<string, Model>) {
+  if (pid !== "amazon-bedrock") return
+  for (const [id, model] of Object.entries(models)) {
+    if (!BEDROCK_1M_MODELS.some((m) => model.api.id.includes(m))) continue
+    if (id.endsWith("-1m")) continue
+    const native = BEDROCK_1M_NATIVE.some((m) => model.api.id.includes(m))
+    const name = model.name.replace(/\s+\((200K|1M Experimental)\)$/i, "")
+    const opts = { ...model.options }
+    const raw = opts["anthropicBeta"]
+    const existing = (Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : []).filter(
+      (item): item is string => typeof item === "string",
+    )
+    delete opts["anthropicBeta"]
+    model.name = `${name} (200K)`
+    model.options = opts
+    model.limit = { ...model.limit, context: Math.min(model.limit.context, 200_000) }
+    const betas = native ? existing : [...new Set([...existing, BEDROCK_1M_BETA])]
+    models[`${id}-1m`] = {
+      ...model,
+      id: ModelID.make(`${id}-1m`),
+      name: `${name} (1M)`,
+      limit: { ...model.limit, context: 1_000_000 },
+      options: { ...model.options, ...(betas.length > 0 ? { anthropicBeta: betas } : {}) },
+    }
+  }
+}
+
 export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
   const models: Record<string, Model> = {}
   for (const [key, model] of Object.entries(provider.models)) {
@@ -1061,6 +1092,7 @@ export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
       }
     }
   }
+  splitBedrock1m(provider.id, models)
   return {
     id: ProviderID.make(provider.id),
     source: "custom",


### PR DESCRIPTION
### Issue for this PR

Closes #25192

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Splits Bedrock Claude catalog entries so 200K and 1M context variants are distinct choices (including `splitBedrock1m` / provider wiring), aligning the picker with real context limits.

### How did you verify your code works?

From `packages/opencode`: `bun typecheck` and provider/catalog tests affected by the split.

### Screenshots / recordings

N/A — not a UI change (model list behavior only if surfaced in UI; no screenshot captured here).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
