### PR TITLE
fix(telemetry): emit Tool.execute span for MCP and plugin tools

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -464,9 +464,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
                 { args },
               )
-              yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
-              const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.promise(() =>
-                execute(args, opts),
+              const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
+                yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
+                return yield* Effect.promise(() => execute(args, opts))
+              }).pipe(
+                Effect.withSpan("Tool.execute", {
+                  attributes: {
+                    "tool.name": key,
+                    "tool.call_id": opts.toolCallId,
+                    "session.id": ctx.sessionID,
+                    "message.id": input.processor.message.id,
+                  },
+                }),
               )
               yield* plugin.trigger(
                 "tool.execute.after",

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -154,7 +154,16 @@ export const layer: Layer.Layer<
                     ...(out.truncated && { outputPath: out.outputPath }),
                   },
                 }
-              }),
+              }).pipe(
+                Effect.withSpan("Tool.execute", {
+                  attributes: {
+                    "tool.name": id,
+                    "session.id": toolCtx.sessionID,
+                    "message.id": toolCtx.messageID,
+                    ...(toolCtx.callID ? { "tool.call_id": toolCtx.callID } : {}),
+                  },
+                }),
+              ),
           }
         }
 


### PR DESCRIPTION
## Summary

- MCP-served tools (`sentry_*`, `exa_*`, etc.) and plugin-defined tools were not emitting a `Tool.execute` span. Only native tools built via `Tool.define()` got one, because the span lives inside `wrap()` in `tool/tool.ts`.
- Add `Effect.withSpan("Tool.execute", ...)` to both bypassed paths, mirroring the attribute shape from `wrap()`: `tool.name`, `tool.call_id`, `session.id`, `message.id`.

## Evidence

Trace `33c8941c89094d50650c2b91e244c778` had 28 `ai.toolCall` spans and only 24 `Tool.execute` children. The 4 missing executions were exactly the MCP tools used in the session:

- `sentry_search_issues`
- `sentry_find_organizations`
- `sentry_whoami`
- `exa_web_search_exa`

Native tools (`bash`, `webfetch`, `glob`, `grep`) all had matching pairs with the same `tool.call_id`. `Permission.ask` fired 28 times (matching `ai.toolCall` count), so MCP tools went through permission gating but skipped the execution wrapper specifically.

## Why it matters

- Lose visibility into MCP/plugin tool timing and errors at the runner level — only the AI SDK's end-to-end `ai.toolCall` is observable.
- Any cross-cutting telemetry filtering on `operation=Tool.execute` silently excludes MCP and plugin traffic.

## Changes

- `packages/opencode/src/session/prompt.ts`: wrap the MCP `ctx.ask` + `execute(args, opts)` body with `Effect.withSpan("Tool.execute", ...)`. Plugin `tool.execute.before`/`after` hooks remain outside the span, matching the native scope (`wrap()` covers decode + execute + truncate; the `before`/`after` triggers happen in the registry consumer).
- `packages/opencode/src/tool/registry.ts`: pipe `fromPlugin()`'s `Effect.gen` body through the same `withSpan` so user-defined tool files and plugin-supplied tools also emit the span.

## Verification

- `bun typecheck` (packages/opencode): passes
- `bun run test test/tool/registry.test.ts test/tool/tool-define.test.ts`: 7/7 pass