### PR TITLE
refactor(cli): convert debug wait, agent list, acp to effectCmd

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -1,6 +1,6 @@
 import * as Log from "@opencode-ai/core/util/log"
-import { bootstrap } from "../bootstrap"
-import { cmd } from "./cmd"
+import { Effect } from "effect"
+import { effectCmd } from "../effect-cmd"
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk"
 import { ACP } from "@/acp/agent"
 import { Server } from "@/server/server"
@@ -9,7 +9,7 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 
 const log = Log.create({ service: "acp-command" })
 
-export const AcpCommand = cmd({
+export const AcpCommand = effectCmd({
   command: "acp",
   describe: "start ACP (Agent Client Protocol) server",
   builder: (yargs) => {
@@ -19,52 +19,53 @@ export const AcpCommand = cmd({
       default: process.cwd(),
     })
   },
-  handler: async (args) => {
+  handler: Effect.fn("Cli.acp")(function* (args) {
     process.env.OPENCODE_CLIENT = "acp"
-    await bootstrap(process.cwd(), async () => {
-      const opts = await resolveNetworkOptions(args)
-      const server = await Server.listen(opts)
+    const opts = yield* Effect.promise(() => resolveNetworkOptions(args))
+    const server = yield* Effect.promise(() => Server.listen(opts))
 
-      const sdk = createOpencodeClient({
-        baseUrl: `http://${server.hostname}:${server.port}`,
-      })
-
-      const input = new WritableStream<Uint8Array>({
-        write(chunk) {
-          return new Promise<void>((resolve, reject) => {
-            process.stdout.write(chunk, (err) => {
-              if (err) {
-                reject(err)
-              } else {
-                resolve()
-              }
-            })
-          })
-        },
-      })
-      const output = new ReadableStream<Uint8Array>({
-        start(controller) {
-          process.stdin.on("data", (chunk: Buffer) => {
-            controller.enqueue(new Uint8Array(chunk))
-          })
-          process.stdin.on("end", () => controller.close())
-          process.stdin.on("error", (err) => controller.error(err))
-        },
-      })
-
-      const stream = ndJsonStream(input, output)
-      const agent = await ACP.init({ sdk })
-
-      new AgentSideConnection((conn) => {
-        return agent.create(conn, { sdk })
-      }, stream)
-
-      log.info("setup connection")
-      process.stdin.resume()
-      await new Promise((resolve, reject) => {
-        process.stdin.on("end", resolve)
-        process.stdin.on("error", reject)
-      })
+    const sdk = createOpencodeClient({
+      baseUrl: `http://${server.hostname}:${server.port}`,
     })
-  },
+
+    const input = new WritableStream<Uint8Array>({
+      write(chunk) {
+        return new Promise<void>((resolve, reject) => {
+          process.stdout.write(chunk, (err) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve()
+            }
+          })
+        })
+      },
+    })
+    const output = new ReadableStream<Uint8Array>({
+      start(controller) {
+        process.stdin.on("data", (chunk: Buffer) => {
+          controller.enqueue(new Uint8Array(chunk))
+        })
+        process.stdin.on("end", () => controller.close())
+        process.stdin.on("error", (err) => controller.error(err))
+      },
+    })
+
+    const stream = ndJsonStream(input, output)
+    const agent = yield* Effect.promise(() => ACP.init({ sdk }))
+
+    new AgentSideConnection((conn) => {
+      return agent.create(conn, { sdk })
+    }, stream)
+
+    log.info("setup connection")
+    process.stdin.resume()
+    yield* Effect.promise(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          process.stdin.on("end", () => resolve())
+          process.stdin.on("error", reject)
+        }),
+    )
+  }),
 })

--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -13,6 +13,8 @@ import { Instance } from "../../project/instance"
 import { WithInstance } from "../../project/with-instance"
 import { EOL } from "os"
 import type { Argv } from "yargs"
+import { Effect } from "effect"
+import { effectCmd } from "../effect-cmd"
 
 type AgentMode = "all" | "primary" | "subagent"
 
@@ -233,28 +235,23 @@ const AgentCreateCommand = cmd({
   },
 })
 
