### PR TITLE
test(server): regression reproducers for #25698

### DIFF
--- a/packages/opencode/test/server/httpapi-listen.test.ts
+++ b/packages/opencode/test/server/httpapi-listen.test.ts
@@ -257,6 +257,46 @@ describe("HttpApi Server.listen", () => {
     }
   })
 
+  // Regression for #25698 (Ope): the app's SDK call to
+  // `client.pty.connectToken({ ptyID })` originally omitted `directory`, so
+  // the server resolved the PTY in its own cwd context — where the project
+  // PTY isn't registered — and returned 404. The fix is to always pass
+  // `directory` from the app side; this test locks in two contracts:
+  //   1. Mint without directory cannot find a PTY registered in another dir.
+  //   2. Mint with the project directory succeeds; the resulting ticket
+  //      consumes cleanly when the WS upgrade carries the same directory.
+  testPty("PTY connect token requires matching directory across mint and connect", async () => {
+    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+    const listener = await startListener()
+    try {
+      const info = await createCat(listener, tmp.path)
+
+      // Mint without directory — server uses its own cwd, can't find the PTY.
+      const ambiguous = await fetch(new URL(PtyPaths.connectToken.replace(":ptyID", info.id), listener.url), {
+        method: "POST",
+        headers: { authorization: authorization(), "x-opencode-ticket": "1" },
+      })
+      expect(ambiguous.status).toBe(404)
+
+      // Mint with the project directory — succeeds, ticket binds to that scope.
+      const scoped = await fetch(
+        new URL(`${PtyPaths.connectToken.replace(":ptyID", info.id)}?directory=${encodeURIComponent(tmp.path)}`, listener.url),
+        {
+          method: "POST",
+          headers: { authorization: authorization(), "x-opencode-ticket": "1" },
+        },
+      )
+      expect(scoped.status).toBe(200)
+      const mint = (await scoped.json()) as { ticket: string }
+
+      // Same directory on the WS upgrade → consume succeeds.
+      const ws = await openSocket(socketURL(listener, info.id, tmp.path, mint.ticket))
+      ws.close(1000)
+    } finally {
+      await stop(listener, "timed out cleaning up directory-scope listener").catch(() => undefined)
+    }
+  })
+
   testPty("keeps PTY websocket tickets optional when server auth is disabled", async () => {
     await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
     const listener = await startNoAuthListener()

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -184,6 +184,52 @@ describe("HttpApi UI fallback", () => {
     expect(await response.text()).toBe("console.log('ok')")
   })
 
+  // Regression for #25698 (Ope): upstream `transfer-encoding: chunked` was
+  // forwarded through the proxy while the proxy itself re-frames the body,
+  // causing browsers to fail with `ERR_INVALID_CHUNKED_ENCODING`.
+  test("strips upstream transfer-encoding header from proxied assets", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
+
+    const response = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        const client = yield* HttpClient.HttpClient
+        return yield* serveUIEffect(HttpServerRequest.fromWeb(new Request("http://localhost/")), {
+          fs,
+          client,
+        })
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            AppFileSystem.defaultLayer,
+            Layer.succeed(
+              HttpClient.HttpClient,
+              HttpClient.make((request) =>
+                Effect.succeed(
+                  HttpClientResponse.fromWeb(
+                    request,
+                    new Response("<html>opencode</html>", {
+                      headers: {
+                        "transfer-encoding": "chunked",
+                        "content-type": "text/html",
+                      },
+                    }),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Effect.map(HttpServerResponse.toWeb),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("transfer-encoding")).toBeNull()
+    expect(await response.text()).toBe("<html>opencode</html>")
+  })
+
   test("serves embedded UI assets when Bun can read them but access reports missing", async () => {
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
     let readPath: string | undefined
@@ -255,6 +301,25 @@ describe("HttpApi UI fallback", () => {
     })
 
     expect(response.status).toBe(200)
+  })
+
+  // Regression for #25698 (Ope): the browser fetches the PWA manifest and
+  // its icons via flows that don't carry app-managed credentials (the
+  // `<link rel="manifest">` request is not under page-auth control), so the
+  // server returning 401 breaks PWA install. These specific public assets
+  // should bypass auth.
+  test("serves the PWA manifest without auth even when a server password is set", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
+
+    for (const path of ["/site.webmanifest", "/web-app-manifest-192x192.png", "/web-app-manifest-512x512.png"]) {
+      const response = await uiApp({
+        password: "secret",
+        username: "opencode",
+        client: httpClient(new Response("ok")),
+      }).request(path)
+      expect(response.status).not.toBe(401)
+    }
   })
 
   test("allows web UI preflight without auth", async () => {


### PR DESCRIPTION
## What this is

Three regression tests that fail on \`dev\` today and lock in the contracts behind @OpeOginni's cleanup PR #25698. **CI will be red** until #25698 lands; this PR is meant to either be:

- Rebased onto #25698 once it merges (CI goes green), or
- Folded into #25698 as part of its own commit (preferred — keeps fix and regression test in one place per the repo's parity guidance).

## State on dev today

| Test | File | Status on dev | Status with #25698 |
|---|---|---|---|
| strips upstream transfer-encoding header from proxied assets | \`httpapi-ui.test.ts\` | ❌ FAIL | ✅ PASS |
| serves the PWA manifest without auth even when a server password is set | \`httpapi-ui.test.ts\` | ❌ FAIL | ✅ PASS |
| PTY connect token requires matching directory across mint and connect | \`httpapi-listen.test.ts\` | ✅ PASS (contract-only) | ✅ PASS |

The third test passes on dev because the **server contract** is correct — strict directory scope match between mint and consume. It documents that contract so future regressions on either side (server loosening match or app stopping to send directory) get caught. It's also the smallest reproducer of the symptom @OpeOginni hit: \`POST /pty/{id}/connect-token\` without \`?directory=\` returns 404 because the PTY is registered in another instance directory than the listener's cwd.

## Verification

Locally cherry-picked #25698 onto this branch and re-ran:

\`\`\`
bun run test test/server/httpapi-ui.test.ts test/server/httpapi-listen.test.ts
 15 pass
 0 fail
 53 expect() calls
\`\`\`

## Recommendation

Close this draft and have @OpeOginni cherry-pick \`fc90986ae\` into #25698. The \`routes/instance/AGENTS.md\` parity guidance asks for regression coverage to live with the fix:

> Add or update parity coverage in \`test/server/httpapi-bridge.test.ts\` or the focused HttpApi tests when behavior or schema parity could regress.

If folding in is awkward for any reason, this branch can land separately after #25698.