### PR TITLE
docs: document the skills config option

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -557,6 +557,27 @@ Note that disabling snapshots means changes made by the agent cannot be rolled b
 
 ---
 
+### Skills
+
+You can register additional skill folder paths or remote skill URLs through the `skills` option. This is in addition to the [default discovery locations](/docs/skills) (`.opencode/skills/`, `~/.config/opencode/skills/`, `.claude/skills/`, `.agents/skills/`).
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": ["~/work/shared-skills"],
+    "urls": ["https://example.com/.well-known/skills/"]
+  }
+}
+```
+
+- `paths` - Extra directories to scan for `SKILL.md` files.
+- `urls` - URLs that publish skills (typically `.well-known/skills/`).
+
+[Learn more about skills](/docs/skills).
+
+---
+
 ### Autoupdate
 
 OpenCode will automatically download any new updates when it starts up. You can disable this with the `autoupdate` option.


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The `skills` config option (defined in `packages/opencode/src/config/skills.ts` with `paths` and `urls` fields, exposed via `packages/opencode/src/config/config.ts`) lets users register extra skill folder paths or remote skill URLs in addition to the default discovery locations, but it wasn't in the public reference at `packages/web/src/content/docs/config.mdx`. Adds a `### Skills` section between `### Snapshot` and `### Autoupdate` with a JSON example and a link back to the existing `/docs/skills` page.

### How did you verify your code works?

- Cross-checked the snippet against the schema annotations: `paths` (`Additional paths to skill folders`) and `urls` (`URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)`).
- No code changes; nothing else to test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
