### PR TITLE
fix(server): emit keep-alive newlines during /session/:id/message

### DIFF
--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -848,8 +848,26 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async (stream) => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
-          stream.write(JSON.stringify(msg))
+
+          // Long synchronous tool calls (large `kubectl` queries, multi-step
+          // git ops, etc.) can hold the response stream silent for many
+          // minutes while `SessionPrompt.prompt` runs. HTTP clients with
+          // finite per-recv timeouts (httpx defaults to 5s; some downstream
+          // workflow runners cap at minutes-to-hours) hit ReadTimeout before
+          // any byte is sent. Emit a periodic newline so the connection
+          // produces traffic; the response stays application/json because
+          // JSON parsers ignore leading whitespace before a value.
+          const keepalive = setInterval(() => {
+            stream.write("\n").catch(() => {})
+          }, 30_000)
+
+          try {
+            const msg = await SessionPrompt.prompt({ ...body, sessionID })
+            clearInterval(keepalive)
+            await stream.write(JSON.stringify(msg))
+          } finally {
+            clearInterval(keepalive)
+          }
         })
       },
     )


### PR DESCRIPTION
## Problem

The `POST /session/:sessionID/message` handler awaits `SessionPrompt.prompt()` to fully complete before writing any byte to the response stream:

```ts
return stream(c, async (stream) => {
  const sessionID = c.req.valid("param").sessionID
  const body = c.req.valid("json")
  const msg = await SessionPrompt.prompt({ ...body, sessionID })  // can take 60+ minutes
  stream.write(JSON.stringify(msg))                                // first write happens here
})
```

For long synchronous tool calls (large `kubectl get events -A`, multi-step `gh pr create` flows, anything that produces no streaming bus events between LLM calls), the wait can exceed many minutes during which **no application bytes flow on the response stream**. The TCP connection stays open with no traffic.

HTTP clients with finite per-recv timeouts then `ReadTimeout` before any byte arrives. We hit this in production with a downstream workflow runner using httpx; the failure stack lands in `_receive_response_headers`:

```
httpcore/_async/http11.py:177  in _receive_response_headers
ApplicationFailureInfo: ReadTimeout
duration: 3604s  (matches the client's read=3600 ceiling)
```

Failures were 100% reproducible on hourly cluster-health agent runs.

## Fix

Emit a `\n` keep-alive every 30s on the response stream while `SessionPrompt.prompt` runs. The response stays valid `application/json` because JSON parsers ignore leading whitespace before a value (verified via `JSON.parse("\n\n\n{...}")` and Python `json.loads(b"\n\n\n{...}")`).

```ts
const keepalive = setInterval(() => {
  stream.write("\n").catch(() => {})
}, 30_000)

try {
  const msg = await SessionPrompt.prompt({ ...body, sessionID })
  clearInterval(keepalive)
  await stream.write(JSON.stringify(msg))
} finally {
  clearInterval(keepalive)
}
```

`clearInterval` runs before the JSON body write so no keep-alive newline can interleave between bytes of the JSON value. The `finally` block covers the throw path.

## Scope

- Only `POST /session/:sessionID/message` is changed. The sibling `/command` and `/shell` endpoints use `c.json(msg)` (non-streaming), which is a different code path with different semantics — left alone here to keep the diff minimal. If they hit the same problem in practice they can be migrated in a follow-up.
- The hey-api-generated TypeScript SDK consumes the response with `response.json()`, which calls `JSON.parse(text)` and tolerates leading whitespace. No SDK change needed.
- `application/json` content-type header is preserved; clients expecting a strict JSON byte stream still get a parseable body.

## Test plan

- [x] `bun turbo typecheck --filter=opencode` passes
- [ ] (reviewer) verify a long-running prompt no longer triggers ReadTimeout in clients with a 3600s recv ceiling
- [ ] (reviewer) verify the existing JS SDK / TUI / desktop clients still parse the response correctly (expected: yes, they read the full body and JSON.parse it)