### PR TITLE
fix: Add Windows support for Zed database path resolution

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/editor-zed.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor-zed.ts
@@ -185,6 +185,7 @@ function isZedActiveEditorRow(row: ZedEditorRow): row is ZedActiveEditorRow {
 export function resolveZedDbPath() {
   const candidates = [
     process.env.OPENCODE_ZED_DB,
+    path.join(os.homedir(), "AppData", "Local", "Zed", "db", "0-stable", "db.sqlite"),
     path.join(os.homedir(), "Library", "Application Support", "Zed", "db", "0-stable", "db.sqlite"),
     path.join(os.homedir(), ".local", "share", "zed", "db", "0-stable", "db.sqlite"),
   ].filter((item): item is string => Boolean(item))


### PR DESCRIPTION
### Issue for this PR

Closes #24796 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

paths does not automatically find the Windows Zed DB under %LOCALAPPDATA%\Zed\db\0-stable\db.sqlite. Setting OPENCODE_ZED_DB manually works in principle
so this PR add the windows path lookup for it. 

### How did you verify your code works?

bun dev locally and zed on windows os to check if zed selection work without setting OPENCODE_ZED_DB env

### Screenshots / recordings

<img width="1856" height="610" alt="image" src="https://github.com/user-attachments/assets/10e6e8cb-9e47-42b9-8ff7-4072c8ef237e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR