### PR TITLE
fix(packages): convert custom-elements.d.ts symlinks to triple-slash references

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,2 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />
+export {}

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,2 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />
+export {}


### PR DESCRIPTION
### Issue for this PR

Closes #25564

### Type of change

- [x] Bug fix

### What does this PR do?

Replaces the symlinks at `packages/app/src/custom-elements.d.ts` and `packages/enterprise/src/custom-elements.d.ts` (both git mode 120000, pointing to `../../ui/src/custom-elements.d.ts`) with real files containing a triple-slash reference:

```ts
/// <reference path=../../ui/src/custom-elements.d.ts />
export {}
```

The symlinks break on Windows clones with the default `core.symlinks=false` — they materialize as plain text files containing the link target string, which TypeScript then ignores, dropping the `<diffs-container>` JSX type augmentation. Triple-slash references work on every platform without git config changes.

`packages/ui/src/custom-elements.d.ts` remains the single source of truth.

### How did you verify your code works?

On Windows (default `core.symlinks=false`, no Developer Mode):

- Confirmed the previous behavior: pre-fix, `bun turbo typecheck` failed on `@opencode-ai/enterprise` with `<diffs-container>` undefined
- After the change: `bun turbo typecheck` — 15/15 packages green
- Inspected `git ls-files --stage` to confirm both files are now mode 100644 (regular files), not 120000 (symlinks)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR