### PR TITLE
fix(agent): initialize plugins before resolving config

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -77,6 +77,10 @@ export const layer = Layer.effect(
     const skill = yield* Skill.Service
     const provider = yield* Provider.Service
 
+    // Some entry points resolve agents before project bootstrap runs, so ensure
+    // plugin config hooks have mutated config before agent state snapshots it.
+    yield* plugin.init()
+
     const state = yield* InstanceState.make<State>(
       Effect.fn("Agent.state")(function* (ctx) {
         const cfg = yield* config.get()


### PR DESCRIPTION
### Issue for this PR

Closes #25441
Also fixes #25450

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Re-submission of #25440 (auto-closed by the template bot, not by a maintainer). Original fix by @quangtran88, I am only repackaging it with the required PR template after hitting the bug myself on a fresh 1.14.32 install.

The bug: in v1.14.32, plugin-registered primary agents (e.g. those provided by `oh-my-openagent` such as `sisyphus`, `prometheus`, `atlas`) no longer appear in the TUI agent picker. Only the built-in `build` and `plan` show up.

Root cause: `Agent.Service` resolves `config.get()` and snapshots it into `InstanceState` before plugin `config()` hooks have run. The TUI hits `GET /agent` very early at startup, which triggers `Agent.Service` resolution before `Plugin.init()` has executed. Plugin-provided agents are therefore absent from the response.

The fix calls `plugin.init()` inside the `Agent.layer` effect, before the state snapshot. This mirrors how other services depend on plugin init being completed first.

### How did you verify your code works?

Reproduced the bug on macOS arm64, opencode `1.14.32` installed via `bun install -g opencode-ai`, with `oh-my-openagent@latest` configured in `~/.config/opencode/opencode.json`.

Log comparison before / after upgrade (same plugin config, same machine):

`1.14.31` (working):
```
GET /agent ... loading plugin oh-my-openagent@latest
GET /agent status=completed duration=1008
=> agent=Sisyphus - Ultraworker mode=primary
```

`1.14.32` (broken):
```
GET /agent ... [server replies before plugins finish loading]
GET /agent status=completed duration=197
loading plugin oh-my-openagent@latest [happens AFTER the response]
=> no plugin agents in the picker
```

After applying this patch (built locally with `bun dev`), `GET /agent` waits for plugins to register and the picker shows the plugin-provided primary agents again.

### Screenshots / recordings

N/A, the visible effect is a non-empty agent list in the TUI Tab picker.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR