### PR TITLE
feat(desktop): add message-level fork action

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -29,7 +29,7 @@ import { previewSelectedLines } from "@opencode-ai/ui/pierre/selection-bridge"
 import { Button } from "@opencode-ai/ui/button"
 import { showToast } from "@opencode-ai/ui/toast"
 import { checksum } from "@opencode-ai/core/util/encode"
-import { useLocation, useSearchParams } from "@solidjs/router"
+import { useLocation, useNavigate, useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import { useComments } from "@/context/comments"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
@@ -192,6 +192,7 @@ export default function Page() {
   const prompt = usePrompt()
   const comments = useComments()
   const terminal = useTerminal()
+  const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams<{ prompt?: string }>()
   const location = useLocation()
   const { params, sessionKey, tabs, view } = useSessionLayout()
@@ -1548,6 +1549,36 @@ export default function Page() {
     return revertMutation.mutateAsync(input)
   }
 
+  const fork = (input: { sessionID: string; messageID: string }) => {
+    if (!params.dir) return
+    const dir = params.dir
+    return sdk.client.session
+      .fork(input)
+      .then((result) => {
+        if (!result.data) {
+          showToast({
+            variant: "error",
+            title: language.t("common.requestFailed"),
+          })
+          return
+        }
+
+        sync.set("session", (list) => {
+          const idx = list.findIndex((item) => item.id === result.data.id)
+          if (idx >= 0) {
+            const out = list.slice()
+            out[idx] = result.data
+            return out
+          }
+          return [...list, result.data]
+        })
+
+        prompt.set(draft(input.messageID), undefined, { dir, id: result.data.id })
+        navigate(`/${dir}/session/${result.data.id}`)
+      })
+      .catch(fail)
+  }
+
   const restore = (id: string) => {
     if (!params.id || reverting()) return
     return restoreMutation.mutateAsync(id)
@@ -1561,7 +1592,7 @@ export default function Page() {
       .map((item) => ({ id: item.id, text: line(item.id) }))
   })
 
-  const actions = { revert }
+  const actions = { revert, fork }
 
   createEffect(() => {
     const sessionID = params.id

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1108,6 +1108,20 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
       .finally(() => setState("busy", false))
   }
 
+  const fork = () => {
+    const act = props.actions?.fork
+    if (!act || busy()) return
+    setState("busy", true)
+    void Promise.resolve()
+      .then(() =>
+        act({
+          sessionID: props.message.sessionID,
+          messageID: props.message.id,
+        }),
+      )
+      .finally(() => setState("busy", false))
+  }
+
   return (
     <div data-component="user-message" data-timeline-part-id={textPart()?.id}>
       <Show when={attachments().length > 0}>
@@ -1170,6 +1184,22 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
                   </span>
                 </Show>
               </span>
+            </Show>
+            <Show when={props.actions?.fork}>
+              <Tooltip value={i18n.t("ui.message.forkMessage")} placement="top" gutter={4}>
+                <IconButton
+                  icon="fork"
+                  size="normal"
+                  variant="ghost"
+                  disabled={!!busy()}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    fork()
+                  }}
+                  aria-label={i18n.t("ui.message.forkMessage")}
+                />
+              </Tooltip>
             </Show>
             <Show when={props.actions?.revert}>
               <Tooltip value={i18n.t("ui.message.revertMessage")} placement="top" gutter={4}>


### PR DESCRIPTION
### Issue for this PR

Closes #25582

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fork to new session option was not present at the OpenCode Desktop app.
So I have added back the option thanks to OpenCode itself and OpenAI ChatGPT 5.3 Codex.

Regarding understanding why the changes work, well, it's my first time dealing with the OpenCode codebase so I'm a bit lost here. However I will say that I have insisted that changes follow contribution guidelines and that it should reuse or recreate TUI based behaviour as much as possible so hopefully that has ended up in a better PR than a regular one-shot vibe-coded PR.

### How did you verify your code works?

- Ran `bun install` from repo root.
- Ran `bun run typecheck` from repo root.
- Ran `bun run typecheck` from `packages/app`.
- Manually tested forking from user messages:
  - new forked session opens,
  - selected message content is restored in the new session prompt,
  - sidebar highlights the forked session,
  - failure fallback uses localized request-failed messaging.

### Screenshots / recordings

The new *Fork the new session* option:
<img width="1009" height="1079" alt="imagen" src="https://github.com/user-attachments/assets/510173c1-e8cd-476c-99b0-699934c77b30" />

How a new forked session is seen:
<img width="1009" height="1079" alt="imagen" src="https://github.com/user-attachments/assets/fcd1c03d-cc30-4d2a-8587-9a9b021385c1" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR