### PR TITLE
chore: add generation completion sentinels

### DIFF
--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -63,3 +63,4 @@ await $`bun prettier --write src/v2`
 await $`rm -rf dist`
 await $`bun tsc`
 await $`rm openapi.json`
+console.log("opencode sdk js build complete")

--- a/script/generate.ts
+++ b/script/generate.ts
@@ -3,7 +3,11 @@
 import { $ } from "bun"
 
 await $`bun ./packages/sdk/js/script/build.ts`
+console.log("opencode generate: sdk build complete")
 
 await $`bun dev generate > ../sdk/openapi.json`.cwd("packages/opencode")
+console.log("opencode generate: openapi export complete")
 
 await $`./script/format.ts`
+console.log("opencode generate: format complete")
+console.log("opencode generate complete")


### PR DESCRIPTION
### Issue for this PR

Closes #25921

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds small `console.info` completion markers to the generation wrapper scripts so long or truncated runs have a clear success marker. The OpenAPI CLI command remains unchanged for JSON output.

AI Assistance: OpenCode + openai/gpt-5.5. Review: Human operator reviewed.

### How did you verify your code works?

- Ran `env -u OPENCODE_SERVER_PASSWORD -u OPENCODE_SERVER_USERNAME bun ./script/generate.ts` and confirmed `opencode generate complete` appeared.
- Confirmed `packages/sdk/openapi.json` still parses as JSON.
- Ran `git diff --check`.
- Pre-push hook ran `bun turbo typecheck`: 12/12 tasks passed.

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
