### PR TITLE
Add debug info command

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -1,5 +1,10 @@
 import { Global } from "@opencode-ai/core/global"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import os from "os"
 import { Duration, Effect } from "effect"
+import { Config } from "@/config/config"
+import { ConfigPlugin } from "@/config/plugin"
 import { effectCmd } from "../../effect-cmd"
 import { cmd } from "../cmd"
 import { ConfigCommand } from "./config"
@@ -26,6 +31,7 @@ export const DebugCommand = cmd({
       .command(SnapshotCommand)
       .command(StartupCommand)
       .command(AgentCommand)
+      .command(InfoCommand)
       .command(PathsCommand)
       .command(WaitCommand)
       .demandCommand(),
@@ -37,6 +43,34 @@ const WaitCommand = effectCmd({
   describe: "wait indefinitely (for debugging)",
   handler: Effect.fn("Cli.debug.wait")(function* () {
     yield* Effect.sleep(Duration.days(1))
+  }),
+})
+
+const InfoCommand = effectCmd({
+  command: "info",
+  describe: "show debug information",
+  handler: Effect.fn("Cli.debug.info")(function* () {
+    const config = yield* Config.Service.use((cfg) => cfg.get())
+    const termProgram = process.env.TERM_PROGRAM
+      ? `${process.env.TERM_PROGRAM}${process.env.TERM_PROGRAM_VERSION ? ` ${process.env.TERM_PROGRAM_VERSION}` : ""}`
+      : undefined
+    const terminal = [termProgram, process.env.TERM].filter((item): item is string => Boolean(item)).join(" / ")
+
+    console.log(`opencode version: ${InstallationVersion}`)
+    console.log(`os: ${os.type()} ${os.release()} ${os.arch()}`)
+    console.log(`terminal: ${terminal || "unknown"}`)
+    console.log("plugins:")
+    if (Flag.OPENCODE_PURE) {
+      console.log("external plugins disabled (--pure)")
+      return
+    }
+    if (!config.plugin_origins?.length) {
+      console.log("none")
+      return
+    }
+    for (const plugin of config.plugin_origins) {
+      console.log(`- ${ConfigPlugin.pluginSpecifier(plugin.spec)}`)
+    }
   }),
 })
 


### PR DESCRIPTION
## Summary
- Add `opencode debug info` for collecting version, OS, terminal, and configured plugin details.
- Respect `--pure` by reporting external plugins as disabled.

## Verification
- `bun typecheck`
- `bun run dev debug info`