### PR TITLE
fix(opencode): recover malformed GLM/NVIDIA tool calls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -641,6 +641,7 @@
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "@npmcli/agent@4.0.0": "patches/@npmcli%2Fagent@4.0.0.patch",
+    "@ai-sdk/openai-compatible@2.0.41": "patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch",
   },
   "overrides": {
     "@types/bun": "catalog:",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@types/node": "catalog:"
   },
   "patchedDependencies": {
+    "@ai-sdk/openai-compatible@2.0.41": "patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch",
     "@npmcli/agent@4.0.0": "patches/@npmcli%2Fagent@4.0.0.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch"

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -538,10 +538,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                 const index = toolCallDelta.index
 
                 if (toolCalls[index] == null) {
-                  if (toolCallDelta.id == null) {
-                    toolCallDelta.id = generateId()
-                    console.warn(`[openai-compatible] Tool call missing 'id', generated fallback: ${toolCallDelta.id}`)
-                  }
+                  const toolCallId = toolCallDelta.id ?? generateId()
 
                   if (toolCallDelta.function?.name == null) {
                     throw new InvalidResponseDataError({
@@ -552,12 +549,12 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
                   controller.enqueue({
                     type: "tool-input-start",
-                    id: toolCallDelta.id,
+                    id: toolCallId,
                     toolName: toolCallDelta.function.name,
                   })
 
                   toolCalls[index] = {
-                    id: toolCallDelta.id,
+                    id: toolCallId,
                     type: "function",
                     function: {
                       name: toolCallDelta.function.name,

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -539,10 +539,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
                 if (toolCalls[index] == null) {
                   if (toolCallDelta.id == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'id' to be a string.`,
-                    })
+                    toolCallDelta.id = generateId()
+                    console.warn(`[openai-compatible] Tool call missing 'id', generated fallback: ${toolCallDelta.id}`)
                   }
 
                   if (toolCallDelta.function?.name == null) {

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -337,6 +337,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       }
       hasFinished: boolean
     }> = []
+    const pendingToolCallIds: Record<number, string> = {}
 
     let finishReason: {
       unified: ReturnType<typeof mapOpenAICompatibleFinishReason>
@@ -538,14 +539,14 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                 const index = toolCallDelta.index
 
                 if (toolCalls[index] == null) {
-                  const toolCallId = toolCallDelta.id ?? generateId()
+                  const toolCallId = toolCallDelta.id ?? pendingToolCallIds[index] ?? generateId()
 
                   if (toolCallDelta.function?.name == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'function.name' to be a string.`,
-                    })
+                    pendingToolCallIds[index] = toolCallId
+                    continue
                   }
+
+                  delete pendingToolCallIds[index]
 
                   controller.enqueue({
                     type: "tool-input-start",

--- a/packages/opencode/test/provider/copilot/openai-compatible-tool-call-id-fallback.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-compatible-tool-call-id-fallback.test.ts
@@ -16,19 +16,27 @@ async function convertReadableStreamToArray<T>(stream: ReadableStream<T>): Promi
 const TEST_PROMPT: LanguageModelV3Prompt = [{ role: "user", content: [{ type: "text", text: "Hello" }] }]
 
 const FIXTURES = {
+  // Provider omits 'id' (NVIDIA/Kimi K2.5 style). Arguments arrive in two chunks to
+  // exercise the accumulation path — the first chunk has an empty arguments string so
+  // isParsableJson doesn't prematurely finalise the call.
   toolCallMissingId: [
-    `data: {"id":"chatcmpl-nvidia-1","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"name":"recall_memories","arguments":"{}"}}]},"finish_reason":null}]}`,
-    `data: {"id":"chatcmpl-nvidia-1","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\":\\"test\\"}"}}]},"finish_reason":"tool_calls"}]}`,
+    `data: {"id":"chatcmpl-nvidia-1","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"name":"recall_memories","arguments":""}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-nvidia-1","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\""}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-nvidia-1","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\\"test\\"}"}}]},"finish_reason":"tool_calls"}]}`,
     `data: [DONE]`,
   ],
+  // Provider includes 'id' — existing IDs must be preserved verbatim.
   toolCallWithId: [
-    `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"id":"call_abc123","index":0,"function":{"name":"recall_memories","arguments":"{}"}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"id":"call_abc123","index":0,"function":{"name":"recall_memories","arguments":""}}]},"finish_reason":null}]}`,
     `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_abc123","index":0,"function":{"arguments":"{\\"query\\":\\"test\\"}"}}]},"finish_reason":"tool_calls"}]}`,
     `data: [DONE]`,
   ],
+  // Two parallel tool calls, both missing 'id'. Each must get a distinct fallback and
+  // accumulate its own arguments correctly.
   multipleToolCallsMissingId: [
-    `data: {"id":"chatcmpl-nvidia-2","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"name":"recall_memories","arguments":"{}"}},{"index":1,"function":{"name":"add_memory","arguments":"{}"}}]},"finish_reason":null}]}`,
-    `data: {"id":"chatcmpl-nvidia-2","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\":\\"test\\"}"}},{"index":1,"function":{"arguments":"{\\"text\\":\\"hello\\"}"}}]},"finish_reason":"tool_calls"}]}`,
+    `data: {"id":"chatcmpl-nvidia-2","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"name":"recall_memories","arguments":""}},{"index":1,"function":{"name":"add_memory","arguments":""}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-nvidia-2","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\""}},{"index":1,"function":{"arguments":"{\\"text\\""}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-nvidia-2","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\\"test\\"}"}},{"index":1,"function":{"arguments":":\\"hello\\"}"}}]},"finish_reason":"tool_calls"}]}`,
     `data: [DONE]`,
   ],
 }
@@ -71,20 +79,20 @@ describe("tool call ID fallback", () => {
 
     const parts = await convertReadableStreamToArray(stream)
 
-    const toolParts = parts.filter(
-      (p) => p.type === "tool-input-start" || p.type === "tool-call" || p.type === "tool-input-end",
-    )
-
-    const toolInputStart = toolParts.find((p) => p.type === "tool-input-start")
+    const toolInputStart = parts.find((p) => p.type === "tool-input-start")
     expect(toolInputStart).toBeDefined()
     expect((toolInputStart as { id: string }).id).toBeTruthy()
 
-    const toolCall = toolParts.find((p) => p.type === "tool-call")
+    const toolCall = parts.find((p) => p.type === "tool-call")
     expect(toolCall).toMatchObject({
       type: "tool-call",
       toolName: "recall_memories",
+      input: '{"query":"test"}',
     })
     expect((toolCall as { toolCallId: string }).toolCallId).toBeTruthy()
+
+    // fallback ID must be consistent across tool-input-start and tool-call
+    expect((toolInputStart as { id: string }).id).toBe((toolCall as { toolCallId: string }).toolCallId)
 
     const finish = parts.find((p) => p.type === "finish")
     expect(finish).toMatchObject({
@@ -104,22 +112,19 @@ describe("tool call ID fallback", () => {
 
     const parts = await convertReadableStreamToArray(stream)
 
-    const toolParts = parts.filter(
-      (p) => p.type === "tool-input-start" || p.type === "tool-call" || p.type === "tool-input-end",
-    )
-
-    const toolInputStart = toolParts.find((p) => p.type === "tool-input-start")
+    const toolInputStart = parts.find((p) => p.type === "tool-input-start")
     expect(toolInputStart).toEqual({
       type: "tool-input-start",
       id: "call_abc123",
       toolName: "recall_memories",
     })
 
-    const toolCall = toolParts.find((p) => p.type === "tool-call")
+    const toolCall = parts.find((p) => p.type === "tool-call")
     expect(toolCall).toMatchObject({
       type: "tool-call",
       toolCallId: "call_abc123",
       toolName: "recall_memories",
+      input: '{"query":"test"}',
     })
   })
 
@@ -145,9 +150,21 @@ describe("tool call ID fallback", () => {
     const toolCalls = parts.filter((p) => p.type === "tool-call")
     expect(toolCalls).toHaveLength(2)
 
-    const toolNames = toolCalls.map((p) => (p as { toolName: string }).toolName)
-    expect(toolNames).toContain("recall_memories")
-    expect(toolNames).toContain("add_memory")
+    const recallCall = toolCalls.find((p) => (p as { toolName: string }).toolName === "recall_memories")
+    expect(recallCall).toMatchObject({
+      type: "tool-call",
+      toolName: "recall_memories",
+      input: '{"query":"test"}',
+    })
+    expect((recallCall as { toolCallId: string }).toolCallId).toBeTruthy()
+
+    const addCall = toolCalls.find((p) => (p as { toolName: string }).toolName === "add_memory")
+    expect(addCall).toMatchObject({
+      type: "tool-call",
+      toolName: "add_memory",
+      input: '{"text":"hello"}',
+    })
+    expect((addCall as { toolCallId: string }).toolCallId).toBeTruthy()
 
     const finish = parts.find((p) => p.type === "finish")
     expect(finish).toMatchObject({

--- a/packages/opencode/test/provider/copilot/openai-compatible-tool-call-id-fallback.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-compatible-tool-call-id-fallback.test.ts
@@ -1,0 +1,158 @@
+import { OpenAICompatibleChatLanguageModel } from "@/provider/sdk/copilot/chat/openai-compatible-chat-language-model"
+import { describe, test, expect, mock } from "bun:test"
+import type { LanguageModelV3Prompt } from "@ai-sdk/provider"
+
+async function convertReadableStreamToArray<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader()
+  const result: T[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result.push(value)
+  }
+  return result
+}
+
+const TEST_PROMPT: LanguageModelV3Prompt = [{ role: "user", content: [{ type: "text", text: "Hello" }] }]
+
+const FIXTURES = {
+  toolCallMissingId: [
+    `data: {"id":"chatcmpl-nvidia-1","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"name":"recall_memories","arguments":"{}"}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-nvidia-1","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\":\\"test\\"}"}}]},"finish_reason":"tool_calls"}]}`,
+    `data: [DONE]`,
+  ],
+  toolCallWithId: [
+    `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"id":"call_abc123","index":0,"function":{"name":"recall_memories","arguments":"{}"}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_abc123","index":0,"function":{"arguments":"{\\"query\\":\\"test\\"}"}}]},"finish_reason":"tool_calls"}]}`,
+    `data: [DONE]`,
+  ],
+  multipleToolCallsMissingId: [
+    `data: {"id":"chatcmpl-nvidia-2","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"function":{"name":"recall_memories","arguments":"{}"}},{"index":1,"function":{"name":"add_memory","arguments":"{}"}}]},"finish_reason":null}]}`,
+    `data: {"id":"chatcmpl-nvidia-2","object":"chat.completion.chunk","created":1677652288,"model":"moonshotai/kimi-k2.5","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\":\\"test\\"}"}},{"index":1,"function":{"arguments":"{\\"text\\":\\"hello\\"}"}}]},"finish_reason":"tool_calls"}]}`,
+    `data: [DONE]`,
+  ],
+}
+
+function createMockFetch(chunks: string[]) {
+  return mock(async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(new TextEncoder().encode(chunk + "\n\n"))
+        }
+        controller.close()
+      },
+    })
+    return new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    })
+  })
+}
+
+function createModel(fetchFn: ReturnType<typeof mock>) {
+  return new OpenAICompatibleChatLanguageModel("test-model", {
+    provider: "copilot.chat",
+    url: () => "https://api.test.com/chat/completions",
+    headers: () => ({ Authorization: "Bearer test-token" }),
+    fetch: fetchFn as any,
+  })
+}
+
+describe("tool call ID fallback", () => {
+  test("should generate fallback ID when streaming tool call is missing id field", async () => {
+    const mockFetch = createMockFetch(FIXTURES.toolCallMissingId)
+    const model = createModel(mockFetch)
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+
+    const toolParts = parts.filter(
+      (p) => p.type === "tool-input-start" || p.type === "tool-call" || p.type === "tool-input-end",
+    )
+
+    const toolInputStart = toolParts.find((p) => p.type === "tool-input-start")
+    expect(toolInputStart).toBeDefined()
+    expect((toolInputStart as { id: string }).id).toBeTruthy()
+
+    const toolCall = toolParts.find((p) => p.type === "tool-call")
+    expect(toolCall).toMatchObject({
+      type: "tool-call",
+      toolName: "recall_memories",
+    })
+    expect((toolCall as { toolCallId: string }).toolCallId).toBeTruthy()
+
+    const finish = parts.find((p) => p.type === "finish")
+    expect(finish).toMatchObject({
+      type: "finish",
+      finishReason: { unified: "tool-calls" },
+    })
+  })
+
+  test("should preserve real id when provider includes it", async () => {
+    const mockFetch = createMockFetch(FIXTURES.toolCallWithId)
+    const model = createModel(mockFetch)
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+
+    const toolParts = parts.filter(
+      (p) => p.type === "tool-input-start" || p.type === "tool-call" || p.type === "tool-input-end",
+    )
+
+    const toolInputStart = toolParts.find((p) => p.type === "tool-input-start")
+    expect(toolInputStart).toEqual({
+      type: "tool-input-start",
+      id: "call_abc123",
+      toolName: "recall_memories",
+    })
+
+    const toolCall = toolParts.find((p) => p.type === "tool-call")
+    expect(toolCall).toMatchObject({
+      type: "tool-call",
+      toolCallId: "call_abc123",
+      toolName: "recall_memories",
+    })
+  })
+
+  test("should generate unique fallback IDs for multiple tool calls missing id", async () => {
+    const mockFetch = createMockFetch(FIXTURES.multipleToolCallsMissingId)
+    const model = createModel(mockFetch)
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+
+    const toolInputStarts = parts.filter((p) => p.type === "tool-input-start")
+    expect(toolInputStarts).toHaveLength(2)
+
+    const ids = toolInputStarts.map((p) => (p as { id: string }).id)
+    expect(ids[0]).toBeTruthy()
+    expect(ids[1]).toBeTruthy()
+    expect(ids[0]).not.toBe(ids[1])
+
+    const toolCalls = parts.filter((p) => p.type === "tool-call")
+    expect(toolCalls).toHaveLength(2)
+
+    const toolNames = toolCalls.map((p) => (p as { toolName: string }).toolName)
+    expect(toolNames).toContain("recall_memories")
+    expect(toolNames).toContain("add_memory")
+
+    const finish = parts.find((p) => p.type === "finish")
+    expect(finish).toMatchObject({
+      type: "finish",
+      finishReason: { unified: "tool-calls" },
+    })
+  })
+})

--- a/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
+++ b/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
@@ -1,61 +1,87 @@
-diff --git a/dist/index.mjs b/dist/index.mjs
-index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..1f8e7373ce03910cd5bfe7540ec189e63e182898 100644
---- a/dist/index.mjs
-+++ b/dist/index.mjs
-@@ -653,6 +653,7 @@
-       fetch: this.config.fetch
-     });
-     const toolCalls = [];
-+    const pendingToolCallIds = {};
-     let finishReason = {
-       unified: "other",
-       raw: void 0
-@@ -753,25 +754,19 @@
-               for (const toolCallDelta of delta.tool_calls) {
-                 const index = (_c = toolCallDelta.index) != null ? _c : toolCalls.length;
-                 if (toolCalls[index] == null) {
--                  if (toolCallDelta.id == null) {
--                    throw new InvalidResponseDataError({
--                      data: toolCallDelta,
--                      message: `Expected 'id' to be a string.`
--                    });
--                  }
-+                  const toolCallId = toolCallDelta.id ?? pendingToolCallIds[index] ?? generateId();
-                   if (((_d = toolCallDelta.function) == null ? void 0 : _d.name) == null) {
--                    throw new InvalidResponseDataError({
--                      data: toolCallDelta,
--                      message: `Expected 'function.name' to be a string.`
--                    });
-+                    pendingToolCallIds[index] = toolCallId;
-+                    continue;
-                   }
-+                  delete pendingToolCallIds[index];
-                   controller.enqueue({
-                     type: "tool-input-start",
--                    id: toolCallDelta.id,
-+                    id: toolCallId,
-                     toolName: toolCallDelta.function.name
-                   });
-                   toolCalls[index] = {
--                    id: toolCallDelta.id,
-+                    id: toolCallId,
-                     type: "function",
-                     function: {
-                       name: toolCallDelta.function.name,
 diff --git a/dist/index.js b/dist/index.js
-index dca128d3a790378c51a24a16d92585178343b278..7388637b492b0ea3c376be8d1253add8ae7f4d5f 100644
+index 168bec7..19170c6 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -666,6 +666,7 @@
-       fetch: this.config.fetch
+@@ -611,6 +611,14 @@ var OpenAICompatibleChatLanguageModel = class {
+         });
+       }
+     }
++    if (choice.message.function_call != null && choice.message.tool_calls == null) {
++      content.push({
++        type: "tool-call",
++        toolCallId: (0, import_provider_utils2.generateId)(),
++        toolName: choice.message.function_call.name,
++        input: choice.message.function_call.arguments
++      });
++    }
+     const providerMetadata = {
+       [metadataKey]: {},
+       ...await ((_f = (_e = this.config.metadataExtractor) == null ? void 0 : _e.extractMetadata) == null ? void 0 : _f.call(_e, {
+@@ -644,6 +652,14 @@ var OpenAICompatibleChatLanguageModel = class {
+   async doStream(options) {
+     var _a;
+     const { args, warnings, metadataKey } = await this.getArgs({ ...options });
++    const requestUrl = this.config.url({
++      path: "/chat/completions",
++      modelId: this.modelId
++    });
++    const requestHeaders = (0, import_provider_utils2.combineHeaders)(this.config.headers(), options.headers);
++    const fallbackBody = this.transformRequestBody({
++      ...args
++    });
+     const body = this.transformRequestBody({
+       ...args,
+       stream: true,
+@@ -651,21 +667,22 @@ var OpenAICompatibleChatLanguageModel = class {
+       stream_options: this.config.includeUsage ? { include_usage: true } : void 0
+     });
+     const metadataExtractor = (_a = this.config.metadataExtractor) == null ? void 0 : _a.createStreamExtractor();
++    const failedResponseHandler = this.failedResponseHandler;
++    const fetch = this.config.fetch;
+     const { responseHeaders, value: response } = await (0, import_provider_utils2.postJsonToApi)({
+-      url: this.config.url({
+-        path: "/chat/completions",
+-        modelId: this.modelId
+-      }),
+-      headers: (0, import_provider_utils2.combineHeaders)(this.config.headers(), options.headers),
++      url: requestUrl,
++      headers: requestHeaders,
+       body,
+-      failedResponseHandler: this.failedResponseHandler,
++      failedResponseHandler,
+       successfulResponseHandler: (0, import_provider_utils2.createEventSourceResponseHandler)(
+         this.chunkSchema
+       ),
+       abortSignal: options.abortSignal,
+-      fetch: this.config.fetch
++      fetch
      });
      const toolCalls = [];
 +    const pendingToolCallIds = {};
++    let sawToolCallStart = false;
      let finishReason = {
        unified: "other",
        raw: void 0
-@@ -766,25 +767,19 @@
-               for (const toolCallDelta of delta.tool_calls) {
+@@ -755,7 +772,12 @@ var OpenAICompatibleChatLanguageModel = class {
+                 delta: delta.content
+               });
+             }
+-            if (delta.tool_calls != null) {
++            const toolCallDeltas = delta.tool_calls ?? (delta.function_call ? [{
++              index: 0,
++              id: void 0,
++              function: delta.function_call
++            }] : void 0);
++            if (toolCallDeltas != null) {
+               if (isActiveReasoning) {
+                 controller.enqueue({
+                   type: "reasoning-end",
+@@ -763,28 +785,23 @@ var OpenAICompatibleChatLanguageModel = class {
+                 });
+                 isActiveReasoning = false;
+               }
+-              for (const toolCallDelta of delta.tool_calls) {
++              for (const toolCallDelta of toolCallDeltas) {
                  const index = (_c = toolCallDelta.index) != null ? _c : toolCalls.length;
                  if (toolCalls[index] == null) {
 -                  if (toolCallDelta.id == null) {
@@ -80,9 +106,293 @@ index dca128d3a790378c51a24a16d92585178343b278..7388637b492b0ea3c376be8d1253add8
 +                    id: toolCallId,
                      toolName: toolCallDelta.function.name
                    });
++                  sawToolCallStart = true;
                    toolCalls[index] = {
 -                    id: toolCallDelta.id,
 +                    id: toolCallId,
                      type: "function",
                      function: {
                        name: toolCallDelta.function.name,
+@@ -860,8 +877,82 @@ var OpenAICompatibleChatLanguageModel = class {
+               }
+             }
+           },
+-          flush(controller) {
++          async flush(controller) {
+             var _a2, _b, _c, _d, _e;
++            if (finishReason.unified === "tool-calls" && !sawToolCallStart) {
++              try {
++                const { value: fallbackResponse } = await (0, import_provider_utils2.postJsonToApi)({
++                  url: requestUrl,
++                  headers: requestHeaders,
++                  body: fallbackBody,
++                  failedResponseHandler,
++                  successfulResponseHandler: (0, import_provider_utils2.createJsonResponseHandler)(
++                    OpenAICompatibleChatResponseSchema
++                  ),
++                  abortSignal: options.abortSignal,
++                  fetch
++                });
++                const fallbackChoice = fallbackResponse.choices[0];
++                const fallbackToolCalls = fallbackChoice.message.tool_calls ?? (fallbackChoice.message.function_call ? [{
++                  id: void 0,
++                  function: fallbackChoice.message.function_call
++                }] : []);
++                if (usage == null && fallbackResponse.usage != null) {
++                  usage = fallbackResponse.usage;
++                }
++                for (const fallbackToolCall of fallbackToolCalls) {
++                  var _f, _g;
++                  const toolName = (_f = fallbackToolCall.function) == null ? void 0 : _f.name;
++                  if (toolName == null) {
++                    continue;
++                  }
++                  const toolCallId = fallbackToolCall.id ?? (0, import_provider_utils2.generateId)();
++                  const input = (_g = fallbackToolCall.function.arguments) != null ? _g : "";
++                  controller.enqueue({
++                    type: "tool-input-start",
++                    id: toolCallId,
++                    toolName
++                  });
++                  if (input.length > 0) {
++                    controller.enqueue({
++                      type: "tool-input-delta",
++                      id: toolCallId,
++                      delta: input
++                    });
++                  }
++                  controller.enqueue({
++                    type: "tool-input-end",
++                    id: toolCallId
++                  });
++                  controller.enqueue({
++                    type: "tool-call",
++                    toolCallId,
++                    toolName,
++                    input
++                  });
++                  sawToolCallStart = true;
++                }
++              } catch (error) {
++                finishReason = {
++                  unified: "error",
++                  raw: "tool_calls_missing_name"
++                };
++                controller.enqueue({
++                  type: "error",
++                  error: error instanceof Error ? error.message : String(error)
++                });
++              }
++              if (!sawToolCallStart) {
++                finishReason = {
++                  unified: "error",
++                  raw: "tool_calls_missing_name"
++                };
++                controller.enqueue({
++                  type: "error",
++                  error: "Provider returned tool_calls without a tool name in streaming or non-stream responses."
++                });
++              }
++            }
+             if (isActiveReasoning) {
+               controller.enqueue({ type: "reasoning-end", id: "reasoning-0" });
+             }
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 1c24da7..e64bf48 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -598,6 +598,14 @@ var OpenAICompatibleChatLanguageModel = class {
+         });
+       }
+     }
++    if (choice.message.function_call != null && choice.message.tool_calls == null) {
++      content.push({
++        type: "tool-call",
++        toolCallId: generateId(),
++        toolName: choice.message.function_call.name,
++        input: choice.message.function_call.arguments
++      });
++    }
+     const providerMetadata = {
+       [metadataKey]: {},
+       ...await ((_f = (_e = this.config.metadataExtractor) == null ? void 0 : _e.extractMetadata) == null ? void 0 : _f.call(_e, {
+@@ -631,6 +639,14 @@ var OpenAICompatibleChatLanguageModel = class {
+   async doStream(options) {
+     var _a;
+     const { args, warnings, metadataKey } = await this.getArgs({ ...options });
++    const requestUrl = this.config.url({
++      path: "/chat/completions",
++      modelId: this.modelId
++    });
++    const requestHeaders = combineHeaders(this.config.headers(), options.headers);
++    const fallbackBody = this.transformRequestBody({
++      ...args
++    });
+     const body = this.transformRequestBody({
+       ...args,
+       stream: true,
+@@ -638,21 +654,22 @@ var OpenAICompatibleChatLanguageModel = class {
+       stream_options: this.config.includeUsage ? { include_usage: true } : void 0
+     });
+     const metadataExtractor = (_a = this.config.metadataExtractor) == null ? void 0 : _a.createStreamExtractor();
++    const failedResponseHandler = this.failedResponseHandler;
++    const fetch = this.config.fetch;
+     const { responseHeaders, value: response } = await postJsonToApi({
+-      url: this.config.url({
+-        path: "/chat/completions",
+-        modelId: this.modelId
+-      }),
+-      headers: combineHeaders(this.config.headers(), options.headers),
++      url: requestUrl,
++      headers: requestHeaders,
+       body,
+-      failedResponseHandler: this.failedResponseHandler,
++      failedResponseHandler,
+       successfulResponseHandler: createEventSourceResponseHandler(
+         this.chunkSchema
+       ),
+       abortSignal: options.abortSignal,
+-      fetch: this.config.fetch
++      fetch
+     });
+     const toolCalls = [];
++    const pendingToolCallIds = {};
++    let sawToolCallStart = false;
+     let finishReason = {
+       unified: "other",
+       raw: void 0
+@@ -742,7 +759,12 @@ var OpenAICompatibleChatLanguageModel = class {
+                 delta: delta.content
+               });
+             }
+-            if (delta.tool_calls != null) {
++            const toolCallDeltas = delta.tool_calls ?? (delta.function_call ? [{
++              index: 0,
++              id: void 0,
++              function: delta.function_call
++            }] : void 0);
++            if (toolCallDeltas != null) {
+               if (isActiveReasoning) {
+                 controller.enqueue({
+                   type: "reasoning-end",
+@@ -750,28 +772,23 @@ var OpenAICompatibleChatLanguageModel = class {
+                 });
+                 isActiveReasoning = false;
+               }
+-              for (const toolCallDelta of delta.tool_calls) {
++              for (const toolCallDelta of toolCallDeltas) {
+                 const index = (_c = toolCallDelta.index) != null ? _c : toolCalls.length;
+                 if (toolCalls[index] == null) {
+-                  if (toolCallDelta.id == null) {
+-                    throw new InvalidResponseDataError({
+-                      data: toolCallDelta,
+-                      message: `Expected 'id' to be a string.`
+-                    });
+-                  }
++                  const toolCallId = toolCallDelta.id ?? pendingToolCallIds[index] ?? generateId();
+                   if (((_d = toolCallDelta.function) == null ? void 0 : _d.name) == null) {
+-                    throw new InvalidResponseDataError({
+-                      data: toolCallDelta,
+-                      message: `Expected 'function.name' to be a string.`
+-                    });
++                    pendingToolCallIds[index] = toolCallId;
++                    continue;
+                   }
++                  delete pendingToolCallIds[index];
+                   controller.enqueue({
+                     type: "tool-input-start",
+-                    id: toolCallDelta.id,
++                    id: toolCallId,
+                     toolName: toolCallDelta.function.name
+                   });
++                  sawToolCallStart = true;
+                   toolCalls[index] = {
+-                    id: toolCallDelta.id,
++                    id: toolCallId,
+                     type: "function",
+                     function: {
+                       name: toolCallDelta.function.name,
+@@ -847,8 +864,82 @@ var OpenAICompatibleChatLanguageModel = class {
+               }
+             }
+           },
+-          flush(controller) {
++          async flush(controller) {
+             var _a2, _b, _c, _d, _e;
++            if (finishReason.unified === "tool-calls" && !sawToolCallStart) {
++              try {
++                const { value: fallbackResponse } = await postJsonToApi({
++                  url: requestUrl,
++                  headers: requestHeaders,
++                  body: fallbackBody,
++                  failedResponseHandler,
++                  successfulResponseHandler: createJsonResponseHandler(
++                    OpenAICompatibleChatResponseSchema
++                  ),
++                  abortSignal: options.abortSignal,
++                  fetch
++                });
++                const fallbackChoice = fallbackResponse.choices[0];
++                const fallbackToolCalls = fallbackChoice.message.tool_calls ?? (fallbackChoice.message.function_call ? [{
++                  id: void 0,
++                  function: fallbackChoice.message.function_call
++                }] : []);
++                if (usage == null && fallbackResponse.usage != null) {
++                  usage = fallbackResponse.usage;
++                }
++                for (const fallbackToolCall of fallbackToolCalls) {
++                  var _f, _g;
++                  const toolName = (_f = fallbackToolCall.function) == null ? void 0 : _f.name;
++                  if (toolName == null) {
++                    continue;
++                  }
++                  const toolCallId = fallbackToolCall.id ?? generateId();
++                  const input = (_g = fallbackToolCall.function.arguments) != null ? _g : "";
++                  controller.enqueue({
++                    type: "tool-input-start",
++                    id: toolCallId,
++                    toolName
++                  });
++                  if (input.length > 0) {
++                    controller.enqueue({
++                      type: "tool-input-delta",
++                      id: toolCallId,
++                      delta: input
++                    });
++                  }
++                  controller.enqueue({
++                    type: "tool-input-end",
++                    id: toolCallId
++                  });
++                  controller.enqueue({
++                    type: "tool-call",
++                    toolCallId,
++                    toolName,
++                    input
++                  });
++                  sawToolCallStart = true;
++                }
++              } catch (error) {
++                finishReason = {
++                  unified: "error",
++                  raw: "tool_calls_missing_name"
++                };
++                controller.enqueue({
++                  type: "error",
++                  error: error instanceof Error ? error.message : String(error)
++                });
++              }
++              if (!sawToolCallStart) {
++                finishReason = {
++                  unified: "error",
++                  raw: "tool_calls_missing_name"
++                };
++                controller.enqueue({
++                  type: "error",
++                  error: "Provider returned tool_calls without a tool name in streaming or non-stream responses."
++                });
++              }
++            }
+             if (isActiveReasoning) {
+               controller.enqueue({ type: "reasoning-end", id: "reasoning-0" });
+             }

--- a/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
+++ b/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
@@ -1,0 +1,64 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..c3cc4cfc431b6f3df93a9329d6dbeb0781191841 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -753,12 +753,7 @@
+               for (const toolCallDelta of delta.tool_calls) {
+                 const index = (_c = toolCallDelta.index) != null ? _c : toolCalls.length;
+                 if (toolCalls[index] == null) {
+-                  if (toolCallDelta.id == null) {
+-                    throw new InvalidResponseDataError({
+-                      data: toolCallDelta,
+-                      message: `Expected 'id' to be a string.`
+-                    });
+-                  }
++                  const toolCallId = toolCallDelta.id ?? generateId();
+                   if (((_d = toolCallDelta.function) == null ? void 0 : _d.name) == null) {
+                     throw new InvalidResponseDataError({
+                       data: toolCallDelta,
+@@ -767,11 +762,11 @@
+                   }
+                   controller.enqueue({
+                     type: "tool-input-start",
+-                    id: toolCallDelta.id,
++                    id: toolCallId,
+                     toolName: toolCallDelta.function.name
+                   });
+                   toolCalls[index] = {
+-                    id: toolCallDelta.id,
++                    id: toolCallId,
+                     type: "function",
+                     function: {
+                       name: toolCallDelta.function.name,
+diff --git a/dist/index.js b/dist/index.js
+index dca128d3a790378c51a24a16d92585178343b278..f5f7b29d7fa9a249e5e1d0108a8de0d0ffa84f32 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -766,12 +766,7 @@
+               for (const toolCallDelta of delta.tool_calls) {
+                 const index = (_c = toolCallDelta.index) != null ? _c : toolCalls.length;
+                 if (toolCalls[index] == null) {
+-                  if (toolCallDelta.id == null) {
+-                    throw new import_provider3.InvalidResponseDataError({
+-                      data: toolCallDelta,
+-                      message: `Expected 'id' to be a string.`
+-                    });
+-                  }
++                  const toolCallId = toolCallDelta.id ?? (0, import_provider_utils2.generateId)();
+                   if (((_d = toolCallDelta.function) == null ? void 0 : _d.name) == null) {
+                     throw new import_provider3.InvalidResponseDataError({
+                       data: toolCallDelta,
+@@ -780,11 +775,11 @@
+                   }
+                   controller.enqueue({
+                     type: "tool-input-start",
+-                    id: toolCallDelta.id,
++                    id: toolCallId,
+                     toolName: toolCallDelta.function.name
+                   });
+                   toolCalls[index] = {
+-                    id: toolCallDelta.id,
++                    id: toolCallId,
+                     type: "function",
+                     function: {
+                       name: toolCallDelta.function.name,

--- a/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
+++ b/patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch
@@ -1,8 +1,16 @@
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..c3cc4cfc431b6f3df93a9329d6dbeb0781191841 100644
+index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..1f8e7373ce03910cd5bfe7540ec189e63e182898 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -753,12 +753,7 @@
+@@ -653,6 +653,7 @@
+       fetch: this.config.fetch
+     });
+     const toolCalls = [];
++    const pendingToolCallIds = {};
+     let finishReason = {
+       unified: "other",
+       raw: void 0
+@@ -753,25 +754,19 @@
                for (const toolCallDelta of delta.tool_calls) {
                  const index = (_c = toolCallDelta.index) != null ? _c : toolCalls.length;
                  if (toolCalls[index] == null) {
@@ -12,12 +20,16 @@ index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..c3cc4cfc431b6f3df93a9329d6dbeb07
 -                      message: `Expected 'id' to be a string.`
 -                    });
 -                  }
-+                  const toolCallId = toolCallDelta.id ?? generateId();
++                  const toolCallId = toolCallDelta.id ?? pendingToolCallIds[index] ?? generateId();
                    if (((_d = toolCallDelta.function) == null ? void 0 : _d.name) == null) {
-                     throw new InvalidResponseDataError({
-                       data: toolCallDelta,
-@@ -767,11 +762,11 @@
+-                    throw new InvalidResponseDataError({
+-                      data: toolCallDelta,
+-                      message: `Expected 'function.name' to be a string.`
+-                    });
++                    pendingToolCallIds[index] = toolCallId;
++                    continue;
                    }
++                  delete pendingToolCallIds[index];
                    controller.enqueue({
                      type: "tool-input-start",
 -                    id: toolCallDelta.id,
@@ -31,10 +43,18 @@ index 3b1e1b6bdec5032e3b4fa5ffbcc8cdf3dfe1cc40..c3cc4cfc431b6f3df93a9329d6dbeb07
                      function: {
                        name: toolCallDelta.function.name,
 diff --git a/dist/index.js b/dist/index.js
-index dca128d3a790378c51a24a16d92585178343b278..f5f7b29d7fa9a249e5e1d0108a8de0d0ffa84f32 100644
+index dca128d3a790378c51a24a16d92585178343b278..7388637b492b0ea3c376be8d1253add8ae7f4d5f 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -766,12 +766,7 @@
+@@ -666,6 +666,7 @@
+       fetch: this.config.fetch
+     });
+     const toolCalls = [];
++    const pendingToolCallIds = {};
+     let finishReason = {
+       unified: "other",
+       raw: void 0
+@@ -766,25 +767,19 @@
                for (const toolCallDelta of delta.tool_calls) {
                  const index = (_c = toolCallDelta.index) != null ? _c : toolCalls.length;
                  if (toolCalls[index] == null) {
@@ -44,12 +64,16 @@ index dca128d3a790378c51a24a16d92585178343b278..f5f7b29d7fa9a249e5e1d0108a8de0d0
 -                      message: `Expected 'id' to be a string.`
 -                    });
 -                  }
-+                  const toolCallId = toolCallDelta.id ?? (0, import_provider_utils2.generateId)();
++                  const toolCallId = toolCallDelta.id ?? pendingToolCallIds[index] ?? (0, import_provider_utils2.generateId)();
                    if (((_d = toolCallDelta.function) == null ? void 0 : _d.name) == null) {
-                     throw new import_provider3.InvalidResponseDataError({
-                       data: toolCallDelta,
-@@ -780,11 +775,11 @@
+-                    throw new import_provider3.InvalidResponseDataError({
+-                      data: toolCallDelta,
+-                      message: `Expected 'function.name' to be a string.`
+-                    });
++                    pendingToolCallIds[index] = toolCallId;
++                    continue;
                    }
++                  delete pendingToolCallIds[index];
                    controller.enqueue({
                      type: "tool-input-start",
 -                    id: toolCallDelta.id,


### PR DESCRIPTION
### Issue for this PR

Closes #25970

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This hardens the `@ai-sdk/openai-compatible` path against malformed tool-call payloads seen from `nvidia/z-ai/glm-5.1`.

It does three things:
- supports legacy `function_call` responses alongside `tool_calls`
- tolerates streamed tool calls that are missing `id` or receive `function.name` later
- if a stream ends with `finish_reason: "tool_calls"` but no usable tool name, performs one non-stream recovery request and then raises a clear error instead of hanging

This keeps the provider bug from turning into a stalled OpenCode session.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode`
- `bun test test/provider/copilot/openai-compatible-tool-call-id-fallback.test.ts --timeout 30000` from `packages/opencode`
- `bun run build -- --single --skip-embed-web-ui` from `packages/opencode`
- Reproduced with `dist/opencode-windows-x64/bin/opencode.exe run --format json --dangerously-skip-permissions -m nvidia/z-ai/glm-5.1 "check your memory"` on build `0.0.0-dev-202605060426`

Notes:
- repo-root `bun typecheck` currently fails in unrelated existing `packages/enterprise/src/custom-elements.d.ts`
- the full `packages/opencode` suite also has existing Windows failures in unrelated PTY/symlink/filesystem tests, but the touched provider test passes

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR