### PR TITLE
fix(acp): return stopReason: cancelled (not end_turn) on user cancel

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1468,6 +1468,22 @@ export class Agent implements ACPAgent {
       cachedWriteTokens: msg.tokens.cache?.write || undefined,
     })
 
+    // The session/prompt RPC resolves the same way whether the turn finished
+    // naturally or was interrupted by `session/cancel` — in both cases it
+    // returns the assistant message. The interrupted path tags the message
+    // with `error.name = "MessageAbortedError"` (set in
+    // `session/processor.ts` halt → `MessageV2.fromError`). ACP defines
+    // a dedicated `stopReason: "cancelled"` for exactly this case; reporting
+    // `end_turn` makes a user cancel indistinguishable from a clean
+    // completion. Usage is also unreliable on cancel — the LLM stream is
+    // killed before the SDK emits its `finish-step` event, so
+    // `msg.tokens` is still at its zero initialiser (input/output/cache
+    // all 0). Reporting `totalTokens: 0` is misleading: the provider has
+    // already consumed the prompt tokens, we just don't know the count.
+    // Omit `usage` on cancel so clients show "unknown" instead of "zero".
+    const wasCancelled = (msg: AssistantMessage | undefined): boolean =>
+      msg?.error?.name === "MessageAbortedError"
+
     if (!cmd) {
       const response = await this.sdk.session.prompt({
         sessionID,
@@ -1484,9 +1500,10 @@ export class Agent implements ACPAgent {
 
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 
+      const cancelled = wasCancelled(msg)
       return {
-        stopReason: "end_turn" as const,
-        usage: msg ? buildUsage(msg) : undefined,
+        stopReason: cancelled ? ("cancelled" as const) : ("end_turn" as const),
+        usage: msg && !cancelled ? buildUsage(msg) : undefined,
         _meta: {},
       }
     }
@@ -1507,9 +1524,10 @@ export class Agent implements ACPAgent {
 
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 
+      const cancelled = wasCancelled(msg)
       return {
-        stopReason: "end_turn" as const,
-        usage: msg ? buildUsage(msg) : undefined,
+        stopReason: cancelled ? ("cancelled" as const) : ("end_turn" as const),
+        usage: msg && !cancelled ? buildUsage(msg) : undefined,
         _meta: {},
       }
     }

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -724,4 +724,99 @@ describe("acp.agent event subscription", () => {
       },
     })
   })
+
+  test("prompt() returns stopReason: cancelled with no usage when message has MessageAbortedError", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, sdk, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        // Server-side `session/prompt` resolves with the in-flight assistant
+        // message tagged with `MessageAbortedError` when the runner is
+        // interrupted by `session/cancel` (see processor.ts halt path).
+        // tokens stay at the zero initialiser because the LLM stream never
+        // emitted `finish-step`.
+        sdk.session.prompt = async () => ({
+          data: {
+            info: {
+              id: "msg_aborted_1",
+              sessionID: sessionId,
+              role: "assistant",
+              time: { created: 1, completed: 2 },
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              cost: 0,
+              parentID: "u1",
+              modelID: "big-pickle",
+              providerID: "opencode",
+              mode: "build",
+              agent: "build",
+              path: { cwd, root: cwd },
+              error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+            },
+          },
+        })
+
+        const result = await (agent as any).prompt({
+          sessionId,
+          prompt: [{ type: "text", text: "long task" }],
+        })
+
+        // ACP defines stopReason: "cancelled" for exactly this case.
+        // Returning "end_turn" hides the cancel from the client.
+        expect(result.stopReason).toBe("cancelled")
+        // Usage on cancel is unreliable — the SDK never emitted finish-step
+        // so tokens are all 0. Reporting `totalTokens: 0` is misleading
+        // (the provider has charged us for prompt tokens, we just don't
+        // know the count). Omit `usage` so clients show "unknown".
+        expect(result.usage).toBeUndefined()
+
+        stop()
+      },
+    })
+  })
+
+  test("prompt() returns stopReason: end_turn with usage on normal completion", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, sdk, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        sdk.session.prompt = async () => ({
+          data: {
+            info: {
+              id: "msg_done_1",
+              sessionID: sessionId,
+              role: "assistant",
+              time: { created: 1, completed: 2 },
+              tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 200, write: 0 } },
+              cost: 0,
+              parentID: "u1",
+              modelID: "big-pickle",
+              providerID: "opencode",
+              mode: "build",
+              agent: "build",
+              path: { cwd, root: cwd },
+            },
+          },
+        })
+
+        const result = await (agent as any).prompt({
+          sessionId,
+          prompt: [{ type: "text", text: "hi" }],
+        })
+
+        expect(result.stopReason).toBe("end_turn")
+        expect(result.usage?.totalTokens).toBe(350)
+        expect(result.usage?.inputTokens).toBe(100)
+
+        stop()
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #25899

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Returns `stopReason: "cancelled"` (not `"end_turn"`) on the ACP `session/prompt` RPC when the turn was interrupted by `session/cancel`, and omits the misleading all-zero `usage` field on cancel.

#### The bug

`Agent.prompt()` resolves the ACP RPC with `stopReason: "end_turn"` whether the turn finished naturally or was interrupted. ACP defines a dedicated `stopReason: "cancelled"` for the cancel case (`zStopReason` in the SDK schema is `"end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled"`), so reporting `end_turn` makes a user cancel indistinguishable from a clean completion.

The same paths also returned `usage: { totalTokens: 0, inputTokens: 0, outputTokens: 0 }` on cancel. The LLM stream is killed before the AI SDK emits its `finish-step` event, so `assistantMessage.tokens` is still at the zero initialiser from `session/prompt.ts`. Reporting `0` is wrong — Anthropic / Bedrock have already charged for the prompt tokens we sent before cancel. Omitting `usage` lets clients render "unknown" instead of "zero work".

#### How the fix detects cancel

When the runner is interrupted, the `Effect.onInterrupt` in `session/processor.ts` runs `halt(new DOMException("Aborted", "AbortError"))`. `MessageV2.fromError` maps `DOMException("AbortError")` to a `MessageAbortedError` and assigns it to `ctx.assistantMessage.error`. The runner's `onInterrupt` callback returns the in-flight assistant message, so `sdk.session.prompt()` resolves with `info.error.name === "MessageAbortedError"`. That tag is wire-stable (`packages/sdk/js/src/v2/gen/types.gen.ts`), so checking it inside the ACP wrapper is safe.

The fix adds:

```ts
const wasCancelled = (msg: AssistantMessage | undefined): boolean =>
  msg?.error?.name === "MessageAbortedError"
```

and uses it at both `Agent.prompt()` return sites:

```ts
const cancelled = wasCancelled(msg)
return {
  stopReason: cancelled ? ("cancelled" as const) : ("end_turn" as const),
  usage: msg && !cancelled ? buildUsage(msg) : undefined,
  _meta: {},
}
```

The third return site (top-level commands like `/compact`) synthesises its own response without a message and is unchanged.

A larger fix would teach the cleanup path to read the AI-SDK `usage` promise during interrupt so we can report real input-token counts even on cancel — but that crosses into provider-specific territory and the stop-reason gap is correct to fix on its own first.

### How did you verify your code works?

- `bun test test/acp/event-subscription.test.ts` — 12 pass / 0 fail (was 10)
  - new: `prompt() returns stopReason: cancelled with no usage when message has MessageAbortedError`
  - new: `prompt() returns stopReason: end_turn with usage on normal completion` (no-regression for the happy path)
- `bun run typecheck` — clean
- Staging E2E against a real sandbox (long bash + `session/cancel` mid-run): pre-fix wire trace observed `stopReason: "end_turn"`, `totalTokens: 0`. Post-fix expected to observe `stopReason: "cancelled"` with no `usage` field. Test script + pre-fix wire dump in our internal `research-notes/2026-05-06-aborted-tool-end-turn/` (Python `repro.py` driving the v2 ACP WS path).
