### PR TITLE
fix(provider): preserve config precedence after model hooks

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1050,6 +1050,97 @@ export namespace Provider {
             providers[providerID] = mergeDeep(match, provider)
           }
 
+          function applyConfig(target: Record<ProviderID, Info>) {
+            for (const [providerID, provider] of configProviders) {
+              const existing = target[providerID]
+              const parsed: Info = {
+                id: ProviderID.make(providerID),
+                name: provider.name ?? existing?.name ?? providerID,
+                env: provider.env ?? existing?.env ?? [],
+                options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
+                source: "config",
+                models: existing?.models ?? {},
+              }
+
+              for (const [modelID, model] of Object.entries(provider.models ?? {})) {
+                const existingModel = parsed.models[model.id ?? modelID]
+                const name = iife(() => {
+                  if (model.name) return model.name
+                  if (model.id && model.id !== modelID) return modelID
+                  return existingModel?.name ?? modelID
+                })
+                const parsedModel: Model = {
+                  id: ModelID.make(modelID),
+                  api: {
+                    id: model.id ?? existingModel?.api.id ?? modelID,
+                    npm:
+                      model.provider?.npm ??
+                      provider.npm ??
+                      existingModel?.api.npm ??
+                      modelsDev[providerID]?.npm ??
+                      "@ai-sdk/openai-compatible",
+                    url: model.provider?.api ?? provider?.api ?? existingModel?.api.url ?? modelsDev[providerID]?.api,
+                  },
+                  status: model.status ?? existingModel?.status ?? "active",
+                  name,
+                  providerID: ProviderID.make(providerID),
+                  capabilities: {
+                    temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
+                    reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
+                    attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
+                    toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
+                    input: {
+                      text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
+                      audio:
+                        model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
+                      image:
+                        model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
+                      video:
+                        model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
+                      pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,
+                    },
+                    output: {
+                      text: model.modalities?.output?.includes("text") ?? existingModel?.capabilities.output.text ?? true,
+                      audio:
+                        model.modalities?.output?.includes("audio") ?? existingModel?.capabilities.output.audio ?? false,
+                      image:
+                        model.modalities?.output?.includes("image") ?? existingModel?.capabilities.output.image ?? false,
+                      video:
+                        model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
+                      pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
+                    },
+                    interleaved: model.interleaved ?? false,
+                  },
+                  cost: {
+                    input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
+                    output: model?.cost?.output ?? existingModel?.cost?.output ?? 0,
+                    cache: {
+                      read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
+                      write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
+                    },
+                  },
+                  options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
+                  limit: {
+                    context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
+                    input: model.limit?.input ?? existingModel?.limit?.input,
+                    output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+                  },
+                  headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
+                  family: model.family ?? existingModel?.family ?? "",
+                  release_date: model.release_date ?? existingModel?.release_date ?? "",
+                  variants: {},
+                }
+                const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
+                parsedModel.variants = mapValues(
+                  pickBy(merged, (v) => !v.disabled),
+                  (v) => omit(v, ["disabled"]),
+                )
+                parsed.models[modelID] = parsedModel
+              }
+              target[providerID] = parsed
+            }
+          }
+
           // load plugins first so config() hook runs before reading cfg.provider
           const plugins = yield* plugin.list()
 
@@ -1064,95 +1155,7 @@ export namespace Provider {
             return true
           }
 
-          // extend database from config
-          for (const [providerID, provider] of configProviders) {
-            const existing = database[providerID]
-            const parsed: Info = {
-              id: ProviderID.make(providerID),
-              name: provider.name ?? existing?.name ?? providerID,
-              env: provider.env ?? existing?.env ?? [],
-              options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
-              source: "config",
-              models: existing?.models ?? {},
-            }
-
-            for (const [modelID, model] of Object.entries(provider.models ?? {})) {
-              const existingModel = parsed.models[model.id ?? modelID]
-              const name = iife(() => {
-                if (model.name) return model.name
-                if (model.id && model.id !== modelID) return modelID
-                return existingModel?.name ?? modelID
-              })
-              const parsedModel: Model = {
-                id: ModelID.make(modelID),
-                api: {
-                  id: model.id ?? existingModel?.api.id ?? modelID,
-                  npm:
-                    model.provider?.npm ??
-                    provider.npm ??
-                    existingModel?.api.npm ??
-                    modelsDev[providerID]?.npm ??
-                    "@ai-sdk/openai-compatible",
-                  url: model.provider?.api ?? provider?.api ?? existingModel?.api.url ?? modelsDev[providerID]?.api,
-                },
-                status: model.status ?? existingModel?.status ?? "active",
-                name,
-                providerID: ProviderID.make(providerID),
-                capabilities: {
-                  temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
-                  reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
-                  attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
-                  toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
-                  input: {
-                    text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
-                    audio:
-                      model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
-                    image:
-                      model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
-                    video:
-                      model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
-                    pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,
-                  },
-                  output: {
-                    text: model.modalities?.output?.includes("text") ?? existingModel?.capabilities.output.text ?? true,
-                    audio:
-                      model.modalities?.output?.includes("audio") ?? existingModel?.capabilities.output.audio ?? false,
-                    image:
-                      model.modalities?.output?.includes("image") ?? existingModel?.capabilities.output.image ?? false,
-                    video:
-                      model.modalities?.output?.includes("video") ?? existingModel?.capabilities.output.video ?? false,
-                    pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
-                  },
-                  interleaved: model.interleaved ?? false,
-                },
-                cost: {
-                  input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
-                  output: model?.cost?.output ?? existingModel?.cost?.output ?? 0,
-                  cache: {
-                    read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
-                    write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
-                  },
-                },
-                options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
-                limit: {
-                  context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
-                  input: model.limit?.input ?? existingModel?.limit?.input,
-                  output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
-                },
-                headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
-                family: model.family ?? existingModel?.family ?? "",
-                release_date: model.release_date ?? existingModel?.release_date ?? "",
-                variants: {},
-              }
-              const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
-              parsedModel.variants = mapValues(
-                pickBy(merged, (v) => !v.disabled),
-                (v) => omit(v, ["disabled"]),
-              )
-              parsed.models[modelID] = parsedModel
-            }
-            database[providerID] = parsed
-          }
+          applyConfig(database)
 
           // load env
           const env = Env.all()
@@ -1274,6 +1277,8 @@ export namespace Provider {
               )
             })
           }
+
+          applyConfig(providers)
 
           for (const [id, provider] of Object.entries(providers)) {
             const providerID = ProviderID.make(id)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2347,6 +2347,73 @@ test("plugin config providers persist after instance dispose", async () => {
   expect(second[ProviderID.make("demo")].models[ModelID.make("chat")]).toBeDefined()
 })
 
+test("provider hook runs for config-only providers and preserves config model overrides", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const root = path.join(dir, ".opencode", "plugin")
+      await mkdir(root, { recursive: true })
+      await Bun.write(
+        path.join(root, "demo-provider-hook.ts"),
+        [
+          "export default {",
+          '  id: "demo.provider-hook",',
+          "  server: async () => ({",
+          "    provider: {",
+          '      id: "demo",',
+          "      async models(provider) {",
+          "        return {",
+          "          ...provider.models,",
+          "          chat: {",
+          '            ...provider.models.chat,',
+          '            name: "Hook Chat",',
+          "          },",
+          "          live: {",
+          '            ...provider.models.chat,',
+          '            api: { ...provider.models.chat.api, id: "live" },',
+          '            name: "Hook Live",',
+          "          },",
+          "        }",
+          "      },",
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            demo: {
+              name: "Demo Provider",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://example.com/v1",
+              models: {
+                chat: {
+                  name: "Config Chat",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers[ProviderID.make("demo")]).toBeDefined()
+      expect(providers[ProviderID.make("demo")].models[ModelID.make("live")]).toBeDefined()
+      expect(providers[ProviderID.make("demo")].models[ModelID.make("chat")].name).toBe("Config Chat")
+    },
+  })
+})
+
 test("plugin config enabled and disabled providers are honored", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION

### Issue for this PR

Closes #25630

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This addresses the regression introduced by #25167 for config-only custom providers. Those providers could stop hitting `provider.models()` even though they were defined in `opencode.json`, while the original fix still needs user config to win over plugin hook output.

#### Summary
- reapply full config provider/model overlays after plugin `provider.models()` hooks run
- keep config-only providers eligible for model hook expansion while preserving user config precedence
- add a regression test covering config-only providers plus config override precedence

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I wrote a plugin that uses the provider hooks.It can be usedIused normally now.

### Screenshots / recordings



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
