### PR TITLE
docs(cli): document OPENCODE_EXPERIMENTAL_HTTPAPI and _WORKSPACES

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -615,3 +615,5 @@ These environment variables enable experimental features that may change or be r
 | `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Enable TY LSP for python files          |
 | `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Enable experimental markdown features   |
 | `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Enable plan mode                        |
+| `OPENCODE_EXPERIMENTAL_HTTPAPI`                 | boolean | Use the experimental Effect HTTP API backend |
+| `OPENCODE_EXPERIMENTAL_WORKSPACES`              | boolean | Enable the experimental multi-workspace UI |


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Two experimental environment variables exported from `packages/core/src/flag/flag.ts` and consumed in `packages/opencode/src` were missing from the experimental env-var table in `packages/web/src/content/docs/cli.mdx`:

- `OPENCODE_EXPERIMENTAL_HTTPAPI` — switches `packages/opencode/src/server/backend.ts` to the Effect HTTP API backend.
- `OPENCODE_EXPERIMENTAL_WORKSPACES` — gates the multi-workspace UI in `packages/opencode/src/session/session.ts` and `packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx`.

Adds them to the existing experimental table.

### How did you verify your code works?

- Cross-checked the new entries against their definitions in `packages/core/src/flag/flag.ts:84-85` and at least one consumer in `packages/opencode/src` for each.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
