### PR TITLE
Fix MCP tool display titles

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -131,7 +131,7 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
     additionalProperties: false,
   }
 
-  return dynamicTool({
+  const converted = dynamicTool({
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(schema),
     execute: async (args: unknown) => {
@@ -147,6 +147,9 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
         },
       )
     },
+  })
+  return Object.assign(converted, {
+    title: mcpTool.title ?? mcpTool.annotations?.title ?? mcpTool.name,
   })
 }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -522,7 +522,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }
 
               const output = {
-                title: "",
+                title: (item as { title?: string }).title ?? "",
                 metadata,
                 output: truncated.content,
                 attachments: attachments.map((attachment) => ({


### PR DESCRIPTION
## Summary
- Preserve MCP tool display titles from tools/list when converting MCP tools to AI SDK tools
- Use the preserved title when completing MCP tool calls so CLI/TUI output does not show `Unknown`
- Falls back to `tool.title`, then `tool.annotations.title`, then the MCP tool name

## Motivation
OpenCode currently renders successful MCP calls as:

```text
⚙ pekg_status Unknown
```

even when the MCP server returns:

```json
{ "name": "status", "title": "PeKG Status", "annotations": { "title": "PeKG Status" } }
```

MCP tool definitions support `title` as the human-readable display name, so the completed tool part should use it instead of an empty title.

Fixes #26044.

## Testing
- Not run locally: this environment does not have `bun` installed, so `bun run --cwd packages/opencode typecheck` could not execute.
- Patch is limited to preserving title metadata and using it in the existing MCP output object.
