### PR TITLE
feat: add plugin file-change notifications

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -43,6 +43,9 @@ import { LSP } from "@/lsp/lsp"
 import { Instruction } from "../session/instruction"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Bus } from "../bus"
+import { File } from "../file"
+import { FileWatcher } from "../file/watcher"
+import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
@@ -139,6 +142,14 @@ export const layer: Layer.Layer<
                   ask: (req) => toolCtx.ask(req),
                   directory: ctx.directory,
                   worktree: ctx.worktree,
+                  notifyFileChanged: async ({ filePath, event = "change" }) =>
+                    // Restore the instance ALS so the async bus publishes still see
+                    // the active project context after the plugin awaits.
+                    Instance.restore(ctx, async () => {
+                      const file = path.isAbsolute(filePath) ? filePath : path.join(ctx.directory, filePath)
+                      await Bus.publish(File.Event.Edited, { file })
+                      await Bus.publish(FileWatcher.Event.Updated, { file, event })
+                    }),
                 }
                 const result = yield* Effect.promise(() => def.execute(args as any, pluginCtx))
                 const output = typeof result === "string" ? result : result.output

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -8,6 +8,8 @@ import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { TestConfig } from "../fixture/config"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { File } from "@/file"
+import { FileWatcher } from "@/file/watcher"
 import { Plugin } from "@/plugin"
 import { Question } from "@/question"
 import { Todo } from "@/session/todo"
@@ -23,6 +25,7 @@ import { Format } from "@/format"
 import { Ripgrep } from "@/file/ripgrep"
 import * as Truncate from "@/tool/truncate"
 import { InstanceState } from "@/effect/instance-state"
+import { MessageID, SessionID } from "@/session/schema"
 
 const node = CrossSpawnSpawner.defaultLayer
 const configLayer = TestConfig.layer({
@@ -183,6 +186,74 @@ describe("tool.registry", () => {
       const registry = yield* ToolRegistry.Service
       const ids = yield* registry.ids()
       expect(ids).toContain("cowsay")
+    }),
+  )
+
+  it.instance("plugin tools can publish file change notifications", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const opencode = path.join(test.directory, ".opencode")
+      const toolDir = path.join(opencode, "tool")
+      const fileName = "refresh.txt"
+      const file = path.join(test.directory, fileName)
+      const toolFile = path.join(toolDir, "notify.ts")
+
+      yield* Effect.promise(() => fs.mkdir(toolDir, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          toolFile,
+          [
+            "import path from \"path\"",
+            "export default {",
+            "  description: 'notify file changes',",
+            "  args: {},",
+            "  execute: async (_args, context) => {",
+            `    const file = path.join(context.directory, ${JSON.stringify(fileName)})`,
+            '    await Bun.write(file, "fresh")',
+            `    await context.notifyFileChanged({ filePath: ${JSON.stringify(fileName)}, event: "change" })`,
+            '    return "done"',
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const tool = (yield* registry.all()).find((tool) => tool.id === "notify")
+      if (!tool) throw new Error("notify tool not found")
+
+      const events: string[] = []
+      const offEdited = Bus.subscribe(File.Event.Edited, (evt) => {
+        if (evt.properties.file === file) events.push("edited")
+      })
+      const offUpdated = Bus.subscribe(FileWatcher.Event.Updated, (evt) => {
+        if (evt.properties.file === file) events.push(`watch:${evt.properties.event}`)
+      })
+
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          offEdited()
+          offUpdated()
+        }),
+      )
+
+      const result = yield* tool.execute({}, {
+        sessionID: SessionID.make("ses_test"),
+        messageID: MessageID.make("msg_test"),
+        agent: "build",
+        abort: new AbortController().signal,
+        messages: [],
+        metadata: () => Effect.void,
+        ask: () => Effect.void,
+      })
+
+      yield* Effect.promise(() => Bun.sleep(10))
+      const content = yield* Effect.promise(() => fs.readFile(file, "utf8"))
+
+      expect(result.output).toBe("done")
+      expect(content).toBe("fresh")
+      expect(events).toEqual(["edited", "watch:change"])
     }),
   )
 })

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -18,6 +18,12 @@ export type ToolContext = {
   abort: AbortSignal
   metadata(input: { title?: string; metadata?: { [key: string]: any } }): void
   ask(input: AskInput): Effect.Effect<void>
+  /**
+   * Tell OpenCode that a file changed after the plugin updated it on disk.
+   * OpenCode uses this to publish the same file and file-watcher events that
+   * native write/edit tools emit.
+   */
+  notifyFileChanged(input: { filePath: string; event?: "add" | "change" }): Promise<void>
 }
 
 type AskInput = {


### PR DESCRIPTION
### Issue for this PR
Closes #26118

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This is the file-watcher half of the plugin post-edit parity work, paired with #14228.

It adds `notifyFileChanged({ filePath, event })` to `@opencode-ai/plugin` tool context so plugin-authored tools can tell OpenCode when they have written a file. The host registry turns that into the same file and file-watcher bus events that native write/edit tools already emit.

This PR does not try to expose LSP itself; that remains covered by #14228.

### How did you verify your code works?

- `bun test test/tool/registry.test.ts`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
