### PR TITLE
fix(tui): repaint Apple Terminal after resize

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,7 +1,14 @@
 import { render, TimeToFirstDraw, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import * as Clipboard from "@tui/util/clipboard"
 import * as Selection from "@tui/util/selection"
-import { createCliRenderer, MouseButton, type CliRendererConfig } from "@opentui/core"
+import {
+  CliRenderEvents,
+  createCliRenderer,
+  MouseButton,
+  RendererControlState,
+  type CliRenderer,
+  type CliRendererConfig,
+} from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import {
   Switch,
@@ -91,6 +98,51 @@ function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   }
 }
 
+function installAppleTerminalRepaintWorkaround(renderer: CliRenderer) {
+  if (process.env.TERM_PROGRAM !== "Apple_Terminal") return
+  if (process.env.OPENCODE_APPLE_TERMINAL_REPAINT_WORKAROUND === "0") return
+
+  const repaint = () => {
+    if (renderer.isDestroyed) return
+
+    // Apple Terminal can leave the alternate screen partially stale after resize
+    // or screen restore. Re-entering OpenTUI's terminal setup clears the current
+    // render buffer, which makes the next frame repaint every cell.
+    if (renderer.controlState !== RendererControlState.EXPLICIT_SUSPENDED) {
+      try {
+        renderer.suspend()
+        process.stdout.write("\x1b[r\x1b[?6l\x1b[2J\x1b[H")
+        renderer.resume()
+        return
+      } catch {
+        // Fall through to a plain clear + render request. This path should only
+        // be hit if the terminal is already mid-teardown.
+      }
+    }
+
+    process.stdout.write("\x1b[r\x1b[?6l\x1b[2J\x1b[H")
+    renderer.requestRender()
+  }
+
+  let pending: ReturnType<typeof setTimeout> | undefined
+  const schedule = () => {
+    if (pending) clearTimeout(pending)
+    pending = setTimeout(() => {
+      pending = undefined
+      repaint()
+    }, 30)
+  }
+
+  process.on("SIGWINCH", schedule)
+  renderer.on(CliRenderEvents.RESIZE, schedule)
+
+  return () => {
+    if (pending) clearTimeout(pending)
+    process.off("SIGWINCH", schedule)
+    renderer.off(CliRenderEvents.RESIZE, schedule)
+  }
+}
+
 function errorMessage(error: unknown) {
   const formatted = FormatError(error)
   if (formatted !== undefined) return formatted
@@ -123,8 +175,10 @@ export function tui(input: {
   return new Promise<void>(async (resolve) => {
     const unguard = win32InstallCtrlCGuard()
     win32DisableProcessedInput()
+    let removeAppleTerminalRepaintWorkaround: (() => void) | undefined
 
     const onExit = async () => {
+      removeAppleTerminalRepaintWorkaround?.()
       unguard?.()
       resolve()
     }
@@ -134,6 +188,7 @@ export function tui(input: {
     }
 
     const renderer = await createCliRenderer(rendererConfig(input.config))
+    removeAppleTerminalRepaintWorkaround = installAppleTerminalRepaintWorkaround(renderer)
     // Prewarm palette before ThemeProvider mounts so `system` theme avoids a first-paint fallback flash.
     void renderer.getPalette({ size: 16 }).catch(() => undefined)
     const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"


### PR DESCRIPTION
## What

- Adds an Apple Terminal-specific repaint workaround for the TUI renderer.
- On SIGWINCH/OpenTUI resize, debounces a terminal reset and re-enters OpenTUI terminal setup so the next frame repaints every cell.
- Keeps the behavior scoped to `TERM_PROGRAM=Apple_Terminal` and allows opt-out with `OPENCODE_APPLE_TERMINAL_REPAINT_WORKAROUND=0`.

## Why

Apple Terminal can occasionally leave the alternate screen partially stale after a resize or screen restore. When that happens, opencode remains alive and the session continues normally, but the visible TUI can show only part of the screen until another resize forces a repaint.

## Validation

- Not run: `bun run --cwd packages/opencode typecheck` failed locally because the interrupted dependency install left `tsgo` unavailable (`/bin/bash: tsgo: command not found`).
