### PR TITLE
feat(lsp): add languageId field to custom LSP server config

### DIFF
--- a/packages/opencode/src/config/lsp.ts
+++ b/packages/opencode/src/config/lsp.ts
@@ -14,6 +14,7 @@ export const Entry = Schema.Union([
   Schema.Struct({
     command: Schema.mutable(Schema.Array(Schema.String)),
     extensions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+    languageId: Schema.optional(Schema.String),
     disabled: Schema.optional(Schema.Boolean),
     env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
     initialization: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -138,7 +138,13 @@ function shouldSeedDiagnosticsOnFirstPush(serverID: string) {
   return serverID === "typescript"
 }
 
-export async function create(input: { serverID: string; server: LSPServer.Handle; root: string; directory: string }) {
+export async function create(input: {
+  serverID: string
+  server: LSPServer.Handle
+  root: string
+  directory: string
+  languageId?: string
+}) {
   const logger = log.clone().tag("serverID", input.serverID)
   logger.info("starting client")
 
@@ -588,7 +594,7 @@ export async function create(input: { serverID: string; server: LSPServer.Handle
         )
         const text = await Filesystem.readText(request.path)
         const extension = path.extname(request.path)
-        const languageId = LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
+        const languageId = input.languageId ?? LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
 
         const document = files[request.path]
         if (document !== undefined) {

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -184,6 +184,7 @@ export const layer = Layer.effect(
                 id: name,
                 root: existing?.root ?? (async (_file, ctx) => ctx.directory),
                 extensions: item.extensions ?? existing?.extensions ?? [],
+                languageId: item.languageId ?? existing?.languageId,
                 spawn: async (root) => ({
                   process: lspspawn(item.command[0], item.command.slice(1), {
                     cwd: root,
@@ -248,6 +249,7 @@ export const layer = Layer.effect(
             server: handle,
             root,
             directory: ctx.directory,
+            languageId: server.languageId,
           }).catch(async (err) => {
             s.broken.add(key)
             await Process.stop(handle.process)

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -58,6 +58,7 @@ const NearestRoot = (includePatterns: string[], excludePatterns?: string[]): Roo
 export interface Info {
   id: string
   extensions: string[]
+  languageId?: string
   global?: boolean
   root: RootFunction
   spawn(root: string, ctx: InstanceContext): Promise<Handle | undefined>

--- a/packages/opencode/test/config/lsp.test.ts
+++ b/packages/opencode/test/config/lsp.test.ts
@@ -51,6 +51,14 @@ describe("ConfigLSP.Info refinement", () => {
       expect(decodeEffect(input)).toEqual(input)
       expect(ConfigLSP.Info.zod.parse(input)).toEqual(input)
     })
+
+    test("custom server with languageId passes", () => {
+      const input = {
+        cfml: { command: ["node", "/path/to/bridge.js"], extensions: [".cfm", ".cfc"], languageId: "coldfusion" },
+      }
+      expect(decodeEffect(input)).toEqual(input)
+      expect(ConfigLSP.Info.zod.parse(input)).toEqual(input)
+    })
   })
 
   describe("rejected inputs", () => {

--- a/packages/opencode/test/fixture/lsp/fake-lsp-server.js
+++ b/packages/opencode/test/fixture/lsp/fake-lsp-server.js
@@ -3,6 +3,7 @@
 let nextId = 1
 let readBuffer = Buffer.alloc(0)
 let lastChange = null
+let lastDidOpen = null
 let initializeParams = null
 let diagnosticRequestCount = 0
 let registeredCapability = false
@@ -139,6 +140,7 @@ function handle(raw) {
   }
 
   if (data.method === "textDocument/didOpen") {
+    lastDidOpen = data.params
     maybeRegister("didOpen")
     return
   }
@@ -203,6 +205,11 @@ function handle(raw) {
 
   if (data.method === "test/get-last-change") {
     sendResponse(data.id, lastChange)
+    return
+  }
+
+  if (data.method === "test/get-last-did-open") {
+    sendResponse(data.id, lastDidOpen)
     return
   }
 

--- a/packages/opencode/test/lsp/client.test.ts
+++ b/packages/opencode/test/lsp/client.test.ts
@@ -144,6 +144,57 @@ describe("LSPClient interop", () => {
     await client.shutdown()
   })
 
+  test("didOpen uses LANGUAGE_EXTENSIONS when no languageId override", async () => {
+    const handle = spawnFakeServer() as any
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "test.ts")
+    await Bun.write(file, "const x = 1\n")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = await LSPClient.create({
+          serverID: "fake",
+          server: handle as unknown as LSPServer.Handle,
+          root: tmp.path,
+          directory: tmp.path,
+        })
+
+        await client.notify.open({ path: file })
+        const didOpen = await client.connection.sendRequest<any>("test/get-last-did-open", {})
+        expect(didOpen.textDocument.languageId).toBe("typescript")
+
+        await client.shutdown()
+      },
+    })
+  })
+
+  test("didOpen uses languageId override from config", async () => {
+    const handle = spawnFakeServer() as any
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "test.qml")
+    await Bun.write(file, "import QtQuick\n")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = await LSPClient.create({
+          serverID: "fake",
+          server: handle as unknown as LSPServer.Handle,
+          root: tmp.path,
+          directory: tmp.path,
+          languageId: "qml",
+        })
+
+        await client.notify.open({ path: file })
+        const didOpen = await client.connection.sendRequest<any>("test/get-last-did-open", {})
+        expect(didOpen.textDocument.languageId).toBe("qml")
+
+        await client.shutdown()
+      },
+    })
+  })
+
   test("sends ranged didChange for incremental sync servers", async () => {
     const handle = spawnFakeServer() as any
     await using tmp = await tmpdir()


### PR DESCRIPTION
### Issue for this PR

Closes #20526

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom LSP servers can specify `extensions` but there's no way to control the `languageId` sent in `textDocument/didOpen`. Extensions not in the built-in `LANGUAGE_EXTENSIONS` map fall back to `"plaintext"`, and the `lsp` tool blocks requests with "No LSP server available for this file type".

This adds an optional `languageId` field to custom LSP server config:

```json
{
  "lsp": {
    "qml": {
      "command": ["qmlls"],
      "extensions": [".qml"],
      "languageId": "qml"
    }
  }
}
```

When set, the client sends that value in `didOpen` instead of looking up the extension in `LANGUAGE_EXTENSIONS`. When unset, behavior is unchanged.

The change threads `languageId` through four layers: config schema, server `Info` interface, server construction from config, and client `create`/`notify.open`.

### How did you verify your code works?

- Added config schema test verifying `languageId` is accepted by both Effect decode and derived Zod
- Added two client tests: one confirming default `LANGUAGE_EXTENSIONS` behavior, one confirming `languageId` override reaches `didOpen`
- All 24 tests pass, full typecheck passes across all 13 packages

### Screenshots / recordings

_N/A - no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR