### PR TITLE
fix(session): backfill sessionID/messageID on plugin-pushed parts

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1212,6 +1212,20 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         { message: info, parts },
       )
 
+      // Plugins may push parts asynchronously (after an await) without populating
+      // the framework-managed identifiers. Backfill them so downstream consumers
+      // (e.g. SyncEvent.run, sessions.updatePart) always have a valid sessionID,
+      // messageID, and id.
+      for (let i = 0; i < parts.length; i++) {
+        const p = parts[i]
+        if (p.sessionID && p.messageID && p.id) continue
+        Object.assign(p, {
+          id: p.id ? PartID.make(p.id) : PartID.ascending(),
+          messageID: info.id,
+          sessionID: input.sessionID,
+        })
+      }
+
       const parsed = MessageV2.Info.zod.safeParse(info)
       if (!parsed.success) {
         log.error("invalid user message before save", {


### PR DESCRIPTION
### Issue for this PR

Closes #23440

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A `chat.message` plugin that pushed a part to `output.parts` after an `await` failed with `SyncEvent.run: "sessionID" required but not found`. Synchronous pushes worked because the parts pre-built by the framework already carried the required `sessionID`/`messageID`/`id`, but plugin-supplied objects (`{ type: "text", text: "..." }`) did not, and `sessions.updatePart` reads `part.sessionID` directly to publish the sync event.

After the `chat.message` hook resolves, the prompt loop now walks the `parts` array and `Object.assign`s any missing framework-managed identifiers from the message context (`info.id` for `messageID`, `input.sessionID` for `sessionID`, an ascending `PartID` if `id` is missing). Parts that already carry all three fields are left untouched, so synchronously-pushed and framework-built parts are unaffected.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/session/prompt.ts` — same 2 pre-existing warnings before and after, 0 errors.
- The reporter's minimal repro (`output.parts.push({ type: "text", text: await ctx.text() })` after a `fetch`) now goes through `sessions.updatePart()` with a populated `sessionID`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
