### PR TITLE
fix(acp): pass server auth to internal client

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -6,6 +6,7 @@ import { ACP } from "@/acp/agent"
 import { Server } from "@/server/server"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { Flag } from "@opencode-ai/core/flag/flag"
 
 const log = Log.create({ service: "acp-command" })
 
@@ -26,6 +27,13 @@ export const AcpCommand = effectCmd({
 
     const sdk = createOpencodeClient({
       baseUrl: `http://${server.hostname}:${server.port}`,
+      headers: Flag.OPENCODE_SERVER_PASSWORD
+        ? {
+            Authorization: `Basic ${Buffer.from(
+              `${Flag.OPENCODE_SERVER_USERNAME ?? "opencode"}:${Flag.OPENCODE_SERVER_PASSWORD}`,
+            ).toString("base64")}`,
+          }
+        : undefined,
     })
 
     const input = new WritableStream<Uint8Array>({


### PR DESCRIPTION
## summary
- pass the configured server basic auth header to ACP's internal SDK client
- fixes `session/new` failing when `OPENCODE_SERVER_PASSWORD` is set

Closes #25568

## testing
- reproduced ACP `session/new` with `OPENCODE_SERVER_PASSWORD=secret` on the default backend
- reproduced ACP `session/new` with `OPENCODE_SERVER_PASSWORD=secret` and `OPENCODE_EXPERIMENTAL_HTTPAPI=false`
- `bun typecheck` from `packages/opencode`