### PR TITLE
fix(tui): keep shell-mode prompt editable

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -17,6 +17,7 @@ import { MessageID, PartID } from "@/session/schema"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
+import { computePromptTraits } from "./traits"
 import { assign } from "./part"
 import { usePromptStash } from "./stash"
 import { DialogStash } from "../dialog-stash"
@@ -557,17 +558,11 @@ export function Prompt(props: PromptProps) {
 
   createEffect(() => {
     if (!input || input.isDestroyed) return
-    const capture =
-      store.mode === "normal"
-        ? auto()?.visible
-          ? (["escape", "navigate", "submit", "tab"] as const)
-          : (["tab"] as const)
-        : undefined
-    input.traits = {
-      capture,
-      suspend: !!props.disabled || store.mode === "shell",
-      status: store.mode === "shell" ? "SHELL" : undefined,
-    }
+    input.traits = computePromptTraits({
+      mode: store.mode,
+      disabled: !!props.disabled,
+      autocompleteVisible: !!auto()?.visible,
+    })
   })
 
   function restoreExtmarksFromParts(parts: PromptInfo["parts"]) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/traits.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/traits.ts
@@ -1,0 +1,31 @@
+import type { EditorTraits } from "@opentui/core"
+
+export type PromptMode = "normal" | "shell"
+
+export interface PromptTraitsInput {
+  mode: PromptMode
+  disabled: boolean
+  autocompleteVisible: boolean
+}
+
+/**
+ * Compute the textarea editor traits for the prompt.
+ *
+ * `traits.suspend` gates the textarea's keybinding actions (backspace,
+ * delete-word, arrow movement, undo/redo, etc.). Shell mode is an active
+ * editing mode — only `disabled` should suspend the textarea, otherwise
+ * users can type in shell mode but cannot delete or move the cursor.
+ */
+export function computePromptTraits(input: PromptTraitsInput): EditorTraits {
+  const capture =
+    input.mode === "normal"
+      ? input.autocompleteVisible
+        ? (["escape", "navigate", "submit", "tab"] as const)
+        : (["tab"] as const)
+      : undefined
+  return {
+    capture,
+    suspend: input.disabled,
+    status: input.mode === "shell" ? "SHELL" : undefined,
+  }
+}

--- a/packages/opencode/test/cli/cmd/tui/prompt-traits.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-traits.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { computePromptTraits } from "../../../../src/cli/cmd/tui/component/prompt/traits"
+
+describe("computePromptTraits", () => {
+  test("normal mode without autocomplete only captures tab", () => {
+    const traits = computePromptTraits({ mode: "normal", disabled: false, autocompleteVisible: false })
+    expect(traits.capture).toEqual(["tab"])
+    expect(traits.suspend).toBe(false)
+    expect(traits.status).toBeUndefined()
+  })
+
+  test("normal mode with autocomplete captures navigation keys", () => {
+    const traits = computePromptTraits({ mode: "normal", disabled: false, autocompleteVisible: true })
+    expect(traits.capture).toEqual(["escape", "navigate", "submit", "tab"])
+    expect(traits.suspend).toBe(false)
+    expect(traits.status).toBeUndefined()
+  })
+
+  test("shell mode does not suspend the textarea", () => {
+    // Suspending the textarea would gate every keybinding action
+    // (backspace, delete-word-backward, arrow movement, etc.) — see
+    // @opentui/core 0.2.x TextareaRenderable.handleKeyPress. Shell mode is
+    // an active editing mode, so suspend must stay off.
+    const traits = computePromptTraits({ mode: "shell", disabled: false, autocompleteVisible: false })
+    expect(traits.suspend).toBe(false)
+  })
+
+  test("shell mode disables capture and labels the prompt", () => {
+    const traits = computePromptTraits({ mode: "shell", disabled: false, autocompleteVisible: false })
+    expect(traits.capture).toBeUndefined()
+    expect(traits.status).toBe("SHELL")
+  })
+
+  test("disabled suspends regardless of mode", () => {
+    expect(computePromptTraits({ mode: "normal", disabled: true, autocompleteVisible: false }).suspend).toBe(true)
+    expect(computePromptTraits({ mode: "shell", disabled: true, autocompleteVisible: false }).suspend).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

In shell mode (`!` prefix), backspace, Ctrl+W, Ctrl+U, arrow keys, and every other editing action are no-ops while plain character insertion still works. Typing is fine, but you can't delete or move the cursor.

## Root cause

`@opentui/core` 0.2.0 (landed via #24810) changed `TextareaRenderable.handleKeyPress` to early-return the keybinding-action lookup when `traits.suspend === true`:

```js
handleKeyPress(key) {
  if (this.traits.suspend !== true) {
    const action = getKeyBindingAction(this._keyBindingsMap, key)
    if (action) { ... }
  }
  // raw character insertion still runs below — that's why typing keeps working
  if (!key.ctrl && !key.meta && ...) { this.insertText(key.sequence) }
}
```

The prompt has set `suspend: !!props.disabled || store.mode === "shell"` since #20741. Pre-0.2.0 the trait was purely informational, so the bug didn't surface. With 0.2.0 it now gates every keybinding action — `backspace`, `delete`, `delete-word-backward` (Ctrl+W / Alt+Backspace), `delete-to-line-start` (Ctrl+U), `delete-to-line-end` (Ctrl+K), arrow movement, word movement, undo/redo. Typing characters still goes through the raw `key.sequence` path, which is why typing works but deletion doesn't.

`suspend` semantically means "the textarea is busy, ignore input" (see `ui/dialog-prompt.tsx` which sets `suspend: props.busy`). Shell mode is an active editing mode — only `props.disabled` should suspend.

## Fix

- Extract the textarea-traits calculation into a pure `computePromptTraits` helper so the contract is explicit and testable.
- Drop `mode === "shell"` from the suspend predicate. The `status: "SHELL"` label and the `!`/`escape`/`backspace`-at-offset-0 mode-toggle handling in `onKeyDown` are unchanged.

## Verification

- New unit tests in `test/cli/cmd/tui/prompt-traits.test.ts` cover capture, suspend, and status across mode/disabled/autocomplete combinations.
- Manual repro via `tuistory`: in shell mode, `backspace` and `Ctrl+W` now delete characters/words; `!` still enters shell mode, `escape` exits with text preserved, and `backspace` at offset 0 exits shell mode.