### PR TITLE
fix(app): respect safe area in web shell

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en" style="background-color: var(--background-base)">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>OpenCode</title>
     <link rel="icon" type="image/png" href="/favicon-96x96-v3.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon-v3.svg" />

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1,5 +1,12 @@
 @import "@opencode-ai/ui/styles/tailwind";
 
+#root {
+  height: 100vh;
+  height: 100dvh;
+  padding: max(1px, env(safe-area-inset-top, 0px)) max(1px, env(safe-area-inset-right, 0px))
+    max(1px, env(safe-area-inset-bottom, 0px)) max(1px, env(safe-area-inset-left, 0px));
+}
+
 @font-face {
   font-family: "JetBrainsMono Nerd Font Mono";
   src: url("/assets/JetBrainsMonoNerdFontMono-Regular.woff2") format("woff2");


### PR DESCRIPTION
## Summary
- Opt web shell into Safari safe-area env values with `viewport-fit=cover`.
- Apply root padding with `max(1px, env(...))` so desktop keeps the existing 1px inset while iOS/iPadOS can expose safe areas.

## Notes
- This avoids a hardcoded iPadOS window-control workaround.
- If iPadOS reports the window controls as `0px` safe-area insets, this is a safe-area correctness patch rather than a guaranteed fix for that overlap.

## Testing
- `bun typecheck` from `packages/app`
- push hook ran `bun turbo typecheck`