### PR TITLE
fix: cancel queued messages without aborting session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -11,6 +11,7 @@ export function DialogMessage(props: {
   messageID: string
   sessionID: string
   setPrompt?: (prompt: PromptInfo) => void
+  queued?: boolean
 }) {
   const sync = useSync()
   const sdk = useSDK()
@@ -21,6 +22,23 @@ export function DialogMessage(props: {
     <DialogSelect
       title="Message Actions"
       options={[
+        ...(props.queued
+          ? [
+              {
+                title: "Cancel",
+                value: "session.deleteMessage",
+                description: "discard queued message",
+                onSelect: (dialog: { clear: () => void }) => {
+                  void sdk.client.session.deleteMessage({
+                    sessionID: props.sessionID,
+                    messageID: props.messageID,
+                    force: "true",
+                  })
+                  dialog.clear()
+                },
+              },
+            ]
+          : []),
         {
           title: "Revert",
           value: "session.revert",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
@@ -33,8 +33,10 @@ export function DialogTimeline(props: {
         value: message.id,
         footer: Locale.time(message.time.created),
         onSelect: (dialog) => {
+          const pendingMessageID = messages.findLast((x) => x.role === "assistant" && !x.time.completed)?.id
+          const queued = !!pendingMessageID && message.id > pendingMessageID
           dialog.replace(() => (
-            <DialogMessage messageID={message.id} sessionID={props.sessionID} setPrompt={props.setPrompt} />
+            <DialogMessage messageID={message.id} sessionID={props.sessionID} setPrompt={props.setPrompt} queued={queued} />
           ))
         },
       })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1190,11 +1190,14 @@ export function Session() {
                           index={index()}
                           onMouseUp={() => {
                             if (renderer.getSelection()?.getSelectedText()) return
+                            const pendingMessageID = pending()
+                            const queued = !!pendingMessageID && message.id > pendingMessageID
                             dialog.replace(() => (
                               <DialogMessage
                                 messageID={message.id}
                                 sessionID={route.sessionID}
                                 setPrompt={(promptInfo) => prompt?.set(promptInfo)}
+                                queued={queued}
                               />
                             ))
                           }}

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -404,7 +404,7 @@ export const SessionApi = HttpApi.make("session")
         ),
         HttpApiEndpoint.delete("deleteMessage", SessionPaths.deleteMessage, {
           params: { sessionID: SessionID, messageID: MessageID },
-          query: WorkspaceRoutingQuery,
+          query: Schema.Struct({ ...WorkspaceRoutingQueryFields, force: Schema.optional(QueryBoolean) }),
           success: described(Schema.Boolean, "Successfully deleted message"),
           error: [HttpApiError.BadRequest, ApiNotFoundError],
         }).annotateMerge(

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -356,9 +356,18 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
 
     const deleteMessage = Effect.fn("SessionHttpApi.deleteMessage")(function* (ctx: {
       params: { sessionID: SessionID; messageID: MessageID }
+      query: { force?: boolean }
     }) {
       yield* requireSession(ctx.params.sessionID)
-      yield* SessionError.mapBusy(runState.assertNotBusy(ctx.params.sessionID))
+      if (ctx.query.force) {
+        const msgs = yield* session.messages({ sessionID: ctx.params.sessionID })
+        const pending = msgs.findLast((m) => m.info.role === "assistant" && m.info.time.completed === undefined)
+        if (!pending || !(ctx.params.messageID > pending.info.id)) {
+          yield* SessionError.mapBusy(runState.assertNotBusy(ctx.params.sessionID))
+        }
+      } else {
+        yield* SessionError.mapBusy(runState.assertNotBusy(ctx.params.sessionID))
+      }
       yield* session.removeMessage(ctx.params)
       return true
     })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3389,6 +3389,7 @@ export class Session2 extends HeyApiClient {
       messageID: string
       directory?: string
       workspace?: string
+      force?: "true" | "false"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3401,6 +3402,7 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "messageID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "query", key: "force" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5779,6 +5779,7 @@ export type SessionDeleteMessageData = {
   query?: {
     directory?: string
     workspace?: string
+    force?: "true" | "false"
   }
   url: "/session/{sessionID}/message/{messageID}"
 }


### PR DESCRIPTION
### Issue for this PR

Closes #4821
Closes #20090

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Clicking a queued message now shows a "Cancel" option that removes it from the queue without interrupting the active response. Revert is still available below it.

To support this, `deleteMessage` accepts an optional `force` query param. When `force=true`, the server verifies the target message is actually queued (chronologically after the active assistant response) before allowing deletion. If the message isn't queued, the normal `assertNotBusy` check applies.

HttpApi route and handler updated. SDK regenerated. The Hono backend route was removed on dev since the original PR was opened, so that change was dropped during rebase.

### How did you verify your code works?

Ran `bun dev`, queued a message while assistant was responding, clicked it, and confirmed Cancel removes it without killing the active response. 

Also confirmed that revert still works as before and that Cancel is only available for queued messages. 

### Screenshots / recordings

<img width="1202" height="907" alt="Cancel Button on queued message click options" src="https://github.com/user-attachments/assets/3f5956f5-c593-4b43-a684-3bd850f2f2b8" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR