### PR TITLE
fix(desktop): add error handling to store-get IPC handler

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -70,10 +70,14 @@ export function registerIpcHandlers(deps: Deps) {
   ipcMain.handle("install-update", () => deps.installUpdate())
   ipcMain.handle("set-background-color", (_event: IpcMainInvokeEvent, color: string) => deps.setBackgroundColor(color))
   ipcMain.handle("store-get", (_event: IpcMainInvokeEvent, name: string, key: string) => {
-    const store = getStore(name)
-    const value = store.get(key)
-    if (value === undefined || value === null) return null
-    return typeof value === "string" ? value : JSON.stringify(value)
+    try {
+      const store = getStore(name)
+      const value = store.get(key)
+      if (value === undefined || value === null) return null
+      return typeof value === "string" ? value : JSON.stringify(value)
+    } catch {
+      return null
+    }
   })
   ipcMain.handle("store-set", (_event: IpcMainInvokeEvent, name: string, key: string, value: string) => {
     getStore(name).set(key, value)


### PR DESCRIPTION
## Summary

Adds error handling to the store-get IPC handler to gracefully handle exceptions and return null instead of crashing.

## Changes

- Wrapped store-get logic in try-catch block
- Returns null on any error
- Prevents IPC handler crashes