### PR TITLE
fix: let provider model hooks see config providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1139,33 +1139,6 @@ const layer: Layer.Layer<
           return true
         }
 
-        for (const hook of plugins) {
-          const p = hook.provider
-          const models = p?.models
-          if (!p || !models) continue
-
-          const providerID = ProviderID.make(p.id)
-          if (disabled.has(providerID)) continue
-
-          const provider = database[providerID]
-          if (!provider) continue
-          const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
-
-          provider.models = yield* Effect.promise(async () => {
-            const next = await models(provider, { auth: pluginAuth })
-            return Object.fromEntries(
-              Object.entries(next).map(([id, model]) => [
-                id,
-                {
-                  ...model,
-                  id: ModelID.make(id),
-                  providerID,
-                },
-              ]),
-            )
-          })
-        }
-
         // extend database from config
         for (const [providerID, provider] of configProviders) {
           const existing = database[providerID]
@@ -1258,6 +1231,33 @@ const layer: Layer.Layer<
             parsed.models[modelID] = parsedModel
           }
           database[providerID] = parsed
+        }
+
+        for (const hook of plugins) {
+          const p = hook.provider
+          const models = p?.models
+          if (!p || !models) continue
+
+          const providerID = ProviderID.make(p.id)
+          if (disabled.has(providerID)) continue
+
+          const provider = database[providerID]
+          if (!provider) continue
+          const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
+
+          provider.models = yield* Effect.promise(async () => {
+            const next = await models(provider, { auth: pluginAuth })
+            return Object.fromEntries(
+              Object.entries(next).map(([id, model]) => [
+                id,
+                {
+                  ...model,
+                  id: ModelID.make(id),
+                  providerID,
+                },
+              ]),
+            )
+          })
         }
 
         // load env


### PR DESCRIPTION
### Issue for this PR

Closes #25630

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugin `provider.models()` hooks were running before configured providers were merged into the provider database. That meant a hook for a user-defined provider looked in the pre-config models.dev database, found no provider, and skipped populating models.

This moves the hook pass to after `cfg.provider` extends `database`, while still before env/auth/custom provider loading. Custom configured providers are therefore visible to the same hook logic as catalog providers.

### How did you verify your code works?

- `git diff --check`
- I could not run local typecheck/tests in this WSL runtime because `bun` is not installed.

### Screenshots / recordings

Not a UI change.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
