### PR TITLE
refactor(acp): drop async from synchronous ACP.init

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -130,7 +130,7 @@ async function sendUsageUpdate(
     })
 }
 
-export async function init({ sdk: _sdk }: { sdk: OpencodeClient }) {
+export function init({ sdk: _sdk }: { sdk: OpencodeClient }) {
   return {
     create: (connection: AgentSideConnection, fullConfig: ACPConfig) => {
       return new Agent(connection, fullConfig)

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -52,7 +52,7 @@ export const AcpCommand = effectCmd({
     })
 
     const stream = ndJsonStream(input, output)
-    const agent = yield* Effect.promise(() => ACP.init({ sdk }))
+    const agent = ACP.init({ sdk })
 
     new AgentSideConnection((conn) => {
       return agent.create(conn, { sdk })


### PR DESCRIPTION
## Summary

`ACP.init` was declared `async` but its body just returns a synchronous factory object — there was no actual async work. The caller in `cli/cmd/acp.ts` was wrapping it in `Effect.promise(() => ACP.init({ sdk }))` purely because of the spurious Promise return type.

Drop the `async`, call directly. Two-line cleanup.