### PR TITLE
fix(opencode): support env-prefixed plugin paths in config

### DIFF
--- a/packages/opencode/src/config/plugin.ts
+++ b/packages/opencode/src/config/plugin.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "url"
 import { isPathPluginSpec, parsePluginSpecifier, resolvePathPluginTarget } from "@/plugin/shared"
 import { zod } from "@/util/effect-zod"
 import { withStatics } from "@/util/schema"
+import os from "os"
 import path from "path"
 
 export const Options = Schema.Record(Schema.String, Schema.Unknown).pipe(withStatics((s) => ({ zod: zod(s) })))
@@ -49,11 +50,52 @@ export function pluginOptions(plugin: Spec): Options | undefined {
   return Array.isArray(plugin) ? plugin[1] : undefined
 }
 
+function expandPathVariablePrefix(spec: string) {
+  if (spec === "~") return os.homedir()
+  if (spec.startsWith("~/") || spec.startsWith("~\\")) return path.join(os.homedir(), spec.slice(2))
+
+  const posix = spec.match(/^\$([A-Za-z_][A-Za-z0-9_]*)(?=$|[\\/])/)
+  if (posix) {
+    const value = process.env[posix[1]]
+    if (value) return value + spec.slice(posix[0].length)
+  }
+
+  const braced = spec.match(/^\$\{([A-Za-z_][A-Za-z0-9_]*)\}(?=$|[\\/])/)
+  if (braced) {
+    const value = process.env[braced[1]]
+    if (value) return value + spec.slice(braced[0].length)
+  }
+
+  const windows = spec.match(/^%([^%]+)%(?=$|[\\/])/)
+  if (windows) {
+    const value = process.env[windows[1]]
+    if (value) return value + spec.slice(windows[0].length)
+  }
+
+  return spec
+}
+
+function hasPathVariablePrefix(spec: string) {
+  if (spec === "~" || spec.startsWith("~/") || spec.startsWith("~\\")) return true
+
+  const posix = spec.match(/^\$([A-Za-z_][A-Za-z0-9_]*)(?=$|[\\/])/)
+  if (posix) return !!process.env[posix[1]]
+
+  const braced = spec.match(/^\$\{([A-Za-z_][A-Za-z0-9_]*)\}(?=$|[\\/])/)
+  if (braced) return !!process.env[braced[1]]
+
+  const windows = spec.match(/^%([^%]+)%(?=$|[\\/])/)
+  if (windows) return !!process.env[windows[1]]
+
+  return false
+}
+
 // Path-like specs are resolved relative to the config file that declared them so merges later on do not
 // accidentally reinterpret `./plugin.ts` relative to some other directory.
 export async function resolvePluginSpec(plugin: Spec, configFilepath: string): Promise<Spec> {
-  const spec = pluginSpecifier(plugin)
-  if (!isPathPluginSpec(spec)) return plugin
+  const raw = pluginSpecifier(plugin)
+  const spec = expandPathVariablePrefix(raw)
+  if (!isPathPluginSpec(raw) && !hasPathVariablePrefix(raw) && !isPathPluginSpec(spec)) return plugin
 
   const base = path.dirname(configFilepath)
   const file = (() => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1968,6 +1968,48 @@ describe("resolvePluginSpec", () => {
     expect(await ConfigPlugin.resolvePluginSpec("@scope/pkg", file)).toBe("@scope/pkg")
   })
 
+  test("resolves $HOME-prefixed plugin directory specs", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const plugin = path.join(dir, "plugin")
+        await fs.mkdir(plugin, { recursive: true })
+        await Filesystem.write(path.join(plugin, "index.ts"), "export default {}")
+      },
+    })
+
+    const previous = process.env.HOME
+    process.env.HOME = tmp.path
+    try {
+      const file = path.join(tmp.path, "opencode.json")
+      const hit = await ConfigPlugin.resolvePluginSpec("$HOME/plugin", file)
+      expect(ConfigPlugin.pluginSpecifier(hit)).toBe(pathToFileURL(path.join(tmp.path, "plugin", "index.ts")).href)
+    } finally {
+      if (previous === undefined) delete process.env.HOME
+      else process.env.HOME = previous
+    }
+  })
+
+  test("resolves %USERPROFILE%-prefixed plugin directory specs", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const plugin = path.join(dir, "plugin")
+        await fs.mkdir(plugin, { recursive: true })
+        await Filesystem.write(path.join(plugin, "index.ts"), "export default {}")
+      },
+    })
+
+    const previous = process.env.USERPROFILE
+    process.env.USERPROFILE = tmp.path
+    try {
+      const file = path.join(tmp.path, "opencode.json")
+      const hit = await ConfigPlugin.resolvePluginSpec("%USERPROFILE%/plugin", file)
+      expect(ConfigPlugin.pluginSpecifier(hit)).toBe(pathToFileURL(path.join(tmp.path, "plugin", "index.ts")).href)
+    } finally {
+      if (previous === undefined) delete process.env.USERPROFILE
+      else process.env.USERPROFILE = previous
+    }
+  })
+
   test("resolves windows-style relative plugin directory specs", async () => {
     if (process.platform !== "win32") return
 


### PR DESCRIPTION
Fixes #25390

`tui.json` plugin specs using env/home-style prefixes were treated as package names instead of local paths.

What changed:
- expand `~`, `$VAR`, `${VAR}`, and `%VAR%` prefixes in plugin specs before path resolution
- keep package specs unchanged
- add regression tests for `$HOME` and `%USERPROFILE%`

Verification:
- `bun --cwd packages/opencode test test/config/config.test.ts --timeout 60000`
- passes locally (82 passed)