### PR TITLE
fix(desktop): suppress browser API Sentry errors in prod

### DIFF
--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -43,7 +43,11 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     integrations: (integrations) => {
       return integrations.filter(
         (i) =>
-          i.name !== "Breadcrumbs" && !(import.meta.env.OPENCODE_CHANNEL === "prod" && i.name === "GlobalHandlers"),
+          i.name !== "Breadcrumbs" &&
+          !(
+            import.meta.env.OPENCODE_CHANNEL === "prod" &&
+            (i.name === "GlobalHandlers" || i.name === "BrowserApiErrors")
+          ),
       )
     },
   })


### PR DESCRIPTION
## Summary
- Filters Sentry's BrowserApiErrors integration from production desktop builds alongside GlobalHandlers.
- Keeps non-production Sentry behavior unchanged for debugging.

## Testing
- bun turbo typecheck