### PR TITLE
fix(app): scope reset archive to workspace

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -70,6 +70,7 @@ import {
   effectiveWorkspaceOrder,
   errorMessage,
   latestRootSession,
+  resetArchiveSessions,
   sortedRootSessions,
 } from "./layout/helpers"
 import {
@@ -1580,17 +1581,15 @@ export default function Layout(props: ParentProps) {
 
     const archivedAt = Date.now()
     await Promise.all(
-      sessions
-        .filter((session) => session.time.archived === undefined)
-        .map((session) =>
-          globalSDK.client.session
-            .update({
-              sessionID: session.id,
-              directory: session.directory,
-              time: { archived: archivedAt },
-            })
-            .catch(() => undefined),
-        ),
+      resetArchiveSessions(sessions, directory).map((session) =>
+        globalSDK.client.session
+          .update({
+            sessionID: session.id,
+            directory: session.directory,
+            time: { archived: archivedAt },
+          })
+          .catch(() => undefined),
+      ),
     )
 
     setBusy(directory, false)
@@ -1687,7 +1686,7 @@ export default function Layout(props: ParentProps) {
         .list({ directory: props.directory })
         .then((x) => x.data ?? [])
         .catch(() => [])
-      const active = sessions.filter((session) => session.time.archived === undefined)
+      const active = resetArchiveSessions(sessions, props.directory)
       setState({ sessions: active })
     }
 

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -14,6 +14,7 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  resetArchiveSessions,
 } from "./helpers"
 import { pathKey } from "@/utils/path-key"
 
@@ -197,6 +198,20 @@ describe("layout workspace helpers", () => {
     )
 
     expect(result?.id).toBe("root")
+  })
+
+  test("archives only active sessions in the reset workspace", () => {
+    const result = resetArchiveSessions(
+      [
+        session({ id: "target", directory: "/repo/worktree" }),
+        session({ id: "target-slash", directory: "/repo/worktree/" }),
+        session({ id: "other", directory: "/repo/other-worktree" }),
+        session({ id: "archived", directory: "/repo/worktree", time: { created: 0, updated: 0, archived: 1 } }),
+      ],
+      "/repo/worktree",
+    )
+
+    expect(result.map((item) => item.id)).toEqual(["target", "target-slash"])
   })
 
   test("finds the direct child on the active session path", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -32,6 +32,9 @@ export const sortedRootSessions = (store: SessionStore, now: number) => roots(st
 export const latestRootSession = (stores: SessionStore[], now: number) =>
   stores.flatMap(roots).sort(sortSessions(now))[0]
 
+export const resetArchiveSessions = (sessions: Session[], directory: string) =>
+  sessions.filter((session) => pathKey(session.directory) === pathKey(directory) && session.time.archived === undefined)
+
 export function hasProjectPermissions<T>(
   request: Record<string, T[] | undefined> | undefined,
   include: (item: T) => boolean = () => true,


### PR DESCRIPTION
### Issue for this PR

Closes #26101

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Resetting a workspace archives sessions after listing them for that directory. That list can include sessions from other worktrees, so the reset flow needs a final directory check before archiving anything.

This filters the archive targets to active sessions whose stored directory matches the workspace being reset. The reset confirmation count uses the same filter so the dialog matches what will happen.

### How did you verify your code works?

Ran these from `packages/app`:

- `bun test src/pages/layout/helpers.test.ts`
- `bun typecheck`

The push hook also ran `bun turbo typecheck` successfully.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR