### PR TITLE
docs: document the username config option

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -478,6 +478,21 @@ This setting applies across all interfaces: TUI, CLI (`opencode run`), desktop a
 
 ---
 
+### Username
+
+You can override the username displayed next to your messages with the `username` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "username": "alex"
+}
+```
+
+When unset, OpenCode uses the operating system username it picks up at startup.
+
+---
+
 ### Sharing
 
 You can configure the [share](/docs/share) feature through the `share` option.


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The `username` option exists in the config schema (`packages/opencode/src/config/config.ts`) and overrides the operating-system-derived username displayed next to your messages, but it was missing from the public reference at `packages/web/src/content/docs/config.mdx`. Adds a `### Username` section between `### Default agent` and `### Sharing` so users can find it.

### How did you verify your code works?

- Cross-checked the new doc snippet against the schema annotation `"Custom username to display in conversations instead of system username"` in `packages/opencode/src/config/config.ts`.
- No code changes; nothing else to test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
