### PR TITLE
test(agent): skip InstanceBootstrap in plugin-agent regression test

### DIFF
--- a/packages/opencode/test/agent/plugin-agent-regression.test.ts
+++ b/packages/opencode/test/agent/plugin-agent-regression.test.ts
@@ -1,65 +1,31 @@
 import { expect } from "bun:test"
-import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Effect, Layer } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
 import { Agent } from "../../src/agent/agent"
-import { InstanceRef } from "../../src/effect/instance-ref"
-import { InstanceLayer } from "../../src/project/instance-layer"
-import { InstanceStore } from "../../src/project/instance-store"
-import { tmpdirScoped } from "../fixture/fixture"
+import { Plugin } from "../../src/plugin"
 import { testEffect } from "../lib/effect"
+import { PLUGIN_AGENT } from "../fixture/agent-plugin.constants"
 
-const pluginAgent = {
-  name: "plugin_added",
-  description: "Added by a plugin via the config hook",
-  mode: "subagent",
-} as const
+// The plugin lives in test/fixture/ as a stable file rather than being written
+// into a per-test tmpdir. Combined with `it.instance` (which uses the noop
+// InstanceBootstrap), this skips FileWatcher / LSP / MCP / etc. — the actual
+// source of Windows teardown flakiness — while still exercising the production
+// code path that matters: plugin load → config hook → agent registration →
+// Agent.list.
+const pluginUrl = pathToFileURL(path.join(import.meta.dir, "..", "fixture", "agent-plugin.ts")).href
 
-const it = testEffect(Layer.mergeAll(Agent.defaultLayer, InstanceLayer.layer, CrossSpawnSpawner.defaultLayer))
+const it = testEffect(Layer.mergeAll(Agent.defaultLayer, Plugin.defaultLayer))
 
