### PR TITLE
fix(tui): label custom agents in dialog selector as custom or native.

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -12,7 +12,7 @@ export function DialogAgent() {
       return {
         value: item.name,
         title: item.name,
-        description: item.native ? "native" : item.description,
+        description: item.native ? "native" : "custom",
       }
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #4825

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

The agent selector dialog renders whenToUse as subtitle text. For custom agents generated by opencode create agent, this field contains multi-paragraph XML with examples, which truncates mid-sentence and breaks the layout. This PR updates the agent select dialog to custom, making it readable in the UI. The dialog is also not scroll-able. So a longer description isn't helpful.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Ran opencode locally, opened the agent selector, confirmed the description renders cleanly.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

**Before:**
<img width="1460" height="866" alt="Screenshot 2026-05-04 at 9 10 37 PM" src="https://github.com/user-attachments/assets/089406e9-1a19-4f52-99c4-ab21abfead02" />

**After:**
<img width="1460" height="866" alt="Screenshot 2026-05-04 at 9 10 13 PM" src="https://github.com/user-attachments/assets/e669c8fe-a930-497a-b765-36e6a3632f35" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
