### PR TITLE
docs(lsp): document built-in biome and dockerfile LSP servers

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -15,11 +15,13 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | ------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------ |
 | astro              | .astro                                                              | Auto-installs for Astro projects                             |
 | bash               | .sh, .bash, .zsh, .ksh                                              | Auto-installs bash-language-server                           |
+| biome              | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .json, .jsonc, .vue, .astro, .svelte, .css, .graphql, .gql, .html | `biome` dependency in project              |
 | clangd             | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++                | Auto-installs for C/C++ projects                             |
 | csharp             | .cs, .csx                                                           | `.NET SDK` installed                                         |
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` command available                              |
 | dart               | .dart                                                               | `dart` command available                                     |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` command available (auto-detects deno.json/deno.jsonc) |
+| dockerfile         | .dockerfile, Dockerfile                                             | `docker-langserver` available (or auto-installs `dockerfile-language-server-nodejs`) |
 | elixir-ls          | .ex, .exs                                                           | `elixir` command available                                   |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` dependency in project                               |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installed                                         |


### PR DESCRIPTION
### Issue for this PR

No specific issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Two built-in LSP servers defined in `packages/opencode/src/lsp/server.ts` were missing from the public reference at `packages/web/src/content/docs/lsp.mdx`:

- `Biome` (`id: "biome"`, lines 283 onwards) — handles JS/TS-family extensions plus `.json`, `.jsonc`, `.vue`, `.astro`, `.svelte`, `.css`, `.graphql`, `.gql`, `.html` and is gated by `biome` being a project dependency.
- `DockerfileLS` (`id: "dockerfile"`) — handles `.dockerfile` and `Dockerfile`, using `docker-langserver` if available or auto-installing `dockerfile-language-server-nodejs` via npm.

Adds rows for both in the existing alphabetical built-in LSP table.

### How did you verify your code works?

- Cross-checked the new rows against the `extensions` arrays and `spawn` requirements in `packages/opencode/src/lsp/server.ts`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
