### PR TITLE
docs(agents): document the variant config option

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -362,6 +362,23 @@ The model ID in your OpenCode config uses the format `provider/model-id`. For ex
 
 ---
 
+### Variant
+
+Use the `variant` config to set a default model variant for this agent. Variants are provider-specific reasoning effort presets (for example `high`, `max`, or `minimal`) and only apply when the agent is running on its own configured `model` — switching to another model resets the variant.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "plan": {
+      "model": "anthropic/claude-haiku-4-20250514",
+      "variant": "high"
+    }
+  }
+}
+```
+
+---
+
 ### Tools (deprecated)
 
 `tools` is **deprecated**. Prefer the agent's [`permission`](#permissions) field for new configs, updates and more fine-grained control.


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The agent schema in `packages/opencode/src/config/agent.ts` defines a `variant: Schema.optional(Schema.String)` field with the annotation "Default model variant for this agent (applies only when using the agent's configured model)". It was not in the agents documentation. Adds a `### Variant` section between `### Model` and `### Tools (deprecated)` so users can find it.

### How did you verify your code works?

- Cross-checked the snippet against the schema annotation in `packages/opencode/src/config/agent.ts`.
- No code changes; nothing else to test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
