### PR TITLE
devex: Enable Electron MCP servers with DevTools debug port

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -74,6 +74,7 @@ setupApp()
 function setupApp() {
   ensureLoopbackNoProxy()
   app.commandLine.appendSwitch("proxy-bypass-list", "<-loopback>")
+  if (!app.isPackaged) app.commandLine.appendSwitch("remote-debugging-port", "9222")
 
   if (!app.requestSingleInstanceLock()) {
     app.quit()


### PR DESCRIPTION
## Summary
- expose Electron's remote debugging port in non-packaged desktop builds
- keeps packaged builds unchanged

## Tests
- `bun typecheck` in `packages/desktop-electron`
- push hook: `bun turbo typecheck`