### PR TITLE
fix(cli): redirect Bun's tempdir when /tmp is mounted noexec

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -17,6 +17,55 @@ function run(target) {
   process.exit(code)
 }
 
+// Linux-only workaround for noexec /tmp.
+// On hardened Linux (CIS / STIG / Lynis baselines mount /tmp with noexec),
+// dlopen() of Bun's extracted libopentui.so fails with "failed to map
+// segment from shared object" and the TUI hangs silently. Detect a noexec
+// mount covering the temp dir and redirect Bun's extraction to a writable,
+// exec-allowed dir under the user's home.
+// Refs: #5175, #3765, #4605, #6080
+function ensureExecutableTmpdir() {
+  if (process.platform !== "linux") return
+  if (process.env.BUN_TMPDIR) return
+
+  const candidate = process.env.TMPDIR || "/tmp"
+  let mounts
+  try {
+    mounts = fs.readFileSync("/proc/self/mounts", "utf8")
+  } catch {
+    return
+  }
+
+  let best = null
+  for (const line of mounts.split("\n")) {
+    const parts = line.split(/\s+/)
+    if (parts.length < 4) continue
+    const mountPoint = parts[1]
+    const options = parts[3]
+    if (
+      candidate === mountPoint ||
+      candidate.startsWith(mountPoint === "/" ? "/" : mountPoint + "/")
+    ) {
+      if (!best || mountPoint.length > best.mountPoint.length) {
+        best = { mountPoint, options }
+      }
+    }
+  }
+
+  if (!best) return
+  if (!best.options.split(",").includes("noexec")) return
+
+  const fallback = path.join(os.homedir(), ".cache", "opencode", "tmp")
+  try {
+    fs.mkdirSync(fallback, { recursive: true })
+    process.env.BUN_TMPDIR = fallback
+  } catch {
+    // best effort; if we can't create the fallback, the original error surfaces
+  }
+}
+
+ensureExecutableTmpdir()
+
 const envPath = process.env.OPENCODE_BIN_PATH
 if (envPath) {
   run(envPath)


### PR DESCRIPTION
### Issue for this PR

Closes #26136

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a silent hang when `/tmp` is mounted `noexec`. This is fairly common on hardened Linux setups (CIS, STIG, Lynis baselines all set `noexec,nodev,nosuid` on `/tmp`), and increasingly common on managed corporate workstations.

The bundled Bun runtime extracts `libopentui.so` to `$TMPDIR` (defaults to `/tmp`) and `dlopen`s it. When the mount has `noexec`, mmap can't grant the EXEC perm on the segments and dlopen fails. The TUI swallows the error and the process just hangs — there's no user-visible output unless you remember to pass `--print-logs --log-level DEBUG`.

Bun reads `BUN_TMPDIR` to override its embedded-file extraction path. The Node launcher in `packages/opencode/bin/opencode` already runs before the Bun child is spawned, so it's the right place to set that env var when needed.

The patch adds `ensureExecutableTmpdir()` which, on Linux only:

1. respects an existing `BUN_TMPDIR` (if the user already set it, don't touch it)
2. parses `/proc/self/mounts` to find the longest mountpoint covering `$TMPDIR` (or `/tmp` if unset)
3. if that mount has the `noexec` option, sets `BUN_TMPDIR` to `$HOME/.cache/opencode/tmp` and `mkdir -p`s it

If `/tmp` is exec-allowed (the common case for everyone not on a hardened box), the function returns immediately and there's zero behavior change. If anything in detection or mkdir fails, it bails out silently so the original error still surfaces — never makes things worse.

The same workaround was already documented as a user wrapper in `#5175`. This just moves it inside the launcher so affected users don't need a wrapper script.

Why this and not a Bun-side fix: a maintainer comment on `#5175` notes the underlying issue is also being worked on in Bun. Once that lands this shim becomes a no-op and can be removed. Until then, this unblocks users.

### How did you verify your code works?

Tested on Ubuntu 24.04 (kernel 6.17) with `/tmp` mounted `rw,nosuid,nodev,noexec`:

Before the patch:

- `opencode` hangs forever
- `opencode --print-logs --log-level DEBUG` shows `Failed to initialize OpenTUI render library: ... failed to map segment from shared object`

After the patch:

- `opencode` brings up the TUI normally; all internal plugins (`home-footer`, `home-tips`, `sidebar-context`, etc.) report `loaded`
- `~/.cache/opencode/tmp/` is created on first run, libopentui.so lands there

Also verified the no-op paths:

- with `BUN_TMPDIR=/some/path` already exported → function returns early, env var preserved
- on a system with exec-allowed `/tmp` (a separate VM) → function still returns early, no `~/.cache/opencode/tmp/` is created

Ran `node --check packages/opencode/bin/opencode` to make sure the launcher still parses.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
