### PR TITLE
feat(tui): opt-in confirm_exit setting requires double ctrl+c to quit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -43,6 +43,7 @@ import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-workspace-create"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
+import { useTuiConfig } from "@tui/context/tui-config"
 
 export type PromptProps = {
   sessionID?: string
@@ -106,6 +107,9 @@ export function Prompt(props: PromptProps) {
   const keybind = useKeybind()
   const local = useLocal()
   const args = useArgs()
+  const tuiConfig = useTuiConfig()
+  let lastExitAttempt = 0
+  const EXIT_CONFIRM_WINDOW_MS = 2000
   const sdk = useSDK()
   const editor = useEditorContext()
   const route = useRoute()
@@ -1108,6 +1112,19 @@ export function Prompt(props: PromptProps) {
                 }
                 if (keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
+                    if (tuiConfig.confirm_exit) {
+                      const now = Date.now()
+                      if (now - lastExitAttempt > EXIT_CONFIRM_WINDOW_MS) {
+                        lastExitAttempt = now
+                        toast.show({
+                          variant: "info",
+                          message: "Press again to exit",
+                          duration: EXIT_CONFIRM_WINDOW_MS,
+                        })
+                        e.preventDefault()
+                        return
+                      }
+                    }
                     await exit()
                     // Don't preventDefault - let textarea potentially handle the event
                     e.preventDefault()

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -24,6 +24,12 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
+  confirm_exit: z
+    .boolean()
+    .optional()
+    .describe(
+      "Require pressing the app_exit keybind (e.g. Ctrl+C) twice within 2s to exit, to avoid accidental quits (default: false)",
+    ),
 })
 
 export const TuiInfo = z


### PR DESCRIPTION
### Issue for this PR

Closes #15932

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A single Ctrl+C against an empty prompt exits opencode immediately, which makes it easy to lose a session by reflex (e.g. when the user meant to clear input or interrupt a different action).

Adds a `confirm_exit` boolean to `TuiOptions`. When enabled, the prompt's `app_exit` handler emits a "Press again to exit" info toast (2s duration) on the first attempt and only calls `exit()` if a second attempt lands within the same 2s window. Default is `false`, so the existing single-press behavior is preserved for users who don't opt in. The behavior is gated only inside the prompt's empty-input branch — matching the only place that currently calls `exit()` for the keybind — so other `app_exit` consumers (dialog cancel, sub-session jump-back) keep their existing semantics.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx packages/opencode/src/cli/cmd/tui/config/tui-schema.ts` — same 10 pre-existing warnings before and after, 0 errors.
- `bun test packages/opencode/test/config/tui.test.ts` — 22 pass / 3 skip / 1 unrelated pre-existing failure (`continues loading tui config when legacy source cannot be stripped` fails identically on `dev` without this change).

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
