### PR TITLE
change /review to no longer be subagent invocation

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -96,7 +96,6 @@ export const layer = Layer.effect(
         get template() {
           return PROMPT_REVIEW.replace("${path}", ctx.worktree)
         },
-        subtask: true,
         hints: hints(PROMPT_REVIEW),
       }
 


### PR DESCRIPTION
I use review all the time and I've found it rather annoying that its a subagent invocation tbh