### PR TITLE
test(effect): stabilize runner active shell check

### DIFF
--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -263,14 +263,25 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
-      const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
-      yield* Effect.sleep("10 millis")
+      const started = yield* Deferred.make<void>()
+      const fiber = yield* runner
+        .ensureRunning(
+          Effect.gen(function* () {
+            yield* Deferred.succeed(started, undefined)
+            return yield* Effect.never.pipe(Effect.as("x"))
+          }),
+        )
+        .pipe(Effect.forkChild)
+      yield* Deferred.await(started).pipe(Effect.timeout("250 millis"))
+      yield* Effect.gen(function* () {
+        while (runner.state._tag !== "Running") yield* Effect.yieldNow
+      }).pipe(Effect.timeout("250 millis"))
 
       const exit = yield* runner.startShell(Effect.succeed("nope")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
 
       yield* runner.cancel
-      yield* Fiber.await(fiber)
+      yield* Fiber.await(fiber).pipe(Effect.timeout("250 millis"))
     }),
   )
 


### PR DESCRIPTION
## Summary
- Replace the `Runner > shell rejects when run is active` test's fixed `10ms` sleep with deterministic synchronization.
- Wait for the run body to start and for the runner state to become `Running` before asserting shell rejection.
- Add short timeouts around waits so future regressions fail quickly instead of consuming the full test timeout.

## Testing
- `bun run test:ci test/effect/runner.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- Push hook: `bun turbo typecheck`