### PR TITLE
refactor(instance-store): consolidate dispose helpers

### DIFF
--- a/packages/opencode/src/cli/bootstrap.ts
+++ b/packages/opencode/src/cli/bootstrap.ts
@@ -9,7 +9,7 @@ export async function bootstrap<T>(directory: string, cb: () => Promise<T>) {
         const result = await cb()
         return result
       } finally {
-        await InstanceStore.runtime.runPromise((s) => s.dispose(Instance.current))
+        await InstanceStore.disposeInstance(Instance.current)
       }
     },
   })

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -88,7 +88,7 @@ export const rpc = {
   async shutdown() {
     Log.Default.info("worker shutting down")
 
-    await InstanceStore.runtime.runPromise((s) => s.disposeAll())
+    await InstanceStore.disposeAllInstances()
     if (server) await server.stop(true)
   },
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -13,7 +13,6 @@ import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
 import { type InstanceContext } from "../project/instance"
 import { InstanceStore } from "../project/instance-store"
-import { InstanceRef } from "@/effect/instance-ref"
 import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { existsSync } from "fs"
 import { GlobalBus } from "@/bus/global"
@@ -739,15 +738,17 @@ export const layer = Layer.effect(
         .writeFileString(file, JSON.stringify(mergeDeep(writable(existing), writable(config)), null, 2))
         .pipe(Effect.orDie)
       if (options?.dispose !== false) {
-        const ctx = yield* InstanceRef
-        if (ctx) yield* Effect.promise(() => InstanceStore.runtime.runPromise((s) => s.dispose(ctx)))
+        // Fail loudly if no instance is bound — silently skipping would
+        // mask "config update without an active instance" bugs. The throw
+        // comes from `Instance.current` inside `InstanceState.context`.
+        const ctx = yield* InstanceState.context
+        yield* Effect.promise(() => InstanceStore.disposeInstance(ctx))
       }
     })
 
     const invalidate = Effect.fn("Config.invalidate")(function* (wait?: boolean) {
       yield* invalidateGlobal
-      const task = InstanceStore.runtime
-        .runPromise((s) => s.disposeAll())
+      const task = InstanceStore.disposeAllInstances()
         .catch(() => undefined)
         .finally(() =>
           GlobalBus.emit("event", {

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -1,7 +1,7 @@
 import { GlobalBus } from "@/bus/global"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
-import { disposeInstance } from "@/effect/instance-registry"
+import { disposeInstance as runDisposers } from "@/effect/instance-registry"
 import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
@@ -94,7 +94,7 @@ export const layer: Layer.Layer<Service, never, Project.Service> = Layer.effect(
 
     const disposeContext = Effect.fn("InstanceStore.disposeContext")(function* (ctx: InstanceContext) {
       yield* Effect.logInfo("disposing instance", { directory: ctx.directory })
-      yield* Effect.promise(() => disposeInstance(ctx.directory))
+      yield* Effect.promise(() => runDisposers(ctx.directory))
       yield* emitDisposed({ directory: ctx.directory, project: ctx.project.id })
     })
 
@@ -135,7 +135,7 @@ export const layer: Layer.Layer<Service, never, Project.Service> = Layer.effect(
             yield* Effect.logInfo("reloading instance", { directory })
             if (previous) {
               yield* Deferred.await(previous.deferred).pipe(Effect.ignore)
-              yield* Effect.promise(() => disposeInstance(directory))
+              yield* Effect.promise(() => runDisposers(directory))
               yield* emitDisposed({ directory, project: input.project?.id })
             }
             yield* completeLoad(directory, input, entry)
@@ -196,5 +196,12 @@ export const layer: Layer.Layer<Service, never, Project.Service> = Layer.effect(
 export const defaultLayer = layer.pipe(Layer.provide(Project.defaultLayer))
 
 export const runtime = makeRuntime(Service, defaultLayer)
+
+// Promise-returning helpers for callers without an Effect runtime in scope.
+// They route through `runtime` (not a yielded Service from a fresh runtime)
+// so they share the cache that `Instance.provide` populates.
+export const disposeInstance = (ctx: InstanceContext) => runtime.runPromise((store) => store.dispose(ctx))
+export const disposeAllInstances = () => runtime.runPromise((store) => store.disposeAll())
+export const reloadInstance = (input: LoadInput) => runtime.runPromise((store) => store.reload(input))
 
 export * as InstanceStore from "./instance-store"

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -42,10 +42,17 @@ export const Instance = {
   restore<R>(ctx: InstanceContext, fn: () => R): R {
     return context.provide(ctx, fn)
   },
+  // followup: `reload` survives because `test/server/project-init-git.test.ts`
+  // spies on this exact method. Once that test asserts on `InstanceStore.reloadInstance`
+  // (or moves to an Effect runtime), this wrapper can drop.
   async reload(input: InstanceStore.LoadInput) {
-    return InstanceStore.runtime.runPromise((store) => store.reload(input))
+    return InstanceStore.reloadInstance(input)
   },
+  // followup: `dispose` survives for legacy fixtures that read `Instance.current`
+  // out of ALS (e.g. `test/fixture/fixture.ts` `provideTmpdirInstance`,
+  // `test/question/question.test.ts` cancellation tests). Convert those to call
+  // `InstanceStore.disposeInstance(ctx)` directly once `Instance.provide` is gone.
   async dispose() {
-    return InstanceStore.runtime.runPromise((store) => store.dispose(Instance.current))
+    return InstanceStore.disposeInstance(Instance.current)
   },
 }

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -200,7 +200,7 @@ export const GlobalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        await InstanceStore.runtime.runPromise((s) => s.disposeAll())
+        await InstanceStore.disposeAllInstances()
         GlobalBus.emit("event", {
           directory: "global",
           payload: {

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -63,7 +63,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono => {
         },
       }),
       async (c) => {
-        await InstanceStore.runtime.runPromise((s) => s.dispose(Instance.current))
+        await InstanceStore.disposeInstance(Instance.current)
         return c.json(true)
       },
     )

--- a/packages/opencode/src/server/routes/instance/project.ts
+++ b/packages/opencode/src/server/routes/instance/project.ts
@@ -81,7 +81,11 @@ export const ProjectRoutes = lazy(() =>
           Project.Service.use((svc) => svc.initGit({ directory: dir, project: prev })),
         )
         if (next.id === prev.id && next.vcs === prev.vcs && next.worktree === prev.worktree) return c.json(next)
-        await Instance.reload({ directory: dir, worktree: dir, project: next })
+        await Instance.reload({
+          directory: dir,
+          worktree: dir,
+          project: next,
+        })
         return c.json(next)
       },
     )

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -9,15 +9,11 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import type { Config } from "@/config/config"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { Instance } from "../../src/project/instance"
-import { InstanceStore } from "../../src/project/instance-store"
 import { TestLLMServer } from "../lib/llm-server"
 
-// Test helper for tearing down all loaded instances. Used in afterEach hooks.
-// Replaces direct Instance.disposeAll() calls so the legacy promise method can be removed.
-// IMPORTANT: must use InstanceStore.runtime, not AppRuntime or a test-layer Service —
-// Instance.provide loads instances into InstanceStore.runtime's Service cache, and that
-// Service is built per-runtime (not shared via memoMap across Effect.runPromise boundaries).
-export const disposeAllInstances = () => InstanceStore.runtime.runPromise((s) => s.disposeAll())
+// Re-export for test ergonomics. The implementation lives next to the runtime
+// it consumes; see `InstanceStore.disposeAllInstances` for the rationale.
+export { disposeAllInstances } from "../../src/project/instance-store"
 
 // Strip null bytes from paths (defensive fix for CI environment issues)
 function sanitizePath(p: string): string {


### PR DESCRIPTION
## Summary
Followup to #25418. That PR removed \`Instance.disposeAll\`/\`Instance.load\` but inlined the same \`InstanceStore.runtime.runPromise(...)\` incantation at 6 production call sites and duplicated the test fixture's helper. This PR replaces those with three top-level helpers exported from \`instance-store.ts\` itself.

## Why
After #25418 the same shape appeared 6 times across production:

\`\`\`ts
await InstanceStore.runtime.runPromise((s) => s.dispose(Instance.current))
await InstanceStore.runtime.runPromise((s) => s.disposeAll())
\`\`\`

Plus a near-identical helper in the test fixture (with a long comment explaining \`runtime\` vs yielded service). Centralizing the pattern in one place removes the duplication and gives the runtime/cache rationale a single canonical home.

## Changes
- **\`src/project/instance-store.ts\`**: export \`disposeInstance(ctx)\`, \`disposeAllInstances()\`, \`reloadInstance(input)\`. Each is a one-line wrapper around \`runtime.runPromise(...)\` so callers without an Effect runtime in scope share the cache that \`Instance.provide\` populates. Renamed the local \`disposeInstance\` import from \`@/effect/instance-registry\` to \`runDisposers\` to avoid a name collision.
- **\`src/project/instance.ts\`**: \`Instance.dispose\` and \`Instance.reload\` now delegate to the new helpers. Added \`// followup\` comments naming the specific test files keeping each one alive.
- **\`src/cli/bootstrap.ts\`**, **\`src/cli/cmd/tui/worker.ts\`**, **\`src/server/routes/global.ts\`**, **\`src/server/routes/instance/index.ts\`**: switched to the helpers.
- **\`src/config/config.ts\`**: switched to the helpers, and restored the original throw-on-missing-instance behavior in \`Config.update\` (the silent no-op introduced in #25418 would have masked "config update without an active instance" bugs). Now uses \`InstanceState.context\` which throws via \`Instance.current\` if neither InstanceRef nor ALS is set.
- **\`src/server/routes/instance/project.ts\`**: reverted an unrelated formatting collapse that snuck into #25418.
- **\`test/fixture/fixture.ts\`**: re-exports \`disposeAllInstances\` from \`instance-store.ts\` instead of duplicating the implementation. The 50+ test imports continue to work unchanged.

## Tests
- \`bun typecheck\` — clean
- \`bun run test\` on the affected suites (\`httpapi-workspace\`, \`control-plane/workspace\`, \`project/instance\`, \`effect/run-service\`, \`bus\`, \`bus-effect\`, \`bus-integration\`, \`effect/instance-state\`) — 87/87 pass

## Followups (not in this PR)
The simplify review surfaced several worthwhile but out-of-scope refactors:
- \`disposeInstanceByDirectory(directory)\` overload so test files holding a \`string\` (not an \`InstanceContext\`) can stop round-tripping through \`Instance.provide\` just to materialize a context.
- Add concurrency to \`disposeAllOnce\` so worker shutdown disposes N projects in parallel rather than serially.
- Audit \`Config.update\`'s default \`dispose: true\` — every config write tears down the entire \`InstanceState\` cache for the directory.
- Replace \`Effect.cachedWithTTL(_, Duration.zero)\` on \`disposeAll\` with a real dedup so rapid \`Config.invalidate\` calls coalesce.