### PR TITLE
feat(acp): extract system prompt from synthetic parts in session/prompt

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1441,8 +1441,18 @@ export class Agent implements ACPAgent {
 
     log.info("parts", { parts })
 
+    // Extract system prompt from synthetic parts (marked with audience: ["assistant"])
+    let system: string | undefined
+    const regularParts = parts.filter((p) => {
+      if (p.type === "text" && p.synthetic) {
+        system = (system || "") + p.text + "\n"
+        return false
+      }
+      return true
+    })
+
     const cmd = (() => {
-      const text = parts
+      const text = regularParts
         .filter((p): p is { type: "text"; text: string } => p.type === "text")
         .map((p) => p.text)
         .join("")
@@ -1476,7 +1486,8 @@ export class Agent implements ACPAgent {
           modelID: model.modelID,
         },
         variant: this.sessionManager.getVariant(sessionID),
-        parts,
+        parts: regularParts,
+        system,
         agent,
         directory,
       })


### PR DESCRIPTION
### Issue for this PR

Closes # (no related issue — discovered during Hermes Agent ↔ OpenCode ACP integration testing)

### Type of change

- [x] New feature

### What does this PR do?

When Claude Code (or Hermes Agent) sends messages via ACP, system messages are formatted as text parts with `annotations.audience: ["assistant"]`. OpenCode already parses this annotation and marks the part as `synthetic`, but currently concatenates all parts — including synthetic ones — into a single prompt blob sent to the LLM.

This means system-level instructions get mixed with user messages, losing the separation between "who the AI is" and "what the user asked."

The fix is straightforward: extract `synthetic` text parts before sending to `session.prompt()`, concatenate them into a `system` string, and pass it as the SDK parameter that already exists for this purpose. Non-synthetic parts go into `parts` as before.

No existing behavior changes — clients that dont use annotations still work identically.

### How did you verify your code works?

- TypeScript compiles cleanly
- ACP handshake (`initialize` / `session/new`) works with stdio transport
- The `synthetic` flag is already set by existing annotation parsing code — this just routes it to the right SDK parameter

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR