### PR TITLE
fix: propagate chunkTimeout to streamText and add max_retries config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -244,24 +244,27 @@ export const Info = Schema.Struct({
       }),
     }),
   ),
-  experimental: Schema.optional(
-    Schema.Struct({
-      disable_paste_summary: Schema.optional(Schema.Boolean),
-      batch_tool: Schema.optional(Schema.Boolean).annotate({ description: "Enable the batch tool" }),
-      openTelemetry: Schema.optional(Schema.Boolean).annotate({
-        description: "Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)",
+    experimental: Schema.optional(
+      Schema.Struct({
+        disable_paste_summary: Schema.optional(Schema.Boolean),
+        batch_tool: Schema.optional(Schema.Boolean).annotate({ description: "Enable the batch tool" }),
+        openTelemetry: Schema.optional(Schema.Boolean).annotate({
+          description: "Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)",
+        }),
+        primary_tools: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+          description: "Tools that should only be available to primary agents.",
+        }),
+        continue_loop_on_deny: Schema.optional(Schema.Boolean).annotate({
+          description: "Continue the agent loop when a tool call is denied",
+        }),
+        mcp_timeout: Schema.optional(PositiveInt).annotate({
+          description: "Timeout in milliseconds for model context protocol (MCP) requests",
+        }),
+        max_retries: Schema.optional(PositiveInt).annotate({
+          description: "Maximum number of retry attempts when a provider request fails. Defaults to 5.",
+        }),
       }),
-      primary_tools: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
-        description: "Tools that should only be available to primary agents.",
-      }),
-      continue_loop_on_deny: Schema.optional(Schema.Boolean).annotate({
-        description: "Continue the agent loop when a tool call is denied",
-      }),
-      mcp_timeout: Schema.optional(PositiveInt).annotate({
-        description: "Timeout in milliseconds for model context protocol (MCP) requests",
-      }),
-    }),
-  ),
+    ),
 })
   .annotate({ identifier: "Config" })
   .pipe(

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -333,6 +333,14 @@ const live: Layer.Layer<
         ? (yield* InstanceState.context).project.id
         : undefined
 
+      // Pass chunkTimeout from provider/model options to streamText for AI SDK-level
+      // chunk idle timeout detection. This catches silenced stream dropouts where
+      // the TCP connection stays open but no SSE chunks arrive.
+      const chunkTimeout = typeof options["chunkTimeout"] === "number" ? options["chunkTimeout"] : undefined
+      if (chunkTimeout) {
+        l.debug("chunk idle timeout configured", { chunkTimeout })
+      }
+
       return streamText({
         onError(error) {
           l.error("stream error", {
@@ -369,6 +377,9 @@ const live: Layer.Layer<
         toolChoice: input.toolChoice,
         maxOutputTokens: params.maxOutputTokens,
         abortSignal: input.abort,
+        // Stream chunk idle timeout: aborts if no SSE chunk arrives within the window.
+        // Catches silent provider dropouts that keep the TCP connection alive but stop sending data.
+        ...(chunkTimeout ? { timeout: { chunkMs: chunkTimeout } } : {}),
         headers: {
           ...(input.model.providerID.startsWith("opencode")
             ? {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -336,7 +336,11 @@ const live: Layer.Layer<
       // Pass chunkTimeout from provider/model options to streamText for AI SDK-level
       // chunk idle timeout detection. This catches silenced stream dropouts where
       // the TCP connection stays open but no SSE chunks arrive.
-      const chunkTimeout = typeof options["chunkTimeout"] === "number" ? options["chunkTimeout"] : undefined
+      const chunkTimeout = typeof options["chunkTimeout"] === "number"
+        ? options["chunkTimeout"]
+        : typeof item.options?.["chunkTimeout"] === "number"
+          ? item.options["chunkTimeout"]
+          : undefined
       if (chunkTimeout) {
         l.debug("chunk idle timeout configured", { chunkTimeout })
       }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -661,7 +661,9 @@ export const layer: Layer.Layer<
       const process = Effect.fn("SessionProcessor.process")(function* (streamInput: LLM.StreamInput) {
         slog.info("process")
         ctx.needsCompaction = false
-        ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        const cfg = yield* config.get()
+        ctx.shouldBreak = cfg.experimental?.continue_loop_on_deny !== true
+        const maxRetries = cfg.experimental?.max_retries
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -690,6 +692,7 @@ export const layer: Layer.Layer<
             Effect.retry(
               SessionRetry.policy({
                 parse,
+                maxAttempts: maxRetries,
                 set: (info) => {
                   // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
                   EventV2.run(SessionEvent.Retried.Sync, {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -106,9 +106,12 @@ export function retryable(error: Err) {
 export function policy(opts: {
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; next: number }) => Effect.Effect<void>
+  maxAttempts?: number
 }) {
+  const maxAttempts = Math.max(1, opts.maxAttempts ?? 5)
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
+      if (meta.attempt > maxAttempts) return Cause.done(meta.attempt)
       const error = opts.parse(meta.input)
       const message = retryable(error)
       if (!message) return Cause.done(meta.attempt)

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -378,7 +378,7 @@ Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 ```
 
 - `timeout` - Request timeout in milliseconds (default: 300000). Set to `false` to disable.
-- `chunkTimeout` - Timeout in milliseconds between streamed response chunks. If no chunk arrives in time, the request is aborted.
+- `chunkTimeout` - Timeout in milliseconds between streamed response chunks. If no chunk arrives in time, the request is aborted. This catches silent provider dropouts where the TCP connection stays open but SSE streaming stops. Recommended: `15000`–`30000` (15–30 seconds) for providers with unreliable streaming. Also propagated to the AI SDK's `timeout.chunkMs` for additional safety at the stream consumer level.
 - `setCacheKey` - Ensure a cache key is always set for designated provider.
 
 You can also configure [local models](/docs/models#local). [Learn more](/docs/models).

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -793,9 +793,13 @@ The `experimental` key contains options that are under active development.
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "experimental": {}
+  "experimental": {
+    "max_retries": 3
+  }
 }
 ```
+
+- `max_retries` - Maximum number of retry attempts when a provider request fails (default: 5). Set to `3` to reduce wait time on flaky endpoints.
 
 :::caution
 Experimental options are not stable. They may change or be removed without notice.

--- a/packages/web/src/content/docs/zh-cn/config.mdx
+++ b/packages/web/src/content/docs/zh-cn/config.mdx
@@ -611,17 +611,21 @@ OpenCode 启动时会自动下载新版本。您可以使用 `autoupdate` 选项
 
 ### 实验性功能
 
-`experimental` 键包含正在积极开发中的选项。
+`experimental` 键包含正在开发中的选项。
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "experimental": {}
+  "experimental": {
+    "max_retries": 3
+  }
 }
 ```
 
+- `max_retries` - 提供商请求失败时的最大重试次数（默认值：5）。对于连接不稳定的端点，可以设置为 `3` 以减少等待时间。
+
 :::caution
-实验性选项不稳定。它们可能会在不另行通知的情况下被更改或移除。
+实验性选项不稳定，可能会在没有通知的情况下更改或移除。
 :::
 
 ---

--- a/packages/web/src/content/docs/zh-cn/config.mdx
+++ b/packages/web/src/content/docs/zh-cn/config.mdx
@@ -238,7 +238,7 @@ opencode run "Hello world"
 
 `small_model` 选项为标题生成等轻量级任务配置单独的模型。默认情况下，如果您的提供商有更便宜的模型可用，OpenCode 会尝试使用该模型，否则会回退到您的主模型。
 
-提供商选项可以包括 `timeout` 和 `setCacheKey`：
+提供商选项可以包括 `timeout`、`chunkTimeout` 和 `setCacheKey`：
 
 ```json title="opencode.json"
 {
@@ -247,6 +247,7 @@ opencode run "Hello world"
     "anthropic": {
       "options": {
         "timeout": 600000,
+        "chunkTimeout": 30000,
         "setCacheKey": true
       }
     }
@@ -255,6 +256,7 @@ opencode run "Hello world"
 ```
 
 - `timeout` - 请求超时时间，单位为毫秒（默认值：300000）。设置为 `false` 可禁用超时。
+- `chunkTimeout` - 流式响应 chunk 之间的超时时间（毫秒）。如果在指定时间内没有收到 chunk，请求将被中止。这可以捕获 provider 静默断开的情况——TCP 连接保持但 SSE 流停止。对于流式不稳定的 provider，推荐设置为 `15000`–`30000`（15–30 秒）。此配置也会传递到 AI SDK 的 `timeout.chunkMs`，在流消费层提供额外的安全保障。
 - `setCacheKey` - 确保始终为指定提供商设置缓存键。
 
 您还可以配置[本地模型](/docs/models#local)。[了解更多](/docs/models)。


### PR DESCRIPTION
Closes #25587

## Summary

**1. Propagate chunkTimeout to streamText timeout.chunkMs**

`chunkTimeout` was already defined in provider config schema and worked at the custom fetch wrapper level (wrapSSE), but was never passed through to Vercel AI SDK streamText call. Now both layers protect against silent stream dropouts where TCP stays open but SSE chunks stop arriving.

Reads from both `item.options` (provider-level) and merged `options` (model/agent/variant level) so `provider.<id>.options.chunkTimeout` works as documented.

**2. Add experimental.max_retries config option**

Default was unbounded retries for transient provider errors, causing long waits on flaky endpoints. Add `experimental.max_retries` (default 5) so users can cap retry attempts.

## Files Changed

| File | Change |
|------|--------|
| packages/opencode/src/session/llm.ts | Pass chunkTimeout → streamText timeout.chunkMs, fallback to item.options |
| packages/opencode/src/session/retry.ts | Add maxAttempts parameter to policy function |
| packages/opencode/src/session/processor.ts | Wire max_retries from config.experimental |
| packages/opencode/src/config/config.ts | Add max_retries field to experimental schema |
| packages/web/src/content/docs/config.mdx | Document chunkTimeout and max_retries |
| packages/web/src/content/docs/zh-cn/config.mdx | Chinese documentation for both options |