### PR TITLE
feat(cli): allow effectCmd instance to be a function of args

### DIFF
--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -37,10 +37,14 @@ interface EffectCmdOpts<Args, A> {
    * directly under AppRuntime — it can yield any `AppServices` but must not
    * yield `InstanceRef` (it'd be undefined, causing a defect).
    *
+   * Function form: `(args) => boolean` decides per-invocation. Useful for
+   * commands like `run --attach <url>` where one flag flips between local
+   * (needs instance) and remote (doesn't).
+   *
    * Use `false` for commands that don't read project state (e.g. `models`,
    * `serve`, `web`, `account`, `db`, `upgrade`).
    */
-  instance?: boolean
+  instance?: boolean | ((args: Args) => boolean)
   /** Defaults to process.cwd(). Override for commands that take a directory positional. */
   directory?: (args: Args) => string
   handler: (args: Args) => Effect.Effect<A, CliError, AppServices | InstanceStore.Service>
@@ -72,7 +76,8 @@ export const effectCmd = <Args, A>(opts: EffectCmdOpts<Args, A>) =>
     async handler(rawArgs) {
       // yargs typing wraps Args in ArgumentsCamelCase<WithDoubleDash<...>>; cast at the boundary.
       const args = rawArgs as unknown as Args
-      if (opts.instance === false) {
+      const useInstance = typeof opts.instance === "function" ? opts.instance(args) : opts.instance !== false
+      if (!useInstance) {
         await AppRuntime.runPromise(opts.handler(args))
         return
       }


### PR DESCRIPTION
## Summary
Extend the \`instance\` opt-out from #25507 to also accept a function:

\`\`\`ts
effectCmd({
  command: "run [message..]",
  instance: (args) => !args.attach,   // ← per-invocation decision
  handler: ...,
})
\`\`\`

For commands where one flag flips between needing and not needing a project instance — e.g. \`run --attach <url>\` (remote server, no local instance) vs \`run "hello"\` (local server, needs bootstrap).

## Backward compatibility
\`instance: boolean | undefined\` form unchanged. Default behavior (load instance) preserved when \`instance\` is not set. Type union widened from \`boolean\` to \`boolean | ((args: Args) => boolean)\` — only additive.

## Implementation
\`\`\`ts
const useInstance = typeof opts.instance === "function" ? opts.instance(args) : opts.instance !== false
\`\`\`
Then the same true/false branches as before.

## Why
Stage 1 of converting \`run.ts\` (672 lines) — its handler has two paths (\`--attach\` skips bootstrap, default uses it). Static \`instance: true|false\` can't express that.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] Smoke: \`serve\` (existing \`instance: false\`) still works
- [x] Smoke: \`models\` (existing default \`instance: true\` via \`undefined\`) still works