### PR TITLE
feat: group changelog bugfixes

### DIFF
--- a/.opencode/command/changelog.md
+++ b/.opencode/command/changelog.md
@@ -18,9 +18,12 @@ Do not use `git log` or author metadata when deciding attribution.
 
 Rules:
 
-- Write the final file with sections in this order:
+- Write the final file with release sections in this order:
   `## Core`, `## TUI`, `## Desktop`, `## SDK`, `## Extensions`
 - Only include sections that have at least one notable entry
+- Within each release section, keep bug fixes grouped under `### Bugfixes`
+- Keep other notable entries under `### Improvements` when a section has bug fixes too
+- Omit empty subsections
 - Keep one bullet per commit you keep
 - Skip commits that are entirely internal, CI, tests, refactors, or otherwise not user-facing
 - Start each bullet with a capital letter

--- a/script/raw-changelog.ts
+++ b/script/raw-changelog.ts
@@ -82,6 +82,11 @@ function section(areas: Set<string>) {
   return "Core"
 }
 
+function type(message: string) {
+  if (message.match(/fix/i)) return "Bugfixes"
+  return "Improvements"
+}
+
 function reverted(commits: Commit[]) {
   const seen = new Map<string, Commit>()
 
@@ -193,13 +198,20 @@ async function thanks(from: string, to: string, reuse: boolean) {
 }
 
 function format(from: string, to: string, list: Commit[], thanks: string[]) {
-  const grouped = new Map<string, string[]>()
-  for (const title of order) grouped.set(title, [])
+  const grouped = new Map<string, Map<string, string[]>>()
+  for (const title of order) {
+    grouped.set(
+      title,
+      new Map([
+        ["Improvements", []],
+        ["Bugfixes", []],
+      ]),
+    )
+  }
 
   for (const commit of list) {
-    const title = section(commit.areas)
     const attr = commit.author && !team.includes(commit.author) ? ` (@${commit.author})` : ""
-    grouped.get(title)!.push(`- \`${commit.hash}\` ${commit.message}${attr}`)
+    grouped.get(section(commit.areas))!.get(type(commit.message))!.push(`- \`${commit.hash}\` ${commit.message}${attr}`)
   }
 
   const lines = [`Last release: ${ref(from)}`, `Target ref: ${to}`, ""]
@@ -209,11 +221,23 @@ function format(from: string, to: string, list: Commit[], thanks: string[]) {
   }
 
   for (const title of order) {
-    const entries = grouped.get(title)
-    if (!entries || entries.length === 0) continue
+    const groups = grouped.get(title)
+    if (!groups || [...groups.values()].every((entries) => entries.length === 0)) continue
     lines.push(`## ${title}`)
-    lines.push(...entries)
-    lines.push("")
+    const improvements = groups.get("Improvements")!
+    const bugfixes = groups.get("Bugfixes")!
+    if (bugfixes.length === 0) {
+      lines.push(...improvements)
+      lines.push("")
+      continue
+    }
+
+    for (const [subtitle, entries] of groups) {
+      if (entries.length === 0) continue
+      lines.push(`### ${subtitle}`)
+      lines.push(...entries)
+      lines.push("")
+    }
   }
 
   if (thanks.length > 0) {


### PR DESCRIPTION
## summary
- Group fix-related changelog entries under Bugfixes within each release section.
- Update the changelog command prompt to preserve bugfix subsections.

Closes #25580

## testing
- bun script/raw-changelog.ts --help
- bunx prettier --check \"script/raw-changelog.ts\" \".opencode/command/changelog.md\"
- bun run lint \"script/raw-changelog.ts\" (5 existing warnings, 0 errors)
- bun turbo typecheck