### PR TITLE
fix(i18n): correct Japanese translation for todo progress

### DIFF
--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -787,7 +787,7 @@ export const dict = {
   "session.review.noVcs.createGit.description": "このプロジェクトの変更を追跡、レビュー、元に戻す",
   "session.review.noVcs.createGit.actionLoading": "Git リポジトリを作成中...",
   "session.review.noVcs.createGit.action": "Git リポジトリを作成",
-  "session.todo.progress": "{{done}} 個中 {{total}} 個の Todo が完了",
+  "session.todo.progress": "{{total}} 個中 {{done}} 個の Todo が完了",
   "session.question.progress": "{{total}} 問中 {{current}} 問",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "エクスプローラー",


### PR DESCRIPTION
### Issue for this PR

Closes #25679

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes an incorrect Japanese translation for `session.todo.progress`. 

Previously, the translation was `{{done}} 個中 {{total}} 個の Todo が完了` (completed `{{total}}` out of `{{done}}`), which is grammatically incorrect in Japanese. 
I swapped the variables to `{{total}} 個中 {{done}} 個の Todo が完了` (completed `{{done}}` out of `{{total}}`) to reflect the correct grammatical order.

### How did you verify your code works?

I built the modified code, started the web server, and verified its operation.

### Screenshots / recordings

<img width="783" height="107" alt="Screenshot 2026-05-05 at 8 42 30" src="https://github.com/user-attachments/assets/d93872e7-2ab8-4961-bb44-d5fe9d9f7bd9" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
