### PR TITLE
fix: ensureTitle falls back to main model when getSmallModel fails

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -186,8 +186,9 @@ export const layer = Layer.effect(
       if (!ag) return
       const mdl = ag.model
         ? yield* provider.getModel(ag.model.providerID, ag.model.modelID)
-        : ((yield* provider.getSmallModel(input.providerID)) ??
-          (yield* provider.getModel(input.providerID, input.modelID)))
+        : (yield* ((yield* provider.getSmallModel(input.providerID)).pipe(
+            Effect.orElse(() => provider.getModel(input.providerID, input.modelID))
+          )))
       const msgs = onlySubtasks
         ? [{ role: "user" as const, content: subtasks.map((p) => p.prompt).join("\n") }]
         : yield* MessageV2.toModelMessagesEffect(context, mdl)


### PR DESCRIPTION
### Issue for this PR

Closes #25344

### Type of change

- [X] Bug fix

### What does this PR do?

When provider.getSmallModel() fails (no small model configured) or returns Option.None, the ?? operator in ensureTitle doesn't handle either case properly:

1. If getSmallModel throws an Effect error, yield* propagates it past ??, and the error is silently swallowed by the t.ignore pipe in the forkIn scope
2. If getSmallModel returns Option.None (which is an object, not nullish), ?? doesn't trigger the fallback to getModel

In both scenarios, mdl ends up as an invalid model, the LLM stream fails, and the session title is never generated — leaving it permanently as "New session - ...".

The fix replaces ?? with Effect.orElse() for proper Effect-TS error recovery, ensuring the main model is always used as a fallback.

### How did you verify your code works?

Confirmed by testing locally: without the fix, all new sessions remain stuck with the default title regardless of message count. The fix ensures the model fallback chain works correctly when no small model is configured.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
