### PR TITLE
Merge: 

### DIFF
--- a/packages/app/src/components/dialog-select-mcp.tsx
+++ b/packages/app/src/components/dialog-select-mcp.tsx
@@ -7,6 +7,7 @@ import { List } from "@opencode-ai/ui/list"
 import { Switch } from "@opencode-ai/ui/switch"
 import { useLanguage } from "@/context/language"
 import { loadMcpQuery } from "@/context/global-sync"
+import { directoryKey } from "@/context/global-sync/utils"
 
 const statusLabels = {
   connected: "mcp.status.connected",
@@ -32,7 +33,7 @@ export const DialogSelectMcp: Component = () => {
       if (sync.data.mcp[name]?.status === "connected") await sdk.client.mcp.disconnect({ name })
       else await sdk.client.mcp.connect({ name })
     },
-    onSuccess: () => queryClient.refetchQueries({ queryKey: loadMcpQuery(sync.directory).queryKey }),
+    onSuccess: () => queryClient.refetchQueries({ queryKey: loadMcpQuery(directoryKey(sync.directory)).queryKey }),
   }))
 
   const enabledCount = createMemo(() => items().filter((i) => i.status === "connected").length)

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -16,6 +16,7 @@ import { normalizeServerUrl, ServerConnection, useServer } from "@/context/serve
 import { useSync } from "@/context/sync"
 import { useCheckServerHealth, type ServerHealth } from "@/utils/server-health"
 import { loadMcpQuery } from "@/context/global-sync"
+import { directoryKey } from "@/context/global-sync/utils"
 
 const pollMs = 10_000
 
@@ -145,7 +146,7 @@ const useMcpToggleMutation = () => {
       const status = sync.data.mcp[name]
       await (status?.status === "connected" ? sdk.client.mcp.disconnect({ name }) : sdk.client.mcp.connect({ name }))
     },
-    onSuccess: () => queryClient.refetchQueries({ queryKey: loadMcpQuery(sync.directory).queryKey }),
+    onSuccess: () => queryClient.refetchQueries({ queryKey: loadMcpQuery(directoryKey(sync.directory)).queryKey }),
     onError: (err) => {
       showToast({
         variant: "error",

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -16,7 +16,7 @@ import { retry } from "@opencode-ai/core/util/retry"
 import { batch } from "solid-js"
 import { reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import type { State, VcsCache } from "./types"
-import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
+import { cmp, directoryKey, normalizeAgentList, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
 import { QueryClient, queryOptions, skipToken } from "@tanstack/solid-query"
 import { loadMcpQuery } from "../global-sync"
@@ -256,6 +256,7 @@ export async function bootstrapDirectory(input: {
   queryClient: QueryClient
 }) {
   const loading = input.store.status !== "complete"
+  const key = directoryKey(input.directory)
   const seededProject = projectID(input.directory, input.global.project)
   const seededPath = input.global.path.directory === input.directory ? input.global.path : undefined
   if (seededProject) input.setStore("project", seededProject)
@@ -272,7 +273,7 @@ export async function bootstrapDirectory(input: {
       () => Promise.resolve(input.loadSessions(input.directory)),
       () =>
         input.queryClient.ensureQueryData(
-          loadAgentsQuery(input.directory, input.sdk, (x) => input.setStore("agent", normalizeAgentList(x.data))),
+          loadAgentsQuery(key, input.sdk, (x) => input.setStore("agent", normalizeAgentList(x.data))),
         ),
       () =>
         retry(() => input.sdk.config.get().then((x) => input.setStore("config", reconcile(x.data!, { merge: false })))),
@@ -282,7 +283,7 @@ export async function bootstrapDirectory(input: {
       !seededPath &&
         (() =>
           input.queryClient.ensureQueryData(
-            loadPathQuery(input.directory, input.sdk, (x) => {
+            loadPathQuery(key, input.sdk, (x) => {
               const next = projectID(x.data?.directory ?? input.directory, input.global.project)
               if (next) input.setStore("project", next)
             }),
@@ -349,9 +350,9 @@ export async function bootstrapDirectory(input: {
           }),
         ),
       () => Promise.resolve(input.loadSessions(input.directory)),
-      () => input.queryClient.fetchQuery(loadMcpQuery(input.directory, input.sdk)),
+      () => input.queryClient.fetchQuery(loadMcpQuery(key, input.sdk)),
       () =>
-        input.queryClient.fetchQuery(loadProvidersQuery(input.directory, input.sdk)).catch((err) => {
+        input.queryClient.fetchQuery(loadProvidersQuery(key, input.sdk)).catch((err) => {
           const project = getFilename(input.directory)
           showToast({
             variant: "error",

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -36,8 +36,8 @@ describe("normalizeAgentList", () => {
 
 describe("directoryKey", () => {
   test("normalizes slashes", () => {
-    expect(String(directoryKey("C:\\Repos\\sst\\opencode"))).toBe("C:/Repos/sst/opencode")
-    expect(String(directoryKey("C:/Repos/sst/opencode"))).toBe("C:/Repos/sst/opencode")
+    expect(String(directoryKey("C:\\Repos\\sst\\opencode"))).toBe("c:/repos/sst/opencode")
+    expect(String(directoryKey("C:/Repos/sst/opencode"))).toBe("c:/repos/sst/opencode")
   })
 
   test("preserves backslashes in posix paths", () => {

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -105,15 +105,15 @@ describe("layout deep links", () => {
 describe("layout workspace helpers", () => {
   test("normalizes trailing slash in workspace key", () => {
     expect(String(pathKey("/tmp/demo///"))).toBe("/tmp/demo")
-    expect(String(pathKey("C:\\tmp\\demo\\\\"))).toBe("C:/tmp/demo")
+    expect(String(pathKey("C:\\tmp\\demo\\\\"))).toBe("c:/tmp/demo")
   })
 
   test("preserves posix and drive roots in workspace key", () => {
     expect(String(pathKey("/"))).toBe("/")
     expect(String(pathKey("///"))).toBe("/")
-    expect(String(pathKey("C:\\"))).toBe("C:/")
-    expect(String(pathKey("C://"))).toBe("C:/")
-    expect(String(pathKey("C:///"))).toBe("C:/")
+    expect(String(pathKey("C:\\"))).toBe("c:/")
+    expect(String(pathKey("C://"))).toBe("c:/")
+    expect(String(pathKey("C:///"))).toBe("c:/")
   })
 
   test("keeps local first while preserving known order", () => {

--- a/packages/app/src/utils/path-key.ts
+++ b/packages/app/src/utils/path-key.ts
@@ -16,7 +16,7 @@ const trimTrailingSlashes = (value: string) => {
 const isWindowsPath = (value: string) => value[1] === ":" || value.startsWith("\\\\")
 
 export const pathKey = (path: string) => {
-  const value = isWindowsPath(path) ? path.replaceAll("\\", "/") : path
+  const value = isWindowsPath(path) ? path.replaceAll("\\", "/").toLowerCase() : path
   const trimmed = trimTrailingSlashes(value)
   if (!trimmed && value.startsWith("/")) return "/" as PathKey
   if (isDrive(trimmed)) return `${trimmed}/` as PathKey


### PR DESCRIPTION
### Issue for this PR

Closes #25928

### Type of change

- [x ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

the same logic how the directory is used to load settings should be used in different locations.
Otherwise different locations calculate the path different.  One part is using \ a other / and then there is the difference with lower/upper case. 

As a result of this an mcp could no longer be activated or disabled for the current session.


### How did you verify your code works?
I build the Exe for OpenCode Desktop on Windows and tested the mcp toggle. 
I have not yet test the complete OpenCode Desktop app nore do I think I'm using all parts of the app.
So I would be happy if someone could verify the change. 

### Screenshots / recordings
no ui change

### Checklist

- [ x] I have tested my changes locally
- [ x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
