### PR TITLE
feat(ui): add dir="auto" for bidirectional text support

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1344,6 +1344,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               aria-multiline="true"
               aria-label={placeholder()}
               contenteditable="true"
+              dir="auto"
               autocapitalize={store.mode === "normal" ? "sentences" : "off"}
               autocorrect={store.mode === "normal" ? "on" : "off"}
               spellcheck={store.mode === "normal"}

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -337,6 +337,7 @@ export function Markdown(
   return (
     <div
       data-component="markdown"
+      dir="auto"
       classList={{
         ...local.classList,
         [local.class ?? ""]: !!local.class,

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1100,7 +1100,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
       <Show when={text()}>
         <>
           <div data-slot="user-message-body">
-            <div data-slot="user-message-text">
+            <div data-slot="user-message-text" dir="auto">
               <HighlightedText text={text()} references={inlineFiles()} agents={agents()} />
             </div>
           </div>


### PR DESCRIPTION
Add `dir="auto"` to key text-rendering elements to enable automatic text-direction detection for multilingual and bidirectional content.

### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

User messages typed in RTL languages (e.g. Arabic, Persian) were displaying left-aligned instead of right-to-left. This happened because the key text containers lacked a `dir` attribute, so the browser defaulted to LTR.

Adding `dir="auto"` fixes this by letting the browser detect text direction automatically based on the first strong character in each element — no extra configuration needed.

Files changed:
- `packages/app/src/components/prompt-input.tsx` — the contenteditable input field
- `packages/ui/src/components/markdown.tsx` — the Markdown root container (AI responses)
- `packages/ui/src/components/message-part.tsx` — the user message text slot

### How did you verify your code works?

Typed Arabic text in the prompt input and verified it renders right-to-left. Confirmed English text continues to render left-to-right in the same elements.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

