### PR TITLE
fix(tui): navigate to home when --continue finds no sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -379,6 +379,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       } else {
         route.navigate({ type: "session", sessionID: match })
       }
+    } else if (sync.status !== "loading") {
+      // No sessions exist — fall back to home instead of leaving the dummy route active
+      continued = true
+      route.navigate({ type: "home" })
     }
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #25989

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `--continue` is used on a project with zero sessions, the TUI sets an initial route with `sessionID: "dummy"` as a placeholder. The `createEffect` in `app.tsx` then tries to find the most recently updated session to navigate to. If sessions exist, it replaces the dummy route.

The bug: when no sessions exist, `match` is `undefined` and the effect does nothing — the route stays at `"dummy"`, which fails server-side validation (session IDs must start with `"ses"`).

The fix adds an `else` branch: when sync has loaded and no matching session is found, navigate to the home screen instead. This is a 4-line change. The headless `run.ts` already handles this case correctly (falls through to creating a new session at line 394), so this aligns TUI behavior with headless behavior.

### How did you verify your code works?

- Ran `bun test test/cli` — 140 tests pass, 0 fail
- Reviewed the `run.ts` codepath to confirm the graceful fallback pattern

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.