### PR TITLE
feat(cli): auto-dispose InstanceContext after effectCmd handlers

### DIFF
--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -2,6 +2,7 @@ import type { Argv } from "yargs"
 import { Effect, Schema } from "effect"
 import { AppRuntime, type AppServices } from "@/effect/app-runtime"
 import { InstanceStore } from "@/project/instance-store"
+import { InstanceRef } from "@/effect/instance-ref"
 import { cmd } from "./cmd/cmd"
 
 /**
@@ -20,6 +21,11 @@ export const fail = (message: string, exitCode = 1) => Effect.fail(new CliError(
 /**
  * Effect-native CLI command builder. Wraps yargs `cmd()` so the handler body is
  * an `Effect` with `InstanceRef` provided and any `AppServices` yieldable.
+ *
+ * The handler is wrapped in `Effect.ensuring(store.dispose(ctx))` so the loaded
+ * InstanceContext is disposed (runDisposers + IPC `server.instance.disposed`)
+ * on every Exit — success, typed failure, defect, or interruption. Matches the
+ * legacy `bootstrap()` finally-disposal semantics without per-handler boilerplate.
  *
  * Errors propagate to the existing top-level handler in `src/index.ts`; use
  * `fail("...")` for user-visible domain failures (clean exit, formatted message).
@@ -47,6 +53,17 @@ export const effectCmd = <Args, A>(opts: {
       // yargs typing wraps Args in ArgumentsCamelCase<WithDoubleDash<...>>; cast at the boundary.
       const args = rawArgs as unknown as Args
       const directory = opts.directory?.(args) ?? process.cwd()
-      await AppRuntime.runPromise(InstanceStore.Service.use((s) => s.provide({ directory }, opts.handler(args))))
+      await AppRuntime.runPromise(
+        InstanceStore.Service.use((store) =>
+          store.provide(
+            { directory },
+            Effect.gen(function* () {
+              const ctx = yield* InstanceRef
+              const body = opts.handler(args)
+              return ctx ? yield* body.pipe(Effect.ensuring(store.dispose(ctx))) : yield* body
+            }),
+          ),
+        ),
+      )
     },
   })


### PR DESCRIPTION
## Summary
Wrap the user handler in \`Effect.ensuring(store.dispose(ctx))\` inside the \`effectCmd\` factory so per-command disposal is automatic — runs disposers and emits \`server.instance.disposed\` on every Exit (success / typed failure / defect / interruption). Matches the legacy \`bootstrap()\` finally semantics without per-handler boilerplate.

Two parallel subagent reviews of the debug-conversion PR (#25479) flagged the 14× repeated \`const ctx = yield* InstanceRef; if (!ctx) return; const store = yield* InstanceStore.Service; return yield* body.pipe(Effect.ensuring(store.dispose(ctx)))\` pattern as a footgun. This PR moves the responsibility into \`effectCmd\` itself.

## Behavioral notes
- Auto-dispose fires for **every** \`effectCmd\` invocation (didn't before).
- For commands previously converted that DIDN'T explicitly dispose (\`models.ts\`, \`pr.ts\`, \`plug.ts\`): they now dispose where they didn't. This is strictly safer (cleanup runs; emits IPC event the legacy \`Instance.provide\` would not have).
- For commands that DO explicitly dispose (\`import.ts\`, \`export.ts\`, \`stats.ts\`, all of \`debug/*\`): the explicit \`store.dispose(ctx)\` becomes a no-op the second time around (\`disposeEntry\` checks \`cache.get(directory) !== entry\` and returns false). Safe but redundant — those calls can be cleaned up in a follow-up.

## Followup (not in this PR)
Drop the now-redundant explicit \`Effect.ensuring(store.dispose(ctx))\` from \`import.ts\`, \`export.ts\`, \`stats.ts\`, and \`debug/*.ts\` once those PRs land. Keeps things tidy without breaking semantics in the meantime.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] Smoke: \`models\` and \`models --refresh\` (existing converted commands) still work end-to-end