### PR TITLE
fix: increase LSP initialize timeout for JDTLS and KotlinLS

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -276,7 +276,7 @@ export async function create(input: { serverID: string; server: LSPServer.Handle
         },
       },
     }),
-    INITIALIZE_TIMEOUT_MS,
+    input.server.initializeTimeout ?? INITIALIZE_TIMEOUT_MS,
   ).catch((err) => {
     logger.error("initialize error", { error: err })
     throw new InitializeError(

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -27,6 +27,8 @@ const output = (cmd: string[], opts: Process.RunOptions = {}) => Process.text(cm
 export interface Handle {
   process: ChildProcessWithoutNullStreams
   initialization?: Record<string, any>
+  /** Override the default 45 s initialize-request timeout (ms). */
+  initializeTimeout?: number
 }
 
 type RootFunction = (file: string, ctx: InstanceContext) => Promise<string | undefined>
@@ -1290,6 +1292,7 @@ export const JDTLS: Info = {
           cwd: root,
         },
       ),
+      initializeTimeout: 180_000,
     }
   },
 }
@@ -1389,6 +1392,7 @@ export const KotlinLS: Info = {
       process: spawn(launcherScript, ["--stdio"], {
         cwd: root,
       }),
+      initializeTimeout: 180_000,
     }
   },
 }


### PR DESCRIPTION
## Problem

JDTLS and KotlinLS are JVM-based language servers that perform Gradle sync and workspace indexing during the LSP `initialize` handshake. For real projects this takes 60–180 seconds, well above the default 45 s timeout — causing `lsp_diagnostics` to fail with `LSP request timeout (method: initialize)`.

See #23982 for full diagnosis and logs.

## Changes

- Add optional `initializeTimeout` field to `LSPServer.Handle` so built-in servers can declare their timeout needs
- Use it in `client.ts` with the existing `INITIALIZE_TIMEOUT_MS` (45 s) as the default — no behavior change for any other server
- Set `initializeTimeout: 180_000` for JDTLS and KotlinLS

## Testing

```
31 pass, 0 fail across test/lsp/*
 9 pass, 0 fail for test/config/lsp.test.ts
Typecheck passes (bun typecheck)
```

Closes #23982