### PR TITLE
fix(mdns): derive service name from domain to avoid collisions

### DIFF
--- a/packages/opencode/src/server/mdns.ts
+++ b/packages/opencode/src/server/mdns.ts
@@ -6,13 +6,24 @@ const log = Log.create({ service: "mdns" })
 let bonjour: Bonjour | undefined
 let currentPort: number | undefined
 
+// mDNS service instance names must be unique on the network. Using a fixed
+// `opencode-<port>` collides when two instances on the same LAN run on the
+// same port even with different `--mdns-domain` values. Derive the name from
+// the configured domain so distinct domains produce distinct service names.
+export function serviceName(port: number, domain?: string): string {
+  const host = (domain ?? "opencode.local").trim()
+  const stripped = host.replace(/\.local\.?$/i, "").replace(/\./g, "-")
+  const prefix = stripped || "opencode"
+  return `${prefix}-${port}`
+}
+
 export function publish(port: number, domain?: string) {
   if (currentPort === port) return
   if (bonjour) unpublish()
 
   try {
     const host = domain ?? "opencode.local"
-    const name = `opencode-${port}`
+    const name = serviceName(port, domain)
     bonjour = new Bonjour()
     const service = bonjour.publish({
       name,

--- a/packages/opencode/test/server/mdns.test.ts
+++ b/packages/opencode/test/server/mdns.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { serviceName } from "../../src/server/mdns"
+
+describe("serviceName", () => {
+  test("uses default opencode prefix when no domain is given", () => {
+    expect(serviceName(4096)).toBe("opencode-4096")
+  })
+
+  test("uses default opencode prefix for the default opencode.local domain", () => {
+    expect(serviceName(4096, "opencode.local")).toBe("opencode-4096")
+  })
+
+  test("derives a unique prefix from a custom mdns domain", () => {
+    expect(serviceName(4096, "vmb.local")).toBe("vmb-4096")
+  })
+
+  test("two distinct domains on the same port produce distinct names", () => {
+    expect(serviceName(4096, "opencode.local")).not.toBe(serviceName(4096, "vmb.local"))
+  })
+
+  test("strips a trailing dot on the .local suffix", () => {
+    expect(serviceName(4096, "vmb.local.")).toBe("vmb-4096")
+  })
+
+  test("falls back to opencode when the domain reduces to an empty prefix", () => {
+    expect(serviceName(4096, ".local")).toBe("opencode-4096")
+  })
+
+  test("handles domains without the .local suffix", () => {
+    expect(serviceName(4096, "my-server")).toBe("my-server-4096")
+  })
+
+  test("replaces inner dots with dashes for multi-label custom domains", () => {
+    expect(serviceName(4096, "team.dev.local")).toBe("team-dev-4096")
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(serviceName(4096, "  vmb.local  ")).toBe("vmb-4096")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #22354

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The mDNS service in `packages/opencode/src/server/mdns.ts` was always advertised under the fixed instance name `opencode-<port>`, regardless of the `--mdns-domain` flag. Two opencode instances on the same LAN that share a port would probe the same service instance name and the second one failed with `Service name is already in use on the network`, even though the user-visible hostname differed.

The fix extracts a pure `serviceName(port, domain)` helper that derives the name prefix from the configured domain: it strips a trailing `.local` (with optional dot), replaces inner dots with dashes for multi-label domains, and falls back to `opencode` if the derived prefix would be empty. Distinct domains now produce distinct mDNS service instance names; the default `opencode.local` keeps the existing `opencode-<port>` form, so the change is backwards compatible for the single-instance case.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/server/mdns.ts packages/opencode/test/server/mdns.test.ts` — 0 warnings, 0 errors.
- Added `packages/opencode/test/server/mdns.test.ts` covering: default domain, custom domain, trailing dot, multi-label domain, empty-prefix fallback, whitespace handling, and the collision case from the bug report.
- `bun test packages/opencode/test/server/mdns.test.ts` — 9/9 pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
