### PR TITLE
fix(opencode): add max_retries config to cap session retry attempts

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -260,6 +260,9 @@ export const Info = Schema.Struct({
       mcp_timeout: Schema.optional(PositiveInt).annotate({
         description: "Timeout in milliseconds for model context protocol (MCP) requests",
       }),
+      max_retries: Schema.optional(PositiveInt).annotate({
+        description: "Maximum retry attempts for transient provider errors before stopping the session. When not set, retries are unbounded.",
+      }),
     }),
   ),
 })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -675,6 +675,7 @@ export const layer: Layer.Layer<
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
 
         return yield* Effect.gen(function* () {
+          const maxRetries = (yield* config.get()).experimental?.max_retries
           yield* Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.reasoningMap = {}
@@ -701,6 +702,7 @@ export const layer: Layer.Layer<
             Effect.retry(
               SessionRetry.policy({
                 parse,
+                maxRetries,
                 set: (info) => {
                   // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
                   EventV2.run(SessionEvent.Retried.Sync, {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -106,12 +106,14 @@ export function retryable(error: Err) {
 export function policy(opts: {
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; next: number }) => Effect.Effect<void>
+  maxRetries?: number
 }) {
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
       const message = retryable(error)
       if (!message) return Cause.done(meta.attempt)
+      if (opts.maxRetries !== undefined && meta.attempt >= opts.maxRetries) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, MessageV2.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis


### PR DESCRIPTION
Closes #25733

SessionRetry.policy() retries retryable errors indefinitely with no maximum
attempt count. This adds experimental.max_retries to let users cap retry
attempts.

- config.ts: add max_retries (PositiveInt, optional) to experimental block
- retry.ts: add maxRetries param to policy(), stop when meta.attempt reaches limit
- processor.ts: read config and pass to policy()

Backward compatible: when max_retries is unset, behavior is unchanged.
When set, retries stop after N attempts and the session surfaces the error.