### PR TITLE
Preapprove agent tmp directory access

### DIFF
--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -11,6 +11,7 @@ const data = path.join(xdgData!, app)
 const cache = path.join(xdgCache!, app)
 const config = path.join(xdgConfig!, app)
 const state = path.join(xdgState!, app)
+const tmp = path.join(os.tmpdir(), app)
 
 const paths = {
   get home() {
@@ -22,6 +23,7 @@ const paths = {
   cache,
   config,
   state,
+  tmp,
 }
 
 export const Path = paths
@@ -32,6 +34,7 @@ await Promise.all([
   fs.mkdir(Path.data, { recursive: true }),
   fs.mkdir(Path.config, { recursive: true }),
   fs.mkdir(Path.state, { recursive: true }),
+  fs.mkdir(Path.tmp, { recursive: true }),
   fs.mkdir(Path.log, { recursive: true }),
   fs.mkdir(Path.bin, { recursive: true }),
 ])
@@ -44,6 +47,7 @@ export interface Interface {
   readonly cache: string
   readonly config: string
   readonly state: string
+  readonly tmp: string
   readonly bin: string
   readonly log: string
 }
@@ -55,6 +59,7 @@ export function make(input: Partial<Interface> = {}): Interface {
     cache: Path.cache,
     config: Flag.OPENCODE_CONFIG_DIR ?? Path.config,
     state: Path.state,
+    tmp: Path.tmp,
     bin: Path.bin,
     log: Path.log,
     ...input,

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -81,7 +81,11 @@ export const layer = Layer.effect(
       Effect.fn("Agent.state")(function* (ctx) {
         const cfg = yield* config.get()
         const skillDirs = yield* skill.dirs()
-        const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]
+        const whitelistedDirs = [
+          Truncate.GLOB,
+          path.join(Global.Path.tmp, "*"),
+          ...skillDirs.map((dir) => path.join(dir, "*")),
+        ]
 
         const defaults = Permission.fromConfig({
           "*": "allow",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -14,6 +14,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { fileURLToPath } from "url"
 import { Config } from "@/config/config"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { Global } from "@opencode-ai/core/global"
 import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
@@ -587,6 +588,7 @@ export const BashTool = Tool.define(
 
         return {
           description: DESCRIPTION.replaceAll("${directory}", instance.directory)
+            .replaceAll("${tmp}", Global.Path.tmp)
             .replaceAll("${os}", process.platform)
             .replaceAll("${shell}", name)
             .replaceAll("${chaining}", chain)

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -4,6 +4,8 @@ Be aware: OS: ${os}, Shell: ${shell}
 
 All commands run in the current working directory by default. Use the `workdir` parameter if you need to run a command in a different directory. AVOID using `cd <directory> && <command>` patterns - use `workdir` instead.
 
+Use `${tmp}` for temporary work outside the workspace. This directory is pre-approved for external directory access.
+
 IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO NOT use it for file operations (reading, writing, editing, searching, finding files) - use the specialized tools for this instead.
 
 Before executing the command, please follow these steps:


### PR DESCRIPTION
## Summary
- Add an opencode-owned tmp path under the OS temporary directory.
- Preapprove that tmp directory for agent external directory access.
- Tell agents in the bash tool prompt to use the preapproved tmp directory for temporary work outside the workspace.

## Verification
- bun typecheck in packages/core
- bun typecheck in packages/opencode