### PR TITLE
docs: document the tool_output config option

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -640,6 +640,27 @@ You can control context compaction behavior through the `compaction` option.
 
 ---
 
+### Tool output
+
+You can tune when tool output is truncated to disk through the `tool_output` option. When the captured output exceeds either limit, OpenCode writes the full text to the truncation directory and returns a preview to the model.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tool_output": {
+    "max_lines": 2000,
+    "max_bytes": 51200
+  }
+}
+```
+
+Both fields are optional and accept positive integers:
+
+- `max_lines` - Maximum number of lines before the output is truncated. Defaults to `2000`.
+- `max_bytes` - Maximum size in bytes before the output is truncated. Defaults to `51200` (50 KiB).
+
+---
+
 ### Watcher
 
 You can configure file watcher ignore patterns through the `watcher` option.


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The `tool_output` option lives in the config schema (`packages/opencode/src/config/config.ts`) and lets users tune when tool output is truncated to the on-disk truncation directory (`max_lines`, default 2000; `max_bytes`, default 51200), but it wasn't in the public reference at `packages/web/src/content/docs/config.mdx`. Adds a `### Tool output` section between `### Compaction` and `### Watcher` with a JSON example and the per-field defaults.

### How did you verify your code works?

- Cross-checked the new doc snippet against the schema annotations in `packages/opencode/src/config/config.ts` (`Maximum lines of tool output before it is truncated and saved to disk (default: 2000)` / `(default: 51200)`).
- No code changes; nothing else to test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
