### PR TITLE
fix(auth): add username option for basic auth in RunCommand

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -277,6 +277,11 @@ export const RunCommand = effectCmd({
         type: "string",
         describe: "basic auth password (defaults to OPENCODE_SERVER_PASSWORD)",
       })
+      .option("username", {
+        alias: ["u"],
+        type: "string",
+        describe: "basic auth username (defaults to OPENCODE_SERVER_USERNAME or 'opencode')",
+      })
       .option("dir", {
         type: "string",
         describe: "directory to run in, path on remote server if attaching",
@@ -657,7 +662,7 @@ export const RunCommand = effectCmd({
       }
 
       if (args.attach) {
-        const headers = ServerAuth.headers({ password: args.password })
+        const headers = ServerAuth.headers({ password: args.password, username: args.username })
         const sdk = createOpencodeClient({ baseUrl: args.attach, directory, headers })
         return await execute(sdk)
       }


### PR DESCRIPTION
### Issue for this PR

Closes #

Related #25113

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Added in remaining `--username` cli option to the `opencode run --attach` command. As this was also recently added to the Docs in another PR #25399

### How did you verify your code works?

bun run typecheck

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
