### PR TITLE
fix(session): add fallback retry handling and harden pre-push bun path

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,20 @@
 #!/bin/sh
 set -e
+
+BUN_BIN="${BUN_BIN:-$(command -v bun 2>/dev/null || true)}"
+if [ -z "$BUN_BIN" ] && [ -x "$HOME/.bun/bin/bun" ]; then
+  BUN_BIN="$HOME/.bun/bin/bun"
+fi
+if [ -z "$BUN_BIN" ]; then
+  echo "bun not found in PATH. Install bun or set BUN_BIN to the bun executable path." >&2
+  exit 127
+fi
+
+export PATH="$(dirname "$BUN_BIN"):$PATH"
+
 # Check if bun version matches package.json
 # keep in sync with packages/script/src/index.ts semver qualifier
-bun -e '
+"$BUN_BIN" -e '
 import { semver } from "bun";
 const pkg = await Bun.file("package.json").json();
 const expectedBunVersion = pkg.packageManager?.split("@")[1];
@@ -17,4 +29,4 @@ if (process.versions.bun !== expectedBunVersion) {
   console.warn(`Warning: Bun version ${process.versions.bun} differs from expected ${expectedBunVersion}`);
 }
 '
-bun typecheck
+"$BUN_BIN" turbo typecheck

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -287,6 +287,10 @@ export const Info = Schema.Struct({
       continue_loop_on_deny: Schema.optional(Schema.Boolean).annotate({
         description: "Continue the agent loop when a tool call is denied",
       }),
+      suppress_retry_status_messages: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Suppress retry status messages shown to users for transient provider retries. Go upsell retry notices are still emitted.",
+      }),
       mcp_timeout: Schema.optional(PositiveInt).annotate({
         description: "Timeout in milliseconds for model context protocol (MCP) requests",
       }),

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -38,6 +38,7 @@ export type StreamInput = {
   sessionID: string
   parentSessionID?: string
   model: Provider.Model
+  fallbackModels?: Provider.Model[]
   agent: Agent.Info
   permission?: Permission.Ruleset
   system: string[]

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1,4 +1,4 @@
-import { Cause, Deferred, Effect, Layer, Context, Scope } from "effect"
+import { Cause, Deferred, Effect, Exit, Layer, Context, Scope } from "effect"
 import * as Stream from "effect/Stream"
 import { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
@@ -23,6 +23,7 @@ import { isRecord } from "@/util/record"
 import { EventV2 } from "@/v2/event"
 import { SessionEvent } from "@/v2/session-event"
 import { Modelv2 } from "@/v2/model"
+import { TuiEvent } from "@/cli/cmd/tui/event"
 import * as DateTime from "effect/DateTime"
 
 const DOOM_LOOP_THRESHOLD = 3
@@ -129,9 +130,9 @@ export const layer: Layer.Layer<
       let aborted = false
       const slog = log.clone().tag("session.id", input.sessionID).tag("messageID", input.assistantMessage.id)
 
-      const parse = (e: unknown) =>
+      const parse = (e: unknown, providerID: Provider.Model["providerID"] = input.model.providerID) =>
         MessageV2.fromError(e, {
-          providerID: input.model.providerID,
+          providerID,
           aborted,
         })
 
@@ -643,9 +644,9 @@ export const layer: Layer.Layer<
         yield* session.updateMessage(ctx.assistantMessage)
       })
 
