### PR TITLE
fix: prefill rejection on Claude Opus 4.6+ (max-steps reminder + proxy paths)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -45,6 +45,20 @@ function sdkKey(npm: string): string | undefined {
   return undefined
 }
 
+function isClaudeModel(model: Provider.Model): boolean {
+  return (
+    (model.providerID === "anthropic" ||
+      model.providerID === "google-vertex-anthropic" ||
+      model.api.id.includes("anthropic") ||
+      model.api.id.includes("claude") ||
+      model.id.includes("anthropic") ||
+      model.id.includes("claude") ||
+      model.api.npm === "@ai-sdk/anthropic" ||
+      model.api.npm === "@ai-sdk/alibaba") &&
+    model.api.npm !== "@ai-sdk/gateway"
+  )
+}
+
 function normalizeMessages(
   msgs: ModelMessage[],
   model: Provider.Model,
@@ -52,7 +66,7 @@ function normalizeMessages(
 ): ModelMessage[] {
   // Anthropic rejects messages with empty content - filter out empty string messages
   // and remove empty text/reasoning parts from array content
-  if (model.api.npm === "@ai-sdk/anthropic") {
+  if (isClaudeModel(model)) {
     msgs = msgs
       .map((msg) => {
         if (typeof msg.content === "string") {
@@ -343,17 +357,7 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
-  if (
-    (model.providerID === "anthropic" ||
-      model.providerID === "google-vertex-anthropic" ||
-      model.api.id.includes("anthropic") ||
-      model.api.id.includes("claude") ||
-      model.id.includes("anthropic") ||
-      model.id.includes("claude") ||
-      model.api.npm === "@ai-sdk/anthropic" ||
-      model.api.npm === "@ai-sdk/alibaba") &&
-    model.api.npm !== "@ai-sdk/gateway"
-  ) {
+  if (isClaudeModel(model)) {
     msgs = applyCaching(msgs, model)
   }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1580,7 +1580,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               sessionID,
               parentSessionID: session.parentID,
               system,
-              messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+              messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
               tools,
               model,
               toolChoice: format.type === "json_schema" ? "required" : undefined,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1409,6 +1409,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
   test("does not filter for non-anthropic providers", () => {
     const openaiModel = {
       ...anthropicModel,
+      id: "openai/gpt-4",
       providerID: "openai",
       api: {
         id: "gpt-4",


### PR DESCRIPTION
## Problem

Claude Opus 4.6+ (and future models that drop assistant prefill support) returns HTTP 400 when the `messages` array sent to the API ends with an `assistant`-role message:

> This model does not support assistant message prefill. The conversation must end with a user message.

Anthropic removed assistant prefill support in the [Feb 5 2026 release](https://www.anthropic.com/news/claude-4) for Opus 4.6+. Two distinct paths in opencode trigger this error for users of those models.

Related community reports: [anomalyco/opencode #17982](https://github.com/anomalyco/opencode/issues/17982), [anomalyco/opencode #20415](https://github.com/anomalyco/opencode/issues/20415), [anomalyco/opencode #13768](https://github.com/anomalyco/opencode/issues/13768), [anthropics/claude-code #52433](https://github.com/anthropics/claude-code/issues/52433), [langchain-ai/langchain #36597](https://github.com/langchain-ai/langchain/issues/36597).

Related (complementary, distinct code path): [#22404](https://github.com/anomalyco/opencode/pull/22404) addresses a third trigger — trailing text-only assistant after a tool-call step in `toModelMessages`, gated on `options.thinking`. This PR does not touch that path; both fixes can land independently.

---

## Fix 1 — `packages/opencode/src/session/prompt.ts`

When `isLastStep` is true (the agent has hit its step budget), a literal assistant-role prefill carrying the `MAX_STEPS` reminder is appended to the messages array:

```diff
-messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+messages: [...modelMsgs, ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS }] : [])],
```

The semantic intent — telling the model it is running out of step budget — is fully preserved. The role change from `"assistant"` to `"user"` is the only change needed.

---

## Fix 2 — `packages/opencode/src/provider/transform.ts`

`normalizeMessages` strips empty assistant content before sending to Anthropic-compatible endpoints, but only when `model.api.npm === "@ai-sdk/anthropic"` (strict equality). Models accessed through OpenAI-compatible proxies (e.g. `@openrouter/ai-sdk-provider`, `@bizrouter/ai-sdk-provider`, GitHub Copilot gateway) don't match this check, so empty trailing assistant messages slip through — and also trigger the prefill rejection on Opus 4.6+.

The `message()` function already uses a comprehensive Claude-detection condition (lines 346–356 before this PR). This PR extracts that condition into a module-level `isClaudeModel()` helper and uses it in both `normalizeMessages` and `message()`:

```diff
+function isClaudeModel(model: Provider.Model): boolean {
+  return (
+    (model.providerID === "anthropic" ||
+      model.providerID === "google-vertex-anthropic" ||
+      model.api.id.includes("anthropic") ||
+      model.api.id.includes("claude") ||
+      model.id.includes("anthropic") ||
+      model.id.includes("claude") ||
+      model.api.npm === "@ai-sdk/anthropic" ||
+      model.api.npm === "@ai-sdk/alibaba") &&
+    model.api.npm !== "@ai-sdk/gateway"
+  )
+}
+
 function normalizeMessages(...) {
   // Anthropic rejects messages with empty content
-  if (model.api.npm === "@ai-sdk/anthropic") {
+  if (isClaudeModel(model)) {
     ...
   }
 }

 export function message(...) {
   ...
-  if (
-    (model.providerID === "anthropic" || ... || model.api.npm === "@ai-sdk/alibaba") &&
-    model.api.npm !== "@ai-sdk/gateway"
-  ) {
+  if (isClaudeModel(model)) {
     msgs = applyCaching(msgs, model)
   }
 }
```

The bedrock-specific block (`@ai-sdk/amazon-bedrock`) is unchanged — it is intentionally separate.

---

## Testing

```
bun --cwd packages/opencode test test/provider/transform.test.ts test/session/prompt.test.ts
 188 pass
 0 fail
 433 expect() calls
```

Pre-push typecheck across all 13 workspace packages: green.

One existing test (`does not filter for non-anthropic providers`) had its `openaiModel` fixture inheriting `id: "anthropic/claude-3-5-sonnet"` from the `anthropicModel` spread — unrealistic for an OpenAI model, and would now (correctly) match the unified `isClaudeModel`. Fixture updated to override the `id` to `"openai/gpt-4"` so the test still asserts what it says.

