### PR TITLE
fix(session): detect empty tool args from gpt-5.5 and prevent abort loop

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -351,6 +351,21 @@ const live: Layer.Layer<
               toolName: lower,
             }
           }
+          const toolName = failed.toolCall.toolName
+          const rawInput = failed.toolCall.input
+          const isEmptyArgs = rawInput == null || (typeof rawInput === "object" && Object.keys(rawInput).length === 0)
+          if (isEmptyArgs && ["apply_patch"].includes(toolName)) {
+            l.info("repairing empty tool args", { tool: toolName })
+            return {
+              ...failed.toolCall,
+              input: JSON.stringify({
+                _empty_args_repair: true,
+                tool: toolName,
+                message: "Model provided empty tool args. Please retry with valid arguments."
+              }),
+              toolName: "invalid",
+            }
+          }
           return {
             ...failed.toolCall,
             input: JSON.stringify({

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -288,6 +288,15 @@ export const layer: Layer.Layer<
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
             }
+
+            // Runtime fix: Abort tool calls with empty args to prevent infinite loops (e.g. gpt-5.5 streaming defect)
+            const isEmptyArgs = Object.keys(value.input ?? {}).length === 0
+            if (isEmptyArgs) {
+              slog.info("Empty tool args detected, aborting", { tool: value.toolName })
+              yield* failToolCall(value.toolCallId, new Error("Empty tool arguments received. Aborting to prevent loop."))
+              return
+            }
+
             yield* updateToolCall(value.toolCallId, (match) => ({
               ...match,
               tool: value.toolName,


### PR DESCRIPTION
## Description

Fixes #20227

This PR addresses the recurring `Tool execution aborted` errors experienced when using gpt-5.5 (and other models) that cause empty or invalid tool arguments during streaming JSON serialization. This manifests as an infinite abort loop in the `apply_patch` tool, rendering the model unusable for file modification tasks.

The `ai` SDK, when streaming tool arguments as JSON, occasionally serializes complex multiline strings (like `patchText`) as an empty `{}` when the model provides malformed or truncated JSON. This empty payload is then passed to the tool execution layer, which aborts because required parameters are missing. Because the model receives the same invalid history on retry, it repeats the error, creating a doom loop.

## Changes

1. **`llm.ts` — `experimental_repairToolCall`**: Added detection for empty tool arguments (`rawInput == null` or `Object.keys(rawInput).length === 0`). When detected for the `apply_patch` tool, it injects a structured error message directing the model to retry with valid arguments, rather than letting the tool executor abort.
2. **`processor.ts` — `tool-call` event handler**: Added an early-exit guard that immediately fails a tool call with a clear error message if the input arguments are empty. This prevents the tool from even starting execution and avoids the downstream `Tool execution aborted` loop.

## References

- Related: OmO Issue #3041, sst/opencode PR #25385
- Related: OpenCode issues #13102, #18108
- Related: OmO PR #3170 (OmO-side workaround for `apply_patch` empty `content`)

## Notes

This is a **runtime-level mitigation**, not a complete fix for the underlying model behavior. It prevents the abort loop by:
- Intercepting invalid tool calls before they reach the executor.
- Providing the model with feedback to retry.
- Falling back gracefully instead of crashing.

A more fundamental fix would require changes in how the `ai` SDK or the model serializes streaming JSON, tracked in the upstream PRs referenced above.

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] My code follows the existing style in the affected files.
- [x] I have run `bun typecheck` and it passes.
- [ ] I have added tests (if applicable).
- [ ] I have updated documentation (if applicable).