### PR TITLE
fix(opencode): allow Ghostty WASM data URLs in web CSP

### DIFF
--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -1,24 +1,21 @@
 import fs from "node:fs/promises"
 import { createHash } from "node:crypto"
-import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Hono } from "hono"
 import { proxy } from "hono/proxy"
 import { ProxyUtil } from "../proxy-util"
-import { DEFAULT_CSP, UI_UPSTREAM, csp, embeddedUI, themePreloadHash, upstreamURL } from "../shared/ui"
+import { UI_UPSTREAM, csp, embeddedUI, embeddedUIFile, embeddedUIHeaders, themePreloadHash, upstreamURL } from "../shared/ui"
 
 export async function serveUI(request: Request) {
   const embeddedWebUI = await embeddedUI()
   const path = new URL(request.url).pathname
 
   if (embeddedWebUI) {
-    const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
+    const match = embeddedUIFile(path, embeddedWebUI)
     if (!match) return Response.json({ error: "Not Found" }, { status: 404 })
 
     if (await fs.exists(match)) {
-      const mime = AppFileSystem.mimeType(match)
-      const headers = new Headers({ "content-type": mime })
-      if (mime.startsWith("text/html")) headers.set("content-security-policy", DEFAULT_CSP)
-      return new Response(new Uint8Array(await fs.readFile(match)), { headers })
+      const body = new Uint8Array(await fs.readFile(match))
+      return new Response(body, { headers: embeddedUIHeaders(match, body) })
     }
 
     return Response.json({ error: "Not Found" }, { status: 404 })

--- a/packages/opencode/src/server/shared/ui.ts
+++ b/packages/opencode/src/server/shared/ui.ts
@@ -10,15 +10,36 @@ const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
   : // @ts-expect-error - generated file at build time
     import("opencode-web-ui.gen.ts").then((module) => module.default as Record<string, string>).catch(() => null)
 
-export const DEFAULT_CSP =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src *"
 export const UI_UPSTREAM = new URL("https://app.opencode.ai")
 
 export const csp = (hash = "") =>
-  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src *`
+  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src * data:`
 
 export function themePreloadHash(body: string) {
   return body.match(/<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i)
+}
+
+function assetLikePath(requestPath: string) {
+  const path = requestPath.startsWith("/") ? requestPath : `/${requestPath}`
+  const name = path.split("/").at(-1) ?? ""
+  return path === "/assets" || path.startsWith("/assets/") || name.includes(".")
+}
+
+export function embeddedUIFile(requestPath: string, embeddedWebUI: Record<string, string>) {
+  const exact = embeddedWebUI[requestPath.replace(/^\//, "")]
+  if (exact) return exact
+  if (assetLikePath(requestPath)) return null
+  return embeddedWebUI["index.html"] ?? null
+}
+
+export function embeddedUIHeaders(file: string, body: Uint8Array) {
+  const mime = AppFileSystem.mimeType(file)
+  const headers = new Headers({ "content-type": mime })
+  if (!mime.startsWith("text/html")) return headers
+
+  const match = themePreloadHash(new TextDecoder().decode(body))
+  headers.set("content-security-policy", csp(match ? createHash("sha256").update(match[2]).digest("base64") : ""))
+  return headers
 }
 
 function requestBody(request: HttpServerRequest.HttpServerRequest) {
@@ -51,10 +72,7 @@ function notFound() {
 }
 
 function embeddedUIResponse(file: string, body: Uint8Array) {
-  const mime = AppFileSystem.mimeType(file)
-  const headers = new Headers({ "content-type": mime })
-  if (mime.startsWith("text/html")) headers.set("content-security-policy", DEFAULT_CSP)
-  return HttpServerResponse.raw(body, { headers })
+  return HttpServerResponse.raw(body, { headers: embeddedUIHeaders(file, body) })
 }
 
 export function serveEmbeddedUIEffect(
@@ -62,7 +80,7 @@ export function serveEmbeddedUIEffect(
   fs: AppFileSystem.Interface,
   embeddedWebUI: Record<string, string>,
 ) {
-  const file = embeddedWebUI[requestPath.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
+  const file = embeddedUIFile(requestPath, embeddedWebUI)
   if (!file) return Effect.succeed(notFound())
 
   return fs.readFile(file).pipe(

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { createHash } from "node:crypto"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Log from "@opencode-ai/core/util/log"
 import { ConfigProvider, Effect, Layer } from "effect"
@@ -258,6 +259,93 @@ describe("HttpApi UI fallback", () => {
     expect(readPath).toBe("/$bunfs/root/assets/app.js")
     expect(response.headers.get("content-type")).toContain("text/javascript")
     expect(await response.text()).toBe("console.log('embedded')")
+  })
+
+  test("sets embedded HTML CSP with the inline theme preload hash", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    const preload = "document.documentElement.dataset.theme = 'dark'"
+    const body = new TextEncoder().encode(
+      `<html><script id="oc-theme-preload-script">${preload}</script><main>opencode</main></html>`,
+    )
+
+    const response = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        return yield* serveEmbeddedUIEffect(
+          "/session/example",
+          {
+            ...fs,
+            readFile: (path) =>
+              path === "/$bunfs/root/index.html" ? Effect.succeed(body) : Effect.die(`unexpected embedded UI path: ${path}`),
+          },
+          { "index.html": "/$bunfs/root/index.html" },
+        )
+      }).pipe(Effect.provide(AppFileSystem.defaultLayer), Effect.map(HttpServerResponse.toWeb)),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-security-policy")).toContain("connect-src * data:")
+    expect(response.headers.get("content-security-policy")).toContain(
+      `sha256-${createHash("sha256").update(preload).digest("base64")}`,
+    )
+  })
+
+  test("allows data URLs in proxied HTML CSP for Ghostty WASM fallback", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI = true
+
+    const response = await uiApp({
+      client: httpClient(new Response("<html>opencode</html>", { headers: { "content-type": "text/html" } })),
+    }).request("/")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-security-policy")).toContain("connect-src * data:")
+  })
+
+  test("does not serve index HTML for missing embedded WASM assets", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+
+    const response = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        return yield* serveEmbeddedUIEffect(
+          "/ghostty-vt.wasm",
+          {
+            ...fs,
+            readFile: () => Effect.die("missing asset should not fall back to index.html"),
+          },
+          { "index.html": "/$bunfs/root/index.html" },
+        )
+      }).pipe(Effect.provide(AppFileSystem.defaultLayer), Effect.map(HttpServerResponse.toWeb)),
+    )
+
+    expect(response.status).toBe(404)
+  })
+
+  test("serves embedded WASM assets with the original bytes", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    const body = new Uint8Array([0x00, 0x61, 0x73, 0x6d])
+
+    const response = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        return yield* serveEmbeddedUIEffect(
+          "/assets/ghostty-vt.wasm",
+          {
+            ...fs,
+            readFile: (path) =>
+              path === "/$bunfs/root/assets/ghostty-vt.wasm"
+                ? Effect.succeed(body)
+                : Effect.die(`unexpected embedded UI path: ${path}`),
+          },
+          { "assets/ghostty-vt.wasm": "/$bunfs/root/assets/ghostty-vt.wasm" },
+        )
+      }).pipe(Effect.provide(AppFileSystem.defaultLayer), Effect.map(HttpServerResponse.toWeb)),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("application/wasm")
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(body)
   })
 
   test("keeps matched API routes ahead of the UI fallback", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #26001
Closes #21088

Related to #9185, #9420, and #5237.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes web UI CSP handling for the embedded app and Ghostty web terminal.

Ghostty loads its WASM runtime from a `data:application/wasm;base64,...` URL. The current CSP blocks that through `connect-src`, so this PR allows `data:` there.

The embedded UI path also used a static CSP that did not include the hash for the inline `oc-theme-preload-script`. This PR generates embedded HTML CSP from the actual inline script body, matching the proxied HTML behavior.

It also avoids falling back to `index.html` for missing asset-like embedded paths, so missing `.wasm`, `.js`, `.css`, and `/assets/...` requests return `404` instead of HTML.

### How did you verify your code works?

Ran:

- `cd packages/app && bun typecheck`
- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test test/server/httpapi-ui.test.ts`

The pre-push hook also ran `bun turbo typecheck` successfully.

The fix was also verified in browser against the reported failure: the terminal opens after allowing `data:` in `connect-src`.

### Screenshots / recordings

No screenshot. This is a CSP/server response fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR