### PR TITLE
fix(agent): initialize plugins before resolving config

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -77,6 +77,10 @@ export const layer = Layer.effect(
     const skill = yield* Skill.Service
     const provider = yield* Provider.Service
 
+    // Some entry points resolve agents before project bootstrap runs, so ensure
+    // plugin config hooks have mutated config before agent state snapshots it.
+    yield* plugin.init()
+
     const state = yield* InstanceState.make<State>(
       Effect.fn("Agent.state")(function* (ctx) {
         const cfg = yield* config.get()


### PR DESCRIPTION
## Summary
- initialize plugins before `Agent` snapshots `cfg.agent`
- align agent resolution with provider resolution and project bootstrap expectations
- fix entry points that resolve plugin-provided default agents before full bootstrap

Closes #25438.

## Why
Plugins can mutate config inside their `config()` hook. `Agent.Service` was reading `config.get()` before plugin initialization was guaranteed, so plugin-provided agents could be missing during early agent resolution.

## Validation
- changed file has the minimal targeted diff in `packages/opencode/src/agent/agent.ts`
- package-level typecheck was attempted from `packages/opencode`
- current `origin/dev` still has unrelated baseline typecheck failures outside this change, including:
  - `../core/src/cross-spawn-spawner.ts`: encoding type mismatch
  - `src/storage/db.node.ts`: missing `node:sqlite` types in the current environment

## Scope
- `packages/opencode/src/agent/agent.ts`