### PR TITLE
fix(tui): list root sessions in session picker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -34,7 +34,7 @@ export function DialogSessionList() {
     () => ({ query: search(), filter: sync.session.query() }),
     async (input) => {
       if (!input.query) return undefined
-      const result = await sdk.client.session.list({ search: input.query, limit: 30, ...input.filter })
+      const result = await sdk.client.session.list({ search: input.query, roots: true, limit: 30, ...input.filter })
       return result.data ?? []
     },
   )

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -126,7 +126,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     function listSessions() {
       return sdk.client.session
-        .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
+        .list({ roots: true, limit: 1000, ...sessionListQuery() })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 

--- a/packages/opencode/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/opencode/test/cli/cmd/tui/sync.test.tsx
@@ -133,14 +133,22 @@ describe("tui sync", () => {
 
     try {
       expect(kv.get("session_directory_filter_enabled", true)).toBe(true)
-      expect(session.at(-1)?.searchParams.get("scope")).toBeNull()
-      expect(session.at(-1)?.searchParams.get("path")).toBe("packages/opencode")
+      const directoryRequest = session.at(-1)
+      expect(directoryRequest?.searchParams.get("scope")).toBeNull()
+      expect(directoryRequest?.searchParams.get("path")).toBe("packages/opencode")
+      expect(directoryRequest?.searchParams.get("roots")).toBe("true")
+      expect(directoryRequest?.searchParams.get("limit")).toBe("1000")
+      expect(directoryRequest?.searchParams.get("start")).toBeNull()
 
       kv.set("session_directory_filter_enabled", false)
       await sync.session.refresh()
 
-      expect(session.at(-1)?.searchParams.get("scope")).toBe("project")
-      expect(session.at(-1)?.searchParams.get("path")).toBeNull()
+      const projectRequest = session.at(-1)
+      expect(projectRequest?.searchParams.get("scope")).toBe("project")
+      expect(projectRequest?.searchParams.get("path")).toBeNull()
+      expect(projectRequest?.searchParams.get("roots")).toBe("true")
+      expect(projectRequest?.searchParams.get("limit")).toBe("1000")
+      expect(projectRequest?.searchParams.get("start")).toBeNull()
     } finally {
       app.renderer.destroy()
       Global.Path.state = previous


### PR DESCRIPTION
Fixes #25897

## Summary
- Request root sessions directly when the TUI bootstraps and refreshes the session store.
- Remove the hardcoded 30-day bootstrap filter and use a bounded root-session limit instead.
- Request root sessions for `/sessions` search so child rows cannot consume the result window before client filtering.

## Verification
- `bun test test/cli/cmd/tui/sync.test.tsx --timeout 30000`
- `bun typecheck`
- `bun turbo typecheck` (pre-push hook)
