### PR TITLE
feat(mcp): log resolved binary path when starting a local MCP server

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -13,6 +13,7 @@ import { Config } from "@/config/config"
 import { ConfigMCP } from "../config/mcp"
 import * as Log from "@opencode-ai/core/util/log"
 import { NamedError } from "@opencode-ai/core/util/error"
+import { which } from "@/util/which"
 import z from "zod/v4"
 import { Installation } from "../installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
@@ -388,16 +389,22 @@ export const layer = Layer.effect(
     ) {
       const [cmd, ...args] = mcp.command
       const cwd = yield* InstanceState.directory
+      const env = {
+        ...process.env,
+        ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
+        ...mcp.environment,
+      }
+      // Log the resolved binary so users can see which executable PATH actually
+      // selected. Useful when the desktop app and shell PATH differ and a stale
+      // node/npx is picked up (#22299).
+      const resolved = which(cmd, env)
+      log.info("mcp local resolved", { key, command: cmd, resolved })
       const transport = new StdioClientTransport({
         stderr: "pipe",
         command: cmd,
         args,
         cwd,
-        env: {
-          ...process.env,
-          ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
-          ...mcp.environment,
-        },
+        env,
       })
       transport.stderr?.on("data", (chunk: Buffer) => {
         log.info(`mcp stderr: ${chunk.toString()}`, { key })


### PR DESCRIPTION
### Issue for this PR

Addresses #22299

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Local MCP servers are spawned via `PATH` lookup, but the desktop launcher's `PATH` can differ from the user's shell `PATH`. When the desktop app inherits a stale `PATH` that resolves an older Node binary, the MCP child fails with cryptic runtime errors (`Class extends value undefined is not a constructor or null`, `MCP error -32000: Connection closed`) and the user has no quick way to confirm which executable was actually picked.

Resolves the configured command against the effective `env` (with the same `which` helper used by ripgrep, LSP, formatter, etc.) before constructing `StdioClientTransport`, and emits a single info log entry alongside the configured command. The log lands under `service=mcp` like the other lifecycle entries, so users can `grep mcp` to see whether `npx`/`node` came from the expected install. This addresses the logging-side request — controlling the `PATH` itself is a separate effort.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/mcp/index.ts` — same 4 pre-existing warnings before and after, 0 errors.
- `bun test packages/opencode/test/mcp/lifecycle.test.ts` — 19/19 pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
