### PR TITLE
fix(acp): return stopReason: cancelled (not end_turn) on user cancel

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1468,6 +1468,22 @@ export class Agent implements ACPAgent {
       cachedWriteTokens: msg.tokens.cache?.write || undefined,
     })
 
+    // The session/prompt RPC resolves the same way whether the turn finished
+    // naturally or was interrupted by `session/cancel` — in both cases it
+    // returns the assistant message. The interrupted path tags the message
+    // with `error.name = "MessageAbortedError"` (set in
+    // `session/processor.ts` halt → `MessageV2.fromError`). ACP defines
+    // a dedicated `stopReason: "cancelled"` for exactly this case; reporting
+    // `end_turn` makes a user cancel indistinguishable from a clean
+    // completion. Usage is also unreliable on cancel — the LLM stream is
+    // killed before the SDK emits its `finish-step` event, so
+    // `msg.tokens` is still at its zero initialiser (input/output/cache
+    // all 0). Reporting `totalTokens: 0` is misleading: the provider has
+    // already consumed the prompt tokens, we just don't know the count.
+    // Omit `usage` on cancel so clients show "unknown" instead of "zero".
+    const wasCancelled = (msg: AssistantMessage | undefined): boolean =>
+      msg?.error?.name === "MessageAbortedError"
+
     if (!cmd) {
       const response = await this.sdk.session.prompt({
         sessionID,
@@ -1484,9 +1500,10 @@ export class Agent implements ACPAgent {
 
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 
+      const cancelled = wasCancelled(msg)
       return {
-        stopReason: "end_turn" as const,
-        usage: msg ? buildUsage(msg) : undefined,
+        stopReason: cancelled ? ("cancelled" as const) : ("end_turn" as const),
+        usage: msg && !cancelled ? buildUsage(msg) : undefined,
         _meta: {},
       }
     }
@@ -1507,9 +1524,10 @@ export class Agent implements ACPAgent {
 
       await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
 
+      const cancelled = wasCancelled(msg)
       return {
-        stopReason: "end_turn" as const,
-        usage: msg ? buildUsage(msg) : undefined,
+        stopReason: cancelled ? ("cancelled" as const) : ("end_turn" as const),
+        usage: msg && !cancelled ? buildUsage(msg) : undefined,
         _meta: {},
       }
     }

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -724,4 +724,99 @@ describe("acp.agent event subscription", () => {
       },
     })
   })
+
+  test("prompt() returns stopReason: cancelled with no usage when message has MessageAbortedError", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, sdk, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        // Server-side `session/prompt` resolves with the in-flight assistant
+        // message tagged with `MessageAbortedError` when the runner is
+        // interrupted by `session/cancel` (see processor.ts halt path).
+        // tokens stay at the zero initialiser because the LLM stream never
+        // emitted `finish-step`.
+        sdk.session.prompt = async () => ({
+          data: {
+            info: {
+              id: "msg_aborted_1",
+              sessionID: sessionId,
+              role: "assistant",
+              time: { created: 1, completed: 2 },
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              cost: 0,
+              parentID: "u1",
+              modelID: "big-pickle",
+              providerID: "opencode",
+              mode: "build",
+              agent: "build",
+              path: { cwd, root: cwd },
+              error: { name: "MessageAbortedError", data: { message: "Aborted" } },
+            },
+          },
+        })
+
+        const result = await (agent as any).prompt({
+          sessionId,
+          prompt: [{ type: "text", text: "long task" }],
+        })
+
+        // ACP defines stopReason: "cancelled" for exactly this case.
+        // Returning "end_turn" hides the cancel from the client.
+        expect(result.stopReason).toBe("cancelled")
+        // Usage on cancel is unreliable — the SDK never emitted finish-step
+        // so tokens are all 0. Reporting `totalTokens: 0` is misleading
+        // (the provider has charged us for prompt tokens, we just don't
+        // know the count). Omit `usage` so clients show "unknown".
+        expect(result.usage).toBeUndefined()
+
+        stop()
+      },
+    })
+  })
+
+  test("prompt() returns stopReason: end_turn with usage on normal completion", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, sdk, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        sdk.session.prompt = async () => ({
+          data: {
+            info: {
+              id: "msg_done_1",
+              sessionID: sessionId,
+              role: "assistant",
+              time: { created: 1, completed: 2 },
+              tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 200, write: 0 } },
+              cost: 0,
+              parentID: "u1",
+              modelID: "big-pickle",
+              providerID: "opencode",
+              mode: "build",
+              agent: "build",
+              path: { cwd, root: cwd },
+            },
+          },
+        })
+
+        const result = await (agent as any).prompt({
+          sessionId,
+          prompt: [{ type: "text", text: "hi" }],
+        })
+
+        expect(result.stopReason).toBe("end_turn")
+        expect(result.usage?.totalTokens).toBe(350)
+        expect(result.usage?.inputTokens).toBe(100)
+
+        stop()
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #25899

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Returns `stopReason: "cancelled"` instead of `"end_turn"` on the ACP `session/prompt` RPC when the turn was interrupted by `session/cancel`, and omits the misleading all-zero `usage` field on cancel.

`Agent.prompt()` currently resolves the ACP RPC with `stopReason: "end_turn"` whether the turn finished naturally or was interrupted. ACP defines a dedicated `stopReason: "cancelled"` for the cancel case, so reporting `end_turn` makes a user cancel indistinguishable from a clean completion.

Cancelled turns can also return `usage: { totalTokens: 0, inputTokens: 0, outputTokens: 0 }`. The LLM stream is killed before the AI SDK emits its `finish-step` usage event, so the assistant message tokens are still at their zero initializer. Reporting zero is misleading; omitting `usage` lets clients treat it as unknown.

The fix detects `msg?.error?.name === "MessageAbortedError"` and uses that at both `Agent.prompt()` return sites that return an assistant message:

```ts
const cancelled = wasCancelled(msg)
return {
  stopReason: cancelled ? ("cancelled" as const) : ("end_turn" as const),
  usage: msg && !cancelled ? buildUsage(msg) : undefined,
  _meta: {},
}
```

The command-only return site is unchanged because it has no assistant message to inspect.

A larger follow-up could recover provider usage during interrupt cleanup, but this PR intentionally keeps the fix scoped to reporting the correct stop reason and avoiding known-bad zero usage.

### How did you verify your code works?

- `bun test test/acp/event-subscription.test.ts` - 12 pass / 0 fail
  - `prompt() returns stopReason: cancelled with no usage when message has MessageAbortedError`
  - `prompt() returns stopReason: end_turn with usage on normal completion`
- `bun run typecheck` - clean

### Screenshots / recordings

N/A - backend protocol fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
