### PR TITLE
fix(tui): avoid opaque flash on startup with transparent custom themes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,7 +1,7 @@
 import { render, TimeToFirstDraw, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import * as Clipboard from "@tui/util/clipboard"
 import * as Selection from "@tui/util/selection"
-import { createCliRenderer, MouseButton, type CliRendererConfig } from "@opentui/core"
+import { createCliRenderer, MouseButton, RGBA, type CliRendererConfig } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import {
   Switch,
@@ -79,6 +79,10 @@ function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
     autoFocus: false,
     openConsoleOnError: false,
     useMouse: mouseEnabled,
+    // Default to a transparent backdrop so transparent custom themes don't show
+    // an opaque flash before the theme finishes loading. The active theme's
+    // background is applied via theme.tsx once it's resolved.
+    backgroundColor: RGBA.fromInts(0, 0, 0, 0),
     consoleOptions: {
       keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }],
       onCopySelection: (text) => {
@@ -877,7 +881,11 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     <box
       width={dimensions().width}
       height={dimensions().height}
-      backgroundColor={theme.background}
+      // While the user's selected theme is still loading async, leave the root
+      // box transparent rather than painting the opencode-default fallback's
+      // opaque background; otherwise transparent custom themes show an opaque
+      // backdrop until the user manually toggles themes.
+      backgroundColor={themeState.isActiveResolved() ? theme.background : RGBA.fromInts(0, 0, 0, 0)}
       onMouseDown={(evt) => {
         if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
         if (evt.button !== MouseButton.RIGHT) return

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -428,6 +428,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     })
 
     createEffect(() => {
+      // Skip syncing the renderer background while the user's selected theme is
+      // still loading async (e.g. a custom theme in ~/.config/opencode/themes).
+      // Otherwise we'd briefly paint the opencode-default fallback's opaque
+      // background, leaving leftover opaque cells when the actual theme is
+      // transparent.
+      if (!store.themes[store.active]) return
       renderer.setBackgroundColor(values().background)
     })
 
@@ -475,6 +481,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       },
       get ready() {
         return store.ready
+      },
+      // True once the currently-active theme is loaded into the store.
+      // Default-bundled themes are present from the first render; custom
+      // themes only become loaded after the async file walk finishes.
+      isActiveResolved() {
+        return store.themes[store.active] !== undefined
       },
     }
   },


### PR DESCRIPTION
### Issue for this PR

Closes #23573

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A custom theme whose background fields are all `none`/transparent rendered with an opaque backdrop on launch; the transparency only kicked in after the user manually opened `/theme`, picked another theme, and switched back. Two compounding causes:

1. `createCliRenderer` was called without `backgroundColor`, so opentui defaulted the renderer backdrop to `RGBA(0.1, 0.1, 0.1, 0.7)` — a semi-opaque dark layer visible until something forced a full repaint.
2. `theme.tsx`'s `values()` memo falls back to the bundled opencode-default theme (opaque) while a user-installed custom theme is still being loaded asynchronously from `~/.config/opencode/themes/`. Both the renderer-background sync `createEffect` and the root `<box>`'s `backgroundColor={theme.background}` read that fallback, painting opaque cells that don't get visually cleared by the later `setBackgroundColor(transparent)`. The `/theme` toggle worked because dialog dismissal forces a full re-render that overwrites those leftover opaque cells.

The fix passes an explicit transparent `backgroundColor` into the renderer config, skips the renderer-background sync `createEffect` while the active theme has not yet been loaded into the store, and gates the root box's `backgroundColor` on a new `isActiveResolved()` helper so it stays transparent until the user's theme resolves. Default-bundled themes (`opencode`, `monokai`, etc.) are present in the store from the first synchronous render, so they paint their own opaque background without flicker.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/cli/cmd/tui/app.tsx packages/opencode/src/cli/cmd/tui/context/theme.tsx` — same 18 pre-existing warnings before and after, 0 errors.
- `bun test packages/opencode/test/cli/tui/theme-store.test.ts` — 5/5 pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
