### PR TITLE
feat(provider): support model system prompts

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -5,6 +5,7 @@ import { PositiveInt, withStatics } from "@/util/schema"
 export const Model = Schema.Struct({
   id: Schema.optional(Schema.String),
   name: Schema.optional(Schema.String),
+  prompt: Schema.optional(Schema.String),
   family: Schema.optional(Schema.String),
   release_date: Schema.optional(Schema.String),
   attachment: Schema.optional(Schema.Boolean),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -895,6 +895,7 @@ export const Model = Schema.Struct({
   providerID: ProviderID,
   api: ProviderApiInfo,
   name: Schema.String,
+  prompt: optionalOmitUndefined(Schema.String),
   family: optionalOmitUndefined(Schema.String),
   capabilities: ProviderCapabilities,
   cost: ProviderCost,
@@ -991,6 +992,7 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
     id: ModelID.make(model.id),
     providerID: ProviderID.make(provider.id),
     name: model.name,
+    prompt: undefined,
     family: model.family,
     api: {
       id: model.id,
@@ -1202,6 +1204,7 @@ const layer: Layer.Layer<
               },
               status: model.status ?? existingModel?.status ?? "active",
               name,
+              prompt: model.prompt ?? existingModel?.prompt,
               providerID: ProviderID.make(providerID),
               capabilities: {
                 temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -103,8 +103,11 @@ const live: Layer.Layer<
       const system: string[] = []
       system.push(
         [
-          // use agent prompt otherwise provider prompt
-          ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
+          ...(input.agent.prompt
+            ? [input.agent.prompt]
+            : input.model.prompt
+              ? [input.model.prompt]
+              : SystemPrompt.provider(input.model)),
           // any custom prompt passed into this call
           ...input.system,
           // any custom prompt from last user message

--- a/packages/opencode/src/tool/apply_patch.txt
+++ b/packages/opencode/src/tool/apply_patch.txt
@@ -1,25 +1,26 @@
-Use the `apply_patch` tool to edit files. Your patch language is a stripped‑down, file‑oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high‑level envelope:
+Edit files using a stripped-down, file-oriented patch format.
 
+Patch envelope:
+
+```
 *** Begin Patch
-[ one or more file sections ]
+[file sections]
 *** End Patch
+```
 
-Within that envelope, you get a sequence of file operations.
-You MUST include a header to specify the action you are taking.
-Each operation starts with one of three headers:
+Each section must start with one header:
 
-*** Add File: <path> - create a new file. Every following line is a + line (the initial contents).
-*** Delete File: <path> - remove an existing file. Nothing follows.
-*** Update File: <path> - patch an existing file in place (optionally with a rename).
+- `*** Add File: <path>` creates a file; every following content line must start with `+`.
+- `*** Delete File: <path>` removes a file; no content follows.
+- `*** Update File: <path>` patches a file in place; may include `*** Move to: <path>` for rename.
 
-Example patch:
+Example:
 
 ```
 *** Begin Patch
 *** Add File: hello.txt
 +Hello world
 *** Update File: src/app.py
-*** Move to: src/main.py
 @@ def greet():
 -print("Hi")
 +print("Hello, world!")
@@ -27,7 +28,4 @@ Example patch:
 *** End Patch
 ```
 
-It is important to remember:
-
-- You must include a header with your intended action (Add/Delete/Update)
-- You must prefix new lines with `+` even when creating a new file
+Always include an action header. Prefix new lines with `+`, including when creating new files.

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -1,119 +1,33 @@
-Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
+Run a bash command in a persistent shell session. Use for terminal operations only: git, package managers, builds, tests, scripts, docker, etc.
 
-Be aware: OS: ${os}, Shell: ${shell}
+OS: ${os}, Shell: ${shell}
 
-All commands run in the current working directory by default. Use the `workdir` parameter if you need to run a command in a different directory. AVOID using `cd <directory> && <command>` patterns - use `workdir` instead.
+Current directory: ${directory}
 
-Use `${tmp}` for temporary work outside the workspace. This directory has already been created, already exists, and is pre-approved for external directory access.
+Use `${tmp}` for temporary work outside the workspace. It already exists and is pre-approved for external directory access.
 
-IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO NOT use it for file operations (reading, writing, editing, searching, finding files) - use the specialized tools for this instead.
+# Command Rules
+- Commands run in the current working directory by default. Use `workdir` instead of `cd <dir> && cmd`.
+- If a command creates files or directories, first verify the parent exists with `ls`.
+- Quote paths containing spaces: `rm "path with spaces/file.txt"`.
+- Provide a concise 5-10 word `description`.
+- Optional `timeout` is milliseconds; default is 120000.
+- Output over ${maxLines} lines or ${maxBytes} bytes is truncated to a file. Read that file with Read offset/limit or search it with Grep; do not pipe through `head`/`tail` just to limit output.
+- Never use interactive git flags like `git rebase -i` or `git add -i`.
 
-Before executing the command, please follow these steps:
+# Prefer Dedicated Tools
+- File search: Glob, not `find` or `ls`.
+- Content search: Grep, not `grep` or `rg`.
+- Read files: Read, not `cat`, `head`, or `tail`.
+- Edit files: Edit, not `sed` or `awk`.
+- Write files: Write, not `echo > file` or heredocs.
+- User-facing communication: respond directly, not `echo`/`printf`.
 
-1. Directory Verification:
-   - If the command will create new directories or files, first use `ls` to verify the parent directory exists and is the correct location
-   - For example, before running "mkdir foo/bar", first use `ls foo` to check that "foo" exists and is the intended parent directory
+# Multiple Commands
+- Independent commands should be separate Bash tool calls in one message so they can run in parallel.
+- ${chaining}
+- Use `;` only when later commands may run even if earlier commands fail.
+- Do not separate commands with newlines, except inside quoted strings.
 
-2. Command Execution:
-   - Always quote file paths that contain spaces with double quotes (e.g., rm "path with spaces/file.txt")
-   - Examples of proper quoting:
-     - mkdir "/Users/name/My Documents" (correct)
-     - mkdir /Users/name/My Documents (incorrect - will fail)
-     - python "/path/with spaces/script.py" (correct)
-     - python /path/with spaces/script.py (incorrect - will fail)
-   - After ensuring proper quoting, execute the command.
-   - Capture the output of the command.
-
-Usage notes:
-  - The command argument is required.
-  - You can specify an optional timeout in milliseconds. If not specified, commands will time out after 120000ms (2 minutes).
-  - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
-  - If the output exceeds ${maxLines} lines or ${maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Do NOT use `head`, `tail`, or other truncation commands to limit output; the full output will already be captured to a file for more precise searching.
-
-  - Avoid using Bash with the `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
-    - File search: Use Glob (NOT find or ls)
-    - Content search: Use Grep (NOT grep or rg)
-    - Read files: Use Read (NOT cat/head/tail)
-    - Edit files: Use Edit (NOT sed/awk)
-    - Write files: Use Write (NOT echo >/cat <<EOF)
-    - Communication: Output text directly (NOT echo/printf)
-  - When issuing multiple commands:
-    - If the commands are independent and can run in parallel, make multiple Bash tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two Bash tool calls in parallel.
-    - ${chaining}
-    - Use ';' only when you need to run commands sequentially but don't care if earlier commands fail
-    - DO NOT use newlines to separate commands (newlines are ok in quoted strings)
-  - AVOID using `cd <directory> && <command>`. Use the `workdir` parameter to change directories instead.
-    <good-example>
-    Use workdir="/foo/bar" with command: pytest tests
-    </good-example>
-    <bad-example>
-    cd /foo/bar && pytest tests
-    </bad-example>
-
-# Committing changes with git
-
-Only create commits when requested by the user. If unclear, ask first. When the user asks you to create a new git commit, follow these steps carefully:
-
-Git Safety Protocol:
-- NEVER update the git config
-- NEVER run destructive/irreversible git commands (like push --force, hard reset, etc) unless the user explicitly requests them
-- NEVER skip hooks (--no-verify, --no-gpg-sign, etc) unless the user explicitly requests it
-- NEVER run force push to main/master, warn the user if they request it
-- Avoid git commit --amend. ONLY use --amend when ALL conditions are met:
-  (1) User explicitly requested amend, OR the commit succeeded and pre-commit hooks auto-modified files that need including — verify by checking `git log` that HEAD is the new commit before amending
-  (2) HEAD commit was created by you in this conversation (verify: git log -1 --format='%an %ae')
-  (3) Commit has NOT been pushed to remote (verify: git status shows "Your branch is ahead")
-- CRITICAL: If commit FAILED or was REJECTED by hook, NEVER amend - fix the issue and create a NEW commit
-- CRITICAL: If you already pushed to remote, NEVER amend unless user explicitly requests it (requires force push)
-- NEVER commit changes unless the user explicitly asks you to. It is VERY IMPORTANT to only commit when explicitly asked, otherwise the user will feel that you are being too proactive.
-
-1. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following bash commands in parallel, each using the Bash tool:
-  - Run a git status command to see all untracked files.
-  - Run a git diff command to see both staged and unstaged changes that will be committed.
-  - Run a git log command to see recent commit messages, so that you can follow this repository's commit message style.
-2. Analyze all staged changes (both previously staged and newly added) and draft a commit message:
-  - Summarize the nature of the changes (eg. new feature, enhancement to an existing feature, bug fix, refactoring, test, docs, etc.). Ensure the message accurately reflects the changes and their purpose (i.e. "add" means a wholly new feature, "update" means an enhancement to an existing feature, "fix" means a bug fix, etc.).
-  - Do not commit files that likely contain secrets (.env, credentials.json, etc.). Warn the user if they specifically request to commit those files
-  - Draft a concise (1-2 sentences) commit message that focuses on the "why" rather than the "what"
-  - Ensure it accurately reflects the changes and their purpose
-3. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following commands:
-   - Add relevant untracked files to the staging area.
-   - Create the commit with a message
-   - Run git status after the commit completes to verify success.
-   Note: git status depends on the commit completing, so run it sequentially after the commit.
-4. If the commit fails due to pre-commit hook, fix the issue and create a NEW commit (see amend rules above)
-
-Important notes:
-- NEVER run additional commands to read or explore code, besides git bash commands
-- NEVER use the TodoWrite or Task tools
-- DO NOT push to the remote repository unless the user explicitly asks you to do so
-- IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
-- If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
-
-# Creating pull requests
-Use the gh command via the Bash tool for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a GitHub URL use the gh command to get the information needed.
-
-IMPORTANT: When the user asks you to create a pull request, follow these steps carefully:
-
-1. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following bash commands in parallel using the Bash tool, in order to understand the current state of the branch since it diverged from the main branch:
-   - Run a git status command to see all untracked files
-   - Run a git diff command to see both staged and unstaged changes that will be committed
-   - Check if the current branch tracks a remote branch and is up to date with the remote, so you know if you need to push to the remote
-   - Run a git log command and `git diff [base-branch]...HEAD` to understand the full commit history for the current branch (from the time it diverged from the base branch)
-2. Analyze all changes that will be included in the pull request, making sure to look at all relevant commits (NOT just the latest commit, but ALL commits that will be included in the pull request!!!), and draft a pull request summary
-3. You can call multiple tools in a single response. When multiple independent pieces of information are requested and all commands are likely to succeed, run multiple tool calls in parallel for optimal performance. run the following commands in parallel:
-   - Create new branch if needed
-   - Push to remote with -u flag if needed
-   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
-<example>
-gh pr create --title "the pr title" --body "$(cat <<'EOF'
-## Summary
-<1-3 bullet points>
-</example>
-
-Important:
-- DO NOT use the TodoWrite or Task tools
-- Return the PR URL when you're done, so the user can see it
-
-# Other common operations
-- View comments on a GitHub PR: gh api repos/foo/bar/pulls/123/comments
+# Safety
+- For git, never commit, push, amend, force-push, skip hooks, or run destructive commands unless explicitly requested.

--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -1,10 +1,11 @@
-Performs exact string replacements in files. 
+Perform exact string replacement in an existing file.
 
-Usage:
-- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. 
-- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: line number + colon + space (e.g., `1: `). Everything after that space is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
-- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
-- Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
-- The edit will FAIL if `oldString` is not found in the file with an error "oldString not found in content".
-- The edit will FAIL if `oldString` is found multiple times in the file with an error "Found multiple matches for oldString. Provide more surrounding lines in oldString to identify the correct match." Either provide a larger string with more surrounding context to make it unique or use `replaceAll` to change every instance of `oldString`. 
-- Use `replaceAll` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
+# Rules
+- You must Read the file at least once in the conversation before editing.
+- Match text exactly, including indentation.
+- Read output has line prefixes like `42:   const x = 1`; do not include `42: ` in `oldString` or `newString`.
+- Prefer editing existing files. Do not create new files unless required.
+- Do not add emojis unless explicitly requested.
+- Fails if `oldString` is not found.
+- Fails if `oldString` matches multiple locations; add surrounding context or use `replaceAll`.
+- Use `replaceAll` for rename/global replacement within the file.

--- a/packages/opencode/src/tool/glob.txt
+++ b/packages/opencode/src/tool/glob.txt
@@ -1,6 +1,8 @@
-- Fast file pattern matching tool that works with any codebase size
-- Supports glob patterns like "**/*.js" or "src/**/*.ts"
-- Returns matching file paths sorted by modification time
-- Use this tool when you need to find files by name patterns
-- When you are doing an open-ended search that may require multiple rounds of globbing and grepping, use the Task tool instead
-- You have the capability to call multiple tools in a single response. It is always better to speculatively perform multiple searches as a batch that are potentially useful.
+Find files by glob pattern quickly.
+
+# Rules
+- Supports patterns like `**/*.js` and `src/**/*.ts`.
+- Returns matching paths sorted by modification time.
+- Use for filename/path discovery.
+- For open-ended searches needing multiple rounds, use Task.
+- Batch independent speculative searches in parallel.

--- a/packages/opencode/src/tool/grep.txt
+++ b/packages/opencode/src/tool/grep.txt
@@ -1,8 +1,9 @@
-- Fast content search tool that works with any codebase size
-- Searches file contents using regular expressions
-- Supports full regex syntax (eg. "log.*Error", "function\s+\w+", etc.)
-- Filter files by pattern with the include parameter (eg. "*.js", "*.{ts,tsx}")
-- Returns file paths and line numbers with at least one match sorted by modification time
-- Use this tool when you need to find files containing specific patterns
-- If you need to identify/count the number of matches within files, use the Bash tool with `rg` (ripgrep) directly. Do NOT use `grep`.
-- When you are doing an open-ended search that may require multiple rounds of globbing and grepping, use the Task tool instead
+Search file contents with regular expressions.
+
+# Rules
+- Supports full regex syntax, e.g. `log.*Error` or `function\s+\w+`.
+- Use `include` to filter files, e.g. `*.js` or `*.{ts,tsx}`.
+- Returns paths and line numbers sorted by modification time.
+- Use when finding files containing specific patterns.
+- To count matches within files, use Bash with `rg`; do not use `grep`.
+- For open-ended multi-round searches, use Task.

--- a/packages/opencode/src/tool/lsp.txt
+++ b/packages/opencode/src/tool/lsp.txt
@@ -1,24 +1,17 @@
-Interact with Language Server Protocol (LSP) servers to get code intelligence features.
+Use Language Server Protocol code intelligence.
 
-Supported operations:
-- goToDefinition: Find where a symbol is defined
-- findReferences: Find all references to a symbol
-- hover: Get hover information (documentation, type info) for a symbol
-- documentSymbol: Get all symbols (functions, classes, variables) in a document
-- workspaceSymbol: List project-wide symbols matching a query string
-- goToImplementation: Find implementations of an interface or abstract method
-- prepareCallHierarchy: Get call hierarchy item at a position (functions/methods)
-- incomingCalls: Find all functions/methods that call the function at a position
-- outgoingCalls: Find all functions/methods called by the function at a position
+# Operations
+- `goToDefinition`: find symbol definition.
+- `findReferences`: find all references.
+- `hover`: get docs/type info.
+- `documentSymbol`: list symbols in a file.
+- `workspaceSymbol`: list project-wide symbols matching `query`; empty query requests all symbols.
+- `goToImplementation`: find interface/abstract method implementations.
+- `prepareCallHierarchy`: get call hierarchy item at position.
+- `incomingCalls`: find callers.
+- `outgoingCalls`: find callees.
 
-All operations require:
-- filePath: The file to operate on
-- line: The line number (1-based, as shown in editors)
-- character: The character offset (1-based, as shown in editors)
-
-workspaceSymbol also accepts:
-- query: A query string to filter symbols by. Empty string requests all symbols.
-
-For workspaceSymbol, filePath is not sent in the LSP workspace/symbol request. It is used by opencode to select and start the matching LSP server.
-
-Note: LSP servers must be configured for the file type. If no server is available, an error will be returned.
+# Parameters
+- All operations require `filePath`, 1-based `line`, and 1-based `character`.
+- `workspaceSymbol` also accepts `query` and does not send `filePath` to the LSP request; opencode uses it to select/start the matching server.
+- Errors if no LSP server is configured for the file type.

--- a/packages/opencode/src/tool/plan-enter.txt
+++ b/packages/opencode/src/tool/plan-enter.txt
@@ -1,14 +1,11 @@
-Use this tool to suggest switching to plan agent when the user's request would benefit from planning before implementation.
+Suggest switching to the plan agent. This asks the user to confirm.
 
-If they explicitly mention wanting to create a plan ALWAYS call this tool first.
+# Use When
+- The user explicitly wants a plan.
+- The task is complex and benefits from planning before changes.
+- You need research/design before implementation.
+- The work spans multiple files or architectural decisions.
 
-This tool will ask the user if they want to switch to plan agent.
-
-Call this tool when:
-- The user's request is complex and would benefit from planning first
-- You want to research and design before making changes
-- The task involves multiple files or significant architectural decisions
-
-Do NOT call this tool:
-- For simple, straightforward tasks
-- When the user explicitly wants immediate implementation
+# Skip When
+- The task is simple and direct.
+- The user explicitly wants immediate implementation.

--- a/packages/opencode/src/tool/plan-exit.txt
+++ b/packages/opencode/src/tool/plan-exit.txt
@@ -1,13 +1,11 @@
-Use this tool when you have completed the planning phase and are ready to exit plan agent.
+Suggest exiting plan mode and switching to the build agent. This asks the user to confirm.
 
-This tool will ask the user if they want to switch to build agent to start implementing the plan.
+# Use When
+- The plan is written and ready.
+- Open questions are clarified.
+- Implementation can begin.
 
-Call this tool:
-- After you have written a complete plan to the plan file
-- After you have clarified any questions with the user
-- When you are confident the plan is ready for implementation
-
-Do NOT call this tool:
-- Before you have created or finalized the plan
-- If you still have unanswered questions about the implementation
-- If the user has indicated they want to continue planning
+# Skip When
+- No final plan exists yet.
+- Important questions remain.
+- The user wants to continue planning.

--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -1,10 +1,7 @@
-Use this tool when you need to ask the user questions during execution. This allows you to:
-1. Gather user preferences or requirements
-2. Clarify ambiguous instructions
-3. Get decisions on implementation choices as you work
-4. Offer choices to the user about what direction to take.
+Ask the user questions during execution for preferences, clarification, implementation decisions, or direction choices.
 
-Usage notes:
-- When `custom` is enabled (default), a "Type your own answer" option is added automatically; don't include "Other" or catch-all options
-- Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
-- If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
+# Rules
+- With `custom` enabled, a free-form answer option is added automatically; do not add "Other" or catch-all options.
+- Answers return as an array of labels.
+- Set `multiple: true` for multi-select.
+- Put the recommended option first and add `(Recommended)` to its label.

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -1,14 +1,13 @@
-Read a file or directory from the local filesystem. If the path does not exist, an error is returned.
+Read a file or directory. Errors if the path does not exist.
 
-Usage:
-- The filePath parameter should be an absolute path.
-- By default, this tool returns up to 2000 lines from the start of the file.
-- The offset parameter is the line number to start from (1-indexed).
-- To read later sections, call this tool again with a larger offset.
-- Use the grep tool to find specific content in large files or files with long lines.
-- If you are unsure of the correct file path, use the glob tool to look up filenames by glob pattern.
-- Contents are returned with each line prefixed by its line number as `<line>: <content>`. For example, if a file has contents "foo\n", you will receive "1: foo\n". For directories, entries are returned one per line (without line numbers) with a trailing `/` for subdirectories.
-- Any line longer than 2000 characters is truncated.
-- Call this tool in parallel when you know there are multiple files you want to read.
-- Avoid tiny repeated slices (30 line chunks). If you need more context, read a larger window.
-- This tool can read image files and PDFs and return them as file attachments.
+# Rules
+- `filePath` must be absolute.
+- Defaults to first 2000 lines. Use 1-based `offset` and `limit` for later sections.
+- File lines are returned as `N: <content>`; example `foo\n` becomes `1: foo\n`.
+- Directory entries are one per line; subdirectories end with `/`.
+- Lines over 2000 characters are truncated.
+- Use Grep for specific content in large files.
+- Use Glob when unsure of the path.
+- Read known independent files in parallel.
+- Avoid tiny repeated slices; request a larger window when more context is needed.
+- Images and PDFs can be returned as attachments.

--- a/packages/opencode/src/tool/skill.txt
+++ b/packages/opencode/src/tool/skill.txt
@@ -1,5 +1,3 @@
-Load a specialized skill when the task at hand matches one of the skills listed in the system prompt.
+Load a specialized skill when the task matches a skill listed in the system prompt.
 
-Use this tool to inject the skill's instructions and resources into current conversation. The output may contain detailed workflow guidance as well as references to scripts, files, etc in the same directory as the skill.
-
-The skill name must match one of the skills listed in your system prompt.
+The skill injects task-specific instructions and resources into the conversation. The skill name must exactly match one listed in the system prompt.

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -1,57 +1,21 @@
-Launch a new agent to handle complex, multistep tasks autonomously.
+Launch a subagent for complex, multi-step work. Always set `subagent_type`.
 
-When using the Task tool, you must specify a subagent_type parameter to select which agent type to use.
+# Use When
+- Executing a custom slash command: pass the slash command as the entire prompt.
+- A task benefits from autonomous exploration, research, design, or review.
+- An available agent description says it should be used proactively.
 
-When to use the Task tool:
-- When you are instructed to execute custom slash commands. Use the Task tool with the slash command invocation as the entire prompt. The slash command can take arguments. For example: Task(description="Check the file", prompt="/check-file path/to/file.py")
+# Do Not Use When
+- Reading a known file path: use Read.
+- Finding files or symbols: use Glob/Grep.
+- Searching within 2-3 known files: read them directly.
+- The task does not match any available agent description.
 
-When NOT to use the Task tool:
-- If you want to read a specific file path, use the Read or Glob tool instead of the Task tool, to find the match more quickly
-- If you are searching for a specific class definition like "class Foo", use the Glob tool instead, to find the match more quickly
-- If you are searching for code within a specific file or set of 2-3 files, use the Read tool instead of the Task tool, to find the match more quickly
-- Other tasks that are not related to the agent descriptions above
-
-
-Usage notes:
-1. Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
-2. When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result. The output includes a task_id you can reuse later to continue the same subagent session.
-3. Each agent invocation starts with a fresh context unless you provide task_id to resume the same subagent session (which continues with its previous messages and tool outputs). When starting fresh, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.
-4. The agent's outputs should generally be trusted
-5. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent. Tell it how to verify its work if possible (e.g., relevant test commands).
-6. If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
-
-Example usage (NOTE: The agents below are fictional examples for illustration only - use the actual agents listed above):
-
-<example_agent_descriptions>
-"code-reviewer": use this agent after you are done writing a significant piece of code
-"greeting-responder": use this agent when to respond to user greetings with a friendly joke
-</example_agent_description>
-
-<example>
-user: "Please write a function that checks if a number is prime"
-assistant: Sure let me write a function that checks if a number is prime
-assistant: First let me use the Write tool to write a function that checks if a number is prime
-assistant: I'm going to use the Write tool to write the following code:
-<code>
-function isPrime(n) {
-  if (n <= 1) return false
-  for (let i = 2; i * i <= n; i++) {
-    if (n % i === 0) return false
-  }
-  return true
-}
-</code>
-<commentary>
-Since a significant piece of code was written and the task was completed, now use the code-reviewer agent to review the code
-</commentary>
-assistant: Now let me use the code-reviewer agent to review the code
-assistant: Uses the Task tool to launch the code-reviewer agent
-</example>
-
-<example>
-user: "Hello"
-<commentary>
-Since the user is greeting, use the greeting-responder agent to respond with a friendly joke
-</commentary>
-assistant: "I'm going to use the Task tool to launch the with the greeting-responder agent"
-</example>
+# Rules
+- Run independent subagents in parallel when useful.
+- Each new call starts fresh unless `task_id` is provided to resume.
+- Give the agent a detailed prompt, including whether it may write code or only research.
+- Specify exactly what the agent should return.
+- Tell the agent how to verify work when applicable.
+- The agent's final result is not shown to the user; summarize it yourself.
+- Trust agent output generally, but integrate it with your own judgment.

--- a/packages/opencode/src/tool/todowrite.txt
+++ b/packages/opencode/src/tool/todowrite.txt
@@ -1,167 +1,34 @@
-Use this tool to create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
-It also helps the user understand the progress of the task and overall progress of their requests.
+Create and maintain a structured task list for the current coding session. Use it to track complex work and show progress.
 
-## When to Use This Tool
-Use this tool proactively in these scenarios:
+# Use When
+- The task has 3+ meaningful steps.
+- The work is non-trivial and needs planning or sequencing.
+- The user explicitly asks for todos.
+- The user gives multiple tasks.
+- New instructions change scope.
+- You finish a task and need to mark it complete or add follow-ups.
 
-1. Complex multistep tasks - When a task requires 3 or more distinct steps or actions
-2. Non-trivial and complex tasks - Tasks that require careful planning or multiple operations
-3. User explicitly requests todo list - When the user directly asks you to use the todo list
-4. User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
-5. After receiving new instructions - Immediately capture user requirements as todos. Feel free to edit the todo list based on new information.
-6. After completing a task - Mark it complete and add any new follow-up tasks
-7. When you start working on a new task, mark the todo as in_progress. Ideally you should only have one todo as in_progress at a time. Complete existing tasks before starting new ones.
+# Skip When
+- The task is single, trivial, or purely informational.
+- The work can be done in fewer than 3 simple steps.
+- Tracking adds no value.
 
-## When NOT to Use This Tool
+# States
+- `pending`: not started.
+- `in_progress`: currently active. Keep only one item in this state.
+- `completed`: finished successfully.
+- `cancelled`: no longer needed.
 
-Skip using this tool when:
-1. There is only a single, straightforward task
-2. The task is trivial and tracking it provides no organizational benefit
-3. The task can be completed in less than 3 trivial steps
-4. The task is purely conversational or informational
+# Rules
+- Update status as work progresses.
+- Mark items complete immediately after finishing; do not batch completions.
+- Complete the current item before starting another.
+- Break complex work into specific, actionable items.
+- Cancel tasks that become irrelevant.
 
-NOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.
+# Examples
+- Multi-feature request: create todos for each feature plus requested test/build verification.
+- Rename across project: search first; if many files are affected, create todos per file or area.
+- Single comment or one command: skip todos and do the work directly.
 
-## Examples of When to Use the Todo List
-
-<example>
-User: I want to add a dark mode toggle to the application settings. Make sure you run the tests and build when you're done!
-Assistant: I'll help add a dark mode toggle to your application settings. Let me create a todo list to track this implementation.
-*Creates todo list with the following items:*
-1. Create dark mode toggle component in Settings page
-2. Add dark mode state management (context/store)
-3. Implement CSS-in-JS styles for dark theme
-4. Update existing components to support theme switching
-5. Run tests and build process, addressing any failures or errors that occur
-*Begins working on the first task*
-
-<reasoning>
-The assistant used the todo list because:
-1. Adding dark mode is a multi-step feature requiring UI, state management, and styling changes
-2. The user explicitly requested tests and build be run afterward
-3. The assistant inferred that tests and build need to pass by adding "Ensure tests and build succeed" as the final task
-</reasoning>
-</example>
-
-<example>
-User: Help me rename the function getCwd to getCurrentWorkingDirectory across my project
-Assistant: Let me first search through your codebase to find all occurrences of 'getCwd'.
-*Uses grep or search tools to locate all instances of getCwd in the codebase*
-Assistant: I've found 15 instances of 'getCwd' across 8 different files. Let me create a todo list to track these changes.
-*Creates todo list with specific items for each file that needs updating*
-
-<reasoning>
-The assistant used the todo list because:
-1. First, the assistant searched to understand the scope of the task
-2. Upon finding multiple occurrences across different files, it determined this was a complex task with multiple steps
-3. The todo list helps ensure every instance is tracked and updated systematically
-4. This approach prevents missing any occurrences and maintains code consistency
-</reasoning>
-</example>
-
-
-<example>
-User: I need to implement these features for my e-commerce site: user registration, product catalog, shopping cart, and checkout flow.
-Assistant: I'll help implement these features. First, let's add all the features to the todo list.
-*Creates a todo list breaking down each feature into specific tasks based on the project architecture*
-Assistant: Let's start with user registration. This will involve creating database models, API endpoints, and frontend forms that integrate with your existing authentication system.
-
-<reasoning>
-The assistant used the todo list because:
-1. The user provided multiple complex features to implement in a comma separated list
-2. The todo list helps organize these large features into manageable tasks
-3. This approach allows for tracking progress across the entire implementation
-</reasoning>
-</example>
-
-<example>
-User: Can you help optimize my React application? It's rendering slowly and has performance issues.</user>
-Assistant: I'll help optimize your React application. First, let me examine your codebase to identify potential performance bottlenecks.
-*Reviews component structure, render patterns, state management, and data fetching*
-Assistant: After analyzing your codebase, I've identified several performance issues. Let me create a todo list to track our optimization efforts.
-*Creates todo list with items like: 1) Implement memoization for expensive calculations in ProductList, 2) Add virtualization for long lists in Dashboard, 3) Optimize image loading in Gallery component, 4) Fix state update loops in ShoppingCart, 5) Review bundle size and implement code splitting*
-Let's start by implementing memoization for the expensive calculations in your ProductList component.</assistant>
-
-<reasoning>
-The assistant used the todo list because:
-1. First, the assistant examined the codebase to identify specific performance issues
-2. Based on this analysis, it identified multiple optimization opportunities
-3. Performance optimization is a non-trivial task requiring multiple steps
-4. The todo list helps methodically track improvements across different components
-5. This systematic approach ensures all performance bottlenecks are addressed
-</reasoning>
-</example>
-
-## Examples of When NOT to Use the Todo List
-
-<example>
-User: How do I print 'Hello World' in Python?
-Assistant: In Python, you can print "Hello World" with this simple code:
-
-python
-print("Hello World")
-
-This will output the text "Hello World" to the console when executed.</assistant>
-
-<reasoning>
-The assistant did not use the todo list because this is a single, trivial task that can be completed in one step. There's no need to track multiple tasks or steps for such a straightforward request.
-</reasoning>
-</example>
-
-<example>
-User: What does the git status command do?
-Assistant: The git status command shows the current state of your working directory and staging area. It displays which changes have been staged, which haven't, and which files aren't being tracked by Git. This is a fundamental command for understanding the current state of your repository before making commits.
-
-<reasoning>
-The assistant did not use the todo list because this is an informational request with no actual coding task to complete. The user is simply asking for an explanation, not for the assistant to perform multiple steps or tasks.
-</reasoning>
-</example>
-
-<example>
-User: Can you add a comment to the calculateTotal function to explain what it does?
-Assistant: Sure, let me add a comment to the calculateTotal function to explain what it does.
-* Uses the Edit tool to add a comment to the calculateTotal function *
-
-<reasoning>
-The assistant did not use the todo list because this is a single, straightforward task confined to one location in the code. Adding a comment doesn't require tracking multiple steps or systematic organization.
-</reasoning>
-</example>
-
-<example>
-User: Run npm install for me and tell me what happens.
-Assistant: I'll run the npm install command for you.
-
-*Executes: npm install*
-
-The command completed successfully. Here's the output:
-[Output of npm install command]
-
-All dependencies have been installed according to your package.json file.
-
-<reasoning>
-The assistant did not use the todo list because this is a single command execution with immediate results. There are no multiple steps to track or organize, making the todo list unnecessary for this straightforward task.
-</reasoning>
-</example>
-
-## Task States and Management
-
-1. **Task States**: Use these states to track progress:
-   - pending: Task not yet started
-   - in_progress: Currently working on (limit to ONE task at a time)
-   - completed: Task finished successfully
-   - cancelled: Task no longer needed
-
-2. **Task Management**:
-   - Update task status in real-time as you work
-   - Mark tasks complete IMMEDIATELY after finishing (don't batch completions)
-   - Only have ONE task in_progress at any time
-   - Complete current tasks before starting new ones
-   - Cancel tasks that become irrelevant
-
-3. **Task Breakdown**:
-   - Create specific, actionable items
-   - Break complex tasks into smaller, manageable steps
-   - Use clear, descriptive task names
-
-When in doubt, use this tool. Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully.
-
+When in doubt for non-trivial coding work, use this tool.

--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -1,13 +1,7 @@
-- Fetches content from a specified URL
-- Takes a URL and optional format as input
-- Fetches the URL content, converts to requested format (markdown by default)
-- Returns the content in the specified format
-- Use this tool when you need to retrieve and analyze web content
+Fetch URL content as markdown, text, or html. Default format is markdown.
 
-Usage notes:
-  - IMPORTANT: if another tool is present that offers better web fetching capabilities, is more targeted to the task, or has fewer restrictions, prefer using that tool instead of this one.
-  - The URL must be a fully-formed valid URL
-  - HTTP URLs will be automatically upgraded to HTTPS
-  - Format options: "markdown" (default), "text", or "html"
-  - This tool is read-only and does not modify any files
-  - Results may be summarized if the content is very large
+# Rules
+- Prefer a more targeted/capable tool when available.
+- URL must be fully formed; HTTP is upgraded to HTTPS.
+- Read-only; does not modify files.
+- Large results may be summarized.

--- a/packages/opencode/src/tool/websearch.txt
+++ b/packages/opencode/src/tool/websearch.txt
@@ -1,14 +1,8 @@
-- Search the web using Exa AI - performs real-time web searches and can scrape content from specific URLs
-- Provides up-to-date information for current events and recent data
-- Supports configurable result counts and returns the content from the most relevant websites
-- Use this tool for accessing information beyond knowledge cutoff
-- Searches are performed automatically within a single API call
+Search the web with Exa AI for current or post-cutoff information.
 
-Usage notes:
-  - Supports live crawling modes: 'fallback' (backup if cached unavailable) or 'preferred' (prioritize live crawling)
-  - Search types: 'auto' (balanced), 'fast' (quick results), 'deep' (comprehensive search)
-  - Configurable context length for optimal LLM integration
-  - Domain filtering and advanced search options available
+# Options
+- Live crawl modes: `fallback` or `preferred`.
+- Search types: `auto`, `fast`, `deep`.
+- Supports configurable context length, domain filters, and advanced options.
 
-The current year is {{year}}. You MUST use this year when searching for recent information or current events
-- Example: If the current year is 2026 and the user asks for "latest AI news", search for "AI news 2026", NOT "AI news 2025"
+Current year is {{year}}. Use it for recent/current queries; e.g. in 2026 search `AI news 2026`, not `AI news 2025`.

--- a/packages/opencode/src/tool/write.txt
+++ b/packages/opencode/src/tool/write.txt
@@ -1,8 +1,8 @@
-Writes a file to the local filesystem.
+Write a file to the local filesystem.
 
-Usage:
-- This tool will overwrite the existing file if there is one at the provided path.
-- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
-- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
-- NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
-- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
+# Rules
+- Overwrites any existing file at the path.
+- If the file exists, Read it first or this tool fails.
+- Prefer editing existing files. Create new files only when required.
+- Do not proactively create documentation or README files unless explicitly requested.
+- Do not add emojis unless explicitly requested.

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -651,6 +651,71 @@ test("model options are merged from existing model", async () => {
   })
 })
 
+test("model prompt is merged from config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              models: {
+                "claude-sonnet-4-20250514": {
+                  prompt: "Use a concise local prompt.",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
+      expect(model.prompt).toBe("Use a concise local prompt.")
+    },
+  })
+})
+
+test("model prompt supports file substitution", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "local-prompt.txt"), "Use prompt from file.\n")
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              models: {
+                "claude-sonnet-4-20250514": {
+                  prompt: "{file:./local-prompt.txt}",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.anthropic, ModelID.make("claude-sonnet-4-20250514"))
+      expect(model.prompt).toBe("Use prompt from file.")
+    },
+  })
+})
+
 test("provider removed when all models filtered out", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -299,6 +299,161 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
 }
 
 describe("session.llm.stream", () => {
+  test("uses model prompt when agent has no prompt", async () => {
+    const server = state.server
+    if (!server) throw new Error("Server not initialized")
+
+    const providerID = "vivgrid"
+    const modelID = "gemini-3.1-pro-preview"
+    const fixture = await loadFixture(providerID, modelID)
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+                models: {
+                  [fixture.model.id]: {
+                    prompt: "Use the configured model prompt.",
+                  },
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(fixture.model.id))
+        const sessionID = SessionID.make("session-model-prompt")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-model-prompt"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: [],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const body = (await request).body
+        const messages = body.messages as Array<{ role: string; content: string }>
+        expect(messages[0]).toEqual({ role: "system", content: "Use the configured model prompt." })
+      },
+    })
+  })
+
+  test("agent prompt takes precedence over model prompt", async () => {
+    const server = state.server
+    if (!server) throw new Error("Server not initialized")
+
+    const providerID = "vivgrid"
+    const modelID = "gemini-3.1-pro-preview"
+    const fixture = await loadFixture(providerID, modelID)
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+                models: {
+                  [fixture.model.id]: {
+                    prompt: "Use the configured model prompt.",
+                  },
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(fixture.model.id))
+        const sessionID = SessionID.make("session-agent-prompt")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          prompt: "Use the agent prompt.",
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-agent-prompt"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: [],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const body = (await request).body
+        const messages = body.messages as Array<{ role: string; content: string }>
+        expect(messages[0]).toEqual({ role: "system", content: "Use the agent prompt." })
+      },
+    })
+  })
+
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1328,6 +1328,7 @@ export type ProviderConfig = {
     [key: string]: {
       id?: string
       name?: string
+      prompt?: string
       family?: string
       release_date?: string
       attachment?: boolean
@@ -1757,6 +1758,7 @@ export type Model = {
     npm: string
   }
   name: string
+  prompt?: string
   family?: string
   capabilities: {
     temperature: boolean

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2125,11 +2125,12 @@ You can use any OpenAI-compatible provider with opencode. Most modern AI provide
          "options": {
            "baseURL": "https://api.myprovider.com/v1"
          },
-         "models": {
-           "my-model-name": {
-             "name": "My Model Display Name"
-           }
-         }
+          "models": {
+            "my-model-name": {
+              "name": "My Model Display Name",
+              "prompt": "{file:./prompts/local-model.txt}"
+            }
+          }
        }
      }
    }
@@ -2137,9 +2138,10 @@ You can use any OpenAI-compatible provider with opencode. Most modern AI provide
 
    Here are the configuration options:
    - **npm**: AI SDK package to use, `@ai-sdk/openai-compatible` for OpenAI-compatible providers (for `/v1/chat/completions`). If your provider/model uses `/v1/responses`, use `@ai-sdk/openai`.
-   - **name**: Display name in UI.
-   - **models**: Available models.
-   - **options.baseURL**: API endpoint URL.
+    - **name**: Display name in UI.
+    - **models**: Available models.
+    - **models.*.prompt**: Optional system prompt for this model. Agent prompts still take precedence.
+    - **options.baseURL**: API endpoint URL.
    - **options.apiKey**: Optionally set the API key, if not using auth.
    - **options.headers**: Optionally set custom headers.
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2125,12 +2125,12 @@ You can use any OpenAI-compatible provider with opencode. Most modern AI provide
          "options": {
            "baseURL": "https://api.myprovider.com/v1"
          },
-          "models": {
-            "my-model-name": {
-              "name": "My Model Display Name",
-              "prompt": "{file:./prompts/local-model.txt}"
-            }
-          }
+         "models": {
+           "my-model-name": {
+             "name": "My Model Display Name",
+             "prompt": "{file:./prompts/local-model.txt}"
+           }
+         }
        }
      }
    }
@@ -2138,10 +2138,10 @@ You can use any OpenAI-compatible provider with opencode. Most modern AI provide
 
    Here are the configuration options:
    - **npm**: AI SDK package to use, `@ai-sdk/openai-compatible` for OpenAI-compatible providers (for `/v1/chat/completions`). If your provider/model uses `/v1/responses`, use `@ai-sdk/openai`.
-    - **name**: Display name in UI.
-    - **models**: Available models.
-    - **models.*.prompt**: Optional system prompt for this model. Agent prompts still take precedence.
-    - **options.baseURL**: API endpoint URL.
+   - **name**: Display name in UI.
+   - **models**: Available models.
+   - **models.*.prompt**: Optional system prompt for this model. Agent prompts still take precedence.
+   - **options.baseURL**: API endpoint URL.
    - **options.apiKey**: Optionally set the API key, if not using auth.
    - **options.headers**: Optionally set custom headers.
 


### PR DESCRIPTION
## Summary
- Add optional `provider.<id>.models.<model>.prompt` config for model-specific system prompts.
- Preserve existing precedence so agent prompts win over model prompts, then fall back to built-in provider prompts.
- Add provider and LLM tests plus docs and regenerated SDK v2 types.

## Verification
- `bun test test/provider/provider.test.ts --timeout 30000`
- `bun test test/session/llm.test.ts --timeout 30000`
- `bun typecheck`
- Push hook: `bun turbo typecheck`