### PR TITLE
fix(session): use finite archived timestamp schema

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -142,9 +142,9 @@ const Share = Schema.Struct({
   url: Schema.String,
 })
 
-// Legacy HTTP accepted any number here, and persisted data may already contain
-// negative values. Keep archive timestamps permissive while other clocks stay non-negative.
-export const ArchivedTimestamp = Schema.Number
+// Legacy HTTP accepted negative values here. Keep archive timestamps permissive
+// while excluding non-finite values that cannot round-trip through JSON.
+export const ArchivedTimestamp = Schema.Finite
 
 const Time = Schema.Struct({
   created: NonNegativeInt,

--- a/packages/opencode/test/server/httpapi-bridge.test.ts
+++ b/packages/opencode/test/server/httpapi-bridge.test.ts
@@ -258,6 +258,18 @@ describe("HttpApi server", () => {
     })
   })
 
+  test("matches SDK-affecting request schema details", () => {
+    const effect = effectOpenApi()
+    const sessionUpdate = effect.paths["/session/{sessionID}"]?.patch?.requestBody
+    const sessionUpdateSchema =
+      typeof sessionUpdate === "object" && sessionUpdate && "content" in sessionUpdate
+        ? sessionUpdate.content?.["application/json"]?.schema
+        : undefined
+    const sessionUpdateProperties = sessionUpdateSchema?.properties as Record<string, OpenApiSchema> | undefined
+    const time = sessionUpdateProperties?.time
+    expect(time?.properties?.archived).toEqual({ type: "number" })
+  })
+
   test("documents event routes as server-sent events", () => {
     const effect = effectOpenApi()
 


### PR DESCRIPTION
## Summary
- Use `Schema.Finite` for session archive timestamps so generated OpenAPI/SDK types stay `number` without non-finite string literal arms.
- Keep negative archive timestamp values accepted for legacy compatibility while rejecting values that cannot round-trip through JSON.
- Add bridge coverage for the SDK-affecting session update request schema.

## Validation
- bun typecheck
- bun run test test/server/httpapi-bridge.test.ts test/server/httpapi-mcp-oauth.test.ts
- pre-push bun turbo typecheck