### PR TITLE
feat(tui): add input.intercept API for plugin keydown interception

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -40,6 +40,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { createFadeIn } from "../../util/signal"
 import { useTextareaKeybindings } from "../textarea-keybindings"
+import * as Intercept from "./intercept"
 import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-workspace-create"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
@@ -1104,6 +1105,10 @@ export function Prompt(props: PromptProps) {
               keyBindings={textareaKeybindings()}
               onKeyDown={async (e) => {
                 if (props.disabled) {
+                  e.preventDefault()
+                  return
+                }
+                if (Intercept.dispatch(e, input)) {
                   e.preventDefault()
                   return
                 }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/intercept.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/intercept.ts
@@ -1,0 +1,21 @@
+import type { ParsedKey, TextareaRenderable } from "@opentui/core"
+
+export type InputInterceptHandler = (evt: ParsedKey, input: TextareaRenderable) => boolean | void
+export type Unregister = () => void
+
+const handlers: InputInterceptHandler[] = []
+
+export function register(handler: InputInterceptHandler): Unregister {
+  handlers.push(handler)
+  return () => {
+    const idx = handlers.indexOf(handler)
+    if (idx >= 0) handlers.splice(idx, 1)
+  }
+}
+
+export function dispatch(evt: ParsedKey, input: TextareaRenderable): boolean {
+  for (const handler of handlers) {
+    if (handler(evt, input)) return true
+  }
+  return false
+}

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -16,6 +16,7 @@ import { DialogConfirm } from "../ui/dialog-confirm"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { DialogSelect, type DialogSelectOption as SelectOption } from "../ui/dialog-select"
 import { Prompt } from "../component/prompt"
+import * as PromptIntercept from "../component/prompt/intercept"
 import { Slot as HostSlot } from "./slots"
 import type { useToast } from "../ui/toast"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
@@ -315,6 +316,11 @@ export function createTuiApi(input: Input): TuiPluginApi {
       },
       create(defaults, overrides) {
         return createPluginKeybind(input.keybind, defaults, overrides)
+      },
+    },
+    input: {
+      intercept(handler) {
+        return PromptIntercept.register(handler)
       },
     },
     get tuiConfig() {

--- a/packages/opencode/src/cli/cmd/tui/plugin/runtime.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/runtime.ts
@@ -535,6 +535,7 @@ function pluginApi(runtime: RuntimeState, plugin: PluginEntry, scope: PluginScop
     route,
     ui: api.ui,
     keybind: api.keybind,
+    input: api.input,
     tuiConfig: api.tuiConfig,
     kv: api.kv,
     state: api.state,

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -172,6 +172,9 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
         }
       },
     },
+    input: {
+      intercept: () => () => {},
+    },
     renderer,
     slots: {
       register: () => "fixture-slot",

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -15,7 +15,7 @@ import type {
   TextPart,
   Config as SdkConfig,
 } from "@opencode-ai/sdk/v2"
-import type { CliRenderer, ParsedKey, RGBA, SlotMode } from "@opentui/core"
+import type { CliRenderer, ParsedKey, RGBA, SlotMode, TextareaRenderable } from "@opentui/core"
 import type { JSX, SolidPlugin } from "@opentui/solid"
 import type { Config as PluginConfig, PluginOptions } from "./index.js"
 
@@ -446,6 +446,8 @@ export type TuiWorkspace = {
   set: (workspaceID?: string) => void
 }
 
+export type TuiInputInterceptHandler = (evt: ParsedKey, input: TextareaRenderable) => boolean | void
+
 export type TuiPluginApi = {
   app: TuiApp
   command: {
@@ -473,6 +475,9 @@ export type TuiPluginApi = {
     match: (key: string, evt: ParsedKey) => boolean
     print: (key: string) => string
     create: (defaults: TuiKeybindMap, overrides?: Record<string, unknown>) => TuiKeybindSet
+  }
+  input: {
+    intercept: (handler: TuiInputInterceptHandler) => () => void
   }
   readonly tuiConfig: Frozen<TuiConfigView>
   kv: TuiKV


### PR DESCRIPTION
### Issue for this PR

Closes #1764

### Type of change

- [x] New feature

### What does this PR do?

Adds an `input.intercept` hook to the TUI plugin API, enabling plugins to intercept keystrokes in the prompt input **before** default handling runs.

This is the foundational API needed to implement vim mode, macro recording, and custom keybinding plugins — without requiring changes to core. The approach uses a simple module-level handler registry. Handlers run in registration order; the first handler returning truthy consumes the key event.

### How did you verify your code works?

- Typecheck passes for all 19 packages in the monorepo
- All 20 existing plugin unit tests pass (`bun test test/cli/tui/plugin*.test.ts`)
- Manual inspection of the dispatch flow: interceptors fire before any other `onKeyDown` logic

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR