### PR TITLE
feat: add /btw side question command

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-btw.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-btw.tsx
@@ -1,0 +1,66 @@
+import { useTheme } from "../context/theme"
+import { useDialog, type DialogContext } from "./dialog"
+import { useKeyboard } from "@opentui/solid"
+import { ScrollBoxRenderable } from "@opentui/core"
+import { createSignal, Show } from "solid-js"
+
+export type DialogBtwProps = {
+  question: string
+  answer: string
+  loading?: boolean
+}
+
+export function DialogBtw(props: DialogBtwProps) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+
+  useKeyboard((evt) => {
+    if (evt.name === "return" || evt.name === "escape" || evt.name === " ") {
+      evt.preventDefault()
+      evt.stopPropagation()
+      dialog.clear()
+    }
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} paddingTop={1} paddingBottom={1} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={1} fg={theme.text}>
+          Side Question
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc/space/enter to dismiss
+        </text>
+      </box>
+      <box paddingBottom={1}>
+        <text fg={theme.textMuted} wrapMode="word">
+          {props.question}
+        </text>
+      </box>
+      <Show when={props.loading}>
+        <box>
+          <text fg={theme.textMuted}>Thinking...</text>
+        </box>
+      </Show>
+      <Show when={!props.loading}>
+        <scrollbox height={Math.min(20, props.answer.split("\n").length + 2)} scrollbarOptions={{ visible: false }}>
+          <text fg={theme.text} wrapMode="word">
+            {props.answer}
+          </text>
+        </scrollbox>
+      </Show>
+    </box>
+  )
+}
+
+export async function showBtwDialog(dialog: DialogContext, question: string, answerPromise: Promise<string>) {
+  dialog.replace(() => <DialogBtw question={question} answer="" loading={true} />)
+
+  try {
+    const answer = await answerPromise
+    dialog.replace(() => <DialogBtw question={question} answer={answer} loading={false} />)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    dialog.replace(() => <DialogBtw question={question} answer={`Error: ${message}`} loading={false} />)
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -43,6 +43,7 @@ import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-workspace-create"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
+import { showBtwDialog } from "../dialog-btw"
 import { useArgs } from "@tui/context/args"
 
 export type PromptProps = {
@@ -832,6 +833,20 @@ export function Prompt(props: PromptProps) {
         command: inputText,
       })
       setStore("mode", "normal")
+    } else if (inputText.startsWith("/btw ") || inputText === "/btw") {
+      const question = inputText.slice(5).trim()
+      if (question && sessionID) {
+        void showBtwDialog(
+          dialog,
+          question,
+          sdk.client.session
+            .btw({
+              sessionID,
+              question,
+            })
+            .then((res) => res.data?.text ?? "No response"),
+        )
+      }
     } else if (
       inputText.startsWith("/") &&
       iife(() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -60,6 +60,7 @@ import { TodoItem } from "../../component/todo-item"
 import { DialogMessage } from "./dialog-message"
 import type { PromptInfo } from "../../component/prompt/history"
 import { DialogConfirm } from "@tui/ui/dialog-confirm"
+import { DialogPrompt } from "@tui/ui/dialog-prompt"
 import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
@@ -88,6 +89,7 @@ import { useTuiConfig } from "../../context/tui-config"
 import { getScrollAcceleration } from "../../util/scroll"
 import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
 import { DialogGoUpsell } from "../../component/dialog-go-upsell"
+import { showBtwDialog } from "../../component/dialog-btw"
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
 
@@ -514,6 +516,31 @@ export function Session() {
           providerID: selectedModel.providerID,
         })
         dialog.clear()
+      },
+    },
+    {
+      title: "Side question",
+      value: "session.btw",
+      category: "Session",
+      slash: {
+        name: "btw",
+      },
+      onSelect: async (dialog) => {
+        dialog.clear()
+        const question = await DialogPrompt.show(dialog, "Side Question", {
+          placeholder: "Ask a quick question...",
+        })
+        if (!question) return
+        void showBtwDialog(
+          dialog,
+          question,
+          sdk.client.session
+            .btw({
+              sessionID: route.sessionID,
+              question,
+            })
+            .then((res) => res.data?.text ?? "No response"),
+        )
       },
     },
     {

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -59,6 +59,7 @@ export function hints(template: string) {
 export const Default = {
   INIT: "init",
   REVIEW: "review",
+  BTW: "btw",
 } as const
 
 export interface Interface {
@@ -98,6 +99,15 @@ export const layer = Layer.effect(
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      }
+      commands[Default.BTW] = {
+        name: Default.BTW,
+        description: "ask a quick side question without adding to the conversation",
+        source: "command",
+        get template() {
+          return "$ARGUMENTS"
+        },
+        hints: ["$ARGUMENTS"],
       }
 
       for (const [name, command] of Object.entries(cfg.command ?? {})) {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -62,6 +62,7 @@ export const SummarizePayload = Schema.Struct({
 export const PromptPayload = Schema.Struct(Struct.omit(SessionPrompt.PromptInput.fields, ["sessionID"]))
 export const CommandPayload = Schema.Struct(Struct.omit(SessionPrompt.CommandInput.fields, ["sessionID"]))
 export const ShellPayload = Schema.Struct(Struct.omit(SessionPrompt.ShellInput.fields, ["sessionID"]))
+export const BtwPayload = Schema.Struct(Struct.omit(SessionPrompt.BtwInput.fields, ["sessionID"]))
 export const RevertPayload = Schema.Struct(Struct.omit(SessionRevert.RevertInput.fields, ["sessionID"]))
 export const PermissionResponsePayload = Schema.Struct({
   response: Permission.Reply,
@@ -87,6 +88,7 @@ export const SessionPaths = {
   prompt: `${root}/:sessionID/message`,
   promptAsync: `${root}/:sessionID/prompt_async`,
   command: `${root}/:sessionID/command`,
+  btw: `${root}/:sessionID/btw`,
   shell: `${root}/:sessionID/shell`,
   revert: `${root}/:sessionID/revert`,
   unrevert: `${root}/:sessionID/unrevert`,
@@ -325,6 +327,18 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.command",
             summary: "Send command",
             description: "Send a new command to a session for execution by the AI assistant.",
+          }),
+        ),
+        HttpApiEndpoint.post("btw", SessionPaths.btw, {
+          params: { sessionID: SessionID },
+          payload: BtwPayload,
+          success: described(Schema.Struct({ text: Schema.String }), "Side question answer"),
+          error: [HttpApiError.BadRequest, HttpApiError.NotFound],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.btw",
+            summary: "Side question",
+            description: "Ask a quick side question without adding to the conversation history.",
           }),
         ),
         HttpApiEndpoint.post("shell", SessionPaths.shell, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -24,6 +24,7 @@ import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import {
+  BtwPayload,
   CommandPayload,
   DiffQuery,
   ForkPayload,
@@ -300,6 +301,14 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* promptSvc.command({ ...ctx.payload, sessionID: ctx.params.sessionID })
     })
 
+    const btw = Effect.fn("SessionHttpApi.btw")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof BtwPayload.Type
+    }) {
+      const text = yield* promptSvc.btw({ ...ctx.payload, sessionID: ctx.params.sessionID })
+      return { text }
+    })
+
     const shell = Effect.fn("SessionHttpApi.shell")(function* (ctx: {
       params: { sessionID: SessionID }
       payload: typeof ShellPayload.Type
@@ -379,6 +388,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("prompt", prompt)
       .handle("promptAsync", promptAsync)
       .handle("command", command)
+      .handle("btw", btw)
       .handle("shell", shell)
       .handle("revert", revert)
       .handle("unrevert", unrevert)

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -985,6 +985,40 @@ export const SessionRoutes = lazy(() =>
         }),
     )
     .post(
+      "/:sessionID/btw",
+      describeRoute({
+        summary: "Side question",
+        description: "Ask a quick side question without adding to the conversation history.",
+        operationId: "session.btw",
+        responses: {
+          200: {
+            description: "Side question answer",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ text: z.string() })),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: SessionID.zod,
+        }),
+      ),
+      validator("json", zodObject(SessionPrompt.BtwInput).omit({ sessionID: true })),
+      async (c) =>
+        jsonRequest("SessionRoutes.btw", c, function* () {
+          const sessionID = c.req.valid("param").sessionID
+          const body = c.req.valid("json") as Omit<SessionPrompt.BtwInput, "sessionID">
+          const svc = yield* SessionPrompt.Service
+          const text = yield* svc.btw({ ...body, sessionID })
+          return { text }
+        }),
+    )
+    .post(
       "/:sessionID/shell",
       describeRoute({
         summary: "Run shell command",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -84,6 +84,7 @@ export interface Interface {
   readonly loop: (input: LoopInput) => Effect.Effect<MessageV2.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts>
   readonly command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts>
+  readonly btw: (input: BtwInput) => Effect.Effect<string>
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
 }
 
@@ -1639,6 +1640,54 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       },
     )
 
+    const btw = Effect.fn("SessionPrompt.btw")(function* (input: BtwInput) {
+      yield* elog.info("btw", { sessionID: input.sessionID, question: input.question })
+      const session = yield* sessions.get(input.sessionID)
+      const mdl =
+        input.model ??
+        ((yield* provider.getSmallModel(session.model?.providerID)) ??
+          (yield* provider.getModel(session.model!.providerID, session.model!.modelID)))
+      const ag = yield* agents.get("build")
+      if (!ag) {
+        const error = new NamedError.Unknown({ message: `Agent not found: "build".` })
+        yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
+        throw error
+      }
+      const msgs = yield* MessageV2.filterCompactedEffect(input.sessionID)
+      const modelMsgs = yield* MessageV2.toModelMessagesEffect(msgs, mdl)
+      const text = yield* llm
+        .stream({
+          agent: ag,
+          user: {
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: input.sessionID,
+            time: { created: Date.now() },
+            model: { providerID: mdl.providerID, modelID: mdl.modelID },
+          },
+          system: [
+            "You are answering a quick side question. The user wants a brief answer based on the conversation context. Do not use any tools. Keep your response concise.",
+          ],
+          tools: {},
+          model: mdl,
+          sessionID: input.sessionID,
+          small: true,
+          messages: [
+            ...modelMsgs,
+            { role: "user", content: `Quick question (answer briefly, no tools): ${input.question}` },
+          ],
+        })
+        .pipe(
+          Stream.filter((e): e is Extract<LLM.Event, { type: "text-delta" }> => e.type === "text-delta"),
+          Stream.map((e) => e.text),
+          Stream.mkString,
+          Effect.orDie,
+        )
+      return text
+        .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
+        .trim()
+    })
+
     const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
       yield* elog.info("command", { sessionID: input.sessionID, command: input.command, agent: input.agent })
       const cmd = yield* commands.get(input.command)
@@ -1762,6 +1811,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       loop,
       shell,
       command,
+      btw,
       resolvePromptParts,
     })
   }),
@@ -1869,6 +1919,13 @@ export const CommandInput = Schema.Struct({
   ),
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
 export type CommandInput = Schema.Schema.Type<typeof CommandInput>
+
+export const BtwInput = Schema.Struct({
+  sessionID: SessionID,
+  question: Schema.String,
+  model: Schema.optional(Schema.String),
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type BtwInput = Schema.Schema.Type<typeof BtwInput>
 
 /** @internal Exported for testing */
 export function createStructuredOutputTool(input: {


### PR DESCRIPTION
## Summary

This PR introduces the `/btw` command, allowing users to ask quick side questions without polluting the conversation history.

## Changes

- **Server**: Added `POST /session/:sessionID/btw` endpoint that streams the current session context to the LLM with an ephemeral prompt (no messages persisted)
- **Command registry**: Registered `btw` as a built-in command so it appears in `/` autocomplete
- **HttpAPI parity**: Added matching Effect HttpApi endpoint and handler
- **TUI**: 
  - Prompt intercept for `/btw <question>` — shows a dismissible overlay dialog with loading/answer states
  - Command palette registration so `/btw` can be triggered via the slash menu too

## How it works

1. User types `/btw what was that config file again?`
2. The TUI sends the question + full session history to the new `session.btw()` endpoint
3. The server makes a one-off LLM call (no tools, no persistence) and returns `{ text }`
4. The answer appears in an overlay that can be dismissed with `Esc`, `Space`, or `Enter`

## Commits

- `feat(server): add /btw side question endpoint`
- `feat(tui): add /btw prompt intercept and dialog overlay`
- `feat(httpapi): add Effect HttpAPI parity for /btw endpoint`
- `feat(tui): register /btw as UI action command in session route`