### PR TITLE
fix(server): apply cors before legacy auth

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -107,10 +107,10 @@ function createHono(opts: CorsOptions, selection: ServerBackend.Selection = Serv
   const backendAttributes = ServerBackend.attributes(selection)
   const app = new Hono()
     .onError(ErrorMiddleware)
+    .use(CorsMiddleware(opts))
     .use(AuthMiddleware)
     .use(LoggerMiddleware(backendAttributes))
     .use(CompressionMiddleware)
-    .use(CorsMiddleware(opts))
     .route("/global", GlobalRoutes())
 
   const runtime = adapter.create(app)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -108,8 +108,8 @@ function createHono(opts: CorsOptions, selection: ServerBackend.Selection = Serv
   const app = new Hono()
     .onError(ErrorMiddleware)
     .use(CorsMiddleware(opts))
-    .use(AuthMiddleware)
     .use(LoggerMiddleware(backendAttributes))
+    .use(AuthMiddleware)
     .use(CompressionMiddleware)
     .route("/global", GlobalRoutes())
 

--- a/packages/opencode/test/server/httpapi-cors.test.ts
+++ b/packages/opencode/test/server/httpapi-cors.test.ts
@@ -63,6 +63,21 @@ describe("HttpApi CORS", () => {
     }),
   )
 
+  it.live("adds CORS headers to legacy unauthorized responses", () =>
+    Effect.gen(function* () {
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          Server.Legacy().app.request("/global/config", {
+            headers: { origin: "https://app.opencode.ai" },
+          }),
+        ),
+      )
+
+      expect(response.status).toBe(401)
+      expect(response.headers.get("access-control-allow-origin")).toBe("https://app.opencode.ai")
+    }),
+  )
+
   it.live("uses custom CORS origins passed to the server", () =>
     Effect.gen(function* () {
       const listener = yield* Effect.acquireRelease(

--- a/packages/opencode/test/server/httpapi-cors.test.ts
+++ b/packages/opencode/test/server/httpapi-cors.test.ts
@@ -65,12 +65,10 @@ describe("HttpApi CORS", () => {
 
   it.live("adds CORS headers to legacy unauthorized responses", () =>
     Effect.gen(function* () {
-      const response = yield* Effect.promise(() =>
-        Promise.resolve(
-          Server.Legacy().app.request("/global/config", {
-            headers: { origin: "https://app.opencode.ai" },
-          }),
-        ),
+      const response = yield* Effect.promise(async () =>
+        Server.Legacy().app.request("/global/config", {
+          headers: { origin: "https://app.opencode.ai" },
+        }),
       )
 
       expect(response.status).toBe(401)


### PR DESCRIPTION
## Summary
- Run legacy Hono CORS middleware before auth so unauthorized browser responses include CORS headers.
- Add a regression for `app.opencode.ai` hitting authenticated local server routes.

## Testing
- `bun test test/server/httpapi-cors.test.ts`
- `bun typecheck`
- pre-push `bun turbo typecheck`