### PR TITLE
fix(app): add readFile callback to file browser for audio preview

### DIFF
--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -17,6 +17,7 @@ import { useComments } from "@/context/comments"
 import { useLanguage } from "@/context/language"
 import { usePrompt } from "@/context/prompt"
 import { getSessionHandoff } from "@/pages/session/handoff"
+import { useSDK } from "@/context/sdk"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 
@@ -172,6 +173,7 @@ function createScrollSync(input: { tab: () => string; view: ReturnType<typeof us
 }
 
 export function FileTabContent(props: { tab: string }) {
+  const sdk = useSDK()
   const file = useFile()
   const comments = useComments()
   const language = useLanguage()
@@ -427,6 +429,11 @@ export function FileTabContent(props: { tab: string }) {
           mode: "auto",
           path: path(),
           current: state()?.content,
+          readFile: (filePath) =>
+            sdk.client.file
+              .read({ path: filePath })
+              .then((x) => x.data)
+              .catch(() => undefined),
           onLoad: scrollSync.queueRestore,
           onError: (args: { kind: "image" | "audio" | "svg" }) => {
             if (args.kind !== "svg") return


### PR DESCRIPTION
## Summary

The file browser (`FileTabContent`) passes a `media` prop to the `File` component, but unlike the review/diff view, it was missing the `readFile` callback.

`FileMedia` uses `readFile` to lazy-load file content (audio, images) when it isn't already pre-loaded in memory. Without it, the component falls through to the `unavailable` state for audio files:

- First open of an audio file (content not yet fetched)
- After LRU cache eviction of the file content
- When navigating directly to a tab (e.g. from session restore)

## Root cause

`FileMedia`'s `request` memo requires `media.readFile` to be set in order to trigger a lazy load. With only `current: state()?.content` passed, the audio player never renders if `current` is `undefined` at evaluation time.

## Fix

Add a `readFile` callback to the media prop — exactly the same pattern already used in `review-tab.tsx` (the diff/review panel), which correctly previews audio in that context:

```ts
readFile: (filePath) =>
  sdk.client.file
    .read({ path: filePath })
    .then((x) => x.data)
    .catch(() => undefined),
```

## Testing

1. Open a project directory in `opencode web`
2. Click an audio file (`.mp3`, `.wav`, `.ogg`, `.m4a`, `.flac`, `.aac`, `.opus`) in the file browser
3. Audio player should appear in the file tab (previously showed "audio preview unavailable")