### PR TITLE
fix(desktop): respect proxy environment

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -200,7 +200,10 @@ async function initialize() {
     }
 
     logger.log("spawning sidecar", { url })
-    const { listener, health } = await spawnLocalServer(hostname, port, password)
+    const { listener, health } = await spawnLocalServer(hostname, port, password, () => {
+      ensureLoopbackNoProxy()
+      useEnvProxy()
+    })
     server = listener
     serverReady.resolve({
       url,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -137,8 +137,8 @@ function useSystemCertificates() {
 
 function useEnvProxy() {
   try {
-    const setGlobalProxyFromEnv = (http as typeof http & { setGlobalProxyFromEnv: () => void }).setGlobalProxyFromEnv
-    setGlobalProxyFromEnv()
+    // Electron 41.2 runs Node 24.14.1; latest @types/node@24 is 24.12.2.
+    ;(http as any).setGlobalProxyFromEnv()
   } catch (error) {
     logger.warn("failed to load proxy environment", error)
   }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { EventEmitter } from "node:events"
 import { existsSync } from "node:fs"
+import * as http from "node:http"
 import { createServer } from "node:net"
 import { homedir } from "node:os"
 import { join } from "node:path"
@@ -77,6 +78,7 @@ setupApp()
 
 function setupApp() {
   ensureLoopbackNoProxy()
+  useEnvProxy()
   app.commandLine.appendSwitch("proxy-bypass-list", "<-loopback>")
   if (!app.isPackaged) app.commandLine.appendSwitch("remote-debugging-port", "9222")
 
@@ -130,6 +132,15 @@ function useSystemCertificates() {
     setDefaultCACertificates([...new Set([...getCACertificates("default"), ...getCACertificates("system")])])
   } catch (error) {
     logger.warn("failed to load system certificates", error)
+  }
+}
+
+function useEnvProxy() {
+  try {
+    const setGlobalProxyFromEnv = (http as typeof http & { setGlobalProxyFromEnv: () => void }).setGlobalProxyFromEnv
+    setGlobalProxyFromEnv()
+  } catch (error) {
+    logger.warn("failed to load proxy environment", error)
   }
 }
 

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -30,8 +30,9 @@ export function setWslConfig(config: WslConfig) {
   getStore().set(WSL_ENABLED_KEY, config.enabled)
 }
 
-export async function spawnLocalServer(hostname: string, port: number, password: string) {
+export async function spawnLocalServer(hostname: string, port: number, password: string, configureEnv?: () => void) {
   prepareServerEnv(password)
+  configureEnv?.()
   const { Log, Server } = await import("virtual:opencode-server")
   await Log.init({ level: "WARN" })
   const listener = await Server.listen({


### PR DESCRIPTION
## Summary
- Enable Node 24 env proxy handling in Desktop before the embedded server starts.
- Keeps loopback in NO_PROXY so local sidecar traffic stays direct.

Fixes #25843

## Testing
- bun typecheck (packages/desktop)
- bun turbo typecheck
- local Node 24 proxy repro confirmed fetch sends CONNECT through HTTPS_PROXY after setGlobalProxyFromEnv()