### PR TITLE
feat(tui): add width_method config option for ZWJ emoji handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -74,6 +74,7 @@ function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   return {
     externalOutputMode: "passthrough",
     targetFps: 60,
+    widthMethod: _config.width_method,
     gatherStats: false,
     exitOnCtrlC: false,
     useKittyKeyboard: {},

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -24,6 +24,12 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
+  width_method: z
+    .enum(["unicode", "wcwidth", "no_zwj"])
+    .optional()
+    .describe(
+      "Character width calculation method. Use 'no_zwj' if ZWJ emoji sequences cause layout corruption in your terminal (common with tmux and older terminals). Default: 'unicode'",
+    ),
 })
 
 export const TuiInfo = z


### PR DESCRIPTION
### Issue for this PR

Closes #6210

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ZWJ emoji sequences (👩‍🚀 👨‍👩‍👧 🏳️‍🌈) corrupt terminal layout when the terminal doesn't render them as joined glyphs. tmux is the big one — text after a ZWJ sequence shifts across the screen, wraps wrong, and input box spacing breaks.

OpenTUI's Zig layer already has a `no_zwj` width mode that handles this correctly. It was already implemented, already tested. It just wasn't reachable from TypeScript. anomalyco/opentui#751 wires that up. This PR is the OpenCode side: a single config option that passes the user's preference through to the `render()` call.

Two files changed:
- `tui-schema.ts`: adds `width_method` to `TuiOptions` (`"unicode" | "wcwidth" | "no_zwj"`, optional)
- `app.tsx`: passes `_config.width_method` to `rendererConfig()`

Users add one line to their `opencode.json`:

```jsonc
{
  "tui": {
    "width_method": "no_zwj"
  }
}
```

No default changes. Anyone not setting this gets identical behavior to today.

**Note**: depends on anomalyco/opentui#751. That PR's review feedback has been addressed and it's waiting on merge. Happy to wait, or if you want to merge this speculatively while that lands, the worst case is a no-op until opentui is bumped.

### How did you verify your code works?

Ran OpenCode in a tmux split with the `no_zwj` config set. Family emoji and profession emoji that previously shifted subsequent text now render as split glyphs (👩 + 🚀 instead of 👩‍🚀) — visually imperfect, but correctly laid out. Terminals that do render ZWJ correctly can leave this unset and see no change.

### Screenshots / recordings

_No UI change visible without a terminal that exhibits the corruption. The fix is the absence of the corruption._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR