### PR TITLE
fix(tui): gate logo subpixel rendering on truecolor support

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/logo.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/logo.tsx
@@ -1,4 +1,5 @@
 import { BoxRenderable, MouseButton, MouseEvent, RGBA, TextAttributes } from "@opentui/core"
+import { useRenderer } from "@opentui/solid"
 import { For, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js"
 import { useTheme, tint } from "@tui/context/theme"
 import * as Sound from "@tui/util/sound"
@@ -554,6 +555,7 @@ function buildIdleState(t: number, ctx: LogoContext): IdleState {
 export function Logo(props: { shape?: LogoShape; ink?: RGBA; idle?: boolean } = {}) {
   const ctx = props.shape ? build(props.shape) : DEFAULT
   const { theme } = useTheme()
+  const renderer = useRenderer()
   const [rings, setRings] = createSignal<Ring[]>([])
   const [hold, setHold] = createSignal<Hold>()
   const [release, setRelease] = createSignal<Release>()
@@ -684,6 +686,7 @@ export function Logo(props: { shape?: LogoShape; ink?: RGBA; idle?: boolean } = 
   })
 
   const idleState = createMemo(() => (props.idle ? buildIdleState(frame().t, ctx) : undefined))
+  const useSubpixelBlocks = () => renderer.capabilities?.rgb === true
 
   const renderLine = (
     line: string,
@@ -789,7 +792,7 @@ export function Logo(props: { shape?: LogoShape; ink?: RGBA; idle?: boolean } = 
       }
 
       // Solid █: render as ▀ so the top pixel (fg) and bottom pixel (bg) can carry independent shimmer values
-      if (char === "█") {
+      if (char === "█" && useSubpixelBlocks()) {
         return (
           <text
             fg={shade(inkTop, theme, n + p + e + b)}


### PR DESCRIPTION
Keep the smoother half-block shimmer on RGB terminals while falling back to normal block glyphs on indexed terminals. This avoids 256-color background quantization artifacts in system-theme splash screen.

Related: #24872