### PR TITLE
fix(provider): surface OpenAI nested error.message in parseAPICallError

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -63,11 +63,19 @@ function message(providerID: ProviderID, e: APICallError) {
 
     try {
       const body = JSON.parse(e.responseBody)
-      // try to extract common error message fields
-      const errMsg = body.message || body.error || body.error?.message
-      if (errMsg && typeof errMsg === "string") {
-        return `${msg}: ${errMsg}`
-      }
+      // Try common error message fields. Use explicit-typeof guards so a truthy
+      // non-string at any level (e.g. body.error being the {message,type,code}
+      // object that OpenAI returns) cannot block a valid string further down
+      // the chain. Matches parseStreamError's pattern below.
+      const errMsg =
+        typeof body.error?.message === "string"
+          ? body.error.message
+          : typeof body.message === "string"
+            ? body.message
+            : typeof body.error === "string"
+              ? body.error
+              : undefined
+      if (errMsg) return `${msg}: ${errMsg}`
     } catch {}
 
     // If responseBody is HTML (e.g. from a gateway or proxy error page),

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "bun:test"
+import { ProviderError } from "../../src/provider/error"
+import { APICallError } from "ai"
+
+function makeAPICallError(opts: {
+  message?: string
+  statusCode?: number
+  responseBody?: string
+}): APICallError {
+  return new APICallError({
+    message: opts.message ?? "",
+    statusCode: opts.statusCode,
+    responseBody: opts.responseBody,
+    isRetryable: false,
+    url: "",
+    requestBodyValues: {},
+  })
+}
+
+describe("ProviderError.parseAPICallError: error message extraction", () => {
+  test("extracts nested error.message from OpenAI-shaped JSON body", () => {
+    // OpenAI returns 4xx errors with {error: {message, type, code}}.
+    // Previously the parser short-circuited on body.error (the object) and
+    // failed the typeof string guard, so the raw structured body was dumped
+    // to the user as e.g. `Bad Request: {"error":{"message":"...", ...}}`.
+    const result = ProviderError.parseAPICallError({
+      providerID: "openai" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({
+          error: {
+            message: "The model `gpt-5-codex` does not exist or you do not have access to it.",
+            type: "invalid_request_error",
+            code: "model_not_found",
+          },
+        }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Bad Request")
+      expect(result.message).toContain("gpt-5-codex")
+      expect(result.message).toContain("does not exist")
+      // Raw structured body must not be dumped when a clean message extracted.
+      expect(result.message).not.toContain('"error":')
+      expect(result.message).not.toContain("{")
+    }
+  })
+
+  test("non-string body.error.message does not block a valid body.message", () => {
+    // Defensive guard: a truthy non-string at any level (e.g. body.error.message
+    // is an array) must not short-circuit a valid string further down the chain.
+    const result = ProviderError.parseAPICallError({
+      providerID: "openai" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({
+          error: { message: ["array", "of", "strings"] },
+          message: "Real human-readable error",
+        }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Real human-readable error")
+      expect(result.message).not.toContain("array")
+    }
+  })
+
+  test("falls back through the chain when body.error has no message but body.message does", () => {
+    const result = ProviderError.parseAPICallError({
+      providerID: "openai" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({
+          error: { code: "rate_limited", type: "throttle" },
+          message: "Slow down",
+        }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Slow down")
+    }
+  })
+
+  test("extracts plain string body.error", () => {
+    // Some providers return {error: "string"} rather than {error: {message: ...}}.
+    const result = ProviderError.parseAPICallError({
+      providerID: "anthropic" as any,
+      error: makeAPICallError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({ error: "Something went wrong" }),
+      }),
+    })
+    expect(result.type).toBe("api_error")
+    if (result.type === "api_error") {
+      expect(result.message).toContain("Something went wrong")
+    }
+  })
+})


### PR DESCRIPTION
Closes #25764

## Problem

In `packages/opencode/src/provider/error.ts`, the OR-chain that extracts the inner error message from a JSON response body short-circuits on OpenAI's standard 4xx response shape:

```ts
const errMsg = body.message || body.error || body.error?.message
//                              ^^^^^^^^^^ truthy object — assigned to errMsg
if (errMsg && typeof errMsg === \"string\") {  // typeof check fails
  return `${msg}: ${errMsg}`
}
// falls through to: return `${msg}: ${e.responseBody}`  — raw body dumped
```

OpenAI returns errors as `{error: {message, type, code}}`. `body.error` is the (truthy) object itself, so the OR short-circuits there, the `typeof errMsg === \"string\"` guard fails, and the parser falls through to dumping the raw response body to the user.

The sibling function `parseStreamError` in the same file already uses the correct defensive pattern at line 153 (`typeof body?.error?.message === \"string\" ? ...`); only `parseAPICallError` had this bug.

## Fix

Replace the OR-chain with explicit-typeof ternaries so a truthy non-string at any level cannot block a valid string further down the chain. After the fix the user sees the actual underlying message instead of the raw structured body (or the redacted `Bad Request: {?:?}` that telemetry pipelines produced).

## Tests

Added 4 tests under `test/provider/error.test.ts` covering OpenAI nested shape, non-string short-circuit guard, missing-message fallback, and plain-string `body.error`.

Full rationale and reproduction in #25764.