### PR TITLE
chore: remove tree-sitter-powershell from trustedDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -665,7 +665,6 @@
   },
   "trustedDependencies": [
     "esbuild",
-    "tree-sitter-powershell",
     "protobufjs",
     "electron",
     "web-tree-sitter",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "protobufjs",
     "tree-sitter",
     "tree-sitter-bash",
-    "tree-sitter-powershell",
     "web-tree-sitter",
     "electron"
   ],


### PR DESCRIPTION
### Issue for this PR

Closes #25563

### Type of change

- [x] Bug fix

### What does this PR do?

Removes `tree-sitter-powershell` from the root `package.json` `trustedDependencies` array.

The package is consumed exclusively via its bundled WASM file in `packages/opencode/src/tool/shell.ts`:

```ts
await import(tree-sitter-powershell/tree-sitter-powershell.wasm as string, { with: { type: wasm } })
```

The native `.node` binding produced by its postinstall (`node-gyp-build`) is never imported. Trusting it just runs an install script that has no usable output:

- On Mac/Linux: compiles a `.node` nobody loads
- On Windows: fails because `tree-sitter-powershell@0.25.10` ships no prebuilds, so `node-gyp-build` falls back to `node-gyp build`, which needs Visual Studio Build Tools

Removing the entry skips the postinstall on every platform. The `.wasm` file is shipped as a static file in the package and continues to load at runtime.

### How did you verify your code works?

On Windows (no VS Build Tools installed):

- Clean `rm -rf node_modules && bun install` — completed without the `tree-sitter-powershell` error (previously aborted mid-way)
- `bun turbo typecheck` — 15/15 packages green
- Smoke-tested the shell tool — PowerShell scripts still parse correctly via the WASM path

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR