### PR TITLE
docs: list and todowrite permissions in the permissions reference

### DIFF
--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -133,10 +133,12 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 - `edit` — all file modifications (covers `edit`, `write`, `patch`)
 - `glob` — file globbing (matches the glob pattern)
 - `grep` — content search (matches the regex pattern)
+- `list` — directory listing (matches the directory path)
 - `bash` — running shell commands (matches parsed commands like `git status --porcelain`)
 - `task` — launching subagents (matches the subagent type)
 - `skill` — loading a skill (matches the skill name)
 - `lsp` — running LSP queries (currently non-granular)
+- `todowrite` — writing to the todo list
 - `question` — asking the user questions during execution
 - `webfetch` — fetching a URL (matches the URL)
 - `websearch` — web search (matches the query)


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The permissions schema in `packages/opencode/src/config/permission.ts` defines `list` (directory listing) and `todowrite` (writing to the todo list), but the public reference at `packages/web/src/content/docs/permissions.mdx` doesn't list either of them. Add them alongside the other permissions so users know they exist and can configure them.

### How did you verify your code works?

- Cross-checked the documented permission keys against `InputObject` in `packages/opencode/src/config/permission.ts`. The doc set now matches the schema set.
- No code changes; nothing else to test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
