### PR TITLE
fix: allow context tooltip on touch devices and add mobile context tab

### DIFF
--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -15,6 +15,7 @@ import { createSessionTabs } from "@/pages/session/helpers"
 interface SessionContextUsageProps {
   variant?: "button" | "indicator"
   placement?: TooltipProps["placement"]
+  onClick?: () => void
 }
 
 function openSessionContext(args: {
@@ -111,7 +112,7 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
               type="button"
               variant="ghost"
               class="size-6"
-              onClick={openContext}
+              onClick={props.onClick ?? openContext}
               aria-label={language.t("context.usage.view")}
             >
               {circle()}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -30,7 +30,7 @@ import { Button } from "@opencode-ai/ui/button"
 import { showToast } from "@opencode-ai/ui/toast"
 import { checksum } from "@opencode-ai/core/util/encode"
 import { useSearchParams } from "@solidjs/router"
-import { NewSessionView, SessionHeader } from "@/components/session"
+import { NewSessionView, SessionHeader, SessionContextTab } from "@/components/session"
 import { useComments } from "@/context/comments"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
 import { useGlobalSync } from "@/context/global-sync"
@@ -513,7 +513,7 @@ export default function Page() {
 
   const [store, setStore] = createStore({
     messageId: undefined as string | undefined,
-    mobileTab: "session" as "session" | "changes",
+    mobileTab: "session" as "session" | "changes" | "context",
     changes: "git" as ChangeMode,
     newSessionWorktree: "main",
     deferRender: false,
@@ -1802,21 +1802,29 @@ export default function Page() {
             <Tabs.List>
               <Tabs.Trigger
                 value="session"
-                class="!w-1/2 !max-w-none"
-                classes={{ button: "w-full" }}
+                class="!w-1/3 !max-w-none"
+                classes={{ button: "w-full !px-3" }}
                 onClick={() => setStore("mobileTab", "session")}
               >
                 {language.t("session.tab.session")}
               </Tabs.Trigger>
               <Tabs.Trigger
                 value="changes"
-                class="!w-1/2 !max-w-none !border-r-0"
-                classes={{ button: "w-full" }}
+                class="!w-1/3 !max-w-none"
+                classes={{ button: "w-full !px-3" }}
                 onClick={() => setStore("mobileTab", "changes")}
               >
                 {hasReview()
                   ? language.t("session.review.filesChanged", { count: reviewCount() })
                   : language.t("session.review.change.other")}
+              </Tabs.Trigger>
+              <Tabs.Trigger
+                value="context"
+                class="!w-1/3 !max-w-none !border-r-0"
+                classes={{ button: "w-full !px-3" }}
+                onClick={() => setStore("mobileTab", "context")}
+              >
+                {language.t("session.tab.context")}
               </Tabs.Trigger>
             </Tabs.List>
           </Tabs>
@@ -1837,46 +1845,54 @@ export default function Page() {
             <Switch>
               <Match when={params.id}>
                 <Show when={messagesReady()}>
-                  <MessageTimeline
-                    mobileChanges={mobileChanges()}
-                    mobileFallback={reviewContent({
-                      diffStyle: "unified",
-                      classes: {
-                        root: "pb-8",
-                        header: "px-4",
-                        container: "px-4",
-                      },
-                      loadingClass: "px-4 py-4 text-text-weak",
-                      emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
-                    })}
-                    actions={actions}
-                    scroll={ui.scroll}
-                    onResumeScroll={resumeScroll}
-                    setScrollRef={setScrollRef}
-                    onScheduleScrollState={scheduleScrollState}
-                    onAutoScrollHandleScroll={autoScroll.handleScroll}
-                    onMarkScrollGesture={markScrollGesture}
-                    hasScrollGesture={hasScrollGesture}
-                    onUserScroll={markUserScroll}
-                    onTurnBackfillScroll={historyWindow.onScrollerScroll}
-                    onAutoScrollInteraction={autoScroll.handleInteraction}
-                    centered={centered()}
-                    setContentRef={(el) => {
-                      content = el
-                      autoScroll.contentRef(el)
+                  <Show
+                    when={!isDesktop() && store.mobileTab === "context"}
+                    fallback={
+                      <MessageTimeline
+                        mobileChanges={mobileChanges()}
+                        mobileFallback={reviewContent({
+                          diffStyle: "unified",
+                          classes: {
+                            root: "pb-8",
+                            header: "px-4",
+                            container: "px-4",
+                          },
+                          loadingClass: "px-4 py-4 text-text-weak",
+                          emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
+                        })}
+                        actions={actions}
+                        scroll={ui.scroll}
+                        onResumeScroll={resumeScroll}
+                        setScrollRef={setScrollRef}
+                        onScheduleScrollState={scheduleScrollState}
+                        onAutoScrollHandleScroll={autoScroll.handleScroll}
+                        onMarkScrollGesture={markScrollGesture}
+                        hasScrollGesture={hasScrollGesture}
+                        onUserScroll={markUserScroll}
+                        onTurnBackfillScroll={historyWindow.onScrollerScroll}
+                        onAutoScrollInteraction={autoScroll.handleInteraction}
+                        centered={centered()}
+                        setContentRef={(el) => {
+                          content = el
+                          autoScroll.contentRef(el)
 
-                      const root = scroller
-                      if (root) scheduleScrollState(root)
-                    }}
-                    turnStart={historyWindow.turnStart()}
-                    historyMore={historyMore()}
-                    historyLoading={historyLoading()}
-                    onLoadEarlier={() => {
-                      void historyWindow.loadAndReveal()
-                    }}
-                    renderedUserMessages={historyWindow.renderedUserMessages()}
-                    anchor={anchor}
-                  />
+                          const root = scroller
+                          if (root) scheduleScrollState(root)
+                        }}
+                        turnStart={historyWindow.turnStart()}
+                        historyMore={historyMore()}
+                        historyLoading={historyLoading()}
+                        onLoadEarlier={() => {
+                          void historyWindow.loadAndReveal()
+                        }}
+                        renderedUserMessages={historyWindow.renderedUserMessages()}
+                        anchor={anchor}
+                        onContextClick={!isDesktop() ? () => setStore("mobileTab", "context") : undefined}
+                      />
+                    }
+                  >
+                    <SessionContextTab />
+                  </Show>
                 </Show>
               </Match>
               <Match when={true}>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -229,6 +229,7 @@ export function MessageTimeline(props: {
   onLoadEarlier: () => void
   renderedUserMessages: UserMessage[]
   anchor: (id: string) => string
+  onContextClick?: () => void
 }) {
   let touchGesture: number | undefined
 
@@ -815,7 +816,7 @@ export function MessageTimeline(props: {
                   <Show when={sessionID()} keyed>
                     {(id) => (
                       <div class="shrink-0 flex items-center gap-3">
-                        <SessionContextUsage placement="bottom" />
+                        <SessionContextUsage placement="bottom" onClick={props.onContextClick} />
                         <Show when={!parentID()}>
                           <DropdownMenu
                             gutter={4}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -116,7 +116,7 @@ export function Tooltip(props: TooltipProps) {
             if (state.block && open) return
             if (justClickedTrigger) {
               justClickedTrigger = false
-              return
+              if (!open) return
             }
             setState("open", open)
           }}
@@ -126,7 +126,10 @@ export function Tooltip(props: TooltipProps) {
             as={"div"}
             data-component="tooltip-trigger"
             class={local.class}
-            onPointerDownCapture={arm}
+            onPointerDownCapture={(event: PointerEvent) => {
+              if (event.pointerType === "touch") return
+              arm()
+            }}
             onKeyDownCapture={(event: KeyboardEvent) => {
               if (event.key !== "Enter" && event.key !== " ") return
               arm()


### PR DESCRIPTION
### Issue for this PR

Closes #10443

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On mobile/touch viewports, tapping the session context indicator did 
nothing because the Tooltip component's pointerdownCapture handler 
called arm() before Kobalte's own touch handler could fire, permanently 
blocking the tooltip. Additionally, the mobile tab bar only had 
"Session" and "Changes" - no way to view full context details.

Changes:
- Tooltip: skip arm() when pointerType is "touch", matching the pattern 
  Kobalte's own TooltipTrigger already uses to avoid interfering with 
  touch events
- Tooltip: allow justClickedTrigger to open the tooltip (it was 
  suppressing both open and close events)
- SessionContextUsage: add optional onClick prop so the click behavior 
  can be overridden on mobile without changing desktop behavior
- MessageTimeline: add optional onContextClick prop, threaded through 
  to SessionContextUsage
- Add Context tab to the mobile tab bar, rendering SessionContextTab 
  inline; tab widths adjusted from 1/2 to 1/3, !px-3 added to 
  center tab labels
> **Note:** The 1/3-width tab layout may cause longer locale labels (e.g. Spanish "4 Archivos Cambiados") to truncate. Should address in a follow-up issue.


### How did you verify your code works?

- Ran bun typecheck in both packages/app and packages/ui
- Manually tested on local dev server:
  - Desktop: tooltip opens on hover, clicking indicator opens 
    side panel as before
  - Mobile (via Chrome DevTools): 
    tapping indicator opens tooltip, Context tab renders 
    SessionContextTab inline
  - All three mobile tabs (Session / Changes / Context) visible 
    and properly centered

### Screenshots / recordings

New tab layout with the 'Context' tab on mobile:
<img width="221" height="472" alt="image" src="https://github.com/user-attachments/assets/791413a5-af65-439c-a675-a77694f2678e" />

<img width="221" height="472" alt="image" src="https://github.com/user-attachments/assets/e12bb878-2abb-4e61-8e44-b8c543423df2" />

https://github.com/user-attachments/assets/f8f92d34-f3f7-49d6-a323-b3c365278ccc

https://github.com/user-attachments/assets/6d040a58-c8c8-4f63-9f43-b07cbacab241


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
