### PR TITLE
fix(opencode): normalize subdirectory git paths

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -77,6 +77,14 @@ export const Event = {
 }
 
 const log = Log.create({ service: "file" })
+const slashes = (value: string) => value.replaceAll("\\", "/")
+const stripGitPrefix = (file: string, prefix: string) => {
+  const base = slashes(prefix)
+  if (!base) return file
+  const next = slashes(file)
+  if (!next.startsWith(base)) return file
+  return next.slice(base.length)
+}
 
 const binary = new Set([
   "exe",
@@ -421,6 +429,7 @@ export const layer = Layer.effect(
     const status = Effect.fn("File.status")(function* () {
       const ctx = yield* InstanceState.context
       if (ctx.project.vcs !== "git") return []
+      const prefix = yield* git.prefix(ctx.directory)
 
       const diffOutput = yield* gitText([
         "-c",
@@ -430,13 +439,17 @@ export const layer = Layer.effect(
         "diff",
         "--numstat",
         "HEAD",
+        "--",
+        ".",
       ])
 
       const changed: Info[] = []
 
       if (diffOutput.trim()) {
         for (const line of diffOutput.trim().split("\n")) {
-          const [added, removed, file] = line.split("\t")
+          const [added, removed, raw] = line.split("\t")
+          if (!raw) continue
+          const file = stripGitPrefix(raw, prefix)
           changed.push({
             path: file,
             added: added === "-" ? 0 : parseInt(added, 10),
@@ -454,10 +467,13 @@ export const layer = Layer.effect(
         "ls-files",
         "--others",
         "--exclude-standard",
+        "--",
+        ".",
       ])
 
       if (untrackedOutput.trim()) {
-        for (const file of untrackedOutput.trim().split("\n")) {
+        for (const raw of untrackedOutput.trim().split("\n")) {
+          const file = stripGitPrefix(raw, prefix)
           const content = yield* appFs
             .readFileString(path.join(ctx.directory, file))
             .pipe(Effect.catch(() => Effect.succeed<string | undefined>(undefined)))
@@ -480,10 +496,13 @@ export const layer = Layer.effect(
         "--name-only",
         "--diff-filter=D",
         "HEAD",
+        "--",
+        ".",
       ])
 
       if (deletedOutput.trim()) {
-        for (const file of deletedOutput.trim().split("\n")) {
+        for (const raw of deletedOutput.trim().split("\n")) {
+          const file = stripGitPrefix(raw, prefix)
           changed.push({
             path: file,
             added: 0,

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -18,6 +18,14 @@ const cfg = [
 
 const out = (result: { text(): string }) => result.text().trim()
 const nuls = (text: string) => text.split("\0").filter(Boolean)
+const slashes = (value: string) => value.replaceAll("\\", "/")
+const stripPrefix = (file: string, prefix: string) => {
+  const base = slashes(prefix)
+  if (!base) return file
+  const next = slashes(file)
+  if (!next.startsWith(base)) return file
+  return next.slice(base.length)
+}
 const fail = (err: unknown) =>
   ({
     exitCode: 1,
@@ -218,7 +226,7 @@ export const layer = Layer.effect(
     })
 
     const show = Effect.fn("Git.show")(function* (cwd: string, ref: string, file: string, prefix = "") {
-      const target = prefix ? `${prefix}${file}` : file
+      const target = prefix ? `${prefix}${file}` : `./${file}`
       const result = yield* run(["show", `${ref}:${target}`], { cwd })
       if (result.exitCode !== 0) return ""
       if (result.stdout.includes(0)) return ""
@@ -226,6 +234,7 @@ export const layer = Layer.effect(
     })
 
     const status = Effect.fn("Git.status")(function* (cwd: string) {
+      const base = yield* prefix(cwd)
       return nuls(
         yield* text(["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."], {
           cwd,
@@ -234,11 +243,12 @@ export const layer = Layer.effect(
         const file = item.slice(3)
         if (!file) return []
         const code = item.slice(0, 2)
-        return [{ file, code, status: kind(code) } satisfies Item]
+        return [{ file: stripPrefix(file, base), code, status: kind(code) } satisfies Item]
       })
     })
 
     const diff = Effect.fn("Git.diff")(function* (cwd: string, ref: string) {
+      const base = yield* prefix(cwd)
       const list = nuls(
         yield* text(["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", ref, "--", "."], { cwd }),
       )
@@ -246,11 +256,12 @@ export const layer = Layer.effect(
         if (idx % 2 !== 0) return []
         const file = list[idx + 1]
         if (!code || !file) return []
-        return [{ file, code, status: kind(code) } satisfies Item]
+        return [{ file: stripPrefix(file, base), code, status: kind(code) } satisfies Item]
       })
     })
 
     const stats = Effect.fn("Git.stats")(function* (cwd: string, ref: string) {
+      const base = yield* prefix(cwd)
       return nuls(
         yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
       ).flatMap((item) => {
@@ -265,7 +276,7 @@ export const layer = Layer.effect(
         const deletions = dels === "-" ? 0 : Number.parseInt(dels || "0", 10)
         return [
           {
-            file,
+            file: stripPrefix(file, base),
             additions: Number.isFinite(additions) ? additions : 0,
             deletions: Number.isFinite(deletions) ? deletions : 0,
           } satisfies Stat,

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -15,6 +15,14 @@ const MAX_PATCH_BYTES = 10_000_000
 const MAX_TOTAL_PATCH_BYTES = 10_000_000
 
 const emptyPatch = (file: string) => formatPatch(structuredPatch(file, file, "", "", "", "", { context: 0 }))
+const slashes = (value: string) => value.replaceAll("\\", "/")
+const stripPrefix = (file: string, prefix: string) => {
+  const base = slashes(prefix)
+  if (!base) return file
+  const next = slashes(file)
+  if (!next.startsWith(base)) return file
+  return next.slice(base.length)
+}
 
 const nums = (list: Git.Stat[]) =>
   new Map(list.map((item) => [item.file, { additions: item.additions, deletions: item.deletions }] as const))
@@ -94,6 +102,7 @@ const splitGitPatch = (patch: Git.Patch) => {
 const batchPatches = Effect.fnUntraced(function* (git: Git.Interface, cwd: string, ref: string, list: Git.Item[]) {
   if (list.length === 0) return { patches: new Map<string, string>(), capped: false }
 
+  const prefix = yield* git.prefix(cwd)
   const result = yield* git.patchAll(cwd, ref, {
     context: PATCH_CONTEXT_LINES,
     maxOutputBytes: MAX_TOTAL_PATCH_BYTES,
@@ -102,9 +111,10 @@ const batchPatches = Effect.fnUntraced(function* (git: Git.Interface, cwd: strin
 
   return {
     patches: splitGitPatch(result).reduce((acc, patch, index) => {
-      const file = fileFromPatchChunk(patch) ?? list[index]?.file
-      if (!file) return acc
-      acc.set(file, (acc.get(file) ?? "") + patch)
+      const file = fileFromPatchChunk(patch)
+      const key = file ? stripPrefix(file, prefix) : list[index]?.file
+      if (!key) return acc
+      acc.set(key, (acc.get(key) ?? "") + patch)
       return acc
     }, new Map<string, string>()),
     capped: result.truncated,

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -430,6 +430,35 @@ describe("file/index Filesystem patterns", () => {
       })
     })
 
+    test("detects modified files relative to a subdirectory", async () => {
+      await using tmp = await tmpdir({ git: true })
+      const dir = path.join(tmp.path, "sub")
+      await fs.mkdir(dir)
+      await fs.writeFile(path.join(dir, "file.txt"), "original\n", "utf-8")
+      await fs.writeFile(path.join(tmp.path, "outside.txt"), "original\n", "utf-8")
+      await $`git add .`.cwd(tmp.path).quiet()
+      await $`git commit --no-gpg-sign -m "add file"`.cwd(tmp.path).quiet()
+      await fs.writeFile(path.join(dir, "file.txt"), "modified\n", "utf-8")
+      await fs.writeFile(path.join(tmp.path, "outside.txt"), "modified\n", "utf-8")
+
+      await WithInstance.provide({
+        directory: dir,
+        fn: async () => {
+          const result = await status()
+          expect(result).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                path: "file.txt",
+                status: "modified",
+              }),
+            ]),
+          )
+          expect(result.some((item) => item.path === "sub/file.txt")).toBe(false)
+          expect(result.some((item) => item.path === "outside.txt")).toBe(false)
+        },
+      })
+    })
+
     test("detects untracked file as added", async () => {
       await using tmp = await tmpdir({ git: true })
       await fs.writeFile(path.join(tmp.path, "new.txt"), "line1\nline2\nline3\n", "utf-8")

--- a/packages/opencode/test/git/git.test.ts
+++ b/packages/opencode/test/git/git.test.ts
@@ -114,6 +114,20 @@ describe("Git", () => {
     })
   })
 
+  test("show() reads files relative to a subdirectory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const dir = path.join(tmp.path, "sub")
+    await fs.mkdir(dir)
+    await fs.writeFile(path.join(dir, "file.txt"), "original\n", "utf-8")
+    await $`git add .`.cwd(tmp.path).quiet()
+    await $`git commit --no-gpg-sign -m "add file"`.cwd(tmp.path).quiet()
+
+    await withGit(async (rt) => {
+      const text = await rt.runPromise(Git.Service.use((git) => git.show(dir, "HEAD", "file.txt")))
+      expect(text).toBe("original\n")
+    })
+  })
+
   test("patch() returns capped native patch output", async () => {
     await using tmp = await tmpdir({ git: true })
     await fs.writeFile(path.join(tmp.path, weird), "before\n", "utf-8")

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -260,6 +260,47 @@ describe("Vcs diff", () => {
     })
   })
 
+  test("diff('git') returns paths relative to the active subdirectory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const dir = path.join(tmp.path, "sub")
+    await fs.mkdir(dir)
+    await fs.writeFile(path.join(dir, "file.txt"), "original\n", "utf-8")
+    await $`git add .`.cwd(tmp.path).quiet()
+    await $`git commit --no-gpg-sign -m "add file"`.cwd(tmp.path).quiet()
+    await fs.writeFile(path.join(dir, "file.txt"), "changed\n", "utf-8")
+    await fs.writeFile(path.join(dir, "new.txt"), "new\n", "utf-8")
+    await fs.writeFile(path.join(tmp.path, "outside.txt"), "outside\n", "utf-8")
+
+    await withVcsOnly(dir, async () => {
+      const diff = await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const vcs = yield* Vcs.Service
+          return yield* vcs.diff("git")
+        }),
+      )
+      expect(diff).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: "file.txt",
+            status: "modified",
+          }),
+        ]),
+      )
+      expect(diff).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: "new.txt",
+            status: "added",
+          }),
+        ]),
+      )
+      expect(diff.some((item) => item.file === "sub/file.txt")).toBe(false)
+      expect(diff.some((item) => item.file === "sub/new.txt")).toBe(false)
+      expect(diff.some((item) => item.file === "outside.txt")).toBe(false)
+      expect(diff.find((item) => item.file === "file.txt")?.patch).toContain("+changed")
+    })
+  })
+
   test("diff('git') keeps batched patches aligned for type changes", async () => {
     if (process.platform === "win32") return
 


### PR DESCRIPTION
### Issue for this PR

Closes #25593

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode is opened from a subdirectory, Git can report paths relative to the repo root. The review UI then tries to read those paths relative to the opened directory and fails.

This normalizes Git status/diff/stat paths to the active directory, reads `git show` targets relative to the active directory, and keeps batched patch keys aligned with the normalized file paths.

### How did you verify your code works?

From `packages/opencode`:

- `bun test --timeout 30000 test/git/git.test.ts -t "show\(\) reads files relative to a subdirectory|status\(\) handles special filenames|diff\(\), stats\(\), and mergeBase|patch\(\) returns capped|show\(\) returns empty text for binary blobs"`
- `bun test --timeout 30000 test/project/vcs.test.ts -t "diff\('git'\) returns paths relative to the active subdirectory|diff\('git'\) returns uncommitted changes|diff\('git'\) keeps batched patches aligned"`
- `bun test --timeout 30000 test/file/index.test.ts -t "detects modified file|detects modified files relative to a subdirectory|detects untracked file as added|detects deleted file|detects mixed changes|returns empty for non-git project|returns diff and patch for modified tracked file"`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR