### PR TITLE
refactor(cli): convert plugin command to effectCmd

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -1,16 +1,16 @@
 import { intro, log, outro, spinner } from "@clack/prompts"
-import type { Argv } from "yargs"
+import { Effect } from "effect"
 
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@opencode-ai/core/global"
 import { installPlugin, patchPluginConfig, readPluginManifest } from "../../plugin/install"
 import { resolvePluginTarget } from "../../plugin/shared"
-import { Instance } from "../../project/instance"
 import { errorMessage } from "../../util/error"
 import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 import { UI } from "../ui"
-import { cmd } from "./cmd"
+import { effectCmd } from "../effect-cmd"
+import { InstanceRef } from "@/effect/instance-ref"
 
 type Spin = {
   start: (msg: string) => void
@@ -175,12 +175,12 @@ export function createPlugTask(input: PlugInput, dep: PlugDeps = defaultPlugDeps
   }
 }
 
-export const PluginCommand = cmd({
+export const PluginCommand = effectCmd({
   command: "plugin <module>",
   aliases: ["plug"],
   describe: "install plugin and update config",
-  builder: (yargs: Argv) => {
-    return yargs
+  builder: (yargs) =>
+    yargs
       .positional("module", {
         type: "string",
         describe: "npm module name",
@@ -196,9 +196,8 @@ export const PluginCommand = cmd({
         type: "boolean",
         default: false,
         describe: "replace existing plugin version",
-      })
-  },
-  handler: async (args) => {
+      }),
+  handler: Effect.fn("Cli.plug")(function* (args) {
     const mod = String(args.module ?? "").trim()
     if (!mod) {
       UI.error("module is required")
@@ -214,20 +213,18 @@ export const PluginCommand = cmd({
       global: Boolean(args.global),
       force: Boolean(args.force),
     })
-    let ok = true
 
-    await Instance.provide({
-      directory: process.cwd(),
-      fn: async () => {
-        ok = await run({
-          vcs: Instance.project.vcs,
-          worktree: Instance.worktree,
-          directory: Instance.directory,
-        })
-      },
-    })
+    const ctx = yield* InstanceRef
+    if (!ctx) return
+    const ok = yield* Effect.promise(() =>
+      run({
+        vcs: ctx.project.vcs,
+        worktree: ctx.worktree,
+        directory: ctx.directory,
+      }),
+    )
 
     outro("Done")
     if (!ok) process.exitCode = 1
-  },
+  }),
 })

--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -31,6 +31,7 @@ export const fail = (message: string, exitCode = 1) => Effect.fail(new CliError(
  */
 export const effectCmd = <Args, A>(opts: {
   command: string | readonly string[]
+  aliases?: string | readonly string[]
   describe: string | false
   builder?: (yargs: Argv) => Argv<Args>
   /** Defaults to process.cwd(). Override for commands that take a directory positional. */
@@ -39,6 +40,7 @@ export const effectCmd = <Args, A>(opts: {
 }) =>
   cmd<{}, Args>({
     command: opts.command,
+    aliases: opts.aliases,
     describe: opts.describe,
     builder: opts.builder as never,
     async handler(rawArgs) {


### PR DESCRIPTION
## Summary
- Convert \`cli/cmd/plug.ts\` from \`cmd()\` + \`Instance.provide\` to \`effectCmd\`.
- \`createPlugTask\` is still a Promise function — wrapped with \`Effect.promise\`.
- Add \`aliases\` option to \`effectCmd\` so the existing \`"plug"\` alias for \`"plugin"\` is preserved.

## Behavioral notes
- Subagent purity audit: PURE.
- One cosmetic ordering: legacy printed \`intro("Install plugin …")\` BEFORE Instance.provide loaded. New prints AFTER InstanceStore.provide loads. Instance load is silent (no clack output), so user-visible output is identical.
- This command does NOT use \`bootstrap()\` (no disposal in legacy finally), same shape as #25465.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] \`plug\` alias still resolves to plugin command