### PR TITLE
docs(de): sync keybinds reference with schema

### DIFF
--- a/packages/web/src/content/docs/de/keybinds.mdx
+++ b/packages/web/src/content/docs/de/keybinds.mdx
@@ -23,7 +23,9 @@ OpenCode verfügt über eine Liste von Tastenkombinationen, die Sie über `tui.j
     "session_list": "<leader>l",
     "session_timeline": "<leader>g",
     "session_fork": "none",
-    "session_rename": "none",
+    "session_rename": "ctrl+r",
+    "session_delete": "ctrl+d",
+    "stash_delete": "ctrl+d",
     "session_share": "none",
     "session_unshare": "none",
     "session_interrupt": "escape",
@@ -52,6 +54,8 @@ OpenCode verfügt über eine Liste von Tastenkombinationen, die Sie über `tui.j
     "model_cycle_recent_reverse": "shift+f2",
     "model_cycle_favorite": "none",
     "model_cycle_favorite_reverse": "none",
+    "model_provider_list": "ctrl+a",
+    "model_favorite_toggle": "ctrl+f",
     "variant_cycle": "ctrl+t",
     "variant_list": "none",
     "command_list": "ctrl+p",
@@ -100,6 +104,7 @@ OpenCode verfügt über eine Liste von Tastenkombinationen, die Sie über `tui.j
     "terminal_suspend": "ctrl+z",
     "terminal_title_toggle": "none",
     "tips_toggle": "<leader>h",
+    "plugin_manager": "none",
     "display_thinking": "none"
   }
 }


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Brings the German keybinds reference at `packages/web/src/content/docs/de/keybinds.mdx` into sync with the schema in `packages/opencode/src/config/keybinds.ts`. Five keybinds were missing from the documented `tui.json` example (`session_delete`, `stash_delete`, `model_provider_list`, `model_favorite_toggle`, `plugin_manager`) and `session_rename` was documented as `"none"` even though the schema default is `"ctrl+r"`. The schema-side defaults remain unchanged; this is a doc-only sync.

### How did you verify your code works?

- Compared the documented JSON entries against the live schema; the doc now contains every entry the schema defines, and the corrected default matches.
- No code changes; nothing else to test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
