### PR TITLE
fix(tui): surface non-stop finish reasons in assistant header

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -82,7 +82,7 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import * as Model from "../../util/model"
-import { formatTranscript } from "../../util/transcript"
+import { formatFinishReason, formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 import { getScrollAcceleration } from "../../util/scroll"
@@ -1362,6 +1362,8 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)
   })
 
+  const finishLabel = createMemo(() => formatFinishReason(props.message.finish))
+
   const duration = createMemo(() => {
     if (!final()) return 0
     if (!props.message.time.completed) return 0
@@ -1432,6 +1434,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>
+              </Show>
+              <Show when={!props.message.error && finishLabel()}>
+                <span style={{ fg: theme.textMuted }}> · {finishLabel()}</span>
               </Show>
             </text>
           </box>

--- a/packages/opencode/src/cli/cmd/tui/util/transcript.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/transcript.ts
@@ -77,8 +77,24 @@ export function formatAssistantHeader(
     msg.time.completed && msg.time.created ? ((msg.time.completed - msg.time.created) / 1000).toFixed(1) + "s" : ""
 
   const modelName = Model.name(providers, msg.providerID, msg.modelID)
+  const finishLabel = formatFinishReason(msg.finish)
 
-  return `## Assistant (${Locale.titlecase(msg.agent)} · ${modelName}${duration ? ` · ${duration}` : ""})\n\n`
+  return `## Assistant (${Locale.titlecase(msg.agent)} · ${modelName}${duration ? ` · ${duration}` : ""}${
+    finishLabel ? ` · ${finishLabel}` : ""
+  })\n\n`
+}
+
+export function formatFinishReason(finish: string | undefined): string {
+  switch (finish) {
+    case "length":
+      return "truncated by length limit"
+    case "content-filter":
+      return "stopped by content filter"
+    case "error":
+      return "ended with error"
+    default:
+      return ""
+  }
 }
 
 export function formatPart(part: Part, options: TranscriptOptions): string {

--- a/packages/opencode/test/cli/tui/transcript.test.ts
+++ b/packages/opencode/test/cli/tui/transcript.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   formatAssistantHeader,
+  formatFinishReason,
   formatMessage,
   formatPart,
   formatTranscript,
@@ -108,6 +109,64 @@ describe("transcript", () => {
       const msg = { ...baseMsg, agent: "plan" }
       const result = formatAssistantHeader(msg, true)
       expect(result).toContain("Plan")
+    })
+
+    test("appends finish reason when truncated by length limit", () => {
+      const msg = { ...baseMsg, finish: "length" }
+      const result = formatAssistantHeader(msg, true)
+      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514 · 5.4s · truncated by length limit)\n\n")
+    })
+
+    test("appends finish reason when stopped by content filter", () => {
+      const msg = { ...baseMsg, finish: "content-filter" }
+      const result = formatAssistantHeader(msg, true)
+      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514 · 5.4s · stopped by content filter)\n\n")
+    })
+
+    test("appends finish reason when ended with error", () => {
+      const msg = { ...baseMsg, finish: "error" }
+      const result = formatAssistantHeader(msg, true)
+      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514 · 5.4s · ended with error)\n\n")
+    })
+
+    test("omits finish reason for normal stop", () => {
+      const msg = { ...baseMsg, finish: "stop" }
+      const result = formatAssistantHeader(msg, true)
+      expect(result).toBe("## Assistant (Build · claude-sonnet-4-20250514 · 5.4s)\n\n")
+    })
+
+    test("omits finish reason when not included in metadata", () => {
+      const msg = { ...baseMsg, finish: "length" }
+      const result = formatAssistantHeader(msg, false)
+      expect(result).toBe("## Assistant\n\n")
+    })
+  })
+
+  describe("formatFinishReason", () => {
+    test("returns label for length", () => {
+      expect(formatFinishReason("length")).toBe("truncated by length limit")
+    })
+
+    test("returns label for content-filter", () => {
+      expect(formatFinishReason("content-filter")).toBe("stopped by content filter")
+    })
+
+    test("returns label for error", () => {
+      expect(formatFinishReason("error")).toBe("ended with error")
+    })
+
+    test("returns empty string for stop", () => {
+      expect(formatFinishReason("stop")).toBe("")
+    })
+
+    test("returns empty string for tool-calls", () => {
+      expect(formatFinishReason("tool-calls")).toBe("")
+    })
+
+    test("returns empty string for unknown values", () => {
+      expect(formatFinishReason("other")).toBe("")
+      expect(formatFinishReason("unknown")).toBe("")
+      expect(formatFinishReason(undefined)).toBe("")
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #23928

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The assistant header status bar already shows `· interrupted` when the message ended with `MessageAbortedError`. When the model itself ends a response abnormally (length limit hit, content filter triggered, error during streaming), `message.finish` is set to `length` / `content-filter` / `error`, the message is treated as final, and the user sees no indication of why the output stopped.

In #23928 the reporter confirmed via SQL query against `part` that storage matches the TUI cut-off (text in storage ends at the same character the TUI shows). The stream/storage path is doing the right thing — the model is returning a truncated response and opencode persists exactly what was returned. Surfacing the cause in the header is the missing piece.

Mirrors the existing `interrupted` indicator pattern in both:
- `AssistantMessage` TUI status bar (`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`)
- `formatAssistantHeader` markdown transcript export (`packages/opencode/src/cli/cmd/tui/util/transcript.ts`)

Header examples after this change:

- length:         `▣ Plan · MiniMax M2.5 · 41.0s · truncated by length limit`
- content-filter: `▣ Build · gpt-4o · 12.3s · stopped by content filter`
- error:          `▣ Build · claude-3-5-sonnet · 5.4s · ended with error`
- stop:           `▣ Build · claude-3-5-sonnet · 5.4s` (unchanged)

### How did you verify your code works?

- `bun test packages/opencode/test/cli/tui/transcript.test.ts` — 29/29 pass (13 new cases covering length/content-filter/error/stop/tool-calls/other/unknown/undefined plus the metadata-disabled path)
- `bun test packages/opencode` — 150/150 pass
- `bun typecheck` clean
- Verified the existing `interrupted` indicator path is unchanged (same `<Show>` block above the new one)

### Screenshots / recordings

Text-only TUI change — captured in the four header examples above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
