### PR TITLE
feat: support serving opencode from a subpath

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -4,20 +4,20 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <title>OpenCode</title>
-    <link rel="icon" type="image/png" href="/favicon-96x96-v3.png" sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href="/favicon-v3.svg" />
-    <link rel="shortcut icon" href="/favicon-v3.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v3.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" type="image/png" href="./favicon-96x96-v3.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="./favicon-v3.svg" />
+    <link rel="shortcut icon" href="./favicon-v3.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon-v3.png" />
+    <link rel="manifest" href="./site.webmanifest" />
     <meta name="theme-color" content="#F8F7F7" />
     <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
-    <meta property="og:image" content="/social-share.png" />
-    <meta property="twitter:image" content="/social-share.png" />
-    <script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>
+    <meta property="og:image" content="./social-share.png" />
+    <meta property="twitter:image" content="./social-share.png" />
+    <script id="oc-theme-preload-script" src="./oc-theme-preload.js"></script>
   </head>
   <body class="antialiased overscroll-none text-12-regular overflow-hidden">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" class="flex flex-col h-dvh p-px"></div>
-    <script src="/src/entry.tsx" type="module"></script>
+    <script src="./src/entry.tsx" type="module"></script>
   </body>
 </html>

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -43,6 +43,7 @@ import { ServerConnection, ServerProvider, serverName, useServer } from "@/conte
 import { SettingsProvider } from "@/context/settings"
 import { TerminalProvider } from "@/context/terminal"
 import DirectoryLayout from "@/pages/directory-layout"
+import { runtimeBasePath, stripBrowserBasePath } from "@/utils/base-path"
 import Layout from "@/pages/layout"
 import { ErrorPage } from "./pages/error"
 import { useCheckServerHealth } from "./utils/server-health"
@@ -52,7 +53,7 @@ const loadSession = () => import("@/pages/session")
 const Session = lazy(loadSession)
 const Loading = () => <div class="size-full" />
 
-if (typeof location === "object" && /\/session(?:\/|$)/.test(location.pathname)) {
+if (typeof location === "object" && /\/session(?:\/|$)/.test(stripBrowserBasePath(location.pathname, runtimeBasePath()))) {
   void loadSession()
 }
 
@@ -294,6 +295,7 @@ function ServerKey(props: ParentProps) {
 
 export function AppInterface(props: {
   children?: JSX.Element
+  basePath?: string
   defaultServer: ServerConnection.Key
   servers?: Array<ServerConnection.Any>
   router?: Component<BaseRouterProps>
@@ -312,6 +314,7 @@ export function AppInterface(props: {
               <GlobalSyncProvider>
                 <Dynamic
                   component={props.router ?? Router}
+                  base={props.basePath}
                   root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
                 >
                   <Route path="/" component={HomeRoute} />

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -6,6 +6,7 @@ import { AppBaseProviders, AppInterface } from "@/app"
 import { type Platform, PlatformProvider } from "@/context/platform"
 import { dict as en } from "@/i18n/en"
 import { dict as zh } from "@/i18n/zh"
+import { currentServerUrl, runtimeBasePath } from "@/utils/base-path"
 import { handleNotificationClick } from "@/utils/notification-click"
 import pkg from "../package.json"
 import { ServerConnection } from "./context/server"
@@ -102,7 +103,7 @@ const getCurrentUrl = () => {
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
-  return location.origin
+  return currentServerUrl()
 }
 
 const getDefaultUrl = () => {
@@ -152,6 +153,7 @@ if (root instanceof HTMLElement) {
       <PlatformProvider value={platform}>
         <AppBaseProviders>
           <AppInterface
+            basePath={runtimeBasePath()}
             defaultServer={ServerConnection.Key.make(getDefaultUrl())}
             servers={[server]}
             disableHealthCheck

--- a/packages/app/src/index-shell.test.ts
+++ b/packages/app/src/index-shell.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test"
+
+describe("index html shell", () => {
+  test("uses relative asset and entry paths so the app can mount under a subpath", async () => {
+    const html = await Bun.file(new URL("../index.html", import.meta.url)).text()
+
+    expect(html).toContain('href="./favicon-v3.svg"')
+    expect(html).toContain('src="./src/entry.tsx"')
+    expect(html).toContain('src="./oc-theme-preload.js"')
+  })
+})

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -8,6 +8,7 @@ import { LocalProvider } from "@/context/local"
 import { SDKProvider } from "@/context/sdk"
 import { SyncProvider, useSync } from "@/context/sync"
 import { decode64 } from "@/utils/base64"
+import { runtimeBasePath, stripBrowserBasePath } from "@/utils/base-path"
 
 function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   const location = useLocation()
@@ -19,7 +20,7 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   createEffect(() => {
     const next = sync.data.path.directory
     if (!next || next === props.directory) return
-    const path = location.pathname.slice(slug().length + 1)
+    const path = stripBrowserBasePath(location.pathname, runtimeBasePath()).slice(slug().length + 1)
     navigate(`/${base64Encode(next)}${path}${location.search}${location.hash}`, { replace: true })
   })
 

--- a/packages/app/src/utils/base-path.test.ts
+++ b/packages/app/src/utils/base-path.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { currentServerUrl, runtimeBasePath, stripBrowserBasePath } from "./base-path"
+
+const originalHead = document.head.innerHTML
+
+afterEach(() => {
+  document.head.innerHTML = originalHead
+})
+
+describe("base path runtime helpers", () => {
+  test("reads the injected base path from document metadata", () => {
+    document.head.innerHTML = '<meta name="opencode-base-path" content="/opencode/">'
+
+    expect(runtimeBasePath(document)).toBe("/opencode")
+  })
+
+  test("builds the current server url from origin and base path", () => {
+    document.head.innerHTML = '<meta name="opencode-base-path" content="/opencode">'
+
+    expect(currentServerUrl(new URL("https://example.com/opencode/session/abc"), document)).toBe("https://example.com/opencode")
+  })
+
+  test("strips the browser mount path before app-specific pathname logic", () => {
+    expect(stripBrowserBasePath("/opencode/session/abc", "/opencode")).toBe("/session/abc")
+    expect(stripBrowserBasePath("/session/abc", "/opencode")).toBe("/session/abc")
+  })
+})

--- a/packages/app/src/utils/base-path.ts
+++ b/packages/app/src/utils/base-path.ts
@@ -1,0 +1,21 @@
+function normalizeBasePath(input?: string | null) {
+  const value = input?.trim() ?? ""
+  if (!value || value === "/") return ""
+  const next = value.startsWith("/") ? value : `/${value}`
+  return next.replace(/\/+$/, "")
+}
+
+export function runtimeBasePath(doc = document) {
+  return normalizeBasePath(doc.querySelector('meta[name="opencode-base-path"]')?.getAttribute("content"))
+}
+
+export function currentServerUrl(location: Pick<Location, "origin"> | URL = window.location, doc = document) {
+  return `${location.origin}${runtimeBasePath(doc)}`.replace(/\/+$/, "")
+}
+
+export function stripBrowserBasePath(pathname: string, basePath = runtimeBasePath()) {
+  if (!basePath) return pathname || "/"
+  if (pathname === basePath) return "/"
+  if (pathname.startsWith(basePath + "/")) return pathname.slice(basePath.length) || "/"
+  return pathname || "/"
+}

--- a/packages/app/src/vite-config.test.ts
+++ b/packages/app/src/vite-config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test"
+
+describe("vite config", () => {
+  test("uses a relative base for subpath-safe asset output", async () => {
+    const source = await Bun.file(new URL("../vite.config.ts", import.meta.url)).text()
+
+    expect(source).toContain('base: "./"')
+  })
+})

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -20,6 +20,7 @@ const sentry =
     : false
 
 export default defineConfig({
+  base: "./",
   plugins: [desktopPlugin, sentry] as any,
   server: {
     host: "0.0.0.0",

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -28,7 +28,7 @@ export default [
     name: "opencode-desktop:theme-preload",
     transformIndexHtml(html) {
       return html.replace(
-        '<script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>',
+        '<script id="oc-theme-preload-script" src="./oc-theme-preload.js"></script>',
         `<script id="oc-theme-preload-script">${readFileSync(theme, "utf8")}</script>`,
       )
     },

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -17,7 +17,7 @@ export const ServeCommand = effectCmd({
     }
     const opts = yield* Effect.promise(() => resolveNetworkOptions(args))
     const server = yield* Effect.promise(() => Server.listen(opts))
-    console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    console.log(`opencode server listening on ${server.url.toString()}`)
 
     yield* Effect.never
   }),

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -48,17 +48,20 @@ export const WebCommand = effectCmd({
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access
-      const localhostUrl = `http://localhost:${server.port}`
-      UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl)
+      const localhostUrl = new URL(server.url)
+      localhostUrl.hostname = "localhost"
+      UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl.toString())
 
       // Show network IPs for remote access
       const networkIPs = getNetworkIPs()
       if (networkIPs.length > 0) {
         for (const ip of networkIPs) {
+          const networkUrl = new URL(server.url)
+          networkUrl.hostname = ip
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,
-            `http://${ip}:${server.port}`,
+            networkUrl.toString(),
           )
         }
       }

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -1,6 +1,7 @@
 import type { Argv, InferredOptionTypes } from "yargs"
 import { Config } from "@/config/config"
 import { AppRuntime } from "@/effect/app-runtime"
+import { normalizeBasePath } from "@/server/base-path"
 
 const options = {
   port: {
@@ -12,6 +13,11 @@ const options = {
     type: "string" as const,
     describe: "hostname to listen on",
     default: "127.0.0.1",
+  },
+  "base-path": {
+    type: "string" as const,
+    describe: "URL prefix to mount the server under",
+    default: "",
   },
   mdns: {
     type: "boolean" as const,
@@ -44,11 +50,15 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
 export function resolveNetworkOptionsNoConfig(args: NetworkOptions, config?: Config.Info) {
   const portExplicitlySet = process.argv.includes("--port")
   const hostnameExplicitlySet = process.argv.includes("--hostname")
+  const basePathExplicitlySet = process.argv.includes("--base-path")
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const mdnsDomainExplicitlySet = process.argv.includes("--mdns-domain")
   const mdns = mdnsExplicitlySet ? args.mdns : (config?.server?.mdns ?? args.mdns)
   const mdnsDomain = mdnsDomainExplicitlySet ? args["mdns-domain"] : (config?.server?.mdnsDomain ?? args["mdns-domain"])
   const port = portExplicitlySet ? args.port : (config?.server?.port ?? args.port)
+  const basePath = normalizeBasePath(
+    basePathExplicitlySet ? args["base-path"] : (config?.server?.basePath ?? args["base-path"]),
+  )
   const hostname = hostnameExplicitlySet
     ? args.hostname
     : mdns && !config?.server?.hostname
@@ -58,5 +68,5 @@ export function resolveNetworkOptionsNoConfig(args: NetworkOptions, config?: Con
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
 
-  return { hostname, port, mdns, mdnsDomain, cors }
+  return { hostname, port, basePath, mdns, mdnsDomain, cors }
 }

--- a/packages/opencode/src/config/server.ts
+++ b/packages/opencode/src/config/server.ts
@@ -7,6 +7,7 @@ export const Server = Schema.Struct({
     description: "Port to listen on",
   }),
   hostname: Schema.optional(Schema.String).annotate({ description: "Hostname to listen on" }),
+  basePath: Schema.optional(Schema.String).annotate({ description: "URL prefix to mount the server under" }),
   mdns: Schema.optional(Schema.Boolean).annotate({ description: "Enable mDNS service discovery" }),
   mdnsDomain: Schema.optional(Schema.String).annotate({
     description: "Custom domain name for mDNS service (default: opencode.local)",

--- a/packages/opencode/src/server/base-path.ts
+++ b/packages/opencode/src/server/base-path.ts
@@ -1,0 +1,24 @@
+export function normalizeBasePath(input?: string) {
+  const value = input?.trim() ?? ""
+  if (!value || value === "/") return ""
+  const next = value.startsWith("/") ? value : `/${value}`
+  return next.replace(/\/+$/, "")
+}
+
+export function stripBasePath(pathname: string, basePath: string) {
+  if (!basePath) return pathname || "/"
+  if (pathname === basePath) return "/"
+  if (pathname.startsWith(basePath + "/")) return pathname.slice(basePath.length) || "/"
+  return pathname || "/"
+}
+
+export function rewriteRequestBasePath(request: Request, basePath: string) {
+  if (!basePath) return request
+  const url = new URL(request.url)
+  const pathname = stripBasePath(url.pathname, basePath)
+  if (pathname === url.pathname) return request
+  url.pathname = pathname
+  return new Request(url, request)
+}
+
+export * as ServerBasePath from "./base-path"

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -72,6 +72,10 @@ import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import * as ServerBackend from "@/server/backend"
 
+type RouteOptions = CorsOptions & {
+  basePath?: string
+}
+
 export const context = Context.makeUnsafe<unknown>(new Map())
 
 const runtime = HttpRouter.middleware()(
@@ -131,18 +135,19 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
   ]),
 )
 
-const uiRoute = HttpRouter.use((router) =>
+const uiRoute = (basePath = "") =>
+  HttpRouter.use((router) =>
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
     const client = yield* HttpClient.HttpClient
-    yield* router.add("*", "/*", (request) => serveUIEffect(request, { fs, client }))
+    yield* router.add("*", "/*", (request) => serveUIEffect(request, { fs, client }, basePath))
   }),
 ).pipe(Layer.provide(authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuthConfig.defaultLayer))))
 
-export function createRoutes(corsOptions?: CorsOptions) {
-  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, uiRoute).pipe(
+export function createRoutes(opts: RouteOptions = {}) {
+  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, uiRoute(opts.basePath)).pipe(
     Layer.provide([
-      cors(corsOptions),
+      cors(opts),
       runtime,
       Account.defaultLayer,
       Agent.defaultLayer,
@@ -200,9 +205,9 @@ const defaultWebHandler = lazy(() =>
   }),
 )
 
-export function webHandler(corsOptions?: CorsOptions) {
-  if (!corsOptions?.cors?.length) return defaultWebHandler()
-  return HttpRouter.toWebHandler(createRoutes(corsOptions), {
+export function webHandler(opts: RouteOptions = {}) {
+  if (!opts.basePath && !opts.cors?.length) return defaultWebHandler()
+  return HttpRouter.toWebHandler(createRoutes(opts), {
     // Server-level CORS options are dynamic; don't reuse the default route layer memoized without them.
     memoMap: Layer.makeMemoMapUnsafe(),
     middleware: disposeMiddleware,

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -8,6 +8,7 @@ import { getMimeType } from "hono/utils/mime"
 import { createHash } from "node:crypto"
 import fs from "node:fs/promises"
 import { ProxyUtil } from "../proxy-util"
+import { stripBasePath } from "../base-path"
 
 const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
   ? Promise.resolve(null)
@@ -20,6 +21,11 @@ const UI_UPSTREAM = new URL("https://app.opencode.ai")
 
 const csp = (hash = "") =>
   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
+
+function injectBasePath(body: string, basePath: string) {
+  if (!basePath) return body
+  return body.replace("</head>", `<meta name="opencode-base-path" content="${basePath}"></head>`)
+}
 
 function themePreloadHash(body: string) {
   return body.match(/<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i)
@@ -49,9 +55,9 @@ function embeddedUI() {
   return embeddedUIPromise
 }
 
-export async function serveUI(request: Request) {
+export async function serveUI(request: Request, basePath = "") {
   const embeddedWebUI = await embeddedUI()
-  const path = new URL(request.url).pathname
+  const path = stripBasePath(new URL(request.url).pathname, basePath)
 
   if (embeddedWebUI) {
     const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
@@ -61,7 +67,8 @@ export async function serveUI(request: Request) {
       const mime = getMimeType(match) ?? "text/plain"
       const headers = new Headers({ "content-type": mime })
       if (mime.startsWith("text/html")) headers.set("content-security-policy", DEFAULT_CSP)
-      return new Response(new Uint8Array(await fs.readFile(match)), { headers })
+      if (!mime.startsWith("text/html")) return new Response(new Uint8Array(await fs.readFile(match)), { headers })
+      return new Response(injectBasePath(await fs.readFile(match, "utf8"), basePath), { headers })
     }
 
     return Response.json({ error: "Not Found" }, { status: 404 })
@@ -71,21 +78,22 @@ export async function serveUI(request: Request) {
     raw: request,
     headers: ProxyUtil.headers(request, { host: UI_UPSTREAM.host }),
   })
-  const match = response.headers.get("content-type")?.includes("text/html")
-    ? themePreloadHash(await response.clone().text())
-    : undefined
+  const html = response.headers.get("content-type")?.includes("text/html") ? injectBasePath(await response.clone().text(), basePath) : undefined
+  const match = html ? themePreloadHash(html) : undefined
   const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
   response.headers.set("Content-Security-Policy", csp(hash))
+  if (html) return new Response(html, { status: response.status, headers: response.headers })
   return response
 }
 
 export function serveUIEffect(
   request: HttpServerRequest.HttpServerRequest,
   services: { fs: AppFileSystem.Interface; client: HttpClient.HttpClient },
+  basePath = "",
 ) {
   return Effect.gen(function* () {
     const embeddedWebUI = yield* Effect.promise(() => embeddedUI())
-    const path = new URL(request.url, "http://localhost").pathname
+    const path = stripBasePath(new URL(request.url, "http://localhost").pathname, basePath)
 
     if (embeddedWebUI) {
       const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
@@ -95,7 +103,8 @@ export function serveUIEffect(
         const mime = getMimeType(match) ?? "text/plain"
         const headers = new Headers({ "content-type": mime })
         if (mime.startsWith("text/html")) headers.set("content-security-policy", DEFAULT_CSP)
-        return HttpServerResponse.raw(yield* services.fs.readFile(match), { headers })
+        if (!mime.startsWith("text/html")) return HttpServerResponse.raw(yield* services.fs.readFile(match), { headers })
+        return HttpServerResponse.text(injectBasePath(yield* services.fs.readFileString(match), basePath), { headers })
       }
 
       return HttpServerResponse.jsonUnsafe({ error: "Not Found" }, { status: 404 })
@@ -110,7 +119,7 @@ export function serveUIEffect(
     const headers = proxyResponseHeaders(response.headers)
 
     if (response.headers["content-type"]?.includes("text/html")) {
-      const body = yield* response.text
+      const body = injectBasePath(yield* response.text, basePath)
       const match = themePreloadHash(body)
       headers.set("Content-Security-Policy", csp(match ? createHash("sha256").update(match[2]).digest("base64") : ""))
       return HttpServerResponse.text(body, { status: response.status, headers })
@@ -124,4 +133,4 @@ export function serveUIEffect(
   })
 }
 
-export const UIRoutes = (): Hono => new Hono().all("/*", (c) => serveUI(c.req.raw))
+export const UIRoutes = (basePath = ""): Hono => new Hono().all("/*", (c) => serveUI(c.req.raw, basePath))

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -19,6 +19,7 @@ import { WorkspaceRoutes } from "./routes/control/workspace"
 import { ExperimentalHttpApiServer } from "./routes/instance/httpapi/server"
 import * as ServerBackend from "./backend"
 import type { CorsOptions } from "./cors"
+import { rewriteRequestBasePath } from "./base-path"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -42,8 +43,13 @@ type ServerApp = {
 type ListenOptions = CorsOptions & {
   port: number
   hostname: string
+  basePath?: string
   mdns?: boolean
   mdnsDomain?: string
+}
+
+type ServerOptions = CorsOptions & {
+  basePath?: string
 }
 
 const DefaultHono = lazy(() =>
@@ -57,9 +63,16 @@ function select() {
 
 export const backend = select
 
-export const Default = () => {
+export const Default = (opts: ServerOptions = {}) => {
+  if (!opts.basePath && !opts.cors?.length) {
+    const selected = select()
+    return selected.backend === "effect-httpapi" ? DefaultHttpApi() : DefaultHono()
+  }
+
   const selected = select()
-  return selected.backend === "effect-httpapi" ? DefaultHttpApi() : DefaultHono()
+  return selected.backend === "effect-httpapi"
+    ? withBackend(selected, createHttpApi(opts))
+    : withBackend(selected, createHono(opts, selected))
 }
 
 function create(opts: ListenOptions) {
@@ -69,7 +82,7 @@ function create(opts: ListenOptions) {
     : withBackend(selected, createHono(opts, selected))
 }
 
-export function Legacy(opts: CorsOptions = {}) {
+export function Legacy(opts: ServerOptions = {}) {
   return withBackend({ backend: "hono", reason: "explicit" }, createHono(opts, { backend: "hono", reason: "explicit" }))
 }
 
@@ -82,12 +95,26 @@ function withBackend<T extends { app: ServerApp; runtime: unknown }>(selection: 
   return built
 }
 
-function createHttpApi(corsOptions?: CorsOptions) {
-  const handler = ExperimentalHttpApiServer.webHandler(corsOptions).handler
+function toRequest(input: string | URL | Request, init?: RequestInit) {
+  return input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init)
+}
+
+function withBasePathHono(app: Hono, basePath: string | undefined) {
+  if (!basePath) return app
+
+  const fetch = app.fetch.bind(app)
+  app.fetch = ((request, env, executionCtx) =>
+    fetch(rewriteRequestBasePath(request, basePath), env, executionCtx)) as typeof app.fetch
+  app.request = ((input, init) => fetch(rewriteRequestBasePath(toRequest(input, init), basePath))) as typeof app.request
+  return app
+}
+
+function createHttpApi(opts: ServerOptions = {}) {
+  const handler = ExperimentalHttpApiServer.webHandler(opts).handler
   const app: ServerApp = {
-    fetch: (request: Request) => handler(request, ExperimentalHttpApiServer.context),
+    fetch: (request: Request) => handler(rewriteRequestBasePath(request, opts.basePath ?? ""), ExperimentalHttpApiServer.context),
     request(input, init) {
-      return app.fetch(input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init))
+      return app.fetch(rewriteRequestBasePath(toRequest(input, init), opts.basePath ?? ""))
     },
   }
   return {
@@ -96,15 +123,18 @@ function createHttpApi(corsOptions?: CorsOptions) {
   }
 }
 
-function createHono(opts: CorsOptions, selection: ServerBackend.Selection = ServerBackend.force(select(), "hono")) {
+function createHono(opts: ServerOptions, selection: ServerBackend.Selection = ServerBackend.force(select(), "hono")) {
   const backendAttributes = ServerBackend.attributes(selection)
-  const app = new Hono()
+  const app = withBasePathHono(
+    new Hono()
     .onError(ErrorMiddleware)
     .use(AuthMiddleware)
     .use(LoggerMiddleware(backendAttributes))
     .use(CompressionMiddleware)
     .use(CorsMiddleware(opts))
-    .route("/global", GlobalRoutes())
+    .route("/global", GlobalRoutes()),
+    opts.basePath,
+  )
 
   const runtime = adapter.create(app)
 
@@ -126,13 +156,13 @@ function createHono(opts: CorsOptions, selection: ServerBackend.Selection = Serv
   workspaceApp.route("/", workspaceLegacyApp)
 
   return {
-    app: app
-      .route("/", ControlPlaneRoutes())
-      .route("/", workspaceApp)
-      .route("/", InstanceRoutes(runtime.upgradeWebSocket))
-      .route("/", UIRoutes()),
-    runtime,
-  }
+      app: app
+        .route("/", ControlPlaneRoutes())
+        .route("/", workspaceApp)
+        .route("/", InstanceRoutes(runtime.upgradeWebSocket))
+        .route("/", UIRoutes(opts.basePath ?? "")),
+      runtime,
+    }
 }
 
 export async function openapi() {
@@ -163,6 +193,7 @@ export async function listen(opts: ListenOptions): Promise<Listener> {
   const next = new URL("http://localhost")
   next.hostname = opts.hostname
   next.port = String(server.port)
+  next.pathname = opts.basePath ? `${opts.basePath}/` : "/"
   url = next
 
   const mdns =

--- a/packages/opencode/test/cli/network.test.ts
+++ b/packages/opencode/test/cli/network.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { resolveNetworkOptionsNoConfig, type NetworkOptions } from "../../src/cli/network"
+
+const argv = [...process.argv]
+
+afterEach(() => {
+  process.argv = [...argv]
+})
+
+const defaults = (): NetworkOptions => ({
+  port: 0,
+  hostname: "127.0.0.1",
+  "base-path": "",
+  mdns: false,
+  "mdns-domain": "opencode.local",
+  cors: [],
+})
+
+describe("resolveNetworkOptionsNoConfig", () => {
+  test("uses and normalizes basePath from config when flag is not set", () => {
+    process.argv = ["node", "opencode"]
+
+    const result = resolveNetworkOptionsNoConfig(defaults(), {
+      server: {
+        basePath: "/opencode/",
+      },
+    })
+
+    expect(result.basePath).toBe("/opencode")
+  })
+
+  test("prefers explicit basePath flag over config", () => {
+    process.argv = ["node", "opencode", "--base-path"]
+
+    const result = resolveNetworkOptionsNoConfig(
+      {
+        ...defaults(),
+        "base-path": "nested/ui",
+      },
+      {
+        server: {
+          basePath: "/opencode",
+        },
+      },
+    )
+
+    expect(result.basePath).toBe("/nested/ui")
+  })
+})

--- a/packages/opencode/test/server/base-path.test.ts
+++ b/packages/opencode/test/server/base-path.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeBasePath, rewriteRequestBasePath, stripBasePath } from "../../src/server/base-path"
+
+describe("base path helpers", () => {
+  test("normalizes root and subpath values", () => {
+    expect(normalizeBasePath(undefined)).toBe("")
+    expect(normalizeBasePath("/")).toBe("")
+    expect(normalizeBasePath("opencode")).toBe("/opencode")
+    expect(normalizeBasePath("/opencode/")).toBe("/opencode")
+  })
+
+  test("strips the configured prefix when present", () => {
+    expect(stripBasePath("/opencode", "/opencode")).toBe("/")
+    expect(stripBasePath("/opencode/session/123", "/opencode")).toBe("/session/123")
+    expect(stripBasePath("/session/123", "/opencode")).toBe("/session/123")
+  })
+
+  test("rewrites request URLs to stripped internal paths", () => {
+    const request = rewriteRequestBasePath(new Request("http://localhost/opencode/session/123?cursor=4"), "/opencode")
+
+    expect(new URL(request.url).pathname).toBe("/session/123")
+    expect(new URL(request.url).searchParams.get("cursor")).toBe("4")
+  })
+})

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -72,13 +72,13 @@ function app(input?: { password?: string; username?: string }) {
   }
 }
 
-function uiApp(input?: { password?: string; username?: string; client?: Layer.Layer<HttpClient.HttpClient> }) {
+function uiApp(input?: { password?: string; username?: string; basePath?: string; client?: Layer.Layer<HttpClient.HttpClient> }) {
   const handler = HttpRouter.toWebHandler(
     HttpRouter.use((router) =>
       Effect.gen(function* () {
         const fs = yield* AppFileSystem.Service
         const client = yield* HttpClient.HttpClient
-        yield* router.add("*", "/*", (request) => serveUIEffect(request, { fs, client }))
+        yield* router.add("*", "/*", (request) => serveUIEffect(request, { fs, client }, input?.basePath ?? ""))
       }),
     ).pipe(
       Layer.provide(authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuthConfig.defaultLayer))),
@@ -186,12 +186,57 @@ describe("HttpApi UI fallback", () => {
     expect(await response.text()).toBe("console.log('ok')")
   })
 
+  test("strips configured base path before proxied asset fetch", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
+    let proxiedUrl: string | undefined
+
+    const response = await uiApp({
+      basePath: "/opencode",
+      client: httpClient(new Response("console.log('ok')", { headers: { "content-type": "text/javascript" } }), (request) => {
+        proxiedUrl = request.url
+      }),
+    }).request("/opencode/assets/app.js")
+
+    expect(response.status).toBe(200)
+    expect(proxiedUrl).toBe("https://app.opencode.ai/assets/app.js")
+  })
+
+  test("injects runtime base path into proxied html", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
+
+    const response = await uiApp({
+      basePath: "/opencode",
+      client: httpClient(
+        new Response("<html><head></head><body>opencode</body></html>", {
+          headers: { "content-type": "text/html" },
+        }),
+      ),
+    }).request("/opencode/")
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('<meta name="opencode-base-path" content="/opencode">')
+  })
+
   test("keeps matched API routes ahead of the UI fallback", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
 
     const response = await Server.Default().app.request("/session/nope")
 
     expect(response.status).toBe(404)
+  })
+
+  test("keeps matched API routes ahead of the UI fallback under a configured base path", async () => {
+    const legacyRoot = await Server.Legacy({ basePath: "/opencode" }).app.request("/session/nope")
+    const legacyPrefixed = await Server.Legacy({ basePath: "/opencode" }).app.request("/opencode/session/nope")
+    expect(legacyPrefixed.status).toBe(legacyRoot.status)
+
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    const httpapiRoot = await Server.Default({ basePath: "/opencode" }).app.request("/session/nope")
+    const httpapi = await Server.Default({ basePath: "/opencode" }).app.request("/opencode/session/nope")
+
+    expect(httpapi.status).toBe(httpapiRoot.status)
   })
 
   test("requires server password for the web UI", async () => {

--- a/packages/web/src/content/docs/ar/server.mdx
+++ b/packages/web/src/content/docs/ar/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### الاستخدام
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### الخيارات
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | تفعيل اكتشاف mDNS                     | `false`          |
 | `--mdns-domain` | اسم نطاق مخصص لخدمة mDNS              | `opencode.local` |
 | `--cors`        | أصول (Origins) متصفح إضافية مسموح بها | `[]`             |
+| `--base-path`   | نقطة نهاية أساسية (بادئة) تُضاف إلى جميع المسارات | `/`              |
 
 يمكن تمرير `--cors` عدة مرات:
 
@@ -84,6 +85,10 @@ http://<hostname>:<port>/doc
 ## واجهات API
 
 يعرض خادم opencode واجهات API التالية.
+
+:::tip
+إذا ضبطت `--base-path` على `/opencode`، فستبدأ جميع عناوين URL الخاصة بواجهات API بـ `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/ar/web.mdx
+++ b/packages/web/src/content/docs/ar/web.mdx
@@ -7,6 +7,18 @@ description: استخدام OpenCode في متصفحك.
 
 ![OpenCode Web - جلسة جديدة](../../../assets/web/web-homepage-new-session.png)
 
+### الاستخدام
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### الخيارات
+
+| العلامة | الوصف | الافتراضي |
+| ------ | ----- | --------- |
+| `--base-path` | بادئة المسار التي سيكون عليها الوصول إلى الخدمة | `/` |
+
 ## البدء
 
 ابدأ تشغيل واجهة الويب عبر تنفيذ:
@@ -134,7 +146,8 @@ opencode attach http://localhost:4096
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/bs/server.mdx
+++ b/packages/web/src/content/docs/bs/server.mdx
@@ -13,7 +13,7 @@ Komanda `opencode serve` pokrece headless HTTP server koji izlaže OpenAPI endpo
 ### Korištenje
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Opcije
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Ukljuci mDNS otkrivanje             | `false`          |
 | `--mdns-domain` | Prilagodeni domen za mDNS servis    | `opencode.local` |
 | `--cors`        | Dodatni browser origin-i koje dozv. | `[]`             |
+| `--base-path`   | Osnovni endpoint (prefiks) dodat svim rutama | `/`              |
 
 `--cors` mozete navesti vise puta:
 
@@ -81,6 +82,10 @@ Na primjer, `http://localhost:4096/doc`. Koristite specifikaciju da generisete k
 ## API-ji
 
 opencode server izlaže sljedece API-je.
+
+:::tip
+Ako postavite `--base-path` na `/opencode`, svi API URL-ovi pocece sa `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/bs/web.mdx
+++ b/packages/web/src/content/docs/bs/web.mdx
@@ -7,6 +7,18 @@ OpenCode može raditi kao web aplikacija u vašem pretraživaču, pružajući is
 
 ![OpenCode Web - Nova sesija](../../../assets/web/web-homepage-new-session.png)
 
+### Upotreba
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Opcije
+
+| Oznaka | Opis | Podrazumijevano |
+| ------ | ---- | --------------- |
+| `--base-path` | Prefiks putanje na kojoj će endpoint biti dostupan | `/` |
+
 ## Početak rada
 
 Pokrenite web interfejs tako što ćete pokrenuti:
@@ -134,7 +146,8 @@ Također možete konfigurirati postavke servera u svom `opencode.json` konfigura
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/da/server.mdx
+++ b/packages/web/src/content/docs/da/server.mdx
@@ -13,7 +13,7 @@ Kommandoen `opencode serve` kører en hovedløs HTTP-server, som afslører et Op
 ### Brug
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Indstillinger
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Aktiver mDNS-opdagelse                       | `false`          |
 | `--mdns-domain` | Brugerdefineret domænenavn for mDNS-tjeneste | `opencode.local` |
 | `--cors`        | Yderligere browseroprindelse for at tillade  | `[]`             |
+| `--base-path`   | Basis-endpoint (præfiks), der føjes foran alle ruter | `/`              |
 
 `--cors` kan angives flere gange:
 
@@ -84,6 +85,10 @@ For eksempel `http://localhost:4096/doc`. Brug specifikationen til at generere k
 ## API'er
 
 OpenCode-serveren viser følgende API'er.
+
+:::tip
+Hvis `--base-path` sættes til `/opencode`, vil alle API-URL'er starte med `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/da/web.mdx
+++ b/packages/web/src/content/docs/da/web.mdx
@@ -7,6 +7,18 @@ OpenCode kan køre som en webapplikation i din browser, hvilket giver den samme 
 
 ![OpenCode Web - Ny session](../../../assets/web/web-homepage-new-session.png)
 
+### Brug
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Indstillinger
+
+| Flag            | Beskrivelse                                       | Standard         |
+| --------------- | ------------------------------------------------- | ---------------- |
+| `--base-path`   | Stipræfikset, hvor endpointet bliver tilgængeligt | `/`              |
+
 ## Kom godt i gang
 
 Start webgrænsefladen ved at køre:
@@ -134,7 +146,8 @@ Du kan også konfigurere serverindstillinger i din `opencode.json`-konfiguration
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/de/server.mdx
+++ b/packages/web/src/content/docs/de/server.mdx
@@ -14,7 +14,7 @@ Er stellt einen OpenAPI-Endpunkt bereit, den ein opencode-Client nutzen kann.
 ### Nutzung
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Optionen
@@ -26,6 +26,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Enable mDNS discovery               | `false`          |
 | `--mdns-domain` | Custom domain name for mDNS service | `opencode.local` |
 | `--cors`        | Additional browser origins to allow | `[]`             |
+| `--base-path`   | Basis-Endpunkt (Praefix) fuer alle Routen | `/`         |
 
 `--cors` kann mehrfach angegeben werden:
 
@@ -88,6 +89,10 @@ Nutze die Spec zum Generieren von Clients, zum Pruefen von Request/Response-Type
 ## APIs
 
 Der opencode-Server stellt folgende APIs bereit.
+
+:::tip
+Wenn `--base-path` auf `/opencode` gesetzt ist, beginnen alle API-URLs mit `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/de/web.mdx
+++ b/packages/web/src/content/docs/de/web.mdx
@@ -7,6 +7,23 @@ OpenCode kann als Webanwendung in Ihrem Browser ausgeführt werden und bietet da
 
 ![OpenCode Web – Neue Sitzung](../../../assets/web/web-homepage-new-session.png)
 
+### Verwendung
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Optionen
+
+| Flag            | Beschreibung                                      | Standard         |
+| --------------- | ------------------------------------------------- | ---------------- |
+| `--port`        | Port, auf dem gelauscht wird                      | `4096`           |
+| `--hostname`    | Hostname, auf dem gelauscht wird                  | `127.0.0.1`      |
+| `--mdns`        | mDNS-Erkennung aktivieren                         | `false`          |
+| `--mdns-domain` | Benutzerdefinierter Domainname für den mDNS-Dienst | `opencode.local` |
+| `--cors`        | Zusätzliche Browser-Origin, die erlaubt werden   | `[]`             |
+| `--base-path`   | Mount-Präfix, unter dem der Endpunkt erreichbar ist | `/`            |
+
 ## Erste Schritte
 
 Starten Sie die Weboberfläche, indem Sie Folgendes ausführen:
@@ -134,7 +151,8 @@ Sie können Servereinstellungen auch in Ihrer `opencode.json`-Konfigurationsdate
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/es/server.mdx
+++ b/packages/web/src/content/docs/es/server.mdx
@@ -13,7 +13,7 @@ El comando `opencode serve` ejecuta un servidor HTTP sin cabeza que expone un pu
 ### Uso
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Opciones
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Habilitar el descubrimiento de mDNS                   | `false`          |
 | `--mdns-domain` | Nombre de dominio personalizado para el servicio mDNS | `opencode.local` |
 | `--cors`        | Orígenes de navegador adicionales para permitir       | `[]`             |
+| `--base-path`   | Endpoint base (prefijo) añadido a todas las rutas     | `/`              |
 
 `--cors` se puede pasar varias veces:
 
@@ -84,6 +85,10 @@ Por ejemplo, `http://localhost:4096/doc`. Utilice la especificación para genera
 ## API
 
 El servidor opencode expone las siguientes API.
+
+:::tip
+Si configura `--base-path` como `/opencode`, todas las URL de la API empezarán por `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/es/web.mdx
+++ b/packages/web/src/content/docs/es/web.mdx
@@ -7,6 +7,23 @@ OpenCode puede ejecutarse como una aplicación web en su navegador, brindando la
 
 ![OpenCode Web - Nueva sesión](../../../assets/web/web-homepage-new-session.png)
 
+### Uso
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Opciones
+
+| Flag            | Descripción                                      | Predeterminado   |
+| --------------- | ------------------------------------------------ | ---------------- |
+| `--port`        | Puerto en el que escuchar                        | `4096`           |
+| `--hostname`    | Nombre del host en el que escuchar               | `127.0.0.1`      |
+| `--mdns`        | Habilitar el descubrimiento mDNS                 | `false`          |
+| `--mdns-domain` | Nombre de dominio personalizado para mDNS        | `opencode.local` |
+| `--cors`        | Orígenes adicionales del navegador que permitir  | `[]`             |
+| `--base-path`   | Prefijo de ruta en el que el endpoint es accesible | `/`            |
+
 ## Empezar
 
 Inicie la interfaz web ejecutando:
@@ -134,7 +151,8 @@ También puede configurar los ajustes del servidor en su archivo de configuraci�
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/fr/server.mdx
+++ b/packages/web/src/content/docs/fr/server.mdx
@@ -13,7 +13,7 @@ La commande `opencode serve` exécute un serveur HTTP sans tête qui expose un p
 ### Usage
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Options
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Activer la découverte mDNS                         | `false`          |
 | `--mdns-domain` | Nom de domaine personnalisé pour le service mDNS   | `opencode.local` |
 | `--cors`        | Origines de navigateur supplémentaires à autoriser | `[]`             |
+| `--base-path`   | Endpoint de base (prefixe) ajoute a toutes les routes | `/`           |
 
 `--cors` peut être transmis plusieurs fois :
 
@@ -84,6 +85,10 @@ Par exemple, `http://localhost:4096/doc`. Utilisez la spécification pour géné
 ## APIs
 
 Le serveur opencode expose les API suivantes.
+
+:::tip
+Si `--base-path` est defini sur `/opencode`, toutes les URL de l'API commenceront par `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/fr/web.mdx
+++ b/packages/web/src/content/docs/fr/web.mdx
@@ -7,6 +7,23 @@ OpenCode peut s'exécuter comme une application Web dans votre navigateur, offra
 
 ![OpenCode Web - Nouvelle session](../../../assets/web/web-homepage-new-session.png)
 
+### Utilisation
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Options
+
+| Flag            | Description                                           | Par défaut       |
+| --------------- | ----------------------------------------------------- | ---------------- |
+| `--port`        | Port sur lequel écouter                               | `4096`           |
+| `--hostname`    | Nom d'hôte sur lequel écouter                         | `127.0.0.1`      |
+| `--mdns`        | Activer la découverte mDNS                            | `false`          |
+| `--mdns-domain` | Nom de domaine personnalisé pour le service mDNS      | `opencode.local` |
+| `--cors`        | Origines de navigateur supplémentaires à autoriser    | `[]`             |
+| `--base-path`   | Préfixe de montage où le point d'accès est disponible | `/`              |
+
 ## Commencer
 
 Démarrez l'interface Web en exécutant :
@@ -134,7 +151,8 @@ Vous pouvez également configurer les paramètres du serveur dans votre fichier 
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/it/server.mdx
+++ b/packages/web/src/content/docs/it/server.mdx
@@ -13,7 +13,7 @@ Il comando `opencode serve` avvia un server HTTP headless che espone un endpoint
 ### Utilizzo
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Opzioni
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Abilita la scoperta mDNS                | `false`          |
 | `--mdns-domain` | Nome di dominio personalizzato mDNS     | `opencode.local` |
 | `--cors`        | Origin browser aggiuntive da permettere | `[]`             |
+| `--base-path`   | Endpoint base (prefisso) anteposto a tutte le route | `/`   |
 
 `--cors` puo essere passato piu volte:
 
@@ -81,6 +82,10 @@ Per esempio, `http://localhost:4096/doc`. Usa la spec per generare client o ispe
 ## API
 
 Il server opencode espone le seguenti API.
+
+:::tip
+Se imposti `--base-path` su `/opencode`, tutti gli URL delle API inizieranno con `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/it/web.mdx
+++ b/packages/web/src/content/docs/it/web.mdx
@@ -7,6 +7,23 @@ OpenCode puo funzionare come applicazione web nel browser, offrendo la stessa po
 
 ![OpenCode Web - Nuova sessione](../../../assets/web/web-homepage-new-session.png)
 
+### Uso
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Opzioni
+
+| Flag            | Descrizione                                          | Predefinito      |
+| --------------- | ---------------------------------------------------- | ---------------- |
+| `--port`        | Porta su cui mettersi in ascolto                     | `4096`           |
+| `--hostname`    | Nome host su cui mettersi in ascolto                 | `127.0.0.1`      |
+| `--mdns`        | Abilita il rilevamento mDNS                          | `false`          |
+| `--mdns-domain` | Nome di dominio personalizzato per il servizio mDNS  | `opencode.local` |
+| `--cors`        | Origini browser aggiuntive da consentire             | `[]`             |
+| `--base-path`   | Prefisso di mount a cui rendere accessibile l'endpoint | `/`            |
+
 ## Per iniziare
 
 Avvia l'interfaccia web eseguendo:
@@ -134,7 +151,8 @@ Puoi anche configurare le impostazioni del server nel file di config `opencode.j
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/ja/server.mdx
+++ b/packages/web/src/content/docs/ja/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### 使用法
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### オプション
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | mDNS 検出を有効にする             | `false`          |
 | `--mdns-domain` | mDNS サービスのカスタムドメイン名 | `opencode.local` |
 | `--cors`        | 許可する追加のブラウザーオリジン  | `[]`             |
+| `--base-path`   | すべてのルートの先頭に付くベースエンドポイント（プレフィックス） | `/`              |
 
 `--cors` は複数回渡すことができます。
 
@@ -79,6 +80,10 @@ http://<hostname>:<port>/doc
 ## API
 
 OpenCode サーバーは次の API を公開します。
+
+:::tip
+`--base-path` を `/opencode` に設定すると、すべての API URL は `/opencode` で始まります。
+:::
 
 ---
 

--- a/packages/web/src/content/docs/ja/web.mdx
+++ b/packages/web/src/content/docs/ja/web.mdx
@@ -7,6 +7,23 @@ OpenCode はブラウザで Web アプリケーションとして実行でき、
 
 ![OpenCode Web - 新しいセッション](../../../assets/web/web-homepage-new-session.png)
 
+### 使用法
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### オプション
+
+| フラグ | 説明 | デフォルト |
+| --- | --- | --- |
+| `--port` | リッスンするポート | `4096` |
+| `--hostname` | リッスンするホスト名 | `127.0.0.1` |
+| `--mdns` | mDNS 検出を有効にする | `false` |
+| `--mdns-domain` | mDNS サービスのカスタムドメイン名 | `opencode.local` |
+| `--cors` | 許可する追加のブラウザーオリジン | `[]` |
+| `--base-path` | アクセス可能にするエンドポイントのベースパス | `/` |
+
 ---
 
 ## はじめる
@@ -135,7 +152,8 @@ opencode attach http://localhost:4096
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/ko/server.mdx
+++ b/packages/web/src/content/docs/ko/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### 사용법
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### 옵션
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | mDNS 탐지 활성화                      | `false`          |
 | `--mdns-domain` | mDNS 서비스의 사용자 지정 도메인 이름 | `opencode.local` |
 | `--cors`        | 허용할 추가 브라우저 origin           | `[]`             |
+| `--base-path`   | 모든 라우트 앞에 붙는 기본 엔드포인트(접두사) | `/`              |
 
 `--cors`는 다수 시간을 통과될 수 있습니다:
 
@@ -84,6 +85,10 @@ http://<hostname>:<port>/doc
 ## API
 
 opencode 서버는 다음과 같은 API를 노출합니다.
+
+:::tip
+`--base-path`를 `/opencode`로 설정하면 모든 API URL이 `/opencode`로 시작합니다.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/ko/web.mdx
+++ b/packages/web/src/content/docs/ko/web.mdx
@@ -7,6 +7,23 @@ opencode는 브라우저에서 웹 응용 프로그램을 실행할 수 있으�
 
 ![opencode Web - 새로운 세션](../../../assets/web/web-homepage-new-session.png)
 
+### 사용법
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### 옵션
+
+| 플래그 | 설명 | 기본값 |
+| --- | --- | --- |
+| `--port` | 수신할 포트 | `4096` |
+| `--hostname` | 수신할 호스트 이름 | `127.0.0.1` |
+| `--mdns` | mDNS 탐색 활성화 | `false` |
+| `--mdns-domain` | mDNS 서비스용 사용자 지정 도메인 이름 | `opencode.local` |
+| `--cors` | 추가로 허용할 브라우저 출처 | `[]` |
+| `--base-path` | 접근할 수 있도록 노출할 엔드포인트의 기본 경로 | `/` |
+
 ## 시작하기
 
 실행하여 웹 인터페이스를 시작:
@@ -134,7 +151,8 @@ opencode attach http://localhost:4096
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/nb/server.mdx
+++ b/packages/web/src/content/docs/nb/server.mdx
@@ -13,7 +13,7 @@ Kommandoen `opencode serve` kjører en hodeløs HTTP-server som eksponerer et Op
 ### Bruk
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Alternativer
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Aktiver mDNS-oppdagelse                       | `false`          |
 | `--mdns-domain` | Egendefinert domenenavn for mDNS-tjeneste     | `opencode.local` |
 | `--cors`        | Ytterligere nettleseropprinnelse som tillates | `[]`             |
+| `--base-path`   | Basisendepunkt (prefiks) som legges til foran alle ruter | `/`              |
 
 `--cors` kan angis flere ganger:
 
@@ -84,6 +85,10 @@ For eksempel `http://localhost:4096/doc`. Bruk spesifikasjonen til å generere k
 ## APIer
 
 opencode-serveren viser følgende APIer.
+
+:::tip
+Hvis `--base-path` settes til `/opencode`, vil alle API-URL-er starte med `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/nb/web.mdx
+++ b/packages/web/src/content/docs/nb/web.mdx
@@ -7,6 +7,18 @@ OpenCode kan kjøres som en nettapplikasjon i nettleseren din, og gir den samme 
 
 ![OpenCode Web - Ny økt](../../../assets/web/web-homepage-new-session.png)
 
+### Bruk
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Alternativer
+
+| Flagg           | Beskrivelse                                       | Standard         |
+| --------------- | ------------------------------------------------- | ---------------- |
+| `--base-path`   | Stiprefikset der endepunktet blir tilgjengelig    | `/`              |
+
 ## Komme i gang
 
 Start web-grensesnittet ved å kjøre:
@@ -97,7 +109,8 @@ Du kan også konfigurere serverinnstillinger i `opencode.json` konfigurasjonsfil
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/pl/server.mdx
+++ b/packages/web/src/content/docs/pl/server.mdx
@@ -13,7 +13,7 @@ Komenda `opencode serve` uruchamia bezgłowy serwer HTTP, który udostępnia pun
 ### Użycie
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Opcje
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Włącz wykrywanie mDNS                        | `false`          |
 | `--mdns-domain` | Niestandardowa nazwa domeny dla usługi mDNS  | `opencode.local` |
 | `--cors`        | Dodatkowe originy przeglądarki do dozwolenia | `[]`             |
+| `--base-path`   | Bazowy endpoint (prefiks) dodawany przed wszystkimi ścieżkami | `/`              |
 
 `--cors` można przekazać wiele razy:
 
@@ -84,6 +85,10 @@ Na przykład `http://localhost:4096/doc`. Użyj specyfikacji, aby wygenerować k
 ## API
 
 Serwer opencode udostępnia następujące interfejsy API.
+
+:::tip
+Jeśli ustawisz `--base-path` na `/opencode`, wszystkie adresy URL API będą zaczynać się od `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/pl/web.mdx
+++ b/packages/web/src/content/docs/pl/web.mdx
@@ -7,6 +7,18 @@ opencode może działać jako aplikacja internetowa w przeglądarce, zapewniają
 
 ![Sieć opencode - Nowa sesja](../../../assets/web/web-homepage-new-session.png)
 
+### Użycie
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Opcje
+
+| Flaga           | Opis                                              | Domyślnie        |
+| --------------- | ------------------------------------------------- | ---------------- |
+| `--base-path`   | Prefiks ścieżki, pod którym endpoint będzie dostępny | `/`           |
+
 ## Pierwsze kroki
 
 Uruchom interfejs sieciowy, uruchamiając:
@@ -134,7 +146,8 @@ Możesz także skonfigurować ustawienia serwera w pliku konfiguracyjnym `openco
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/pt-br/server.mdx
+++ b/packages/web/src/content/docs/pt-br/server.mdx
@@ -13,7 +13,7 @@ O comando `opencode serve` executa um servidor HTTP sem cabeça que expõe um en
 ### Uso
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Opções
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Habilitar descoberta mDNS                         | `false`          |
 | `--mdns-domain` | Nome de domínio personalizado para o serviço mDNS | `opencode.local` |
 | `--cors`        | Origens adicionais de navegador a permitir        | `[]`             |
+| `--base-path`   | Endpoint base(prefixo) em todas as rotas          | `/`              |
 
 `--cors` pode ser passado várias vezes:
 
@@ -81,6 +82,10 @@ Por exemplo, `http://localhost:4096/doc`. Use a especificação para gerar clien
 ## APIs
 
 O servidor opencode expõe as seguintes APIs.
+
+:::tip
+Ao setar o "--base-path" como "/opencode" por exemplo, as URLs das APIs abaixos ficarão com "/opencode" no começo!
+:::
 
 ---
 

--- a/packages/web/src/content/docs/pt-br/web.mdx
+++ b/packages/web/src/content/docs/pt-br/web.mdx
@@ -7,6 +7,23 @@ O opencode pode ser executado como uma aplicação web no seu navegador, proporc
 
 ![opencode Web - Nova Sessão](../../../assets/web/web-homepage-new-session.png)
 
+### Uso
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Opções
+
+| Flag            | Descrição                                         | Padrão           |
+| --------------- | ------------------------------------------------- | ---------------- |
+| `--port`        | Porta para escutar                                | `4096`           |
+| `--hostname`    | Nome do host para escutar                         | `127.0.0.1`      |
+| `--mdns`        | Habilitar descoberta mDNS                         | `false`          |
+| `--mdns-domain` | Nome de domínio personalizado para o serviço mDNS | `opencode.local` |
+| `--cors`        | Origens adicionais de navegador a permitir        | `[]`             |
+| `--base-path`   | Endpoint para ser acessível                       | `/`              |
+
 ## Primeiros passos
 
 Inicie a interface web executando:
@@ -134,7 +151,8 @@ Você também pode configurar as configurações do servidor no seu arquivo de c
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/ru/server.mdx
+++ b/packages/web/src/content/docs/ru/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### Использование
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Параметры
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | Включить обнаружение mDNS                   | `false`          |
 | `--mdns-domain` | Пользовательское доменное имя для mDNS      | `opencode.local` |
 | `--cors`        | Разрешенные дополнительные источники (CORS) | `[]`             |
+| `--base-path`   | Базовый путь (префикс), добавляемый ко всем маршрутам | `/`              |
 
 `--cors` можно передать несколько раз:
 
@@ -84,6 +85,10 @@ For example, `http://localhost:4096/doc`. Use the spec to generate clients or in
 ## API
 
 Сервер opencode предоставляет следующие API.
+
+:::tip
+Если задать `--base-path` как `/opencode`, все URL API будут начинаться с `/opencode`.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/ru/web.mdx
+++ b/packages/web/src/content/docs/ru/web.mdx
@@ -7,6 +7,18 @@ opencode может работать как веб-приложение в ва�
 
 ![opencode Web — новый сеанс](../../../assets/web/web-homepage-new-session.png)
 
+### Использование
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Параметры
+
+| Флаг            | Описание                                          | По умолчанию     |
+| --------------- | ------------------------------------------------- | ---------------- |
+| `--base-path`   | Префикс пути, по которому будет доступен endpoint | `/`              |
+
 ## Начало работы
 
 Запустите веб-интерфейс, выполнив:
@@ -134,7 +146,8 @@ opencode attach http://localhost:4096
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/th/server.mdx
+++ b/packages/web/src/content/docs/th/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### การใช้งาน
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### ตัวเลือก
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | เปิดใช้งานการค้นพบ mDNS                  | `false`          |
 | `--mdns-domain` | ชื่อโดเมนที่กำหนดเองสำหรับบริการ mDNS    | `opencode.local` |
 | `--cors`        | ต้นกำเนิดเบราว์เซอร์เพิ่มเติมที่จะอนุญาต | `[]`             |
+| `--base-path`   | เอนด์พอยต์ฐาน (คำนำหน้า) ที่จะเติมหน้าทุกรูต | `/`              |
 
 `--cors` สามารถส่งผ่านได้หลายครั้ง:
 
@@ -84,6 +85,10 @@ http://<hostname>:<port>/doc
 ## API
 
 เซิร์ฟเวอร์ opencode เปิดเผย API ต่อไปนี้
+
+:::tip
+หากตั้งค่า `--base-path` เป็น `/opencode` URL ของ API ทั้งหมดจะขึ้นต้นด้วย `/opencode`
+:::
 
 ---
 

--- a/packages/web/src/content/docs/th/web.mdx
+++ b/packages/web/src/content/docs/th/web.mdx
@@ -7,6 +7,18 @@ OpenCode สามารถทำงานเป็นเว็บแอปพ�
 
 ![เว็บ OpenCode - เซสชันใหม่](../../../assets/web/web-homepage-new-session.png)
 
+### การใช้งาน
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### ตัวเลือก
+
+| แฟล็ก | คำอธิบาย | ค่าเริ่มต้น |
+| ----- | -------- | ----------- |
+| `--base-path` | คำนำหน้าพาธที่ใช้เมานต์เพื่อให้ endpoint เข้าถึงได้ | `/` |
+
 ## เริ่มต้นใช้งาน
 
 เริ่มเว็บอินเตอร์เฟสด้วยการรัน:
@@ -134,7 +146,8 @@ opencode attach http://localhost:4096
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/tr/server.mdx
+++ b/packages/web/src/content/docs/tr/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### Kullanım
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### Seçenekler
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | mDNS keşfini etkinleştir                       | `false`          |
 | `--mdns-domain` | mDNS hizmeti için özel alan adı                | `opencode.local` |
 | `--cors`        | İzin verilecek ek tarayıcı kaynakları (origin) | `[]`             |
+| `--base-path`   | Tüm rotalara eklenen temel uç nokta (önek)     | `/`              |
 
 `--cors` birden fazla kez geçilebilir:
 
@@ -82,6 +83,10 @@ http://<hostname>:<port>/doc
 ## API'ler
 
 opencode sunucusu aşağıdaki API'leri sunar.
+
+:::tip
+`--base-path` değerini `/opencode` olarak ayarlarsanız tüm API URL'leri `/opencode` ile başlar.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/tr/web.mdx
+++ b/packages/web/src/content/docs/tr/web.mdx
@@ -7,6 +7,18 @@ opencode, tarayıcınızda bir web uygulaması olarak çalışabilir ve bir term
 
 ![opencode Web - Yeni Oturum](../../../assets/web/web-homepage-new-session.png)
 
+### Kullanım
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### Seçenekler
+
+| Bayrak | Açıklama | Varsayılan |
+| ------ | -------- | ---------- |
+| `--base-path` | Uç noktanın erişilebilir olacağı yol öneki | `/` |
+
 ## Başlarken
 
 Aşağıdakileri çalıştırarak web arayüzünü başlatın:
@@ -134,7 +146,8 @@ Sunucu ayarlarını `opencode.json` yapılandırma dosyanızda da yapılandırab
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/zh-cn/server.mdx
+++ b/packages/web/src/content/docs/zh-cn/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### 用法
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### 选项
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | 启用 mDNS 发现        | `false`          |
 | `--mdns-domain` | mDNS 服务的自定义域名 | `opencode.local` |
 | `--cors`        | 额外允许的浏览器来源  | `[]`             |
+| `--base-path`   | 添加到所有路由前面的基础端点（前缀） | `/`              |
 
 `--cors` 可以多次传递：
 
@@ -81,6 +82,10 @@ http://<hostname>:<port>/doc
 ## API
 
 opencode 服务器暴露以下 API。
+
+:::tip
+如果将 `--base-path` 设置为 `/opencode`，所有 API URL 都会以 `/opencode` 开头。
+:::
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/web.mdx
+++ b/packages/web/src/content/docs/zh-cn/web.mdx
@@ -7,6 +7,23 @@ OpenCode 可以作为 Web 应用在浏览器中运行，无需终端即可获得
 
 ![OpenCode Web - New Session](../../../assets/web/web-homepage-new-session.png)
 
+### 用法
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### 选项
+
+| 标志 | 说明 | 默认值 |
+| --- | --- | --- |
+| `--port` | 监听端口 | `4096` |
+| `--hostname` | 监听的主机名 | `127.0.0.1` |
+| `--mdns` | 启用 mDNS 发现 | `false` |
+| `--mdns-domain` | mDNS 服务的自定义域名 | `opencode.local` |
+| `--cors` | 额外允许的浏览器来源 | `[]` |
+| `--base-path` | 可访问端点的基础路径（挂载前缀） | `/` |
+
 ## 快速开始
 
 运行以下命令启动 Web 界面：
@@ -134,7 +151,8 @@ opencode attach http://localhost:4096
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```

--- a/packages/web/src/content/docs/zh-tw/server.mdx
+++ b/packages/web/src/content/docs/zh-tw/server.mdx
@@ -13,7 +13,7 @@ export const typesUrl = `${config.github}/blob/dev/packages/sdk/js/src/gen/types
 ### 用法
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--base-path <string>]
 ```
 
 #### 選項
@@ -25,6 +25,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--mdns`        | 啟用 mDNS 探索          | `false`          |
 | `--mdns-domain` | mDNS 服務的自訂網域名稱 | `opencode.local` |
 | `--cors`        | 額外允許的瀏覽器來源    | `[]`             |
+| `--base-path`   | 加到所有路由前面的基礎端點（前綴） | `/`              |
 
 `--cors` 可以多次傳遞：
 
@@ -81,6 +82,10 @@ http://<hostname>:<port>/doc
 ## API
 
 opencode 伺服器暴露以下 API。
+
+:::tip
+如果將 `--base-path` 設為 `/opencode`，所有 API URL 都會以 `/opencode` 開頭。
+:::
 
 ---
 

--- a/packages/web/src/content/docs/zh-tw/web.mdx
+++ b/packages/web/src/content/docs/zh-tw/web.mdx
@@ -7,6 +7,23 @@ OpenCode 可以作為 Web 應用程式在瀏覽器中執行，無需終端機即
 
 ![OpenCode Web - New Session](../../../assets/web/web-homepage-new-session.png)
 
+### 用法
+
+```bash
+opencode web [--port <number>] [--hostname <string>] [--cors <origin>] [--mdns <boolean>] [--mdns-domain <string>] [--base-path <string>]
+```
+
+#### 選項
+
+| 旗標 | 說明 | 預設值 |
+| --- | --- | --- |
+| `--port` | 監聽連接埠 | `4096` |
+| `--hostname` | 監聽的主機名稱 | `127.0.0.1` |
+| `--mdns` | 啟用 mDNS 探索 | `false` |
+| `--mdns-domain` | mDNS 服務的自訂網域名稱 | `opencode.local` |
+| `--cors` | 額外允許的瀏覽器來源 | `[]` |
+| `--base-path` | 可存取端點的基礎路徑（掛載前綴） | `/` |
+
 ## 快速開始
 
 執行以下指令啟動 Web 介面：
@@ -134,7 +151,8 @@ opencode attach http://localhost:4096
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["https://example.com"]
+    "cors": ["https://example.com"],
+    "basePath": "/"
   }
 }
 ```


### PR DESCRIPTION
### Issue for this PR

Closes #13847

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This adds native `basePath` support for the OpenCode server and web UI so it can be served cleanly from a subpath such as `/opencode/` instead of assuming `/`.

On the server side, requests can now arrive either with the configured prefix still present or already stripped by a reverse proxy, and both cases resolve to the same internal route tree. On the frontend side, the app shell now emits relative asset URLs, the HTML response exposes the effective mount path, and the browser uses that path when building API, SSE, WebSocket, and router URLs.

These changes work because they keep the existing API paths unchanged internally and treat the subpath as a transport/runtime concern at the server boundary and browser bootstrap boundary. That makes the legacy Hono backend, the experimental HttpApi backend, and the built app all agree on the same effective mount path.

### How did you verify your code works?

- Ran `npm exec -- bun test test/server/base-path.test.ts test/cli/network.test.ts test/server/httpapi-ui.test.ts` in `packages/opencode`
- Ran `npm exec -- bun typecheck` in `packages/opencode`
- Ran `npm exec -- bun test --preload ./happydom.ts ./src/utils/base-path.test.ts ./src/index-shell.test.ts ./src/vite-config.test.ts` in `packages/app`
- Ran `npm exec -- bun typecheck` in `packages/app`
- Ran `npm exec -- bun run build` in `packages/app`
- Confirmed the emitted `packages/app/dist/index.html` uses relative asset URLs such as `./assets/...`
- Build "localcode" based on this commit on docker and execute the command "opencode web --hostname 127.0.0.1 --port "4096" --base-path /opencode" and put a NGINX on front with: 
```
location /opencode/ {
      proxy_pass http://127.0.0.1:4096;
      proxy_http_version 1.1;
      proxy_set_header Host $host;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header X-Forwarded-Proto $scheme;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection $connection_upgrade;
    } 
```
### Screenshots / recordings

(See the URL on browser, that starts with "http://localhost/opencode")
<img width="1920" height="1077" alt="image" src="https://github.com/user-attachments/assets/c17d2822-238c-4270-ac13-28c9b071511a" />
<img width="1920" height="1077" alt="image" src="https://github.com/user-attachments/assets/bea5260c-56ce-4349-9e54-02fabb6a382f" />
<img width="1920" height="1077" alt="image" src="https://github.com/user-attachments/assets/f767296c-4464-43ec-bb95-a1a79696c420" />

Don't have visual UI changes; this PR changes mount-path, assets, routing and request behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
