### PR TITLE
fix(file): audio preview in web file browser

### DIFF
--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -17,6 +17,7 @@ import { useComments } from "@/context/comments"
 import { useLanguage } from "@/context/language"
 import { usePrompt } from "@/context/prompt"
 import { getSessionHandoff } from "@/pages/session/handoff"
+import { useSDK } from "@/context/sdk"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 
@@ -172,6 +173,7 @@ function createScrollSync(input: { tab: () => string; view: ReturnType<typeof us
 }
 
 export function FileTabContent(props: { tab: string }) {
+  const sdk = useSDK()
   const file = useFile()
   const comments = useComments()
   const language = useLanguage()
@@ -427,6 +429,11 @@ export function FileTabContent(props: { tab: string }) {
           mode: "auto",
           path: path(),
           current: state()?.content,
+          readFile: (filePath) =>
+            sdk.client.file
+              .read({ path: filePath })
+              .then((x) => x.data)
+              .catch(() => undefined),
           onLoad: scrollSync.queueRestore,
           onError: (args: { kind: "image" | "audio" | "svg" }) => {
             if (args.kind !== "svg") return

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -429,7 +429,7 @@ export function FileTabContent(props: { tab: string }) {
           mode: "auto",
           path: path(),
           current: state()?.content,
-          readFile: (filePath) =>
+          readFile: (filePath: string) =>
             sdk.client.file
               .read({ path: filePath })
               .then((x) => x.data)

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -277,16 +277,30 @@ const mime: Record<string, string> = {
   heif: "image/heif",
 }
 
+const audioMime: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  flac: "audio/flac",
+  opus: "audio/opus",
+}
+
+const AUDIO_MAX_BYTES = 10 * 1024 * 1024 // 10 MB
+
 type Entry = { files: string[]; dirs: string[] }
 
 const ext = (file: string) => path.extname(file).toLowerCase().slice(1)
 const name = (file: string) => path.basename(file).toLowerCase()
 const isImageByExtension = (file: string) => image.has(ext(file))
+const isAudioByExtension = (file: string) => ext(file) in audioMime
 const isTextByExtension = (file: string) => text.has(ext(file))
 const isTextByName = (file: string) => textName.has(name(file))
 const isBinaryByExtension = (file: string) => binary.has(ext(file))
 const isImage = (mimeType: string) => mimeType.startsWith("image/")
 const getImageMimeType = (file: string) => mime[ext(file)] || "image/" + ext(file)
+const getAudioMimeType = (file: string) => audioMime[ext(file)] || "audio/" + ext(file)
 
 function shouldEncode(mimeType: string) {
   const type = mimeType.toLowerCase()
@@ -331,7 +345,7 @@ export interface Interface {
   }) => Effect.Effect<string[]>
 }
 
-export class Service extends Context.Service<Service, Interface>()("@opencode/File") {}
+export class Service extends Context.Service<Service, Interface>()("@opencode/File") { }
 
 export const layer = Layer.effect(
   Service,
@@ -523,6 +537,22 @@ export const layer = Layer.effect(
           }
         }
         return { type: "text" as const, content: "" }
+      }
+
+      if (isAudioByExtension(file)) {
+        const exists = yield* appFs.existsSafe(full)
+        if (exists) {
+          const bytes = yield* appFs.readFile(full).pipe(Effect.catch(() => Effect.succeed(new Uint8Array())))
+          if (bytes.byteLength <= AUDIO_MAX_BYTES) {
+            return {
+              type: "text" as const,
+              content: Buffer.from(bytes).toString("base64"),
+              mimeType: getAudioMimeType(file),
+              encoding: "base64" as const,
+            }
+          }
+        }
+        return { type: "binary" as const, content: "" }
       }
 
       const knownText = isTextByExtension(file) || isTextByName(file)


### PR DESCRIPTION
## Summary

Audio files selected in the web file browser showed "audio preview unavailable" due to two separate bugs:

### Bug 1 — Server returns no content for audio files

`packages/opencode/src/file/index.ts`: Audio extensions (`wav`, `mp3`, `ogg`, `m4a`, `aac`, `flac`, `opus`) are listed in the `binary` set, causing the `read` handler to return `{type:'binary', content:''}` with no content or MIME type before the file is ever read.

**Fix:** Add an `isAudioByExtension` check before the binary early-return, mirroring the existing image handling. Files up to 10 MB are returned as base64 with the correct `audio/*` MIME type.

### Bug 2 — Frontend missing `readFile` callback

`packages/app/src/pages/session/file-tabs.tsx`: `FileTabContent` passes a `media` prop to `FileMedia` but was missing the `readFile` callback. `FileMedia` uses this to lazy-load content when it isn't pre-loaded — without it, audio always shows "unavailable".

**Fix:** Add the `readFile` callback using the same pattern as `review-tab.tsx`.

## Testing

Open an audio file (`.wav`, `.mp3`, etc.) in the web file browser — it should now render a `<audio controls>` player.
