### PR TITLE
fix(console): remove Cloudflare cache config from download fetch

### DIFF
--- a/packages/console/app/src/routes/download/[channel]/[platform].ts
+++ b/packages/console/app/src/routes/download/[channel]/[platform].ts
@@ -32,13 +32,6 @@ export async function GET({ params: { platform, channel } }: APIEvent) {
 
   const resp = await fetch(
     `https://github.com/anomalyco/${channel === "stable" ? "opencode" : "opencode-beta"}/releases/latest/download/${assetName}`,
-    {
-      cf: {
-        // in case gh releases has rate limits
-        cacheTtl: 60 * 5,
-        cacheEverything: true,
-      },
-    } as any,
   )
 
   const downloadName = downloadNames[platform]


### PR DESCRIPTION
## Summary
Removes the Cloudflare cache configuration from the download route fetch call.

## Changes
- Removed the `cf` object with `cacheTtl` and `cacheEverything` options from the GitHub releases fetch call in the download route

This change simplifies the fetch call by removing the Cloudflare-specific caching configuration.