### PR TITLE
refactor(cli/github+run): Stage 4 — drop AppRuntime.runPromise bridges

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -29,7 +29,6 @@ import { Provider } from "@/provider/provider"
 import { Bus } from "../../bus"
 import { MessageV2 } from "../../session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
-import { AppRuntime } from "@/effect/app-runtime"
 import { Git } from "@/git"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
@@ -206,6 +205,8 @@ export const GithubInstallCommand = effectCmd({
     const maybeCtx = yield* InstanceRef
     if (!maybeCtx) return yield* Effect.die("InstanceRef not provided")
     const ctx = maybeCtx
+    const modelsDev = yield* ModelsDev.Service
+    const gitSvc = yield* Git.Service
     yield* Effect.promise(async () => {
       {
         UI.empty()
@@ -213,7 +214,7 @@ export const GithubInstallCommand = effectCmd({
         const app = await getAppInfo()
         await installGitHubApp()
 
-        const providers = await AppRuntime.runPromise(ModelsDev.Service.use((s) => s.get())).then((p) => {
+        const providers = await Effect.runPromise(modelsDev.get()).then((p) => {
           // TODO: add guide for copilot, for now just hide it
           delete p["github-copilot"]
           return p
@@ -261,9 +262,9 @@ export const GithubInstallCommand = effectCmd({
           }
 
           // Get repo info
-          const info = await AppRuntime.runPromise(
-            Git.Service.use((git) => git.run(["remote", "get-url", "origin"], { cwd: ctx.worktree })),
-          ).then((x) => x.text().trim())
+          const info = await Effect.runPromise(gitSvc.run(["remote", "get-url", "origin"], { cwd: ctx.worktree })).then(
+            (x) => x.text().trim(),
+          )
           const parsed = parseGitHubRemote(info)
           if (!parsed) {
             prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
@@ -440,6 +441,10 @@ export const GithubRunCommand = effectCmd({
   handler: Effect.fn("Cli.github.run")(function* (args) {
     const ctx = yield* InstanceRef
     if (!ctx) return yield* Effect.die("InstanceRef not provided")
+    const gitSvc = yield* Git.Service
+    const sessionSvc = yield* Session.Service
+    const sessionShare = yield* SessionShare.Service
+    const sessionPrompt = yield* SessionPrompt.Service
     yield* Effect.promise(async () => {
       const isMock = args.token || args.event
 
@@ -503,21 +508,20 @@ export const GithubRunCommand = effectCmd({
           : "issue"
         : undefined
       const gitText = async (args: string[]) => {
-        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: ctx.worktree })))
+        const result = await Effect.runPromise(gitSvc.run(args, { cwd: ctx.worktree }))
         if (result.exitCode !== 0) {
           throw new Process.RunFailedError(["git", ...args], result.exitCode, result.stdout, result.stderr)
         }
         return result.text().trim()
       }
       const gitRun = async (args: string[]) => {
-        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: ctx.worktree })))
+        const result = await Effect.runPromise(gitSvc.run(args, { cwd: ctx.worktree }))
         if (result.exitCode !== 0) {
           throw new Process.RunFailedError(["git", ...args], result.exitCode, result.stdout, result.stderr)
         }
         return result
       }
-      const gitStatus = (args: string[]) =>
-        AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: ctx.worktree })))
+      const gitStatus = (args: string[]) => Effect.runPromise(gitSvc.run(args, { cwd: ctx.worktree }))
       const commitChanges = async (summary: string, actor?: string) => {
         const args = ["commit", "-m", summary]
         if (actor) args.push("-m", `Co-authored-by: ${actor} <${actor}@users.noreply.github.com>`)
@@ -554,24 +558,22 @@ export const GithubRunCommand = effectCmd({
 
         // Setup opencode session
         const repoData = await fetchRepo()
-        session = await AppRuntime.runPromise(
-          Session.Service.use((svc) =>
-            svc.create({
-              permission: [
-                {
-                  permission: "question",
-                  action: "deny",
-                  pattern: "*",
-                },
-              ],
-            }),
-          ),
+        session = await Effect.runPromise(
+          sessionSvc.create({
+            permission: [
+              {
+                permission: "question",
+                action: "deny",
+                pattern: "*",
+              },
+            ],
+          }),
         )
         subscribeSessionEvents()
         shareId = await (async () => {
           if (share === false) return
           if (!share && repoData.data.private) return
-          await AppRuntime.runPromise(SessionShare.Service.use((svc) => svc.share(session.id)))
+          await Effect.runPromise(sessionShare.share(session.id))
           return session.id.slice(-8)
         })()
         console.log("opencode session", session.id)
@@ -944,9 +946,9 @@ export const GithubRunCommand = effectCmd({
       async function chat(message: string, files: PromptFiles = []) {
         console.log("Sending message to opencode...")
 
-        return AppRuntime.runPromise(
+        return Effect.runPromise(
           Effect.gen(function* () {
-            const prompt = yield* SessionPrompt.Service
+            const prompt = sessionPrompt
             const result = yield* prompt.prompt({
               sessionID: session.id,
               messageID: MessageID.ascending(),

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,7 +27,6 @@ import { ShellTool } from "../../tool/shell"
 import { ShellID } from "../../tool/shell/id"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "@/util/locale"
-import { AppRuntime } from "@/effect/app-runtime"
 
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
@@ -300,6 +299,7 @@ export const RunCommand = effectCmd({
         default: false,
       }),
   handler: Effect.fn("Cli.run")(function* (args) {
+    const agentSvc = yield* Agent.Service
     yield* Effect.promise(async () => {
       let message = [...args.message, ...(args["--"] || [])]
         .map((arg) => (arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg))
@@ -603,7 +603,7 @@ export const RunCommand = effectCmd({
             return name
           }
 
-          const entry = await AppRuntime.runPromise(Agent.Service.use((svc) => svc.get(name)))
+          const entry = await Effect.runPromise(agentSvc.get(name))
           if (!entry) {
             UI.println(
               UI.Style.TEXT_WARNING_BOLD + "!",


### PR DESCRIPTION
## Summary

Continues the Stage 4 cleanup arc — drops the remaining inline `AppRuntime.runPromise(Service.use(...))` bridges in `cli/cmd/github.ts` and `cli/cmd/run.ts`.

- **github.ts**: yield `Git` / `Session` / `SessionShare` / `SessionPrompt` / `ModelsDev` once at the top of each handler; replace the 8 inline `AppRuntime.runPromise(...)` sites with `Effect.runPromise(svc.method(...))` on the in-scope service.
- **run.ts**: same pattern for the single `Agent.Service.get` site.
- Removes the now-unused `AppRuntime` imports from both files.

Pure refactor — services already had typed `R = Service` requirements, just lifted them up one level so the runtime resolves them once instead of per-call. No behavior change.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test test/cli/github-action.test.ts test/cli/github-remote.test.ts` — 31 pass