### PR TITLE
fix(mcp): ensure Accept header includes both required values for Streamable HTTP

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -300,12 +300,25 @@ export const layer = Layer.effect(
         )
       }
 
+      // Custom fetch that ensures Accept header includes both required values
+      // for MCP Streamable HTTP spec compliance. Some servers (e.g. Zhipu/BigModel)
+      // reject requests without both application/json and text/event-stream (#6972, #25650).
+      const mcpFetch: typeof fetch = (input, init) => {
+        const headers = new Headers(init?.headers)
+        const accept = headers.get("accept") ?? ""
+        if (!accept.includes("application/json") || !accept.includes("text/event-stream")) {
+          headers.set("accept", "application/json, text/event-stream")
+        }
+        return fetch(input, { ...init, headers })
+      }
+
       const transports: Array<{ name: string; transport: TransportWithAuth }> = [
         {
           name: "StreamableHTTP",
           transport: new StreamableHTTPClientTransport(url, {
             authProvider,
             requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
+            fetch: mcpFetch,
           }),
         },
         {

--- a/packages/opencode/test/mcp/headers.test.ts
+++ b/packages/opencode/test/mcp/headers.test.ts
@@ -6,13 +6,13 @@ import type { MCP as MCPNS } from "../../src/mcp/index"
 const transportCalls: Array<{
   type: "streamable" | "sse"
   url: string
-  options: { authProvider?: unknown; requestInit?: RequestInit }
+  options: { authProvider?: unknown; requestInit?: RequestInit; fetch?: unknown }
 }> = []
 
 // Mock the transport constructors to capture their arguments
 void mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: class MockStreamableHTTP {
-    constructor(url: URL, options?: { authProvider?: unknown; requestInit?: RequestInit }) {
+    constructor(url: URL, options?: { authProvider?: unknown; requestInit?: RequestInit; fetch?: unknown }) {
       transportCalls.push({
         type: "streamable",
         url: url.toString(),
@@ -173,6 +173,66 @@ test("no requestInit when headers are not provided", async () => {
       for (const call of transportCalls) {
         // No headers means requestInit should be undefined
         expect(call.options.requestInit).toBeUndefined()
+      }
+    },
+  })
+})
+
+test("streamable http transport receives custom fetch that sets Accept header", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          mcp: {
+            test: {
+              type: "remote",
+              url: "https://example.com/mcp",
+            },
+          },
+        }),
+      )
+    },
+    run: async () => {
+      const mcp = await Effect.runPromise(service)
+      await Effect.runPromise(
+        WithInstance.provide(
+          mcp
+            .connect({
+              url: "https://example.com/mcp",
+            })
+            .pipe(Effect.catch(() => Effect.void)),
+        ),
+      )
+
+      const streamableCall = transportCalls.find((c) => c.type === "streamable")
+      expect(streamableCall).toBeDefined()
+      expect(streamableCall!.options.fetch).toBeTypeOf("function")
+
+      // Verify the custom fetch adds Accept header
+      const customFetch = streamableCall!.options.fetch as typeof fetch
+      const mockResponse = new Response("ok")
+      const originalFetch = globalThis.fetch
+      let capturedHeaders: Headers | undefined
+      globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers)
+        return Promise.resolve(mockResponse)
+      }) as typeof fetch
+
+      try {
+        // Test with only text/event-stream (simulates SDK's GET request)
+        await customFetch("https://example.com/mcp", {
+          headers: { accept: "text/event-stream" },
+        })
+        expect(capturedHeaders!.get("accept")).toBe("application/json, text/event-stream")
+
+        // Test with both already set (simulates SDK's POST request)
+        await customFetch("https://example.com/mcp", {
+          headers: { accept: "application/json, text/event-stream" },
+        })
+        expect(capturedHeaders!.get("accept")).toBe("application/json, text/event-stream")
+      } finally {
+        globalThis.fetch = originalFetch
       }
     },
   })


### PR DESCRIPTION
### Issue for this PR

Closes #25650
Closes #6972

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The MCP SDK sets `Accept: text/event-stream` on the initial GET request for SSE stream opening. Some servers (Zhipu/BigModel) validate that ALL requests include both `application/json` and `text/event-stream` in Accept, returning 400 instead of the expected 405. This causes `StreamableHTTPClientTransport` to throw before the POST (which correctly sets both values) is ever attempted.

The fix passes a custom `fetch` to `StreamableHTTPClientTransport` that checks the Accept header on each request and ensures both values are present. This is compliant with the MCP Streamable HTTP spec which states clients SHOULD include both.

### How did you verify your code works?

1. Added a test in `test/mcp/headers.test.ts` that verifies the custom fetch correctly augments the Accept header
2. All 4 MCP header tests pass: `bun test test/mcp/headers.test.ts`
3. Verified the custom fetch preserves already-correct headers (POST path) and fixes incomplete ones (GET path)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

> 🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.