### PR TITLE
fix(cli): bridge Instance.current ALS in effectCmd handlers (regression from #25522)

### DIFF
--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -92,10 +92,12 @@ export const effectCmd = <Args, A>(opts: EffectCmdOpts<Args, A>) =>
       const { store, ctx } = await AppRuntime.runPromise(
         InstanceStore.Service.use((store) => store.load({ directory }).pipe(Effect.map((ctx) => ({ store, ctx })))),
       )
-      await Instance.restore(ctx, () =>
-        AppRuntime.runPromise(
-          opts.handler(args).pipe(Effect.provideService(InstanceRef, ctx), Effect.ensuring(store.dispose(ctx))),
-        ),
-      )
+      try {
+        await Instance.restore(ctx, () =>
+          AppRuntime.runPromise(opts.handler(args).pipe(Effect.provideService(InstanceRef, ctx))),
+        )
+      } finally {
+        await AppRuntime.runPromise(store.dispose(ctx))
+      }
     },
   })

--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -3,6 +3,7 @@ import { Effect, Schema } from "effect"
 import { AppRuntime, type AppServices } from "@/effect/app-runtime"
 import { InstanceStore } from "@/project/instance-store"
 import { InstanceRef } from "@/effect/instance-ref"
+import { Instance } from "@/project/instance"
 import { cmd, type WithDoubleDash } from "./cmd/cmd"
 
 /**
@@ -82,16 +83,18 @@ export const effectCmd = <Args, A>(opts: EffectCmdOpts<Args, A>) =>
         return
       }
       const directory = opts.directory?.(args) ?? process.cwd()
-      await AppRuntime.runPromise(
-        InstanceStore.Service.use((store) =>
-          store.provide(
-            { directory },
-            Effect.gen(function* () {
-              const ctx = yield* InstanceRef
-              const body = opts.handler(args)
-              return ctx ? yield* body.pipe(Effect.ensuring(store.dispose(ctx))) : yield* body
-            }),
-          ),
+      // Two-phase: load ctx, then run body inside Instance.current ALS.
+      // Effect's InstanceRef is provided via fiber context, but that context is
+      // lost across `await` inside `Effect.promise(async () => ...)` callbacks
+      // — when handlers re-enter Effect via `AppRuntime.runPromise(svc.method())`
+      // there, attach() falls back to Instance.current ALS, which Node preserves
+      // across awaits. Matches the pre-effectCmd `bootstrap()` behavior.
+      const { store, ctx } = await AppRuntime.runPromise(
+        InstanceStore.Service.use((store) => store.load({ directory }).pipe(Effect.map((ctx) => ({ store, ctx })))),
+      )
+      await Instance.restore(ctx, () =>
+        AppRuntime.runPromise(
+          opts.handler(args).pipe(Effect.provideService(InstanceRef, ctx), Effect.ensuring(store.dispose(ctx))),
         ),
       )
     },

--- a/packages/opencode/test/cli/effect-cmd-instance-als.test.ts
+++ b/packages/opencode/test/cli/effect-cmd-instance-als.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
+import { InstanceRef } from "../../src/effect/instance-ref"
+import { InstanceBootstrap } from "../../src/project/bootstrap-service"
+import { Instance } from "../../src/project/instance"
+import { InstanceStore } from "../../src/project/instance-store"
+import { disposeAllInstances, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const noopBootstrap = Layer.succeed(
+  InstanceBootstrap.Service,
+  InstanceBootstrap.Service.of({ run: Effect.void }),
+)
+
+const it = testEffect(
+  Layer.mergeAll(InstanceStore.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(noopBootstrap)),
+)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+// Reproduces the regression from PR #25522: when an effectCmd handler does
+// `yield* Effect.promise(async () => { ... await someRunPromise(svcMethod) ... })`,
+// the inner runPromise creates a fresh fiber after `await` whose context lacks
+// the outer InstanceRef. Services that read `InstanceState.context` then fall
+// back to `Instance.current` ALS — which must still be set by effectCmd.
+describe("effectCmd Instance.current ALS bridge", () => {
+  it.live("preserves Instance.current ALS across Effect.promise(async) → runPromise re-entry", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const ctx = yield* store.load({ directory: dir })
+
+      // Mimic effectCmd: install ALS, then run the body via runPromise.
+      const inner = Effect.gen(function* () {
+        // First, prove Effect-level InstanceRef is provided on the synchronous path.
+        const fromRef = yield* InstanceRef
+        expect(fromRef?.directory).toBe(dir)
+
+        // Now cross into Effect.promise(async) and re-enter Effect from the async closure.
+        // The inner runPromise gets a fresh fiber whose context has InstanceRef = undefined.
+        // Without the ALS bridge, Instance.current would throw — and any service that
+        // yields InstanceState.context would die with LocalContext.NotFound.
+        yield* Effect.promise(async () => {
+          await new Promise((r) => setTimeout(r, 5))
+          const current = await Effect.runPromise(
+            Effect.sync(() => {
+              try {
+                return Instance.current
+              } catch {
+                return undefined
+              }
+            }),
+          )
+          expect(current?.directory).toBe(dir)
+        })
+      }).pipe(Effect.provideService(InstanceRef, ctx))
+
+      // SANITY: replace the next line with `yield* Effect.promise(() => Effect.runPromise(inner))`
+      // (no Instance.restore) and the test must fail with `current?.directory` undefined.
+      yield* Effect.promise(() => Instance.restore(ctx, () => Effect.runPromise(inner)))
+    }),
+  )
+})

--- a/packages/opencode/test/cli/effect-cmd-instance-als.test.ts
+++ b/packages/opencode/test/cli/effect-cmd-instance-als.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "bun:test"
 import { Effect } from "effect"
+import fs from "fs/promises"
 import { Instance } from "../../src/project/instance"
 import { disposeAllInstances, provideTestInstance, tmpdir } from "../fixture/fixture"
 
@@ -14,6 +15,15 @@ afterEach(async () => {
 // then fall back to `Instance.current` ALS, which must be installed at the JS
 // callback boundary (Node ALS persists across awaits, Effect's fiber context
 // does not). `provideTestInstance` mirrors effectCmd's load + ALS-restore wrap.
+// Pins effect-cmd.ts directly: the pattern test below exercises the load +
+// Instance.restore + dispose triple via the shared `provideTestInstance` fixture,
+// so a regression that removed `Instance.restore` from effect-cmd.ts wouldn't
+// fail it. This grep guards the actual production callsite.
+test("effect-cmd.ts wraps the handler body in Instance.restore", async () => {
+  const source = await fs.readFile(new URL("../../src/cli/effect-cmd.ts", import.meta.url), "utf8")
+  expect(source).toContain("Instance.restore(ctx")
+})
+
 test("Instance.current reachable from inner runPromise inside Effect.promise(async)", async () => {
   await using dir = await tmpdir({ git: true })
   await provideTestInstance({

--- a/packages/opencode/test/cli/effect-cmd-instance-als.test.ts
+++ b/packages/opencode/test/cli/effect-cmd-instance-als.test.ts
@@ -1,49 +1,26 @@
-import { afterEach, describe, expect } from "bun:test"
-import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import { Effect, Layer } from "effect"
-import { InstanceRef } from "../../src/effect/instance-ref"
-import { InstanceBootstrap } from "../../src/project/bootstrap-service"
+import { afterEach, expect, test } from "bun:test"
+import { Effect } from "effect"
 import { Instance } from "../../src/project/instance"
-import { InstanceStore } from "../../src/project/instance-store"
-import { disposeAllInstances, tmpdirScoped } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
-
-const noopBootstrap = Layer.succeed(
-  InstanceBootstrap.Service,
-  InstanceBootstrap.Service.of({ run: Effect.void }),
-)
-
-const it = testEffect(
-  Layer.mergeAll(InstanceStore.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(noopBootstrap)),
-)
+import { disposeAllInstances, provideTestInstance, tmpdir } from "../fixture/fixture"
 
 afterEach(async () => {
   await disposeAllInstances()
 })
 
-// Reproduces the regression from PR #25522: when an effectCmd handler does
-// `yield* Effect.promise(async () => { ... await someRunPromise(svcMethod) ... })`,
-// the inner runPromise creates a fresh fiber after `await` whose context lacks
-// the outer InstanceRef. Services that read `InstanceState.context` then fall
-// back to `Instance.current` ALS — which must still be set by effectCmd.
-describe("effectCmd Instance.current ALS bridge", () => {
-  it.live("preserves Instance.current ALS across Effect.promise(async) → runPromise re-entry", () =>
-    Effect.gen(function* () {
-      const dir = yield* tmpdirScoped({ git: true })
-      const store = yield* InstanceStore.Service
-      const ctx = yield* store.load({ directory: dir })
-
-      // Mimic effectCmd: install ALS, then run the body via runPromise.
-      const inner = Effect.gen(function* () {
-        // First, prove Effect-level InstanceRef is provided on the synchronous path.
-        const fromRef = yield* InstanceRef
-        expect(fromRef?.directory).toBe(dir)
-
-        // Now cross into Effect.promise(async) and re-enter Effect from the async closure.
-        // The inner runPromise gets a fresh fiber whose context has InstanceRef = undefined.
-        // Without the ALS bridge, Instance.current would throw — and any service that
-        // yields InstanceState.context would die with LocalContext.NotFound.
-        yield* Effect.promise(async () => {
+// Regression for PR #25522: when an effectCmd handler does
+// `yield* Effect.promise(async () => { ... await runPromise(svcMethod) ... })`,
+// the inner runPromise creates a fresh fiber after `await` whose Effect context
+// has lost the outer InstanceRef. Services that read `InstanceState.context`
+// then fall back to `Instance.current` ALS, which must be installed at the JS
+// callback boundary (Node ALS persists across awaits, Effect's fiber context
+// does not). `provideTestInstance` mirrors effectCmd's load + ALS-restore wrap.
+test("Instance.current reachable from inner runPromise inside Effect.promise(async)", async () => {
+  await using dir = await tmpdir({ git: true })
+  await provideTestInstance({
+    directory: dir.path,
+    fn: () =>
+      Effect.runPromise(
+        Effect.promise(async () => {
           await new Promise((r) => setTimeout(r, 5))
           const current = await Effect.runPromise(
             Effect.sync(() => {
@@ -54,13 +31,8 @@ describe("effectCmd Instance.current ALS bridge", () => {
               }
             }),
           )
-          expect(current?.directory).toBe(dir)
-        })
-      }).pipe(Effect.provideService(InstanceRef, ctx))
-
-      // SANITY: replace the next line with `yield* Effect.promise(() => Effect.runPromise(inner))`
-      // (no Instance.restore) and the test must fail with `current?.directory` undefined.
-      yield* Effect.promise(() => Instance.restore(ctx, () => Effect.runPromise(inner)))
-    }),
-  )
+          expect(current?.directory).toBe(dir.path)
+        }),
+      ),
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a latent breakage introduced in PR #25522 (the original effectCmd conversion of github.ts). Any handler that does `yield* Effect.promise(async () => { ... await AppRuntime.runPromise(svc.method()) ... })` loses the outer `InstanceRef` for the inner Effect run.

### Root cause

Effect's fiber context propagates only through Effect's own scheduling. Inside an `async` callback after the first `await`, `Fiber.getCurrent()` returns undefined, so `attach()` in `run-service.ts` can't recover the outer fiber's `InstanceRef`. The inner Effect then runs with `InstanceRef` defaulting to `undefined`, and `InstanceState.context` falls through to `Instance.current` ALS — which the new `effectCmd` was no longer setting (the legacy `bootstrap()` path used to via `WithInstance.provide`).

End result: services that yield `InstanceState.context` (e.g. `Session.create`, `SessionShare.share`, `SessionPrompt.prompt`, `Agent.get`) die with `LocalContext.NotFound` when invoked from inside an `Effect.promise(async)` block in any effectCmd handler. This broke `opencode github run`, which exercises exactly that pattern.

The bug was caught by a review-agent audit of an unrelated stage-4 PR (#25539). Empirically confirmed with a focused test (see below).

### Fix

In `effectCmd`, split load and body into two `AppRuntime.runPromise` calls so the body can run inside `Instance.restore(ctx, ...)`. Node's `AsyncLocalStorage` persists across awaits, so any nested `AppRuntime.runPromise` inside an async closure now recovers the instance via `attach()`'s ALS fallback. Restores pre-#25522 behavior without giving up the Effect-context `InstanceRef` on the synchronous path.

```ts
// before
await AppRuntime.runPromise(
  InstanceStore.Service.use((store) =>
    store.provide({ directory }, Effect.gen(function* () { ... })),
  ),
)

// after
const { store, ctx } = await AppRuntime.runPromise(
  InstanceStore.Service.use((store) => store.load({ directory }).pipe(Effect.map((ctx) => ({ store, ctx })))),
)
await Instance.restore(ctx, () =>
  AppRuntime.runPromise(
    opts.handler(args).pipe(Effect.provideService(InstanceRef, ctx), Effect.ensuring(store.dispose(ctx))),
  ),
)
```

### Regression test

`test/cli/effect-cmd-instance-als.test.ts` reproduces the exact pattern: store.load → Effect.promise(async => { runPromise inside }) and asserts that `Instance.current` is reachable from the inner async closure. Replacing the `Instance.restore(...)` wrap with a bare `Effect.runPromise(inner)` causes the test to fail (manually verified) — proves the fix is load-bearing.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test test/cli/effect-cmd-instance-als.test.ts` — 1 pass; verified the test fails without the restore wrap
- [x] `bun run test test/project/instance.test.ts test/cli/` — 148 pass