### PR TITLE
feat: add Create Folder button to Web UI homepage

### DIFF
--- a/packages/app/src/components/dialog-create-folder.tsx
+++ b/packages/app/src/components/dialog-create-folder.tsx
@@ -1,0 +1,113 @@
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { Button } from "@opencode-ai/ui/button"
+import { createMemo, createSignal, Show } from "solid-js"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useGlobalSync } from "@/context/global-sync"
+import { useLanguage } from "@/context/language"
+
+interface DialogCreateFolderProps {
+  /** Called with the absolute path of the successfully created folder. */
+  onCreated: (path: string) => void
+}
+
+function joinPath(base: string, name: string) {
+  return base.replace(/\/+$/, "") + "/" + name
+}
+
+// Characters disallowed in directory names across major platforms.
+const INVALID_CHARS = /[<>:"|?*\x00-\x1F]/
+
+export function DialogCreateFolder(props: DialogCreateFolderProps) {
+  const sdk = useGlobalSDK()
+  const sync = useGlobalSync()
+  const dialog = useDialog()
+  const language = useLanguage()
+
+  const home = createMemo(() => sync.data.path.home || "~")
+
+  const [folderName, setFolderName] = createSignal("")
+  const [parentDir, setParentDir] = createSignal(home())
+  const [error, setError] = createSignal("")
+  const [creating, setCreating] = createSignal(false)
+
+  async function handleCreate() {
+    const name = folderName().trim()
+    if (!name) {
+      setError(language.t("dialog.createFolder.error.empty"))
+      return
+    }
+    if (INVALID_CHARS.test(name)) {
+      setError(language.t("dialog.createFolder.error.invalid"))
+      return
+    }
+
+    const parent = parentDir().trim() || home()
+    const fullPath = joinPath(parent, name)
+
+    setError("")
+    setCreating(true)
+    try {
+      // Pass the parent as `directory` so InstanceMiddleware resolves an
+      // instance context (the same way DialogSelectDirectory uses file.list).
+      const res = await sdk.client.file.mkdir({ directory: parent, path: fullPath })
+      const created = res.data?.path
+      if (!created) {
+        setError(language.t("dialog.createFolder.error.failed"))
+        return
+      }
+      props.onCreated(created)
+      dialog.close()
+    } catch (err: any) {
+      setError(err?.message ?? language.t("dialog.createFolder.error.failed"))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <Dialog title={language.t("dialog.createFolder.title")}>
+      <div class="flex flex-col gap-4 p-4">
+        {/* Parent directory */}
+        <div class="flex flex-col gap-1">
+          <label class="text-12-regular text-text-weak">{language.t("dialog.createFolder.parentLabel")}</label>
+          <input
+            type="text"
+            class="w-full rounded-md border border-border-base-base bg-bg-base-base px-3 py-2 text-14-regular text-text-strong placeholder:text-text-weak focus:outline-none focus:ring-1 focus:ring-border-focus-base"
+            value={parentDir()}
+            onInput={(e) => setParentDir(e.currentTarget.value)}
+          />
+        </div>
+
+        {/* Folder name */}
+        <div class="flex flex-col gap-1">
+          <label class="text-12-regular text-text-weak">{language.t("dialog.createFolder.label")}</label>
+          <input
+            type="text"
+            class="w-full rounded-md border border-border-base-base bg-bg-base-base px-3 py-2 text-14-regular text-text-strong placeholder:text-text-weak focus:outline-none focus:ring-1 focus:ring-border-focus-base"
+            placeholder={language.t("dialog.createFolder.placeholder")}
+            value={folderName()}
+            onInput={(e) => {
+              setFolderName(e.currentTarget.value)
+              setError("")
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleCreate()
+            }}
+            autofocus
+          />
+        </div>
+
+        {/* Inline error */}
+        <Show when={error()}>
+          <p class="text-12-regular text-text-critical">{error()}</p>
+        </Show>
+
+        {/* Submit */}
+        <Button class="w-full justify-center" onClick={() => void handleCreate()} disabled={creating()}>
+          {creating() ? language.t("common.loading") : language.t("dialog.createFolder.create")}
+        </Button>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -23,6 +23,7 @@ export const dict = {
 
   "command.sidebar.toggle": "Toggle sidebar",
   "command.project.open": "Open project",
+  "command.project.create": "New folder",
   "command.project.previous": "Previous project",
   "command.project.next": "Next project",
   "command.provider.connect": "Connect provider",
@@ -522,6 +523,15 @@ export const dict = {
   "home.recentProjects": "Recent projects",
   "home.empty.title": "No recent projects",
   "home.empty.description": "Get started by opening a local project",
+
+  "dialog.createFolder.title": "New folder",
+  "dialog.createFolder.label": "Folder name",
+  "dialog.createFolder.placeholder": "my-project",
+  "dialog.createFolder.parentLabel": "Parent directory",
+  "dialog.createFolder.create": "Create folder",
+  "dialog.createFolder.error.empty": "Folder name is required",
+  "dialog.createFolder.error.failed": "Failed to create folder",
+  "dialog.createFolder.error.invalid": "Folder name contains invalid characters",
 
   "session.tab.session": "Session",
   "session.tab.review": "Review",

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -9,6 +9,7 @@ import { usePlatform } from "@/context/platform"
 import { DateTime } from "luxon"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { DialogSelectDirectory } from "@/components/dialog-select-directory"
+import { DialogCreateFolder } from "@/components/dialog-create-folder"
 import { DialogSelectServer } from "@/components/dialog-select-server"
 import { useServer } from "@/context/server"
 import { useGlobalSync } from "@/context/global-sync"
@@ -68,6 +69,16 @@ export default function Home() {
     }
   }
 
+  function createFolder() {
+    dialog.show(() => (
+      <DialogCreateFolder
+        onCreated={(path) => {
+          openProject(path)
+        }}
+      />
+    ))
+  }
+
   return (
     <div class="mx-auto mt-55 w-full md:w-auto px-4">
       <Logo class="md:w-xl opacity-12" />
@@ -90,9 +101,14 @@ export default function Home() {
           <div class="mt-20 w-full flex flex-col gap-4">
             <div class="flex gap-2 items-center justify-between pl-3">
               <div class="text-14-medium text-text-strong">{language.t("home.recentProjects")}</div>
-              <Button icon="folder-add-left" size="normal" class="pl-2 pr-3" onClick={chooseProject}>
-                {language.t("command.project.open")}
-              </Button>
+              <div class="flex gap-2">
+                <Button icon="folder-add-left" size="normal" class="pl-2 pr-3" onClick={createFolder}>
+                  {language.t("command.project.create")}
+                </Button>
+                <Button icon="folder-add-left" size="normal" class="pl-2 pr-3" onClick={chooseProject}>
+                  {language.t("command.project.open")}
+                </Button>
+              </div>
             </div>
             <ul class="flex flex-col gap-2">
               <For each={recent()}>
@@ -116,9 +132,14 @@ export default function Home() {
         <Match when={!sync.ready}>
           <div class="mt-30 mx-auto flex flex-col items-center gap-3">
             <div class="text-12-regular text-text-weak">{language.t("common.loading")}</div>
-            <Button class="px-3" onClick={chooseProject}>
-              {language.t("command.project.open")}
-            </Button>
+            <div class="flex gap-2">
+              <Button class="px-3" onClick={createFolder}>
+                {language.t("command.project.create")}
+              </Button>
+              <Button class="px-3" onClick={chooseProject}>
+                {language.t("command.project.open")}
+              </Button>
+            </div>
           </div>
         </Match>
         <Match when={true}>
@@ -128,9 +149,14 @@ export default function Home() {
               <div class="text-14-medium text-text-strong">{language.t("home.empty.title")}</div>
               <div class="text-12-regular text-text-weak">{language.t("home.empty.description")}</div>
             </div>
-            <Button class="px-3 mt-1" onClick={chooseProject}>
-              {language.t("command.project.open")}
-            </Button>
+            <div class="flex gap-2 mt-1">
+              <Button class="px-3" onClick={createFolder}>
+                {language.t("command.project.create")}
+              </Button>
+              <Button class="px-3" onClick={chooseProject}>
+                {language.t("command.project.open")}
+              </Button>
+            </div>
           </div>
         </Match>
       </Switch>

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1020,6 +1020,13 @@ export default function Layout(props: ParentProps) {
         onSelect: () => layout.sidebar.toggle(),
       },
       {
+        id: "project.create",
+        title: language.t("command.project.create"),
+        category: language.t("command.category.project"),
+        keybind: "mod+shift+n",
+        onSelect: () => createProject(),
+      },
+      {
         id: "project.open",
         title: language.t("command.project.open"),
         category: language.t("command.category.project"),
@@ -1475,6 +1482,20 @@ export default function Layout(props: ParentProps) {
         )
       })
     }
+  }
+
+  function createProject() {
+    const run = ++dialogRun
+    void import("@/components/dialog-create-folder").then((x) => {
+      if (dialogDead || dialogRun !== run) return
+      dialog.show(() => (
+        <x.DialogCreateFolder
+          onCreated={(path) => {
+            void openProject(path)
+          }}
+        />
+      ))
+    })
   }
 
   const deleteWorkspace = async (root: string, directory: string, leaveDeletedWorkspace = false) => {

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -9,6 +9,7 @@ import { formatPatch, structuredPatch } from "diff"
 import fuzzysort from "fuzzysort"
 import ignore from "ignore"
 import path from "path"
+import { mkdir as fsMkdir } from "fs/promises"
 import { Global } from "@opencode-ai/core/global"
 import { containsPath } from "../project/instance-context"
 import * as Log from "@opencode-ai/core/util/log"
@@ -323,6 +324,7 @@ export interface Interface {
   readonly status: () => Effect.Effect<Info[]>
   readonly read: (file: string) => Effect.Effect<Content>
   readonly list: (dir?: string) => Effect.Effect<Node[]>
+  readonly mkdir: (absolutePath: string) => Effect.Effect<string>
   readonly search: (input: {
     query: string
     limit?: number
@@ -644,8 +646,17 @@ export const layer = Layer.effect(
       return output
     })
 
+    const mkdir = Effect.fn("File.mkdir")(function* (absolutePath: string) {
+      const resolved = path.resolve(absolutePath)
+      yield* Effect.tryPromise({
+        try: () => fsMkdir(resolved, { recursive: true }),
+        catch: (err) => new Error(err instanceof Error ? err.message : "Failed to create directory"),
+      })
+      return resolved
+    })
+
     log.info("init")
-    return Service.of({ init, status, read, list, search })
+    return Service.of({ init, status, read, list, mkdir, search })
   }),
 )
 

--- a/packages/opencode/src/server/routes/instance/file.ts
+++ b/packages/opencode/src/server/routes/instance/file.ts
@@ -7,6 +7,7 @@ import { LSP } from "@/lsp/lsp"
 import { Instance } from "@/project/instance"
 import { lazy } from "@/util/lazy"
 import { jsonRequest } from "./trace"
+import { errors } from "../../error"
 
 export const FileRoutes = lazy(() =>
   new Hono()
@@ -162,6 +163,37 @@ export const FileRoutes = lazy(() =>
         jsonRequest("FileRoutes.read", c, function* () {
           const svc = yield* File.Service
           return yield* svc.read(c.req.valid("query").path)
+        }),
+    )
+    .post(
+      "/file/mkdir",
+      describeRoute({
+        summary: "Create directory",
+        description: "Create a new directory at the given absolute path. Parent directories are created as needed.",
+        operationId: "file.mkdir",
+        responses: {
+          200: {
+            description: "Absolute path of the created directory",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ path: z.string() })),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          path: z.string().min(1),
+        }),
+      ),
+      async (c) =>
+        jsonRequest("FileRoutes.mkdir", c, function* () {
+          const svc = yield* File.Service
+          const resolved = yield* svc.mkdir(c.req.valid("json").path)
+          return { path: resolved }
         }),
     )
     .get(

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
@@ -36,6 +36,7 @@ export const FilePaths = {
   list: "/file",
   content: "/file/content",
   status: "/file/status",
+  mkdir: "/file/mkdir",
 } as const
 
 export const FileApi = HttpApi.make("file")

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -83,6 +83,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, opts?: CorsOptions): H
     app.get(FilePaths.list, (c) => handler(c.req.raw, context))
     app.get(FilePaths.content, (c) => handler(c.req.raw, context))
     app.get(FilePaths.status, (c) => handler(c.req.raw, context))
+    app.post(FilePaths.mkdir, (c) => handler(c.req.raw, context))
     app.get(InstancePaths.path, (c) => handler(c.req.raw, context))
     app.post(InstancePaths.dispose, (c) => handler(c.req.raw, context))
     app.get(InstancePaths.vcs, (c) => handler(c.req.raw, context))

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -39,6 +39,7 @@ import type {
   ExperimentalWorkspaceSessionRestoreResponses,
   ExperimentalWorkspaceStatusResponses,
   FileListResponses,
+  FileMkdirResponses,
   FilePartInput,
   FilePartSource,
   FileReadResponses,
@@ -1454,6 +1455,44 @@ export class File extends HeyApiClient {
       url: "/file/content",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Create directory
+   *
+   * Create a new directory at the given absolute path. Parent directories are created as needed.
+   */
+  public mkdir<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      path: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const { directory, workspace, path, ...rest } = parameters
+    const params = buildClientParams(
+      [{ directory, workspace }],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<FileMkdirResponses, unknown, ThrowOnError>({
+      url: "/file/mkdir",
+      ...options,
+      ...params,
+      body: { path },
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3985,6 +3985,29 @@ export type FileStatusResponses = {
 
 export type FileStatusResponse = FileStatusResponses[keyof FileStatusResponses]
 
+export type FileMkdirInput = {
+  path: string
+}
+
+export type FileMkdirData = {
+  body: FileMkdirInput
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/file/mkdir"
+}
+
+export type FileMkdirResponses = {
+  /**
+   * Absolute path of the created directory
+   */
+  200: { path: string }
+}
+
+export type FileMkdirResponse = FileMkdirResponses[keyof FileMkdirResponses]
+
 export type InstanceDisposeData = {
   body?: never
   path?: never


### PR DESCRIPTION
### Issue for this PR

Closes #21255

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Users who access OpenCode through the web UI have no way to create a new project directory from the browser — they must SSH into the server and run `mkdir` manually before they can open a folder as a project. This adds a **New Folder** button to the homepage that lets them create a directory without leaving the browser.

**Backend** (`packages/opencode/src/file/`):
- Added `mkdir(absolutePath)` to the `File` service interface and its Effect implementation. It calls `fs.mkdir` with `{ recursive: true }` and returns the resolved absolute path.

**Route** (`packages/opencode/src/server/routes/instance/file.ts`):
- Added `POST /file/mkdir` alongside the existing `GET /file`, `GET /file/content`, and `GET /file/status` routes. It accepts `{ path: string }` in the request body, delegates to `File.Service.mkdir`, and returns `{ path: string }`. Uses the same `InstanceMiddleware` directory-param routing as every other file route, so the frontend can pass a `directory` query param to resolve instance context for any parent directory — including the home directory used by `DialogSelectDirectory`.

**SDK** (`packages/sdk/js/src/v2/gen/`):
- Added `FileMkdirInput`, `FileMkdirData`, `FileMkdirResponses`, and `FileMkdirResponse` types to `types.gen.ts`.
- Added `File.mkdir()` method to `sdk.gen.ts` following the same `buildClientParams` pattern as `File.list()` and `File.read()`.

**Frontend** (`packages/app/src/`):
- `components/dialog-create-folder.tsx` — new dialog with a parent-directory input (pre-filled with `$HOME`) and a folder-name input. Validates that the name is non-empty and free of platform-invalid characters, then calls `sdk.client.file.mkdir({ directory: parent, path: fullPath })`. On success it calls `onCreated(path)` to open the new folder as a project.
- `pages/home.tsx` — "New Folder" button placed next to "Open Project" in all three homepage states (recent-projects header row, loading state, empty state).
- `pages/layout.tsx` — `project.create` command registered in the command palette under the *Project* category with a `Mod+Shift+N` keybind, using the same lazy-import pattern as `chooseProject`.
- `i18n/en.ts` — added `command.project.create` and all `dialog.createFolder.*` keys.

### How did you verify your code works?

Manually tested against a local OpenCode dev server: opened the Web UI, clicked "New Folder", entered a parent path and folder name, and confirmed the directory was created on disk and immediately opened as a project.

### Screenshots / recordings

_UI change — screenshots to be added once the build runs in the dev environment._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR