### PR TITLE
feat(provider): add preserveReasoningInContent config option to fix Qwen preserve_thinking interoperability

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -53,7 +53,16 @@ export const Model = Schema.Struct({
   provider: Schema.optional(
     Schema.Struct({ npm: Schema.optional(Schema.String), api: Schema.optional(Schema.String) }),
   ),
-  options: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
+  options: Schema.optional(
+    Schema.StructWithRest(
+      Schema.Struct({
+        preserveReasoningInContent: Schema.optional(Schema.Boolean).annotate({
+          description: "When true, formats reasoning history as <thinking> tags within the content instead of using reasoning_content (required for Qwen3.6 preserve_thinking)."
+        })
+      }),
+      [Schema.Record(Schema.String, Schema.Any)]
+    )
+  ),
   headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   variants: Schema.optional(
     Schema.Record(

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -214,6 +214,39 @@ function normalizeMessages(
     })
   }
 
+  const isQwen = model.id.toLowerCase().includes("qwen") || model.api.id.toLowerCase().includes("qwen")
+  const preserveReasoningInContent =
+    _options?.preserveReasoningInContent === true ||
+    (model.options as any)?.preserveReasoningInContent === true
+
+  if (isQwen || preserveReasoningInContent) {
+    msgs = msgs.map((msg) => {
+      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+        const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
+        const reasoningText = reasoningParts.map((part: any) => part.text).join("")
+        
+        if (reasoningText) {
+          const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
+          return {
+            ...msg,
+            content: [
+              { type: "text", text: `<thinking>${reasoningText}</thinking>\n\n` },
+              ...filteredContent,
+            ],
+            providerOptions: {
+              ...msg.providerOptions,
+              openaiCompatible: {
+                ...msg.providerOptions?.openaiCompatible,
+                reasoning_content: undefined,
+              },
+            },
+          }
+        }
+      }
+      return msg
+    })
+  }
+
   if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -214,12 +214,11 @@ function normalizeMessages(
     })
   }
 
-  const isQwen = model.id.toLowerCase().includes("qwen") || model.api.id.toLowerCase().includes("qwen")
   const preserveReasoningInContent =
     _options?.preserveReasoningInContent === true ||
     (model.options as any)?.preserveReasoningInContent === true
 
-  if (isQwen || preserveReasoningInContent) {
+  if (preserveReasoningInContent) {
     msgs = msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
         const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")


### PR DESCRIPTION
### Issue for this PR

Closes # (No existing issue)

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds a `preserveReasoningInContent` config flag to solve an interoperability issue with the `preserve_thinking` feature on Qwen models (specifically tested with `Qwen3.6-35B-A3B-FP8` running on vLLM).

Currently, OpenCode automatically extracts historical reasoning into a separate `reasoning_content` property. However, for Qwen to successfully access its previous reasoning turns in vLLM, the historical reasoning must be embedded directly within the assistant's `content` string, wrapped in explicit `<thinking>...</thinking>` tags. When OpenCode strips these out, the model loses its chain of thought in subsequent prompts.

To fix this:
1. I added `preserveReasoningInContent` to the `Model` schema in `src/config/provider.ts`.
2. Updated `src/provider/transform.ts` so that when this flag is enabled, it correctly transforms the reasoning history into `<thinking>` tags within the content body and unsets `reasoning_content`.

### How did you verify your code works?

I tested this locally against my own vLLM instance running `Qwen3.6-35B-A3B-FP8`. 
I prompted the model to mentally generate two random numbers, but only output one. In the next turn, I asked it for the second number. 
Without this flag, the model fails to recall the second number because the reasoning is stripped. With the flag enabled in my `opencode.json`, I verified via `mitmproxy` that the payload correctly contains the `<thinking>` tags, and the model successfully recalled the second number.

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
