### PR TITLE
refactor(cli): convert run command to effectCmd

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -1,6 +1,6 @@
 import type { CommandModule } from "yargs"
 
-type WithDoubleDash<T> = T & { "--"?: string[] }
+export type WithDoubleDash<T> = T & { "--"?: string[] }
 
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -1,10 +1,10 @@
 import type { Argv } from "yargs"
 import path from "path"
 import { pathToFileURL } from "url"
+import { Effect } from "effect"
 import { UI } from "../ui"
-import { cmd } from "./cmd"
+import { effectCmd } from "../effect-cmd"
 import { Flag } from "@opencode-ai/core/flag/flag"
-import { bootstrap } from "../bootstrap"
 import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
@@ -203,11 +203,17 @@ function normalizePath(input?: string) {
   return input
 }
 
-export const RunCommand = cmd({
+export const RunCommand = effectCmd({
   command: "run [message..]",
   describe: "run opencode with a message",
-  builder: (yargs: Argv) => {
-    return yargs
+  // --attach connects to a remote server (no local instance needed); the
+  // default path runs an in-process server and needs the project instance.
+  instance: (args) => !args.attach,
+  // For --dir without --attach, load instance for the resolved target dir.
+  // The handler also chdirs (preserving the legacy order: chdir → file resolution).
+  directory: (args) => (args.dir && !args.attach ? path.resolve(process.cwd(), args.dir) : process.cwd()),
+  builder: (yargs: Argv) =>
+    yargs
       .positional("message", {
         describe: "message to send",
         type: "string",
@@ -291,9 +297,9 @@ export const RunCommand = cmd({
         type: "boolean",
         describe: "auto-approve permissions that are not explicitly denied (dangerous!)",
         default: false,
-      })
-  },
-  handler: async (args) => {
+      }),
+  handler: Effect.fn("Cli.run")(function* (args) {
+    yield* Effect.promise(async () => {
     let message = [...args.message, ...(args["--"] || [])]
       .map((arg) => (arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg))
       .join(" ")
@@ -661,13 +667,14 @@ export const RunCommand = cmd({
       return await execute(sdk)
     }
 
-    await bootstrap(process.cwd(), async () => {
-      const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
-        const request = new Request(input, init)
-        return Server.Default().app.fetch(request)
-      }) as typeof globalThis.fetch
-      const sdk = createOpencodeClient({ baseUrl: "http://opencode.internal", fetch: fetchFn })
-      await execute(sdk)
+    // Default path: effectCmd already loaded the instance via InstanceStore.provide
+    // (see `instance: (args) => !args.attach`), so no bootstrap() wrap needed here.
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init)
+      return Server.Default().app.fetch(request)
+    }) as typeof globalThis.fetch
+    const sdk = createOpencodeClient({ baseUrl: "http://opencode.internal", fetch: fetchFn })
+    await execute(sdk)
     })
-  },
+  }),
 })

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -667,8 +667,6 @@ export const RunCommand = effectCmd({
       return await execute(sdk)
     }
 
-    // Default path: effectCmd already loaded the instance via InstanceStore.provide
-    // (see `instance: (args) => !args.attach`), so no bootstrap() wrap needed here.
     const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const request = new Request(input, init)
       return Server.Default().app.fetch(request)

--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -5,6 +5,8 @@ import { InstanceStore } from "@/project/instance-store"
 import { InstanceRef } from "@/effect/instance-ref"
 import { cmd } from "./cmd/cmd"
 
+type WithDoubleDash<T> = T & { "--"?: string[] }
+
 /**
  * User-visible command failure. Throw via `fail("...")` from an effectCmd handler
  * to surface a printed message + non-zero exit. Recognised by the global error
@@ -47,7 +49,7 @@ interface EffectCmdOpts<Args, A> {
   instance?: boolean | ((args: Args) => boolean)
   /** Defaults to process.cwd(). Override for commands that take a directory positional. */
   directory?: (args: Args) => string
-  handler: (args: Args) => Effect.Effect<A, CliError, AppServices | InstanceStore.Service>
+  handler: (args: WithDoubleDash<Args>) => Effect.Effect<A, CliError, AppServices | InstanceStore.Service>
 }
 
 /**
@@ -75,7 +77,7 @@ export const effectCmd = <Args, A>(opts: EffectCmdOpts<Args, A>) =>
     builder: opts.builder as never,
     async handler(rawArgs) {
       // yargs typing wraps Args in ArgumentsCamelCase<WithDoubleDash<...>>; cast at the boundary.
-      const args = rawArgs as unknown as Args
+      const args = rawArgs as unknown as WithDoubleDash<Args>
       const useInstance = typeof opts.instance === "function" ? opts.instance(args) : opts.instance !== false
       if (!useInstance) {
         await AppRuntime.runPromise(opts.handler(args))

--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -3,9 +3,7 @@ import { Effect, Schema } from "effect"
 import { AppRuntime, type AppServices } from "@/effect/app-runtime"
 import { InstanceStore } from "@/project/instance-store"
 import { InstanceRef } from "@/effect/instance-ref"
-import { cmd } from "./cmd/cmd"
-
-type WithDoubleDash<T> = T & { "--"?: string[] }
+import { cmd, type WithDoubleDash } from "./cmd/cmd"
 
 /**
  * User-visible command failure. Throw via `fail("...")` from an effectCmd handler


### PR DESCRIPTION
## Summary
Stage 3 of the run.ts conversion (Stage 1 is #25517 — function-form \`instance\`).

- \`cmd()\` → \`effectCmd({ instance: (args) => !args.attach, directory: ... })\`
  - **\`--attach\` path**: no instance load (matches legacy — legacy didn't load either; SDK talks to the remote server)
  - **default path**: instance loaded by \`effectCmd\` via \`InstanceStore.provide\`, auto-disposed on exit (matches legacy \`bootstrap()\` finally)
- Drop the \`bootstrap(process.cwd(), async () => {...})\` wrapper since \`effectCmd\` handles it now.
- The entire legacy handler body is wrapped in \`Effect.promise()\` inside \`Effect.fn\` for byte-equivalent behavior. \`process.exit(1)\` paths and the internal \`AppRuntime.runPromise(Agent.Service.use(...))\` agent-validation call all preserved as-is.

Also extends \`effectCmd\` to type \`handler\` args as \`WithDoubleDash<Args>\` so \`args["--"]\` (yargs's "everything after \`--\` separator") works without casts. Matches the legacy \`cmd()\` wrapper's shape.

## Why this conversion is safe
The \`Effect.promise(async () => { ... })\` wrap means the handler body executes as a Promise inside the Effect runtime — same async semantics as legacy \`async (args) => { ... }\`. No behavior change to:
- arg parsing, file resolution, validation, \`process.exit(1)\` paths
- session/share/execute/loop closures
- agent validation (\`sdk.app.agents\` for \`--attach\`, \`AppRuntime.runPromise(Agent.Service.use)\` for default)
- SDK construction (\`createOpencodeClient\` with remote URL or local fetch)

## Stacked on #25517
Depends on the function-form \`instance\` opt-out landing first.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] \`run\` (no args) → \`Error: You must provide a message or a command\` exit 1
- [x] \`run --fork "hi"\` → \`Error: --fork requires --continue or --session\` exit 1
- [x] \`run --file /tmp/nonexistent.txt "hi"\` → \`Error: File not found: ...\` exit 1
- [x] \`run --attach http://127.0.0.1:1 "hi"\` → connects, no instance load, fails gracefully → \`Error: Session not found\` exit 1