### PR TITLE
refactor(cli): convert web + account to effectCmd (instance: false)

### DIFF
--- a/packages/opencode/src/cli/cmd/account.ts
+++ b/packages/opencode/src/cli/cmd/account.ts
@@ -3,7 +3,7 @@ import { Duration, Effect, Match, Option } from "effect"
 import { UI } from "../ui"
 import { Account } from "@/account/account"
 import { AccountID, OrgID, PollExpired, type PollResult, type AccountError } from "@/account/schema"
-import { AppRuntime } from "@/effect/app-runtime"
+import { effectCmd } from "../effect-cmd"
 import * as Prompt from "../effect/prompt"
 import open from "open"
 
@@ -172,60 +172,65 @@ const openEffect = Effect.fn("open")(function* () {
   yield* Prompt.outro("Opened " + url)
 })
 
-export const LoginCommand = cmd({
+export const LoginCommand = effectCmd({
   command: "login <url>",
   describe: false,
+  instance: false,
   builder: (yargs) =>
     yargs.positional("url", {
       describe: "server URL",
       type: "string",
       demandOption: true,
     }),
-  async handler(args) {
+  handler: Effect.fn("Cli.account.login")(function* (args) {
     UI.empty()
-    await AppRuntime.runPromise(loginEffect(args.url))
-  },
+    yield* Effect.orDie(loginEffect(args.url))
+  }),
 })
 
-export const LogoutCommand = cmd({
+export const LogoutCommand = effectCmd({
   command: "logout [email]",
   describe: false,
+  instance: false,
   builder: (yargs) =>
     yargs.positional("email", {
       describe: "account email to log out from",
       type: "string",
     }),
-  async handler(args) {
+  handler: Effect.fn("Cli.account.logout")(function* (args) {
     UI.empty()
-    await AppRuntime.runPromise(logoutEffect(args.email))
-  },
+    yield* Effect.orDie(logoutEffect(args.email))
+  }),
 })
 
-export const SwitchCommand = cmd({
+export const SwitchCommand = effectCmd({
   command: "switch",
   describe: false,
-  async handler() {
+  instance: false,
+  handler: Effect.fn("Cli.account.switch")(function* () {
     UI.empty()
-    await AppRuntime.runPromise(switchEffect())
-  },
+    yield* Effect.orDie(switchEffect())
+  }),
 })
 
-export const OrgsCommand = cmd({
+export const OrgsCommand = effectCmd({
   command: "orgs",
   describe: false,
-  async handler() {
+  instance: false,
+  handler: Effect.fn("Cli.account.orgs")(function* () {
     UI.empty()
-    await AppRuntime.runPromise(orgsEffect())
-  },
+    yield* Effect.orDie(orgsEffect())
+  }),
 })
 
-export const OpenCommand = cmd({
+export const OpenCommand = effectCmd({
   command: "open",
   describe: false,
-  async handler() {
+  instance: false,
+  handler: Effect.fn("Cli.account.open")(function* () {
     UI.empty()
-    await AppRuntime.runPromise(openEffect())
-  },
+    yield* Effect.orDie(openEffect())
+  }),
 })
 
 export const ConsoleCommand = cmd({

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -19,7 +19,6 @@ export const ServeCommand = effectCmd({
     const server = yield* Effect.promise(() => Server.listen(opts))
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 
-    yield* Effect.promise(() => new Promise<void>(() => {}))
-    yield* Effect.promise(() => server.stop())
+    yield* Effect.never
   }),
 })

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,21 +1,25 @@
+import { Effect } from "effect"
 import { Server } from "../../server/server"
-import { cmd } from "./cmd"
+import { effectCmd } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 
-export const ServeCommand = cmd({
+export const ServeCommand = effectCmd({
   command: "serve",
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "starts a headless opencode server",
-  handler: async (args) => {
+  // Server loads instances per-request via x-opencode-directory header — no
+  // need for an ambient project InstanceContext at startup.
+  instance: false,
+  handler: Effect.fn("Cli.serve")(function* (args) {
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
-    const opts = await resolveNetworkOptions(args)
-    const server = await Server.listen(opts)
+    const opts = yield* Effect.promise(() => resolveNetworkOptions(args))
+    const server = yield* Effect.promise(() => Server.listen(opts))
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 
-    await new Promise(() => {})
-    await server.stop()
-  },
+    yield* Effect.promise(() => new Promise<void>(() => {}))
+    yield* Effect.promise(() => server.stop())
+  }),
 })

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -1,6 +1,7 @@
+import { Effect } from "effect"
 import { Server } from "../../server/server"
 import { UI } from "../ui"
-import { cmd } from "./cmd"
+import { effectCmd } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import open from "open"
@@ -28,16 +29,19 @@ function getNetworkIPs() {
   return results
 }
 
-export const WebCommand = cmd({
+export const WebCommand = effectCmd({
   command: "web",
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
-  handler: async (args) => {
+  // Server loads instances per-request via x-opencode-directory header — no
+  // ambient project InstanceContext needed at startup.
+  instance: false,
+  handler: Effect.fn("Cli.web")(function* (args) {
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
-    const opts = await resolveNetworkOptions(args)
-    const server = await Server.listen(opts)
+    const opts = yield* Effect.promise(() => resolveNetworkOptions(args))
+    const server = yield* Effect.promise(() => Server.listen(opts))
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
@@ -75,7 +79,6 @@ export const WebCommand = cmd({
       open(displayUrl).catch(() => {})
     }
 
-    await new Promise(() => {})
-    await server.stop()
-  },
+    yield* Effect.never
+  }),
 })

--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -18,6 +18,34 @@ export class CliError extends Schema.TaggedErrorClass<CliError>()("CliError", {
 
 export const fail = (message: string, exitCode = 1) => Effect.fail(new CliError({ message, exitCode }))
 
+interface EffectCmdOpts<Args, A> {
+  command: string | readonly string[]
+  aliases?: string | readonly string[]
+  describe: string | false
+  builder?: (yargs: Argv) => Argv<Args>
+  /**
+   * Whether the command needs a project InstanceContext. Defaults to true.
+   *
+   * `true` (default): wraps the handler in `InstanceStore.Service.provide({directory})`
+   * so `InstanceRef` resolves to a loaded `InstanceContext`. Auto-disposes via
+   * `Effect.ensuring(store.dispose(ctx))` on every Exit (matches the legacy
+   * `bootstrap()` finally-disposal). Runs InstanceBootstrap (config + plugin
+   * init + LSP/File/etc forks) eagerly.
+   *
+   * `false`: skip the instance entirely. Saves the InstanceBootstrap work and
+   * suppresses the `server.instance.disposed` IPC event. The handler runs
+   * directly under AppRuntime — it can yield any `AppServices` but must not
+   * yield `InstanceRef` (it'd be undefined, causing a defect).
+   *
+   * Use `false` for commands that don't read project state (e.g. `models`,
+   * `serve`, `web`, `account`, `db`, `upgrade`).
+   */
+  instance?: boolean
+  /** Defaults to process.cwd(). Override for commands that take a directory positional. */
+  directory?: (args: Args) => string
+  handler: (args: Args) => Effect.Effect<A, CliError, AppServices | InstanceStore.Service>
+}
+
 /**
  * Effect-native CLI command builder. Wraps yargs `cmd()` so the handler body is
  * an `Effect` with `InstanceRef` provided and any `AppServices` yieldable.
@@ -35,15 +63,7 @@ export const fail = (message: string, exitCode = 1) => Effect.fail(new CliError(
  * `effectCmd`, swapping the underlying `cmd()` factory for effect/cli's
  * `Command.make(...)` won't touch any handler bodies.
  */
-export const effectCmd = <Args, A>(opts: {
-  command: string | readonly string[]
-  aliases?: string | readonly string[]
-  describe: string | false
-  builder?: (yargs: Argv) => Argv<Args>
-  /** Defaults to process.cwd(). Override for commands that take a directory positional. */
-  directory?: (args: Args) => string
-  handler: (args: Args) => Effect.Effect<A, CliError, AppServices | InstanceStore.Service>
-}) =>
+export const effectCmd = <Args, A>(opts: EffectCmdOpts<Args, A>) =>
   cmd<{}, Args>({
     command: opts.command,
     aliases: opts.aliases,
@@ -52,6 +72,10 @@ export const effectCmd = <Args, A>(opts: {
     async handler(rawArgs) {
       // yargs typing wraps Args in ArgumentsCamelCase<WithDoubleDash<...>>; cast at the boundary.
       const args = rawArgs as unknown as Args
+      if (opts.instance === false) {
+        await AppRuntime.runPromise(opts.handler(args))
+        return
+      }
       const directory = opts.directory?.(args) ?? process.cwd()
       await AppRuntime.runPromise(
         InstanceStore.Service.use((store) =>


### PR DESCRIPTION
## Summary
First users of #25507's \`instance: false\` opt-out:
- **\`web\`**: server resolves project directories per-request via \`x-opencode-directory\` header — same shape as just-converted \`serve\`. Uses \`Effect.never\` to block.
- **\`account\`** (5 subcommands: login, logout, switch, orgs, open): operates on global account state, no project instance needed. Each was already a thin \`await AppRuntime.runPromise(somethingEffect())\` wrap around an Effect-native body — now the body becomes the handler directly. \`Effect.orDie\` preserves the legacy unhandled-error path through \`FormatError\`'s "Unexpected error" banner.

\`ConsoleCommand\` stays on \`cmd()\` (just dispatches to subcommands).

## Behavioral notes
- No instance load, no \`server.instance.disposed\` IPC event — matches legacy behavior exactly (these commands never loaded an instance before either).
- \`account\` errors (typed \`AccountError\`) are now defects via \`Effect.orDie\`. Top-level \`FormatError\` has no special case for them either way → same "Unexpected error" banner + exit 1 in both legacy and new.

## Stacked on #25507
Depends on \`instance: false\` landing.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] Smoke: \`web --port 0\` shows logo + URL, opens browser
- [x] Smoke: \`auth list\` (uses \`AccountCommand\` indirectly) renders provider names
- [x] Smoke: \`console --help\` shows all 5 subcommands
- [x] Smoke: \`console orgs\` → "No accounts found" (matches legacy)