### PR TITLE
fix(app): confirm workspace deletion on Enter

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -71,6 +71,7 @@ import {
   errorMessage,
   latestRootSession,
   sortedRootSessions,
+  workspaceDeleteKeyAction,
 } from "./layout/helpers"
 import {
   collectNewSessionDeepLinks,
@@ -1622,7 +1623,30 @@ export default function Layout(props: ParentProps) {
       dirty: false,
     })
 
+    const handleDelete = () => {
+      const leaveDeletedWorkspace = !!params.dir && pathKey(currentDir()) === pathKey(props.directory)
+      if (leaveDeletedWorkspace) {
+        navigateWithSidebarReset(`/${base64Encode(props.root)}/session`)
+      }
+      dialog.close()
+      void deleteWorkspace(props.root, props.directory, leaveDeletedWorkspace)
+    }
+
     onMount(() => {
+      makeEventListener(
+        window,
+        "keydown",
+        (event) => {
+          const action = workspaceDeleteKeyAction(event, data.status)
+          if (action === "ignore") return
+          event.preventDefault()
+          event.stopPropagation()
+          if (action === "block") return
+          handleDelete()
+        },
+        { capture: true },
+      )
+
       globalSDK.client.file
         .status({ directory: props.directory })
         .then((x) => {
@@ -1634,15 +1658,6 @@ export default function Layout(props: ParentProps) {
           setData({ status: "error", dirty: false })
         })
     })
-
-    const handleDelete = () => {
-      const leaveDeletedWorkspace = !!params.dir && pathKey(currentDir()) === pathKey(props.directory)
-      if (leaveDeletedWorkspace) {
-        navigateWithSidebarReset(`/${base64Encode(props.root)}/session`)
-      }
-      dialog.close()
-      void deleteWorkspace(props.root, props.directory, leaveDeletedWorkspace)
-    }
 
     const description = () => {
       if (data.status === "loading") return language.t("workspace.status.checking")

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -14,6 +14,7 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  workspaceDeleteKeyAction,
 } from "./helpers"
 import { pathKey } from "@/utils/path-key"
 
@@ -215,6 +216,14 @@ describe("layout workspace helpers", () => {
   test("formats fallback project display name", () => {
     expect(displayName({ worktree: "/tmp/app" })).toBe("app")
     expect(displayName({ worktree: "/tmp/app", name: "My App" })).toBe("My App")
+  })
+
+  test("maps workspace delete dialog Enter keys", () => {
+    expect(workspaceDeleteKeyAction(new KeyboardEvent("keydown", { key: "Escape" }), "ready")).toBe("ignore")
+    expect(workspaceDeleteKeyAction(new KeyboardEvent("keydown", { key: "Enter" }), "loading")).toBe("block")
+    expect(workspaceDeleteKeyAction(new KeyboardEvent("keydown", { key: "Enter", repeat: true }), "ready")).toBe("block")
+    expect(workspaceDeleteKeyAction(new KeyboardEvent("keydown", { key: "Enter" }), "ready")).toBe("confirm")
+    expect(workspaceDeleteKeyAction(new KeyboardEvent("keydown", { key: "Enter" }), "error")).toBe("confirm")
   })
 
   test("extracts api error message and fallback", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -55,6 +55,15 @@ export const childSessionOnPath = (sessions: Session[] | undefined, rootID: stri
 export const displayName = (project: { name?: string; worktree: string }) =>
   project.name || getFilename(project.worktree)
 
+export function workspaceDeleteKeyAction(
+  event: Pick<KeyboardEvent, "key" | "repeat">,
+  status: "loading" | "ready" | "error",
+) {
+  if (event.key !== "Enter") return "ignore"
+  if (event.repeat || status === "loading") return "block"
+  return "confirm"
+}
+
 export const errorMessage = (err: unknown, fallback: string) => {
   if (err && typeof err === "object" && "data" in err) {
     const data = (err as { data?: { message?: string } }).data


### PR DESCRIPTION
### Issue for this PR

Fixes #25425

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The workspace delete confirmation now handles Enter while the dialog is open. After the status check finishes, Enter calls the same delete path as the primary button. While the status check is still loading, Enter is swallowed so it does not close the dialog through the focused close control.

The keyboard decision is covered by a focused layout helper test.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/pages/layout/helpers.test.ts` from `packages/app`
- `bun typecheck` from `packages/app`
- `bun typecheck` from `packages/ui`
- `git diff --check`
- Pre-push hook completed `bun turbo typecheck` successfully

### Screenshots / recordings

Not included; this changes keyboard behavior only and has no visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
