### PR TITLE
feat(worktree): add .worktreeinclude support for copying gitignored files to new worktrees

### DIFF
--- a/packages/opencode/src/worktree/include.ts
+++ b/packages/opencode/src/worktree/include.ts
@@ -1,0 +1,206 @@
+import { Effect, Path } from "effect"
+import ignore from "ignore"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import * as Log from "@opencode-ai/core/util/log"
+import { FileIgnore } from "../file/ignore"
+import { errorMessage } from "../util/error"
+
+const log = Log.create({ service: "worktree.include" })
+
+export const FILENAME = ".worktreeinclude"
+
+// Hard-skip: never recurse into a `.git` directory regardless of user patterns.
+// Other heavy directories (node_modules, dist, …) are pruned via FileIgnore.match
+// below so users can override by listing them explicitly in `.worktreeinclude`.
+const HARD_SKIP_DIRECTORIES = new Set([".git"])
+
+const COPY_CONCURRENCY = 8
+
+export interface ApplyResult {
+  readonly copied: string[]
+  readonly failed: { path: string; error: string }[]
+}
+
+const copyFileEntry = Effect.fnUntraced(function* (
+  fs: AppFileSystem.Interface,
+  pathSvc: Path.Path,
+  src: string,
+  dst: string,
+  type: AppFileSystem.DirEntry["type"],
+) {
+  const parent = pathSvc.dirname(dst)
+  yield* fs.makeDirectory(parent, { recursive: true })
+
+  if (type === "symlink") {
+    const target = yield* fs.readLink(src)
+    yield* fs.remove(dst, { recursive: true, force: true } as any).pipe(Effect.catch(() => Effect.void))
+    yield* fs.symlink(target, dst)
+    return
+  }
+
+  yield* fs.copyFile(src, dst)
+  const info = yield* fs.stat(src).pipe(Effect.catch(() => Effect.succeed(undefined)))
+  const mode = info?.mode
+  if (typeof mode === "number") {
+    yield* fs.chmod(dst, mode).pipe(Effect.catch(() => Effect.void))
+  }
+})
+
+// Internal helpers explicitly type their R channel as `never` so that
+// `apply` does not accidentally bubble up an `any` requirement to its callers.
+type IncludeEffect<A> = Effect.Effect<A, any, never>
+
+function copyDirectoryRecursive(
+  fs: AppFileSystem.Interface,
+  pathSvc: Path.Path,
+  src: string,
+  dst: string,
+): IncludeEffect<void> {
+  return Effect.gen(function* () {
+    yield* fs.makeDirectory(dst, { recursive: true })
+    const entries = yield* fs
+      .readDirectoryEntries(src)
+      .pipe(Effect.catch(() => Effect.succeed([] as AppFileSystem.DirEntry[])))
+    for (const entry of entries) {
+      if (HARD_SKIP_DIRECTORIES.has(entry.name)) continue
+      const childSrc = pathSvc.join(src, entry.name)
+      const childDst = pathSvc.join(dst, entry.name)
+      if (entry.type === "directory") {
+        yield* copyDirectoryRecursive(fs, pathSvc, childSrc, childDst)
+      } else {
+        yield* copyFileEntry(fs, pathSvc, childSrc, childDst, entry.type)
+      }
+    }
+  })
+}
+
+const copyOne = Effect.fnUntraced(function* (
+  fs: AppFileSystem.Interface,
+  pathSvc: Path.Path,
+  source: string,
+  destination: string,
+  rel: string,
+  type: AppFileSystem.DirEntry["type"],
+) {
+  const src = pathSvc.join(source, rel)
+  const dst = pathSvc.join(destination, rel)
+
+  if (type === "directory") {
+    const parent = pathSvc.dirname(dst)
+    yield* fs.makeDirectory(parent, { recursive: true })
+    yield* copyDirectoryRecursive(fs, pathSvc, src, dst)
+    return
+  }
+
+  yield* copyFileEntry(fs, pathSvc, src, dst, type)
+})
+
+type Match = { rel: string; type: AppFileSystem.DirEntry["type"] }
+
+function visitForMatches(
+  fs: AppFileSystem.Interface,
+  pathSvc: Path.Path,
+  source: string,
+  matcher: ReturnType<typeof ignore>,
+  relDir: string,
+  matches: Match[],
+): IncludeEffect<void> {
+  return Effect.gen(function* () {
+    const absDir = relDir ? pathSvc.join(source, relDir) : source
+    const entries = yield* fs
+      .readDirectoryEntries(absDir)
+      .pipe(Effect.catch(() => Effect.succeed([] as AppFileSystem.DirEntry[])))
+
+    for (const entry of entries) {
+      if (HARD_SKIP_DIRECTORIES.has(entry.name)) continue
+
+      const rel = relDir ? `${relDir}/${entry.name}` : entry.name
+      const isDir = entry.type === "directory"
+      const probe = isDir ? `${rel}/` : rel
+
+      if (matcher.ignores(probe)) {
+        // User explicitly matched this entry. For directories we copy wholesale;
+        // descendants are handled by `copyDirectoryRecursive`.
+        matches.push({ rel, type: entry.type })
+        continue
+      }
+
+      if (isDir) {
+        // Skip standard build/cache directories so monorepos don't blow up walk
+        // time. Users can override by listing the directory in `.worktreeinclude`
+        // (matched above before this prune fires).
+        if (FileIgnore.match(rel)) continue
+        yield* visitForMatches(fs, pathSvc, source, matcher, rel, matches)
+      }
+    }
+  })
+}
+
+const walk = Effect.fnUntraced(function* (
+  fs: AppFileSystem.Interface,
+  pathSvc: Path.Path,
+  source: string,
+  matcher: ReturnType<typeof ignore>,
+) {
+  const matches: Match[] = []
+  yield* visitForMatches(fs, pathSvc, source, matcher, "", matches)
+  return matches
+})
+
+export const apply = Effect.fn("Worktree.includeIgnored")(function* (input: {
+  source: string
+  destination: string
+  fs: AppFileSystem.Interface
+  pathSvc: Path.Path
+}) {
+  const { fs, pathSvc } = input
+
+  const includeFile = pathSvc.join(input.source, FILENAME)
+  const text = yield* fs.readFileString(includeFile).pipe(Effect.catch(() => Effect.succeed("")))
+  const trimmed = text.trim()
+  const empty: ApplyResult = { copied: [], failed: [] }
+  if (!trimmed) {
+    log.debug("worktreeinclude: no patterns", {
+      source: input.source,
+      destination: input.destination,
+      includeFile,
+      hasFile: text.length > 0,
+    })
+    return empty
+  }
+
+  log.debug("worktreeinclude: scanning", {
+    source: input.source,
+    destination: input.destination,
+    patternBytes: trimmed.length,
+  })
+
+  const matcher = ignore().add(text)
+  const matched = yield* walk(fs, pathSvc, input.source, matcher)
+  if (!matched.length) {
+    log.debug("worktreeinclude: no matches", { source: input.source })
+    return empty
+  }
+
+  const copied: string[] = []
+  const failed: { path: string; error: string }[] = []
+
+  yield* Effect.forEach(
+    matched,
+    (item) =>
+      copyOne(fs, pathSvc, input.source, input.destination, item.rel, item.type).pipe(
+        Effect.tap(() => Effect.sync(() => copied.push(item.rel))),
+        Effect.catchCause((cause) =>
+          Effect.sync(() => {
+            failed.push({ path: item.rel, error: errorMessage(cause) })
+            log.warn("worktreeinclude copy failed", { path: item.rel, cause: errorMessage(cause) })
+          }),
+        ),
+      ),
+    { concurrency: COPY_CONCURRENCY, discard: true },
+  )
+
+  return { copied, failed } satisfies ApplyResult
+})
+
+export * as WorktreeInclude from "./include"

