### PR TITLE
update: normalize download asset names to match new naming convention

### DIFF
--- a/packages/console/app/src/routes/download/[channel]/[platform].ts
+++ b/packages/console/app/src/routes/download/[channel]/[platform].ts
@@ -2,11 +2,11 @@ import type { APIEvent } from "@solidjs/start"
 import type { DownloadPlatform } from "../types"
 
 const prodAssetNames: Record<string, string> = {
-  "darwin-aarch64-dmg": "opencode-desktop-darwin-aarch64.dmg",
-  "darwin-x64-dmg": "opencode-desktop-darwin-x64.dmg",
-  "windows-x64-nsis": "opencode-desktop-windows-x64.exe",
+  "darwin-aarch64-dmg": "opencode-desktop-mac-arm64.dmg",
+  "darwin-x64-dmg": "opencode-desktop-mac-x64.dmg",
+  "windows-x64-nsis": "opencode-desktop-win-x64.exe",
   "linux-x64-deb": "opencode-desktop-linux-amd64.deb",
-  "linux-x64-appimage": "opencode-desktop-linux-amd64.AppImage",
+  "linux-x64-appimage": "opencode-desktop-linux-x86_64.AppImage",
   "linux-x64-rpm": "opencode-desktop-linux-x86_64.rpm",
 } satisfies Record<DownloadPlatform, string>
 


### PR DESCRIPTION
Updates the download asset names in the console app to use a consistent naming convention:\n\n- darwin-aarch64-dmg: \"opencode-desktop-darwin-aarch64.dmg\" → \"opencode-desktop-mac-arm64.dmg\"\n- darwin-x64-dmg: \"opencode-desktop-darwin-x64.dmg\" → \"opencode-desktop-mac-x64.dmg\"\n- windows-x64-nsis: \"opencode-desktop-windows-x64.exe\" → \"opencode-desktop-win-x64.exe\"\n- linux-x64-appimage: \"opencode-desktop-linux-amd64.AppImage\" → \"opencode-desktop-linux-x86_64.AppImage\"\n\nThis aligns the internal asset naming with the new desktop build naming scheme.