### PR TITLE
feat: Preserve todo progress during compaction

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -21,6 +21,8 @@ import { makeRuntime } from "@/effect/run-service"
 import { fn } from "@/util/fn"
 import { EventV2 } from "@/v2/event"
 import { SessionEvent } from "@/v2/session-event"
+import { Todo } from "./todo"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 
 const log = Log.create({ service: "session.compaction" })
 
@@ -40,6 +42,8 @@ const PRUNE_PROTECTED_TOOLS = ["skill"]
 const DEFAULT_TAIL_TURNS = 2
 const MIN_PRESERVE_RECENT_TOKENS = 2_000
 const MAX_PRESERVE_RECENT_TOKENS = 8_000
+const ANCHOR_START = "<!-- opencode-compaction-anchors:start -->"
+const ANCHOR_END = "<!-- opencode-compaction-anchors:end -->"
 const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
 <template>
 ## Goal
@@ -101,6 +105,51 @@ function summaryText(message: MessageV2.WithParts) {
     .join("\n\n")
     .trim()
   return text || undefined
+}
+
+function cleanAnchorLine(input: string) {
+  return input.replace(/\s+/g, " ").trim() || "(empty)"
+}
+
+function stripAnchors(input: string) {
+  let result = input
+  while (true) {
+    const start = result.indexOf(ANCHOR_START)
+    if (start === -1) return result.trim()
+    const end = result.indexOf(ANCHOR_END, start + ANCHOR_START.length)
+    if (end === -1) return result.slice(0, start).trim()
+    result = `${result.slice(0, start).trimEnd()}\n\n${result.slice(end + ANCHOR_END.length).trimStart()}`
+  }
+}
+
+function appendAnchors(input: { summary: string; anchors?: string }) {
+  const summary = stripAnchors(input.summary)
+  if (!input.anchors) return summary
+  return [summary, input.anchors].filter(Boolean).join("\n\n").trim()
+}
+
+function formatAnchors(input: { todos: Todo.Info[]; plan?: string }) {
+  const sections = [
+    input.todos.length
+      ? [
+          "## Current TODO State",
+          ...input.todos.map(
+            (todo) =>
+              `- ${cleanAnchorLine(todo.status)} / ${cleanAnchorLine(todo.priority)}: ${cleanAnchorLine(todo.content)}`,
+          ),
+        ].join("\n")
+      : undefined,
+    input.plan
+      ? [
+          "## Current Plan",
+          `- Path: ${input.plan}`,
+          "- Read this file before executing or updating the plan.",
+        ].join("\n")
+      : undefined,
+  ].filter((item): item is string => Boolean(item))
+
+  if (!sections.length) return undefined
+  return [ANCHOR_START, ...sections, ANCHOR_END].join("\n")
 }
 
 function completedCompactions(messages: MessageV2.WithParts[]) {
@@ -218,6 +267,8 @@ export const layer: Layer.Layer<
   | Plugin.Service
   | SessionProcessor.Service
   | Provider.Service
+  | Todo.Service
+  | AppFileSystem.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -228,6 +279,8 @@ export const layer: Layer.Layer<
     const plugin = yield* Plugin.Service
     const processors = yield* SessionProcessor.Service
     const provider = yield* Provider.Service
+    const todo = yield* Todo.Service
+    const fs = yield* AppFileSystem.Service
 
     const isOverflow = Effect.fn("SessionCompaction.isOverflow")(function* (input: {
       tokens: MessageV2.Assistant["tokens"]
@@ -293,6 +346,55 @@ export const layer: Layer.Layer<
         head: input.messages.slice(0, keep.start),
         tail_start_id: keep.id,
       }
+    })
+
+    const buildAnchors = Effect.fn("SessionCompaction.buildAnchors")(function* (input: { sessionID: SessionID }) {
+      const ctx = yield* InstanceState.context
+      const info = yield* session.get(input.sessionID)
+      const plan = Session.plan(info, ctx)
+      const planExists = yield* fs.existsSafe(plan).pipe(Effect.catch(() => Effect.succeed(false)))
+      return formatAnchors({
+        todos: yield* todo.get(input.sessionID),
+        plan: planExists ? plan : undefined,
+      })
+    })
+
+    const persistAnchors = Effect.fn("SessionCompaction.persistAnchors")(function* (input: {
+      sessionID: SessionID
+      messageID: MessageID
+    }) {
+      const anchors = yield* buildAnchors({ sessionID: input.sessionID })
+      const current = (yield* session.messages({ sessionID: input.sessionID })).find(
+        (item) => item.info.id === input.messageID,
+      )
+      if (!current) return ""
+
+      const textParts = current.parts.filter((part): part is MessageV2.TextPart => part.type === "text")
+      const lastTextPart = textParts.at(-1)
+      if (!lastTextPart) {
+        if (!anchors) return summaryText(current) ?? ""
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          messageID: input.messageID,
+          sessionID: input.sessionID,
+          type: "text",
+          text: anchors,
+        })
+        return anchors
+      }
+
+      const parts = current.parts.map((part) => {
+        if (part.type !== "text") return part
+        const text =
+          part.id === lastTextPart.id ? appendAnchors({ summary: part.text, anchors }) : stripAnchors(part.text)
+        return { ...part, text }
+      })
+      for (const part of parts) {
+        const original = current.parts.find((item) => item.id === part.id)
+        if (part.type !== "text" || original?.type !== "text" || part.text === original.text) continue
+        yield* session.updatePart(part)
+      }
+      return summaryText({ info: current.info, parts }) ?? ""
     })
 
     // goes backwards through parts until there are PRUNE_PROTECT tokens worth of tool
@@ -390,17 +492,18 @@ export const layer: Layer.Layer<
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
       const prior = completedCompactions(history)
       const hidden = new Set(prior.flatMap((item) => [item.userIndex, item.assistantIndex]))
-      const previousSummary = prior.at(-1)?.summary
+      const previousSummary = stripAnchors(prior.at(-1)?.summary ?? "") || undefined
       const selected = yield* select({
         messages: history.filter((_, index) => !hidden.has(index)),
         cfg,
         model,
       })
+      const anchors = yield* buildAnchors({ sessionID: input.sessionID })
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
         { sessionID: input.sessionID },
-        { context: [], prompt: undefined },
+        { context: anchors ? [anchors] : [], prompt: undefined },
       )
       const nextPrompt = compacting.prompt ?? buildPrompt({ previousSummary, context: compacting.context })
       const msgs = structuredClone(selected.head)
@@ -560,16 +663,11 @@ export const layer: Layer.Layer<
 
       if (processor.message.error) return "stop"
       if (result === "continue") {
-        const summary = summaryText(
-          (yield* session.messages({ sessionID: input.sessionID })).find((item) => item.info.id === msg.id) ?? {
-            info: msg,
-            parts: [],
-          },
-        )
+        const summary = yield* persistAnchors({ sessionID: input.sessionID, messageID: msg.id })
         EventV2.run(SessionEvent.Compaction.Ended.Sync, {
           sessionID: input.sessionID,
           timestamp: DateTime.makeUnsafe(Date.now()),
-          text: summary ?? "",
+          text: summary,
           include: selected.tail_start_id,
         })
         yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
@@ -623,6 +721,8 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(SessionProcessor.defaultLayer),
     Layer.provide(Agent.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
+    Layer.provide(Todo.defaultLayer),
+    Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(Bus.layer),
     Layer.provide(Config.defaultLayer),
   ),

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, mock, test } from "bun:test"
 import { APICallError } from "ai"
 import { Cause, Effect, Exit, Layer, ManagedRuntime } from "effect"
 import * as Stream from "effect/Stream"
+import path from "path"
+import { mkdir } from "fs/promises"
 import z from "zod"
 import { Bus } from "../../src/bus"
 import { Config } from "@/config/config"
@@ -20,6 +22,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
+import { Todo } from "../../src/session/todo"
 import { SessionV2 } from "../../src/v2/session"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import type { Provider } from "@/provider/provider"
