### PR TITLE
docs: update SDK docs to reference v2 SDK exclusively

### DIFF
--- a/packages/web/src/content/docs/sdk.mdx
+++ b/packages/web/src/content/docs/sdk.mdx
@@ -4,7 +4,7 @@ description: Type-safe JS client for opencode server.
 ---
 
 import config from "../../../config.mjs"
-export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types.gen.ts`
+export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/v2/gen/types.gen.ts`
 
 The opencode JS/TS SDK provides a type-safe client for interacting with the server.
 Use it to build integrations and control opencode programmatically.
@@ -28,7 +28,7 @@ npm install @opencode-ai/sdk
 Create an instance of opencode:
 
 ```javascript
-import { createOpencode } from "@opencode-ai/sdk"
+import { createOpencode } from "@opencode-ai/sdk/v2"
 
 const { client } = await createOpencode()
 ```
@@ -52,7 +52,7 @@ This starts both a server and a client
 You can pass a configuration object to customize behavior. The instance still picks up your `opencode.json`, but you can override or add configuration inline:
 
 ```javascript
-import { createOpencode } from "@opencode-ai/sdk"
+import { createOpencode } from "@opencode-ai/sdk/v2"
 
 const opencode = await createOpencode({
   hostname: "127.0.0.1",
@@ -72,7 +72,7 @@ opencode.server.close()
 If you already have a running instance of opencode, you can create a client instance to connect to it:
 
 ```javascript
-import { createOpencodeClient } from "@opencode-ai/sdk"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 
 const client = createOpencodeClient({
   baseUrl: "http://localhost:4096",
@@ -96,7 +96,7 @@ const client = createOpencodeClient({
 The SDK includes TypeScript definitions for all API types. Import them directly:
 
 ```typescript
-import type { Session, Message, Part } from "@opencode-ai/sdk"
+import type { Session, Message, Part } from "@opencode-ai/sdk/v2"
 ```
 
 All types are generated from the server's OpenAPI specification and available in the <a href={typesUrl}>types file</a>.
@@ -318,7 +318,7 @@ const { providers, default: defaults } = await client.config.providers()
 | `session.shell({ path, body })`                            | Run a shell command                | Returns <a href={typesUrl}><code>AssistantMessage</code></a>                                                                                                                                                             |
 | `session.revert({ path, body })`                           | Revert a message                   | Returns <a href={typesUrl}><code>Session</code></a>                                                                                                                                                                      |
 | `session.unrevert({ path })`                               | Restore reverted messages          | Returns <a href={typesUrl}><code>Session</code></a>                                                                                                                                                                      |
-| `postSessionByIdPermissionsByPermissionId({ path, body })` | Respond to a permission request    | Returns `boolean`                                                                                                                                                                                                        |
+| `permission.reply({ path, body })`                         | Respond to a permission request    | Returns `boolean`                                                                                                                                                                                                        |
 
 ---
 
@@ -360,7 +360,7 @@ await client.session.prompt({
 | `find.text({ query })`    | Search for text in files           | Array of match objects with `path`, `lines`, `line_number`, `absolute_offset`, `submatches` |
 | `find.files({ query })`   | Find files and directories by name | `string[]` (paths)                                                                          |
 | `find.symbols({ query })` | Find workspace symbols             | <a href={typesUrl}><code>Symbol[]</code></a>                                                |
-| `file.read({ query })`    | Read a file                        | `{ type: "raw" \| "patch", content: string }`                                               |
+| `file.read({ query })`    | Read a file                        | `{ type: "text" \| "binary", content: string }`                                             |
 | `file.status({ query? })` | Get status for tracked files       | <a href={typesUrl}><code>File[]</code></a>                                                  |
 
 `find.files` supports a few optional query fields:


### PR DESCRIPTION
- Update all imports to @opencode-ai/sdk/v2
- Fix types URL to point to v2 generated types
- Fix file.read response type: text|binary (not raw|patch)
- Fix permission method name: permission.reply (not postSessionByIdPermissionsByPermissionId)
