### PR TITLE
fix(opencode): only intercept registered local slash commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -30,6 +30,12 @@ export type CommandOption = DialogSelectOption<string> & {
   enabled?: boolean
 }
 
+function matchesSlash(option: CommandOption, name: string) {
+  const slash = option.slash
+  if (!slash) return false
+  return slash.name === name || !!slash.aliases?.includes(name)
+}
+
 function init() {
   const root = getOwner()
   const [registrations, setRegistrations] = createSignal<Accessor<CommandOption[]>[]>([])
@@ -83,6 +89,18 @@ function init() {
           return
         }
       }
+    },
+    hasSlash(name: string) {
+      return entries().some((option) => isVisible(option) && matchesSlash(option, name))
+    },
+    executeSlash(name: string) {
+      for (const option of entries()) {
+        if (!isVisible(option)) continue
+        if (!matchesSlash(option, name)) continue
+        option.onSelect?.(dialog)
+        return true
+      }
+      return false
     },
     slashes() {
       return visibleOptions().flatMap((option) => {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -20,6 +20,7 @@ import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { computePromptTraits } from "./traits"
 import { assign } from "./part"
+import { getLocalSlashCommand } from "./slash"
 import { usePromptStash } from "./stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
@@ -825,6 +826,17 @@ export function Prompt(props: PromptProps) {
     const trimmed = store.prompt.input.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       void exit()
+      return true
+    }
+    const localSlash = getLocalSlashCommand(store.prompt.input, command.hasSlash)
+    if (localSlash && command.executeSlash(localSlash)) {
+      input.extmarks.clear()
+      input.clear()
+      setStore("prompt", {
+        input: "",
+        parts: [],
+      })
+      setStore("extmarkToPartIndex", new Map())
       return true
     }
     const selectedModel = local.model.current()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/slash.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/slash.ts
@@ -1,0 +1,10 @@
+export function getLocalSlashCommand(input: string, hasSlash: (name: string) => boolean) {
+  const trimmed = input.trim()
+  if (!trimmed.startsWith("/")) return
+  if (trimmed.includes(" ") || trimmed.includes("\n")) return
+
+  const name = trimmed.slice(1)
+  if (!name) return
+
+  return hasSlash(name) ? name : undefined
+}

--- a/packages/opencode/test/cli/cmd/tui/prompt-slash.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-slash.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { getLocalSlashCommand } from "../../../../src/cli/cmd/tui/component/prompt/slash"
+
+describe("getLocalSlashCommand", () => {
+  test("returns a standalone local slash command name", () => {
+    expect(getLocalSlashCommand("  /spec  ", (name) => name === "spec")).toBe("spec")
+  })
+
+  test("does not intercept unknown standalone slash commands", () => {
+    expect(getLocalSlashCommand("/review", () => false)).toBeUndefined()
+  })
+
+  test("does not intercept slash commands with arguments or multiline content", () => {
+    const hasSlash = () => true
+
+    expect(getLocalSlashCommand("/spec draft", hasSlash)).toBeUndefined()
+    expect(getLocalSlashCommand("/spec\ndraft", hasSlash)).toBeUndefined()
+  })
+
+  test("does not intercept bare slashes or regular text", () => {
+    const hasSlash = () => true
+
+    expect(getLocalSlashCommand("/", hasSlash)).toBeUndefined()
+    expect(getLocalSlashCommand("spec", hasSlash)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #25932

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Standalone local slash execution should only run when the typed slash command matches a registered local TUI slash command. Before this change, a single-token command like /review could be consumed by the local slash path, which cleared the prompt and skipped the normal command handling. This change adds an explicit registered-slash check before intercepting the prompt and keeps the existing command flow for non-local slash commands.

### How did you verify your code works?

- bun test ./test/cli/cmd/tui/prompt-slash.test.ts
- bun test ./test/session/prompt.test.ts
- bun typecheck
- git push hook also ran bun turbo typecheck

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR