### PR TITLE
chore: drop placeholder random/hello scripts from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "typecheck": "bun turbo typecheck",
     "postinstall": "bun run --cwd packages/opencode fix-node-pty",
     "prepare": "husky",
-    "random": "echo 'Random script'",
-    "hello": "echo 'Hello World!'",
     "test": "echo 'do not run tests from root' && exit 1"
   },
   "workspaces": {


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Drops two unused placeholder scripts (`random`: `echo 'Random script'`, `hello`: `echo 'Hello World!'`) from the root `package.json`. They are not referenced by any other script in the workspace, by any CI workflow, or by any doc, so they only clutter `bun run` / `npm run` tab completion.

### How did you verify your code works?

- `grep -rn "bun run random\|npm run random\|bun run hello\|npm run hello" packages script .github` returned nothing — no caller relies on either script.
- The remaining scripts in the file are unchanged.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
