### PR TITLE
refactor(cli/mcp+agent): Stage 4 — drop AppRuntime.runPromise bridges

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -1,6 +1,5 @@
 import { cmd } from "./cmd"
 import * as prompts from "@clack/prompts"
-import { AppRuntime } from "@/effect/app-runtime"
 import { UI } from "../ui"
 import { Global } from "@opencode-ai/core/global"
 import { Agent } from "../../agent/agent"
@@ -66,6 +65,7 @@ const AgentCreateCommand = effectCmd({
     const maybeCtx = yield* InstanceRef
     if (!maybeCtx) return yield* Effect.die("InstanceRef not provided")
     const ctx = maybeCtx
+    const agentSvc = yield* Agent.Service
     yield* Effect.promise(async () => {
       const cliPath = args.path
       const cliDescription = args.description
@@ -127,9 +127,7 @@ const AgentCreateCommand = effectCmd({
       const spinner = prompts.spinner()
       spinner.start("Generating agent configuration...")
       const model = args.model ? Provider.parseModel(args.model) : undefined
-      const generated = await AppRuntime.runPromise(
-        Agent.Service.use((svc) => svc.generate({ description, model })),
-      ).catch((error) => {
+      const generated = await Effect.runPromise(agentSvc.generate({ description, model })).catch((error) => {
         spinner.stop(`LLM failed to generate agent: ${error.message}`, 1)
         if (isFullyNonInteractive) process.exit(1)
         throw new UI.CancelledError()

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -19,7 +19,6 @@ import { Global } from "@opencode-ai/core/global"
 import { modify, applyEdits } from "jsonc-parser"
 import { Filesystem } from "@/util/filesystem"
 import { Bus } from "../../bus"
-import { AppRuntime } from "../../effect/app-runtime"
 import { Effect } from "effect"
 
 function getAuthStatusIcon(status: MCP.AuthStatus): string {
@@ -606,11 +605,13 @@ export const McpDebugCommand = effectCmd({
       demandOption: true,
     }),
   handler: Effect.fn("Cli.mcp.debug")(function* (args) {
+    const config = yield* Config.Service.use((cfg) => cfg.get())
+    const mcp = yield* MCP.Service
+    const auth = yield* McpAuth.Service
     yield* Effect.promise(async () => {
       UI.empty()
       prompts.intro("MCP OAuth Debug")
 
-      const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get()))
       const mcpServers = config.mcp ?? {}
       const serverName = args.name
 
@@ -636,15 +637,11 @@ export const McpDebugCommand = effectCmd({
       prompts.log.info(`Server: ${serverName}`)
       prompts.log.info(`URL: ${serverConfig.url}`)
 
-      // Check stored auth status
-      const { authStatus, entry } = await AppRuntime.runPromise(
-        Effect.gen(function* () {
-          const mcp = yield* MCP.Service
-          const auth = yield* McpAuth.Service
-          return {
-            authStatus: yield* mcp.getAuthStatus(serverName),
-            entry: yield* auth.get(serverName),
-          }
+      // Check stored auth status — services already in hand, run inline.
+      const { authStatus, entry } = await Effect.runPromise(
+        Effect.all({
+          authStatus: mcp.getAuthStatus(serverName),
+          entry: auth.get(serverName),
         }),
       )
       prompts.log.info(`Auth status: ${getAuthStatusIcon(authStatus)} ${getAuthStatusText(authStatus)}`)
@@ -704,11 +701,6 @@ export const McpDebugCommand = effectCmd({
 
           // Try to discover OAuth metadata
           const oauthConfig = typeof serverConfig.oauth === "object" ? serverConfig.oauth : undefined
-          const auth = await AppRuntime.runPromise(
-            Effect.gen(function* () {
-              return yield* McpAuth.Service
-            }),
-          )
           const authProvider = new McpOAuthProvider(
             serverName,
             serverConfig.url,


### PR DESCRIPTION
## Summary
For commands where services were called via \`AppRuntime.runPromise(X.Service.use(...))\` inside the handler body, lift the services to the top of the \`Effect.fn\` handler and call their methods directly. Drops the \`AppRuntime\` import entirely from both files.

### \`mcp.ts\` (McpDebugCommand)
Yield \`Config\` + \`MCP\` + \`McpAuth\` services upfront, use them via closure inside the existing \`Effect.promise\` body:
- \`Config.get()\` → top-of-handler yield
- \`mcp.getAuthStatus + auth.get\` → \`Effect.runPromise(Effect.all({...}))\` (services already in scope, no AppRuntime needed)
- 3rd \`AppRuntime.runPromise(McpAuth.Service)\` → just removed; \`auth\` already yielded

### \`agent.ts\` (AgentCreateCommand)
Yield \`Agent.Service\` upfront, replace \`AppRuntime.runPromise(Agent.Service.use((svc) => svc.generate(...)))\` with \`Effect.runPromise(agentSvc.generate(...))\`.

## Net
4 \`AppRuntime.runPromise\` calls → 0 in both files. The remaining \`Effect.promise\` wraps stay because the bodies have many \`@clack/prompts\` awaits that aren't worth wrapping individually (each prompt would become \`yield* Effect.promise(() => prompts.X(...))\` for no real win).

## Stacked on #25525
Depends on the agent + providers + mcp Stage 3 conversion landing first.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] Smoke: \`mcp list\`, \`agent --help\` work as before