### PR TITLE
Extract InstanceStore.provide helper

### DIFF
--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -1,5 +1,6 @@
 import { GlobalBus } from "@/bus/global"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
+import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance } from "@/effect/instance-registry"
 import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -19,6 +20,7 @@ export interface Interface {
   readonly reload: (input: LoadInput) => Effect.Effect<InstanceContext>
   readonly dispose: (ctx: InstanceContext) => Effect.Effect<void>
   readonly disposeAll: () => Effect.Effect<void>
+  readonly provide: <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/InstanceStore") {}
@@ -168,6 +170,9 @@ export const layer: Layer.Layer<Service, never, Project.Service> = Layer.effect(
       return yield* cachedDisposeAll
     })
 
+    const provide = <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+      load(input).pipe(Effect.flatMap((ctx) => effect.pipe(Effect.provideService(InstanceRef, ctx))))
+
     yield* Effect.addFinalizer(() => disposeAll().pipe(Effect.ignore))
 
     return Service.of({
@@ -175,6 +180,7 @@ export const layer: Layer.Layer<Service, never, Project.Service> = Layer.effect(
       reload,
       dispose,
       disposeAll,
+      provide,
     })
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -1,7 +1,6 @@
-import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
+import { WorkspaceRef } from "@/effect/instance-ref"
 import { AppRuntime } from "@/effect/app-runtime"
 import { InstanceBootstrap } from "@/project/bootstrap"
-import type { InstanceContext } from "@/project/instance"
 import { InstanceStore } from "@/project/instance-store"
 import { Effect, Layer } from "effect"
 import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
@@ -23,23 +22,15 @@ function decode(input: string): string {
   }
 }
 
-function makeInstanceContext(store: InstanceStore.Interface, directory: string): Effect.Effect<InstanceContext> {
-  return store.load({
-    directory: decode(directory),
-    init: () => AppRuntime.runPromise(InstanceBootstrap),
-  })
-}
-
 function provideInstanceContext<E>(
   effect: Effect.Effect<HttpServerResponse.HttpServerResponse, E>,
   store: InstanceStore.Interface,
 ): Effect.Effect<HttpServerResponse.HttpServerResponse, E, WorkspaceRouteContext> {
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
-    const ctx = yield* makeInstanceContext(store, route.directory)
-    return yield* effect.pipe(
-      Effect.provideService(InstanceRef, ctx),
-      Effect.provideService(WorkspaceRef, route.workspaceID),
+    return yield* store.provide(
+      { directory: decode(route.directory), init: () => AppRuntime.runPromise(InstanceBootstrap) },
+      effect.pipe(Effect.provideService(WorkspaceRef, route.workspaceID)),
     )
   })
 }


### PR DESCRIPTION
## Summary
- Adds \`InstanceStore.provide(input, effect)\` — loads the cached instance context and provides \`InstanceRef\` to the wrapped effect.
- Refactors the HttpApi instance-context middleware (\`makeInstanceContext\` + manual \`provideService(InstanceRef)\`) to use the new helper.
- Gives non-middleware callers (CLI bridges, background jobs) a single primitive for entering an instance scope from Effect-native code.

## Why
The instance-context middleware was inlining \`store.load\` + \`Effect.provideService(InstanceRef, ctx)\`. Any other Effect-native call site that needs to enter an instance scope would copy that same pattern. Extracting it as \`InstanceStore.provide\` removes the duplication and makes the next conversion (CLI commands moving to native Effect bodies) a one-liner.

## Tests
- \`bun run test test/project/instance.test.ts test/server/httpapi-instance-context.test.ts\` — 15/15 pass
- \`bun run typecheck\` — clean