### PR TITLE
fix(tui): retain current model and agent across session switches

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -241,26 +241,32 @@ export function Prompt(props: PromptProps) {
     ),
   )
 
-  // Initialize agent/model/variant from last user message when session changes
+  // Initialize agent/model/variant from the session's last user message on the
+  // first session that loads. On subsequent session switches, preserve the
+  // user's current agent/model selection rather than reverting to the session's
+  // historical configuration.
   let syncedSessionID: string | undefined
+  let initialized = false
   createEffect(() => {
     const sessionID = props.sessionID
     const msg = lastUserMessage()
 
-    if (sessionID !== syncedSessionID) {
-      if (!sessionID || !msg) return
+    if (sessionID === syncedSessionID) return
+    if (!sessionID || !msg) return
 
-      syncedSessionID = sessionID
+    syncedSessionID = sessionID
 
-      // Only set agent if it's a primary agent (not a subagent)
-      const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
-      if (msg.agent && isPrimaryAgent) {
-        // Keep command line --agent if specified.
-        if (!args.agent) local.agent.set(msg.agent)
-        if (msg.model) {
-          local.model.set(msg.model)
-          local.model.variant.set(msg.model.variant)
-        }
+    if (initialized) return
+    initialized = true
+
+    // Only set agent if it's a primary agent (not a subagent)
+    const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
+    if (msg.agent && isPrimaryAgent) {
+      // Keep command line --agent if specified.
+      if (!args.agent) local.agent.set(msg.agent)
+      if (msg.model) {
+        local.model.set(msg.model)
+        local.model.variant.set(msg.model.variant)
       }
     }
   })


### PR DESCRIPTION
### Issue for this PR

Closes #4930

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the user switched between sessions via `Ctrl+X l`, the prompt's `createEffect` watching `props.sessionID` reset the agent and model from the picked session's last user message every time, overriding whatever the user had selected before the switch.

The fix adds an `initialized` flag in that effect so the restoration runs only on the first session sync (initial app load), giving the TUI sensible defaults from the session on startup. On every subsequent session switch the effect short-circuits and leaves the user's current `local.agent` / `local.model` / `local.model.variant` untouched. The existing primary-agent guard and `--agent` CLI override still apply.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` — same 10 pre-existing warnings before and after the change, 0 errors (verified by stashing the change and re-running).
- Traced the reactive flow: initial load (`syncedSessionID` undefined, `initialized` false) restores from the session's last user message and sets `initialized = true`; subsequent `Ctrl+X l` switches update `syncedSessionID` but skip the restoration block.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
