### PR TITLE
feat(tool): increase webfetch response size limit from 5MB to 20MB

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -5,7 +5,7 @@ import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
 import { isImageAttachment } from "@/util/media"
 
-const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
+const MAX_RESPONSE_SIZE = 20 * 1024 * 1024 // 20MB
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
 const MAX_TIMEOUT = 120 * 1000 // 2 minutes
 
@@ -93,12 +93,12 @@ export const WebFetchTool = Tool.define(
           // Check content length
           const contentLength = response.headers["content-length"]
           if (contentLength && parseInt(contentLength) > MAX_RESPONSE_SIZE) {
-            throw new Error("Response too large (exceeds 5MB limit)")
+            throw new Error("Response too large (exceeds 20MB limit)")
           }
 
           const arrayBuffer = yield* response.arrayBuffer
           if (arrayBuffer.byteLength > MAX_RESPONSE_SIZE) {
-            throw new Error("Response too large (exceeds 5MB limit)")
+            throw new Error("Response too large (exceeds 20MB limit)")
           }
 
           const contentType = response.headers["content-type"] || ""


### PR DESCRIPTION
## Summary

- Increase `MAX_RESPONSE_SIZE` in the webfetch tool from 5MB to 20MB
- Update error messages to reflect the new limit

## Why

The 5MB limit blocks thorough web research on content-heavy pages like AI leaderboards (LMSYS, Artificial Analysis), documentation sites, and data-heavy dashboards. These pages routinely exceed 5MB due to embedded charts, scripts, and interactive elements — even when the actual text content is small.

20MB provides enough headroom for proper investigation while still protecting against memory exhaustion.

## Changes

| File | Change |
|------|--------|
| `packages/opencode/src/tool/webfetch.ts` | `MAX_RESPONSE_SIZE`: 5MB -> 20MB |
| | Error messages updated accordingly |
