### PR TITLE
feat(tui): configurable custom home placeholders

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2192,7 +2192,7 @@
 
     "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }, "sha512-7JjjA49VGNOsMRI8QRUhVudZmv0CnJ18SliSgK1ojszs/c3ijftgVkzvXdkSLN4miDTzbkXewf65D6ZBo6W+GQ=="],
+    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
@@ -3362,7 +3362,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.8", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-J87BxkLXykmisLQ+KA4x2+O6rVf+PJrtFUO8lGyiRg4lyxJLJ8/v0sRAKdVZQOy6tR6lMRAF1NqzCf9BQijm0w=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#20bd361", {}, "anomalyco-ghostty-web-20bd361", "sha512-dW0nwaiBBcun9y5WJSvm3HxDLe5o9V0xLCndQvWonRVubU8CS1PHxZpLffyPt1YujPWC13ez03aWxcuKBPYYGQ=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#20bd361", {}, "anomalyco-ghostty-web-20bd361"],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -57,6 +57,8 @@ export type PromptProps = {
   placeholders?: {
     normal?: string[]
     shell?: string[]
+    rawNormal?: boolean
+    rawShell?: boolean
   }
 }
 
@@ -1016,10 +1018,11 @@ export function Prompt(props: PromptProps) {
     if (store.mode === "shell") {
       if (!shell().length) return undefined
       const example = shell()[store.placeholder % shell().length]
-      return `Run a command... "${example}"`
+      return props.placeholders?.rawShell ? example : `Run a command... "${example}"`
     }
     if (!list().length) return undefined
-    return `Ask anything... "${list()[store.placeholder % list().length]}"`
+    const example = list()[store.placeholder % list().length]
+    return props.placeholders?.rawNormal ? example : `Ask anything... "${example}"`
   })
 
   const spinnerDef = createMemo(() => {

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -33,6 +33,23 @@ export const TuiInfo = z
     keybinds: KeybindOverride.optional(),
     plugin: ConfigPlugin.Spec.zod.array().optional(),
     plugin_enabled: z.record(z.string(), z.boolean()).optional(),
+    placeholders: z
+      .object({
+        input: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Replaces the prompt input placeholder on the home screen. Items are used literally (no 'Ask anything...' prefix) and rotated.",
+          ),
+        shell: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Replaces the shell-mode prompt placeholder on the home screen. Items are used literally (no 'Run a command...' prefix) and rotated.",
+          ),
+      })
+      .optional()
+      .describe("Customize the rotating placeholder text shown inside the prompt input on the home screen."),
   })
   .extend(TuiOptions.shape)
   .strict()

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -8,6 +8,7 @@ import { useArgs } from "../context/args"
 import { useRouteData } from "@tui/context/route"
 import { usePromptRef } from "../context/prompt"
 import { useLocal } from "../context/local"
+import { useTuiConfig } from "@tui/context/tui-config"
 import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
 
 let once = false
@@ -24,6 +25,15 @@ export function Home() {
   const [ref, setRef] = createSignal<PromptRef | undefined>()
   const args = useArgs()
   const local = useLocal()
+  const config = useTuiConfig()
+  const userInput = config.placeholders?.input
+  const userShell = config.placeholders?.shell
+  const placeholders = {
+    normal: userInput ?? placeholder.normal,
+    shell: userShell ?? placeholder.shell,
+    rawNormal: !!userInput,
+    rawShell: !!userShell,
+  }
   let sent = false
 
   const bind = (r: PromptRef | undefined) => {
@@ -74,7 +84,7 @@ export function Home() {
               ref={bind}
               workspaceID={project.workspace.current()}
               right={<TuiPluginRuntime.Slot name="home_prompt_right" workspace_id={project.workspace.current()} />}
-              placeholders={placeholder}
+              placeholders={placeholders}
             />
           </TuiPluginRuntime.Slot>
         </box>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

### What does this PR do?

  Adds a `placeholders` field to `tui.json` so users can override
   the rotating placeholder text inside the prompt input on the
  home screen.

  - `placeholders.input` replaces the normal-mode placeholder
  pool.
  - `placeholders.shell` replaces the shell-mode placeholder
  pool.
  - Items are used **literally** — when a user supplies their own
   array, the built-in `Ask anything... "..."` / `Run a
  command... "..."` framing is dropped so the strings show as-is.
   Without this the user's strings would still be wrapped in the
  prefix, which I didn't want for my own setup.
  - Either field can be set independently; the other keeps its
  default. Omitting `placeholders` entirely keeps the existing
  behavior.

  Why this works: the placeholder string is built in one place —
  `placeholderText` in `component/prompt/index.tsx` — which
  already reads the rotating index off
  `props.placeholders.normal/shell`. I added two internal-only
  flags (`rawNormal`, `rawShell`) on that same prop. When set,
  `placeholderText` returns the rotated item literally instead of
   wrapping it in the prefix. `home.tsx` is the only caller that
  turns the flags on, and it does so based on whether the user
  supplied an array. Existing random-pick rotation (on mount, on
  session change, on entering shell mode) is preserved unchanged.

  Files touched:
  - `packages/opencode/src/cli/cmd/tui/config/tui-schema.ts` —
  schema entry.
  -
  `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
  — `rawNormal` / `rawShell` flags + branching in
  `placeholderText`.
  - `packages/opencode/src/cli/cmd/tui/routes/home.tsx` — reads
  `useTuiConfig().placeholders` and forwards arrays with the raw
  flags set.

### How did you verify your code works?

  Ran `bunx tsgo --noEmit` in `packages/opencode` and
  `packages/plugin` — both clean.

  Manually with `bun run dev`:
  - No `placeholders` in `tui.json` → home shows `Ask anything...
   "Fix broken tests"` rotation as before.
  - `placeholders.input: ["foo", "bar"]` → input rotates through
  `foo` / `bar` literally, no prefix.
  - `placeholders.shell: ["git status"]` → entering shell mode
  with `!` shows `git status` literally.
  - Setting only `input` left shell on its default and vice
  versa.
  - Single-item array always shows that item; multi-item picks
  randomly across new sessions.

### Screenshots / recordings
  
  
<img width="1422" height="719" alt="Screenshot 2026-05-02 at 3 06 13 pm" src="https://github.com/user-attachments/assets/c9820b0a-4389-48d3-945a-f6c1ae2c3158" />

  
<img width="1422" height="719" alt="Screenshot 2026-05-02 at 3 12 01 pm" src="https://github.com/user-attachments/assets/58d4db99-c8e3-439f-98b0-43442b3b87ce" />

  

  Before:

  Ask anything... "Fix broken tests"

  After (`tui.json`):

  ```json
  {
    "$schema": "https://opencode.ai/tui.json",
    "placeholders": {
      "input": ["whatever I want here", "another literal"],
      "shell": ["git command?"]
    }
  }
  ```

  Renders:

  whatever I want here

  (no Ask anything... prefix, no quotes)

  Checklist

  - I have tested my changes locally
  - I have not included unrelated changes in this PR