-it.live("plugin-registered agents appear in Agent.list", () =>
-  Effect.gen(function* () {
-    const dir = yield* tmpdirScoped()
-    const pluginFile = path.join(dir, "plugin.ts")
-
-    yield* Effect.promise(async () => {
-      await Promise.all([
-        Bun.write(
-          pluginFile,
-          [
-            "export default async () => ({",
-            "  config: async (cfg) => {",
-            "    cfg.agent = cfg.agent ?? {}",
-            `    cfg.agent[${JSON.stringify(pluginAgent.name)}] = {`,
-            `      description: ${JSON.stringify(pluginAgent.description)},`,
-            `      mode: ${JSON.stringify(pluginAgent.mode)},`,
-            "    }",
-            "  },",
-            "})",
-            "",
-          ].join("\n"),
-        ),
-        Bun.write(
-          path.join(dir, "opencode.json"),
-          JSON.stringify({
-            $schema: "https://opencode.ai/config.json",
-            plugin: [pathToFileURL(pluginFile).href],
-          }),
-        ),
-      ])
-    })
-
-    const agents = yield* InstanceStore.Service.use((store) =>
-      Effect.gen(function* () {
-        const ctx = yield* store.load({ directory: dir })
-        yield* Effect.addFinalizer(() => store.dispose(ctx).pipe(Effect.ignore))
-        return yield* Agent.Service.use((svc) => svc.list()).pipe(Effect.provideService(InstanceRef, ctx))
-      }),
-    )
-    const added = agents.find((agent) => agent.name === pluginAgent.name)
-
-    expect(added?.description).toBe(pluginAgent.description)
-    expect(added?.mode).toBe(pluginAgent.mode)
-  }),
+it.instance(
+  "plugin-registered agents appear in Agent.list",
+  () =>
+    Effect.gen(function* () {
+      yield* Plugin.Service.use((p) => p.init())
+      const agents = yield* Agent.Service.use((svc) => svc.list())
+      const added = agents.find((agent) => agent.name === PLUGIN_AGENT.name)
+      expect(added?.description).toBe(PLUGIN_AGENT.description)
+      expect(added?.mode).toBe(PLUGIN_AGENT.mode)
+    }),
+  { config: { plugin: [pluginUrl] } },
 )

--- a/packages/opencode/test/agent/plugin-agent-regression.test.ts
+++ b/packages/opencode/test/agent/plugin-agent-regression.test.ts
@@ -7,12 +7,9 @@ import { Plugin } from "../../src/plugin"
 import { testEffect } from "../lib/effect"
 import { PLUGIN_AGENT } from "../fixture/agent-plugin.constants"
 
-// The plugin lives in test/fixture/ as a stable file rather than being written
-// into a per-test tmpdir. Combined with `it.instance` (which uses the noop
-// InstanceBootstrap), this skips FileWatcher / LSP / MCP / etc. — the actual
-// source of Windows teardown flakiness — while still exercising the production
-// code path that matters: plugin load → config hook → agent registration →
-// Agent.list.
+// `it.instance` skips InstanceBootstrap so FileWatcher / LSP / MCP don't spin
+// up — those services hang during scope teardown on Windows and aren't needed
+// to verify plugin → config hook → Agent.list.
 const pluginUrl = pathToFileURL(path.join(import.meta.dir, "..", "fixture", "agent-plugin.ts")).href
 
 const it = testEffect(Layer.mergeAll(Agent.defaultLayer, Plugin.defaultLayer))

--- a/packages/opencode/test/fixture/agent-plugin.constants.ts
+++ b/packages/opencode/test/fixture/agent-plugin.constants.ts
@@ -1,0 +1,8 @@
+// Mirrors the values applied by `agent-plugin.ts` so the test can assert
+// against the same literals. Kept in a separate file because every export in
+// `agent-plugin.ts` must be a plugin function (the loader throws otherwise).
+export const PLUGIN_AGENT = {
+  name: "plugin_added",
+  description: "Added by a plugin via the config hook",
+  mode: "subagent",
+} as const

--- a/packages/opencode/test/fixture/agent-plugin.constants.ts
+++ b/packages/opencode/test/fixture/agent-plugin.constants.ts
@@ -1,6 +1,4 @@
-// Mirrors the values applied by `agent-plugin.ts` so the test can assert
-// against the same literals. Kept in a separate file because every export in
-// `agent-plugin.ts` must be a plugin function (the loader throws otherwise).
+// Separate file because every export in `agent-plugin.ts` must be a function.
 export const PLUGIN_AGENT = {
   name: "plugin_added",
   description: "Added by a plugin via the config hook",

--- a/packages/opencode/test/fixture/agent-plugin.ts
+++ b/packages/opencode/test/fixture/agent-plugin.ts
@@ -1,0 +1,17 @@
+// Stable test fixture for test/agent/plugin-agent-regression.test.ts. Lives in
+// the repo (not a tmpdir) so the test can skip the heavy InstanceBootstrap
+// chain (FileWatcher / LSP / MCP / etc.) — that's the actual source of Windows
+// teardown flakiness, not the plugin import path itself.
+//
+// Exports must all be functions; the plugin loader throws on any export that
+// isn't (`getLegacyPlugins` in src/plugin/index.ts). Constants for the test
+// live alongside this file in `agent-plugin.constants.ts`.
+export default async () => ({
+  config: async (cfg: { agent?: Record<string, unknown> }) => {
+    cfg.agent = cfg.agent ?? {}
+    cfg.agent["plugin_added"] = {
+      description: "Added by a plugin via the config hook",
+      mode: "subagent",
+    }
+  },
+})

--- a/packages/opencode/test/fixture/agent-plugin.ts
+++ b/packages/opencode/test/fixture/agent-plugin.ts
@@ -1,11 +1,6 @@
-// Stable test fixture for test/agent/plugin-agent-regression.test.ts. Lives in
-// the repo (not a tmpdir) so the test can skip the heavy InstanceBootstrap
-// chain (FileWatcher / LSP / MCP / etc.) — that's the actual source of Windows
-// teardown flakiness, not the plugin import path itself.
-//
-// Exports must all be functions; the plugin loader throws on any export that
-// isn't (`getLegacyPlugins` in src/plugin/index.ts). Constants for the test
-// live alongside this file in `agent-plugin.constants.ts`.
+// Every export in this file must be a plugin function — `getLegacyPlugins`
+// (src/plugin/index.ts) throws on anything else. Test constants live in
+// `agent-plugin.constants.ts`.
 export default async () => ({
   config: async (cfg: { agent?: Record<string, unknown> }) => {
     cfg.agent = cfg.agent ?? {}


### PR DESCRIPTION
## Problem

The plugin-agent regression test occasionally hangs for 30s on Windows CI (saw it during the CI run for #25726). It passes alone and on Linux/macOS reliably; the flake is Windows + combined-suite specific.

## Root cause

The test loads through `InstanceLayer.layer` (full `InstanceBootstrap.defaultLayer`), which fork-scopes:

- `FileWatcher` (native `@parcel/watcher`)
- `LSP` (child processes)
- `MCP` (child processes / network)
- `Snapshot`, `Vcs`, `ShareNext`, `Format`, `File`, `Project`

All of these have native handles. On Windows, several don't always release within the test scope's close window — the 30s timeout fires before teardown completes. None of them are needed to test "plugin config hook adds an agent → Agent.list reflects it."

The test itself only cares about: plugin load → config hook → agent registration → Agent.list.

## Fix

Two structural changes, no production code touched:

1. **Move the plugin to a stable repo fixture** (`test/fixture/agent-plugin.ts`) instead of writing it into a per-test tmpdir. Keeps the import path stable across runs, eliminates Windows tmpdir/file-handle interactions during teardown.
2. **Switch from `it.live` + `InstanceLayer.layer` to `it.instance`** (which uses the noop `InstanceBootstrap` like all other instance-scoped tests in this repo). Manually call `Plugin.Service.init()` in the body — the only bootstrap step the test actually depends on.

Production code path exercised is unchanged: plugin load → config hook → agent registration → Agent.list.

## Gotcha discovered

The plugin loader's `getLegacyPlugins` (`src/plugin/index.ts:80`) iterates **every** module export and throws `TypeError` on any export that isn't a function (or `{server: function}`). So the test constants that the assertion needs to compare against had to live in a sibling `agent-plugin.constants.ts`, not the plugin file itself. I added a comment in the fixture pointing this out so the next person doesn't trip on it.

## Verification

- Test passes alone (`bun run test test/agent/plugin-agent-regression.test.ts`): 1/1 ✅
- All agent tests pass (`bun run test test/agent/`): 39/39 ✅
- `bun run typecheck`: clean ✅

Should resolve the Windows-only flake observed in #25726's CI run.
