### PR TITLE
fix(app): show all subagent sessions in sidebar with collapsible chevron

### DIFF
--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./deep-links"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import {
+  childSessions,
   childSessionOnPath,
   displayName,
   effectiveWorkspaceOrder,
@@ -221,5 +222,44 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+
+  test("returns all direct children sorted newest first", () => {
+    const root = session({ id: "root", directory: "/workspace" })
+    const child1 = session({ id: "child1", directory: "/workspace", parentID: "root", time: { created: 1, updated: 1, archived: undefined } })
+    const child2 = session({ id: "child2", directory: "/workspace", parentID: "root", time: { created: 2, updated: 3, archived: undefined } })
+    const child3 = session({ id: "child3", directory: "/workspace", parentID: "root", time: { created: 3, updated: 2, archived: undefined } })
+
+    const result = childSessions([root, child1, child2, child3], "root", 120_000)
+
+    expect(result.map((s) => s.id)).toEqual(["child2", "child3", "child1"])
+  })
+
+  test("excludes archived children", () => {
+    const root = session({ id: "root", directory: "/workspace" })
+    const active = session({ id: "active", directory: "/workspace", parentID: "root", time: { created: 1, updated: 1, archived: undefined } })
+    const archived = session({ id: "archived", directory: "/workspace", parentID: "root", time: { created: 2, updated: 2, archived: 1 } })
+
+    const result = childSessions([root, active, archived], "root", 120_000)
+
+    expect(result.map((s) => s.id)).toEqual(["active"])
+  })
+
+  test("returns empty array when no children", () => {
+    const root = session({ id: "root", directory: "/workspace" })
+
+    const result = childSessions([root], "root", 120_000)
+
+    expect(result).toEqual([])
+  })
+
+  test("excludes non-direct descendants", () => {
+    const root = session({ id: "root", directory: "/workspace" })
+    const child = session({ id: "child", directory: "/workspace", parentID: "root" })
+    const grandchild = session({ id: "grandchild", directory: "/workspace", parentID: "child" })
+
+    const result = childSessions([root, child, grandchild], "root", 120_000)
+
+    expect(result.map((s) => s.id)).toEqual(["child"])
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -52,6 +52,11 @@ export const childSessionOnPath = (sessions: Session[] | undefined, rootID: stri
   }
 }
 
+export const childSessions = (sessions: Session[] | undefined, rootID: string, now: number) =>
+  (sessions ?? [])
+    .filter((s) => s.parentID === rootID && !s.time?.archived)
+    .sort(sortSessions(now))
+
 export const displayName = (project: { name?: string; worktree: string }) =>
   project.name || getFilename(project.worktree)
 

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -1,12 +1,14 @@
 import type { Session } from "@opencode-ai/sdk/v2/client"
 import { Avatar } from "@opencode-ai/ui/avatar"
+import { Button } from "@opencode-ai/ui/button"
+import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getFilename } from "@opencode-ai/core/util/path"
 import { A, useParams } from "@solidjs/router"
-import { type Accessor, createMemo, For, type JSX, Match, Show, Switch } from "solid-js"
+import { type Accessor, createMemo, createSignal, For, type JSX, Match, Show, Switch } from "solid-js"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { getAvatarColors, type LocalProject, useLayout } from "@/context/layout"
@@ -15,7 +17,7 @@ import { usePermission } from "@/context/permission"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionTitle } from "@/utils/session-title"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
-import { childSessionOnPath, hasProjectPermissions } from "./helpers"
+import { childSessions, hasProjectPermissions } from "./helpers"
 
 const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
@@ -95,6 +97,9 @@ const SessionRow = (props: {
   hasPermissions: Accessor<boolean>
   hasError: Accessor<boolean>
   unseenCount: Accessor<number>
+  hasChildren: Accessor<boolean>
+  expanded: Accessor<boolean>
+  onToggleChildren: () => void
   clearHoverProjectSoon: () => void
   sidebarOpened: Accessor<boolean>
   warmPress: () => void
@@ -113,27 +118,52 @@ const SessionRow = (props: {
         props.clearHoverProjectSoon()
       }}
     >
-      <Show when={props.isWorking() || props.hasPermissions() || props.hasError() || props.unseenCount() > 0}>
-        <div
-          class="shrink-0 size-6 flex items-center justify-center"
-          style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
-        >
-          <Switch>
-            <Match when={props.isWorking()}>
-              <Spinner class="size-[15px]" />
-            </Match>
-            <Match when={props.hasPermissions()}>
-              <div class="size-1.5 rounded-full bg-surface-warning-strong" />
-            </Match>
-            <Match when={props.hasError()}>
-              <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
-            </Match>
-            <Match when={props.unseenCount() > 0}>
-              <div class="size-1.5 rounded-full bg-text-interactive-base" />
-            </Match>
-          </Switch>
-        </div>
-      </Show>
+      <div
+        class="shrink-0 size-6 flex items-center justify-center relative"
+        style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
+      >
+        <Show when={props.isWorking() || props.hasPermissions() || props.hasError() || props.unseenCount() > 0}>
+          <div
+            class="absolute inset-0 flex items-center justify-center transition-opacity"
+            classList={{
+              "group-hover/session:opacity-0": props.hasChildren(),
+              "opacity-0": props.expanded(),
+            }}
+          >
+            <Switch>
+              <Match when={props.isWorking()}>
+                <Spinner class="size-[15px]" />
+              </Match>
+              <Match when={props.hasPermissions()}>
+                <div class="size-1.5 rounded-full bg-surface-warning-strong" />
+              </Match>
+              <Match when={props.hasError()}>
+                <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
+              </Match>
+              <Match when={props.unseenCount() > 0}>
+                <div class="size-1.5 rounded-full bg-text-interactive-base" />
+              </Match>
+            </Switch>
+          </div>
+        </Show>
+        <Show when={props.hasChildren()}>
+          <IconButton
+            icon={props.expanded() ? "chevron-down" : "chevron-right"}
+            variant="ghost"
+            size="small"
+            class="absolute inset-0 size-6 rounded-xs transition-opacity"
+            classList={{
+              "opacity-0 group-hover/session:opacity-100": !props.expanded(),
+            }}
+            aria-label={props.expanded() ? "Collapse" : "Expand"}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              props.onToggleChildren()
+            }}
+          />
+        </Show>
+      </div>
       <span class="text-14-regular text-text-strong min-w-0 flex-1 truncate">{title()}</span>
     </A>
   )
@@ -172,10 +202,15 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
 
   const tint = createMemo(() => messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent))
   const tooltip = createMemo(() => props.showTooltip ?? (props.mobile || !props.sidebarExpanded()))
-  const currentChild = createMemo(() => {
-    if (!props.showChild) return
-    return childSessionOnPath(sessionStore.session, props.session.id, params.id)
+  const children = createMemo(() => {
+    if (!props.showChild) return []
+    return childSessions(sessionStore.session, props.session.id, Date.now())
   })
+  const hasChildren = createMemo(() => children().length > 0)
+  const [expanded, setExpanded] = createSignal(false)
+  const [fullyExpanded, setFullyExpanded] = createSignal(false)
+  const visible = createMemo(() => children().slice(0, 3))
+  const hasMore = createMemo(() => children().length > 3 && !fullyExpanded())
 
   const warm = (span: number, priority: "high" | "low") => {
     const nav = props.navList?.()
@@ -208,6 +243,9 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       hasPermissions={hasPermissions}
       hasError={hasError}
       unseenCount={unseenCount}
+      hasChildren={hasChildren}
+      expanded={expanded}
+      onToggleChildren={() => setExpanded((v) => !v)}
       clearHoverProjectSoon={props.clearHoverProjectSoon}
       sidebarOpened={layout.sidebar.opened}
       warmPress={() => warm(2, "high")}
@@ -268,12 +306,29 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           </Show>
         </div>
       </div>
-      <Show when={currentChild()} keyed>
-        {(child) => (
-          <div class="w-full">
-            <SessionItem {...props} session={child} level={(props.level ?? 0) + 1} />
-          </div>
-        )}
+      <Show when={hasChildren()}>
+        <Collapsible open={expanded()} onOpenChange={setExpanded}>
+          <Collapsible.Content>
+            <For each={fullyExpanded() ? children() : visible()}>
+              {(child) => (
+                <div class="w-full">
+                  <SessionItem {...props} session={child} level={(props.level ?? 0) + 1} />
+                </div>
+              )}
+            </For>
+            <Show when={hasMore()}>
+              <div class="w-full" style={{ "padding-left": `${8 + ((props.level ?? 0) + 1) * 16}px` }}>
+                <Button
+                  variant="ghost"
+                  class="text-12-regular text-text-weak w-full text-left justify-start py-0.5 pl-6"
+                  onClick={() => setFullyExpanded(true)}
+                >
+                  {language.t("common.loadMore")}
+                </Button>
+              </div>
+            </Show>
+          </Collapsible.Content>
+        </Collapsible>
       </Show>
     </>
   )


### PR DESCRIPTION
### Issue for this PR

Closes #6191

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The sidebar was filtering subagent sessions to only the active path, so users couldn't see parallel subagent threads — that's the bug from #6191. This restores all of them and adds a hover-reveal chevron so trees with many subagents stay tidy.

The chevron lives in the existing size-6 status slot (same one the spinner uses), so adding it doesn't shift any row layout. It fades in on hover, hides the spinner while active, and toggles collapse/expand on click.

### How did you verify your code works?

- New unit tests in `helpers.test.ts` cover the visibility logic (active path vs all-subagents)
- Manual: ran a multi-agent task with several parallel subagents; all rows visible, chevron collapses/expands cleanly, no row jitter on hover

### Screenshots / recordings

<img width="350" alt="Subagent thread expanded — all subagents visible in sidebar" src="https://github.com/user-attachments/assets/641bccc7-36e0-4100-a7da-7385dbbb5b8f" />

<img width="346" alt="Hover-reveal chevron in the size-6 status slot" src="https://github.com/user-attachments/assets/75953a1a-eaa2-459e-ae8b-a5bc39085ab7" />

<img width="355" alt="Subagent thread collapsed via chevron click" src="https://github.com/user-attachments/assets/fa8f140b-0801-427d-be05-cba6f2d9947b" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR