### PR TITLE
fix(cli): detect MIME type for --file flag instead of hardcoding text/plain

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -333,7 +333,7 @@ export const RunCommand = effectCmd({
             process.exit(1)
           }
 
-          const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : "text/plain"
+          const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : await Filesystem.mimeType(resolvedPath)
 
           files.push({
             type: "file",


### PR DESCRIPTION
### Issue for this PR

Closes #16723
Closes #24698
Closes #25353

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `--file` flag on `opencode run` hardcodes MIME type as `text/plain` for all non-directory attachments. This means images, PDFs, and other binary files get the wrong content type, which causes providers to reject or misinterpret them.

The fix replaces the hardcoded string with a call to the existing `Filesystem.mimeType()` utility, which looks up MIME from the file extension. Unknown extensions fall back to `application/octet-stream` per RFC 2046.

This is the same one-line change as #24933 which has been waiting on review for over a week.

### How did you verify your code works?

- `bun typecheck` passes (full turbo typecheck across all 13 packages)
- Manual test: `opencode run --file screenshot.png "describe"` correctly sends `image/png`
- Manual test: `opencode run --file notes.txt "summarize"` still sends `text/plain`

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR