### PR TITLE
fix(httpapi): re-land workspace create payload accepts missing extra

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/workspace.ts
@@ -9,7 +9,10 @@ import { WorkspaceRoutingMiddleware } from "../middleware/workspace-routing"
 import { described } from "./metadata"
 
 const root = "/experimental/workspace"
-export const CreatePayload = Schema.Struct(Struct.omit(Workspace.CreateInput.fields, ["projectID"]))
+export const CreatePayload = Schema.Struct({
+  ...Struct.omit(Workspace.CreateInput.fields, ["projectID", "extra"]),
+  extra: Schema.optional(Workspace.CreateInput.fields.extra),
+})
 export const SessionRestorePayload = Schema.Struct(Struct.omit(Workspace.SessionRestoreInput.fields, ["workspaceID"]))
 export const SessionRestoreResponse = Schema.Struct({
   total: NonNegativeInt,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
@@ -24,6 +24,7 @@ export const workspaceHandlers = HttpApiBuilder.group(InstanceHttpApi, "workspac
       return yield* workspace
         .create({
           ...ctx.payload,
+          extra: ctx.payload.extra ?? null,
           projectID: instance.project.id,
         })
         .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))

--- a/packages/opencode/test/server/httpapi-workspace.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace.test.ts
@@ -27,9 +27,9 @@ const it = testEffect(
   Layer.mergeAll(NodeServices.layer, Project.defaultLayer, Session.defaultLayer, Workspace.defaultLayer),
 )
 
-function request(path: string, directory: string, init: RequestInit = {}) {
+function request(path: string, directory: string, init: RequestInit = {}, httpApi = true) {
   return Effect.promise(() => {
-    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = httpApi
     const headers = new Headers(init.headers)
     headers.set("x-opencode-directory", directory)
     return Promise.resolve(Server.Default().app.request(path, { ...init, headers }))
@@ -192,6 +192,55 @@ describe("workspace HttpApi", () => {
       const listed = yield* request(WorkspacePaths.list, dir)
       expect(listed.status).toBe(200)
       expect(yield* Effect.promise(() => listed.json())).toEqual([])
+    }),
+  )
+
+  it.live("creates workspace with the TUI payload shape", () =>
+    Effect.gen(function* () {
+      Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      registerAdapter(project.project.id, "local-test", localAdapter(path.join(dir, ".workspace")))
+
+      const created = yield* request(WorkspacePaths.list, dir, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "local-test", branch: null }),
+      })
+
+      expect(created.status).toBe(200)
+      expect((yield* Effect.promise(() => created.json())) as Workspace.Info).toMatchObject({
+        type: "local-test",
+        name: "local-test",
+        extra: null,
+      })
+    }),
+  )
+
+  it.live("documents legacy Hono accepting the TUI payload shape", () =>
+    Effect.gen(function* () {
+      Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      registerAdapter(project.project.id, "local-test", localAdapter(path.join(dir, ".workspace")))
+
+      const created = yield* request(
+        WorkspacePaths.list,
+        dir,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ type: "local-test", branch: null }),
+        },
+        false,
+      )
+
+      expect(created.status).toBe(200)
+      expect((yield* Effect.promise(() => created.json())) as Workspace.Info).toMatchObject({
+        type: "local-test",
+        name: "local-test",
+        extra: null,
+      })
     }),
   )
 


### PR DESCRIPTION
## Summary
PR #25371 (\`fix: accept workspace create payload without extra\`) was merged into the feature branch \`kit/instance-loader-service\` instead of \`dev\`, after PR #25277 had already merged that feature branch. Result: the fix never reached \`dev\` and the TUI's "New Workspace" dialog still gets a 400 \`HttpApiSchemaError: Payload\` when posting \`{ type: 'worktree', branch: null }\`.

This PR cherry-picks \`481f8667a\` onto \`dev\` so the schema and tests land where they were always intended.

## Reproduction (motel trace)
TUI creates a workspace and the server returns 400. Trace in motel shows:

\`\`\`
http.server POST /experimental/workspace
opencode.server.backend = effect-httpapi
http.response.status_code = 400
exception.type = HttpApiSchemaError
exception.message = Payload
\`\`\`

## Fix
\`packages/opencode/src/server/routes/instance/httpapi/groups/workspace.ts\` — \`extra\` becomes \`Schema.optional\` in \`CreatePayload\`.

\`packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts\` — handler defaults \`extra\` to \`null\` before calling \`workspace.create\`.

## Tests
- \`packages/opencode/test/server/httpapi-workspace.test.ts\` — covers the TUI payload shape on both HttpApi and the legacy Hono path.
- \`bun run test test/server/httpapi-workspace.test.ts\` passes (7/7).
- \`bun typecheck\` passes.