### PR TITLE
fix(acp): drain message events before returning end_turn

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -147,6 +147,8 @@ export class Agent implements ACPAgent {
   private bashSnapshots = new Map<string, string>()
   private toolStarts = new Set<string>()
   private permissionQueues = new Map<string, Promise<void>>()
+  private messageCompletionResolvers = new Map<string, () => void>()
+  private completedAssistantMessageIds = new Set<string>()
   private permissionOptions: PermissionOption[] = [
     { optionId: "once", kind: "allow_once", name: "Allow once" },
     { optionId: "always", kind: "allow_always", name: "Always allow" },
@@ -267,6 +269,19 @@ export class Agent implements ACPAgent {
             }
           })
         this.permissionQueues.set(permission.sessionID, next)
+        return
+      }
+
+      case "message.updated": {
+        const info = event.properties.info
+        if (info.role === "assistant" && info.time.completed !== undefined) {
+          this.completedAssistantMessageIds.add(info.id)
+          const resolver = this.messageCompletionResolvers.get(info.id)
+          if (resolver) {
+            this.messageCompletionResolvers.delete(info.id)
+            resolver()
+          }
+        }
         return
       }
 
@@ -529,6 +544,34 @@ export class Agent implements ACPAgent {
         return
       }
     }
+  }
+
+  // Block until `message.updated` for `messageId` (with `time.completed`
+  // set) has been observed by the event subscription. Because
+  // `runEventSubscription` processes events sequentially via `for await`
+  // and awaits each `handleEvent` (which awaits the inner
+  // `connection.sessionUpdate(...)`), waiting for the completed event
+  // guarantees every prior `message.part.delta` chunk for this turn has
+  // already been forwarded to ACP. Without this, `prompt()` returns
+  // `stopReason: "end_turn"` while trailing chunk events are still queued
+  // in the SDK event stream, putting `agent_message_chunk` frames on the
+  // wire AFTER the RPC reply (a protocol violation visible to ACP clients
+  // as text appearing post-end_turn).
+  private waitForMessageCompletion(messageId: string, timeoutMs: number): Promise<void> {
+    if (this.completedAssistantMessageIds.has(messageId)) {
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => {
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
+        this.messageCompletionResolvers.delete(messageId)
+        resolve()
+      }
+      this.messageCompletionResolvers.set(messageId, finish)
+      setTimeout(finish, timeoutMs)
+    })
   }
 
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {
@@ -1481,6 +1524,12 @@ export class Agent implements ACPAgent {
       })
       const msg = response.data?.info
 
+      // Drain trailing message.part.delta events before returning end_turn —
+      // see `waitForMessageCompletion` for why.
+      if (msg?.id) {
+        await this.waitForMessageCompletion(msg.id, 5000)
+      }
+
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 
       return {
@@ -1503,6 +1552,10 @@ export class Agent implements ACPAgent {
         directory,
       })
       const msg = response.data?.info
+
+      if (msg?.id) {
+        await this.waitForMessageCompletion(msg.id, 5000)
+      }
 
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 


### PR DESCRIPTION
Fixes #25421.

## Summary

`Agent.prompt()` returns `stopReason: "end_turn"` as soon as `sdk.session.prompt()` resolves, but `message.part.delta` events for the assistant's final text are still queued in the SDK event stream at that moment — they get processed by `runEventSubscription` and forwarded to ACP as `agent_message_chunk` frames AFTER the RPC reply has already been sent. See the linked issue for a wire trace and protocol-level discussion.

## Fix

In `Agent.prompt()`, after `await sdk.session.prompt(...)` resolves, await `message.updated` for the response message id (i.e. `info.time.completed` set) before returning `end_turn`.

Why this is sufficient:

- `runEventSubscription` consumes `sdk.global.event()` via sequential `for await`, awaiting each `handleEvent` call.
- `message.updated` (with `time.completed` set) is the SDK's "this assistant message is fully written" signal, fired AFTER all `message.part.delta` events for the same message.
- Therefore once `message.updated` has been processed by `handleEvent`, every prior delta for that message has already been awaited through `connection.sessionUpdate(...)` — i.e. on the ACP wire.

A 5-second timeout fallback prevents deadlock if the upstream completion event is dropped or the message never reaches a completed state.

Applied to both `prompt()` branches that have a response message id (the cmd-less branch at `agent.ts:1471` and the slash-command branch at `:1497`). The compact path doesn't carry an assistant message id so it's left as-is.

## Test plan

- [x] `bun run typecheck` clean
- [x] Existing `test/acp/event-subscription.test.ts` (11 tests) all pass
- [x] No new compiler warnings
- [ ] Manual wire trace verification: re-run a streaming prompt against a built binary and confirm `agent_message_chunk` for the final delta arrives BEFORE the `id:N result:end_turn` reply (will follow up with results)

Happy to add a regression test using the existing `createFakeAgent` harness in `test/acp/event-subscription.test.ts` — kept out of the initial diff to stay focused, but the harness already supports event injection so it's straightforward to push timed `message.part.delta` + `message.updated` events and assert ordering. Let me know.
