### PR TITLE
docs(opencode): clarify C# LSP requires csharp-ls

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -16,7 +16,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | astro              | .astro                                                              | Auto-installs for Astro projects                             |
 | bash               | .sh, .bash, .zsh, .ksh                                              | Auto-installs bash-language-server                           |
 | clangd             | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++                | Auto-installs for C/C++ projects                             |
-| csharp             | .cs, .csx                                                           | `.NET SDK` installed                                         |
+| csharp             | .cs, .csx                                                           | `.NET SDK` installed; csharp-ls command available            |
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` command available                              |
 | dart               | .dart                                                               | `dart` command available                                     |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` command available (auto-detects deno.json/deno.jsonc) |


### PR DESCRIPTION
### Issue for this PR

The LSP Servers built-in table listed **csharp** as only requiring the `.NET SDK`. OpenCode actually starts **`csharp-ls`**, which is a separate global tool and is **not** installed with the SDK. Users who only have the SDK still see missing-server behavior / the `dotnet tool install -g csharp-ls` hint, and the docs did not state that **csharp-ls** must be on `PATH`.

N/A (no existing issue; docs-only clarification)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the **csharp** row in the built-in LSP requirements table so it reflects that **`csharp-ls`** must be available (e.g. `dotnet tool install -g csharp-ls` with `%USERPROFILE%\.dotnet\tools` or equivalent on `PATH`), in addition to the `.NET SDK` for normal project loading. This matches how other rows describe an external command (`*command* command available`) where appropriate.

The product already launches **`csharp-ls`** for `.cs` / `.csx`; the SDK alone does not ship that executable. Documenting **csharp-ls** matches runtime behavior and correct setup expectations.

### How did you verify your code works?

- Reviewed the Markdown file locally: table renders and columns align.
- On a machine with the `.NET SDK` but without `csharp-ls`, OpenCode shows the `dotnet tool install -g csharp-ls` message; the updated row explains that requirement.

### Screenshots / recordings

N/A — documentation-only change, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR