### PR TITLE
refactor(cli): convert github subcommands to effectCmd

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -18,10 +18,9 @@ import type {
 } from "@octokit/webhooks-types"
 import { UI } from "../ui"
 import { cmd } from "./cmd"
+import { effectCmd } from "../effect-cmd"
 import { ModelsDev } from "@/provider/models"
-import { Instance } from "@/project/instance"
-import { WithInstance } from "@/project/with-instance"
-import { bootstrap } from "../bootstrap"
+import { InstanceRef } from "@/effect/instance-ref"
 import { SessionShare } from "@/share/session"
 import { Session } from "@/session/session"
 import type { SessionID } from "../../session/schema"
@@ -200,13 +199,14 @@ export const GithubCommand = cmd({
   async handler() {},
 })
 
-export const GithubInstallCommand = cmd({
+export const GithubInstallCommand = effectCmd({
   command: "install",
   describe: "install the GitHub agent",
-  async handler() {
-    await WithInstance.provide({
-      directory: process.cwd(),
-      async fn() {
+  handler: Effect.fn("Cli.github.install")(function* () {
+    const maybeCtx = yield* InstanceRef
+    if (!maybeCtx) return yield* Effect.die("InstanceRef not provided")
+    const ctx = maybeCtx
+    yield* Effect.promise(async () => {
         {
           UI.empty()
           prompts.intro("Install GitHub agent")
@@ -254,7 +254,7 @@ export const GithubInstallCommand = cmd({
           }
 
           async function getAppInfo() {
-            const project = Instance.project
+            const project = ctx.project
             if (project.vcs !== "git") {
               prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
               throw new UI.CancelledError()
@@ -262,14 +262,14 @@ export const GithubInstallCommand = cmd({
 
             // Get repo info
             const info = await AppRuntime.runPromise(
-              Git.Service.use((git) => git.run(["remote", "get-url", "origin"], { cwd: Instance.worktree })),
+              Git.Service.use((git) => git.run(["remote", "get-url", "origin"], { cwd: ctx.worktree })),
             ).then((x) => x.text().trim())
             const parsed = parseGitHubRemote(info)
             if (!parsed) {
               prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
               throw new UI.CancelledError()
             }
-            return { owner: parsed.owner, repo: parsed.repo, root: Instance.worktree }
+            return { owner: parsed.owner, repo: parsed.repo, root: ctx.worktree }
           }
 
           async function promptProvider() {
@@ -420,12 +420,11 @@ jobs:
             prompts.log.success(`Added workflow file: "${WORKFLOW_FILE}"`)
           }
         }
-      },
     })
-  },
+  }),
 })
 
-export const GithubRunCommand = cmd({
+export const GithubRunCommand = effectCmd({
   command: "run",
   describe: "run the GitHub agent",
   builder: (yargs) =>
@@ -438,8 +437,10 @@ export const GithubRunCommand = cmd({
         type: "string",
         describe: "GitHub personal access token (github_pat_********)",
       }),
-  async handler(args) {
-    await bootstrap(process.cwd(), async () => {
+  handler: Effect.fn("Cli.github.run")(function* (args) {
+    const ctx = yield* InstanceRef
+    if (!ctx) return yield* Effect.die("InstanceRef not provided")
+    yield* Effect.promise(async () => {
       const isMock = args.token || args.event
 
       const context = isMock ? (JSON.parse(args.event!) as Context) : github.context
@@ -502,21 +503,21 @@ export const GithubRunCommand = cmd({
           : "issue"
         : undefined
       const gitText = async (args: string[]) => {
-        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: Instance.worktree })))
+        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: ctx.worktree })))
         if (result.exitCode !== 0) {
           throw new Process.RunFailedError(["git", ...args], result.exitCode, result.stdout, result.stderr)
         }
         return result.text().trim()
       }
       const gitRun = async (args: string[]) => {
-        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: Instance.worktree })))
+        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: ctx.worktree })))
         if (result.exitCode !== 0) {
           throw new Process.RunFailedError(["git", ...args], result.exitCode, result.stdout, result.stderr)
         }
         return result
       }
       const gitStatus = (args: string[]) =>
-        AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: Instance.worktree })))
+        AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: ctx.worktree })))
       const commitChanges = async (summary: string, actor?: string) => {
         const args = ["commit", "-m", summary]
         if (actor) args.push("-m", `Co-authored-by: ${actor} <${actor}@users.noreply.github.com>`)
@@ -1646,5 +1647,5 @@ query($owner: String!, $repo: String!, $number: Int!) {
         })
       }
     })
-  },
+  }),
 })


### PR DESCRIPTION
## Summary
**Final CLI conversion.** \`GithubInstallCommand\` and \`GithubRunCommand\` both move from \`cmd()\` + their respective wrappers to \`effectCmd\` (default \`instance: true\` since both need a project context).

- \`GithubInstallCommand\`: drop \`WithInstance.provide\` wrapper. \`ctx\` via \`InstanceRef\`. \`Instance.project\` / \`Instance.worktree\` → \`ctx.project\` / \`ctx.worktree\`.
- \`GithubRunCommand\`: drop \`bootstrap()\` wrapper. \`ctx\` via \`InstanceRef\`. \`Instance.worktree\` → \`ctx.worktree\` (3 sites).
- The big bodies (install ~220 lines, run ~1220 lines) wrapped in \`Effect.promise(async () => {...})\` for byte-equivalent behavior. Same Stage 3 pattern from #25519.
- Parent \`GithubCommand\` stays on \`cmd()\` (just dispatches subcommands).
- Drop now-unused imports: \`WithInstance\`, \`bootstrap\`, \`Instance\`.

\`ctx\` is type-narrowed via const reassignment (\`const ctx = maybeCtx\`) because TS doesn't track the \`if (!maybeCtx) return\` narrow across the \`Effect.promise\` async closure boundary.

## Behavioral notes
- Both commands previously loaded an instance + ran it via ALS-bound \`Instance.current\`. New: instance loaded by \`effectCmd\` via \`InstanceStore.provide\`, \`InstanceRef\` provides \`ctx\` directly.
- Both now auto-dispose on exit via \`effectCmd\`'s \`Effect.ensuring\` wrap (matches legacy bootstrap behavior; \`WithInstance.provide\` legacy didn't dispose at all — strict improvement).
- Internal \`AppRuntime.runPromise(...)\` calls inside the Effect.promise body work the same (separate runtime invocations, AppServices available).

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] \`github --help\` shows install + run subcommands
- [x] \`github install --help\` / \`github run --help\` show flags correctly