### PR TITLE
fix(opencode): pass mcp_timeout as AI SDK streamText stepMs to prevent 120s timeout

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -334,6 +334,9 @@ const live: Layer.Layer<
         : undefined
 
       return streamText({
+        timeout: cfg.experimental?.mcp_timeout
+          ? { stepMs: cfg.experimental.mcp_timeout }
+          : undefined,
         onError(error) {
           l.error("stream error", {
             error,


### PR DESCRIPTION
The AI SDK streamText() defaults stepMs to 120s, which covers the entire step including tool execution. This caused MCP tool calls to timeout at 120s even when experimental.mcp_timeout was configured to a much larger value, because the AI SDK step timeout fired before the MCP-level timeout.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP tool calls timeout at 120s regardless of `experimental.mcp_timeout` config.

The AI SDK `streamText()` has a `stepMs` param (default 120s) that covers the entire step — LLM call + tool execution. OpenCode correctly passes `mcp_timeout` to MCP SDK's `callTool()`, but never sets `stepMs` on `streamText()`. So the AI SDK's 120s default fires before the MCP-level timeout is ever reached.

Fix: pass `experimental.mcp_timeout` as `stepMs` to `streamText()`, so the AI SDK step timeout aligns with the MCP timeout. When `mcp_timeout` is not configured, behavior is unchanged (AI SDK default applies).

### How did you verify your code works?

- Typecheck: pass (0 errors)
- Lint: pass (0 errors)
- Tests: 2324 pass / 3 fail — failures are pre-existing `installation > latest` network tests, unrelated to this change

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

