### PR TITLE
fix(session): server always generates message ID, store client-provided ID as clientMessageID

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -397,6 +397,7 @@ export const User = Schema.Struct({
   }),
   system: Schema.optional(Schema.String),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),
+  clientMessageID: Schema.optional(Schema.String),
 })
   .annotate({ identifier: "UserMessage" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -758,12 +758,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
             const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
             const userMsg: MessageV2.User = {
-              id: input.messageID ?? MessageID.ascending(),
+              id: MessageID.ascending(),
               sessionID: input.sessionID,
               time: { created: Date.now() },
               role: "user",
               agent: input.agent,
               model: { providerID: model.providerID, modelID: model.modelID },
+              clientMessageID: input.messageID,
             }
             yield* sessions.updateMessage(userMsg)
             const userPart: MessageV2.Part = {
@@ -940,7 +941,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const variant = input.variant ?? (ag.variant && full?.variants?.[ag.variant] ? ag.variant : undefined)
 
       const info: MessageV2.User = {
-        id: input.messageID ?? MessageID.ascending(),
+        id: MessageID.ascending(),
         role: "user",
         sessionID: input.sessionID,
         time: { created: Date.now() },
@@ -953,6 +954,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         },
         system: input.system,
         format: input.format,
+        clientMessageID: input.messageID,
       }
 
       const current = Database.use((db) =>

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2059,3 +2059,107 @@ it.live(
     ),
   30_000,
 )
+
+// clientMessageID tests — verifying that server always generates the canonical message ID
+// and stores any caller-provided messageID as clientMessageID only.
+
+it.live("prompt stores caller-provided messageID as clientMessageID, not as the message id", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "clientMessageID test",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      const clientID = MessageID.ascending()
+
+      yield* llm.text("response")
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        messageID: clientID,
+        parts: [{ type: "text", text: "hello" }],
+      })
+
+      const msgs = yield* sessions.messages({ sessionID: session.id })
+      const userMsg = msgs.find((m) => m.info.role === "user")
+
+      expect(userMsg).toBeDefined()
+      if (userMsg && userMsg.info.role === "user") {
+        // The stored id must be a fresh server-generated ID, not the caller-provided one
+        expect(userMsg.info.id).not.toBe(clientID)
+        // The caller-provided ID is preserved in clientMessageID
+        expect(userMsg.info.clientMessageID).toBe(clientID)
+      }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("assistant parentID points to server-generated user message id when messageID is provided", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "parentID test",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      const clientID = MessageID.ascending()
+
+      yield* llm.text("response")
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        messageID: clientID,
+        parts: [{ type: "text", text: "hello" }],
+      })
+
+      const msgs = yield* sessions.messages({ sessionID: session.id })
+      const userMsg = msgs.find((m) => m.info.role === "user")
+      const assistantMsg = msgs.find((m) => m.info.role === "assistant")
+
+      expect(userMsg).toBeDefined()
+      expect(assistantMsg).toBeDefined()
+      if (userMsg && assistantMsg && assistantMsg.info.role === "assistant") {
+        // Assistant must reference the server-generated user message id
+        expect(assistantMsg.info.parentID).toBe(userMsg.info.id)
+        // And that id is NOT the client-provided one
+        expect(assistantMsg.info.parentID).not.toBe(clientID)
+      }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("prompt without messageID still creates user message with no clientMessageID", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "no clientMessageID test",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* llm.text("response")
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        parts: [{ type: "text", text: "hello" }],
+      })
+
+      const msgs = yield* sessions.messages({ sessionID: session.id })
+      const userMsg = msgs.find((m) => m.info.role === "user")
+
+      expect(userMsg).toBeDefined()
+      if (userMsg && userMsg.info.role === "user") {
+        expect(userMsg.info.clientMessageID).toBeUndefined()
+      }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #11869

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a caller passes a custom \`messageID\` to \`prompt\`, OpenCode used it directly:


`id: input.messageID ?? MessageID.ascending(),`

Passing an ID takes a different async code path than the no-ID case. With openai-compatible providers like LiteLLM, streaming starts fast enough that by the time the stream processor attaches, the first \`text-start\` chunk has already come and gone. The Vercel AI SDK tracks text parts by ID in \`activeTextContent\` — \`text-start\` registers the entry, \`text-delta\` looks it up. If \`text-start\` is dropped because the processor wasn't ready yet, \`text-delta\` finds nothing and throws:

`
text part chatcmpl-xxx not found`


The no-\`messageID\` path doesn't hit this because it's synchronous — the processor is always attached before LiteLLM sends anything.

I looked at whether an \`await\` could fix it. \`createUserMessage\` is already awaited before the loop. The race is inside \`streamText\`'s \`eventProcessor\` TransformStream, which is internal to the AI SDK — there's nowhere in OpenCode's code to insert an await that reliably closes the window.

The fix: always generate the ID server-side, store whatever the caller sent as \`clientMessageID\`:


```
// Before
id: input.messageID ?? MessageID.ascending(),

// After
id: MessageID.ascending(),
clientMessageID: input.messageID,
```


One code path now. Processor always attaches before streaming starts. Callers can still correlate their ID via \`clientMessageID\` on the \`message.updated\` SSE event. This also fixes the clock skew stall from #24476 / #25024 as a side effect — client-generated IDs can arrive out of order when clocks differ.

### How did you verify your code works?

Added three tests to \`test/session/prompt.test.ts\`:

- When \`messageID\` is passed, the stored message gets a server-generated \`id\`, not the caller's value
- The caller's value is saved as \`clientMessageID\`
- The assistant's \`parentID\` references the server-generated \`id\`
- When no \`messageID\` is passed, \`clientMessageID\` is \`undefined\`

All pass. There's one pre-existing timeout failure in the suite unrelated to this change.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR