### PR TITLE
feat: add copy_on_select tui config to control auto-copy behavior

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -260,8 +260,14 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       setReady(true)
     })
 
+  const disableCopyOnSelect = () => {
+    if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return true
+    if (tuiConfig.copy_on_select !== undefined) return !tuiConfig.copy_on_select
+    return false
+  }
+
   useKeyboard((evt) => {
-    if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
+    if (!disableCopyOnSelect()) return
     const sel = renderer.getSelection()
     if (!sel) return
 
@@ -884,14 +890,14 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       height={dimensions().height}
       backgroundColor={theme.background}
       onMouseDown={(evt) => {
-        if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
+        if (!disableCopyOnSelect()) return
         if (evt.button !== MouseButton.RIGHT) return
 
         if (!Selection.copy(renderer, toast)) return
         evt.preventDefault()
         evt.stopPropagation()
       }}
-      onMouseUp={Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT ? undefined : () => Selection.copy(renderer, toast)}
+      onMouseUp={disableCopyOnSelect() ? undefined : () => Selection.copy(renderer, toast)}
     >
       <Show when={Flag.OPENCODE_SHOW_TTFD}>
         <TimeToFirstDraw />

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -24,6 +24,7 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
+  copy_on_select: z.boolean().optional().describe("Enable or disable copy on select (auto-copy selected text to clipboard). Default: false on Windows, true on macOS/Linux"),
 })
 
 export const TuiInfo = z

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -5,6 +5,7 @@ import { MouseButton, Renderable, RGBA } from "@opentui/core"
 import { createStore } from "solid-js/store"
 import { useToast } from "./toast"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { useTuiConfig } from "@tui/context/tui-config"
 import * as Selection from "@tui/util/selection"
 
 export function Dialog(
@@ -155,6 +156,12 @@ export function DialogProvider(props: ParentProps) {
   const value = init()
   const renderer = useRenderer()
   const toast = useToast()
+  const tuiConfig = useTuiConfig()
+  const disableCopyOnSelect = () => {
+    if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return true
+    if (tuiConfig.copy_on_select !== undefined) return !tuiConfig.copy_on_select
+    return false
+  }
   return (
     <ctx.Provider value={value}>
       {props.children}
@@ -162,7 +169,7 @@ export function DialogProvider(props: ParentProps) {
         position="absolute"
         zIndex={3000}
         onMouseDown={(evt) => {
-          if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
+          if (!disableCopyOnSelect()) return
           if (evt.button !== MouseButton.RIGHT) return
 
           if (!Selection.copy(renderer, toast)) return
@@ -170,7 +177,7 @@ export function DialogProvider(props: ParentProps) {
           evt.stopPropagation()
         }}
         onMouseUp={
-          !Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT ? () => Selection.copy(renderer, toast) : undefined
+          disableCopyOnSelect() ? undefined : () => Selection.copy(renderer, toast)
         }
       >
         <Show when={value.stack.length}>


### PR DESCRIPTION
### Issue for this PR

Closes #N/A

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `copy_on_select` behavior (auto-copy selected text to clipboard on mouse-up) was only controllable via the `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT` env var, with a platform-dependent default:

- Windows: disabled by default (copy via right-click / Ctrl+C)
- macOS/Linux: enabled by default (auto-copies on mouse-up)

This PR adds `copy_on_select` as a `tui.json` config option so users can control the behavior per-platform without setting environment variables.

**Changes:**
- `packages/opencode/src/cli/cmd/tui/config/tui-schema.ts`: Added `copy_on_select: z.boolean().optional()` to `TuiOptions`
- `packages/opencode/src/cli/cmd/tui/app.tsx`: Replace `Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT` with a helper that checks env var > tui config > platform default
- `packages/opencode/src/cli/cmd/tui/ui/dialog.tsx`: Same helper added to `DialogProvider`

**Usage in `~/.config/opencode/tui.json`:**
```json
{
  "copy_on_select": false
}
```

Default behavior is unchanged when the option is not set.

### How did you verify your code works?

Follows the same pattern as the recently added `message_click_actions` TUI config option. The guard condition mirrors existing patterns in the same files. Env var `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT` still takes precedence when explicitly set.

### Screenshots / recordings

N/A — no UI change, only a config option that alters existing mouse/keyboard behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR