### PR TITLE
fix(opencode): exclude .map files from CLI binary

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -61,6 +61,7 @@ const createEmbeddedWebUIBundle = async () => {
   await $`bun run --cwd ${appDir} build`
   const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: dist })))
     .map((file) => file.replaceAll("\\", "/"))
+    .filter((file) => !file.endsWith(".map"))
     .sort()
   const imports = files.map((file, i) => {
     const spec = path.relative(dir, path.join(dist, file)).replaceAll("\\", "/")


### PR DESCRIPTION
### Issue for this PR


### Type of change

- [x] Bug fix

### What does this PR do?

The CLI build embeds all web UI dist files via a catch-all `Bun.Glob("**/*")` in `build.ts`. This catches `.map` source map files that are only needed for Sentry uploads in the hosted deployment. They are dead weight in a compiled Bun binary.

Adds a `.filter()` to skip `.map` files, saving ~24MB (167MB → 144MB).

### How did you verify your code works?

- Built with `bun run build --single` — binary compiles and passes smoke test (`opencode --version`)
- `opencode serve` serves the web UI correctly without the embedded source maps

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR