### PR TITLE
fix: propagate hashline tool.execute.before args and add ref params t…

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -419,6 +419,23 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: input.agent,
       })) {
         const schema = ProviderTransform.schema(input.model, EffectZod.toJsonSchema(item.parameters))
+        // Hashline: inject ref-based edit params into edit tool schema
+        // for models with strict JSON Schema validation (e.g. DeepSeek).
+        if (item.id === "edit" && schema?.properties) {
+          schema.properties.content = { type: "string", description: "Replacement text when using startRef-based edits." }
+          schema.properties.operation = { type: "string", description: "Set to 'replace' to use startRef+content instead of oldString/newString. Triggers hash validation." }
+          schema.properties.ref = { type: "string", description: "Alias for startRef. Single-line ref from Read output, e.g. '3#A0C#393'." }
+          schema.properties.startRef = { type: "string", description: "Start ref from Read output, e.g. '3#A0C#393'. Validates target line content before replacing." }
+          schema.properties.endRef = { type: "string", description: "End ref for multi-line range replacement. Only used with startRef." }
+          schema.properties.fileRev = { type: "string", description: "REV token from Read output, e.g. '2ED9E6A9'. When set, edit fails if file hash mismatch." }
+          schema.properties.expectedFileHash = { type: "string", description: "Alternative to fileRev: expected full file hash for validation." }
+          schema.properties.safeReapply = { type: "boolean", description: "If true and edit fails, reapplies with refs adjusted to new context." }
+          schema.properties.operations = { type: "array", description: "Batch multiple same-file edits. Replaces oldString/newString when set.", items: { type: "object", properties: { op: { type: "string", enum: ["replace", "replace_range"] }, ref: { type: "string", description: "Single-line ref" }, startRef: { type: "string", description: "Start ref" }, endRef: { type: "string", description: "End ref for range" }, content: { type: "string", description: "Replacement content" } }, required: ["op", "content"] } }
+          // oldString/newString optional when hashline ref-params are used
+          if (Array.isArray(schema.required)) {
+            schema.required = schema.required.filter((r) => r !== "oldString" && r !== "newString")
+          }
+        }
         tools[item.id] = tool({
           description: item.description,
           inputSchema: jsonSchema(schema),
@@ -426,12 +443,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             return run.promise(
               Effect.gen(function* () {
                 const ctx = context(args, options)
+                const hookOutput = { args }
                 yield* plugin.trigger(
                   "tool.execute.before",
                   { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
-                  { args },
+                  hookOutput,
                 )
-                const result = yield* item.execute(args, ctx)
+                const result = yield* item.execute(hookOutput.args, ctx)
                 const output = {
                   ...result,
                   attachments: result.attachments?.map((attachment) => ({


### PR DESCRIPTION
## Summary

When using the hashline plugin (@angdrew/opencode-hashline-plugin), edit tool call args like `startRef`, `operation`, `content` were not exposed in the JSON Schema sent to the LLM. Models with strict schema validation (e.g. DeepSeek) could not pass these parameters, making hashline ref-based editing unavailable to them.

This PR fixes three issues in `prompt.ts`:

### Changes

1. **Inject hashline ref parameters into edit tool JSON Schema** — Adds `startRef`, `endRef`, `content`, `operation`, `operations[]`, `fileRev`, `safeReapply` as optional properties so strict-schema models can use them.

2. **Remove `oldString`/`newString` from JSON Schema `required` array** — Allows the model to call `edit()` with `startRef+content` instead of `oldString/newString`. The hashline plugin's `tool.execute.before` hook will translate ref-based args back to `{ filePath, oldString, newString }` before Effect Schema decode.

3. **Propagate plugin-modified args to `item.execute`** — The `tool.execute.before` hook modifies `output.args`, but the original `args` variable was passed to `item.execute()`. Changed to use `hookOutput.args` so the hashline plugin's translation (ref→oldString) actually takes effect.

### Testing

Verified with `opencode run` cli command:
```
Read /tmp/hash-test/test4.md → got hashline refs
edit({ startRef: "4#250#DB0", operation: "replace", content: "banana-edited" })
  → no SchemaError("Missing key at oldString")
  → file content correctly updated
```

### Backward compatibility

All changes are fully backward compatible. Existing `edit({ filePath, oldString, newString })` calls continue to work unchanged.