### PR TITLE
refactor(project): yield instance context in bootstrap

### DIFF
--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -7,7 +7,7 @@ import * as Project from "./project"
 import * as Vcs from "./vcs"
 import { Bus } from "../bus"
 import { Command } from "../command"
-import { Instance } from "./instance"
+import { InstanceState } from "@/effect/instance-state"
 import * as Log from "@opencode-ai/core/util/log"
 import { FileWatcher } from "@/file/watcher"
 import { ShareNext } from "@/share/share-next"
@@ -15,7 +15,8 @@ import * as Effect from "effect/Effect"
 import { Config } from "@/config/config"
 
 export const InstanceBootstrap = Effect.gen(function* () {
-  Log.Default.info("bootstrapping", { directory: Instance.directory })
+  const ctx = yield* InstanceState.context
+  Log.Default.info("bootstrapping", { directory: ctx.directory })
   // everything depends on config so eager load it for nice traces
   yield* Config.Service.use((svc) => svc.get())
   // Plugin can mutate config so it has to be initialized before anything else.
@@ -32,10 +33,11 @@ export const InstanceBootstrap = Effect.gen(function* () {
     ].map((s) => Effect.forkDetach(s.use((i) => i.init()))),
   ).pipe(Effect.withSpan("InstanceBootstrap.init"))
 
+  const projectID = ctx.project.id
   yield* Bus.Service.use((svc) =>
     svc.subscribeCallback(Command.Event.Executed, async (payload) => {
       if (payload.properties.name === Command.Default.INIT) {
-        Project.setInitialized(Instance.project.id)
+        Project.setInitialized(projectID)
       }
     }),
   )


### PR DESCRIPTION
## Summary
- Replace legacy bootstrap `Instance` ALS reads with yielded `InstanceState.context`.
- Capture the project id before the command subscription callback to preserve behavior without reading legacy instance state inside the callback.

## Verification
- `bun typecheck` from `packages/opencode`
- No focused project/bootstrap test found under `packages/opencode`