### PR TITLE
fix(format): restore stdout/stderr ignore for formatter processes

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -91,6 +91,9 @@ export const layer = Layer.effect(
                     cwd: dir,
                     env: item.environment,
                     extendEnv: true,
+                    stdin: "ignore",
+                    stdout: "ignore",
+                    stderr: "ignore",
                   }),
                 )
                 .pipe(

--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -227,37 +227,6 @@ describe("Format", () => {
     ),
   )
 
-  it.live("file() completes even when formatter spawns background child processes", () =>
-    provideTmpdirInstance(
-      (path) =>
-        Effect.gen(function* () {
-          const file = `${path}/test.bg`
-          yield* Effect.promise(() => Bun.write(file, "x"))
-
-          // This formatter exits immediately but backgrounds a long-running child
-          // process (sleep 999). Without stdout/stderr/stdin: "ignore", the
-          // grandchild inherits the pipe FDs and keeps them open, so the
-          // spawner's "close" event never fires and file() hangs forever.
-          yield* Format.Service.use((fmt) =>
-            Effect.gen(function* () {
-              yield* fmt.init()
-              yield* fmt.file(file)
-            }),
-          )
-        }),
-      {
-        config: {
-          formatter: {
-            bg: {
-              command: ["sh", "-c", "sleep 999 &"],
-              extensions: [".bg"],
-            },
-          },
-        },
-      },
-    ),
-  )
-
   it.live("runs matching formatters sequentially for the same file", () =>
     provideTmpdirInstance(
       (path) =>

--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -227,6 +227,37 @@ describe("Format", () => {
     ),
   )
 
+  it.live("file() completes even when formatter spawns background child processes", () =>
+    provideTmpdirInstance(
+      (path) =>
+        Effect.gen(function* () {
+          const file = `${path}/test.bg`
+          yield* Effect.promise(() => Bun.write(file, "x"))
+
+          // This formatter exits immediately but backgrounds a long-running child
+          // process (sleep 999). Without stdout/stderr/stdin: "ignore", the
+          // grandchild inherits the pipe FDs and keeps them open, so the
+          // spawner's "close" event never fires and file() hangs forever.
+          yield* Format.Service.use((fmt) =>
+            Effect.gen(function* () {
+              yield* fmt.init()
+              yield* fmt.file(file)
+            }),
+          )
+        }),
+      {
+        config: {
+          formatter: {
+            bg: {
+              command: ["sh", "-c", "sleep 999 &"],
+              extensions: [".bg"],
+            },
+          },
+        },
+      },
+    ),
+  )
+
   it.live("runs matching formatters sequentially for the same file", () =>
     provideTmpdirInstance(
       (path) =>


### PR DESCRIPTION
### Issue for this PR

Closes #26032

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The ChildProcessSpawner migration in 5cd54ec dropped stdout/stderr: "ignore" when refactoring the formatter to use Effect's spawner. The old Process.spawn defaulted stdout and stderr to "ignore" (not "pipe"):

  stdio: [opts.stdin ?? "ignore", opts.stdout ?? "ignore", opts.stderr ?? "ignore"]

It also resolved on the "exit" event, which fires when the process itself exits. ChildProcessSpawner instead defaults to "pipe" for all stdio and resolves on the "close" event, which only fires after every file descriptor referencing the pipes is closed — including those held by grandchild processes that inherited them.

If a formatter like pants spawns worker subprocesses, those children keep the pipe FDs open after the formatter exits. "close" never fires, the Deferred that handle.exitCode awaits is never resolved, and the edit/write tool hangs indefinitely.

Restoring stdout/stderr: "ignore" avoids creating pipes entirely, so "close" fires immediately when the formatter process exits regardless of any background children it may have spawned.

### How did you verify your code works?

I've verified manually and also added a test. Manual verification included manually killing the held process in the original version of the code (which is when an edit actually managed to finish instead of hanging) and also verified the new code indeed finishes.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
