### PR TITLE
fix(ui): preserve SVG tags in DOMPurify config for KaTeX math rendering

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -33,6 +33,8 @@ const config = {
   SANITIZE_NAMED_PROPS: true,
   FORBID_TAGS: ["style"],
   FORBID_CONTENTS: ["style", "script"],
+  ADD_TAGS: ["svg", "path"],
+  ADD_ATTR: ["d", "viewBox", "preserveAspectRatio", "xmlns"],
 }
 
 const iconPaths = {


### PR DESCRIPTION
### Issue for this PR
Closes #25812

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

DOMPurify was stripping `<svg>` and `<path>` elements from KaTeX-rendered HTML. KaTeX renders `\sqrt`, `\overrightarrow`, `\widehat`, `\widetilde`, `\overbrace`, `\underbrace` as inline SVG — these were silently removed during sanitization, leaving the radicand visible but the radical symbol missing.

Added `ADD_TAGS: ["svg", "path"]` and the necessary SVG attributes (`d`, `viewBox`, `preserveAspectRatio`, `xmlns`) to the DOMPurify config.

### How did you verify your code works?

Tested in desktop dev build:

$$\sqrt{x^2 + y^2}$$
$$\sqrt[4]{a^3 + b^3}$$
$$F(t) = \sqrt{t + 1} + \sqrt[7]{t^2 - 9}$$
$$\overrightarrow{AB}$$
$$\widehat{XYZ}$$
$$\widetilde{f(x)}$$
$$\overbrace{x_1 + x_2 + \cdots + x_n}^{n\text{ terms}}$$
$$\underbrace{a + a + \cdots + a}_{m\text{ times}}$$

All render correctly. DOMPurify still strips event handlers on SVG elements.

### Screenshots / recordings

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR