### PR TITLE
fix(mcp): support native windows shell execution for local servers

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -386,7 +386,13 @@ export const layer = Layer.effect(
       key: string,
       mcp: ConfigMCP.Info & { type: "local" },
     ) {
-      const [cmd, ...args] = mcp.command
+      const [baseCmd, ...baseArgs] = mcp.command
+      const isWin = process.platform === "win32"
+
+      // Inyección nativa del shell para evitar errores de entorno en Windows
+      const cmd = isWin ? "cmd.exe" : baseCmd
+      const args = isWin ? ["/c", baseCmd, ...baseArgs] : baseArgs
+
       const cwd = yield* InstanceState.directory
       const transport = new StdioClientTransport({
         stderr: "pipe",
@@ -395,7 +401,7 @@ export const layer = Layer.effect(
         cwd,
         env: {
           ...process.env,
-          ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
+          ...(baseCmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
           ...mcp.environment,
         },
       })


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them -->
This PR fixes a critical issue on Windows where local MCP servers (like WordPress) fail to connect because `StdioClientTransport` does not invoke a native shell context. 

I modified `packages/opencode/src/mcp/index.ts` to detect `win32` platforms and wrap commands in `cmd.exe /c`. This ensures that environment variables are correctly injected and the child process starts successfully without requiring manual `.bat` workarounds.

## Linked Issues
<!-- Use "Fixes #123" to link the issue -->
Fixes #25904
Resolves #22310, #6994

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] fix: bug fix (non-breaking change which fixes an issue)
- [ ] feat: new feature (non-breaking change which adds functionality)
- [ ] docs: documentation update
- [ ] chore: maintenance tasks

## Logic Changes & Verification
<!-- Explain how you verified the changes. Include screenshots for UI changes if applicable -->
Verified locally on Windows 11 with the following environment:
1. **Setup**: Configured a local WordPress MCP server in `opencode.json` using direct `node` commands.
2. **Execution**: Ran the CLI using `bun run --cwd packages/opencode --conditions=browser src/index.ts mcp list`.
3. **Result**: The server status changed from "failed" to **"connected"**.
4. **Platform Safety**: Verified that the logic is exclusive to `process.platform === "win32"`.

## Checklist
<!-- Review the following and check the boxes that apply -->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] This PR is small, focused, and avoids "AI-generated walls of text".