### PR TITLE
fix(lsp): ignore pyright virtualenv diagnostics

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -162,13 +162,27 @@ export async function create(input: { serverID: string; server: LSPServer.Handle
   const published = new Map<string, { at: number; version?: number }>()
   const diagnosticRegistrations = new Map<string, CapabilityRegistration>()
   const registrationListeners = new Set<() => void>()
+  const shouldIgnoreDiagnostics = (filePath: string) => {
+    if (input.serverID !== "pyright") return false
+    const relative = path.relative(input.root, filePath)
+    if (relative.startsWith("..") || path.isAbsolute(relative)) return false
+    return relative.split(/[\\/]+/).some((part) => part === ".venv" || part === "venv")
+  }
   const mergedDiagnostics = (filePath: string) =>
     dedupeDiagnostics([...(pushDiagnostics.get(filePath) ?? []), ...(pullDiagnostics.get(filePath) ?? [])])
   const updatePushDiagnostics = (filePath: string, next: Diagnostic[]) => {
+    if (shouldIgnoreDiagnostics(filePath)) {
+      pushDiagnostics.delete(filePath)
+      return
+    }
     pushDiagnostics.set(filePath, next)
     Bus.publish(Event.Diagnostics, { path: filePath, serverID: input.serverID })
   }
   const updatePullDiagnostics = (filePath: string, next: Diagnostic[]) => {
+    if (shouldIgnoreDiagnostics(filePath)) {
+      pullDiagnostics.delete(filePath)
+      return
+    }
     pullDiagnostics.set(filePath, next)
   }
   const emitRegistrationChange = () => {

--- a/packages/opencode/test/lsp/client.test.ts
+++ b/packages/opencode/test/lsp/client.test.ts
@@ -445,6 +445,72 @@ describe("LSPClient interop", () => {
     })
   })
 
+  test("pyright ignores virtualenv workspace pull diagnostics", async () => {
+    const handle = spawnFakeServer() as any
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "main.py")
+    const source = path.join(tmp.path, "app.py")
+    const virtualenv = path.join(tmp.path, ".venv", "lib", "python3.12", "site-packages", "pkg.py")
+    await Bun.write(file, "print('main')\n")
+    await Bun.write(source, "print('app')\n")
+    await Bun.write(virtualenv, "print('pkg')\n")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = await LSPClient.create({
+          serverID: "pyright",
+          server: handle as unknown as LSPServer.Handle,
+          root: tmp.path,
+          directory: tmp.path,
+        })
+
+        await client.connection.sendRequest("test/configure-pull-diagnostics", {
+          registerOn: "didOpen",
+          registrations: [{ identifier: "workspace", workspaceDiagnostics: true }],
+          workspaceDiagnosticsByIdentifier: {
+            workspace: [
+              {
+                uri: pathToFileURL(source).href,
+                items: [
+                  {
+                    range: {
+                      start: { line: 0, character: 0 },
+                      end: { line: 0, character: 5 },
+                    },
+                    message: "source diagnostic",
+                    severity: 1,
+                  },
+                ],
+              },
+              {
+                uri: pathToFileURL(virtualenv).href,
+                items: [
+                  {
+                    range: {
+                      start: { line: 0, character: 0 },
+                      end: { line: 0, character: 5 },
+                    },
+                    message: "virtualenv diagnostic",
+                    severity: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        const version = await client.notify.open({ path: file })
+        await client.waitForDiagnostics({ path: file, version, mode: "full" })
+
+        expect(client.diagnostics.get(source)?.[0]?.message).toBe("source diagnostic")
+        expect(client.diagnostics.has(virtualenv)).toBe(false)
+
+        await client.shutdown()
+      },
+    })
+  })
+
   test("full mode treats an empty workspace pull response as handled", async () => {
     const handle = spawnFakeServer() as any
     await using tmp = await tmpdir()


### PR DESCRIPTION
### Issue for this PR

Closes #25408

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Filters pyright diagnostics for files inside `venv` and `.venv` before they are merged into the LSP diagnostic state. This keeps workspace diagnostics from surfacing virtualenv noise while preserving diagnostics for source files.

### How did you verify your code works?

- `bun test test/lsp/client.test.ts --filter "pyright ignores virtualenv workspace pull diagnostics"`
- `bun typecheck`
- `bun lint` completed with 0 errors, existing warnings only

### Screenshots / recordings

Not applicable, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR