### PR TITLE
feat(tui): show subagent cost rollup in sidebar and task history

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -59,6 +59,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session_diff: {
         [sessionID: string]: Snapshot.FileDiff[]
       }
+      session_cost: {
+        [sessionID: string]: { self: number; subagents: number; subagent_count: number }
+      }
       todo: {
         [sessionID: string]: Todo[]
       }
@@ -96,6 +99,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session: [],
       session_status: {},
       session_diff: {},
+      session_cost: {},
       todo: {},
       message: {},
       part: {},
@@ -112,7 +116,21 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const kv = useKV()
 
     const fullSyncedSessions = new Set<string>()
+    const inflightCostRefresh = new Set<string>()
     let syncedWorkspace = project.workspace.current()
+
+    async function refreshCost(sessionID: string) {
+      if (inflightCostRefresh.has(sessionID)) return
+      inflightCostRefresh.add(sessionID)
+      try {
+        const response = await sdk.client.session.cost({ sessionID })
+        if (response.data) setStore("session_cost", sessionID, response.data)
+      } catch {
+        // Ignore transient errors; sidebar will keep last known value.
+      } finally {
+        inflightCostRefresh.delete(sessionID)
+      }
+    }
 
     function sessionListQuery(): { scope?: "project"; path?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
@@ -251,6 +269,18 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         case "message.updated": {
+          // When an assistant message completes, refresh any cached cost
+          // rollups. This catches subagent completions for ancestor sidebars
+          // without tracking parent_id chains client-side.
+          if (
+            event.properties.info.role === "assistant" &&
+            event.properties.info.time?.completed &&
+            (event.properties.info.cost ?? 0) > 0
+          ) {
+            for (const id of Object.keys(store.session_cost)) {
+              void refreshCost(id)
+            }
+          }
           const messages = store.message[event.properties.info.sessionID]
           if (!messages) {
             setStore("message", event.properties.info.sessionID, [event.properties.info])
@@ -512,13 +542,22 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (last.role === "user") return "working"
           return last.time.completed ? "idle" : "working"
         },
+        cost(sessionID: string) {
+          // Returns the last fetched value (or undefined). The caller is
+          // expected to have triggered `syncCost` for this session.
+          return store.session_cost[sessionID]
+        },
+        syncCost(sessionID: string) {
+          return refreshCost(sessionID)
+        },
         async sync(sessionID: string) {
           if (fullSyncedSessions.has(sessionID)) return
-          const [session, messages, todo, diff] = await Promise.all([
+          const [session, messages, todo, diff, cost] = await Promise.all([
             sdk.client.session.get({ sessionID }, { throwOnError: true }),
             sdk.client.session.messages({ sessionID, limit: 100 }),
             sdk.client.session.todo({ sessionID }),
             sdk.client.session.diff({ sessionID }),
+            sdk.client.session.cost({ sessionID }),
           ])
           setStore(
             produce((draft) => {
@@ -531,6 +570,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
                 draft.part[message.info.id] = message.parts
               }
               draft.session_diff[sessionID] = diff.data ?? []
+              if (cost.data) draft.session_cost[sessionID] = cost.data
             }),
           )
           fullSyncedSessions.add(sessionID)

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -1,6 +1,6 @@
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
-import { createMemo } from "solid-js"
+import { createEffect, createMemo } from "solid-js"
 
 const id = "internal:sidebar-context"
 
@@ -12,7 +12,24 @@ const money = new Intl.NumberFormat("en-US", {
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
-  const cost = createMemo(() => msg().reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0))
+
+  // Fetch the cost rollup whenever the session changes; the rollup is
+  // refreshed automatically when descendant sessions complete an assistant turn.
+  createEffect(() => {
+    const id = props.session_id
+    if (!id) return
+    props.api.state.session.refreshCost(id)
+  })
+
+  // Prefer the server-side rollup (which includes the parent's own cost). Fall
+  // back to summing local messages so we still render before the first fetch
+  // resolves.
+  const cost = createMemo(() => {
+    const rollup = props.api.state.session.cost(props.session_id)
+    if (rollup) return { self: rollup.self, subagents: rollup.subagents, subagent_count: rollup.subagent_count }
+    const self = msg().reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0)
+    return { self, subagents: 0, subagent_count: 0 }
+  })
 
   const state = createMemo(() => {
     const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
@@ -32,6 +49,14 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
     }
   })
 
+  const costLine = createMemo(() => {
+    const c = cost()
+    if (c.subagent_count > 0) {
+      return `${money.format(c.self)} (${money.format(c.subagents)} subagents) spent`
+    }
+    return `${money.format(c.self)} spent`
+  })
+
   return (
     <box>
       <text fg={theme().text}>
@@ -39,7 +64,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
       <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
-      <text fg={theme().textMuted}>{money.format(cost())} spent</text>
+      <text fg={theme().textMuted}>{costLine()}</text>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -167,6 +167,12 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       question(sessionID) {
         return sync.data.question[sessionID] ?? []
       },
+      cost(sessionID) {
+        return sync.data.session_cost[sessionID]
+      },
+      refreshCost(sessionID) {
+        void sync.session.syncCost(sessionID)
+      },
     },
     part(messageID) {
       return sync.data.part[messageID] ?? []

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -97,6 +97,8 @@ const GO_UPSELL_LAST_SEEN_AT = "go_upsell_last_seen_at"
 const GO_UPSELL_DONT_SHOW = "go_upsell_dont_show"
 const GO_UPSELL_WINDOW = 86_400_000 // 24 hrs
 
+const taskMoney = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" })
+
 const context = createContext<{
   width: number
   sessionID: string
@@ -1989,6 +1991,17 @@ function Task(props: ToolProps<typeof TaskTool>) {
     return assistant - first
   })
 
+  // Total cost of this subagent task (includes its own descendant subagents).
+  // Falls back to summing the locally-cached child messages until the
+  // server-side rollup arrives.
+  const totalCost = createMemo(() => {
+    const id = props.metadata.sessionId
+    if (!id) return 0
+    const rollup = sync.data.session_cost[id]
+    if (rollup) return rollup.self + rollup.subagents
+    return messages().reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0)
+  })
+
   const content = createMemo(() => {
     if (!props.input.description) return ""
     let content = [`${Locale.titlecase(props.input.subagent_type ?? "General")} Task — ${props.input.description}`]
@@ -2003,7 +2016,9 @@ function Task(props: ToolProps<typeof TaskTool>) {
     }
 
     if (props.part.state.status === "completed") {
-      content.push(`└ ${tools().length} toolcalls · ${Locale.duration(duration())}`)
+      const cost = totalCost()
+      const costSuffix = cost > 0 ? ` · ${taskMoney.format(cost)}` : ""
+      content.push(`└ ${tools().length} toolcalls · ${Locale.duration(duration())}${costSuffix}`)
     }
 
     return content.join("\n")

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -72,6 +72,7 @@ export const SessionPaths = {
   status: `${root}/status`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
+  cost: `${root}/:sessionID/cost`,
   todo: `${root}/:sessionID/todo`,
   diff: `${root}/:sessionID/diff`,
   messages: `${root}/:sessionID/message`,
@@ -140,6 +141,18 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.children",
             summary: "Get session children",
             description: "Retrieve all child sessions that were forked from the specified parent session.",
+          }),
+        ),
+        HttpApiEndpoint.get("cost", SessionPaths.cost, {
+          params: { sessionID: SessionID },
+          success: described(Session.Cost, "Cost rollup"),
+          error: [HttpApiError.BadRequest, HttpApiError.NotFound],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.cost",
+            summary: "Get session cost rollup",
+            description:
+              "Get the cumulative cost of this session plus the rolled-up cost of all descendant subagent sessions.",
           }),
         ),
         HttpApiEndpoint.get("todo", SessionPaths.todo, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -86,6 +86,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* session.children(ctx.params.sessionID)
     })
 
+    const cost = Effect.fn("SessionHttpApi.cost")(function* (ctx: { params: { sessionID: SessionID } }) {
+      return yield* session.cost(ctx.params.sessionID)
+    })
+
     const todo = Effect.fn("SessionHttpApi.todo")(function* (ctx: { params: { sessionID: SessionID } }) {
       return yield* todoSvc.get(ctx.params.sessionID)
     })
@@ -363,6 +367,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("status", status)
       .handle("get", get)
       .handle("children", children)
+      .handle("cost", cost)
       .handle("todo", todo)
       .handle("diff", diff)
       .handle("messages", messages)

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -114,6 +114,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, opts?: CorsOptions): H
     app.get(SessionPaths.status, (c) => handler(c.req.raw, context))
     app.get(SessionPaths.get, (c) => handler(c.req.raw, context))
     app.get(SessionPaths.children, (c) => handler(c.req.raw, context))
+    app.get(SessionPaths.cost, (c) => handler(c.req.raw, context))
     app.get(SessionPaths.todo, (c) => handler(c.req.raw, context))
     app.get(SessionPaths.diff, (c) => handler(c.req.raw, context))
     app.get(SessionPaths.messages, (c) => handler(c.req.raw, context))

--- a/packages/opencode/src/server/routes/instance/session.ts
+++ b/packages/opencode/src/server/routes/instance/session.ts
@@ -187,6 +187,40 @@ export const SessionRoutes = lazy(() =>
       },
     )
     .get(
+      "/:sessionID/cost",
+      describeRoute({
+        summary: "Get session cost rollup",
+        tags: ["Session"],
+        description:
+          "Get the cumulative cost of this session plus the rolled-up cost of all descendant subagent sessions.",
+        operationId: "session.cost",
+        responses: {
+          200: {
+            description: "Cost rollup",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Cost.zod),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: Session.CostInput.zod,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        return jsonRequest("SessionRoutes.cost", c, function* () {
+          const session = yield* Session.Service
+          return yield* session.cost(sessionID)
+        })
+      },
+    )
+    .get(
       "/:sessionID/todo",
       describeRoute({
         summary: "Get session todos",

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -234,6 +234,16 @@ export const ForkInput = Schema.Struct({
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
 export const GetInput = SessionID
 export const ChildrenInput = SessionID
+export const CostInput = SessionID
+export const Cost = Schema.Struct({
+  /** Cumulative cost of assistant messages on this session only. */
+  self: Schema.Finite,
+  /** Cumulative cost of assistant messages across all descendant sessions (subagents and their descendants). */
+  subagents: Schema.Finite,
+  /** Number of descendant sessions contributing to `subagents`. */
+  subagent_count: NonNegativeInt,
+}).pipe(withStatics((s) => ({ zod: zod(s) })))
+export type Cost = Schema.Schema.Type<typeof Cost>
 export const RemoveInput = SessionID
 export const SetTitleInput = Schema.Struct({ sessionID: SessionID, title: Schema.String }).pipe(
   withStatics((s) => ({ zod: zod(s) })),
@@ -448,6 +458,7 @@ export interface Interface {
   readonly diff: (sessionID: SessionID) => Effect.Effect<Snapshot.FileDiff[]>
   readonly messages: (input: { sessionID: SessionID; limit?: number }) => Effect.Effect<MessageV2.WithParts[]>
   readonly children: (parentID: SessionID) => Effect.Effect<Info[]>
+  readonly cost: (sessionID: SessionID) => Effect.Effect<Cost>
   readonly remove: (sessionID: SessionID) => Effect.Effect<void>
   readonly updateMessage: <T extends MessageV2.Info>(msg: T) => Effect.Effect<T>
   readonly removeMessage: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<MessageID>
@@ -552,6 +563,42 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
           .all(),
       )
       return rows.map(fromRow)
+    })
+
+    const sumAssistantCost = (sessionID: SessionID) => {
+      let total = 0
+      for (const message of MessageV2.stream(sessionID)) {
+        if (message.info.role === "assistant") total += message.info.cost ?? 0
+      }
+      return total
+    }
+
+    const cost: Interface["cost"] = Effect.fn("Session.cost")(function* (sessionID: SessionID) {
+      // BFS through descendants. Avoids unbounded recursion stack and lets us
+      // collect every transitively-spawned subagent session.
+      const descendants: SessionID[] = []
+      const queue: SessionID[] = [sessionID]
+      const seen = new Set<SessionID>([sessionID])
+      while (queue.length > 0) {
+        const parents = queue.splice(0, queue.length)
+        const rows = yield* db((d) =>
+          d
+            .select({ id: SessionTable.id, parent_id: SessionTable.parent_id })
+            .from(SessionTable)
+            .where(inArray(SessionTable.parent_id, parents))
+            .all(),
+        )
+        for (const row of rows) {
+          if (seen.has(row.id)) continue
+          seen.add(row.id)
+          descendants.push(row.id)
+          queue.push(row.id)
+        }
+      }
+      const self = sumAssistantCost(sessionID)
+      let subagents = 0
+      for (const id of descendants) subagents += sumAssistantCost(id)
+      return { self, subagents, subagent_count: descendants.length }
     })
 
     const remove: Interface["remove"] = Effect.fnUntraced(function* (sessionID: SessionID) {
@@ -794,6 +841,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
       diff,
       messages,
       children,
+      cost,
       remove,
       updateMessage,
       removeMessage,

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -289,6 +289,8 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
         status: opts.state?.session?.status ?? (() => undefined),
         permission: opts.state?.session?.permission ?? (() => []),
         question: opts.state?.session?.question ?? (() => []),
+        cost: opts.state?.session?.cost ?? (() => undefined),
+        refreshCost: opts.state?.session?.refreshCost ?? (() => {}),
       },
       part: opts.state?.part ?? (() => []),
       lsp: opts.state?.lsp ?? (() => []),

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -279,6 +279,10 @@ export type TuiState = {
     status: (sessionID: string) => SessionStatus | undefined
     permission: (sessionID: string) => ReadonlyArray<PermissionRequest>
     question: (sessionID: string) => ReadonlyArray<QuestionRequest>
+    /** Returns the cached cost rollup for `sessionID`, or `undefined` if none has been fetched yet. */
+    cost: (sessionID: string) => TuiSessionCost | undefined
+    /** Triggers an asynchronous refresh of the cost rollup for `sessionID`. */
+    refreshCost: (sessionID: string) => void
   }
   part: (messageID: string) => ReadonlyArray<Part>
   lsp: () => ReadonlyArray<TuiSidebarLspItem>
@@ -306,6 +310,15 @@ export type TuiSidebarMcpItem = {
   name: string
   status: McpStatus["status"]
   error?: string
+}
+
+export type TuiSessionCost = {
+  /** Cumulative cost of assistant messages on this session only. */
+  readonly self: number
+  /** Cumulative cost of assistant messages across all descendant sessions. */
+  readonly subagents: number
+  /** Number of descendant sessions contributing to `subagents`. */
+  readonly subagent_count: number
 }
 
 export type TuiSidebarLspItem = Pick<LspStatus, "id" | "root" | "status">

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -123,6 +123,8 @@ import type {
   SessionChildrenResponses,
   SessionCommandErrors,
   SessionCommandResponses,
+  SessionCostErrors,
+  SessionCostResponses,
   SessionCreateErrors,
   SessionCreateResponses,
   SessionDeleteErrors,
@@ -3052,6 +3054,38 @@ export class Session2 extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<SessionChildrenResponses, SessionChildrenErrors, ThrowOnError>({
       url: "/session/{sessionID}/children",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get session cost rollup
+   *
+   * Get the cumulative cost of this session plus the rolled-up cost of all descendant subagent sessions.
+   */
+  public cost<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionCostResponses, SessionCostErrors, ThrowOnError>({
+      url: "/session/{sessionID}/cost",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5216,6 +5216,44 @@ export type SessionChildrenResponses = {
 
 export type SessionChildrenResponse = SessionChildrenResponses[keyof SessionChildrenResponses]
 
+export type SessionCostData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/cost"
+}
+
+export type SessionCostErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionCostError = SessionCostErrors[keyof SessionCostErrors]
+
+export type SessionCostResponses = {
+  /**
+   * Cost rollup
+   */
+  200: {
+    self: number
+    subagents: number
+    subagent_count: number
+  }
+}
+
+export type SessionCostResponse = SessionCostResponses[keyof SessionCostResponses]
+
 export type SessionTodoData = {
   body?: never
   path: {


### PR DESCRIPTION
Subagent (Task tool) calls run in separate child sessions, so their LLM spend was previously invisible from the parent. The sidebar showed only the parent session's own cost, and the history task block had no cost line at all.

Add `Session.cost(sessionID)` that BFS-walks descendants and sums assistant message cost across the subtree, exposed via a new `GET /session/:id/cost` route (Hono + HttpApi parity). The TUI sync caches the rollup and invalidates it on `message.updated` for any completed assistant message, so subagent completions propagate to ancestor sidebars without tracking parent_id chains client-side.

Sidebar now renders `$X.XX ($Y.YY subagents) spent` when subagents exist, and the completed Task tool footer in the message stream gains a `· $X.XX` suffix showing that subagent task's total spend (its own plus its own descendants).

### Issue for this PR

- https://github.com/anomalyco/opencode/issues/22103

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I ran the prompt "I want to test subagent cost feature. use @explore to in parallel for @src/ and @specs/  and explain their contents to me"

### Screenshots / recordings


<img width="1655" height="311" alt="Screenshot 2026-05-04 at 15 24 59" src="https://github.com/user-attachments/assets/c3e41e27-31a9-4f91-a8b4-fae7ffb498e9" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