--- a/packages/opencode/src/worktree/include.ts
+++ b/packages/opencode/src/worktree/include.ts
@@ -28,8 +28,7 @@ const copyFileEntry = Effect.fnUntraced(function* (
   dst: string,
   type: AppFileSystem.DirEntry["type"],
 ) {
-  const parent = pathSvc.dirname(dst)
-  yield* fs.makeDirectory(parent, { recursive: true })
+  yield* fs.makeDirectory(pathSvc.dirname(dst), { recursive: true })
 
   if (type === "symlink") {
     const target = yield* fs.readLink(src)
@@ -86,8 +85,8 @@ const copyOne = Effect.fnUntraced(function* (
   const dst = pathSvc.join(destination, rel)
 
   if (type === "directory") {
-    const parent = pathSvc.dirname(dst)
-    yield* fs.makeDirectory(parent, { recursive: true })
+    // `copyDirectoryRecursive` runs `makeDirectory(dst, { recursive: true })`
+    // which also creates the parent — no need to do it twice.
     yield* copyDirectoryRecursive(fs, pathSvc, src, dst)
     return
   }
@@ -136,49 +135,32 @@ function visitForMatches(
   })
 }
 
-const walk = Effect.fnUntraced(function* (
-  fs: AppFileSystem.Interface,
-  pathSvc: Path.Path,
-  source: string,
-  matcher: ReturnType<typeof ignore>,
-) {
-  const matches: Match[] = []
-  yield* visitForMatches(fs, pathSvc, source, matcher, "", matches)
-  return matches
-})
-
 export const apply = Effect.fn("Worktree.includeIgnored")(function* (input: {
   source: string
   destination: string
   fs: AppFileSystem.Interface
   pathSvc: Path.Path
 }) {
-  const { fs, pathSvc } = input
+  const { fs, pathSvc, source, destination } = input
 
-  const includeFile = pathSvc.join(input.source, FILENAME)
+  const includeFile = pathSvc.join(source, FILENAME)
   const text = yield* fs.readFileString(includeFile).pipe(Effect.catch(() => Effect.succeed("")))
   const trimmed = text.trim()
   const empty: ApplyResult = { copied: [], failed: [] }
   if (!trimmed) {
     log.debug("worktreeinclude: no patterns", {
-      source: input.source,
-      destination: input.destination,
+      source,
+      destination,
       includeFile,
       hasFile: text.length > 0,
     })
     return empty
   }
 
-  log.debug("worktreeinclude: scanning", {
-    source: input.source,
-    destination: input.destination,
-    patternBytes: trimmed.length,
-  })
-
-  const matcher = ignore().add(text)
-  const matched = yield* walk(fs, pathSvc, input.source, matcher)
-  if (!matched.length) {
-    log.debug("worktreeinclude: no matches", { source: input.source })
+  const matches: Match[] = []
+  yield* visitForMatches(fs, pathSvc, source, ignore().add(text), "", matches)
+  if (!matches.length) {
+    log.debug("worktreeinclude: no matches", { source, destination })
     return empty
   }
 
@@ -186,9 +168,9 @@ export const apply = Effect.fn("Worktree.includeIgnored")(function* (input: {
   const failed: { path: string; error: string }[] = []
 
   yield* Effect.forEach(
-    matched,
+    matches,
     (item) =>
-      copyOne(fs, pathSvc, input.source, input.destination, item.rel, item.type).pipe(
+      copyOne(fs, pathSvc, source, destination, item.rel, item.type).pipe(
         Effect.tap(() => Effect.sync(() => copied.push(item.rel))),
         Effect.catchCause((cause) =>
           Effect.sync(() => {
@@ -199,6 +181,21 @@ export const apply = Effect.fn("Worktree.includeIgnored")(function* (input: {
       ),
     { concurrency: COPY_CONCURRENCY, discard: true },
   )
+
+  log.debug("worktreeinclude applied", {
+    source,
+    destination,
+    copied: copied.length,
+    failed: failed.length,
+  })
+  if (failed.length) {
+    log.warn("worktreeinclude partial failure", {
+      source,
+      destination,
+      count: failed.length,
+      sample: failed.slice(0, 3),
+    })
+  }
 
   return { copied, failed } satisfies ApplyResult
 })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -233,6 +233,17 @@ export const layer: Layer.Layer<
       yield* project.addSandbox(ctx.project.id, info.directory).pipe(Effect.catch(() => Effect.void))
     })
 
+    // Copy gitignored files declared in `.worktreeinclude` from the source repo
+    // into a freshly populated worktree directory. `apply` logs its own success
+    // and partial-failure summaries; we only need to swallow unexpected causes
+    // so the caller's boot/reset flow keeps going.
+    const applyInclude = (source: string, destination: string) =>
+      WorktreeInclude.apply({ source, destination, fs, pathSvc }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.sync(() => log.warn("worktreeinclude failed", { destination, cause: errorMessage(cause) })),
+        ),
+      )
+
     const boot = Effect.fnUntraced(function* (info: Info, startCommand?: string) {
       const ctx = yield* InstanceState.context
       const workspaceID = yield* InstanceState.workspaceID
@@ -252,38 +263,7 @@ export const layer: Layer.Layer<
         return
       }
 
-      // Copy gitignored files declared in `.worktreeinclude` (e.g. `.env`).
-      // Failures here only produce warnings — they must not block worktree boot.
-      yield* WorktreeInclude.apply({
-        source: ctx.worktree,
-        destination: info.directory,
-        fs,
-        pathSvc,
-      }).pipe(
-        Effect.tap((result) =>
-          Effect.sync(() => {
-            if (result.copied.length || result.failed.length) {
-              log.debug("worktreeinclude applied", {
-                directory: info.directory,
-                copied: result.copied.length,
-                failed: result.failed.length,
-              })
-            }
-            if (result.failed.length) {
-              log.warn("worktreeinclude partial failure", {
-                directory: info.directory,
-                count: result.failed.length,
-                sample: result.failed.slice(0, 3),
-              })
-            }
-          }),
-        ),
-        Effect.catchCause((cause) =>
-          Effect.sync(() =>
-            log.warn("worktreeinclude failed", { directory: info.directory, cause: errorMessage(cause) }),
-          ),
-        ),
-      )
+      yield* applyInclude(ctx.worktree, info.directory)
 
       const booted = yield* Effect.promise(() =>
         Instance.provide({
@@ -601,38 +581,7 @@ export const layer: Layer.Layer<
         throw new ResetFailedError({ message: `Worktree reset left local changes:\n${status.text.trim()}` })
       }
 
-      // Re-copy gitignored files declared in `.worktreeinclude` after `git clean`
-      // wiped them. Failures only produce warnings.
-      yield* WorktreeInclude.apply({
-        source: ctx.worktree,
-        destination: worktreePath,
-        fs,
-        pathSvc,
-      }).pipe(
-        Effect.tap((result) =>
-          Effect.sync(() => {
-            if (result.copied.length || result.failed.length) {
-              log.debug("worktreeinclude applied", {
-                directory: worktreePath,
-                copied: result.copied.length,
-                failed: result.failed.length,
-              })
-            }
-            if (result.failed.length) {
-              log.warn("worktreeinclude partial failure", {
-                directory: worktreePath,
-                count: result.failed.length,
-                sample: result.failed.slice(0, 3),
-              })
-            }
-          }),
-        ),
-        Effect.catchCause((cause) =>
-          Effect.sync(() =>
-            log.warn("worktreeinclude failed", { directory: worktreePath, cause: errorMessage(cause) }),
-          ),
-        ),
-      )
+      yield* applyInclude(ctx.worktree, worktreePath)
 
       yield* runStartScripts(worktreePath, { projectID: ctx.project.id }).pipe(
         Effect.catchCause((cause) => Effect.sync(() => log.error("worktree start task failed", { cause }))),

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -23,6 +23,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { InstanceState } from "@/effect/instance-state"
 import { zod as effectZod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
+import { WorktreeInclude } from "./include"
 
 const log = Log.create({ service: "worktree" })
 
@@ -251,6 +252,39 @@ export const layer: Layer.Layer<
         })
         return
       }
+
+      // Copy gitignored files declared in `.worktreeinclude` (e.g. `.env`).
+      // Failures here only produce warnings — they must not block worktree boot.
+      yield* WorktreeInclude.apply({
+        source: ctx.worktree,
+        destination: info.directory,
+        fs,
+        pathSvc,
+      }).pipe(
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            if (result.copied.length || result.failed.length) {
+              log.debug("worktreeinclude applied", {
+                directory: info.directory,
+                copied: result.copied.length,
+                failed: result.failed.length,
+              })
+            }
+            if (result.failed.length) {
+              log.warn("worktreeinclude partial failure", {
+                directory: info.directory,
+                count: result.failed.length,
+                sample: result.failed.slice(0, 3),
+              })
+            }
+          }),
+        ),
+        Effect.catchCause((cause) =>
+          Effect.sync(() =>
+            log.warn("worktreeinclude failed", { directory: info.directory, cause: errorMessage(cause) }),
+          ),
+        ),
+      )
 
       const booted = yield* Effect.promise(() =>
         Instance.provide({
@@ -568,6 +602,39 @@ export const layer: Layer.Layer<
       if (status.text.trim()) {
         throw new ResetFailedError({ message: `Worktree reset left local changes:\n${status.text.trim()}` })
       }
+
+      // Re-copy gitignored files declared in `.worktreeinclude` after `git clean`
+      // wiped them. Failures only produce warnings.
+      yield* WorktreeInclude.apply({
+        source: ctx.worktree,
+        destination: worktreePath,
+        fs,
+        pathSvc,
+      }).pipe(
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            if (result.copied.length || result.failed.length) {
+              log.debug("worktreeinclude applied", {
+                directory: worktreePath,
+                copied: result.copied.length,
+                failed: result.failed.length,
+              })
+            }
+            if (result.failed.length) {
+              log.warn("worktreeinclude partial failure", {
+                directory: worktreePath,
+                count: result.failed.length,
+                sample: result.failed.slice(0, 3),
+              })
+            }
+          }),
+        ),
+        Effect.catchCause((cause) =>
+          Effect.sync(() =>
+            log.warn("worktreeinclude failed", { directory: worktreePath, cause: errorMessage(cause) }),
+          ),
+        ),
+      )
 
       yield* runStartScripts(worktreePath, { projectID: ctx.project.id }).pipe(
         Effect.catchCause((cause) => Effect.sync(() => log.error("worktree start task failed", { cause }))),

--- a/packages/opencode/test/worktree/include.test.ts
+++ b/packages/opencode/test/worktree/include.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer, Path } from "effect"
+import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import path from "path"
+import * as fs from "fs/promises"
+import os from "os"
+import { WorktreeInclude } from "../../src/worktree/include"
+import { testEffect } from "../lib/effect"
+
+const live = Layer.mergeAll(AppFileSystem.layer.pipe(Layer.provide(NodeFileSystem.layer)), NodePath.layer)
+const { effect: it } = testEffect(live)
+
+async function makeTmp() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "opencode-worktreeinclude-"))
+}
+
+async function write(dir: string, rel: string, content: string) {
+  const full = path.join(dir, rel)
+  await fs.mkdir(path.dirname(full), { recursive: true })
+  await fs.writeFile(full, content)
+}
+
+async function exists(p: string) {
+  try {
+    await fs.stat(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe("WorktreeInclude.apply", () => {
+  it(
+    "is a no-op when .worktreeinclude is missing",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      yield* Effect.promise(() => write(source, ".env", "SECRET=1"))
+
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      expect(result.copied).toEqual([])
+      expect(result.failed).toEqual([])
+      expect(yield* Effect.promise(() => exists(path.join(destination, ".env")))).toBe(false)
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+
+  it(
+    "is a no-op when .worktreeinclude is empty / whitespace",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      yield* Effect.promise(() => write(source, ".worktreeinclude", "   \n\n"))
+      yield* Effect.promise(() => write(source, ".env", "SECRET=1"))
+
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      expect(result.copied).toEqual([])
+      expect(yield* Effect.promise(() => exists(path.join(destination, ".env")))).toBe(false)
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+
+  it(
+    "copies matching files and creates parent directories",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      yield* Effect.promise(() => write(source, ".worktreeinclude", ".env\n.env.local\nconfig/secrets.json\n"))
+      yield* Effect.promise(() => write(source, ".env", "A=1"))
+      yield* Effect.promise(() => write(source, ".env.local", "B=2"))
+      yield* Effect.promise(() => write(source, "config/secrets.json", '{"k":"v"}'))
+      yield* Effect.promise(() => write(source, "README.md", "should not copy"))
+
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+
+      expect(result.failed).toEqual([])
+      expect(result.copied.sort()).toEqual([".env", ".env.local", "config/secrets.json"].sort())
+
+      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".env"), "utf8"))).toBe("A=1")
+      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".env.local"), "utf8"))).toBe("B=2")
+      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, "config/secrets.json"), "utf8"))).toBe(
+        '{"k":"v"}',
+      )
+      expect(yield* Effect.promise(() => exists(path.join(destination, "README.md")))).toBe(false)
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+
+  it(
+    "copies an entire matched directory recursively",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      yield* Effect.promise(() => write(source, ".worktreeinclude", ".secrets/\n"))
+      yield* Effect.promise(() => write(source, ".secrets/a.txt", "a"))
+      yield* Effect.promise(() => write(source, ".secrets/nested/b.txt", "b"))
+
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      expect(result.failed).toEqual([])
+      expect(result.copied).toContain(".secrets")
+
+      expect(yield* Effect.promise(() => exists(path.join(destination, ".secrets")))).toBe(true)
+      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".secrets/a.txt"), "utf8"))).toBe("a")
+      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".secrets/nested/b.txt"), "utf8"))).toBe(
+        "b",
+      )
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+
+  it(
+    "honours negation patterns",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      yield* Effect.promise(() => write(source, ".worktreeinclude", ".env*\n!.env.public\n"))
+      yield* Effect.promise(() => write(source, ".env", "S=1"))
+      yield* Effect.promise(() => write(source, ".env.local", "S=2"))
+      yield* Effect.promise(() => write(source, ".env.public", "P=3"))
+
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+
+      expect(result.failed).toEqual([])
+      expect(result.copied.sort()).toEqual([".env", ".env.local"].sort())
+      expect(yield* Effect.promise(() => exists(path.join(destination, ".env.public")))).toBe(false)
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+
+  it(
+    "skips the .git directory entirely",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      yield* Effect.promise(() => write(source, ".worktreeinclude", "**\n"))
+      yield* Effect.promise(() => write(source, ".git/HEAD", "ref"))
+      yield* Effect.promise(() => write(source, "keep.txt", "ok"))
+
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+
+      expect(result.copied).not.toContain(".git")
+      expect(result.copied).not.toContain(".git/HEAD")
+      expect(yield* Effect.promise(() => exists(path.join(destination, ".git")))).toBe(false)
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+
+  it(
+    "does not descend into standard build directories like node_modules",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      yield* Effect.promise(() => write(source, ".worktreeinclude", ".env\n"))
+      yield* Effect.promise(() => write(source, ".env", "SECRET=1"))
+      // Make a node_modules with a sentinel that would be picked up if walk
+      // descended into it AND the matcher was permissive enough.
+      yield* Effect.promise(() => write(source, "node_modules/foo/.env", "leaked"))
+      yield* Effect.promise(() => write(source, "node_modules/foo/index.js", "x"))
+      yield* Effect.promise(() => write(source, "dist/.env", "leaked"))
+
+      const start = Date.now()
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      const elapsed = Date.now() - start
+
+      expect(result.failed).toEqual([])
+      expect(result.copied).toEqual([".env"])
+      expect(yield* Effect.promise(() => exists(path.join(destination, "node_modules")))).toBe(false)
+      expect(yield* Effect.promise(() => exists(path.join(destination, "dist")))).toBe(false)
+      // Sanity: pruning should keep this fast even with junk inside skipped dirs.
+      expect(elapsed).toBeLessThan(2000)
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+
+  it(
+    "lets users explicitly include otherwise-pruned directories",
+    Effect.gen(function* () {
+      const appFs = yield* AppFileSystem.Service
+      const pathSvc = yield* Path.Path
+      const source = yield* Effect.promise(() => makeTmp())
+      const destination = yield* Effect.promise(() => makeTmp())
+      // `vendor` is in the standard prune list. Listing it explicitly should
+      // still result in it being copied wholesale.
+      yield* Effect.promise(() => write(source, ".worktreeinclude", "vendor/\n"))
+      yield* Effect.promise(() => write(source, "vendor/lib.js", "v"))
+      yield* Effect.promise(() => write(source, "vendor/inner/extra.js", "e"))
+
+      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+
+      expect(result.failed).toEqual([])
+      expect(result.copied).toContain("vendor")
+      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, "vendor/lib.js"), "utf8"))).toBe("v")
+      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, "vendor/inner/extra.js"), "utf8"))).toBe(
+        "e",
+      )
+
+      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
+      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+    }),
+  )
+})

