### PR TITLE
fix(httpapi): add basic auth challenge for browser login

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -5,6 +5,7 @@ import { HttpApiError, HttpApiMiddleware, HttpApiSecurity } from "effect/unstabl
 
 const AUTH_TOKEN_QUERY = "auth_token"
 const UNAUTHORIZED = 401
+const WWW_AUTHENTICATE = "Basic realm=\"opencode\""
 
 export class Authorization extends HttpApiMiddleware.Service<Authorization>()(
   "@opencode/ExperimentalHttpApiAuthorization",
@@ -82,7 +83,12 @@ function validateRawCredential<A, E, R>(
 ) {
   if (!isAuthRequired(config)) return effect
   if (!isCredentialAuthorized(credential, config))
-    return Effect.succeed(HttpServerResponse.empty({ status: UNAUTHORIZED }))
+    return Effect.succeed(
+      HttpServerResponse.empty({
+        status: UNAUTHORIZED,
+        headers: { "www-authenticate": WWW_AUTHENTICATE },
+      }),
+    )
   return effect
 }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -5,7 +5,7 @@ import { HttpApiError, HttpApiMiddleware, HttpApiSecurity } from "effect/unstabl
 
 const AUTH_TOKEN_QUERY = "auth_token"
 const UNAUTHORIZED = 401
-const WWW_AUTHENTICATE = "Basic realm=\"opencode\""
+const WWW_AUTHENTICATE = "Basic realm=\"Secure Area\""
 
 export class Authorization extends HttpApiMiddleware.Service<Authorization>()(
   "@opencode/ExperimentalHttpApiAuthorization",

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -201,7 +201,7 @@ describe("HttpApi UI fallback", () => {
     const response = await uiApp({ password: "secret", username: "opencode" }).request("/")
 
     expect(response.status).toBe(401)
-    expect(response.headers.get("www-authenticate")).toBe('Basic realm="opencode"')
+    expect(response.headers.get("www-authenticate")).toBe('Basic realm="Secure Area"')
   })
 
   test("accepts auth token for the web UI", async () => {

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -201,6 +201,7 @@ describe("HttpApi UI fallback", () => {
     const response = await uiApp({ password: "secret", username: "opencode" }).request("/")
 
     expect(response.status).toBe(401)
+    expect(response.headers.get("www-authenticate")).toBe('Basic realm="opencode"')
   })
 
   test("accepts auth token for the web UI", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #25585

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Adds a `WWW-Authenticate` challenge to unauthorized web UI responses so browsers show the Basic Auth login prompt.
- Uses `Basic realm="Secure Area"` to align with browser/Electron Basic Auth prompt behavior.

### How did you verify your code works?

I was able to run the server like so `OPENCODE_EXPERIMENTAL_HTTPAPI=true OPENCODE_SERVER_PASSWORD=ope_2 bun run dev serve` and the browser auth challenge flow was working as well as being able to use the web app properly.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR