### PR TITLE
Improve shell completion docs and avoid full init for completion probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bas
 XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
+#### Shell Completion
+
+OpenCode can generate shell completion scripts with `opencode completion`.
+
+```bash
+# Bash
+SHELL="$(command -v bash)" opencode completion >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh
+SHELL="$(command -v zsh)" opencode completion >> ~/.zshrc
+source ~/.zshrc
+```
+
+On macOS, you may want to use `~/.bash_profile` or `~/.zprofile` instead.
+
 ### Agents
 
 OpenCode includes two built-in agents you can switch between with the `Tab` key.

--- a/README.zh.md
+++ b/README.zh.md
@@ -97,6 +97,22 @@ OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bas
 XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
+#### Shell 补全
+
+OpenCode 支持通过 `opencode completion` 生成 shell 补全脚本。
+
+```bash
+# Bash
+SHELL="$(command -v bash)" opencode completion >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh
+SHELL="$(command -v zsh)" opencode completion >> ~/.zshrc
+source ~/.zshrc
+```
+
+在 macOS 上，你可能更想写入 `~/.bash_profile` 或 `~/.zprofile`。
+
 ### Agents
 
 OpenCode 内置两种 Agent，可用 `Tab` 键快速切换：

--- a/packages/opencode/src/cli/completion.ts
+++ b/packages/opencode/src/cli/completion.ts
@@ -1,0 +1,4 @@
+export function isShellCompletionInvocation(argv: readonly string[]) {
+  if (argv.includes("--get-yargs-completions")) return true
+  return argv.find((arg) => !arg.startsWith("-")) === "completion"
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -39,6 +39,7 @@ import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
+import { isShellCompletionInvocation } from "./cli/completion"
 
 const processMetadata = ensureProcessMetadata("main")
 
@@ -55,6 +56,7 @@ process.on("uncaughtException", (e) => {
 })
 
 const args = hideBin(process.argv)
+const shellCompletionInvocation = isShellCompletionInvocation(args)
 
 function show(out: string) {
   const text = out.trimStart()
@@ -88,6 +90,8 @@ const cli = yargs(args)
     type: "boolean",
   })
   .middleware(async (opts) => {
+    if (shellCompletionInvocation) return
+
     if (opts.pure) {
       process.env.OPENCODE_PURE = "1"
     }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -8,6 +8,7 @@ import { Flock } from "@opencode-ai/core/util/flock"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { withTransientReadRetry } from "@/util/effect-http-client"
+import { isShellCompletionInvocation } from "@/cli/completion"
 
 const Cost = Schema.Struct({
   input: Schema.Finite,
@@ -181,7 +182,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | HttpClie
       )
     })
 
-    if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
+    if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !isShellCompletionInvocation(process.argv.slice(2))) {
       // Schedule.spaced runs the effect once, then waits between completions.
       yield* Effect.forkScoped(refresh().pipe(Effect.repeat(Schedule.spaced("60 minutes")), Effect.ignore))
     }

--- a/packages/opencode/test/cli/completion.test.ts
+++ b/packages/opencode/test/cli/completion.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { isShellCompletionInvocation } from "../../src/cli/completion"
+
+describe("isShellCompletionInvocation", () => {
+  test("matches the yargs completion command", () => {
+    expect(isShellCompletionInvocation(["completion"])).toBe(true)
+    expect(isShellCompletionInvocation(["--pure", "completion"])).toBe(true)
+  })
+
+  test("matches yargs completion probe calls", () => {
+    expect(isShellCompletionInvocation(["--get-yargs-completions", "opencode"])).toBe(true)
+  })
+
+  test("ignores normal cli invocations", () => {
+    expect(isShellCompletionInvocation([])).toBe(false)
+    expect(isShellCompletionInvocation(["run", "fix this"])).toBe(false)
+    expect(isShellCompletionInvocation(["./completion"])).toBe(false)
+  })
+})

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -88,6 +88,22 @@ You can also install it with the following commands:
   paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
+### Shell completion
+
+OpenCode can generate shell completion scripts with `opencode completion`.
+
+```bash
+# Bash
+SHELL="$(command -v bash)" opencode completion >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh
+SHELL="$(command -v zsh)" opencode completion >> ~/.zshrc
+source ~/.zshrc
+```
+
+On macOS, you may want to use `~/.bash_profile` or `~/.zprofile` instead.
+
 #### Windows
 
 :::tip[Recommended: Use WSL]

--- a/packages/web/src/content/docs/zh-cn/index.mdx
+++ b/packages/web/src/content/docs/zh-cn/index.mdx
@@ -88,6 +88,22 @@ curl -fsSL https://opencode.ai/install | bash
   paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
+### Shell 补全
+
+OpenCode 支持通过 `opencode completion` 生成 shell 补全脚本。
+
+```bash
+# Bash
+SHELL="$(command -v bash)" opencode completion >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh
+SHELL="$(command -v zsh)" opencode completion >> ~/.zshrc
+source ~/.zshrc
+```
+
+在 macOS 上，你可能更想写入 `~/.bash_profile` 或 `~/.zprofile`。
+
 #### Windows
 
 :::tip[推荐：使用 WSL]


### PR DESCRIPTION
### Issue for this PR

Closes #25692

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This fixes slow shell completion probes.

`opencode completion` generates scripts that call `opencode --get-yargs-completions ...` on every completion request. Before this change, that path still went through the normal CLI startup flow, so completion requests did extra work they do not need.

This PR:

- adds `isShellCompletionInvocation()` to detect completion-only invocations
- skips global CLI middleware for completion invocations
- skips background models.dev refresh scheduling for completion invocations
- adds a regression test for the detection helper
- documents Bash/Zsh shell completion setup in the main README and docs landing pages

The fix works because completion probes now avoid unrelated startup work and stay on a smaller execution path.

### How did you verify your code works?

- Ran `bun test test/cli/completion.test.ts`
- Ran `bun typecheck`
- Manually verified that a completion invocation in a fresh XDG directory no longer creates runtime DB side effects

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR