### PR TITLE
fix: detect file MIME type from extension for -f attachments

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -19,6 +19,21 @@ import { ReadTool } from "../../tool/read"
 import { WebFetchTool } from "../../tool/webfetch"
 import { EditTool } from "../../tool/edit"
 import { WriteTool } from "../../tool/write"
+
+const MIME_MAP: Record<string, string> = {
+  png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif",
+  bmp: "image/bmp", webp: "image/webp", ico: "image/x-icon", tif: "image/tiff",
+  tiff: "image/tiff", svg: "image/svg+xml", svgz: "image/svg+xml", avif: "image/avif",
+  apng: "image/apng", jxl: "image/jxl", heic: "image/heic", heif: "image/heif",
+  mp4: "video/mp4", webm: "video/webm", mov: "video/quicktime", avi: "video/x-msvideo",
+  mp3: "audio/mpeg", wav: "audio/wav", ogg: "audio/ogg", flac: "audio/flac",
+  pdf: "application/pdf",
+}
+
+function resolveMime(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase().slice(1)
+  return MIME_MAP[ext] ?? "text/plain"
+}
 import { WebSearchTool } from "../../tool/websearch"
 import { TaskTool } from "../../tool/task"
 import { SkillTool } from "../../tool/skill"
@@ -320,7 +335,7 @@ export const RunCommand = cmd({
           process.exit(1)
         }
 
-        const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : "text/plain"
+        const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : resolveMime(resolvedPath)
 
         files.push({
           type: "file",


### PR DESCRIPTION
### Issue for this PR

Closes #25353

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a one-line bug where all files attached with `--file` / `-f` were hardcoded as `text/plain` regardless of their actual type. This prevented image files (PNG, JPEG, WebP) from being base64-encoded and passed as `data:image/...` URLs to vision models.

**Root cause:** In `cli/cmd/run.ts`, the MIME assignment was `text/plain` for all non-directory files.

**Fix:** Added a `resolveMime()` helper that maps known file extensions to correct MIME types (image/png, image/jpeg, image/gif, image/webp, audio/*, video/*, application/pdf). Unknown extensions still default to `text/plain`.

**Why it works:** The downstream pipeline in `session/prompt.ts` already handles non-text MIME types — reads binary, base64-encodes, creates `data:` URLs. It was simply never reached.

### How did you verify your code works?

Tested locally with OpenCode 1.14.28:
- PNG via `--file` → MIME is now `image/png` (was `text/plain`)
- Downstream prompt.ts correctly base64-encodes and creates `data:image/png;base64,...` URL
- Text files and unknown extensions still default to `text/plain` (backward compatible)
- `bun typecheck` passes without regressions

### Screenshots / recordings

_No UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR