### PR TITLE
fix(mcp): support native windows shell execution for local servers

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -386,7 +386,13 @@ export const layer = Layer.effect(
       key: string,
       mcp: ConfigMCP.Info & { type: "local" },
     ) {
-      const [cmd, ...args] = mcp.command
+      const [baseCmd, ...baseArgs] = mcp.command
+      const isWin = process.platform === "win32"
+
+      // Inyección nativa del shell para evitar errores de entorno en Windows
+      const cmd = isWin ? "cmd.exe" : baseCmd
+      const args = isWin ? ["/c", baseCmd, ...baseArgs] : baseArgs
+
       const cwd = yield* InstanceState.directory
       const transport = new StdioClientTransport({
         stderr: "pipe",
@@ -395,7 +401,7 @@ export const layer = Layer.effect(
         cwd,
         env: {
           ...process.env,
-          ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
+          ...(baseCmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
           ...mcp.environment,
         },
       })


### PR DESCRIPTION
## Description
This PR fixes a Windows-specific issue where local MCP servers fail to connect when using `StdioClientTransport`. On Windows, commands like `npx` or `node` often fail to inherit the environment context or crash if not executed within a native shell. 

I modified `packages/opencode/src/mcp/index.ts` to detect the Windows platform and wrap commands in `cmd.exe /c`, ensuring stable execution and correct environment variable injection for Windows users.

## Linked Issue
Fixes #25904

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Logic Changes & Verification
I verified this fix locally on Windows 11:
1. Configured a local WordPress MCP server using a direct `node` command in `opencode.json`.
2. Verified that `opencode mcp list` correctly shows the server as **connected** (it previously failed without a .bat bypass).
3. Confirmed that the change only triggers on `win32` platforms, maintaining original behavior for macOS/Linux.

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] This PR is small, focused, and explains the "why" and "how".