### PR TITLE
fix(tui): avoid opentui-spinner color type conflicts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/spinner.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/spinner.ts
@@ -1,6 +1,7 @@
 import type { ColorInput } from "@opentui/core"
 import { RGBA } from "@opentui/core"
-import type { ColorGenerator } from "opentui-spinner"
+
+type ColorGenerator = (frameIndex: number, charIndex: number, totalFrames: number, totalChars: number) => ColorInput
 
 interface AdvancedGradientOptions {
   colors: ColorInput[]


### PR DESCRIPTION
### Issue for this PR

Closes #26119

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a package typecheck failure in `packages/opencode/src/cli/cmd/tui/ui/spinner.ts` caused by importing `ColorGenerator` through `opentui-spinner`.

The problem is that the repo uses `@opentui/core@0.2.2`, while `opentui-spinner@0.0.6` is typed against `@opentui/core@^0.1.49`. That causes Bun to install two different `@opentui/core` type graphs, and the branded `ColorInput` / `RGBA` types stop matching.

This PR replaces the imported `ColorGenerator` type with an equivalent local structural alias in `spinner.ts`.

Why this works:
- it avoids pulling the conflicting nested `@opentui/core` types through `opentui-spinner`
- runtime behavior does not change because this is type-only wiring
- `bun typecheck` succeeds again in `packages/opencode`

### How did you verify your code works?

From `packages/opencode`:
- `bun typecheck`

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
