### PR TITLE
fix: Respect OTEL variables

### DIFF
--- a/packages/core/src/effect/observability.ts
+++ b/packages/core/src/effect/observability.ts
@@ -39,11 +39,18 @@ export function resource(): { serviceName: string; serviceVersion: string; attri
     }
   })()
 
+  // Respect OTEL_SERVICE_NAME and "service.name" in OTEL_RESOURCE_ATTRIBUTES;
+  // fall back to "opencode" only if neither is set.
+  const serviceName = process.env.OTEL_SERVICE_NAME ?? attributes["service.name"] ?? "opencode"
+  // Remove "service.name" from attributes to avoid duplication — it is
+  // promoted to the top-level serviceName field consumed by both SDKs.
+  const { "service.name": _removed, ...remainingAttributes } = attributes
+
   return {
-    serviceName: "opencode",
+    serviceName,
     serviceVersion: InstallationVersion,
     attributes: {
-      ...attributes,
+      ...remainingAttributes,
       "deployment.environment.name": InstallationChannel,
       "opencode.client": Flag.OPENCODE_CLIENT,
       "opencode.process_role": processMetadata.processRole,

--- a/packages/core/src/effect/observability.ts
+++ b/packages/core/src/effect/observability.ts
@@ -39,11 +39,7 @@ export function resource(): { serviceName: string; serviceVersion: string; attri
     }
   })()
 
-  // Respect OTEL_SERVICE_NAME and "service.name" in OTEL_RESOURCE_ATTRIBUTES;
-  // fall back to "opencode" only if neither is set.
   const serviceName = process.env.OTEL_SERVICE_NAME ?? attributes["service.name"] ?? "opencode"
-  // Remove "service.name" from attributes to avoid duplication — it is
-  // promoted to the top-level serviceName field consumed by both SDKs.
   const { "service.name": _removed, ...remainingAttributes } = attributes
 
   return {

--- a/packages/core/src/effect/observability.ts
+++ b/packages/core/src/effect/observability.ts
@@ -40,14 +40,14 @@ export function resource(): { serviceName: string; serviceVersion: string; attri
   })()
 
   const serviceName = process.env.OTEL_SERVICE_NAME ?? attributes["service.name"] ?? "opencode"
-  const { "service.name": _removed, ...remainingAttributes } = attributes
+  const { "service.name": _removed, "deployment.environment.name": _env, ...remainingAttributes } = attributes
 
   return {
     serviceName,
     serviceVersion: InstallationVersion,
     attributes: {
       ...remainingAttributes,
-      "deployment.environment.name": InstallationChannel,
+      "deployment.environment.name": attributes["deployment.environment.name"] ?? InstallationChannel,
       "opencode.client": Flag.OPENCODE_CLIENT,
       "opencode.process_role": processMetadata.processRole,
       "opencode.run_id": processMetadata.runID,

--- a/packages/core/src/effect/observability.ts
+++ b/packages/core/src/effect/observability.ts
@@ -40,11 +40,12 @@ export function resource(): { serviceName: string; serviceVersion: string; attri
   })()
 
   const serviceName = process.env.OTEL_SERVICE_NAME ?? attributes["service.name"] ?? "opencode"
-  const { "service.name": _removed, "deployment.environment.name": _env, ...remainingAttributes } = attributes
+  const serviceVersion = attributes["service.version"] ?? InstallationVersion
+  const { "service.name": _n, "service.version": _v, "deployment.environment.name": _env, ...remainingAttributes } = attributes
 
   return {
     serviceName,
-    serviceVersion: InstallationVersion,
+    serviceVersion,
     attributes: {
       ...remainingAttributes,
       "deployment.environment.name": attributes["deployment.environment.name"] ?? InstallationChannel,


### PR DESCRIPTION
### Issue for this PR

Closes #25839

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Do not overwrite values of fundamental OTEL env variables allowing better control for telemetry.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Ran locally with OTEL enabled and this command:

```bash
OTEL_RESOURCE_ATTRIBUTES="hello=world,deployment.environment.name=my-env" OTEL_SERVICE_NAME="my-service" OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 bun dev
```

and ensured variables landed in jaeger correctly

### Screenshots / recordings

<img width="445" height="292" alt="Screenshot 2026-05-05 at 11 00 29" src="https://github.com/user-attachments/assets/926050b1-8edb-4b1a-af97-7da095d9a2fe" />
<img width="441" height="562" alt="Screenshot 2026-05-05 at 11 00 54" src="https://github.com/user-attachments/assets/d1aeaf39-09b4-4f4c-948b-d66a1c7b323b" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
