### PR TITLE
feat(run): add --timeout flag to abort scripted runs after N seconds

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -291,6 +291,10 @@ export const RunCommand = cmd({
         describe: "auto-approve permissions that are not explicitly denied (dangerous!)",
         default: false,
       })
+      .option("timeout", {
+        type: "number",
+        describe: "abort the run if it has not finished after this many seconds",
+      })
   },
   handler: async (args) => {
     let message = [...args.message, ...(args["--"] || [])]
@@ -627,24 +631,37 @@ export const RunCommand = cmd({
         process.exit(1)
       })
 
-      if (args.command) {
-        await sdk.session.command({
-          sessionID,
-          agent,
-          model: args.model,
-          command: args.command,
-          arguments: message,
-          variant: args.variant,
-        })
-      } else {
-        const model = args.model ? Provider.parseModel(args.model) : undefined
-        await sdk.session.prompt({
-          sessionID,
-          agent,
-          model,
-          variant: args.variant,
-          parts: [...files, { type: "text", text: message }],
-        })
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+      if (args.timeout && args.timeout > 0) {
+        timeoutHandle = setTimeout(() => {
+          UI.error(`Run timed out after ${args.timeout}s`)
+          // Best-effort abort; ignore failures so the timeout exit always wins.
+          sdk.session.abort({ sessionID }).catch(() => {})
+          process.exit(124)
+        }, args.timeout * 1000)
+      }
+      try {
+        if (args.command) {
+          await sdk.session.command({
+            sessionID,
+            agent,
+            model: args.model,
+            command: args.command,
+            arguments: message,
+            variant: args.variant,
+          })
+        } else {
+          const model = args.model ? Provider.parseModel(args.model) : undefined
+          await sdk.session.prompt({
+            sessionID,
+            agent,
+            model,
+            variant: args.variant,
+            parts: [...files, { type: "text", text: message }],
+          })
+        }
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle)
       }
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #3583

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

There is no way to bound `opencode run` from scripts: if the model never finishes (network stall, infinite tool loop, etc.) the process hangs indefinitely.

Adds a `--timeout <seconds>` yargs option to `RunCommand`. When set, the handler installs a `setTimeout` before awaiting `sdk.session.prompt` / `sdk.session.command`; if it fires, the handler best-effort calls `sdk.session.abort({ sessionID })` so the server-side run is interrupted, prints a clear `Run timed out after Ns` error, and exits with code `124` (the standard GNU coreutils timeout exit code) so callers can distinguish a timeout from other failures. The timer is cleared in a `finally` block when the prompt/command await completes normally, so successful runs are unchanged.

### How did you verify your code works?

- `bun run typecheck` (tsgo) — clean.
- `oxlint packages/opencode/src/cli/cmd/run.ts` — same 8 pre-existing warnings before and after, 0 errors.
- Manually traced control flow: `--timeout 5` → 5s `setTimeout` armed before the prompt await, fires `sdk.session.abort` and `process.exit(124)`; on normal completion the `finally` clears the handle and the function returns as before; the loop catch path (`loop().catch(... process.exit(1))`) is untouched.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
