### PR TITLE
fix: prevent shell commands from killing all Node.js processes

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -58,6 +58,12 @@ export const layer = Layer.effect(
             `  Platform: ${process.platform}`,
             `  Today's date: ${new Date().toDateString()}`,
             `</env>`,
+            ``,
+            `## System Safety (Critical)`,
+            ``,
+            `- **NEVER** run commands that kill all Node.js processes (e.g., \`taskkill /F /IM node.exe\`, \`killall node\`, \`pkill node\`, \`Get-Process node | Stop-Process\`, etc.).`,
+            `- OpenCode is built on Node.js (\`node.exe\`). Killing all Node processes will immediately crash the AI assistant and terminate the current session.`,
+            `- If you need to stop a specific process, target it by PID or use process-manager commands scoped to the project (e.g., \`npm stop\`, \`pm2 stop <name>\`).`,
           ].join("\n"),
         ]
       }),

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -28,6 +28,18 @@ export { Parameters } from "./shell/prompt"
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
 const CWD = new Set(["cd", "chdir", "popd", "pushd", "push-location", "set-location"])
+
+const DANGEROUS_COMMAND_PATTERNS = [
+  /taskkill\s+.*\/?[Ff]\s+.*\/?[Ii][Mm]\s+node\.?exe/i,
+  /taskkill\s+.*\/?[Ii][Mm]\s+node\.?exe/i,
+  /killall\s+node/i,
+  /pkill\s+node/i,
+  /Get-Process\s+.*node\s*\|\s*Stop-Process/i,
+]
+
+function isDangerousCommand(command: string): boolean {
+  return DANGEROUS_COMMAND_PATTERNS.some((pattern) => pattern.test(command))
+}
 const FILES = new Set([
   ...CWD,
   "rm",
@@ -601,6 +613,11 @@ export const ShellTool = Tool.define(
                 throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
               }
               const timeout = params.timeout ?? DEFAULT_TIMEOUT
+              if (isDangerousCommand(params.command)) {
+                throw new Error(
+                  `Command blocked for system safety: "${params.command}". This command would kill all Node.js processes, which crashes OpenCode because it is built on Node.js (node.exe). If you need to stop a specific process, target it by PID or use project-scoped commands like "npm stop" or "pm2 stop <name>".`,
+                )
+              }
               const ps = Shell.ps(shell)
               yield* Effect.scoped(
                 Effect.gen(function* () {

--- a/packages/opencode/src/tool/shell/shell.txt
+++ b/packages/opencode/src/tool/shell/shell.txt
@@ -8,6 +8,12 @@ Use `${tmp}` for temporary work outside the workspace. This directory has alread
 
 IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO NOT use it for file operations (reading, writing, editing, searching, finding files) - use the specialized tools for this instead.
 
+## System Safety (Critical)
+
+- **NEVER** run commands that kill all Node.js processes (e.g., `taskkill /F /IM node.exe`, `killall node`, `pkill node`, `Get-Process node | Stop-Process`, etc.).
+- OpenCode is built on Node.js (`node.exe`). Killing all Node processes will immediately crash the AI assistant and terminate the current session.
+- If you need to stop a specific process, target it by PID or use process-manager commands scoped to the project (e.g., `npm stop`, `pm2 stop <name>`).
+
 ${commandSection}
 
 # Committing changes with git


### PR DESCRIPTION
### Issue for this PR

Closes #7950

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode is built on Node.js (`node.exe`). When the AI runs commands like `taskkill /F /IM node.exe`, `killall node`, `pkill node`, or `Get-Process node | Stop-Process`, it kills its own process and immediately crashes the assistant.

This PR adds defense in depth with three layers:

1. **System prompt guard** — Injects a critical safety reminder into the environment prompt for all models, instructing the AI never to run broad Node process-killing commands.
2. **Shell tool prompt guard** — Adds the same safety rule to the bash/shell tool description so the AI sees it every time the tool is invoked.
3. **Runtime command guard** — Validates shell commands before execution in ShellTool and throws a clear error if a dangerous pattern is detected.

Safer alternatives like targeting a specific PID (`kill 12345`) or using project-scoped stop commands (`npm stop`, `pm2 stop <name>`) remain unaffected.

### How did you verify your code works?

Tested locally on Windows:
- Commands like `taskkill /F /IM node.exe` are blocked before execution
- Similar broad patterns (`killall node`, `pkill node`, `Get-Process node | Stop-Process`) are also rejected
- PID-based commands still work as expected
- Project-scoped stop commands continue to work
- Normal shell usage is unaffected for safe commands

Also reproduced the original issue before applying the fix, where killing all Node processes terminated the active OpenCode session.

### Screenshots / recordings

N/A — this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
