### PR TITLE
fix(mcp): truncate tool keys longer than 64 characters

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -12,6 +12,7 @@ import {
 import { Config } from "@/config/config"
 import { ConfigMCP } from "../config/mcp"
 import * as Log from "@opencode-ai/core/util/log"
+import { Hash } from "@opencode-ai/core/util/hash"
 import { NamedError } from "@opencode-ai/core/util/error"
 import z from "zod/v4"
 import { Installation } from "../installation"
@@ -113,6 +114,19 @@ function isMcpConfigured(entry: McpEntry): entry is ConfigMCP.Info {
 }
 
 const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_")
+
+// Anthropic and OpenAI tool calling APIs reject tool names longer than 64
+// characters; long MCP server names + tool names can exceed that and cause
+// requests to fail validation. Truncate deterministically with a short hash
+// suffix to keep keys unique across collisions.
+const MAX_TOOL_NAME_LENGTH = 64
+
+function buildToolKey(clientName: string, toolName: string): string {
+  const key = sanitize(clientName) + "_" + sanitize(toolName)
+  if (key.length <= MAX_TOOL_NAME_LENGTH) return key
+  const suffix = "_" + Hash.fast(key).slice(0, 8)
+  return key.slice(0, MAX_TOOL_NAME_LENGTH - suffix.length) + suffix
+}
 
 function remoteURL(key: string, value: string) {
   if (URL.canParse(value)) return new URL(value)
@@ -654,7 +668,16 @@ export const layer = Layer.effect(
 
             const timeout = entry?.timeout ?? defaultTimeout
             for (const mcpTool of listed) {
-              result[sanitize(clientName) + "_" + sanitize(mcpTool.name)] = convertMcpTool(mcpTool, client, timeout)
+              const full = sanitize(clientName) + "_" + sanitize(mcpTool.name)
+              const key = buildToolKey(clientName, mcpTool.name)
+              if (key !== full) {
+                log.warn("mcp tool name truncated to fit 64-char limit", {
+                  clientName,
+                  toolName: mcpTool.name,
+                  key,
+                })
+              }
+              result[key] = convertMcpTool(mcpTool, client, timeout)
             }
           }),
         { concurrency: "unbounded" },

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -704,6 +704,45 @@ test(
 )
 
 // ========================================================================
+// Test: long server/tool names are truncated to fit the 64-char limit (#3523)
+// ========================================================================
+
+test(
+  "tools() truncates tool keys longer than 64 chars while preserving uniqueness",
+  withInstance(
+    {
+      "very-long-mcp-server-name-that-pushes-tool-keys-past-the-limit": {
+        type: "local",
+        command: ["echo", "test"],
+      },
+    },
+    (mcp) =>
+      Effect.gen(function* () {
+        const serverName = "very-long-mcp-server-name-that-pushes-tool-keys-past-the-limit"
+        lastCreatedClientName = serverName
+        const serverState = getOrCreateClientState(serverName)
+        serverState.tools = [
+          { name: "alpha", description: "Tool alpha", inputSchema: { type: "object", properties: {} } },
+          { name: "bravo", description: "Tool bravo", inputSchema: { type: "object", properties: {} } },
+        ]
+
+        yield* mcp.add(serverName, { type: "local", command: ["echo", "test"] })
+
+        const tools = yield* mcp.tools()
+        const keys = Object.keys(tools)
+
+        expect(keys.length).toBe(2)
+        for (const key of keys) {
+          expect(key.length).toBeLessThanOrEqual(64)
+          expect(key).toMatch(/^[a-zA-Z0-9_-]+$/)
+        }
+        // Both tools must produce distinct keys even after truncation.
+        expect(new Set(keys).size).toBe(2)
+      }),
+  ),
+)
+
+// ========================================================================
 // Test: transport leak — local stdio timeout (#19168)
 // ========================================================================
 


### PR DESCRIPTION
### Issue for this PR

Closes #3523

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Anthropic and OpenAI tool calling APIs reject tool names longer than 64 characters. When an MCP server is configured with a long name, the registered tool key `<sanitized_server>_<sanitized_tool>` produced in `packages/opencode/src/mcp/index.ts` could exceed that limit, causing the request to fail validation and the session to die silently with no further prompts processed.

The fix adds a `buildToolKey(clientName, toolName)` helper that returns `<sanitized_client>_<sanitized_tool>` when the natural form fits within 64 characters, and otherwise truncates the key and appends an 8-character SHA-1 hash of the original key (`<truncated>_<hash>`) so collisions remain unique. The `tools()` registration loop now goes through the helper and emits a warn log when truncation happens so users can rename if they want a stable readable key.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/mcp/index.ts packages/opencode/test/mcp/lifecycle.test.ts` — same 11 pre-existing warnings before and after, 0 errors.
- Added a regression test in `packages/opencode/test/mcp/lifecycle.test.ts` using a 62-character server name that asserts all registered keys are sanitized, ≤ 64 characters, and unique across tools from the same server.
- `bun test packages/opencode/test/mcp/lifecycle.test.ts` — 20/20 pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
