### PR TITLE
feat(tui): add skill_list keybind to open the skills dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -432,6 +432,7 @@ export function Prompt(props: PromptProps) {
         title: "Skills",
         value: "prompt.skills",
         category: "Prompt",
+        keybind: "skill_list",
         slash: {
           name: "skills",
         },

--- a/packages/opencode/src/config/keybinds.ts
+++ b/packages/opencode/src/config/keybinds.ts
@@ -59,6 +59,7 @@ const KeybindsSchema = Schema.Struct({
   model_cycle_favorite: keybind("none", "Next favorite model"),
   model_cycle_favorite_reverse: keybind("none", "Previous favorite model"),
   command_list: keybind("ctrl+p", "List available commands"),
+  skill_list: keybind("none", "List available skills"),
   agent_list: keybind("<leader>a", "List agents"),
   agent_cycle: keybind("tab", "Next agent"),
   agent_cycle_reverse: keybind("shift+tab", "Previous agent"),

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -55,6 +55,7 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
     "variant_cycle": "ctrl+t",
     "variant_list": "none",
     "command_list": "ctrl+p",
+    "skill_list": "none",
     "agent_list": "<leader>a",
     "agent_cycle": "tab",
     "agent_cycle_reverse": "shift+tab",


### PR DESCRIPTION
### Issue for this PR

Closes #21758

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Skills are currently only reachable through the `/skills` slash command. The keybind config exposes `theme_list`, `agent_list`, `model_list`, `command_list`, etc. but no skills counterpart, so users who rely on skills can't bind them to a shortcut.

Adds a `skill_list` field to the keybind schema with default `none` (the same opt-in pattern used by `variant_list`, `plugin_manager`, `messages_next`, etc.) and wires `keybind: "skill_list"` into the existing prompt-level `Skills` command so the keybind dispatcher already knows how to open the dialog. Documentation is updated to list the new keybind alongside the others.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/config/keybinds.ts packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` — same 11 pre-existing warnings before and after, 0 errors.
- `bun test packages/opencode/test/keybind.test.ts` — 47/47 pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
