### PR TITLE
docs(ecosystem): add @datadog/opencode-plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -52,6 +52,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
+| [@datadog/opencode-plugin](https://github.com/datadog-labs/opencode-plugin)                        | Query Datadog logs, metrics, traces, dashboards, and more via the Datadog MCP                     |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

No related issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `@datadog/opencode-plugin` to the ecosystem plugins list. The plugin ships a preconfigured Datadog MCP server so OpenCode can query Datadog logs, metrics, traces, dashboards, monitors, and incidents through natural conversation. Source: https://github.com/datadog-labs/opencode-plugin (Apache-2.0).

### How did you verify your code works?

Rendered the updated `ecosystem.mdx` locally; the new row aligns with the surrounding entries and the link resolves to the public repository.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR