### PR TITLE
fix: regression w/ auth login where stderr was ignored instead of inherited

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -316,6 +316,7 @@ export const ProvidersLoginCommand = cmd({
           prompts.log.info(`Running \`${wellknown.auth.command.join(" ")}\``)
           const proc = Process.spawn(wellknown.auth.command, {
             stdout: "pipe",
+            stderr: "inherit",
           })
           if (!proc.stdout) {
             prompts.log.error("Failed")


### PR DESCRIPTION
Commit 814c1d398c changed the well-known auth login command from Bun.spawn to the Process wrapper, which made unspecified stderr default to ignored instead of Bun's inherited stderr behavior. This restores stderr inheritance so remote auth helpers like cloudflared can show the login URL again

Closes #15200.