### PR TITLE
fix(prompt): remove shell mode suspension from input traits

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -565,7 +565,7 @@ export function Prompt(props: PromptProps) {
         : undefined
     input.traits = {
       capture,
-      suspend: !!props.disabled || store.mode === "shell",
+      suspend: !!props.disabled,
       status: store.mode === "shell" ? "SHELL" : undefined,
     }
   })


### PR DESCRIPTION
### Issue for this PR

Closes #25294

### Type of change

- [x] Bug fix

### What does this PR do?

Removes the `store.mode === "shell"` condition from the `suspend` trait in the TUI prompt component. Previously, entering shell mode unconditionally suspended the prompt input. After this change, the prompt only suspends when `props.disabled` is true, allowing the input to remain active in shell mode if appropriate.

### How did you verify your code works?

- Ran `bun turbo typecheck` (passed)
- Change is isolated to a single line in the prompt component
- Was able to replicate the issue before the change, confirmed change fixed it.

### Screenshots / recordings
N/A — logic change, no visual UI modification.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR