### PR TITLE
fix: propagate chunkTimeout to streamText timeout.chunkMs for silent stream dropout detection

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -333,6 +333,14 @@ const live: Layer.Layer<
         ? (yield* InstanceState.context).project.id
         : undefined
 
+      // Pass chunkTimeout from provider/model options to streamText for AI SDK-level
+      // chunk idle timeout detection. This catches silenced stream dropouts where
+      // the TCP connection stays open but no SSE chunks arrive.
+      const chunkTimeout = typeof options["chunkTimeout"] === "number" ? options["chunkTimeout"] : undefined
+      if (chunkTimeout) {
+        l.debug("chunk idle timeout configured", { chunkTimeout })
+      }
+
       return streamText({
         onError(error) {
           l.error("stream error", {
@@ -369,6 +377,9 @@ const live: Layer.Layer<
         toolChoice: input.toolChoice,
         maxOutputTokens: params.maxOutputTokens,
         abortSignal: input.abort,
+        // Stream chunk idle timeout: aborts if no SSE chunk arrives within the window.
+        // Catches silent provider dropouts that keep the TCP connection alive but stop sending data.
+        ...(chunkTimeout ? { timeout: { chunkMs: chunkTimeout } } : {}),
         headers: {
           ...(input.model.providerID.startsWith("opencode")
             ? {

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -378,7 +378,7 @@ Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 ```
 
 - `timeout` - Request timeout in milliseconds (default: 300000). Set to `false` to disable.
-- `chunkTimeout` - Timeout in milliseconds between streamed response chunks. If no chunk arrives in time, the request is aborted.
+- `chunkTimeout` - Timeout in milliseconds between streamed response chunks. If no chunk arrives in time, the request is aborted. This catches silent provider dropouts where the TCP connection stays open but SSE streaming stops. Recommended: `15000`–`30000` (15–30 seconds) for providers with unreliable streaming. Also propagated to the AI SDK's `timeout.chunkMs` for additional safety at the stream consumer level.
 - `setCacheKey` - Ensure a cache key is always set for designated provider.
 
 You can also configure [local models](/docs/models#local). [Learn more](/docs/models).

--- a/packages/web/src/content/docs/zh-cn/config.mdx
+++ b/packages/web/src/content/docs/zh-cn/config.mdx
@@ -238,7 +238,7 @@ opencode run "Hello world"
 
 `small_model` 选项为标题生成等轻量级任务配置单独的模型。默认情况下，如果您的提供商有更便宜的模型可用，OpenCode 会尝试使用该模型，否则会回退到您的主模型。
 
-提供商选项可以包括 `timeout` 和 `setCacheKey`：
+提供商选项可以包括 `timeout`、`chunkTimeout` 和 `setCacheKey`：
 
 ```json title="opencode.json"
 {
@@ -247,6 +247,7 @@ opencode run "Hello world"
     "anthropic": {
       "options": {
         "timeout": 600000,
+        "chunkTimeout": 30000,
         "setCacheKey": true
       }
     }
@@ -255,6 +256,7 @@ opencode run "Hello world"
 ```
 
 - `timeout` - 请求超时时间，单位为毫秒（默认值：300000）。设置为 `false` 可禁用超时。
+- `chunkTimeout` - 流式响应 chunk 之间的超时时间（毫秒）。如果在指定时间内没有收到 chunk，请求将被中止。这可以捕获 provider 静默断开的情况——TCP 连接保持但 SSE 流停止。对于流式不稳定的 provider，推荐设置为 `15000`–`30000`（15–30 秒）。此配置也会传递到 AI SDK 的 `timeout.chunkMs`，在流消费层提供额外的安全保障。
 - `setCacheKey` - 确保始终为指定提供商设置缓存键。
 
 您还可以配置[本地模型](/docs/models#local)。[了解更多](/docs/models)。


### PR DESCRIPTION
## Summary

- Propagates chunkTimeout to streamText timeout.chunkMs in Vercel AI SDK layer. The config option already existed in the provider schema and worked at the custom fetch wrapper level (provider.ts wrapSSE), but was not passed through to the streamText call.

- Catches silent provider dropouts where TCP connection stays open but SSE chunks stop arriving. Without chunk-level idle timeout, the session hangs indefinitely with no retry triggered.

- Enhanced documentation in both English and Chinese with failure scenario description and recommended timeout values (15-30 seconds).

## Files Changed

| File | Change |
|------|--------|
| `packages/opencode/src/session/llm.ts` | Extract chunkTimeout from options, pass as timeout.chunkMs to streamText |
| `packages/web/src/content/docs/config.mdx` | Enhanced chunkTimeout description |
| `packages/web/src/content/docs/zh-cn/config.mdx` | Added missing Chinese documentation for chunkTimeout |