### PR TITLE
fix: retry overloaded OpenAI stream errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -123,7 +123,10 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   const responseBody = JSON.stringify(body)
   if (body.type !== "error") return
 
-  switch (body?.error?.code) {
+  const errorCode = typeof body?.error?.code === "string" ? body.error.code : ""
+  const errorType = typeof body?.error?.type === "string" ? body.error.type : ""
+
+  switch (errorCode) {
     case "context_length_exceeded":
       return {
         type: "context_overflow",
@@ -158,6 +161,20 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
         isRetryable: true,
         responseBody,
       }
+  }
+
+  if (
+    errorType === "service_unavailable_error" ||
+    errorCode === "server_is_overloaded" ||
+    errorCode.includes("unavailable") ||
+    errorCode.includes("exhausted")
+  ) {
+    return {
+      type: "api_error",
+      message: typeof body?.error?.message === "string" ? body.error.message : "Provider is overloaded",
+      isRetryable: true,
+      responseBody,
+    }
   }
 }
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -323,4 +323,27 @@ describe("session.message-v2.fromError", () => {
     expect(result.data.isRetryable).toBe(true)
     expect(SessionRetry.retryable(result)).toBe("An error occurred while processing your request.")
   })
+
+  test("converts OpenAI overloaded stream chunks to retryable APIError", () => {
+    const result = MessageV2.fromError(
+      {
+        message: JSON.stringify({
+          type: "error",
+          sequence_number: 2,
+          error: {
+            type: "service_unavailable_error",
+            code: "server_is_overloaded",
+            message: "Our servers are currently overloaded. Please try again later.",
+            param: null,
+          },
+        }),
+      },
+      { providerID: ProviderID.make("openai") },
+    )
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    if (!MessageV2.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.isRetryable).toBe(true)
+    expect(SessionRetry.retryable(result)).toBe("Our servers are currently overloaded. Please try again later.")
+  })
 })


### PR DESCRIPTION
## Summary
- Classify OpenAI `service_unavailable_error` / `server_is_overloaded` stream chunks as retryable API errors.
- Add regression coverage for the overloaded Responses SSE error shape so sessions use the existing retry path instead of surfacing a terminal error.

Fixes #25731

## Verification
- `git diff --check -- packages/opencode/src/provider/error.ts packages/opencode/test/session/retry.test.ts`
- `bun test test/session/retry.test.ts` from `packages/opencode` was attempted but blocked in this worktree by missing preload dependency: `@opentui/solid/preload`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.42 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1h 2m and 681,876 tokens on this with the user in an interactive session.
