### PR TITLE
Use instance test helper in grep tests

### DIFF
--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from "bun:test"
 import path from "path"
 import { Effect, Layer } from "effect"
 import { GrepTool } from "../../src/tool/grep"
-import { provideInstance, provideTmpdirInstance } from "../fixture/fixture"
+import { provideInstance, TestInstance } from "../fixture/fixture"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Truncate } from "@/tool/truncate"
@@ -54,61 +54,58 @@ describe("tool.grep", () => {
     }),
   )
 
-  it.live("no matches returns correct output", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        yield* Effect.promise(() => Bun.write(path.join(dir, "test.txt"), "hello world"))
-        const info = yield* GrepTool
-        const grep = yield* info.init()
-        const result = yield* grep.execute(
-          {
-            pattern: "xyznonexistentpatternxyz123",
-            path: dir,
-          },
-          ctx,
-        )
-        expect(result.metadata.matches).toBe(0)
-        expect(result.output).toBe("No files found")
-      }),
-    ),
+  it.instance("no matches returns correct output", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "test.txt"), "hello world"))
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      const result = yield* grep.execute(
+        {
+          pattern: "xyznonexistentpatternxyz123",
+          path: test.directory,
+        },
+        ctx,
+      )
+      expect(result.metadata.matches).toBe(0)
+      expect(result.output).toBe("No files found")
+    }),
   )
 
-  it.live("finds matches in tmp instance", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        yield* Effect.promise(() => Bun.write(path.join(dir, "test.txt"), "line1\nline2\nline3"))
-        const info = yield* GrepTool
-        const grep = yield* info.init()
-        const result = yield* grep.execute(
-          {
-            pattern: "line",
-            path: dir,
-          },
-          ctx,
-        )
-        expect(result.metadata.matches).toBeGreaterThan(0)
-      }),
-    ),
+  it.instance("finds matches in tmp instance", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "test.txt"), "line1\nline2\nline3"))
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      const result = yield* grep.execute(
+        {
+          pattern: "line",
+          path: test.directory,
+        },
+        ctx,
+      )
+      expect(result.metadata.matches).toBeGreaterThan(0)
+    }),
   )
 
-  it.live("supports exact file paths", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        const file = path.join(dir, "test.txt")
-        yield* Effect.promise(() => Bun.write(file, "line1\nline2\nline3"))
-        const info = yield* GrepTool
-        const grep = yield* info.init()
-        const result = yield* grep.execute(
-          {
-            pattern: "line2",
-            path: file,
-          },
-          ctx,
-        )
-        expect(result.metadata.matches).toBe(1)
-        expect(result.output).toContain(file)
-        expect(result.output).toContain("Line 2: line2")
-      }),
-    ),
+  it.instance("supports exact file paths", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const file = path.join(test.directory, "test.txt")
+      yield* Effect.promise(() => Bun.write(file, "line1\nline2\nline3"))
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      const result = yield* grep.execute(
+        {
+          pattern: "line2",
+          path: file,
+        },
+        ctx,
+      )
+      expect(result.metadata.matches).toBe(1)
+      expect(result.output).toContain(file)
+      expect(result.output).toContain("Line 2: line2")
+    }),
   )
 })


### PR DESCRIPTION
## Summary
- port tmpdir-backed grep tool tests to `it.instance(...)`
- use `TestInstance` for temporary directory access

## Verification
- `bun typecheck`
- `bun run test test/tool/grep.test.ts`
- push hook ran `bun turbo typecheck`