### PR TITLE
fix(opencode): scope continue sessions to root worktree

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -114,10 +114,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const fullSyncedSessions = new Set<string>()
     let syncedWorkspace = project.workspace.current()
 
-    function sessionListQuery(): { scope?: "project"; path?: string } {
+    function sessionListQuery(): { directory?: string; scope?: "project"; path?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
       if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
       return {
+        directory: project.data.instance.path.directory,
         path: path
           .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)
           .replaceAll("\\", "/"),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -833,6 +833,9 @@ function* listByProject(
           : or(...conds)!,
       )
     }
+    if (input.path === "" && input.directory) {
+      conditions.push(eq(SessionTable.directory, input.directory))
+    }
   } else if (input.scope !== "project" && !Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
     if (input.directory) {
       conditions.push(eq(SessionTable.directory, input.directory))

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { $ } from "bun"
 import { Effect } from "effect"
 import { Instance } from "../../src/project/instance"
 import { WithInstance } from "../../src/project/with-instance"
@@ -170,6 +171,47 @@ describe("session.list", () => {
         ).map((s) => s.id)
         expect(pathIDs).toContain(current.id)
         expect(pathIDs).not.toContain(sibling.id)
+      },
+    })
+  })
+
+  test("filters root worktree sessions by directory when path is empty", async () => {
+    Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = false
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const main = path.join(dir, "main")
+        const feature = path.join(dir, "feature")
+        await mkdir(main, { recursive: true })
+        await $`git init`.cwd(main).quiet()
+        await $`git config core.fsmonitor false`.cwd(main).quiet()
+        await $`git config commit.gpgsign false`.cwd(main).quiet()
+        await $`git config user.email "test@opencode.test"`.cwd(main).quiet()
+        await $`git config user.name "Test"`.cwd(main).quiet()
+        await $`git commit --allow-empty -m "root commit"`.cwd(main).quiet()
+        await $`git worktree add ${feature} -b feature`.cwd(main).quiet()
+        return { main, feature }
+      },
+    })
+
+    const main = await WithInstance.provide({
+      directory: tmp.extra.main,
+      fn: async () => svc.create({ title: "main-root" }),
+    })
+    const feature = await WithInstance.provide({
+      directory: tmp.extra.feature,
+      fn: async () => svc.create({ title: "feature-root" }),
+    })
+
+    expect(main.projectID).toBe(feature.projectID)
+    expect(main.path).toBe("")
+    expect(feature.path).toBe("")
+
+    await WithInstance.provide({
+      directory: tmp.extra.feature,
+      fn: async () => {
+        const ids = (await svc.list({ directory: tmp.extra.feature, path: "" })).map((s) => s.id)
+        expect(ids).toContain(feature.id)
+        expect(ids).not.toContain(main.id)
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #25963

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode --continue` uses the session list to pick the latest root session. After session filtering moved to project-relative paths, root-level git worktrees all share the same empty relative path (`""`).

That meant a session from one checkout could appear in the list while attaching to another checkout of the same repo, and `--continue` could pick whichever root session was most recently updated.

This PR passes the current absolute directory along with the TUI session list query, then uses that directory when the project-relative path is empty. Non-empty path filtering still uses the existing path-based behavior.

I also added a regression test with two real git worktrees for the same repo. Both sessions have `path === ""`, and the test verifies that listing for the feature worktree does not include the main worktree session.

### How did you verify your code works?

I first reproduced the bug with a failing test:

- `bun test test/server/session-list.test.ts -t "filters root worktree sessions by directory when path is empty"`

Before the fix, the test failed because the feature worktree session list included the main worktree session.

After applying the fix, I ran:

- `bun test test/server/session-list.test.ts`
- `bun typecheck`
- `git diff --check`

Results:

- `9 pass, 0 fail`
- `bun typecheck` completed successfully
- `git diff --check` completed successfully

### Screenshots / recordings

N/A. This is session selection behavior and does not change UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
