### PR TITLE
fix(tui): stop plugin selection mouse jumps

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/plugins.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/plugins.tsx
@@ -155,7 +155,6 @@ function showInstall(api: TuiPluginApi) {
 function View(props: { api: TuiPluginApi }) {
   const size = useTerminalDimensions()
   const [list, setList] = createSignal(props.api.plugins.list())
-  const [cur, setCur] = createSignal<string | undefined>()
   const [lock, setLock] = createSignal(false)
 
   createEffect(() => {
@@ -207,15 +206,12 @@ function View(props: { api: TuiPluginApi }) {
     <DialogSelect
       title="Plugins"
       options={rows()}
-      current={cur()}
-      onMove={(item) => setCur(item.value)}
       keybind={[
         {
           title: "toggle",
           keybind: key,
           disabled: lock(),
           onTrigger: (item) => {
-            setCur(item.value)
             flip(item.value)
           },
         },
@@ -229,7 +225,6 @@ function View(props: { api: TuiPluginApi }) {
         },
       ]}
       onSelect={(item) => {
-        setCur(item.value)
         flip(item.value)
       }}
     />


### PR DESCRIPTION
### Issue for this PR

Closes #25903

### Type of change

- [x] Bug fix
- [ ] Refactor / code improvement
- [ ] New feature
- [ ] Documentation

### What does this PR do?

Fixes the plugin manager selection jumping when using the mouse. The plugin manager was feeding `DialogSelect` movement back into `current`, so hover selection caused `DialogSelect` to re-center the list while the cursor was still over it.

This removes that feedback loop and lets `DialogSelect` keep the transient hover/keyboard selection internally.

### How did you verify your code works?

- Ran `/home/a33511/.bun/bin/bun typecheck` from `packages/opencode`.
- Built local `dev` and fix binaries and compared the plugin manager behavior.
- Verified mouse hover, click, scroll, and keyboard/mouse mixed selection in the Plugins dialog.

### Screenshots / recordings

Not included. This is a TUI mouse interaction fix and was verified locally with before/after binaries.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR