### PR TITLE
feat(provider): repair malformed SSE JSON via jsonrepair

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -435,6 +435,7 @@
         "ignore": "7.0.5",
         "immer": "11.1.4",
         "jsonc-parser": "3.3.1",
+        "jsonrepair": "3.14.0",
         "mime-types": "3.0.2",
         "minimatch": "10.0.3",
         "npm-package-arg": "13.0.2",
@@ -3717,6 +3718,8 @@
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
+
+    "jsonrepair": ["jsonrepair@3.14.0", "", { "bin": { "jsonrepair": "bin/cli.js" } }, "sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -154,6 +154,7 @@
     "ignore": "7.0.5",
     "immer": "11.1.4",
     "jsonc-parser": "3.3.1",
+    "jsonrepair": "3.14.0",
     "mime-types": "3.0.2",
     "minimatch": "10.0.3",
     "npm-package-arg": "13.0.2",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -247,6 +247,10 @@ export const Info = Schema.Struct({
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),
+      enable_sse_json_repair: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Enable SSE chunk JSON repair. When enabled, malformed JSON in SSE data lines is repaired via jsonrepair to keep the stream alive. Disabled by default to minimize behavior changes; turn on if upstream providers return malformed SSE payloads.",
+      }),
       batch_tool: Schema.optional(Schema.Boolean).annotate({ description: "Enable the batch tool" }),
       openTelemetry: Schema.optional(Schema.Boolean).annotate({
         description: "Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -25,6 +25,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { isRecord } from "@/util/record"
 import { optionalOmitUndefined, withStatics } from "@/util/schema"
+import { repairSSE } from "./sse-repair"
 
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
@@ -1412,7 +1413,12 @@ const layer: Layer.Layer<
 
     const list = Effect.fn("Provider.list")(() => InstanceState.use(state, (s) => s.providers))
 
-    async function resolveSDK(model: Model, s: State, envs: Record<string, string | undefined>) {
+    async function resolveSDK(
+      model: Model,
+      s: State,
+      envs: Record<string, string | undefined>,
+      sdkOpts: { repairSSE: boolean },
+    ) {
       try {
         using _ = log.time("getSDK", {
           providerID: model.providerID,
@@ -1509,8 +1515,9 @@ const layer: Layer.Layer<
             timeout: false,
           })
 
-          if (!chunkAbortCtl) return res
-          return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+          const maybeRepaired = sdkOpts.repairSSE ? repairSSE(res) : res
+          if (!chunkAbortCtl) return maybeRepaired
+          return wrapSSE(maybeRepaired, chunkTimeout, chunkAbortCtl)
         }
 
         const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]
@@ -1583,9 +1590,12 @@ const layer: Layer.Layer<
       const key = `${model.providerID}/${model.id}`
       if (s.models.has(key)) return s.models.get(key)!
 
+      const cfg = yield* config.get()
+      const sdkOpts = { repairSSE: cfg.experimental?.enable_sse_json_repair === true }
+
       return yield* Effect.promise(async () => {
         const provider = s.providers[model.providerID]
-        const sdk = await resolveSDK(model, s, envs)
+        const sdk = await resolveSDK(model, s, envs, sdkOpts)
 
         try {
           const language = s.modelLoaders[model.providerID]

--- a/packages/opencode/src/provider/sse-repair.ts
+++ b/packages/opencode/src/provider/sse-repair.ts
@@ -1,0 +1,101 @@
+import { jsonrepair } from "jsonrepair"
+import * as Log from "@opencode-ai/core/util/log"
+
+// Some OpenAI-compatible endpoints (observed with Z.AI GLM-5.1) occasionally echo
+// hallucinated SSE fragments as plain text inside the `content` field without
+// escaping the embedded quotes. The outer JSON becomes malformed and the AI SDK's
+// parseJsonEventStream rejects the whole chunk, tearing down the entire stream.
+//
+// This module patches SSE responses at the byte layer: we split the body on the
+// SSE event boundary (`\n\n`), try to strictly parse every `data:` payload, and
+// only when that fails we ask `jsonrepair` to recover it. Valid payloads pass
+// through byte-for-byte; unrepairable payloads are forwarded unchanged so the
+// downstream parser still surfaces the original error.
+
+const log = Log.create({ service: "provider/sse-repair" })
+
+// Walks one SSE event block and rewrites the `data:` lines whose payload can be
+// rescued by jsonrepair. Exported so unit tests can hit it without mocking a
+// streaming Response.
+export function repairSSEEvent(event: string): string {
+  const lines = event.split("\n")
+  let changed = false
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    // SSE field names other than `data:` (event / id / retry / comment) never
+    // carry JSON so we never touch them.
+    if (!line.startsWith("data:")) continue
+
+    // Preserve the exact amount of whitespace between `data:` and the payload
+    // so a repaired event stays byte-compatible with the original framing.
+    const after = line.slice(5)
+    const leading = after.match(/^\s*/)?.[0] ?? ""
+    const payload = after.slice(leading.length)
+    if (!payload || payload === "[DONE]") continue
+
+    // Fast path: the overwhelming majority of chunks are already valid JSON.
+    // We only pay the jsonrepair cost on failure.
+    try {
+      JSON.parse(payload)
+      continue
+    } catch {}
+
+    try {
+      const repaired = jsonrepair(payload)
+      // jsonrepair is aggressive and occasionally returns syntactically valid
+      // but semantically odd JSON, so we round-trip through JSON.parse to make
+      // sure the replacement is actually parseable before committing to it.
+      JSON.parse(repaired)
+      lines[i] = "data:" + leading + repaired
+      changed = true
+      log.warn("sse chunk repaired", { preview: payload.slice(0, 200) })
+    } catch {
+      // Leave the line untouched so the AI SDK still sees the original error
+      // rather than a silently swallowed chunk.
+    }
+  }
+  return changed ? lines.join("\n") : event
+}
+
+// Wraps a streaming Response so each `data:` payload is repaired in-flight.
+// No-ops on non-SSE responses (identity is returned, helpful for tests and
+// caller short-circuit checks).
+export function repairSSE(res: Response): Response {
+  if (!res.body) return res
+  if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
+
+  const decoder = new TextDecoder("utf-8")
+  const encoder = new TextEncoder()
+  // Buffer straddles TCP/chunk boundaries; SSE events can be split across many
+  // underlying Uint8Arrays, so we only emit once we see a full `\n\n`.
+  let buffer = ""
+
+  const transformed = res.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        buffer += decoder.decode(chunk, { stream: true })
+        while (true) {
+          const idx = buffer.indexOf("\n\n")
+          if (idx === -1) break
+          const event = buffer.slice(0, idx)
+          buffer = buffer.slice(idx + 2)
+          controller.enqueue(encoder.encode(repairSSEEvent(event) + "\n\n"))
+        }
+      },
+      flush(controller) {
+        // Drain any remaining bytes (servers that forget the trailing `\n\n`).
+        buffer += decoder.decode()
+        if (buffer.length) {
+          controller.enqueue(encoder.encode(repairSSEEvent(buffer)))
+          buffer = ""
+        }
+      },
+    }),
+  )
+
+  return new Response(transformed, {
+    headers: new Headers(res.headers),
+    status: res.status,
+    statusText: res.statusText,
+  })
+}

--- a/packages/opencode/test/provider/repair-sse.test.ts
+++ b/packages/opencode/test/provider/repair-sse.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "bun:test"
+import { repairSSE, repairSSEEvent } from "@/provider/sse-repair"
+
+function sseResponse(body: string): Response {
+  return new Response(body, { headers: { "content-type": "text/event-stream" } })
+}
+
+async function readAll(res: Response): Promise<string> {
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  let out = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  out += decoder.decode()
+  return out
+}
+
+test("repairSSEEvent passes valid events unchanged", () => {
+  const valid = `data: {"id":"abc","choices":[{"delta":{"content":"hi"}}]}`
+  expect(repairSSEEvent(valid)).toBe(valid)
+})
+
+test("repairSSEEvent passes [DONE] unchanged", () => {
+  expect(repairSSEEvent("data: [DONE]")).toBe("data: [DONE]")
+})
+
+test("repairSSEEvent leaves non-data lines untouched", () => {
+  const block = `event: ping\n: keep-alive\nid: 5`
+  expect(repairSSEEvent(block)).toBe(block)
+})
+
+test("repairSSEEvent repairs the Z.AI hallucinated-SSE payload", () => {
+  const broken = `data: {"id":"20260420032348d6275404213948ac","choices":[{"index":0,"delta":{"role":"assistant","content":"data: {"id":"20260420032457d424e96cb1da4f11","choices":[{"index":0,"delta":{"role":"assistant","content":"Two"}}]}}]}`
+  const repaired = repairSSEEvent(broken)
+  expect(repaired).not.toBe(broken)
+  const payload = repaired.slice("data:".length).trim()
+  const parsed = JSON.parse(payload) as {
+    id: string
+    choices: Array<{ delta: { content: string } }>
+  }
+  expect(parsed.id).toBe("20260420032348d6275404213948ac")
+  expect(typeof parsed.choices[0].delta.content).toBe("string")
+})
+
+test("repairSSEEvent leaves empty and [DONE] payloads untouched", () => {
+  expect(repairSSEEvent("data:")).toBe("data:")
+  expect(repairSSEEvent("data: [DONE]")).toBe("data: [DONE]")
+})
+
+test("repairSSEEvent repairs the Qwen truncated-then-spliced payload", () => {
+  // Real-world Qwen sample: the first chunk is cut off mid-field (`logpro`)
+  // and the server splices the next SSE frame (`data: {...}`) in place,
+  // leaving a single malformed JSON line that jsonrepair must recover.
+  const broken = `data: {"id":"chatcmpl-8w4gtjb6tplr8g1xoxrjvi","object":"chat.completion.chunk","created":1777577130,"model":"qwen/qwen3.6-27b","system_fingerprint":"qwen/qwen3.6-27b","choices":[{"index":0,"delta":{"reasoning_content":"\\n"},"logprodata: {"id":"chatcmpl-b7yoftfoinwhk4joyloyjt","object":"chat.completion.chunk","created":1777577321,"model":"qwen/qwen3.6-27b","system_fingerprint":"qwen/qwen3.6-27b","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Let"},"logprobs":null,"finish_reason":null}]}`
+  const repaired = repairSSEEvent(broken)
+  expect(repaired).not.toBe(broken)
+  const payload = repaired.slice("data:".length).trim()
+  const parsed = JSON.parse(payload) as {
+    id: string
+    model: string
+    choices: Array<{ index: number; delta: Record<string, unknown> }>
+  }
+  // The outer frame's id/model must survive — these are the anchors the
+  // downstream parser relies on to associate the chunk with a request.
+  expect(parsed.id).toBe("chatcmpl-8w4gtjb6tplr8g1xoxrjvi")
+  expect(parsed.model).toBe("qwen/qwen3.6-27b")
+  expect(parsed.choices[0].index).toBe(0)
+})
+
+test("repairSSE passes through non-SSE responses unchanged", async () => {
+  const res = new Response('{"a":1}', { headers: { "content-type": "application/json" } })
+  const out = repairSSE(res)
+  expect(out).toBe(res)
+})
+
+test("repairSSE repairs events while streaming", async () => {
+  const broken = `data: {"id":"20260420032348d6275404213948ac","choices":[{"index":0,"delta":{"role":"assistant","content":"data: {"id":"20260420032457d424e96cb1da4f11","choices":[{"index":0,"delta":{"role":"assistant","content":"Two"}}]}}]}`
+  const valid = `data: {"z":2}`
+  const body = `${valid}\n\n${broken}\n\ndata: [DONE]\n\n`
+  const out = await readAll(repairSSE(sseResponse(body)))
+  const events = out.split("\n\n").filter((e) => e.length > 0)
+  expect(events.length).toBe(3)
+  expect(events[0]).toBe(valid)
+  expect(events[2]).toBe("data: [DONE]")
+  const repairedPayload = events[1].slice("data:".length).trim()
+  expect(() => JSON.parse(repairedPayload)).not.toThrow()
+})
+
+test("repairSSE handles chunked boundaries split inside one event", async () => {
+  const event = `data: {"id":"a","choices":[{"delta":{"content":"ok"}}]}\n\n`
+  const encoder = new TextEncoder()
+  const bytes = encoder.encode(event)
+  const split = Math.floor(bytes.length / 2)
+  const stream = new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      ctrl.enqueue(bytes.slice(0, split))
+      ctrl.enqueue(bytes.slice(split))
+      ctrl.close()
+    },
+  })
+  const res = new Response(stream, { headers: { "content-type": "text/event-stream" } })
+  const out = await readAll(repairSSE(res))
+  expect(out).toBe(event)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #25247, #23442

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Some OpenAI-compatible providers (observed with Z.AI GLM-5.1 and Qwen) occasionally emit SSE data frames whose JSON is malformed - unescaped quotes inside content, or the next frame spliced mid-field. The AI SDK's parseJsonEventStream then throws and terminates the whole stream.

Add a byte-level TransformStream wrapper that, for each SSE event, strict-parses every data: payload first and only falls back to jsonrepair on failure. Repaired payloads are round-trip validated before being written back; unrepairable chunks pass through unchanged so the downstream parser still surfaces the original error.

Opt-in via experimental.enable_sse_json_repair (default false) to avoid any behavior change for users not hitting this bug.

by the way, [jsonrepair](https://www.npmjs.com/package/jsonrepair) is a popular tool used for fixing malformed JSON text from LLMs. Its key features include:

- Automatically completing missing quotes, brackets, and commas
- Repairing unescaped double quotes (which directly addresses the notebook issue)
- Streaming support (jsonrepair/stream)
- Zero dependencies, written in native TypeScript


### How did you verify your code works?
Origin malformed JSON text:
<img width="518" height="706" alt="image" src="https://github.com/user-attachments/assets/72fe05e5-7128-4c05-b10d-ab34068dda13" />
Valid JSON text after `jsonrepair`
<img width="549" height="709" alt="image" src="https://github.com/user-attachments/assets/cc8a7a65-1076-4bed-a117-63e4697057da" />


All the unit tests under `packages/opencode/test/provider/repair-sse.test.ts` have passed.
<img width="1720" height="376" alt="image" src="https://github.com/user-attachments/assets/e664b75c-6d6e-415d-a013-ef0149c50941" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
