### PR TITLE
fix(session): avoid repeated compaction of retained tail

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1630,6 +1630,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             if (result === "stop") return "break" as const
             if (result === "compact") {
+              if (hasCompactedAfterLastFinished) return "break" as const
               yield* compaction.create({
                 sessionID,
                 agent: lastUser.agent,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1427,6 +1427,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 
+          const hasCompactedAfterLastFinished =
+            lastFinished !== undefined &&
+            msgs.some(
+              (msg) =>
+                msg.info.role === "assistant" &&
+                msg.info.summary === true &&
+                msg.info.finish !== undefined &&
+                !msg.info.error &&
+                msg.info.parentID > lastFinished.id,
+            )
           const lastAssistantMsg = msgs.findLast(
             (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
           )
@@ -1478,6 +1488,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (
             lastFinished &&
+            !hasCompactedAfterLastFinished &&
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1427,6 +1427,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 
+          const lastUserMsg = msgs.findLast((msg) => msg.info.role === "user" && msg.info.id === lastUser.id)
+          const isCompactionContinue =
+            lastUserMsg?.parts.some(
+              (part) =>
+                part.type === "text" && part.synthetic === true && part.metadata?.compaction_continue === true,
+            ) ?? false
           const hasCompactedAfterLastFinished =
             lastFinished !== undefined &&
             msgs.some(
@@ -1492,7 +1498,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
-            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+            yield* compaction.create({
+              sessionID,
+              agent: lastUser.agent,
+              model: lastUser.model,
+              auto: !isCompactionContinue,
+            })
             continue
           }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1634,7 +1634,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 sessionID,
                 agent: lastUser.agent,
                 model: lastUser.model,
-                auto: true,
+                auto: !isCompactionContinue,
                 overflow: !handle.message.finish,
               })
             }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -465,7 +465,8 @@ it.live("does not recompact an assistant already covered by compaction", () =>
         metadata: { compaction_continue: true },
         text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
       })
-      yield* llm.text("continued")
+      yield* llm.text("continued", { usage: { input: 95_000, output: 100 } })
+      yield* llm.text("summary")
 
       const result = yield* prompt.loop({ sessionID: chat.id })
       expect(result.info.role).toBe("assistant")

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -482,6 +482,79 @@ it.live("does not recompact an assistant already covered by compaction", () =>
   ),
 )
 
+it.live("does not auto-continue after compacting a synthetic continuation overflow", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Synthetic overflow",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      const followup = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: followup.id,
+        sessionID: chat.id,
+        type: "text",
+        synthetic: true,
+        metadata: { compaction_continue: true },
+        text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
+      })
+      const assistant: MessageV2.Assistant = {
+        id: MessageID.ascending(),
+        role: "assistant",
+        parentID: followup.id,
+        sessionID: chat.id,
+        mode: "build",
+        agent: "build",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 3, output: 128, reasoning: 0, cache: { read: 110_449, write: 7_438 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        time: { created: Date.now() },
+        finish: "tool-calls",
+      }
+      yield* sessions.updateMessage(assistant)
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: assistant.id,
+        sessionID: chat.id,
+        type: "text",
+        text: "overflowing synthetic continuation reply",
+      })
+      yield* llm.text("summary")
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+      expect(result.info.role === "assistant" ? result.info.summary : false).toBe(true)
+      expect(yield* llm.calls).toBe(1)
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const compaction = msgs
+        .flatMap((msg) => msg.parts)
+        .find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+      expect(compaction).toMatchObject({ type: "compaction", auto: false })
+      const syntheticContinues = msgs
+        .flatMap((msg) => msg.parts)
+        .filter(
+          (part) =>
+            part.type === "text" && part.synthetic === true && part.metadata?.compaction_continue === true,
+        )
+      expect(syntheticContinues).toHaveLength(1)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("prompt emits v2 prompted and synthetic events", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* () {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -508,35 +508,13 @@ it.live("does not auto-continue after compacting a synthetic continuation overfl
         metadata: { compaction_continue: true },
         text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
       })
-      const assistant: MessageV2.Assistant = {
-        id: MessageID.ascending(),
-        role: "assistant",
-        parentID: followup.id,
-        sessionID: chat.id,
-        mode: "build",
-        agent: "build",
-        cost: 0,
-        path: { cwd: "/tmp", root: "/tmp" },
-        tokens: { input: 3, output: 128, reasoning: 0, cache: { read: 110_449, write: 7_438 } },
-        modelID: ref.modelID,
-        providerID: ref.providerID,
-        time: { created: Date.now() },
-        finish: "tool-calls",
-      }
-      yield* sessions.updateMessage(assistant)
-      yield* sessions.updatePart({
-        id: PartID.ascending(),
-        messageID: assistant.id,
-        sessionID: chat.id,
-        type: "text",
-        text: "overflowing synthetic continuation reply",
-      })
+      yield* llm.text("overflowing synthetic continuation reply", { usage: { input: 95_000, output: 100 } })
       yield* llm.text("summary")
 
       const result = yield* prompt.loop({ sessionID: chat.id })
       expect(result.info.role).toBe("assistant")
       expect(result.info.role === "assistant" ? result.info.summary : false).toBe(true)
-      expect(yield* llm.calls).toBe(1)
+      expect(yield* llm.calls).toBe(2)
 
       const msgs = yield* sessions.messages({ sessionID: chat.id })
       const compaction = msgs

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -374,6 +374,114 @@ it.live("loop calls LLM and returns assistant message", () =>
   ),
 )
 
+it.live("does not recompact an assistant already covered by compaction", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Compacted",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      const first = yield* user(chat.id, "first")
+      const preserved: MessageV2.Assistant = {
+        id: MessageID.ascending(),
+        role: "assistant",
+        parentID: first.id,
+        sessionID: chat.id,
+        mode: "build",
+        agent: "build",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 3, output: 142, reasoning: 0, cache: { read: 0, write: 121_073 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        time: { created: Date.now() },
+        finish: "stop",
+      }
+      yield* sessions.updateMessage(preserved)
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: preserved.id,
+        sessionID: chat.id,
+        type: "text",
+        text: "preserved large reply",
+      })
+
+      const compact = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: compact.id,
+        sessionID: chat.id,
+        type: "compaction",
+        auto: true,
+        tail_start_id: first.id,
+      })
+      const summaryMsg: MessageV2.Assistant = {
+        id: MessageID.ascending(),
+        role: "assistant",
+        parentID: compact.id,
+        sessionID: chat.id,
+        mode: "compaction",
+        agent: "compaction",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        time: { created: Date.now() },
+        finish: "stop",
+        summary: true,
+      }
+      yield* sessions.updateMessage(summaryMsg)
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: summaryMsg.id,
+        sessionID: chat.id,
+        type: "text",
+        text: "summary",
+      })
+      const followup = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: followup.id,
+        sessionID: chat.id,
+        type: "text",
+        synthetic: true,
+        metadata: { compaction_continue: true },
+        text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
+      })
+      yield* llm.text("continued")
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+      expect(result.parts.some((part) => part.type === "text" && part.text === "continued")).toBe(true)
+      expect(yield* llm.calls).toBe(1)
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const compactions = msgs
+        .flatMap((msg) => msg.parts)
+        .filter((part): part is MessageV2.CompactionPart => part.type === "compaction")
+      expect(compactions).toHaveLength(1)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("prompt emits v2 prompted and synthetic events", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* () {


### PR DESCRIPTION
## Summary
- Skip auto-compacting a retained assistant message when a later successful compaction summary already covers it.
- Add a prompt-loop regression for the preserved-tail compaction case that previously created repeated compaction turns.

## Verification
- `bun test test/session/prompt.test.ts -t "does not recompact an assistant already covered by compaction"`
- `bun test test/session/prompt.test.ts`
- `bun run typecheck`
- `bun run build`
- `GIT_MASTER=1 git push -u fork fix/compaction-loop-recompact` pre-push hook: `bun turbo typecheck`