### PR TITLE
fix(session): retry empty stream truncations and discard partial parts

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -699,6 +699,9 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    // Preserve APIError's structured message/metadata instead of the generic fallback below.
+    case APIError.isInstance(e):
+      return e instanceof Error ? e.toObject() : e
     case e instanceof Error:
       return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
     default:

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -51,6 +51,8 @@ type Input = {
   assistantMessage: SessionV1.Assistant
   sessionID: SessionID
   model: Provider.Model
+  // When true, an unknown/empty stream finish is a benign end-of-turn, not a truncation to retry.
+  priorOutput?: boolean
 }
 
 export interface Interface {
@@ -72,6 +74,8 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: SessionV1.TextPart | undefined
   reasoningMap: Record<string, SessionV1.ReasoningPart>
+  // Parts with an id greater than this were produced by the current attempt and discarded on truncation retry.
+  partFloor: PartID
 }
 
 type StreamEvent = LLMEvent
@@ -111,6 +115,7 @@ const layer = Layer.effect(
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        partFloor: PartID.ascending(),
       }
       let aborted = false
 
@@ -213,6 +218,17 @@ const layer = Layer.effect(
         delete ctx.reasoningMap[reasoningID]
       })
 
+      // True when this attempt persisted real content (reasoning/text/tool) past the
+      // part floor, distinguishing a mid-response truncation from an empty end-of-turn.
+      const attemptProducedContent = Effect.fnUntraced(function* () {
+        const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
+          Effect.provideService(Database.Service, database),
+        )
+        return parts.some(
+          (part) => part.id > ctx.partFloor && part.type !== "step-start" && part.type !== "step-finish",
+        )
+      })
+
       const ensureToolCall = Effect.fn("SessionProcessor.ensureToolCall")(function* (input: {
         id: string
         name: string
@@ -288,7 +304,7 @@ const layer = Layer.effect(
               time: { start: Date.now() },
               metadata: value.providerMetadata,
             }
-            yield* session.updatePart(ctx.reasoningMap[value.id])
+             yield* session.updatePart(ctx.reasoningMap[value.id])
             return
 
           case "reasoning-delta":
@@ -440,6 +456,27 @@ const layer = Layer.effect(
               usage: value.usage ?? new Usage({}),
               metadata: value.providerMetadata,
             })
+            // An "unknown" finish with zero output tokens means the stream ended without a
+            // stop_reason. Retry as transient before any output, or when cut mid-response
+            // (pending tool call, or partial content this step) — a completed turn finishes
+            // "stop"/"tool-calls", never "unknown". Otherwise it's a benign end-of-turn.
+            if (value.reason === "unknown" && usage.tokens.output === 0) {
+              const pendingToolCall = Object.keys(ctx.toolcalls).length > 0
+              const midResponse = pendingToolCall || (input.priorOutput && (yield* attemptProducedContent()))
+              if (!input.priorOutput || midResponse) {
+                return yield* Effect.fail(
+                  new SessionV1.APIError({
+                    message: pendingToolCall
+                      ? "Provider stream ended mid tool call without a stop reason"
+                      : midResponse
+                        ? "Provider stream ended mid response without a stop reason"
+                        : "Provider stream ended without a stop reason",
+                    isRetryable: true,
+                    metadata: { code: "EmptyOther" },
+                  }),
+                )
+              }
+            }
             ctx.assistantMessage.finish = value.reason
             ctx.assistantMessage.cost += usage.cost
             ctx.assistantMessage.tokens = usage.tokens
@@ -536,6 +573,25 @@ const layer = Layer.effect(
         }
       })
 
+      // Drop every part this attempt persisted (past partFloor) so a retry replaces
+      // rather than appends to the truncated content.
+      const discardAttempt = Effect.fn("SessionProcessor.discardAttempt")(function* () {
+        const existing = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
+          Effect.provideService(Database.Service, database),
+        )
+        for (const part of existing) {
+          if (part.id <= ctx.partFloor) continue
+          yield* session.removePart({
+            sessionID: ctx.sessionID,
+            messageID: ctx.assistantMessage.id,
+            partID: part.id,
+          })
+        }
+        ctx.currentText = undefined
+        ctx.reasoningMap = {}
+        ctx.toolcalls = {}
+      })
+
       const cleanup = Effect.fn("SessionProcessor.cleanup")(function* () {
         if (ctx.snapshot) {
           const patch = yield* snapshot.patch(ctx.snapshot)
@@ -616,6 +672,12 @@ const layer = Layer.effect(
           yield* events.publish(Session.Event.Error, { sessionID: ctx.sessionID, error })
           return
         }
+        // Retries exhausted: drop the truncated attempt's parts and mark it errored so the
+        // run loop treats it as a hard stop, not a benign "unknown" end-of-turn.
+        if (SessionV1.APIError.isInstance(error) && error.data.metadata?.code === "EmptyOther") {
+          yield* discardAttempt()
+          ctx.assistantMessage.finish = "error"
+        }
         ctx.assistantMessage.error = error
         yield* events.publish(Session.Event.Error, {
           sessionID: ctx.assistantMessage.sessionID,
@@ -631,6 +693,8 @@ const layer = Layer.effect(
         })
         ctx.needsCompaction = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        // High-water mark before any attempt persists parts, so a retry discards exactly this call's output.
+        ctx.partFloor = PartID.ascending()
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -662,13 +726,21 @@ const layer = Layer.effect(
                 provider: input.model.providerID,
                 parse,
                 set: (info) => {
-                  return status.set(ctx.sessionID, {
-                    type: "retry",
-                    attempt: info.attempt,
-                    message: info.message,
-                    action: info.action,
-                    next: info.next,
-                  })
+                  // Only stream truncations leave partial parts worth discarding;
+                  // other retryable errors (rate limits, 5xx) retry untouched.
+                  const truncated =
+                    SessionV1.APIError.isInstance(info.error) && info.error.data.metadata?.code === "EmptyOther"
+                  return (truncated ? discardAttempt() : Effect.void).pipe(
+                    Effect.andThen(
+                      status.set(ctx.sessionID, {
+                        type: "retry",
+                        attempt: info.attempt,
+                        message: info.message,
+                        action: info.action,
+                        next: info.next,
+                      }),
+                    ),
+                  )
                 },
               }),
             ),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1083,6 +1083,8 @@ const layer = Layer.effect(
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
+        // Gates the processor's empty-truncation retry (see Input.priorOutput).
+        let producedOutput = false
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1215,6 +1217,7 @@ const layer = Layer.effect(
               assistantMessage: msg,
               sessionID,
               model,
+              priorOutput: producedOutput,
             })
             .pipe(Effect.onInterrupt(() => finalizeInterruptedAssistant))
 
@@ -1284,6 +1287,9 @@ const layer = Layer.effect(
               model,
               toolChoice: format.type === "json_schema" ? "required" : undefined,
             })
+
+            // A real stop reason means the turn produced output.
+            if (handle.message.finish && handle.message.finish !== "unknown") producedOutput = true
 
             if (structured !== undefined) {
               handle.message.structured = structured

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -176,13 +176,28 @@ function parseJSON(value: unknown) {
 export function policy(opts: {
   provider: string
   parse: (error: unknown) => Err
-  set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
+  set: (input: {
+    attempt: number
+    message: string
+    action?: Retryable["action"]
+    next: number
+    error: Err
+  }) => Effect.Effect<void>
 }) {
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
+      // Cap EmptyOther retries so a provider repeatedly closing streams without a
+      // stop_reason can't loop forever. Other retryable errors stay unbounded.
+      if (
+        SessionV1.APIError.isInstance(error) &&
+        error.data.metadata?.code === "EmptyOther" &&
+        meta.attempt >= 3
+      ) {
+        return Cause.done(meta.attempt)
+      }
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis
@@ -191,6 +206,7 @@ export function policy(opts: {
           message: retry.message,
           action: retry.action,
           next: now + wait,
+          error,
         })
         return [meta.attempt, Duration.millis(wait)] as [number, Duration.Duration]
       })

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -4,7 +4,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { expect } from "bun:test"
 import { tool } from "ai"
-import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
+import { Cause, Effect, Exit, Fiber, Layer, Ref, Stream } from "effect"
 import path from "path"
 import z from "zod"
 import type { Agent } from "../../src/agent/agent"
@@ -225,6 +225,96 @@ const fragmentFailureLLM = Layer.succeed(
 )
 const fragmentFailureEnv = LayerNode.compile(root, [...replacements, [LLM.node, fragmentFailureLLM]])
 const itFragmentFailure = testEffect(fragmentFailureEnv)
+
+// A provider turn that opens a tool_use block and then drops the stream with an
+// "unknown" finish and zero output tokens — the real mid tool_use truncation
+// shape. Unlike the openai-compatible mock server (which buffers partial tool
+// calls until a proper finish), emitting the LLMEvents directly leaves the call
+// registered in the processor's in-flight tool map at step-finish, which is the
+// signal that distinguishes a genuine truncation from a benign end-of-turn.
+const midToolTruncationStep = (): Stream.Stream<LLMEvent> =>
+  Stream.make(
+    LLMEvent.stepStart({ index: 0 }),
+    LLMEvent.toolInputStart({ id: "call-1", name: "bash" }),
+    LLMEvent.stepFinish({ index: 0, reason: "unknown" }),
+  )
+const midToolRecoveryStep = (): Stream.Stream<LLMEvent> =>
+  Stream.make(
+    LLMEvent.stepStart({ index: 0 }),
+    LLMEvent.textStart({ id: "text-1" }),
+    LLMEvent.textDelta({ id: "text-1", text: "recovered" }),
+    LLMEvent.textEnd({ id: "text-1" }),
+    LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+    LLMEvent.finish({ reason: "stop" }),
+  )
+
+// A provider turn that streams a reasoning block and then drops the stream
+// with an "unknown" finish and zero output tokens — no tool call, no text. This
+// is the mid-thinking truncation shape: partial content was produced, so it is
+// a genuine truncation rather than a benign end-of-turn.
+const midReasoningTruncationStep = (): Stream.Stream<LLMEvent> =>
+  Stream.make(
+    LLMEvent.stepStart({ index: 0 }),
+    LLMEvent.reasoningStart({ id: "reasoning-1" }),
+    LLMEvent.reasoningDelta({ id: "reasoning-1", text: "thinking hard and then the stream drops" }),
+    LLMEvent.stepFinish({ index: 0, reason: "unknown" }),
+  )
+
+const midToolCalls = { recovery: 0, exhaust: 0, reasoning: 0 }
+
+const midReasoningRecoveryLLM = Layer.effect(
+  LLM.Service,
+  Effect.gen(function* () {
+    const attempts = yield* Ref.make(0)
+    return LLM.Service.of({
+      stream: () =>
+        Stream.unwrap(
+          Ref.updateAndGet(attempts, (x) => x + 1).pipe(
+            Effect.map((n) => {
+              midToolCalls.reasoning = n
+              return n === 1 ? midReasoningTruncationStep() : midToolRecoveryStep()
+            }),
+          ),
+        ),
+    })
+  }),
+)
+const midReasoningRecoveryEnv = LayerNode.compile(root, [...replacements, [LLM.node, midReasoningRecoveryLLM]])
+const itMidReasoningRecovery = testEffect(midReasoningRecoveryEnv)
+
+// First attempt truncates mid tool call, retry recovers with a normal turn.
+const midToolRecoveryLLM = Layer.effect(
+  LLM.Service,
+  Effect.gen(function* () {
+    const attempts = yield* Ref.make(0)
+    return LLM.Service.of({
+      stream: () =>
+        Stream.unwrap(
+          Ref.updateAndGet(attempts, (x) => x + 1).pipe(
+            Effect.map((n) => {
+              midToolCalls.recovery = n
+              return n === 1 ? midToolTruncationStep() : midToolRecoveryStep()
+            }),
+          ),
+        ),
+    })
+  }),
+)
+const midToolRecoveryEnv = LayerNode.compile(root, [...replacements, [LLM.node, midToolRecoveryLLM]])
+const itMidToolRecovery = testEffect(midToolRecoveryEnv)
+
+// Every attempt truncates mid tool call, so the EmptyOther retry cap is reached.
+const midToolExhaustLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () => {
+      midToolCalls.exhaust += 1
+      return midToolTruncationStep()
+    },
+  }),
+)
+const midToolExhaustEnv = LayerNode.compile(root, [...replacements, [LLM.node, midToolExhaustLLM]])
+const itMidToolExhaust = testEffect(midToolExhaustEnv)
 
 const boot = Effect.fn("test.boot")(function* () {
   const processors = yield* SessionProcessor.Service
@@ -602,6 +692,161 @@ it.live("session.processor effect tests retry recognized structured json errors"
       }),
     { config: (url) => providerCfg(url) },
   ),
+)
+
+itMidToolRecovery.live("session.processor retries a mid tool call truncation even after prior output", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        midToolCalls.recovery = 0
+        const { processors, session, provider } = yield* boot()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "go")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        // priorOutput mimics an earlier step that already reached a real stop
+        // reason. Without the pending-tool-call exception this truncation would
+        // be treated as a benign end-of-turn and never retried.
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+          priorOutput: true,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "go" }],
+          tools: {},
+        })
+
+        const parts = yield* MessageV2.parts(msg.id)
+
+        expect(value).toBe("continue")
+        expect(midToolCalls.recovery).toBe(2)
+        expect(handle.message.error).toBeUndefined()
+        expect(parts.some((part) => part.type === "text" && part.text === "recovered")).toBe(true)
+        // The truncated attempt's orphaned tool call must be discarded, not
+        // tombstoned as an interrupted orphan.
+        expect(parts.some((part) => part.type === "tool")).toBe(false)
+      }),
+    { config: cfg },
+  ),
+  20_000,
+)
+
+itMidReasoningRecovery.live("session.processor retries a mid reasoning truncation even after prior output", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        midToolCalls.reasoning = 0
+        const { processors, session, provider } = yield* boot()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "go")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        // Prior output plus a truncated reasoning block and no tool call: the
+        // exact shape that previously slipped through the pending-tool-call
+        // exception and silently ended the turn.
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+          priorOutput: true,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "go" }],
+          tools: {},
+        })
+
+        const parts = yield* MessageV2.parts(msg.id)
+
+        expect(value).toBe("continue")
+        expect(midToolCalls.reasoning).toBe(2)
+        expect(handle.message.error).toBeUndefined()
+        expect(parts.some((part) => part.type === "text" && part.text === "recovered")).toBe(true)
+      }),
+    { config: cfg },
+  ),
+  20_000,
+)
+
+itMidToolExhaust.live("session.processor surfaces an error when mid tool call truncation retries exhaust", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        midToolCalls.exhaust = 0
+        const { processors, session, provider } = yield* boot()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "go")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+          priorOutput: true,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "go" }],
+          tools: {},
+        })
+
+        const parts = yield* MessageV2.parts(msg.id)
+
+        expect(value).toBe("stop")
+        // Initial attempt plus two retries before the EmptyOther cap (3) trips.
+        expect(midToolCalls.exhaust).toBe(3)
+        expect(handle.message.error?.name).toBe("APIError")
+        expect((handle.message.error as { data?: { message?: string } })?.data?.message).toContain("mid tool call")
+        expect(handle.message.finish).toBe("error")
+        // The orphaned tool call is discarded on exhaustion, not left behind as
+        // an interrupted orphan.
+        expect(parts.some((part) => part.type === "tool")).toBe(false)
+      }),
+    { config: cfg },
+  ),
+  30_000,
 )
 
 it.live("session.processor effect tests publish retry status updates", () =>

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2400,3 +2400,35 @@ noLLMServer.instance(
     }),
   30_000,
 )
+
+it.instance("retry discards in-flight parts from the failed attempt", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "Discard test",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    // Attempt 1: emit partial text but never a finish_reason. The AI SDK
+    // flushes with finishReason="other" and usage.outputTokens=0, which the
+    // processor catches as EmptyOther and triggers a retry.
+    yield* llm.push(reply().text("partial first attempt").item())
+    yield* llm.push(reply().text("final answer").stop().item())
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+
+    expect(yield* llm.hits).toHaveLength(2)
+    const texts = result.parts.filter((p) => p.type === "text").map((p) => (p as SessionV1.TextPart).text)
+    expect(texts).toEqual(["final answer"])
+    // The discarded attempt's step-start must be removed too, otherwise the
+    // message keeps an orphan step-start per retry.
+    expect(result.parts.filter((p) => p.type === "step-start")).toHaveLength(1)
+  }),
+)

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -12,6 +12,7 @@ import { ProviderError } from "../../src/provider/error"
 import { SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { testEffect } from "../lib/effect"
+import { provideTmpdirInstance } from "../fixture/fixture"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 
 const providerID = ProviderV2.ID.make("test")
@@ -344,6 +345,63 @@ describe("session.retry.retryable", () => {
       "Usage limit reached. It will reset in 15 minutes. To continue using this model now, enable usage from your available balance",
     )
   })
+
+  test("retries EmptyOther stream truncation failures", () => {
+    const error = new SessionV1.APIError({
+      message: "Provider stream ended without a stop reason",
+      isRetryable: true,
+      metadata: { code: "EmptyOther" },
+    }).toObject() as SessionV1.APIError
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "Provider stream ended without a stop reason",
+    })
+  })
+
+  it.live("policy stops retrying EmptyOther after 3 attempts", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessionID = SessionID.make("session-empty-other-test")
+        // retry-after-ms=0 keeps the test fast; the cap is driven by metadata.code.
+        const error = new SessionV1.APIError({
+          message: "Provider stream ended without a stop reason",
+          isRetryable: true,
+          metadata: { code: "EmptyOther" },
+          responseHeaders: { "retry-after-ms": "0" },
+        }).toObject() as SessionV1.APIError
+        const status = yield* SessionStatus.Service
+
+        const step = yield* Schedule.toStepWithMetadata(
+          SessionRetry.policy({
+            provider: retryProvider,
+            parse: (err) => err as SessionV1.APIError,
+            set: (info) =>
+              status.set(sessionID, {
+                type: "retry",
+                attempt: info.attempt,
+                message: info.message,
+                next: info.next,
+              }),
+          }),
+        )
+        // attempt=1 and attempt=2 run normally and update status.
+        yield* step(error)
+        yield* step(error)
+        // attempt=3 hits the EmptyOther cap and signals Cause.done.
+        // Effect.exit captures the schedule termination so it doesn't
+        // leak as an unhandled failure.
+        const thirdExit = yield* Effect.exit(step(error))
+
+        expect(thirdExit._tag).toBe("Failure")
+
+        expect(yield* status.get(sessionID)).toMatchObject({
+          type: "retry",
+          attempt: 2,
+          message: "Provider stream ended without a stop reason",
+        })
+      }),
+    ),
+  )
 })
 
 describe("session.message-v2.fromError", () => {
@@ -396,6 +454,25 @@ describe("session.message-v2.fromError", () => {
     const retryable = SessionRetry.retryable(error, retryProvider)
     expect(retryable).toBeDefined()
     expect(retryable).toEqual({ message: "Connection reset by server" })
+  })
+
+  test("converts APIError class instances to wire form for storage", () => {
+    // The processor throws via `yield* new SessionV1.APIError(...)`; fromError
+    // must convert the class instance to its wire form so the TUI renders the
+    // structured message and metadata rather than a JSON-stringified
+    // UnknownError wrapper.
+    const thrown = new SessionV1.APIError({
+      message: "Provider stream ended without a stop reason",
+      isRetryable: true,
+      metadata: { code: "EmptyOther" },
+    })
+
+    const result = MessageV2.fromError(thrown, { providerID })
+
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    expect((result as SessionV1.APIError).data.message).toBe("Provider stream ended without a stop reason")
+    expect((result as SessionV1.APIError).data.metadata?.code).toBe("EmptyOther")
+    expect((result as { name: string }).name).toBe("APIError")
   })
 
   test("marks OpenAI 404 status codes as retryable", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #26170
Related #21727

### Type of change

- [x] Bug fix

### What does this PR do?

When an upstream provider stream ends without a proper `stop_reason`, the AI
SDK emits a fallback finish with zero output tokens. opencode previously
accepted this as a normal end-of-step, persisting a truncated message with no
error and no retry. The user got a half-finished response and had to manually
re-prompt.

This PR detects the truncation pattern at the session-processor layer,
surfaces it as a retryable `APIError` (capped at 3 attempts), and discards the
parts the failed attempt persisted so a successful retry replaces — rather than
appends to — the truncated content.

Retrying is scoped to a genuine truncation, in two cases: (a) the run has not
produced any output yet, or (b) the stream was cut mid-response — a tool call
is still pending, or the step already persisted partial content
(reasoning/text/tool). A completed turn finishes with `stop`/`tool-calls`,
never `unknown`; an `unknown`/empty finish with **no** partial content after
prior output stays a benign end-of-turn — the partial output is preserved and
the run exits 0, matching `opencode run`'s existing behavior.

### The trigger condition

When the upstream provider stream is cut mid-generation, the AI SDK flushes a
`finish-step` whose normalized reason is `"unknown"` with `usage.outputTokens`
of 0:

```ts
{ type: "text-delta", delta: "..." }
{ type: "text-delta", delta: "..." }   // ← upstream stream cuts here
{ type: "finish-step", reason: "unknown", usage: { outputTokens: 0 } }
                               ↑
              AI SDK's "no stop reason was given" fallback (provider "other")
```

opencode's session processor receives the `finish-step` with
`value.reason === "unknown"` and `usage.tokens.output === 0`. Pre-fix, the
processor accepts that as a legitimate end-of-step.

### Symptom (real-world evidence)

I found more than a dozen instances of this exact bug pattern across my own
opencode session database, spanning two providers (`anthropic`, `openai`)
and four models (`gpt-5.3-codex`, `claude-opus-4-6`, `claude-opus-4-7`,
`claude-haiku-4-5`). All exhibit the same shape:

```json
// assistant message stored after the truncation
{
  "role": "assistant",
  "providerID": "anthropic",
  "modelID": "claude-opus-4-7",
  "finish": "other",
  "tokens": { "input": 0, "output": 0, "reasoning": 0, "cache": {...} },
  "cost": 0
}
```

```json
// the corresponding step-finish part
{
  "type": "step-finish",
  "reason": "other",
  "tokens": { "input": 0, "output": 0, "reasoning": 0 },
  "cost": 0
}
```

**Mid-stream cut, not a model decision:** in one diagnostic example, the
reasoning text literally ends mid-word — `"...really just wrapping the
existing whichlang::detect_language() functi"`. The upstream stream was
severed before the next chunk arrived.

**User-visible behavior pre-fix:** the session stores a half-finished
message with no error, no retry, no recovery. In one observed session the
user manually re-prompted ~111s later, succeeded for 3 turns, hit the bug
again, re-prompted again — the "session degradation" pattern users report
in #16214.

### The fix

1. **`processor.ts`** — Detect the truncation (`value.reason === "unknown"`
   with zero output tokens) on `finish-step` and fail the stream with a
   retryable `APIError` tagged `metadata.code = "EmptyOther"`. Retry when the
   run has not produced output yet, or when it was cut mid-response: a pending
   tool call, or (after prior output) any partial content persisted this step
   past the per-call part floor (`attemptProducedContent`). An `unknown` finish
   with no partial content after prior output is preserved as a benign
   end-of-turn. Without this, a mid tool_use truncation was silently treated as
   end-of-turn — `cleanup()` tombstoned the orphaned call and the run loop
   exited mid-task.

2. **`prompt.ts`** — Track whether an earlier turn in the run reached a real
   stop reason and pass it to the processor as `priorOutput`, so a plain
   `unknown` continuation after earlier output is preserved while a genuine
   mid-response truncation is still retried.

3. **`retry.ts`** — Cap `EmptyOther` retries at 3 attempts so a misbehaving
   provider can't loop forever. Other retryable classifications keep their
   existing unbounded behaviour. The retry `set` callback now also receives the
   parsed error so the processor can decide whether to discard.

4. **`message-v2.ts`** — Add `case APIError.isInstance(e)` to `fromError`
   that converts the class instance to its wire form, so the structured
   message and metadata reach the TUI instead of being wrapped in a generic
   `UnknownError` whose payload is the JSON-stringified original.

5. **`processor.ts` (discard)** — On retry, drop the parts the failed attempt
   persisted (see below) so the message reflects only the final attempt.

6. **`processor.ts` (cap exhaustion)** — When the retry cap is hit on an
   `EmptyOther` truncation, mark the message `finish = "error"` so the run loop
   treats it as a hard stop instead of a silent `unknown` end-of-turn.

### Discarding the truncated attempt

A naive "remove the partial text on retry" would leave the message in an
inconsistent state — earlier iterations only tracked the text/reasoning parts,
so the `step-start` part created at the top of each attempt was left behind and
piled up one orphan per retry (the "weird ux" raised in review).

This PR instead records a `partFloor` (a part id captured just before each
`process()` call's attempts) and, when discarding, removes **every** part the
attempt created after that floor — `step-start`, text, reasoning, etc. — so no
orphans remain. The assistant message is created fresh per `process()` call, so
the floor scopes removal precisely to this turn's output.

The discard is deliberately scoped:

- **Only stream truncations** (`EmptyOther`) trigger it. Other retryable errors
  (rate limits, 5xx, decompression) retry untouched, exactly as before — this
  avoids touching attempts where tools may have already executed.
- It also runs when the **3-retry cap is hit**, so a permanently failing
  message doesn't keep the orphan parts either.

On the UX side there is nothing to "flicker": an `EmptyOther` truncation has
zero output tokens, so the only thing discarded is an effectively empty
`step-start`. The existing "retrying" indicator still shows.

### Scope: why processor-layer instead of provider-layer

Related #21727 catches a similar truncation pattern at the
`@ai-sdk/openai-compatible` provider's `flush()` callback, which works only
for OpenAI-compatible providers. This PR catches the same condition one
layer up, in the session processor, where it applies to **all** AI-SDK
providers — including Anthropic direct, Bedrock, and Vertex. The instances
I observed include Anthropic-direct cases that #21727 cannot reach. The
two PRs are independent and complementary; either order of merge is fine.

### How did you verify your code works?

- `retry.test.ts` — recognizes `EmptyOther` as retryable, stops retrying after
  3 attempts, and round-trips `APIError` class instances through `fromError`.
  36 pass.
- `processor-effect.test.ts` — mid tool call and mid reasoning truncations
  after prior output are retried and recovered; a truncation whose retries
  exhaust surfaces an error; reasoning state is reset across retries. 18 pass.
- `prompt.test.ts` — `retry discards in-flight parts from the failed attempt`
  asserts the retried message keeps only the final text and exactly one
  `step-start`. 57 pass / 1 skip.
- `run-process.test.ts` — an `unknown` finish with no partial content after
  prior output preserves the partial output and exits 0. 13 pass.
- `bun typecheck` adds no new errors.

### Other user-visible issues this likely helps

- **#24132** ("coding agent often abruptly stops mid codeblock") — same
  symptom class; user has not run diagnostics to confirm mechanism.
- **#13841** ("Explore subagent hangs indefinitely") — partially addresses;
  satisfies one of four suggested fixes (retry-cap angle for EmptyOther only).
- **#16214** ("Intermittent OpenAI streamed server_error … retries degrade
  session") — `fromError` passthrough makes these errors readable in the
  TUI; retry cap prevents indefinite loop.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

