### PR TITLE
fix(opencode): strip directory query when proxying to remote workspace

### DIFF
--- a/packages/opencode/src/server/shared/workspace-routing.ts
+++ b/packages/opencode/src/server/shared/workspace-routing.ts
@@ -32,5 +32,14 @@ export function workspaceProxyURL(target: string | URL, requestURL: URL) {
   proxyURL.search = requestURL.search
   proxyURL.hash = requestURL.hash
   proxyURL.searchParams.delete("workspace")
+  // The SDK rewrites the client's `x-opencode-directory` header into a
+  // `?directory=` query before sending. When the request is then proxied
+  // to a remote workspace, that local-machine path leaks through and the
+  // remote falls back to `worktree="/"` because the path doesn't exist on
+  // its filesystem — which corrupts downstream `path.relative()` callers
+  // (notably `sessionListQuery`) and wipes the TUI's session list.
+  // Strip it so the workspace adapter's `target.headers["x-opencode-directory"]`
+  // (the workspace's directory on the remote) wins.
+  proxyURL.searchParams.delete("directory")
   return proxyURL
 }

--- a/packages/opencode/test/server/workspace-routing.test.ts
+++ b/packages/opencode/test/server/workspace-routing.test.ts
@@ -75,6 +75,18 @@ describe("workspaceProxyURL", () => {
     expect(result.searchParams.get("keep")).toBe("yes")
   })
 
+  test("strips directory query so the remote uses its own working directory", () => {
+    // The SDK rewrites the client's `x-opencode-directory` header into a
+    // `?directory=` query before sending. Forwarding that local-machine
+    // path to a remote workspace makes the remote fall back to
+    // `worktree="/"` (the path doesn't exist on its filesystem) and
+    // corrupts downstream `path.relative()` callers.
+    const url = new URL("http://localhost/path?workspace=ws_123&directory=%2FUsers%2Falice%2Fproj")
+    const result = workspaceProxyURL("http://remote:8080", url)
+    expect(result.searchParams.get("workspace")).toBeNull()
+    expect(result.searchParams.get("directory")).toBeNull()
+  })
+
   test("preserves hash from request", () => {
     const url = new URL("http://localhost/page#section")
     const result = workspaceProxyURL("http://remote:8080", url)


### PR DESCRIPTION
### Issue for this PR

Closes #26075

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`workspaceProxyURL` strips `?workspace=` before forwarding a request to a remote workspace, but it doesn't strip `?directory=`. The SDK rewrites the client's `x-opencode-directory` header into a `?directory=` query for GET/HEAD (`packages/sdk/js/src/v2/client.ts`), so when a request flows through the workspace-routing middleware, the local client's directory leaks to the remote.

The remote then tries to resolve a path that doesn't exist on its filesystem, falls back to `worktree: "/"`, and that broken path corrupts downstream `path.relative()` callers — most visibly `sessionListQuery` in the TUI sync context, which then returns no sessions and the session route renders empty.

Adding `proxyURL.searchParams.delete("directory")` next to the existing `workspace` strip lets the adapter's `target.headers["x-opencode-directory"]` (the workspace's own directory on the remote) win, which is the intended contract.

### How did you verify your code works?

- Added a unit test in `packages/opencode/test/server/workspace-routing.test.ts` asserting both `workspace` and `directory` are stripped. Full file: 16/16 pass via `bun --cwd packages/opencode test test/server/workspace-routing.test.ts`.
- Reproduced the bug directly without the fix: `curl 'https://<remote>/path?directory=<some-local-path-not-on-remote>'` returns `{"worktree": "/", ...}`. Removing the `directory` param returns the correct workspace path. Confirms why the proxied request was triggering the wrong fallback.
- Reproduced end-to-end with a custom remote `WorkspaceAdapter`: before the fix, `/warp` succeeded but the TUI showed a blank session view. After the fix, the session view renders correctly.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR