### PR TITLE
fix(opencode): handle cancel in upgrade process and customize spinner

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -1,5 +1,6 @@
 import { cmd } from "./cmd"
 import * as prompts from "@clack/prompts"
+import { createSpinner } from "../prompt"
 import { UI } from "../ui"
 import { Global } from "@opencode-ai/core/global"
 import { Agent } from "../../agent/agent"
@@ -124,7 +125,7 @@ const AgentCreateCommand = effectCmd({
       }
 
       // Generate agent
-      const spinner = prompts.spinner()
+      const spinner = createSpinner()
       spinner.start("Generating agent configuration...")
       const model = args.model ? Provider.parseModel(args.model) : undefined
       const generated = await Effect.runPromise(agentSvc.generate({ description, model })).catch((error) => {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -2,6 +2,7 @@ import path from "path"
 import { exec } from "child_process"
 import { Filesystem } from "@/util/filesystem"
 import * as prompts from "@clack/prompts"
+import { createSpinner } from "../prompt"
 import { map, pipe, sortBy, values } from "remeda"
 import { Octokit } from "@octokit/rest"
 import { graphql } from "@octokit/graphql"
@@ -325,7 +326,7 @@ export const GithubInstallCommand = effectCmd({
         }
 
         async function installGitHubApp() {
-          const s = prompts.spinner()
+          const s = createSpinner()
           s.start("Installing GitHub app")
 
           // Get installation

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -5,6 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import * as prompts from "@clack/prompts"
+import { createSpinner } from "../prompt"
 import { UI } from "../ui"
 import { MCP } from "../../mcp"
 import { McpAuth } from "../../mcp/auth"
@@ -253,7 +254,7 @@ export const McpAuthCommand = effectCmd({
       prompts.log.warn(`${serverName} has expired credentials. Re-authenticating...`)
     }
 
-    const spinner = prompts.spinner()
+    const spinner = createSpinner()
     spinner.start("Starting OAuth flow...")
 
     // Subscribe to browser open failure events to show URL for manual opening
@@ -665,7 +666,7 @@ export const McpDebugCommand = effectCmd({
         }
       }
 
-      const spinner = prompts.spinner()
+      const spinner = createSpinner()
       spinner.start("Testing connection...")
 
       // Test basic HTTP connectivity first

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -1,4 +1,5 @@
-import { intro, log, outro, spinner } from "@clack/prompts"
+import { intro, log, outro } from "@clack/prompts"
+import { createSpinner } from "../prompt"
 import { Effect } from "effect"
 
 import { ConfigPaths } from "@/config/paths"
@@ -45,7 +46,7 @@ export type PlugCtx = {
 }
 
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => createSpinner(),
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -1,6 +1,7 @@
 import type { Argv } from "yargs"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
+import { createSpinner } from "../prompt"
 import { Installation } from "../../installation"
 import { Global } from "@opencode-ai/core/global"
 import fs from "fs/promises"
@@ -142,7 +143,7 @@ async function showRemovalSummary(targets: RemovalTargets, method: Installation.
 }
 
 async function executeUninstall(method: Installation.Method, targets: RemovalTargets) {
-  const spinner = prompts.spinner()
+  const spinner = createSpinner()
   const errors: string[] = []
 
   for (const dir of targets.directories) {

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -1,6 +1,7 @@
 import type { Argv } from "yargs"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
+import { createSpinner } from "../prompt"
 import { Installation } from "../../installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 
@@ -52,7 +53,7 @@ export const UpgradeCommand = {
     }
 
     prompts.log.info(`From ${InstallationVersion} → ${target}`)
-    const spinner = prompts.spinner({ frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] })
+    const spinner = createSpinner()
     spinner.start("Upgrading...")
     const err = await Installation.upgrade(method, target).catch((err) => err)
     if (err) {

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -37,7 +37,7 @@ export const UpgradeCommand = {
         ],
         initialValue: false,
       })
-      if (!install) {
+      if (prompts.isCancel(install) || !install) {
         prompts.outro("Done")
         return
       }
@@ -52,7 +52,7 @@ export const UpgradeCommand = {
     }
 
     prompts.log.info(`From ${InstallationVersion} → ${target}`)
-    const spinner = prompts.spinner()
+    const spinner = prompts.spinner({ frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] })
     spinner.start("Upgrading...")
     const err = await Installation.upgrade(method, target).catch((err) => err)
     if (err) {

--- a/packages/opencode/src/cli/effect/prompt.ts
+++ b/packages/opencode/src/cli/effect/prompt.ts
@@ -1,5 +1,6 @@
 import * as prompts from "@clack/prompts"
 import { Effect, Option } from "effect"
+import { createSpinner } from "../prompt"
 
 export const intro = (msg: string) => Effect.sync(() => prompts.intro(msg))
 export const outro = (msg: string) => Effect.sync(() => prompts.outro(msg))
@@ -29,7 +30,7 @@ export const password = (opts: Parameters<typeof prompts.password>[0]) =>
   Effect.promise(() => prompts.password(opts)).pipe(Effect.map((result) => optional(result)))
 
 export const spinner = () => {
-  const s = prompts.spinner()
+  const s = createSpinner()
   return {
     start: (msg: string) => Effect.sync(() => s.start(msg)),
     stop: (msg: string, code?: number) => Effect.sync(() => s.stop(msg, code)),

--- a/packages/opencode/src/cli/prompt.ts
+++ b/packages/opencode/src/cli/prompt.ts
@@ -1,0 +1,5 @@
+import * as prompts from "@clack/prompts"
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const
+
+export const createSpinner = () => prompts.spinner({ frames: [...SPINNER_FRAMES] })


### PR DESCRIPTION
### Issue for this PR

Closes #26154

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `upgrade` command had two issues:

1. **Cancel not handled**: When the user pressed `Ctrl+C` or dismissed the confirmation prompt, `prompts.isCancel()` was not checked. The cancelled value was falsy but only a bare `!install` check was used — this works incidentally but `prompts.isCancel()` should be checked explicitly to correctly handle the cancel signal returned by `@clack/prompts`.

2. **Default spinner frames**: The default spinner frames use characters in the range U+25D0–U+25D3 (◐◓◑◒), which are classified as "Neutral" width in the Unicode standard — meaning each font decides their rendered size independently. Many monospace fonts (Menlo, SF Mono, Fira Code, etc.) render these glyphs inconsistently: some frames appear slightly wider or taller than others, causing visible jitter in the animation. The Braille dot characters (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) are classified as "Narrow" width and render at a consistent single column width across fonts, producing a stable animation.

### How did you verify your code works?

Tested locally by running `bun dev upgrade`, pressing `Ctrl+C` at the confirmation prompt and confirming it exits cleanly with "Done". Also verified the spinner renders correctly during the upgrade process.

### Screenshots / recordings

_N/A — CLI-only change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR