### PR TITLE
fix: exit with error when --continue finds no sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -73,6 +73,7 @@ export const AttachCommand = cmd({
         await validateSession({
           url: args.url,
           sessionID: args.session,
+          continue: args.continue,
           directory,
           headers,
         })

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -215,6 +215,7 @@ export const TuiThreadCommand = cmd({
         await validateSession({
           url: transport.url,
           sessionID: args.session,
+          continue: args.continue,
           directory: cwd,
           fetch: transport.fetch,
         })

--- a/packages/opencode/src/cli/cmd/tui/validate-session.ts
+++ b/packages/opencode/src/cli/cmd/tui/validate-session.ts
@@ -4,21 +4,36 @@ import { SessionID } from "@/session/schema"
 export async function validateSession(input: {
   url: string
   sessionID?: string
+  continue?: boolean
   directory?: string
   fetch?: typeof fetch
   headers?: RequestInit["headers"]
 }) {
-  if (!input.sessionID) return
+  if (input.sessionID) {
+    const result = SessionID.zod.safeParse(input.sessionID)
+    if (!result.success) {
+      throw new Error(`Invalid session ID: ${result.error.issues.at(0)?.message ?? "unknown error"}`)
+    }
 
-  const result = SessionID.zod.safeParse(input.sessionID)
-  if (!result.success) {
-    throw new Error(`Invalid session ID: ${result.error.issues.at(0)?.message ?? "unknown error"}`)
+    await createOpencodeClient({
+      baseUrl: input.url,
+      directory: input.directory,
+      fetch: input.fetch,
+      headers: input.headers,
+    }).session.get({ sessionID: result.data }, { throwOnError: true })
   }
 
-  await createOpencodeClient({
-    baseUrl: input.url,
-    directory: input.directory,
-    fetch: input.fetch,
-    headers: input.headers,
-  }).session.get({ sessionID: result.data }, { throwOnError: true })
+  if (input.continue) {
+    const client = createOpencodeClient({
+      baseUrl: input.url,
+      directory: input.directory,
+      fetch: input.fetch,
+      headers: input.headers,
+    })
+    const sessions = await client.session.list({ take: 1 }, { throwOnError: true })
+    const rootSessions = sessions.filter((s) => !s.parentID)
+    if (rootSessions.length === 0) {
+      throw new Error("No sessions to continue. Start a new session without --continue.")
+    }
+  }
 }


### PR DESCRIPTION
When starting opencode on a project with no sessions, using `--continue`/-c errors with an invalid dummy sessionID and leaves the TUI in a broken state.

### Issue for this PR

Closes #25989

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `--continue` is used, the session list is now checked before the TUI starts. If no root sessions exist, it exits with a clear error message instead of entering the TUI with an invalid dummy sessionID that fails validation.

### How did you verify your code works?

- Confirmed `validate-session.ts` checks for root sessions when `--continue` is passed
- Verified the error message prints and exits before the TUI renders

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._