### PR TITLE
docs: add missing keybinds to the reference table

### DIFF
--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -24,6 +24,8 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
     "session_timeline": "<leader>g",
     "session_fork": "none",
     "session_rename": "none",
+    "session_delete": "ctrl+d",
+    "stash_delete": "ctrl+d",
     "session_share": "none",
     "session_unshare": "none",
     "session_interrupt": "escape",
@@ -52,6 +54,8 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
     "model_cycle_recent_reverse": "shift+f2",
     "model_cycle_favorite": "none",
     "model_cycle_favorite_reverse": "none",
+    "model_provider_list": "ctrl+a",
+    "model_favorite_toggle": "ctrl+f",
     "variant_cycle": "ctrl+t",
     "variant_list": "none",
     "command_list": "ctrl+p",
@@ -100,6 +104,7 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
     "terminal_suspend": "ctrl+z",
     "terminal_title_toggle": "none",
     "tips_toggle": "<leader>h",
+    "plugin_manager": "none",
     "display_thinking": "none"
   }
 }

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -23,7 +23,7 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
     "session_list": "<leader>l",
     "session_timeline": "<leader>g",
     "session_fork": "none",
-    "session_rename": "none",
+    "session_rename": "ctrl+r",
     "session_delete": "ctrl+d",
     "stash_delete": "ctrl+d",
     "session_share": "none",


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Five keybinds defined in `packages/opencode/src/config/keybinds.ts` were missing from the public reference at `packages/web/src/content/docs/keybinds.mdx`: `session_delete`, `stash_delete`, `model_provider_list`, `model_favorite_toggle`, and `plugin_manager`. `session_rename` was also documented as `"none"` even though the schema's default is `"ctrl+r"`.

Adds the missing entries to the sample `tui.json` block, placed in the sections that mirror how they are grouped in the schema (session deletes alongside `session_rename`/`session_share`, model dialog actions alongside `model_cycle_*`, and `plugin_manager` near `tips_toggle`/`display_thinking`). Also corrects `session_rename` to `"ctrl+r"` to match the schema.

### How did you verify your code works?

- Re-ran a `comm`/`diff` sweep that surfaced the gap originally — the documented set now matches the runtime schema for non-leader/identifier entries (`leader` is documented separately as the leader explanation, and pure schema-internal names like `shape`/`identifier` are not user-facing).
- No code changes; nothing else to test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