-      const halt = Effect.fn("SessionProcessor.halt")(function* (e: unknown) {
+      const halt = Effect.fn("SessionProcessor.halt")(function* (e: unknown, providerID?: Provider.Model["providerID"]) {
         slog.error("process", { error: errorMessage(e), stack: e instanceof Error ? e.stack : undefined })
-        const error = parse(e)
+        const error = parse(e, providerID)
         if (MessageV2.ContextOverflowError.isInstance(error)) {
           ctx.needsCompaction = true
           yield* bus.publish(Session.Event.Error, { sessionID: ctx.sessionID, error })
@@ -673,13 +674,29 @@ export const layer: Layer.Layer<
       const process = Effect.fn("SessionProcessor.process")(function* (streamInput: LLM.StreamInput) {
         slog.info("process")
         ctx.needsCompaction = false
-        ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        const cfg = yield* config.get()
+        ctx.shouldBreak = cfg.experimental?.continue_loop_on_deny !== true
+        const suppressRetryStatusMessages = cfg.experimental?.suppress_retry_status_messages === true
+        const hasFallbackCandidates = (streamInput.fallbackModels?.length ?? 0) > 0
+        let fallbackNotified = false
+        const candidates = [streamInput.model, ...(streamInput.fallbackModels ?? [])].filter(
+          (item, index, all) =>
+            all.findIndex((x) => x.providerID === item.providerID && x.id === item.id) === index,
+        )
 
-        return yield* Effect.gen(function* () {
-          yield* Effect.gen(function* () {
+        const executeCandidate = Effect.fnUntraced(function* (candidate: Provider.Model, shouldRetry: boolean) {
+          ctx.model = candidate
+          ctx.assistantMessage.modelID = candidate.id
+          ctx.assistantMessage.providerID = candidate.providerID
+          yield* session.updateMessage(ctx.assistantMessage)
+
+          const base = Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.reasoningMap = {}
-            const stream = llm.stream(streamInput)
+            const stream = llm.stream({
+              ...streamInput,
+              model: candidate,
+            })
 
             yield* stream.pipe(
               Stream.tap((event) => handleEvent(event)),
@@ -691,7 +708,7 @@ export const layer: Layer.Layer<
               Effect.gen(function* () {
                 aborted = true
                 if (!ctx.assistantMessage.error) {
-                  yield* halt(new DOMException("Aborted", "AbortError"))
+                  yield* halt(new DOMException("Aborted", "AbortError"), candidate.providerID)
                 }
               }),
             ),
@@ -699,32 +716,81 @@ export const layer: Layer.Layer<
               (cause) => !Cause.hasInterruptsOnly(cause),
               (cause) => Effect.fail(Cause.squash(cause)),
             ),
-            Effect.retry(
-              SessionRetry.policy({
-                parse,
-                set: (info) => {
-                  // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
-                  EventV2.run(SessionEvent.Retried.Sync, {
-                    sessionID: ctx.sessionID,
-                    attempt: info.attempt,
-                    error: {
-                      message: info.message,
-                      isRetryable: true,
-                    },
-                    timestamp: DateTime.makeUnsafe(Date.now()),
-                  })
-                  return status.set(ctx.sessionID, {
-                    type: "retry",
-                    attempt: info.attempt,
-                    message: info.message,
-                    next: info.next,
-                  })
-                },
-              }),
-            ),
-            Effect.catch(halt),
-            Effect.ensuring(cleanup()),
           )
+
+          const withRetry = shouldRetry
+            ? base.pipe(
+                Effect.retry(
+                  SessionRetry.policy({
+                    parse: (error) => parse(error, candidate.providerID),
+                    set: (info) => {
+                      const isGoUpsellRetry = info.message === SessionRetry.GO_UPSELL_MESSAGE
+                      const lowerRetryMessage = info.message.toLowerCase()
+                      const isRateLimitRetry =
+                        lowerRetryMessage.includes("429") ||
+                        lowerRetryMessage.includes("rate limit") ||
+                        lowerRetryMessage.includes("too many requests")
+                      const retryStatus = {
+                        type: "retry" as const,
+                        attempt: info.attempt,
+                        message: info.message,
+                        next: info.next,
+                      }
+                      EventV2.run(SessionEvent.Retried.Sync, {
+                        sessionID: ctx.sessionID,
+                        attempt: info.attempt,
+                        error: {
+                          message: info.message,
+                          isRetryable: true,
+                        },
+                        timestamp: DateTime.makeUnsafe(Date.now()),
+                      })
+                      if (isGoUpsellRetry) {
+                        return status.set(ctx.sessionID, retryStatus)
+                      }
+                      if ((suppressRetryStatusMessages || hasFallbackCandidates) && !isRateLimitRetry) return Effect.void
+                      if (!isRateLimitRetry) return status.set(ctx.sessionID, retryStatus)
+                      return status.shouldEmitRateLimitRetry(ctx.sessionID).pipe(
+                        Effect.flatMap((shouldEmit) => (shouldEmit ? status.set(ctx.sessionID, retryStatus) : Effect.void)),
+                      )
+                    },
+                  }),
+                ),
+              )
+            : base
+
+          return yield* withRetry.pipe(Effect.ensuring(cleanup()))
+        })
+
+        return yield* Effect.gen(function* () {
+          for (let index = 0; index < candidates.length; index++) {
+            const candidate = candidates[index]
+            const shouldRetry = index === candidates.length - 1
+            const exit = yield* Effect.exit(executeCandidate(candidate, shouldRetry))
+            if (Exit.isSuccess(exit)) break
+
+            const error = Cause.squash(exit.cause)
+            if (index < candidates.length - 1) {
+              const next = candidates[index + 1]
+              slog.warn("switching fallback model", {
+                from: `${candidate.providerID}/${candidate.id}`,
+                to: `${next.providerID}/${next.id}`,
+                reason: errorMessage(error),
+              })
+              if (!fallbackNotified) {
+                fallbackNotified = true
+                yield* bus.publish(TuiEvent.ToastShow, {
+                  title: "Model fallback",
+                  message: `Switched to ${next.name} after ${candidate.name} failed`,
+                  variant: "warning",
+                  duration: 5000,
+                })
+              }
+              continue
+            }
+
+            yield* halt(error, candidate.providerID)
+          }
 
           if (ctx.needsCompaction) return "compact"
           if (ctx.blocked || ctx.assistantMessage.error) return "stop"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -914,6 +914,40 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return yield* Effect.failCause(exit.cause)
     })
 
+    const resolveFallbackModels = Effect.fn("SessionPrompt.resolveFallbackModels")(function* (
+      agent: Agent.Info,
+      model: Provider.Model,
+      sessionID: SessionID,
+    ) {
+      const refs = (Array.isArray(agent.options?.["fallback_models"]) ? agent.options["fallback_models"] : []).flatMap(
+        (item) => {
+          if (typeof item === "string") return [item]
+          if (!item || typeof item !== "object") return []
+          if (!("model" in item) || typeof item.model !== "string") return []
+          return [item.model]
+        },
+      )
+
+      const resolved = yield* Effect.forEach(
+        refs,
+        (value) =>
+          Effect.gen(function* () {
+            const parsed = Provider.parseModel(value)
+            return yield* getModel(parsed.providerID, parsed.modelID, sessionID)
+          }).pipe(Effect.option),
+        { concurrency: "unbounded" },
+      )
+
+      return resolved
+        .filter(Option.isSome)
+        .map((item) => item.value)
+        .filter(
+          (item, index, all) =>
+            all.findIndex((x) => x.providerID === item.providerID && x.id === item.id) === index &&
+            !(item.providerID === model.providerID && item.id === model.id),
+        )
+    })
+
     const lastModel = Effect.fnUntraced(function* (sessionID: SessionID) {
       const match = yield* sessions.findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model)
       if (Option.isSome(match) && match.value.info.role === "user") return match.value.info.model
@@ -1571,6 +1605,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
+            const fallbackModels = yield* resolveFallbackModels(agent, model, sessionID)
             const system = [...env, ...instructions, ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
@@ -1584,6 +1619,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
               tools,
               model,
+              fallbackModels,
               toolChoice: format.type === "json_schema" ? "required" : undefined,
             })
 

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -45,6 +45,7 @@ export const Event = {
 export interface Interface {
   readonly get: (sessionID: SessionID) => Effect.Effect<Info>
   readonly list: () => Effect.Effect<Map<SessionID, Info>>
+  readonly shouldEmitRateLimitRetry: (sessionID: SessionID) => Effect.Effect<boolean>
   readonly set: (sessionID: SessionID, status: Info) => Effect.Effect<void>
 }
 
@@ -58,6 +59,9 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make(
       Effect.fn("SessionStatus.state")(() => Effect.succeed(new Map<SessionID, Info>())),
     )
+    const rateLimitRetryState = yield* InstanceState.make(
+      Effect.fn("SessionStatus.rateLimitRetryState")(() => Effect.succeed(new Set<SessionID>())),
+    )
 
     const get = Effect.fn("SessionStatus.get")(function* (sessionID: SessionID) {
       const data = yield* InstanceState.get(state)
@@ -66,6 +70,13 @@ export const layer = Layer.effect(
 
     const list = Effect.fn("SessionStatus.list")(function* () {
       return new Map(yield* InstanceState.get(state))
+    })
+
+    const shouldEmitRateLimitRetry = Effect.fn("SessionStatus.shouldEmitRateLimitRetry")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(rateLimitRetryState)
+      if (data.has(sessionID)) return false
+      data.add(sessionID)
+      return true
     })
 
     const set = Effect.fn("SessionStatus.set")(function* (sessionID: SessionID, status: Info) {
@@ -79,7 +90,7 @@ export const layer = Layer.effect(
       data.set(sessionID, status)
     })
 
-    return Service.of({ get, list, set })
+    return Service.of({ get, list, shouldEmitRateLimitRetry, set })
   }),
 )
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -14,6 +14,7 @@ import { Session } from "@/session/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionProcessor } from "../../src/session/processor"
+import { SessionRetry } from "../../src/session/retry"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
@@ -598,6 +599,132 @@ it.live("session.processor effect tests publish retry status updates", () =>
         expect(states).toStrictEqual([1])
       }),
     { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests suppress retry status updates when configured", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const bus = yield* Bus.Service
+
+        yield* llm.error(503, { error: "boom" })
+        yield* llm.text("")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "retry")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const states: number[] = []
+        const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
+          if (evt.properties.sessionID !== chat.id) return
+          if (evt.properties.status.type === "retry") states.push(evt.properties.status.attempt)
+        })
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "retry" }],
+          tools: {},
+        })
+
+        off()
+
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(states).toStrictEqual([])
+      }),
+    {
+      git: true,
+      config: (url) => ({
+        ...providerCfg(url),
+        experimental: {
+          suppress_retry_status_messages: true,
+        },
+      }),
+    },
+  ),
+)
+
+it.live("session.processor effect tests preserve go upsell retry status updates when suppression is enabled", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const bus = yield* Bus.Service
+
+        yield* llm.error(429, {
+          type: "error",
+          error: {
+            code: "FreeUsageLimitError",
+            message: "free usage exhausted",
+          },
+        })
+        yield* llm.text("")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "retry")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const messages: string[] = []
+        const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
+          if (evt.properties.sessionID !== chat.id) return
+          if (evt.properties.status.type === "retry") messages.push(evt.properties.status.message)
+        })
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "retry" }],
+          tools: {},
+        })
+
+        off()
+
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(messages).toStrictEqual([SessionRetry.GO_UPSELL_MESSAGE])
+      }),
+    {
+      git: true,
+      config: (url) => ({
+        ...providerCfg(url),
+        experimental: {
+          suppress_retry_status_messages: true,
+        },
+      }),
+    },
   ),
 )
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1233,6 +1233,7 @@ export type Config = {
     openTelemetry?: boolean
     primary_tools?: Array<string>
     continue_loop_on_deny?: boolean
+    suppress_retry_status_messages?: boolean
     mcp_timeout?: number
   }
 }


### PR DESCRIPTION
### Issue for this PR

Not sure but
Closes # #25150 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

My problem was:
When using Model A which had no more limits I wanted opencode to use the Model B as fallback.
This PR fixes the session fallback behavior so Agents can remain on Model A while reliably falling back to Model B when needed. I removed noisy retry status messaging by suppressing repeated rate-limit retry status updates per session after the first occurrence. (Done by config change experimental.suppress_retry_status_message => true)
Furthermore Ipdates the pre-push hook to resolve Bun in our restricted shell environments, preventing turbo package-manager resolution failures during push checks.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

- Ran `bun typecheck`
- Tested:  
  `bun test test/session/session.test.ts test/server/session-actions.test.ts`
- Built compiled binary with `bun run build --single --skip-embed-web-ui`
- Verified compiled runtime fallback behavior and output on repeated runs.
### Screenshots / recordings
I dont have recordings
_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