--- a/packages/opencode/test/worktree/include.test.ts
+++ b/packages/opencode/test/worktree/include.test.ts
@@ -3,228 +3,179 @@ import { Effect, Layer, Path } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import path from "path"
-import * as fs from "fs/promises"
-import os from "os"
+import * as fsp from "fs/promises"
 import { WorktreeInclude } from "../../src/worktree/include"
 import { testEffect } from "../lib/effect"
 
 const live = Layer.mergeAll(AppFileSystem.layer.pipe(Layer.provide(NodeFileSystem.layer)), NodePath.layer)
 const { effect: it } = testEffect(live)
 
-async function makeTmp() {
-  return fs.mkdtemp(path.join(os.tmpdir(), "opencode-worktreeinclude-"))
-}
+const setup = Effect.fn(function* () {
+  const fs = yield* AppFileSystem.Service
+  const pathSvc = yield* Path.Path
+  // Scoped temp dirs are removed automatically when the test scope ends.
+  const source = yield* fs.makeTempDirectoryScoped({ prefix: "opencode-worktreeinclude-src-" })
+  const destination = yield* fs.makeTempDirectoryScoped({ prefix: "opencode-worktreeinclude-dst-" })
 
-async function write(dir: string, rel: string, content: string) {
-  const full = path.join(dir, rel)
-  await fs.mkdir(path.dirname(full), { recursive: true })
-  await fs.writeFile(full, content)
-}
+  const write = (rel: string, content: string) =>
+    Effect.promise(async () => {
+      const full = path.join(source, rel)
+      await fsp.mkdir(path.dirname(full), { recursive: true })
+      await fsp.writeFile(full, content)
+    })
 
-async function exists(p: string) {
-  try {
-    await fs.stat(p)
-    return true
-  } catch {
-    return false
-  }
-}
+  const exists = (rel: string) =>
+    Effect.promise(async () => {
+      try {
+        await fsp.stat(path.join(destination, rel))
+        return true
+      } catch {
+        return false
+      }
+    })
+
+  const read = (rel: string) => Effect.promise(() => fsp.readFile(path.join(destination, rel), "utf8"))
+
+  const apply = () => WorktreeInclude.apply({ source, destination, fs, pathSvc })
+
+  return { source, destination, write, exists, read, apply }
+})
 
 describe("WorktreeInclude.apply", () => {
   it(
     "is a no-op when .worktreeinclude is missing",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
-      yield* Effect.promise(() => write(source, ".env", "SECRET=1"))
+      const t = yield* setup()
+      yield* t.write(".env", "SECRET=1")
 
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      const result = yield* t.apply()
       expect(result.copied).toEqual([])
       expect(result.failed).toEqual([])
-      expect(yield* Effect.promise(() => exists(path.join(destination, ".env")))).toBe(false)
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+      expect(yield* t.exists(".env")).toBe(false)
     }),
   )
 
   it(
     "is a no-op when .worktreeinclude is empty / whitespace",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
-      yield* Effect.promise(() => write(source, ".worktreeinclude", "   \n\n"))
-      yield* Effect.promise(() => write(source, ".env", "SECRET=1"))
+      const t = yield* setup()
+      yield* t.write(".worktreeinclude", "   \n\n")
+      yield* t.write(".env", "SECRET=1")
 
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      const result = yield* t.apply()
       expect(result.copied).toEqual([])
-      expect(yield* Effect.promise(() => exists(path.join(destination, ".env")))).toBe(false)
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+      expect(yield* t.exists(".env")).toBe(false)
     }),
   )
 
   it(
     "copies matching files and creates parent directories",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
-      yield* Effect.promise(() => write(source, ".worktreeinclude", ".env\n.env.local\nconfig/secrets.json\n"))
-      yield* Effect.promise(() => write(source, ".env", "A=1"))
-      yield* Effect.promise(() => write(source, ".env.local", "B=2"))
-      yield* Effect.promise(() => write(source, "config/secrets.json", '{"k":"v"}'))
-      yield* Effect.promise(() => write(source, "README.md", "should not copy"))
+      const t = yield* setup()
+      yield* t.write(".worktreeinclude", ".env\n.env.local\nconfig/secrets.json\n")
+      yield* t.write(".env", "A=1")
+      yield* t.write(".env.local", "B=2")
+      yield* t.write("config/secrets.json", '{"k":"v"}')
+      yield* t.write("README.md", "should not copy")
 
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
-
+      const result = yield* t.apply()
       expect(result.failed).toEqual([])
       expect(result.copied.sort()).toEqual([".env", ".env.local", "config/secrets.json"].sort())
-
-      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".env"), "utf8"))).toBe("A=1")
-      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".env.local"), "utf8"))).toBe("B=2")
-      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, "config/secrets.json"), "utf8"))).toBe(
-        '{"k":"v"}',
-      )
-      expect(yield* Effect.promise(() => exists(path.join(destination, "README.md")))).toBe(false)
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+      expect(yield* t.read(".env")).toBe("A=1")
+      expect(yield* t.read(".env.local")).toBe("B=2")
+      expect(yield* t.read("config/secrets.json")).toBe('{"k":"v"}')
+      expect(yield* t.exists("README.md")).toBe(false)
     }),
   )
 
   it(
     "copies an entire matched directory recursively",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
-      yield* Effect.promise(() => write(source, ".worktreeinclude", ".secrets/\n"))
-      yield* Effect.promise(() => write(source, ".secrets/a.txt", "a"))
-      yield* Effect.promise(() => write(source, ".secrets/nested/b.txt", "b"))
+      const t = yield* setup()
+      yield* t.write(".worktreeinclude", ".secrets/\n")
+      yield* t.write(".secrets/a.txt", "a")
+      yield* t.write(".secrets/nested/b.txt", "b")
 
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      const result = yield* t.apply()
       expect(result.failed).toEqual([])
       expect(result.copied).toContain(".secrets")
-
-      expect(yield* Effect.promise(() => exists(path.join(destination, ".secrets")))).toBe(true)
-      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".secrets/a.txt"), "utf8"))).toBe("a")
-      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, ".secrets/nested/b.txt"), "utf8"))).toBe(
-        "b",
-      )
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+      expect(yield* t.exists(".secrets")).toBe(true)
+      expect(yield* t.read(".secrets/a.txt")).toBe("a")
+      expect(yield* t.read(".secrets/nested/b.txt")).toBe("b")
     }),
   )
 
   it(
     "honours negation patterns",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
-      yield* Effect.promise(() => write(source, ".worktreeinclude", ".env*\n!.env.public\n"))
-      yield* Effect.promise(() => write(source, ".env", "S=1"))
-      yield* Effect.promise(() => write(source, ".env.local", "S=2"))
-      yield* Effect.promise(() => write(source, ".env.public", "P=3"))
+      const t = yield* setup()
+      yield* t.write(".worktreeinclude", ".env*\n!.env.public\n")
+      yield* t.write(".env", "S=1")
+      yield* t.write(".env.local", "S=2")
+      yield* t.write(".env.public", "P=3")
 
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
-
+      const result = yield* t.apply()
       expect(result.failed).toEqual([])
       expect(result.copied.sort()).toEqual([".env", ".env.local"].sort())
-      expect(yield* Effect.promise(() => exists(path.join(destination, ".env.public")))).toBe(false)
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+      expect(yield* t.exists(".env.public")).toBe(false)
     }),
   )
 
   it(
     "skips the .git directory entirely",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
-      yield* Effect.promise(() => write(source, ".worktreeinclude", "**\n"))
-      yield* Effect.promise(() => write(source, ".git/HEAD", "ref"))
-      yield* Effect.promise(() => write(source, "keep.txt", "ok"))
+      const t = yield* setup()
+      yield* t.write(".worktreeinclude", "**\n")
+      yield* t.write(".git/HEAD", "ref")
+      yield* t.write("keep.txt", "ok")
 
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
-
+      const result = yield* t.apply()
       expect(result.copied).not.toContain(".git")
       expect(result.copied).not.toContain(".git/HEAD")
-      expect(yield* Effect.promise(() => exists(path.join(destination, ".git")))).toBe(false)
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+      expect(yield* t.exists(".git")).toBe(false)
     }),
   )
 
   it(
     "does not descend into standard build directories like node_modules",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
-      yield* Effect.promise(() => write(source, ".worktreeinclude", ".env\n"))
-      yield* Effect.promise(() => write(source, ".env", "SECRET=1"))
+      const t = yield* setup()
+      yield* t.write(".worktreeinclude", ".env\n")
+      yield* t.write(".env", "SECRET=1")
       // Make a node_modules with a sentinel that would be picked up if walk
       // descended into it AND the matcher was permissive enough.
-      yield* Effect.promise(() => write(source, "node_modules/foo/.env", "leaked"))
-      yield* Effect.promise(() => write(source, "node_modules/foo/index.js", "x"))
-      yield* Effect.promise(() => write(source, "dist/.env", "leaked"))
+      yield* t.write("node_modules/foo/.env", "leaked")
+      yield* t.write("node_modules/foo/index.js", "x")
+      yield* t.write("dist/.env", "leaked")
 
       const start = Date.now()
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
+      const result = yield* t.apply()
       const elapsed = Date.now() - start
 
       expect(result.failed).toEqual([])
       expect(result.copied).toEqual([".env"])
-      expect(yield* Effect.promise(() => exists(path.join(destination, "node_modules")))).toBe(false)
-      expect(yield* Effect.promise(() => exists(path.join(destination, "dist")))).toBe(false)
+      expect(yield* t.exists("node_modules")).toBe(false)
+      expect(yield* t.exists("dist")).toBe(false)
       // Sanity: pruning should keep this fast even with junk inside skipped dirs.
       expect(elapsed).toBeLessThan(2000)
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
     }),
   )
 
   it(
     "lets users explicitly include otherwise-pruned directories",
     Effect.gen(function* () {
-      const appFs = yield* AppFileSystem.Service
-      const pathSvc = yield* Path.Path
-      const source = yield* Effect.promise(() => makeTmp())
-      const destination = yield* Effect.promise(() => makeTmp())
+      const t = yield* setup()
       // `vendor` is in the standard prune list. Listing it explicitly should
       // still result in it being copied wholesale.
-      yield* Effect.promise(() => write(source, ".worktreeinclude", "vendor/\n"))
-      yield* Effect.promise(() => write(source, "vendor/lib.js", "v"))
-      yield* Effect.promise(() => write(source, "vendor/inner/extra.js", "e"))
+      yield* t.write(".worktreeinclude", "vendor/\n")
+      yield* t.write("vendor/lib.js", "v")
+      yield* t.write("vendor/inner/extra.js", "e")
 
-      const result = yield* WorktreeInclude.apply({ source, destination, fs: appFs, pathSvc })
-
+      const result = yield* t.apply()
       expect(result.failed).toEqual([])
       expect(result.copied).toContain("vendor")
-      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, "vendor/lib.js"), "utf8"))).toBe("v")
-      expect(yield* Effect.promise(() => fs.readFile(path.join(destination, "vendor/inner/extra.js"), "utf8"))).toBe(
-        "e",
-      )
-
-      yield* Effect.promise(() => fs.rm(source, { recursive: true, force: true }))
-      yield* Effect.promise(() => fs.rm(destination, { recursive: true, force: true }))
+      expect(yield* t.read("vendor/lib.js")).toBe("v")
+      expect(yield* t.read("vendor/inner/extra.js")).toBe("e")
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When creating a new git worktree (workspace), gitignored files like \`.env\` or \`.env.local\` are not checked out since they are untracked. This PR adds support for a \`.worktreeinclude\` file in the project root that lists which files should be copied into every new worktree — using the same \`.gitignore\` syntax already familiar to users (and compatible with Claude Code's own \`.worktreeinclude\` feature).

**How it works:**

1. After \`git reset --hard\` populates the new worktree, \`WorktreeInclude.apply\` reads \`.worktreeinclude\` from the source repo root.
2. It walks the source tree, matching entries against the patterns using the \`ignore\` npm package (already a dependency).
3. Standard build/cache directories (\`node_modules\`, \`dist\`, \`.next\`, \`target\`, \`vendor\`, \`bin\`, \`.turbo\`, etc.) are automatically pruned during the walk so large monorepos don't incur a costly traversal. Users can override this by listing a directory explicitly in \`.worktreeinclude\`.
4. Matched files, directories (copied recursively), and symlinks are copied to the new worktree directory. File modes are preserved.
5. Any copy failure is logged as a warning and skipped — it never blocks the rest of the boot sequence.
6. The same logic runs in \`reset()\` after \`git clean -ffdx\`, so gitignored files are restored when a worktree is reset.

**Why \`fs\` and \`pathSvc\` are passed as arguments instead of yielded as services:**

The desktop app calls \`Worktree.create\`, which forks \`boot()\` into a background fiber via \`Effect.forkIn(scope)\`. In that forked context the ambient Effect service registry no longer contains \`effect/Path\`, causing a \`Service not found\` die. Passing the already-resolved services from the outer layer closure avoids this entirely.

**Example \`.worktreeinclude\`:**
\`\`\`
.env
.env.local
config/secrets.json
\`\`\`

### How did you verify your code works?

- Added 8 unit tests in \`packages/opencode/test/worktree/include.test.ts\` covering: no-op when file is missing or empty, file copy with parent directory creation, recursive directory copy, negation patterns, hard-skip of \`.git\`, prune of \`node_modules\`/\`dist\`, and explicit user override of pruned directories.
- Tested locally via \`bun dev:desktop\` against a real monorepo (\`jjalbot\`) with a \`.worktreeinclude\` containing \`.env\`. Confirmed \`.env\` is copied into the new worktree directory and the previous \`Service not found: effect/Path\` error no longer appears in the logs.
- All tests pass: \`bun test test/worktree/include.test.ts\` → 8/8.
- Full repo typecheck passes via the pre-push hook (\`bun turbo typecheck\`).

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR