### PR TITLE
feat: make modified files in sidebar clickable to open with OS default app

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/files.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/files.tsx
@@ -1,5 +1,7 @@
 import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
 import { createMemo, For, Show, createSignal } from "solid-js"
+import openFile from "open"
+import path from "path"
 
 const id = "internal:sidebar-files"
 
@@ -22,8 +24,13 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
         <Show when={list().length <= 2 || open()}>
           <For each={list()}>
             {(item) => (
-              <box flexDirection="row" gap={1} justifyContent="space-between">
-                <text fg={theme().textMuted} wrapMode="none">
+              <box
+                flexDirection="row"
+                gap={1}
+                justifyContent="space-between"
+                onMouseUp={() => openFile(path.resolve(props.api.state.path.directory, item.file)).catch(() => {})}
+              >
+                <text fg={theme().primary} wrapMode="none">
                   {item.file}
                 </text>
                 <box flexDirection="row" gap={1} flexShrink={0}>


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Files listed under "Modified Files" in the session sidebar are now clickable. Clicking a file opens it with the OS default application for that file type (e.g., VS Code for .ts, browser for .html).

I often review changed files in opencode without having my editor open. Manually navigating to each file is slow -- clicking the file directly in the sidebar is much faster.

Implementation: resolves the project-relative diff path to absolute using the project directory, then opens it via the `open` package (same pattern used by Link for URLs). File names are styled in the primary accent color to indicate clickability, consistent with how links appear elsewhere.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` -- passes cleanly. The pre-push `turbo typecheck` across all packages also passed. Reviewed the data flow: diff file paths are relative to the project directory, `state.path.directory` provides the absolute project root, and the `<Show when={list().length > 0}>` guard ensures the directory is populated before files are rendered.

### Screenshots / recordings

N/A (terminal UI change, visual difference is the file name color changing from muted to primary accent)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR