### PR TITLE
fix(instance): restore InstanceBootstrap init parameter for non-Effec…

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -80,7 +80,6 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make<State>(
       Effect.fn("Agent.state")(function* (ctx) {
         const cfg = yield* config.get()
-        yield* plugin.init()
         const skillDirs = yield* skill.dirs()
         const whitelistedDirs = [
           Truncate.GLOB,

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -80,6 +80,7 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make<State>(
       Effect.fn("Agent.state")(function* (ctx) {
         const cfg = yield* config.get()
+        yield* plugin.init()
         const skillDirs = yield* skill.dirs()
         const whitelistedDirs = [
           Truncate.GLOB,

--- a/packages/opencode/src/cli/bootstrap.ts
+++ b/packages/opencode/src/cli/bootstrap.ts
@@ -1,9 +1,11 @@
 import { Instance } from "../project/instance"
 import { InstanceStore } from "../project/instance-store"
+import { getBootstrapRunEffect } from "../effect/app-runtime"
 
 export async function bootstrap<T>(directory: string, cb: () => Promise<T>) {
   return Instance.provide({
     directory,
+    init: await getBootstrapRunEffect(),
     fn: async () => {
       try {
         const result = await cb()

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -10,7 +10,7 @@ import { GlobalBus } from "@/bus/global"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { writeHeapSnapshot } from "node:v8"
 import { Heap } from "@/cli/heap"
-import { AppRuntime } from "@/effect/app-runtime"
+import { AppRuntime, getBootstrapRunEffect } from "@/effect/app-runtime"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
 
 ensureProcessMetadata("worker")
@@ -77,6 +77,7 @@ export const rpc = {
   async checkUpgrade(input: { directory: string }) {
     await Instance.provide({
       directory: input.directory,
+      init: await getBootstrapRunEffect(),
       fn: async () => {
         await upgrade().catch(() => {})
       },

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -1,4 +1,4 @@
-import { Layer, ManagedRuntime } from "effect"
+import { Effect, Layer, ManagedRuntime } from "effect"
 import { attach } from "./run-service"
 import * as Observability from "@opencode-ai/core/effect/observability"
 
@@ -39,6 +39,7 @@ import { Command } from "@/command"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
 import { Format } from "@/format"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceStore } from "@/project/instance-store"
 import { Project } from "@/project/project"
 import { Vcs } from "@/project/vcs"
@@ -91,6 +92,7 @@ export const AppLayer = Layer.mergeAll(
   Truncate.defaultLayer,
   ToolRegistry.defaultLayer,
   Format.defaultLayer,
+  InstanceBootstrap.defaultLayer,
   InstanceStore.defaultLayer,
   Project.defaultLayer,
   Vcs.defaultLayer,
@@ -127,4 +129,16 @@ export const AppRuntime: Runtime = {
     return rt.runCallback(wrap(effect))
   },
   dispose: () => rt.dispose(),
+}
+
+let bootstrapRun: Promise<Effect.Effect<void>>
+export function getBootstrapRunEffect(): Promise<Effect.Effect<void>> {
+  if (!bootstrapRun) {
+    bootstrapRun = AppRuntime.runPromise(
+      Effect.gen(function* () {
+        return (yield* InstanceBootstrap.Service).run
+      }),
+    )
+  }
+  return bootstrapRun
 }

--- a/packages/opencode/src/server/routes/instance/middleware.ts
+++ b/packages/opencode/src/server/routes/instance/middleware.ts
@@ -1,6 +1,6 @@
 import type { MiddlewareHandler } from "hono"
 import { Instance } from "@/project/instance"
-import { AppRuntime } from "@/effect/app-runtime"
+import { getBootstrapRunEffect } from "@/effect/app-runtime"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { WorkspaceID } from "@/control-plane/schema"
@@ -23,6 +23,7 @@ export function InstanceMiddleware(workspaceID?: WorkspaceID): MiddlewareHandler
       async fn() {
         return Instance.provide({
           directory,
+          init: await getBootstrapRunEffect(),
           async fn() {
             return next()
           },

--- a/packages/opencode/src/server/routes/instance/project.ts
+++ b/packages/opencode/src/server/routes/instance/project.ts
@@ -8,7 +8,7 @@ import z from "zod"
 import { ProjectID } from "@/project/schema"
 import { errors } from "../../error"
 import { lazy } from "@/util/lazy"
-import { AppRuntime } from "@/effect/app-runtime"
+import { getBootstrapRunEffect } from "@/effect/app-runtime"
 import { jsonRequest, runRequest } from "./trace"
 
 export const ProjectRoutes = lazy(() =>
@@ -82,7 +82,7 @@ export const ProjectRoutes = lazy(() =>
           Project.Service.use((svc) => svc.initGit({ directory: dir, project: prev })),
         )
         if (next.id === prev.id && next.vcs === prev.vcs && next.worktree === prev.worktree) return c.json(next)
-        await InstanceStore.reloadInstance({ directory: dir, worktree: dir, project: next })
+        await InstanceStore.reloadInstance({ directory: dir, worktree: dir, project: next, init: await getBootstrapRunEffect() })
         return c.json(next)
       },
     )

--- a/packages/opencode/src/server/workspace.ts
+++ b/packages/opencode/src/server/workspace.ts
@@ -5,10 +5,10 @@ import { WorkspaceID } from "@/control-plane/schema"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Workspace } from "@/control-plane/workspace"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { getBootstrapRunEffect, AppRuntime } from "@/effect/app-runtime"
 import { Instance } from "@/project/instance"
 import { Session } from "@/session/session"
 import { SessionID } from "@/session/schema"
-import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
 import * as Log from "@opencode-ai/core/util/log"
 import { ServerProxy } from "./proxy"
@@ -94,11 +94,13 @@ export function WorkspaceRouterMiddleware(upgrade: UpgradeWebSocket): Middleware
     const target = await adapter.target(workspace)
 
     if (target.type === "local") {
+      const init = await getBootstrapRunEffect()
       return WorkspaceContext.provide({
         workspaceID: WorkspaceID.make(workspaceID),
         fn: () =>
           Instance.provide({
             directory: target.directory,
+            init,
             async fn() {
               return next()
             },


### PR DESCRIPTION
### Issue for this PR

Fixes #25450
Ref [oh-my-openagent#3758](https://github.com/code-yeongyu/oh-my-openagent/issues/3758)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem**: oh-my-openagent and other plugins that register agents via the `config` hook stopped working in v1.14.32. Only native agents (`build`, `plan`) appeared in the TUI.

**Root cause**: When `InstanceBootstrap` was refactored from a bare `Effect` to an Effect `Service`, the `init` parameter of `Instance.provide()` changed from `() => Promise<any>` to `Effect.Effect<void>`. The httpapi middleware was correctly updated to pass `bootstrap.run`, but the legacy Hono middleware and CLI entry points simply deleted the `init` parameter instead of adapting it. Without `init`, `InstanceBootstrap.run()` never executes for these paths — meaning plugins never initialize, their `config` hooks never fire, and plugin-registered agents never appear in `cfg.agent`.

**Fix** (7 files, +29/-6):

1. **Root cause**: Added `getBootstrapRunEffect()` helper that lazily resolves `InstanceBootstrap.Service.run` from AppRuntime, so legacy callers can pass the Effect without being inside an Effect context. Added `init: await getBootstrapRunEffect()` to all 5 affected call sites (`InstanceMiddleware`, workspace router, CLI bootstrap, TUI worker, project reload).

2. **Defense-in-depth**: Added `yield* plugin.init()` inside the Agent state builder (before it iterates `cfg.agent`). This protects CLI commands and other entry points where `Instance.provide()` is called without `init`. (`plugin.init()` is idempotent — it returns the cached Plugin state if already initialized.)

### How did you verify your code works?

- Type-checked the full `packages/opencode` package (only pre-existing `spinner.ts` error remains, unrelated)
- Verified the fix matches the v1.14.31 behavior: InstanceBootstrap runs before Agent state is built
- Confirmed the defense-in-depth follows the same pattern as PR #25440 but placed correctly inside the state builder (where `InstanceRef` context is available), not at layer init time
- The `getBootstrapRunEffect()` helper is cached after first call, so subsequent requests have zero overhead

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR