### PR TITLE
fix(windows): detach child process to prevent taskkill /F /IM node.exe from killing opencode

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -6,15 +6,18 @@ const path = require("path")
 const os = require("os")
 
 function run(target) {
-  const result = childProcess.spawnSync(target, process.argv.slice(2), {
-    stdio: "inherit",
+  const child = childProcess.spawn(target, process.argv.slice(2), {
+    stdio: [0, 1, 2],
+    detached: true,
+    windowsHide: false,
   })
-  if (result.error) {
-    console.error(result.error.message)
+  child.on("error", (err) => {
+    console.error(err.message)
     process.exit(1)
-  }
-  const code = typeof result.status === "number" ? result.status : 0
-  process.exit(code)
+  })
+  child.on("exit", (code) => {
+    process.exit(typeof code === "number" ? code : 0)
+  })
 }
 
 const envPath = process.env.OPENCODE_BIN_PATH


### PR DESCRIPTION
### Issue for this PR

Closes #25930

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, when OpenCode is installed via npm, the `bin/opencode` launcher is a Node.js script that uses `childProcess.spawnSync()` to run the compiled `opencode.exe` binary. Because `spawnSync` is synchronous, the `node.exe` process stays alive as a blocking parent of `opencode.exe` for the entire session. Running `taskkill /F /IM node.exe` (or similar) kills the node launcher, which also brings down `opencode.exe`.

This fixes it by switching from `spawnSync` to `spawn` with `detached: true` and explicit stdio handles (`[0, 1, 2]`). The child process now runs in its own process group, so force-killing `node.exe` no longer cascades to `opencode.exe`.

Note: PR #25762 addresses a related but different aspect — it adds prompt/runtime guards to prevent the AI from *issuing* these commands. This PR fixes the underlying process architecture so that even if the commands are run (by the user manually, or any other scenario), OpenCode survives.

### How did you verify your code works?

- `node --check` confirms the launcher script is syntactically valid
- `bun run dev` launches OpenCode correctly — TUI renders, console output works
- Tested the patched launcher with the npm-installed version: OpenCode stays alive after running `taskkill /F /IM node.exe` in a separate terminal
- Exit codes propagate correctly when OpenCode exits normally

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR