### PR TITLE
fix: add exit event fallback for child process close hang on Windows

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -273,6 +273,12 @@ export const make = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
+        setTimeout(() => {
+          if (!end) {
+            end = true
+            Deferred.doneUnsafe(signal, Exit.succeed(args))
+          }
+        }, 2000)
       })
       proc.on("close", (...args) => {
         if (end) return

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -282,6 +282,29 @@ describe("cross-spawn spawner", () => {
         expect(running).toBe(false)
       }),
     )
+
+    fx.effect(
+      "exit fallback resolves when close hangs due to grandchild holding pipe",
+      Effect.gen(function* () {
+        if (process.platform !== "win32") return
+
+        const started = Date.now()
+        const handle = yield* js(`
+          const { spawn } = require('child_process')
+          spawn(process.execPath, ['-e', 'setTimeout(()=>{}, 10000)'], {
+            stdio: ['ignore', process.stdout, 'ignore'],
+            detached: true
+          })
+          process.exit(0)
+        `)
+        const code = yield* handle.exitCode
+        const elapsed = Date.now() - started
+
+        expect(elapsed).toBeGreaterThan(1500)
+        expect(elapsed).toBeLessThan(5000)
+        expect(code).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+    )
   })
 
   describe("error handling", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #24784

Replaces #24783 (stale - branch diverged from dev and could no longer merge cleanly).

### Type of change

- [x] Bug fix

### What does this PR do?

On Windows, when a child process spawns grandchild processes (e.g., build tools like hvigor/Gradle daemons), the grandchild may inherit the stdout/stderr pipe handles. Even after the direct child exits, these inherited handles keep the pipe open, preventing Node.js close event from firing.

The exitCode in cross-spawn-spawner.ts was resolved only on close event, causing bash tool to hang indefinitely in Effect.raceAll waiting for handle.exitCode.

This PR adds a fallback: resolve exitCode on exit event with a 2-second delay. If close fires within 2 seconds (normal case), behavior is unchanged. If close does not fire (daemon holds pipe), fallback resolves after 2 seconds.

### How did you verify your code works?

1. Typecheck passes: bun typecheck in packages/core
2. New test added for the Windows-specific fallback scenario
3. Logic identical to #24783, rebased on latest dev

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
