### PR TITLE
Effectify plugin agent regression test

### DIFF
--- a/packages/opencode/test/agent/plugin-agent-regression.test.ts
+++ b/packages/opencode/test/agent/plugin-agent-regression.test.ts
@@ -1,52 +1,65 @@
-import { afterEach, expect, test } from "bun:test"
+import { expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
-import { AppRuntime } from "../../src/effect/app-runtime"
 import { Agent } from "../../src/agent/agent"
-import { Instance } from "../../src/project/instance"
-import { WithInstance } from "../../src/project/with-instance"
-import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+import { InstanceRef } from "../../src/effect/instance-ref"
+import { InstanceLayer } from "../../src/project/instance-layer"
+import { InstanceStore } from "../../src/project/instance-store"
+import { tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
-afterEach(async () => {
-  await disposeAllInstances()
-})
+const pluginAgent = {
+  name: "plugin_added",
+  description: "Added by a plugin via the config hook",
+  mode: "subagent",
+} as const
 
-test("plugin-registered agents appear in Agent.list", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      const pluginFile = path.join(dir, "plugin.ts")
-      await Bun.write(
-        pluginFile,
-        [
-          "export default async () => ({",
-          "  config: async (cfg) => {",
-          "    cfg.agent = cfg.agent ?? {}",
-          "    cfg.agent.plugin_added = {",
-          '      description: "Added by a plugin via the config hook",',
-          '      mode: "subagent",',
-          "    }",
-          "  },",
-          "})",
-          "",
-        ].join("\n"),
-      )
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          plugin: [pathToFileURL(pluginFile).href],
-        }),
-      )
-    },
-  })
+const it = testEffect(Layer.mergeAll(Agent.defaultLayer, InstanceLayer.layer, CrossSpawnSpawner.defaultLayer))
 
-  await WithInstance.provide({
-    directory: tmp.path,
-    fn: async () => {
-      const agents = await AppRuntime.runPromise(Agent.Service.use((svc) => svc.list()))
-      const added = agents.find((agent) => agent.name === "plugin_added")
-      expect(added?.description).toBe("Added by a plugin via the config hook")
-      expect(added?.mode).toBe("subagent")
-    },
-  })
-})
+it.live("plugin-registered agents appear in Agent.list", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const pluginFile = path.join(dir, "plugin.ts")
+
+    yield* Effect.promise(async () => {
+      await Promise.all([
+        Bun.write(
+          pluginFile,
+          [
+            "export default async () => ({",
+            "  config: async (cfg) => {",
+            "    cfg.agent = cfg.agent ?? {}",
+            `    cfg.agent[${JSON.stringify(pluginAgent.name)}] = {`,
+            `      description: ${JSON.stringify(pluginAgent.description)},`,
+            `      mode: ${JSON.stringify(pluginAgent.mode)},`,
+            "    }",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        ),
+        Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(pluginFile).href],
+          }),
+        ),
+      ])
+    })
+
+    const agents = yield* InstanceStore.Service.use((store) =>
+      Effect.gen(function* () {
+        const ctx = yield* store.load({ directory: dir })
+        yield* Effect.addFinalizer(() => store.dispose(ctx).pipe(Effect.ignore))
+        return yield* Agent.Service.use((svc) => svc.list()).pipe(Effect.provideService(InstanceRef, ctx))
+      }),
+    )
+    const added = agents.find((agent) => agent.name === pluginAgent.name)
+
+    expect(added?.description).toBe(pluginAgent.description)
+    expect(added?.mode).toBe(pluginAgent.mode)
+  }),
+)


### PR DESCRIPTION
## Summary
- Convert the plugin-registered agent regression test to `testEffect` so it runs inside the Effect test runtime.
- Use the real instance bootstrap layer so plugin config hooks still execute before `Agent.list()`.
- Dispose the loaded instance in the scoped test body before temp directory cleanup.

## Tests
- `bun run test test/agent/plugin-agent-regression.test.ts`
- `for i in 1 2 3; do bun run test test/agent/plugin-agent-regression.test.ts || exit $?; done`
- `bun run test test/agent/agent.test.ts test/agent/plugin-agent-regression.test.ts`
- `bun typecheck`
- push hook: `bun turbo typecheck`