### PR TITLE
fix(session): distinguish malformed known-tool input from unknown tools

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -340,25 +340,18 @@ const live: Layer.Layer<
           })
         },
         async experimental_repairToolCall(failed) {
-          const lower = failed.toolCall.toolName.toLowerCase()
-          if (lower !== failed.toolCall.toolName && tools[lower]) {
+          const repaired = repairToolCallFailure({
+            toolCall: failed.toolCall,
+            errorMessage: failed.error.message,
+            toolNames: Object.keys(tools),
+          })
+          if (repaired.toolName !== failed.toolCall.toolName && repaired.toolName !== "invalid") {
             l.info("repairing tool call", {
               tool: failed.toolCall.toolName,
-              repaired: lower,
+              repaired: repaired.toolName,
             })
-            return {
-              ...failed.toolCall,
-              toolName: lower,
-            }
           }
-          return {
-            ...failed.toolCall,
-            input: JSON.stringify({
-              tool: failed.toolCall.toolName,
-              error: failed.error.message,
-            }),
-            toolName: "invalid",
-          }
+          return repaired
         },
         temperature: params.temperature,
         topP: params.topP,
@@ -445,6 +438,48 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(Plugin.defaultLayer),
   ),
 )
+
+export function repairToolCallFailure<T extends { toolName: string; input?: string }>(input: {
+  toolCall: T
+  errorMessage: string
+  toolNames: Iterable<string>
+}): T {
+  const tools = new Set(input.toolNames)
+  const lower = input.toolCall.toolName.toLowerCase()
+
+  if (lower !== input.toolCall.toolName && tools.has(lower)) {
+    return {
+      ...input.toolCall,
+      toolName: lower,
+    } as T
+  }
+
+  const original = input.toolCall.toolName
+  const known = tools.has(original) || tools.has(lower)
+
+  if (known) {
+    return {
+      ...input.toolCall,
+      input: JSON.stringify({
+        type: "known_tool_invalid_input",
+        tool: original,
+        error: input.errorMessage,
+        hint: "The tool name is valid, but the input was malformed or truncated. Retry with valid input or split large operations into smaller chunks.",
+      }),
+      toolName: "invalid",
+    } as T
+  }
+
+  return {
+    ...input.toolCall,
+    input: JSON.stringify({
+      type: "unknown_tool",
+      tool: original,
+      error: input.errorMessage,
+    }),
+    toolName: "invalid",
+  } as T
+}
 
 function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" | "user">) {
   const disabled = Permission.disabled(

--- a/packages/opencode/src/tool/invalid.ts
+++ b/packages/opencode/src/tool/invalid.ts
@@ -4,6 +4,8 @@ import * as Tool from "./tool"
 export const Parameters = Schema.Struct({
   tool: Schema.String,
   error: Schema.String,
+  type: Schema.optional(Schema.String),
+  hint: Schema.optional(Schema.String),
 })
 
 export const InvalidTool = Tool.define(
@@ -11,11 +13,20 @@ export const InvalidTool = Tool.define(
   Effect.succeed({
     description: "Do not use",
     parameters: Parameters,
-    execute: (params: { tool: string; error: string }) =>
+    execute: (params: { tool: string; error: string; type?: string; hint?: string }) =>
       Effect.succeed({
-        title: "Invalid Tool",
-        output: `The arguments provided to the tool are invalid: ${params.error}`,
-        metadata: {},
+        title: params.type === "unknown_tool" ? "Unknown Tool" : "Invalid Tool Input",
+        output: [
+          `Tool: ${params.tool}`,
+          `Error: ${params.error}`,
+          params.hint ? `Hint: ${params.hint}` : undefined,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        metadata: {
+          ...(params.type ? { type: params.type } : {}),
+          tool: params.tool,
+        },
       }),
   }),
 )

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -4,7 +4,7 @@ import { tool, type ModelMessage } from "ai"
 import { Cause, Effect, Exit, Stream } from "effect"
 import z from "zod"
 import { makeRuntime } from "../../src/effect/run-service"
-import { LLM } from "../../src/session/llm"
+import { LLM, repairToolCallFailure } from "../../src/session/llm"
 import { Instance } from "../../src/project/instance"
 import { WithInstance } from "../../src/project/with-instance"
 import { Provider } from "@/provider/provider"
@@ -32,6 +32,52 @@ const llm = makeRuntime(LLM.Service, LLM.defaultLayer)
 async function drain(input: LLM.StreamInput) {
   return llm.runPromise((svc) => svc.stream(input).pipe(Stream.runDrain))
 }
+
+describe("session.llm.repairToolCallFailure", () => {
+  test("repairs tool name casing when lower-case tool exists", () => {
+    const repaired = repairToolCallFailure({
+      toolCall: { toolName: "Write", input: "{}" },
+      errorMessage: "No such tool",
+      toolNames: ["write", "bash"],
+    })
+
+    expect(repaired.toolName).toBe("write")
+    expect(repaired.input).toBe("{}")
+  })
+
+  test("classifies known tool invalid input", () => {
+    const repaired = repairToolCallFailure({
+      toolCall: { toolName: "write", input: "{ malformed" },
+      errorMessage: "JSON parsing failed",
+      toolNames: ["write", "bash"],
+    })
+
+    expect(repaired.toolName).toBe("invalid")
+    const input = JSON.parse(String(repaired.input))
+    expect(input).toEqual({
+      type: "known_tool_invalid_input",
+      tool: "write",
+      error: "JSON parsing failed",
+      hint: "The tool name is valid, but the input was malformed or truncated. Retry with valid input or split large operations into smaller chunks.",
+    })
+  })
+
+  test("classifies unknown tool separately", () => {
+    const repaired = repairToolCallFailure({
+      toolCall: { toolName: "does_not_exist", input: "{}" },
+      errorMessage: "No such tool",
+      toolNames: ["write", "bash"],
+    })
+
+    expect(repaired.toolName).toBe("invalid")
+    const input = JSON.parse(String(repaired.input))
+    expect(input).toEqual({
+      type: "unknown_tool",
+      tool: "does_not_exist",
+      error: "No such tool",
+    })
+  })
+})
 
 describe("session.llm.hasToolCalls", () => {
   test("returns false for empty messages array", () => {

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -141,7 +141,13 @@ exports[`tool parameters JSON Schema (wire shape) invalid 1`] = `
     "error": {
       "type": "string",
     },
+    "hint": {
+      "type": "string",
+    },
     "tool": {
+      "type": "string",
+    },
+    "type": {
       "type": "string",
     },
   },

--- a/packages/opencode/test/tool/parameters.test.ts
+++ b/packages/opencode/test/tool/parameters.test.ts
@@ -131,6 +131,21 @@ describe("tool parameters", () => {
     test("accepts tool + error", () => {
       expect(parse(Invalid, { tool: "foo", error: "bar" })).toEqual({ tool: "foo", error: "bar" })
     })
+    test("accepts optional type + hint", () => {
+      expect(
+        parse(Invalid, {
+          tool: "write",
+          error: "JSON parsing failed",
+          type: "known_tool_invalid_input",
+          hint: "Retry with valid input or split large operations into smaller chunks.",
+        }),
+      ).toEqual({
+        tool: "write",
+        error: "JSON parsing failed",
+        type: "known_tool_invalid_input",
+        hint: "Retry with valid input or split large operations into smaller chunks.",
+      })
+    })
     test("rejects missing fields", () => {
       expect(accepts(Invalid, { tool: "foo" })).toBe(false)
       expect(accepts(Invalid, { error: "bar" })).toBe(false)


### PR DESCRIPTION
### Issue for this PR

Fixes #25789

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR distinguishes two different tool-call repair failure cases:

1. A model calls a tool that does not exist.
2. A model calls a valid/known tool, but the tool input is malformed.

Previously, both cases were routed through the `invalid` tool in a way that made malformed input for a valid tool look like a generic invalid/unknown tool call.

The change extracts the classification logic into `repairToolCallFailure()` and keeps the existing lowercase tool-name repair behavior.

The `invalid` tool now accepts optional `type` and `hint` fields so callers can distinguish:

- `unknown_tool`
- `known_tool_invalid_input`

This gives users and maintainers clearer feedback when a valid tool was selected but its input could not be parsed.

### How did you verify your code works?

Tested locally with:

    cd packages/opencode
    bun test --timeout 30000 test/session/llm.test.ts
    bun test --timeout 30000 test/tool/parameters.test.ts
    bun run typecheck

Results:

- `test/session/llm.test.ts`: 17 pass, 0 fail
- `test/tool/parameters.test.ts`: 54 pass, 0 fail
- `bun run typecheck`: pass

I also ran a manual smoke test with a patched source build:

- normal `write` tool usage still works
- large single-write requests still work
- intentionally unknown tool calls are reported as `unknown_tool`
- malformed input for a known tool is covered by regression tests

### Screenshots / recordings

N/A — this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR