### PR TITLE
refactor(cli): drop ModelsDev Promise compat shim

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -212,7 +212,7 @@ export const GithubInstallCommand = cmd({
           const app = await getAppInfo()
           await installGitHubApp()
 
-          const providers = await ModelsDev.get().then((p) => {
+          const providers = await AppRuntime.runPromise(ModelsDev.Service.use((s) => s.get())).then((p) => {
             // TODO: add guide for copilot, for now just hide it
             delete p["github-copilot"]
             return p

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -4,6 +4,9 @@ import { cmd } from "./cmd"
 import * as prompts from "@clack/prompts"
 import { UI } from "../ui"
 import { ModelsDev } from "@/provider/models"
+
+const getModels = () => AppRuntime.runPromise(ModelsDev.Service.use((s) => s.get()))
+const refreshModels = () => AppRuntime.runPromise(ModelsDev.Service.use((s) => s.refresh(true)))
 import { map, pipe, sortBy, values } from "remeda"
 import path from "path"
 import os from "os"
@@ -245,7 +248,7 @@ export const ProvidersListCommand = cmd({
         return Object.entries(yield* auth.all())
       }),
     )
-    const database = await ModelsDev.get()
+    const database = await getModels()
 
     for (const [providerID, result] of results) {
       const name = database[providerID]?.name || providerID
@@ -334,14 +337,14 @@ export const ProvidersLoginCommand = cmd({
           prompts.outro("Done")
           return
         }
-        await ModelsDev.refresh(true).catch(() => {})
+        await refreshModels().catch(() => {})
 
         const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get()))
 
         const disabled = new Set(config.disabled_providers ?? [])
         const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
 
-        const providers = await ModelsDev.get().then((x) => {
+        const providers = await getModels().then((x) => {
           const filtered: Record<string, (typeof x)[string]> = {}
           for (const [key, value] of Object.entries(x)) {
             if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
@@ -505,7 +508,7 @@ export const ProvidersLogoutCommand = cmd({
       prompts.log.error("No credentials found")
       return
     }
-    const database = await ModelsDev.get()
+    const database = await getModels()
     const selected = await prompts.select({
       message: "Select provider",
       options: credentials.map(([key, value]) => ({

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -7,7 +7,6 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Flock } from "@opencode-ai/core/util/flock"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
-import { makeRuntime } from "@/effect/run-service"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 
 const Cost = Schema.Struct({
@@ -195,12 +194,5 @@ export const defaultLayer: Layer.Layer<Service> = layer.pipe(
   Layer.provide(FetchHttpClient.layer),
   Layer.provide(AppFileSystem.defaultLayer),
 )
-
-// Promise-style compat for callers in Promise-context (Hono routes, legacy CLI handlers).
-// makeRuntime uses the shared memoMap so this runtime's Service instance is the same one
-// AppRuntime sees — Effect callers and Promise callers operate on the same cache.
-const runtime = makeRuntime(Service, defaultLayer)
-export const get = () => runtime.runPromise((s) => s.get())
-export const refresh = (force = false) => runtime.runPromise((s) => s.refresh(force))
 
 export * as ModelsDev from "./models"


### PR DESCRIPTION
## Summary
- Route the two remaining Promise-context `ModelsDev.get/refresh` callers (`cli/cmd/github.ts` and `cli/cmd/providers.ts`) through the Effect Service via `AppRuntime.runPromise(ModelsDev.Service.use(...))`.
- Delete the standalone `makeRuntime` + `get/refresh` shim from `provider/models.ts` — no callers left.

Stacked on #25434 (already merged).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test test/provider/ test/server/` — 441 pass
- [x] Manual smoke: `bun run src/index.ts auth list` renders provider names from the models database (proves `providers.ts` Service path works end-to-end)