### PR TITLE
fix: retry nested overloaded provider errors

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -89,15 +89,19 @@ export function retryable(error: Err) {
     }
   })
   if (!json || typeof json !== "object") return undefined
-  const code = typeof json.code === "string" ? json.code : ""
+  const codes = [
+    typeof json.code === "string" ? json.code : "",
+    typeof json.error?.code === "string" ? json.error.code : "",
+    typeof json.error?.type === "string" ? json.error.type : "",
+  ]
 
   if (json.type === "error" && json.error?.type === "too_many_requests") {
     return "Too Many Requests"
   }
-  if (code.includes("exhausted") || code.includes("unavailable")) {
+  if (codes.some((code) => code.includes("exhausted") || code.includes("unavailable") || code.includes("overloaded"))) {
     return "Provider is overloaded"
   }
-  if (json.type === "error" && typeof json.error?.code === "string" && json.error.code.includes("rate_limit")) {
+  if (json.type === "error" && codes.some((code) => code.includes("rate_limit"))) {
     return "Rate Limited"
   }
   return undefined

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1180,6 +1180,29 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("serializes OpenAI response server_is_overloaded stream chunks as retryable APIError", () => {
+    const body = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "service_unavailable_error",
+        code: "server_is_overloaded",
+        message: "Our servers are currently overloaded. Please try again later.",
+        param: null,
+      },
+    }
+    const result = MessageV2.fromError({ message: JSON.stringify(body) }, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: body.error.message,
+        isRetryable: true,
+        responseBody: JSON.stringify(body),
+      },
+    })
+  })
+
   test("detects context overflow from APICallError provider messages", () => {
     const cases = [
       "prompt is too long: 213462 tokens > 200000 maximum",

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -126,6 +126,21 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBe("Provider is overloaded")
   })
 
+  test("maps nested overloaded provider codes", () => {
+    const error = wrap(
+      JSON.stringify({
+        type: "error",
+        error: {
+          type: "service_unavailable_error",
+          code: "server_is_overloaded",
+          message: "Our servers are currently overloaded. Please try again later.",
+        },
+      }),
+    )
+
+    expect(SessionRetry.retryable(error)).toBe("Provider is overloaded")
+  })
+
   test("does not retry unknown json messages", () => {
     const error = wrap(JSON.stringify({ error: { message: "no_kv_space" } }))
     expect(SessionRetry.retryable(error)).toBeUndefined()


### PR DESCRIPTION
### Issue for this PR

Fixes #25884

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI-compatible overload stream errors can carry `server_is_overloaded` inside `error.code` and `service_unavailable_error` inside `error.type`.

The stream parser now already converts that chunk into a retryable API error on `dev`; this PR also teaches the retry classifier to recognize the same nested shape if it reaches retry handling as JSON. It adds regression coverage for both paths.

### How did you verify your code works?

- `bun test test/session/retry.test.ts`
- `bun test test/session/message-v2.test.ts`
- `bun typecheck` from `packages/opencode`
- Push hook: `bun turbo typecheck`

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR