### PR TITLE
fix: navigate to home when --continue finds no sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -379,6 +379,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       } else {
         route.navigate({ type: "session", sessionID: match })
       }
+    } else {
+      // No sessions to continue - fall back to home instead of stuck "dummy" route
+      continued = true
+      route.navigate({ type: "home" })
     }
   })
 


### PR DESCRIPTION
When starting opencode on a project with no sessions, using `--continue`/-c errors with an invalid dummy sessionID and leaves the TUI in a broken state.

### Issue for this PR

Closes #25989

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `--continue` is used, the TUI sets the initial route to `sessionID: dummy` as a placeholder, then resolves to the most recent session. When no sessions exist, that resolution does nothing and the invalid dummy ID hits the validator.

The fix: when no session is found, mark the continue handler as done and navigate to the home route instead. This matches how `run.ts` already handles the missing-session case.

### How did you verify your code works?

- Confirmed the continue effect at line 363 sets `route.navigate` to home when `sync.data.session` has no root sessions
- Verified home route behavior: it starts a fresh session normally through the existing flow

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._