### PR TITLE
fix(cli): strip leading slash from --command argument

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -214,7 +214,7 @@ export const RunCommand = cmd({
         default: [],
       })
       .option("command", {
-        describe: "the command to run, use message for args",
+        describe: "the command to run (without leading slash), use message for args",
         type: "string",
       })
       .option("continue", {
@@ -632,7 +632,7 @@ export const RunCommand = cmd({
           sessionID,
           agent,
           model: args.model,
-          command: args.command,
+          command: args.command.replace(/^\//, ""),
           arguments: message,
           variant: args.variant,
         })


### PR DESCRIPTION
### Issue for this PR

Closes #25364

### Type of change

- [x] Bug fix

### What does this PR do?

When using `opencode run --command`, users familiar with the TUI naturally include a leading slash (e.g. `--command /test`), but the command registry stores names without it, so the lookup fails with "Command not found".

The fix strips a leading `/` from the `--command` value before dispatch (`run.ts:635`), so both `--command test` and `--command /test` work. Also updated the option description to say "without leading slash" to make this clearer upfront.

### How did you verify your code works?

Traced the command dispatch path from `run.ts` → `sdk.session.command` → `prompt.ts:1521` (`commands.get(input.command)`). The registry keys are plain names (e.g. `"test"`), so stripping `/` before the lookup is the correct fix.

### Screenshots / recordings

N/A — CLI-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR