### PR TITLE
fix(core): use current workspace with /new; fix warping into local project

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
@@ -129,11 +129,11 @@ export function DialogWorkspaceSelect(props: {
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .flatMap((session) => (session.workspaceID ? [session.workspaceID] : []))
       .filter((workspaceID, index, list) => list.indexOf(workspaceID) === index)
-      .slice(0, 3)
       .flatMap((workspaceID) => {
         const workspace = project.workspace.get(workspaceID)
-        return workspace ? [workspace] : []
+        return workspace && project.workspace.status(workspace.id) === "connected" ? [workspace] : []
       })
+      .slice(0, 3)
     return [
       ...list.map((adapter) => ({
         title: adapter.name,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -182,6 +182,7 @@ export function Prompt(props: PromptProps) {
   const [warpNotice, setWarpNotice] = createSignal<string>()
   const currentProviderLabel = createMemo(() => local.model.parsed().provider)
   const hasRightContent = createMemo(() => Boolean(props.right))
+  const defaultWorkspaceID = createMemo(() => props.workspaceID ?? project.workspace.current())
 
   function selectWorkspace(selection: WorkspaceSelection | undefined) {
     setWorkspaceSelection(selection)
@@ -861,14 +862,14 @@ export function Prompt(props: PromptProps) {
     if (sessionID == null) {
       const workspace = workspaceSelection()
       const workspaceID = iife(() => {
-        if (!workspace) return undefined
+        if (!workspace) return defaultWorkspaceID()
         if (workspace.type === "none") return undefined
         if (workspace.type === "existing") return workspace.workspaceID
         return undefined
       })
 
       const res = await sdk.client.session.create({
-        workspace: props.workspaceID,
+        workspace: workspaceID,
         agent: agent.name,
         model: {
           providerID: selectedModel.providerID,
@@ -1145,7 +1146,17 @@ export function Prompt(props: PromptProps) {
     | undefined
   >(() => {
     const selected = workspaceSelection()
-    if (!selected) return
+    if (!selected) {
+      const workspaceID = defaultWorkspaceID()
+      if (props.sessionID || !workspaceID) return
+      const workspace = project.workspace.get(workspaceID)
+      return {
+        type: "existing",
+        workspaceType: workspace?.type ?? "unknown",
+        workspaceName: workspace?.name ?? workspaceID,
+        status: project.workspace.status(workspaceID) ?? "error",
+      }
+    }
     if (selected.type === "none") return
     if (props.sessionID && !workspaceCreating()) return
     if (selected.type === "new") {

--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -146,6 +146,16 @@ function matchLegacyOpenApi(input: Record<string, unknown>) {
           if (properties?.branch) properties.branch = { anyOf: [properties.branch, { type: "null" }] }
           if (properties?.extra) properties.extra = { anyOf: [properties.extra, { type: "null" }] }
         }
+        if (path === "/experimental/workspace/warp" && method === "post") {
+          const ref = operation.requestBody.content?.["application/json"]?.schema?.$ref?.replace(
+            "#/components/schemas/",
+            "",
+          )
+          const properties = ref
+            ? spec.components?.schemas?.[ref]?.properties
+            : operation.requestBody.content?.["application/json"]?.schema?.properties
+          if (properties?.id) properties.id = { anyOf: [properties.id, { type: "null" }] }
+        }
       }
       for (const response of Object.values(operation.responses ?? {})) {
         for (const content of Object.values(response.content ?? {})) {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1019,7 +1019,7 @@ export class Workspace extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
-      id?: string
+      id?: string | null
       sessionID?: string
     },
     options?: Options<never, ThrowOnError>,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -6656,7 +6656,7 @@ export type ExperimentalWorkspaceRemoveResponse =
 
 export type ExperimentalWorkspaceWarpData = {
   body?: {
-    id: string
+    id: string | null
     sessionID: string
   }
   path?: never


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a few workspace follow-up issues in the TUI:

- Uses the selected `/warp` workspace when creating a new session from the home prompt instead of falling back to the local project.
- Defaults `/new` sessions to the current workspace when the TUI is already scoped to one.
- Filters workspace pickers to connected workspaces before choosing the three most recent entries.
- Preserves `null` when warping a session back to the local project, and updates the generated SDK type so the API contract allows `id: null`.

These work because session creation now derives its workspace from the explicit warp selection first, then the current TUI workspace, while local-project warp sends the server's expected `null` value instead of omitting `id`.

### How did you verify your code works?

Ran `bun typecheck` from `packages/opencode`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR