### PR TITLE
fix(session): clone tool input before passing to EventV2 to prevent Immer freeze

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -397,7 +397,7 @@ export const layer = Layer.effect(
                 sessionID: ctx.sessionID,
                 callID: value.id,
                 tool: value.name,
-                input,
+                input: structuredClone(input),
                 provider: {
                   executed: toolCall.part.metadata?.providerExecuted === true,
                   ...(value.providerMetadata ? { metadata: value.providerMetadata } : {}),


### PR DESCRIPTION
### Issue for this PR

Closes #25873

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes `TypeError: Attempted to assign to readonly property` that occurs on every tool call when `OPENCODE_EXPERIMENTAL=true` and a plugin mutates tool args in `tool.execute.before` hooks (e.g. oh-my-openagent).

**Root cause:** In [`processor.ts:329`](https://github.com/anomalyco/opencode/blob/7ded0ec9e91f62e3f0fa9c0d058ac6e86cdb4cd8/packages/opencode/src/session/processor.ts#L329), the `tool-call` event handler passes `value.input` by reference to `EventV2.run()`. This reference is the same object as the tool's `args` in `execute(args, options)`. The call flows through `SyncEvent.run` -> `SessionMessageUpdater.update()` -> Immer `produce()`, which calls `Object.freeze()` on the entire produced state tree, including the original args object. When a plugin hook subsequently tries to mutate `args.command`, it throws.

**Fix:** Clone the input before passing to `EventV2.run` so Immer freezes the clone instead of the original:

```diff
-              input: value.input,
+              input: structuredClone(value.input),
```

**Instrumented proof:**
```
BEFORE EventV2.run: value.input frozen=false
AFTER EventV2.run:  value.input frozen=true
```

### How did you verify your code works?

1. Built v1.14.34 binary with `OPENCODE_EXPERIMENTAL=true` + oh-my-openagent plugin
2. Unpatched: 8/8 tool calls crash with `Attempted to assign to readonly property`
3. Patched: 8/8 tool calls succeed
4. `OPENCODE_EXPERIMENTAL=false`: 8/8 succeed (confirms the flag gates the code path)
5. `git bisect` across 12,213 commits identified [commit a3bc5d35b](https://github.com/anomalyco/opencode/commit/a3bc5d35b) (PR #24512) as the first bad commit
6. File-level revert of only `processor.ts` fixes the crash
7. Stubbing `EventV2.run` as a no-op fixes the crash

### Screenshots / recordings

_N/A (not a UI change)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR