### PR TITLE
fix(desktop): add macOS settings menu entry

### DIFF
--- a/packages/desktop/src/main/menu.ts
+++ b/packages/desktop/src/main/menu.ts
@@ -24,6 +24,11 @@ export function createMenu(deps: Deps) {
           click: () => deps.checkForUpdates(),
         },
         {
+          label: "Settings",
+          accelerator: "Cmd+,",
+          click: () => deps.trigger("settings.open"),
+        },
+        {
           label: "Reload Webview",
           click: () => deps.reload(),
         },


### PR DESCRIPTION
### Issue for this PR

Closes #26080

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the existing `Settings` action to the macOS app menu in the desktop app.

The settings UI already existed and `Cmd+,` already opened it, but there was no matching `Settings` item in the standard macOS app menu. This change wires the new menu entry to the existing `settings.open` command, so it uses the same behavior that was already present.

### How did you verify your code works?

I ran the desktop app locally on macOS and verified that:
- `Settings` now appears in the `OpenCode` app menu
- clicking `OpenCode > Settings` opens the settings dialog
- `Cmd+,` still opens the same settings dialog

### Screenshots / recordings

<img width="270" height="283" alt="opencode-after-macos-menu-items" src="https://github.com/user-attachments/assets/dfc87825-95c2-406a-8157-b439fdc1f473" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR