### PR TITLE
fix(opencode): prevent /undo from using unsafe root pathspecs

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -379,21 +379,34 @@ export const layer: Layer.Layer<
             Effect.gen(function* () {
               const ops: { hash: string; file: string; rel: string }[] = []
               const seen = new Set<string>()
+              const worktree = path.resolve(state.worktree)
+
+              const normalize = (file: string) => {
+                const resolved = path.resolve(file)
+                const rel = path.relative(worktree, resolved).replaceAll("\\", "/")
+                const outside = rel === ".." || rel.startsWith("../")
+                const root = !rel || rel === "."
+                const absoluteRel = path.isAbsolute(rel) || /^[A-Za-z]:[\\/]/.test(rel)
+                if (outside || root || absoluteRel) return
+                return { file: resolved, rel }
+              }
+
               for (const item of patches) {
                 for (const file of item.files) {
-                  if (seen.has(file)) continue
-                  seen.add(file)
-                  ops.push({
-                    hash: item.hash,
-                    file,
-                    rel: path.relative(state.worktree, file).replaceAll("\\", "/"),
-                  })
+                  const normalized = normalize(file)
+                  if (!normalized) {
+                    log.warn("skipping unsafe revert target", { file, hash: item.hash })
+                    continue
+                  }
+                  if (seen.has(normalized.rel)) continue
+                  seen.add(normalized.rel)
+                  ops.push({ hash: item.hash, file: normalized.file, rel: normalized.rel })
                 }
               }
 
               const single = Effect.fnUntraced(function* (op: (typeof ops)[number]) {
                 log.info("reverting", { file: op.file, hash: op.hash })
-                const result = yield* git([...core, ...args(["checkout", op.hash, "--", op.file])], {
+                const result = yield* git([...core, ...args(["checkout", op.hash, "--", op.rel])], {
                   cwd: state.worktree,
                 })
                 if (result.code === 0) return
@@ -459,7 +472,7 @@ export const layer: Layer.Layer<
                 if (list.length) {
                   log.info("reverting", { hash: first.hash, files: list.length })
                   const result = yield* git(
-                    [...core, ...args(["checkout", first.hash, "--", ...list.map((item) => item.file)])],
+                    [...core, ...args(["checkout", first.hash, "--", ...list.map((item) => item.rel)])],
                     {
                       cwd: state.worktree,
                     },

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -331,6 +331,33 @@ test("revert non-existent file", async () => {
   })
 })
 
+test("revert ignores worktree root targets", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await run(tmp.path, (snapshot) => snapshot.track())
+      expect(before).toBeTruthy()
+
+      const marker = `${tmp.path}/b.txt`
+      const initial = await fs.stat(marker)
+      await new Promise((resolve) => setTimeout(resolve, 1200))
+
+      await run(tmp.path, (snapshot) =>
+        snapshot.revert([
+          {
+            hash: before!,
+            files: [tmp.path],
+          },
+        ]),
+      )
+
+      const next = await fs.stat(marker)
+      expect(next.mtimeMs).toBe(initial.mtimeMs)
+    },
+  })
+})
+
 test("unicode filenames", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
Fixes #25400

`/undo` can receive snapshot patch entries that resolve to an unsafe target (for example worktree root).
When that reaches git checkout pathspec handling, it can broaden the checkout scope and touch unrelated files.

What changed:
- normalize revert targets against the active worktree
- skip unsafe targets (worktree root or outside worktree)
- use normalized relative pathspecs for checkout calls
- add a regression test that verifies worktree-root targets are ignored

Verification:
- `bun --cwd packages/opencode test test/snapshot/snapshot.test.ts -t revert --timeout 120000`
- `bun --cwd packages/opencode test test/session/revert-compact.test.ts --timeout 120000`