@@ -29,6 +32,7 @@ import { ProviderTest } from "../fake/provider"
 import { testEffect } from "../lib/effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestConfig } from "../fixture/config"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 
 void Log.init({ print: false })
 
@@ -49,6 +53,12 @@ const svc = {
   },
   updatePart<T extends MessageV2.Part>(part: T) {
     return run(SessionNs.Service.use((svc) => svc.updatePart(part)))
+  },
+}
+
+const todoSvc = {
+  update(input: { sessionID: SessionID; todos: Todo.Info[] }) {
+    return Effect.runPromise(Todo.Service.use((svc) => svc.update(input)).pipe(Effect.provide(Todo.defaultLayer)))
   },
 }
 
@@ -179,6 +189,15 @@ async function summaryAssistant(sessionID: SessionID, parentID: MessageID, root:
   return msg
 }
 
+function textOf(message: MessageV2.WithParts | undefined) {
+  return (
+    message?.parts
+      .filter((part): part is MessageV2.TextPart => part.type === "text")
+      .map((part) => part.text)
+      .join("\n\n") ?? ""
+  )
+}
+
 async function lastCompactionPart(sessionID: SessionID) {
   return (await svc.messages({ sessionID }))
     .at(-2)
@@ -230,6 +249,8 @@ function runtime(
       Layer.provide(layer(result)),
       Layer.provide(Agent.defaultLayer),
       Layer.provide(plugin),
+      Layer.provide(Todo.defaultLayer),
+      Layer.provide(AppFileSystem.defaultLayer),
       Layer.provide(bus),
       Layer.provide(config),
     ),
@@ -243,6 +264,8 @@ const deps = Layer.mergeAll(
   Plugin.defaultLayer,
   Bus.layer,
   Config.defaultLayer,
+  Todo.defaultLayer,
+  AppFileSystem.defaultLayer,
 )
 
 const env = Layer.mergeAll(
@@ -288,6 +311,8 @@ function liveRuntime(layer: Layer.Layer<LLM.Service>, provider = ProviderTest.fa
       Layer.provide(Permission.defaultLayer),
       Layer.provide(Agent.defaultLayer),
       Layer.provide(Plugin.defaultLayer),
+      Layer.provide(Todo.defaultLayer),
+      Layer.provide(AppFileSystem.defaultLayer),
       Layer.provide(status),
       Layer.provide(bus),
       Layer.provide(config),
@@ -1634,6 +1659,199 @@ describe("session.compaction.process", () => {
           expect(captured).not.toContain("keep this turn")
           expect(captured).not.toContain("and this one too")
           expect(captured).not.toContain("What did we do so far?")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("persists current todos in compacted summary", async () => {
+    const stub = llm()
+    let captured = ""
+    stub.push(
+      reply("summary", (input) => {
+        captured = JSON.stringify(input.messages)
+      }),
+    )
+
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        await todoSvc.update({
+          sessionID: session.id,
+          todos: [
+            { content: "Preserve todos", status: "in_progress", priority: "high" },
+            { content: "Run verification", status: "pending", priority: "medium" },
+          ],
+        })
+        await user(session.id, "older context")
+        await SessionCompaction.create({
+          sessionID: session.id,
+          agent: "build",
+          model: ref,
+          auto: false,
+        })
+
+        const rt = liveRuntime(stub.layer, wide())
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          const summary = MessageV2.filterCompacted(MessageV2.stream(session.id)).find(
+            (msg) => msg.info.role === "assistant" && msg.info.summary,
+          )
+          const text = textOf(summary)
+          expect(captured).toContain("## Current TODO State")
+          expect(text).toContain("## Current TODO State")
+          expect(text).toContain("- in_progress / high: Preserve todos")
+          expect(text).toContain("- pending / medium: Run verification")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("replaces stale todo anchors across repeated compactions", async () => {
+    const stub = llm()
+    let captured = ""
+    stub.push(reply("summary one"))
+    stub.push(
+      reply("summary two", (input) => {
+        captured = JSON.stringify(input.messages)
+      }),
+    )
+
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        await todoSvc.update({
+          sessionID: session.id,
+          todos: [{ content: "Preserve todos", status: "in_progress", priority: "high" }],
+        })
+        await user(session.id, "older context")
+        await SessionCompaction.create({
+          sessionID: session.id,
+          agent: "build",
+          model: ref,
+          auto: false,
+        })
+
+        const rt = liveRuntime(stub.layer, wide())
+        try {
+          let msgs = await svc.messages({ sessionID: session.id })
+          let parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          await todoSvc.update({
+            sessionID: session.id,
+            todos: [{ content: "Preserve todos", status: "completed", priority: "high" }],
+          })
+          await user(session.id, "latest context")
+          await SessionCompaction.create({
+            sessionID: session.id,
+            agent: "build",
+            model: ref,
+            auto: false,
+          })
+
+          msgs = MessageV2.filterCompacted(MessageV2.stream(session.id))
+          parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          const summary = MessageV2.filterCompacted(MessageV2.stream(session.id)).findLast(
+            (msg) => msg.info.role === "assistant" && msg.info.summary,
+          )
+          const text = textOf(summary)
+          expect(captured).not.toContain("in_progress / high: Preserve todos")
+          expect(text).toContain("- completed / high: Preserve todos")
+          expect(text).not.toContain("- in_progress / high: Preserve todos")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("persists plan path in compacted summary when a plan file exists", async () => {
+    const stub = llm()
+    stub.push(reply("summary"))
+
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const plan = path.join(tmp.path, ".opencode", "plans", `${session.time.created}-${session.slug}.md`)
+        await mkdir(path.dirname(plan), { recursive: true })
+        await Bun.write(plan, "# Plan\n")
+        await user(session.id, "older context")
+        await SessionCompaction.create({
+          sessionID: session.id,
+          agent: "build",
+          model: ref,
+          auto: false,
+        })
+
+        const rt = liveRuntime(stub.layer, wide())
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          const summary = MessageV2.filterCompacted(MessageV2.stream(session.id)).find(
+            (msg) => msg.info.role === "assistant" && msg.info.summary,
+          )
+          const text = textOf(summary)
+          expect(text).toContain("## Current Plan")
+          expect(text).toContain(`- Path: ${plan}`)
+          expect(text).toContain("Read this file before executing or updating the plan.")
         } finally {
           await rt.dispose()
         }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -186,7 +186,7 @@ function makeHttp() {
   )
   const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
   const proc = SessionProcessor.layer.pipe(Layer.provide(summary), Layer.provideMerge(deps))
-  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(deps))
+  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(todo), Layer.provideMerge(deps))
   return Layer.mergeAll(
     TestLLMServer.layer,
     SessionPrompt.layer.pipe(

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -136,7 +136,7 @@ function makeHttp() {
   )
   const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
   const proc = SessionProcessor.layer.pipe(Layer.provide(SessionSummary.defaultLayer), Layer.provideMerge(deps))
-  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(deps))
+  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(todo), Layer.provideMerge(deps))
   return Layer.mergeAll(
     TestLLMServer.layer,
     SessionSummary.defaultLayer,


### PR DESCRIPTION
### Issue for this PR

Closes #18071
Closes #18564
Closes #5934
Closes #15096

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Todo progress could be lost from the model context after compaction because the summary relied on the model to remember and include it.

This PR adds deterministic compaction anchors for the current `TodoWrite` state, plus the active plan file path when one exists. The anchors are included during compaction and written back into the compacted summary after it succeeds. Repeated compactions strip old anchor blocks first, so stale todo statuses are replaced by the latest state.

### How did you verify your code works?

Added regression tests for:
- preserving current todos in compacted summaries
- replacing stale todo anchors across repeated compactions
- preserving the plan file path when a plan exists

Ran:
- `bun test test/session/compaction.test.ts`
- `bun typecheck`
- `git diff --check`

### Screenshots / recordings

N/A, this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
