### PR TITLE
docs: capitalize Neovim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ It's very similar to Claude Code in terms of capability. Here are the key differ
 - 100% open source
 - Not coupled to any provider. Although we recommend the models we provide through [OpenCode Zen](https://opencode.ai/zen), OpenCode can be used with Claude, OpenAI, Google, or even local models. As models evolve, the gaps between them will close and pricing will drop, so being provider-agnostic is important.
 - Built-in opt-in LSP support
-- A focus on TUI. OpenCode is built by neovim users and the creators of [terminal.shop](https://terminal.shop); we are going to push the limits of what's possible in the terminal.
+- A focus on TUI. OpenCode is built by Neovim users and the creators of [terminal.shop](https://terminal.shop); we are going to push the limits of what's possible in the terminal.
 - A client/server architecture. This, for example, can allow OpenCode to run on your computer while you drive it remotely from a mobile app, meaning that the TUI frontend is just one of the possible clients.
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #21678

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This fixes a small typo in the README by capitalizing `Neovim`.

The README previously said `neovim users`. Since Neovim is a proper name, this changes it to `Neovim users`.

### How did you verify your code works?

I checked the README diff and confirmed only this wording changed.

### Screenshots / recordings

N/A. This is a documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
