### PR TITLE
refactor(cli/providers): Stage 4 — drop inline AppRuntime.runPromise calls

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -1,6 +1,5 @@
 import { cmd } from "./cmd"
 import * as prompts from "@clack/prompts"
-import { AppRuntime } from "@/effect/app-runtime"
 import { UI } from "../ui"
 import { Global } from "@opencode-ai/core/global"
 import { Agent } from "../../agent/agent"
@@ -66,6 +65,7 @@ const AgentCreateCommand = effectCmd({
     const maybeCtx = yield* InstanceRef
     if (!maybeCtx) return yield* Effect.die("InstanceRef not provided")
     const ctx = maybeCtx
+    const agentSvc = yield* Agent.Service
     yield* Effect.promise(async () => {
       const cliPath = args.path
       const cliDescription = args.description
@@ -127,9 +127,7 @@ const AgentCreateCommand = effectCmd({
       const spinner = prompts.spinner()
       spinner.start("Generating agent configuration...")
       const model = args.model ? Provider.parseModel(args.model) : undefined
-      const generated = await AppRuntime.runPromise(
-        Agent.Service.use((svc) => svc.generate({ description, model })),
-      ).catch((error) => {
+      const generated = await Effect.runPromise(agentSvc.generate({ description, model })).catch((error) => {
         spinner.stop(`LLM failed to generate agent: ${error.message}`, 1)
         if (isFullyNonInteractive) process.exit(1)
         throw new UI.CancelledError()

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -19,7 +19,6 @@ import { Global } from "@opencode-ai/core/global"
 import { modify, applyEdits } from "jsonc-parser"
 import { Filesystem } from "@/util/filesystem"
 import { Bus } from "../../bus"
-import { AppRuntime } from "../../effect/app-runtime"
 import { Effect } from "effect"
 
 function getAuthStatusIcon(status: MCP.AuthStatus): string {
@@ -606,11 +605,13 @@ export const McpDebugCommand = effectCmd({
       demandOption: true,
     }),
   handler: Effect.fn("Cli.mcp.debug")(function* (args) {
+    const config = yield* Config.Service.use((cfg) => cfg.get())
+    const mcp = yield* MCP.Service
+    const auth = yield* McpAuth.Service
     yield* Effect.promise(async () => {
       UI.empty()
       prompts.intro("MCP OAuth Debug")
 
-      const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get()))
       const mcpServers = config.mcp ?? {}
       const serverName = args.name
 
@@ -636,15 +637,11 @@ export const McpDebugCommand = effectCmd({
       prompts.log.info(`Server: ${serverName}`)
       prompts.log.info(`URL: ${serverConfig.url}`)
 
-      // Check stored auth status
-      const { authStatus, entry } = await AppRuntime.runPromise(
-        Effect.gen(function* () {
-          const mcp = yield* MCP.Service
-          const auth = yield* McpAuth.Service
-          return {
-            authStatus: yield* mcp.getAuthStatus(serverName),
-            entry: yield* auth.get(serverName),
-          }
+      // Check stored auth status — services already in hand, run inline.
+      const { authStatus, entry } = await Effect.runPromise(
+        Effect.all({
+          authStatus: mcp.getAuthStatus(serverName),
+          entry: auth.get(serverName),
         }),
       )
       prompts.log.info(`Auth status: ${getAuthStatusIcon(authStatus)} ${getAuthStatusText(authStatus)}`)
@@ -704,11 +701,6 @@ export const McpDebugCommand = effectCmd({
 
           // Try to discover OAuth metadata
           const oauthConfig = typeof serverConfig.oauth === "object" ? serverConfig.oauth : undefined
-          const auth = await AppRuntime.runPromise(
-            Effect.gen(function* () {
-              return yield* McpAuth.Service
-            }),
-          )
           const authProvider = new McpOAuthProvider(
             serverName,
             serverConfig.url,

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -239,19 +239,16 @@ export const ProvidersListCommand = effectCmd({
   // Lists global credentials + provider env vars; no project instance needed.
   instance: false,
   handler: Effect.fn("Cli.providers.list")(function* (_args) {
+    const authSvc = yield* Auth.Service
+    const modelsDev = yield* ModelsDev.Service
     yield* Effect.promise(async () => {
       UI.empty()
       const authPath = path.join(Global.Path.data, "auth.json")
       const homedir = os.homedir()
       const displayPath = authPath.startsWith(homedir) ? authPath.replace(homedir, "~") : authPath
       prompts.intro(`Credentials ${UI.Style.TEXT_DIM}${displayPath}`)
-      const results = await AppRuntime.runPromise(
-        Effect.gen(function* () {
-          const auth = yield* Auth.Service
-          return Object.entries(yield* auth.all())
-        }),
-      )
-      const database = await getModels()
+      const results = Object.entries(await Effect.runPromise(authSvc.all()))
+      const database = await Effect.runPromise(modelsDev.get())
 
       for (const [providerID, result] of results) {
         const name = database[providerID]?.name || providerID
@@ -307,6 +304,8 @@ export const ProvidersLoginCommand = effectCmd({
         type: "string",
       }),
   handler: Effect.fn("Cli.providers.login")(function* (args) {
+    const cfgSvc = yield* Config.Service
+    const pluginSvc = yield* Plugin.Service
     yield* Effect.promise(async () => {
       UI.empty()
       prompts.intro("Add credential")
@@ -341,7 +340,7 @@ export const ProvidersLoginCommand = effectCmd({
       }
       await refreshModels().catch(() => {})
 
-      const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get()))
+      const config = await Effect.runPromise(cfgSvc.get())
 
       const disabled = new Set(config.disabled_providers ?? [])
       const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
@@ -355,12 +354,7 @@ export const ProvidersLoginCommand = effectCmd({
         }
         return filtered
       })
-      const hooks = await AppRuntime.runPromise(
-        Effect.gen(function* () {
-          const plugin = yield* Plugin.Service
-          return yield* plugin.list()
-        }),
-      )
+      const hooks = await Effect.runPromise(pluginSvc.list())
 
       const priority: Record<string, number> = {
         opencode: 0,
@@ -499,20 +493,17 @@ export const ProvidersLogoutCommand = effectCmd({
   // Removes a global auth credential; no project instance needed.
   instance: false,
   handler: Effect.fn("Cli.providers.logout")(function* (_args) {
+    const authSvc = yield* Auth.Service
+    const modelsDev = yield* ModelsDev.Service
     yield* Effect.promise(async () => {
       UI.empty()
-      const credentials: Array<[string, Auth.Info]> = await AppRuntime.runPromise(
-        Effect.gen(function* () {
-          const auth = yield* Auth.Service
-          return Object.entries(yield* auth.all())
-        }),
-      )
+      const credentials: Array<[string, Auth.Info]> = Object.entries(await Effect.runPromise(authSvc.all()))
       prompts.intro("Remove credential")
       if (credentials.length === 0) {
         prompts.log.error("No credentials found")
         return
       }
-      const database = await getModels()
+      const database = await Effect.runPromise(modelsDev.get())
       const selected = await prompts.select({
         message: "Select provider",
         options: credentials.map(([key, value]) => ({
@@ -522,12 +513,7 @@ export const ProvidersLogoutCommand = effectCmd({
       })
       if (prompts.isCancel(selected)) throw new UI.CancelledError()
       const providerID = selected as string
-      await AppRuntime.runPromise(
-        Effect.gen(function* () {
-          const auth = yield* Auth.Service
-          yield* auth.remove(providerID)
-        }),
-      )
+      await Effect.runPromise(authSvc.remove(providerID))
       prompts.outro("Logout successful")
     })
   }),


### PR DESCRIPTION
## Summary
For each providers handler, lift services to the top of the \`Effect.fn\` body and call methods on them via \`Effect.runPromise\` inside the existing \`Effect.promise\` wrap.

| Handler | Services yielded upfront | Inline calls dropped |
|---|---|---|
| \`providers list\` | Auth + ModelsDev | \`authSvc.all()\`, \`modelsDev.get()\` |
| \`providers login\` | Config + Plugin | \`cfgSvc.get()\`, \`pluginSvc.list()\` |
| \`providers logout\` | Auth + ModelsDev | \`authSvc.all()\`, \`modelsDev.get()\`, \`authSvc.remove()\` |

5 of 8 \`AppRuntime.runPromise\` sites eliminated. Same pattern as #25530 for mcp/agent.

## Out of scope
The 3 remaining \`AppRuntime.runPromise\` calls are top-level helpers (\`getModels\` / \`refreshModels\` / \`put\`) called from the non-handler \`handlePluginAuth\` function — converting those requires threading service refs through helper boundaries. Different change.

## Test plan
- [x] \`bun run typecheck\`
- [x] \`bun run test test/cli/\` — 137 pass
- [x] Smoke: \`auth list\` (\`providers list\` via alias) renders provider names + env vars