-const AgentListCommand = cmd({
+const AgentListCommand = effectCmd({
   command: "list",
   describe: "list all available agents",
-  async handler() {
-    await WithInstance.provide({
-      directory: process.cwd(),
-      async fn() {
-        const agents = await AppRuntime.runPromise(Agent.Service.use((svc) => svc.list()))
-        const sortedAgents = agents.sort((a, b) => {
-          if (a.native !== b.native) {
-            return a.native ? -1 : 1
-          }
-          return a.name.localeCompare(b.name)
-        })
-
-        for (const agent of sortedAgents) {
-          process.stdout.write(`${agent.name} (${agent.mode})` + EOL)
-          process.stdout.write(`  ${JSON.stringify(agent.permission, null, 2)}` + EOL)
-        }
-      },
+  handler: Effect.fn("Cli.agent.list")(function* () {
+    const agents = yield* Agent.Service.use((svc) => svc.list())
+    const sortedAgents = agents.sort((a, b) => {
+      if (a.native !== b.native) {
+        return a.native ? -1 : 1
+      }
+      return a.name.localeCompare(b.name)
     })
-  },
+
+    for (const agent of sortedAgents) {
+      process.stdout.write(`${agent.name} (${agent.mode})` + EOL)
+      process.stdout.write(`  ${JSON.stringify(agent.permission, null, 2)}` + EOL)
+    }
+  }),
 })
 
 export const AgentCommand = cmd({

--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -1,5 +1,6 @@
 import { Global } from "@opencode-ai/core/global"
-import { bootstrap } from "../../bootstrap"
+import { Duration, Effect } from "effect"
+import { effectCmd } from "../../effect-cmd"
 import { cmd } from "../cmd"
 import { ConfigCommand } from "./config"
 import { FileCommand } from "./file"
@@ -26,17 +27,17 @@ export const DebugCommand = cmd({
       .command(StartupCommand)
       .command(AgentCommand)
       .command(PathsCommand)
-      .command({
-        command: "wait",
-        describe: "wait indefinitely (for debugging)",
-        async handler() {
-          await bootstrap(process.cwd(), async () => {
-            await new Promise((resolve) => setTimeout(resolve, 1_000 * 60 * 60 * 24))
-          })
-        },
-      })
+      .command(WaitCommand)
       .demandCommand(),
   async handler() {},
+})
+
+const WaitCommand = effectCmd({
+  command: "wait",
+  describe: "wait indefinitely (for debugging)",
+  handler: Effect.fn("Cli.debug.wait")(function* () {
+    yield* Effect.sleep(Duration.days(1))
+  }),
 })
 
 const PathsCommand = cmd({


### PR DESCRIPTION
## Summary

Three small CLI commands migrated from the legacy `bootstrap()` / `WithInstance.provide` Promise wrappers to `effectCmd`. Each handler is now a native `Effect.fn` body that yields `AppServices` directly. Step in the longer arc of retiring `cli/bootstrap.ts` and the Promise/ALS bridge layer.

## Commits

1. **`refactor(cli): convert debug wait to effectCmd`** — the inline `wait` subcommand (slept for 24h via `setTimeout`) becomes `Effect.sleep(Duration.days(1))` in a top-level `WaitCommand`.
2. **`refactor(cli): convert agent list to effectCmd`** — small handler, mechanical conversion. Drops the `AppRuntime.runPromise(Agent.Service.use(...))` wrapper for direct `yield* Agent.Service.use(...)`.
3. **`refactor(cli): convert acp to effectCmd`** — wraps the ACP server setup in `Effect.fn`, with `Effect.promise(...)` around the few async calls (`resolveNetworkOptions`, `Server.listen`, `ACP.init`, the stdin-end Promise).

## Effect on `cli/bootstrap.ts`

Two of three conversions kill `bootstrap()` callers:
- `acp.ts:24` (gone)
- `debug/index.ts:33` (gone)

Remaining `bootstrap()` callers in-tree:
- `cli/cmd/github.ts:442`
- `cli/cmd/run.ts:664`

Plus the public re-export at `node.ts:3` — that stays as a public API surface for embedders.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test test/agent/` — 39 pass

## Out of scope (follow-ups)

- `github.ts` and `run.ts` `bootstrap()` callers
- Direct `WithInstance.provide` callers in `agent create`, `mcp` (6 subcommands), `providers`, TUI plugin runtime, TUI worker
- Hono path retirement (separate effort)