### PR TITLE
Use instance test helper in glob tests

### DIFF
--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -8,7 +8,7 @@ import { Ripgrep } from "../../src/file/ripgrep"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { Agent } from "../../src/agent/agent"
-import { provideTmpdirInstance } from "../fixture/fixture"
+import { TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(
@@ -33,49 +33,47 @@ const ctx = {
 }
 
 describe("tool.glob", () => {
-  it.live("matches files from a directory path", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        yield* Effect.promise(() => Bun.write(path.join(dir, "a.ts"), "export const a = 1\n"))
-        yield* Effect.promise(() => Bun.write(path.join(dir, "b.txt"), "hello\n"))
-        const info = yield* GlobTool
-        const glob = yield* info.init()
-        const result = yield* glob.execute(
+  it.instance("matches files from a directory path", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "a.ts"), "export const a = 1\n"))
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "b.txt"), "hello\n"))
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      const result = yield* glob.execute(
+        {
+          pattern: "*.ts",
+          path: test.directory,
+        },
+        ctx,
+      )
+      expect(result.metadata.count).toBe(1)
+      expect(result.output).toContain(path.join(test.directory, "a.ts"))
+      expect(result.output).not.toContain(path.join(test.directory, "b.txt"))
+    }),
+  )
+
+  it.instance("rejects exact file paths", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const file = path.join(test.directory, "a.ts")
+      yield* Effect.promise(() => Bun.write(file, "export const a = 1\n"))
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      const exit = yield* glob
+        .execute(
           {
             pattern: "*.ts",
-            path: dir,
+            path: file,
           },
           ctx,
         )
-        expect(result.metadata.count).toBe(1)
-        expect(result.output).toContain(path.join(dir, "a.ts"))
-        expect(result.output).not.toContain(path.join(dir, "b.txt"))
-      }),
-    ),
-  )
-
-  it.live("rejects exact file paths", () =>
-    provideTmpdirInstance((dir) =>
-      Effect.gen(function* () {
-        const file = path.join(dir, "a.ts")
-        yield* Effect.promise(() => Bun.write(file, "export const a = 1\n"))
-        const info = yield* GlobTool
-        const glob = yield* info.init()
-        const exit = yield* glob
-          .execute(
-            {
-              pattern: "*.ts",
-              path: file,
-            },
-            ctx,
-          )
-          .pipe(Effect.exit)
-        expect(Exit.isFailure(exit)).toBe(true)
-        if (Exit.isFailure(exit)) {
-          const err = Cause.squash(exit.cause)
-          expect(err instanceof Error ? err.message : String(err)).toContain("glob path must be a directory")
-        }
-      }),
-    ),
+        .pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const err = Cause.squash(exit.cause)
+        expect(err instanceof Error ? err.message : String(err)).toContain("glob path must be a directory")
+      }
+    }),
   )
 })


### PR DESCRIPTION
## Summary
- port glob tool tests to `it.instance(...)`
- use `TestInstance` for temporary directory access

## Verification
- `bun typecheck`
- `bun run test test/tool/glob.test.ts`
- push hook ran `bun turbo typecheck`