### PR TITLE
fix(opencode): Bedrock non-Anthropic normalize and xhigh to max effort

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -215,6 +215,49 @@ function normalizeMessages(
   }
 
   if (
+    model.api.npm === "@ai-sdk/amazon-bedrock" &&
+    !model.api.id.includes("anthropic") &&
+    !model.api.id.includes("mistral")
+  ) {
+    const keys = ["bedrock", model.providerID]
+    const strip = (opts: Record<string, unknown> | undefined): Record<string, unknown> | undefined => {
+      if (!opts) return opts
+      let out = opts
+      for (const k of keys) {
+        const bucket = out[k] as Record<string, unknown> | undefined
+        if (bucket?.cachePoint) {
+          const { cachePoint: _, ...rest } = bucket
+          out = { ...out, [k]: Object.keys(rest).length > 0 ? rest : undefined }
+        }
+      }
+      return out
+    }
+    return msgs.map((msg) => {
+      let content = msg.content
+      if (msg.role === "assistant" && Array.isArray(content)) {
+        content = content.filter(
+          (part) =>
+            (part as { type: string }).type !== "reasoning" &&
+            (part as { type: string }).type !== "redacted-reasoning",
+        ) as typeof content
+        if (content.length === 0)
+          content = [{ type: "text" as const, text: "..." }] as typeof content
+      }
+      if (Array.isArray(content)) {
+        content = content.map((part) => {
+          const p = part as { providerOptions?: Record<string, unknown> }
+          const cleaned = strip(p.providerOptions)
+          return cleaned !== p.providerOptions ? { ...part, providerOptions: cleaned } : part
+        }) as typeof content
+      }
+      const cleaned = strip(msg.providerOptions as Record<string, unknown> | undefined)
+      if (content !== msg.content || cleaned !== msg.providerOptions)
+        return { ...msg, content, providerOptions: cleaned } as typeof msg
+      return msg
+    })
+  }
+
+  if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
     model.api.npm !== "@openrouter/ai-sdk-provider"
@@ -679,7 +722,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             {
               reasoningConfig: {
                 type: "adaptive",
-                maxReasoningEffort: effort,
+                maxReasoningEffort: effort === "xhigh" ? "max" : effort,
                 ...(model.api.id.includes("opus-4-7") || model.api.id.includes("opus-4.7")
                   ? { display: "summarized" }
                   : {}),

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3004,7 +3004,7 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
-    test("anthropic opus 4.7 returns adaptive reasoning options with xhigh", () => {
+    test("anthropic opus 4.7 returns adaptive reasoning options with xhigh mapped to max", () => {
       const model = createMockModel({
         id: "bedrock/anthropic-claude-opus-4-7",
         providerID: "bedrock",
@@ -3019,7 +3019,7 @@ describe("ProviderTransform.variants", () => {
       expect(result.xhigh).toEqual({
         reasoningConfig: {
           type: "adaptive",
-          maxReasoningEffort: "xhigh",
+          maxReasoningEffort: "max",
           display: "summarized",
         },
       })


### PR DESCRIPTION
### Issue for this PR

Closes #25193

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

For `@ai-sdk/amazon-bedrock` models that are not the Anthropic or Mistral adapters, `normalizeMessages` strips cache breakpoints and reasoning-shaped assistant parts (with a text placeholder if the message would otherwise be empty). For adaptive variants, maps UI `xhigh` to Bedrock `max` for `maxReasoningEffort`, keeping Opus 4.7 summarized display behavior. Tests updated for the Bedrock Opus 4.7 `xhigh` case.

### How did you verify your code works?

From `packages/opencode`: `bun typecheck` and `bun test test/provider/transform.test.ts`.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
