### PR TITLE
fix(provider): keep tool-call and tool-result paired in anthropic normalize

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -137,12 +137,12 @@ function normalizeMessages(
       if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
 
       const parts = msg.content
-      const first = parts.findIndex((part) => part.type === "tool-call")
+      const first = parts.findIndex((part) => part.type === "tool-call" || part.type === "tool-result")
       if (first === -1) return [msg]
-      if (!parts.slice(first).some((part) => part.type !== "tool-call")) return [msg]
+      if (!parts.slice(first).some((part) => part.type !== "tool-call" && part.type !== "tool-result")) return [msg]
       return [
-        { ...msg, content: parts.filter((part) => part.type !== "tool-call") },
-        { ...msg, content: parts.filter((part) => part.type === "tool-call") },
+        { ...msg, content: parts.filter((part) => part.type !== "tool-call" && part.type !== "tool-result") },
+        { ...msg, content: parts.filter((part) => part.type === "tool-call" || part.type === "tool-result") },
       ]
     })
   }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1497,6 +1497,84 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
     ])
   })
+  test("keeps tool-call and tool-result paired when splitting anthropic messages", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+          { type: "text", text: "I checked your home directory." },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "I checked your home directory." }],
+    })
+    expect(result[1]).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+        { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+      ],
+    })
+  })
+
+  test("keeps tool-call and tool-result paired when interleaved with text", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "text", text: "Let me check." },
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Let me check." }],
+    })
+    expect(result[1]).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+        { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+      ],
+    })
+  })
+
+  test("does not split when tool-result follows tool-call with no trailing text", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I checked your home directory." },
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toMatchObject([
+      { type: "text", text: "I checked your home directory." },
+      { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+      { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+    ])
+  })
+
 
   test("splits vertex anthropic assistant messages when text trails tool calls", () => {
     const model = {


### PR DESCRIPTION
### Issue for this PR

Closes #25774

### Type of change

- [x] Bug fix

### What does this PR do?

`normalizeMessages()` in `packages/opencode/src/provider/transform.ts` splits assistant turns where text trails `tool-call` blocks for Anthropic / Vertex Anthropic. The previous split only treated `tool-call` as a tool part, so for a turn shaped like `[tool-call, tool-result, text]` the `tool-result` ended up in the text-group message and the `tool-call` was emitted on its own. After provider/SDK merge this looks like a `tool_use` without an immediately following `tool_result`, so Anthropic returns `tool_use ids were found without tool_result blocks immediately after`.

This change treats `tool-call` and `tool-result` as a single "tool" group:

- the split point is the first `tool-call` or `tool-result` part
- the early-out covers turns that are pure tool parts
- the partition keeps every `tool-call` next to its `tool-result`

So `[tool-call, tool-result, text]` becomes `[text]` + `[tool-call, tool-result]`, and `[text, tool-call, tool-result]` is left alone.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts` — 143 pass / 0 fail (3 new tests covering the paired/interleaved/no-trailing-text cases).
- `bun test test/session/message-v2.test.ts` — 27 pass / 0 fail.
- `bun test test/session/llm.test.ts` — 14 pass / 0 fail.
- `bun typecheck` — clean.
- Manual: rebuilt `opencode` from this branch, replaced the binary on two machines (codeg-fob + codeg-ops), restarted `com.opencode.serve`, and confirmed `agent`/`app` endpoints return 200 over the local port and over Tailscale.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR