### PR TITLE
Fix workspace warp SDK null id

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -146,6 +146,10 @@ function matchLegacyOpenApi(input: Record<string, unknown>) {
           if (properties?.branch) properties.branch = { anyOf: [properties.branch, { type: "null" }] }
           if (properties?.extra) properties.extra = { anyOf: [properties.extra, { type: "null" }] }
         }
+        if (path === "/experimental/workspace/warp" && method === "post") {
+          const properties = operation.requestBody.content?.["application/json"]?.schema?.properties
+          if (properties?.id) properties.id = nullable(properties.id)
+        }
       }
       for (const response of Object.values(operation.responses ?? {})) {
         for (const content of Object.values(response.content ?? {})) {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1019,7 +1019,7 @@ export class Workspace extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
-      id?: string
+      id?: string | null
       sessionID?: string
     },
     options?: Options<never, ThrowOnError>,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -6665,7 +6665,7 @@ export type ExperimentalWorkspaceRemoveResponse =
 
 export type ExperimentalWorkspaceWarpData = {
   body?: {
-    id: string
+    id: string | null
     sessionID: string
   }
   path?: never


### PR DESCRIPTION
## Summary
- Preserve nullable `id` in the public OpenAPI shape for workspace warp.
- Regenerate SDK types so `experimental.workspace.warp({ id: null })` typechecks for local-project detach.

## Testing
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/sdk/js`
- pre-push `bun turbo typecheck`