### PR TITLE
Fix tui infinite loop

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -481,8 +481,10 @@ export function Autocomplete(props: {
   }
 
   function moveTo(next: number) {
+    if (store.selected === next) return
     setStore("selected", next)
     if (!scroll) return
+    if (store.input === "mouse") return
     const viewportHeight = Math.min(height(), options().length)
     const scrollBottom = scroll.scrollTop + viewportHeight
     if (next < scroll.scrollTop) {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -143,11 +143,18 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const selected = createMemo(() => flat()[store.selected])
 
   createEffect(
-    on([() => store.filter, () => props.current], ([filter, current]) => {
+    on([() => store.filter, () => props.current], ([filter, current], prevInput) => {
+      const prevFilter = prevInput ? prevInput[0] : undefined
+      const prevCurrent = prevInput ? prevInput[1] : undefined
+
       setTimeout(() => {
-        if (filter.length > 0) {
+        // Abort if the state changed while waiting in the timeout queue
+        // This breaks the infinite ping-pong reactivity loop when moving the mouse quickly
+        if (!isDeepEqual(props.current, current)) return
+
+        if (filter !== prevFilter && filter.length > 0) {
           moveTo(0, true)
-        } else if (current) {
+        } else if (!isDeepEqual(current, prevCurrent) && current) {
           const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
           if (currentIndex >= 0) {
             moveTo(currentIndex, true)
@@ -166,10 +173,12 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   }
 
   function moveTo(next: number, center = false) {
+    if (store.selected === next) return
     setStore("selected", next)
     const option = selected()
     if (option) props.onMove?.(option)
     if (!scroll) return
+    if (store.input === "mouse") return
     const target = scroll.getChildren().find((child) => {
       return child.id === JSON.stringify(selected()?.value)
     })


### PR DESCRIPTION
### Issue for this PR

Closes #25310

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

This was an ai fix and attempted review by myself to show why it works.

- Aborts stale `setTimeout` state updates in `dialog-select.tsx` if the active selection has already moved on.
- Prevents `moveTo` from aggressively auto-scrolling to the center when navigating with the mouse.
- Adds early returns in both `dialog-select.tsx` and `autocomplete.tsx` to prevent redundant state updates when the index hasn't changed.

### How did you verify your code works?

### Screenshots / recordings


https://github.com/user-attachments/assets/c4e5311b-64b9-40b3-b439-a95dab011daf


https://github.com/user-attachments/assets/829aaa49-efec-4dc7-9fd3-7d7c3efb2f34



### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._