### PR TITLE
fix(opencode): strip transfer-encoding in UI proxy and allow public manifest assets

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -481,7 +481,7 @@ export const Terminal = (props: TerminalProps) => {
 
       const connectToken = async () => {
         const result = await client.pty.connectToken(
-          { ptyID: id },
+          { ptyID: id, directory },
           {
             throwOnError: false,
             headers: { "x-opencode-ticket": "1" },

--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -13,6 +13,7 @@ import { compress } from "hono/compress"
 import * as ServerBackend from "./backend"
 import { isAllowedCorsOrigin, type CorsOptions } from "./cors"
 import { isPtyConnectPath, PTY_CONNECT_TICKET_QUERY } from "./shared/pty-ticket"
+import { isPublicUIPath } from "./shared/public-ui"
 
 const log = Log.create({ service: "server" })
 
@@ -45,6 +46,7 @@ export const AuthMiddleware: MiddlewareHandler = (c, next) => {
   if (c.req.method === "OPTIONS") return next()
   const password = Flag.OPENCODE_SERVER_PASSWORD
   if (!password) return next()
+  if (isPublicUIPath(c.req.method, c.req.path)) return next()
   if (isPtyConnectPath(c.req.path) && c.req.query(PTY_CONNECT_TICKET_QUERY)) return next()
   const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
 

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/authorization.ts
@@ -3,6 +3,7 @@ import { Effect, Encoding, Layer, Redacted } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiError, HttpApiMiddleware } from "effect/unstable/httpapi"
 import { hasPtyConnectTicketURL } from "@/server/shared/pty-ticket"
+import { isPublicUIPath } from "@/server/shared/public-ui"
 
 const AUTH_TOKEN_QUERY = "auth_token"
 const UNAUTHORIZED = 401
@@ -92,6 +93,7 @@ export const authorizationRouterMiddleware = HttpRouter.middleware()(
       Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest
         const url = new URL(request.url, "http://localhost")
+        if (isPublicUIPath(request.method, url.pathname)) return yield* effect
         if (hasPtyConnectTicketURL(url)) return yield* effect
         return yield* credentialFromURL(url, request).pipe(
           Effect.flatMap((credential) => validateRawCredential(effect, credential, config)),

--- a/packages/opencode/src/server/shared/public-ui.ts
+++ b/packages/opencode/src/server/shared/public-ui.ts
@@ -1,0 +1,12 @@
+// Static UI assets the browser fetches without app-managed credentials, e.g.
+// the manifest link in <head>. These bypass auth so the page can install/render
+// the manifest icons even when a server password is configured.
+export const PUBLIC_UI_PATHS = new Set<string>([
+  "/site.webmanifest",
+  "/web-app-manifest-192x192.png",
+  "/web-app-manifest-512x512.png",
+])
+
+export function isPublicUIPath(method: string, pathname: string) {
+  return method === "GET" && PUBLIC_UI_PATHS.has(pathname)
+}

--- a/packages/opencode/src/server/shared/ui.ts
+++ b/packages/opencode/src/server/shared/ui.ts
@@ -33,6 +33,7 @@ function proxyResponseHeaders(headers: Record<string, string>) {
   // transfer metadata makes browsers decode already-decoded assets again.
   result.delete("content-encoding")
   result.delete("content-length")
+  result.delete("transfer-encoding")
   return result
 }
 


### PR DESCRIPTION

### Issue for this PR

Closes #25697

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Fixes net::ERR_INVALID_CHUNKED_ENCODING 200 (OK) when loading / through opencode serve's UI proxy.
- Fixes 401 Unauthorized on /site.webmanifest and PWA icons when OPENCODE_SERVER_PASSWORD is set.
- Fixes terminal websocket startup when the app uses an auth_token-style flow by scoping PTY connect tokens to the same directory the websocket uses.

### How did you verify your code works?

- Reproduced and verified both serve UI issues:
  - / previously failed with ERR_INVALID_CHUNKED_ENCODING; now loads cleanly.
  - /site.webmanifest returned 401 with a server password set; now returns 200.
- Manually verified PTY terminal startup: token mint and websocket connect now consistently succeed because directory matches across both requests.

- Ran focused server tests:
  - bun test test/server/httpapi-ui.test.ts
  - bun test test/server/httpapi-authorization.test.ts
  - bun test test/server/httpapi-listen.test.ts
- Manually verified production proxy and local preview proxy through opencode serve.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR