### PR TITLE
docs(cli): document additional user-facing OPENCODE_* env vars

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -575,6 +575,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
 | `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |
 | `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
+| `OPENCODE_ALWAYS_NOTIFY_UPDATE`       | boolean | Always show the new-version notification          |
 | `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
 | `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
 | `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
@@ -585,6 +586,11 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
 | `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
 | `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
+| `OPENCODE_DISABLE_EXTERNAL_SKILLS`    | boolean | Disable loading skills from `.claude` and `.agents` |
+| `OPENCODE_DISABLE_PROJECT_CONFIG`     | boolean | Ignore project-level `opencode.json` / `.opencode/` |
+| `OPENCODE_DISABLE_EMBEDDED_WEB_UI`    | boolean | Disable the embedded web UI served by `opencode serve` |
+| `OPENCODE_PURE`                       | boolean | Run without external plugins or installed skills |
+| `OPENCODE_MODELS_PATH`                | string  | Local path to a `models.dev` JSON dump            |
 | `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
 | `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
 | `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Six user-facing environment variables exported from `packages/core/src/flag/flag.ts` (and consumed in `packages/opencode/src`) were missing from the env-var reference table in `packages/web/src/content/docs/cli.mdx`:

- `OPENCODE_ALWAYS_NOTIFY_UPDATE`
- `OPENCODE_DISABLE_EXTERNAL_SKILLS`
- `OPENCODE_DISABLE_PROJECT_CONFIG`
- `OPENCODE_DISABLE_EMBEDDED_WEB_UI`
- `OPENCODE_PURE`
- `OPENCODE_MODELS_PATH`

Adds them to the existing table next to the closely-related entries (e.g. `OPENCODE_ALWAYS_NOTIFY_UPDATE` under `OPENCODE_DISABLE_AUTOUPDATE`, the skill/project flags grouped with `OPENCODE_DISABLE_CLAUDE_CODE_*`).

### How did you verify your code works?

- Cross-checked each new entry against its definition in `packages/core/src/flag/flag.ts` and confirmed at least one consumer in `packages/opencode/src`.
- Ran the same `comm` diff that surfaced the gap; the documented user-facing flag set now matches the runtime flag set (internal/dev-only flags like `OPENCODE_DB`, `OPENCODE_SHOW_TTFD`, `OPENCODE_SKIP_MIGRATIONS`, `OPENCODE_PLUGIN_META_FILE`, `OPENCODE_WORKSPACE_ID`, etc. remain undocumented intentionally).

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
