### PR TITLE
fix(acp): drain message events before returning end_turn

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -147,6 +147,8 @@ export class Agent implements ACPAgent {
   private bashSnapshots = new Map<string, string>()
   private toolStarts = new Set<string>()
   private permissionQueues = new Map<string, Promise<void>>()
+  private messageCompletionResolvers = new Map<string, () => void>()
+  private completedAssistantMessageIds = new Set<string>()
   private permissionOptions: PermissionOption[] = [
     { optionId: "once", kind: "allow_once", name: "Allow once" },
     { optionId: "always", kind: "allow_always", name: "Always allow" },
@@ -267,6 +269,19 @@ export class Agent implements ACPAgent {
             }
           })
         this.permissionQueues.set(permission.sessionID, next)
+        return
+      }
+
+      case "message.updated": {
+        const info = event.properties.info
+        if (info.role === "assistant" && info.time.completed !== undefined) {
+          this.completedAssistantMessageIds.add(info.id)
+          const resolver = this.messageCompletionResolvers.get(info.id)
+          if (resolver) {
+            this.messageCompletionResolvers.delete(info.id)
+            resolver()
+          }
+        }
         return
       }
 
@@ -529,6 +544,34 @@ export class Agent implements ACPAgent {
         return
       }
     }
+  }
+
+  // Block until `message.updated` for `messageId` (with `time.completed`
+  // set) has been observed by the event subscription. Because
+  // `runEventSubscription` processes events sequentially via `for await`
+  // and awaits each `handleEvent` (which awaits the inner
+  // `connection.sessionUpdate(...)`), waiting for the completed event
+  // guarantees every prior `message.part.delta` chunk for this turn has
+  // already been forwarded to ACP. Without this, `prompt()` returns
+  // `stopReason: "end_turn"` while trailing chunk events are still queued
+  // in the SDK event stream, putting `agent_message_chunk` frames on the
+  // wire AFTER the RPC reply (a protocol violation visible to ACP clients
+  // as text appearing post-end_turn).
+  private waitForMessageCompletion(messageId: string, timeoutMs: number): Promise<void> {
+    if (this.completedAssistantMessageIds.has(messageId)) {
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => {
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
+        this.messageCompletionResolvers.delete(messageId)
+        resolve()
+      }
+      this.messageCompletionResolvers.set(messageId, finish)
+      setTimeout(finish, timeoutMs)
+    })
   }
 
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {
@@ -1481,6 +1524,12 @@ export class Agent implements ACPAgent {
       })
       const msg = response.data?.info
 
+      // Drain trailing message.part.delta events before returning end_turn —
+      // see `waitForMessageCompletion` for why.
+      if (msg?.id) {
+        await this.waitForMessageCompletion(msg.id, 5000)
+      }
+
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 
       return {
@@ -1503,6 +1552,10 @@ export class Agent implements ACPAgent {
         directory,
       })
       const msg = response.data?.info
+
+      if (msg?.id) {
+        await this.waitForMessageCompletion(msg.id, 5000)
+      }
 
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -558,19 +558,33 @@ export class Agent implements ACPAgent {
   // wire AFTER the RPC reply (a protocol violation visible to ACP clients
   // as text appearing post-end_turn).
   private waitForMessageCompletion(messageId: string, timeoutMs: number): Promise<void> {
+    // Cache hit means the completion event landed before we got here. Consume
+    // the entry so the set doesn't grow unbounded over the agent's lifetime.
     if (this.completedAssistantMessageIds.has(messageId)) {
+      this.completedAssistantMessageIds.delete(messageId)
       return Promise.resolve()
     }
     return new Promise<void>((resolve) => {
       let settled = false
-      const finish = () => {
+      let timer: ReturnType<typeof setTimeout> | null = null
+      const finish = (timedOut: boolean) => {
         if (settled) return
         settled = true
+        if (timer) clearTimeout(timer)
         this.messageCompletionResolvers.delete(messageId)
+        if (timedOut) {
+          // Defensive: returning end_turn without observing completion means a
+          // chunk could still land post-reply. Log so the regression is visible
+          // in the field rather than a silent UX glitch.
+          log.warn("waitForMessageCompletion: timeout waiting for message.updated", {
+            messageId,
+            timeoutMs,
+          })
+        }
         resolve()
       }
-      this.messageCompletionResolvers.set(messageId, finish)
-      setTimeout(finish, timeoutMs)
+      this.messageCompletionResolvers.set(messageId, () => finish(false))
+      timer = setTimeout(() => finish(true), timeoutMs)
     })
   }
 

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -722,4 +722,100 @@ describe("acp.agent event subscription", () => {
       },
     })
   })
+
+  test("prompt() awaits message.updated for response messageID before returning end_turn", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sdk, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const messageID = "msg_completion_test_1"
+
+        // Mock sdk.session.prompt: resolve only when we tell it to. The
+        // returned `info` carries the messageID our fix awaits via
+        // `waitForMessageCompletion`.
+        let resolveSdkPrompt: (() => void) | null = null
+        const sdkPromptPromise = new Promise<any>((resolve) => {
+          resolveSdkPrompt = () =>
+            resolve({
+              data: {
+                info: {
+                  id: messageID,
+                  sessionID: sessionId,
+                  role: "assistant",
+                  time: { created: 1, completed: 2 },
+                  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                  cost: 0,
+                  parentID: "u1",
+                  modelID: "big-pickle",
+                  providerID: "opencode",
+                  mode: "build",
+                  agent: "build",
+                  path: { cwd, root: cwd },
+                },
+              },
+            })
+        })
+        sdk.session.prompt = async () => sdkPromptPromise
+
+        let promptDone = false
+        const promptPromise = (agent as any)
+          .prompt({
+            sessionId,
+            prompt: [{ type: "text", text: "test" }],
+          })
+          .then((r: any) => {
+            promptDone = true
+            return r
+          })
+          .catch((err: unknown) => {
+            promptDone = true
+            throw err
+          })
+
+        // Let agent.prompt() reach the `await sdk.session.prompt(...)` boundary,
+        // then resolve it. After resolution, prompt() should be blocked inside
+        // waitForMessageCompletion(messageID, ...) — the regression check.
+        await new Promise((r) => setTimeout(r, 20))
+        resolveSdkPrompt!()
+        await new Promise((r) => setTimeout(r, 60))
+        expect(promptDone).toBe(false)
+
+        // Push the assistant message-completed event. The new
+        // `case "message.updated"` handler should resolve the waiter.
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.updated",
+            properties: {
+              sessionID: sessionId,
+              info: {
+                id: messageID,
+                sessionID: sessionId,
+                role: "assistant",
+                time: { created: 1, completed: 2 },
+                parentID: "u1",
+                modelID: "big-pickle",
+                providerID: "opencode",
+                mode: "build",
+                agent: "build",
+                path: { cwd, root: cwd },
+                cost: 0,
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              },
+            },
+          } as any,
+        })
+
+        const result = await promptPromise
+        expect(promptDone).toBe(true)
+        expect(result.stopReason).toBe("end_turn")
+
+        stop()
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #25421

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Agent.prompt()` returns `stopReason: "end_turn"` as soon as `sdk.session.prompt()` resolves. But trailing `message.part.delta` events for the assistant's final text deltas are still in the SDK event stream at that moment — they get processed by `runEventSubscription` and forwarded as `agent_message_chunk` to the ACP connection AFTER the prompt RPC reply has been written. On the wire you see chunks landing 5–50ms after `id:N result:end_turn`.

Why the fix works: `runEventSubscription` is a sequential `for await` that awaits each `handleEvent` call (which awaits `connection.sessionUpdate`). The `message.updated` event with `info.time.completed` set is emitted AFTER all `message.part.delta` events for the same message. So if `prompt()` waits for that completion event before returning, every prior chunk has already been flushed to the ACP connection.

The patch adds a per-messageId waiter resolved by a new `case "message.updated"` handler, and awaits it after `sdk.session.prompt(...)` resolves in both non-compact branches of `prompt()`. A 5s timeout falls through if the completion event never arrives, so a dropped event can't deadlock the turn.

The compact path doesn't carry an assistant message id, left untouched.

### How did you verify your code works?

- `bun run typecheck` clean
- Existing `test/acp/event-subscription.test.ts` (11 tests) all pass — no regressions
- End-to-end on a real ACP client (TrueNorth's `tn-claw` sidecar): rebuilt the binary, captured WS frames in DevTools, confirmed `end_turn` is now the last `ch:acp` frame for the turn (3s quiet window observed empty)

Pre-fix wire trace:
```
... agent_message_chunk frames ...
{"id":2,"result":{"stopReason":"end_turn",...}}
{"method":"session/update","params":{...,"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"\n\nDone. Created `/path/to/file`"}}}}   <-- arrives 10ms after end_turn
```

Post-fix: the trailing chunk above is gone — `end_turn` is the final frame.

Happy to add a unit regression test using the existing `createFakeAgent` harness if reviewers want.

### Screenshots / recordings

N/A — backend protocol fix. Wire trace included above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
