### PR TITLE
fix(npm): resolve cached package name from install dir for non-registry specs

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -112,22 +112,39 @@ export const layer = Layer.effect(
 
     const add = Effect.fn("Npm.add")(function* (pkg: string) {
       const dir = directory(pkg)
-      const name = (() => {
+      const npaName = (() => {
         try {
-          return npa(pkg).name ?? pkg
+          return npa(pkg).name ?? undefined
         } catch {
-          return pkg
+          return undefined
         }
       })()
 
-      if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
-        return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+      if (yield* afs.existsSafe(dir)) {
+        // For non-registry specs (remote tarball URLs, git+https://, github:
+        // shorthand, file: paths), npa(pkg).name returns undefined — only
+        // registry packages have inferable names from the spec alone. Read
+        // the install-root package.json (written by Arborist on the initial
+        // install) to recover the actual installed package name from its
+        // first dependency entry, matching what the fresh-install path
+        // computes from the arborist tree below.
+        const cachedPkg = yield* afs.readJson(path.join(dir, "package.json")).pipe(Effect.option)
+        if (Option.isSome(cachedPkg)) {
+          const deps = (cachedPkg.value as { dependencies?: Record<string, unknown> })?.dependencies
+          const first = deps && Object.keys(deps)[0]
+          if (first) {
+            return resolveEntryPoint(first, path.join(dir, "node_modules", first))
+          }
+        }
+        // Cache directory exists but is empty / has no installable package.json —
+        // fall through to the Arborist install path below.
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
       const first = tree.edgesOut.values().next().value?.to
       if (!first) {
-        const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        const fallbackName = npaName ?? pkg
+        const result = resolveEntryPoint(fallbackName, path.join(dir, "node_modules", fallbackName))
         if (Option.isSome(result.entrypoint)) return result
         return yield* new InstallFailedError({ add: [pkg], dir })
       }

--- a/packages/opencode/test/npm.test.ts
+++ b/packages/opencode/test/npm.test.ts
@@ -1,0 +1,201 @@
+import fs from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer, Stream } from "effect"
+import { NodeFileSystem } from "@effect/platform-node"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Global } from "@opencode-ai/core/global"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { Npm } from "@opencode-ai/core/npm"
+import { tmpdir } from "./fixture/fixture"
+import os from "os"
+
+const win = process.platform === "win32"
+const encoder = new TextEncoder()
+function mockSpawner(handler: (cmd: string, args: readonly string[]) => string = () => "") {
+  const spawner = ChildProcessSpawner.make((command) => {
+    const std = ChildProcess.isStandardCommand(command) ? command : undefined
+    const output = handler(std?.command ?? "", std?.args ?? [])
+    return Effect.succeed(
+      ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(0),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: { [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") } as any,
+        stdout: output ? Stream.make(encoder.encode(output)) : Stream.empty,
+        stderr: Stream.empty,
+        all: Stream.empty,
+        getInputFd: () => ({ [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") }) as any,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      }),
+    )
+  })
+  return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)
+}
+
+const writePackage = (dir: string, pkg: Record<string, unknown>) =>
+  Bun.write(
+    path.join(dir, "package.json"),
+    JSON.stringify({
+      version: "1.0.0",
+      ...pkg,
+    }),
+  )
+
+describe("Npm.sanitize", () => {
+  test("keeps normal scoped package specs unchanged", () => {
+    expect(Npm.sanitize("@opencode/acme")).toBe("@opencode/acme")
+    expect(Npm.sanitize("@opencode/acme@1.0.0")).toBe("@opencode/acme@1.0.0")
+    expect(Npm.sanitize("prettier")).toBe("prettier")
+  })
+
+  test("handles git https specs", () => {
+    const spec = "acme@git+https://github.com/opencode/acme.git"
+    const expected = win ? "acme@git+https_//github.com/opencode/acme.git" : spec
+    expect(Npm.sanitize(spec)).toBe(expected)
+  })
+})
+
+describe("Npm.install", () => {
+  test("respects omit from project .npmrc", async () => {
+    await using tmp = await tmpdir()
+
+    await writePackage(tmp.path, {
+      name: "fixture",
+      dependencies: {
+        "prod-pkg": "file:./prod-pkg",
+      },
+      devDependencies: {
+        "dev-pkg": "file:./dev-pkg",
+      },
+    })
+    await Bun.write(path.join(tmp.path, ".npmrc"), "omit=dev\n")
+    await fs.mkdir(path.join(tmp.path, "prod-pkg"))
+    await fs.mkdir(path.join(tmp.path, "dev-pkg"))
+    await writePackage(path.join(tmp.path, "prod-pkg"), { name: "prod-pkg" })
+    await writePackage(path.join(tmp.path, "dev-pkg"), { name: "dev-pkg" })
+
+    await Npm.install(tmp.path)
+
+    await expect(fs.stat(path.join(tmp.path, "node_modules", "prod-pkg"))).resolves.toBeDefined()
+    await expect(fs.stat(path.join(tmp.path, "node_modules", "dev-pkg"))).rejects.toThrow()
+  })
+})
+
+describe("Npm.add cache fast-path", () => {
+  // Helper: build a layer where Global.cache points at the given dir.
+  // Other Global fields aren't read by Npm.add but Service.of requires them.
+  function cacheLayer(cacheDir: string) {
+    const tmp = os.tmpdir()
+    return Npm.layer.pipe(
+      Layer.provide(mockSpawner()),
+      Layer.provide(EffectFlock.layer),
+      Layer.provide(AppFileSystem.layer),
+      Layer.provide(
+        Layer.succeed(
+          Global.Service,
+          Global.Service.of({
+            home: tmp,
+            data: tmp,
+            cache: cacheDir,
+            config: tmp,
+            state: tmp,
+            repos: tmp,
+            bin: tmp,
+            log: tmp,
+            tmp,
+          }),
+        ),
+      ),
+      Layer.provide(NodeFileSystem.layer),
+    )
+  }
+
+  // Helper: simulate a populated cache install for `pkg` whose actual
+  // installed name is `installedName`. Mirrors what Arborist produces:
+  //   <cache>/packages/<sanitize(pkg)>/package.json     (declares dep)
+  //   <cache>/packages/<sanitize(pkg)>/node_modules/<installedName>/package.json
+  async function seedCache(cacheDir: string, pkg: string, installedName: string) {
+    const installRoot = path.join(cacheDir, "packages", Npm.sanitize(pkg))
+    const pkgDir = path.join(installRoot, "node_modules", installedName)
+    await fs.mkdir(pkgDir, { recursive: true })
+    await Bun.write(
+      path.join(installRoot, "package.json"),
+      JSON.stringify({ dependencies: { [installedName]: pkg } }),
+    )
+    await Bun.write(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: installedName, version: "1.0.0", main: "index.js" }),
+    )
+    await Bun.write(path.join(pkgDir, "index.js"), "module.exports = {}")
+    return { installRoot, pkgDir }
+  }
+
+  test("resolves remote tarball URL to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const url =
+      "https://github.com/sjawhar/opencode-anthropic-auth/releases/download/v0.4.2/sjawhar-opencode-anthropic-auth-0.4.2.tgz"
+    const installed = "@sjawhar/opencode-anthropic-auth"
+    const { pkgDir } = await seedCache(tmp.path, url, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(url)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves git+https spec to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "git+https://github.com/example/some-repo.git"
+    const installed = "@example/some-repo"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves github: shorthand to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "github:example/another-repo"
+    const installed = "another-repo"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("resolves local tarball file: spec to actual installed package directory", async () => {
+    await using tmp = await tmpdir()
+    const spec = "file:/some/local/path/example-1.0.0.tgz"
+    const installed = "@example/local-pkg"
+    const { pkgDir } = await seedCache(tmp.path, spec, installed)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+
+  test("still resolves registry packages correctly", async () => {
+    await using tmp = await tmpdir()
+    const spec = "prettier"
+    const { pkgDir } = await seedCache(tmp.path, spec, spec)
+
+    const result = await Effect.runPromise(
+      Npm.Service.use((svc) => svc.add(spec)).pipe(Effect.provide(cacheLayer(tmp.path))),
+    )
+
+    expect(result.directory).toBe(pkgDir)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #23653

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the regression introduced in #18308 where `Npm.add()` cached install dirs keyed on `npa(pkg).name`, which returns `undefined` for non-registry specs (remote tarball URLs, `git+https://`, GitHub shorthand like `Edison-A-N/opencode-preview`, `file:` paths). On a cache hit the code then called `resolveEntryPoint(undefined, ...)`, breaking subsequent installs of these specs.

The fix recovers the actual installed package name by reading the install-root `package.json` (written by Arborist on the initial install) and using its first dependency entry — matching what the fresh-install path computes from the arborist tree below it.

Why this works:
- For **registry specs** (`lodash@4`), `npa(pkg).name` returns the package name as before — unchanged.
- For **non-registry specs** with a previously installed cache, the cached `package.json` contains a `dependencies` map whose first key is the actual installed package name (Arborist writes this when reifying). We read that name and resolve against `node_modules/<actual-name>/` correctly.
- For **cache directory exists but no parseable deps** (corrupted/partial cache), we fall through to the Arborist install path so the package gets re-reified instead of returning a broken entrypoint.

### How did you verify your code works?

- New unit tests in `packages/opencode/test/npm.test.ts` covering:
  - Cache-hit path returning the actual installed package name (not the npa-derived `undefined`)
  - Re-install behavior when the cache directory exists without the package installed (corrupted cache recovery)
  - Registry-spec path unchanged
- Full `packages/opencode` and `packages/core` test suites run locally — pass
- `bun typecheck` passes on both packages

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR