### PR TITLE
feat(cli):fish and zsh shell completion

### DIFF
--- a/packages/opencode/src/cli/cmd/completion.ts
+++ b/packages/opencode/src/cli/cmd/completion.ts
@@ -2,9 +2,11 @@ import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import path from "path"
 
-export function detectShell(shellEnv: string | undefined): "bash" | "fish" {
+export function detectShell(shellEnv: string | undefined): "bash" | "fish" | "zsh" {
   if (!shellEnv) return "bash"
-  if (path.basename(shellEnv) === "fish") return "fish"
+  const name = path.basename(shellEnv)
+  if (name === "fish") return "fish"
+  if (name === "zsh") return "zsh"
   return "bash"
 }
 
@@ -91,9 +93,44 @@ complete -c opencode -f -a '(__opencode_yargs_completions)'
 `
 }
 
-export function completionScript(shell: "bash" | "fish") {
+function zshScript() {
+  // Matches the official yargs v18 zsh completion template.
+  // Uses _describe for completions with descriptions (yargs emits "name:description"
+  // format natively when invoked from a zsh context) and falls back to _default
+  // (file completion) when no matches are found.
+  return `#compdef opencode
+###-begin-opencode-completions-###
+#
+# yargs command completion script
+#
+# Installation: opencode completion --shell zsh >> ~/.zshrc
+#    or opencode completion --shell zsh >> ~/.zprofile on OSX.
+#
+_opencode_yargs_completions()
+{
+  local reply
+  local si=$IFS
+  IFS=$'\\n' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" opencode --get-yargs-completions "\${words[@]}"))
+  IFS=$si
+  if [[ \${#reply} -gt 0 ]]; then
+    _describe 'values' reply
+  else
+    _default
+  fi
+}
+if [[ "'\${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+  _opencode_yargs_completions "$@"
+else
+  compdef _opencode_yargs_completions opencode
+fi
+###-end-opencode-completions-###
+`
+}
+
+export function completionScript(shell: "bash" | "fish" | "zsh") {
   if (shell === "bash") return bashScript()
   if (shell === "fish") return fishScript()
+  if (shell === "zsh") return zshScript()
   const _exhaustive: never = shell
   throw new Error(`Unsupported shell: ${_exhaustive}`)
 }
@@ -105,7 +142,7 @@ export const CompletionCommand = cmd({
     yargs.option("shell", {
       type: "string",
       describe: "shell type (auto-detected from $SHELL if omitted)",
-      choices: ["bash", "fish"] as const,
+      choices: ["bash", "fish", "zsh"] as const,
     }),
   handler: async (args) => {
     const shell = args.shell ?? detectShell(process.env.SHELL)

--- a/packages/opencode/src/cli/cmd/completion.ts
+++ b/packages/opencode/src/cli/cmd/completion.ts
@@ -1,0 +1,114 @@
+import type { Argv } from "yargs"
+import { cmd } from "./cmd"
+import path from "path"
+
+export function detectShell(shellEnv: string | undefined): "bash" | "fish" {
+  if (!shellEnv) return "bash"
+  if (path.basename(shellEnv) === "fish") return "fish"
+  return "bash"
+}
+
+function bashScript() {
+  // Matches the official yargs v18 completion script with mapfile for proper
+  // handling of completions containing spaces or special characters.
+  // Bash does not support tab-separated descriptions natively (compgen -W
+  // breaks on tabs), so completions are plain command/option names only.
+  return `###-begin-opencode-completions-###
+#
+# yargs command completion script
+#
+# Installation: opencode completion --shell bash >> ~/.bashrc
+#    or opencode completion --shell bash >> ~/.bash_profile on OSX.
+#
+_opencode_yargs_completions()
+{
+    local cur_word args type_list
+
+    cur_word="\${COMP_WORDS[COMP_CWORD]}"
+    args=("\${COMP_WORDS[@]}")
+
+    # ask yargs to generate completions, filtering out internal placeholders
+    # see https://stackoverflow.com/a/40944195/7080036 for the spaces-handling awk
+    mapfile -t type_list < <(opencode --get-yargs-completions "\${args[@]}" | grep -vxF '\$0')
+    mapfile -t COMPREPLY < <(compgen -W "$( printf '%q ' "\${type_list[@]}" )" -- "\${cur_word}" |
+        awk '/ / { print "\\""\$0"\\"" } /^[^ ]+\$/ { print \$0 }')
+
+    # if no match was found, fall back to filename completion
+    if [ \${#COMPREPLY[@]} -eq 0 ]; then
+      COMPREPLY=()
+    fi
+
+    return 0
+}
+complete -o bashdefault -o default -F _opencode_yargs_completions opencode
+###-end-opencode-completions-###
+`
+}
+
+function fishScript() {
+  return `###-begin-opencode-completions-###
+#
+# Fish shell completions for opencode
+#
+# Installation:
+#   opencode completion --shell fish | source                                    # Current session
+#   opencode completion --shell fish > ~/.config/fish/completions/opencode.fish  # Permanent
+#
+
+function __opencode_yargs_completions
+    set -l tokens (commandline -opc)
+    set -l current (commandline -ct)
+
+    # Ask yargs to generate completions.
+    # Setting SHELL=zsh triggers yargs' built-in "name:description" output format.
+    # We parse the colon-separated pairs and convert to Fish's tab-separated format.
+    set -l completions (SHELL=zsh command opencode --get-yargs-completions $tokens $current 2>/dev/null)
+
+    for completion in $completions
+        # Parse yargs "name:description" format into Fish's tab-separated format.
+        # Yargs escapes literal colons in names as "\\:" so we split on the first
+        # unescaped colon only. Fish's complete builtin expects "name\\tdescription"
+        # where \\t is a real tab character -- printf handles this correctly.
+        set -l parts (string split -m 1 ':' -- $completion)
+
+        # Filter out yargs internal placeholders (matched after parsing since
+        # SHELL=zsh output includes descriptions like "$0:start opencode tui")
+        switch $parts[1]
+            case '$0' '_generate_completions'
+                continue
+        end
+
+        if test (count $parts) -gt 1 -a -n "$parts[2]"
+            printf '%s\\t%s\\n' $parts[1] $parts[2]
+        else
+            echo $completion
+        end
+    end
+end
+
+complete -c opencode -f -a '(__opencode_yargs_completions)'
+###-end-opencode-completions-###
+`
+}
+
+export function completionScript(shell: "bash" | "fish") {
+  if (shell === "bash") return bashScript()
+  if (shell === "fish") return fishScript()
+  const _exhaustive: never = shell
+  throw new Error(`Unsupported shell: ${_exhaustive}`)
+}
+
+export const CompletionCommand = cmd({
+  command: "completion",
+  describe: "generate shell completion script",
+  builder: (yargs: Argv) =>
+    yargs.option("shell", {
+      type: "string",
+      describe: "shell type (auto-detected from $SHELL if omitted)",
+      choices: ["bash", "fish"] as const,
+    }),
+  handler: async (args) => {
+    const shell = args.shell ?? detectShell(process.env.SHELL)
+    process.stdout.write(completionScript(shell))
+  },
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -31,6 +31,7 @@ import { SessionCommand } from "./cli/cmd/session"
 import { DbCommand } from "./cli/cmd/db"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
+import { CompletionCommand } from "./cli/cmd/completion"
 import { Heap } from "./cli/heap"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
 import { isRecord } from "@/util/record"
@@ -111,7 +112,7 @@ const cli = yargs(args)
     })
   })
   .usage("")
-  .completion("completion", "generate shell completion script")
+  .command(CompletionCommand)
   .command(AcpCommand)
   .command(McpCommand)
   .command(TuiThreadCommand)

--- a/packages/opencode/test/cli/completion.test.ts
+++ b/packages/opencode/test/cli/completion.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test"
+import { completionScript, detectShell } from "../../src/cli/cmd/completion"
+
+describe("cli.completion", () => {
+  describe("detectShell", () => {
+    test("detects fish from /usr/bin/fish", () => {
+      expect(detectShell("/usr/bin/fish")).toBe("fish")
+    })
+
+    test("detects fish from /bin/fish", () => {
+      expect(detectShell("/bin/fish")).toBe("fish")
+    })
+
+    test("detects fish from bare name", () => {
+      expect(detectShell("fish")).toBe("fish")
+    })
+
+    test("detects bash from /bin/bash", () => {
+      expect(detectShell("/bin/bash")).toBe("bash")
+    })
+
+    test("detects bash from bare name", () => {
+      expect(detectShell("bash")).toBe("bash")
+    })
+
+    test("detects zsh from /bin/zsh", () => {
+      expect(detectShell("/bin/zsh")).toBe("zsh")
+    })
+
+    test("detects zsh from /usr/bin/zsh", () => {
+      expect(detectShell("/usr/bin/zsh")).toBe("zsh")
+    })
+
+    test("detects zsh from bare name", () => {
+      expect(detectShell("zsh")).toBe("zsh")
+    })
+
+    test("defaults to bash for unknown shell", () => {
+      expect(detectShell("/bin/ksh")).toBe("bash")
+    })
+
+    test("does not match shell path containing fish as substring", () => {
+      expect(detectShell("/usr/bin/fisherman")).toBe("bash")
+    })
+
+    test("defaults to bash for undefined", () => {
+      expect(detectShell(undefined)).toBe("bash")
+    })
+
+    test("defaults to bash for empty string", () => {
+      expect(detectShell("")).toBe("bash")
+    })
+  })
+
+  describe("completionScript", () => {
+    describe("bash", () => {
+      test("contains completion function", () => {
+        expect(completionScript("bash")).toContain("_opencode_yargs_completions")
+      })
+
+      test("registers with complete builtin", () => {
+        expect(completionScript("bash")).toContain("complete -o bashdefault -o default -F")
+      })
+
+      test("uses yargs completions flag", () => {
+        expect(completionScript("bash")).toContain("--get-yargs-completions")
+      })
+
+      test("has begin/end markers", () => {
+        const script = completionScript("bash")
+        expect(script).toContain("###-begin-opencode-completions-###")
+        expect(script).toContain("###-end-opencode-completions-###")
+      })
+
+      test("quotes cur_word in compgen", () => {
+        expect(completionScript("bash")).toContain('-- "${cur_word}"')
+      })
+
+      test("uses mapfile for safe word splitting", () => {
+        expect(completionScript("bash")).toContain("mapfile -t")
+      })
+
+      test("filters out $0 placeholder from completions", () => {
+        expect(completionScript("bash")).toContain("grep -vxF '$0'")
+      })
+    })
+
+    describe("fish", () => {
+      test("uses Fish complete builtin", () => {
+        expect(completionScript("fish")).toContain("complete -c opencode")
+      })
+
+      test("uses commandline for input", () => {
+        expect(completionScript("fish")).toContain("commandline")
+      })
+
+      test("uses proper function syntax", () => {
+        const script = completionScript("fish")
+        expect(script).toContain("function ")
+        expect(script).toContain("\nend")
+      })
+
+      test("uses yargs completions flag", () => {
+        expect(completionScript("fish")).toContain("--get-yargs-completions")
+      })
+
+      test("does not contain bash syntax", () => {
+        const script = completionScript("fish")
+        expect(script).not.toContain("COMPREPLY")
+        expect(script).not.toContain("compgen")
+      })
+
+      test("suppresses file completions", () => {
+        expect(completionScript("fish")).toContain("complete -c opencode -f")
+      })
+
+      test("has begin/end markers", () => {
+        const script = completionScript("fish")
+        expect(script).toContain("###-begin-opencode-completions-###")
+        expect(script).toContain("###-end-opencode-completions-###")
+      })
+
+      test("suppresses stderr from completion probe", () => {
+        expect(completionScript("fish")).toContain("2>/dev/null")
+      })
+
+      test("sets SHELL=zsh to get yargs description output", () => {
+        expect(completionScript("fish")).toContain("SHELL=zsh")
+      })
+
+      test("parses yargs colon-separated name:description format", () => {
+        const script = completionScript("fish")
+        expect(script).toContain("string split")
+        expect(script).toContain(":")
+      })
+
+      test("uses printf for tab-separated description output", () => {
+        expect(completionScript("fish")).toContain("printf '%s\\t%s\\n'")
+      })
+
+      test("filters out yargs internal placeholders after parsing", () => {
+        const script = completionScript("fish")
+        // Filter must run on $parts[1] (parsed name), not the raw completion
+        // string, because SHELL=zsh output includes descriptions like "$0:desc"
+        expect(script).toContain("switch $parts[1]")
+        expect(script).toContain("'$0'")
+        expect(script).toContain("'_generate_completions'")
+        expect(script).toContain("continue")
+      })
+    })
+
+    describe("zsh", () => {
+      test("uses compdef for completion registration", () => {
+        expect(completionScript("zsh")).toContain("compdef")
+      })
+
+      test("uses _describe for completion display", () => {
+        expect(completionScript("zsh")).toContain("_describe 'values' reply")
+      })
+
+      test("uses yargs completions flag", () => {
+        expect(completionScript("zsh")).toContain("--get-yargs-completions")
+      })
+
+      test("has begin/end markers", () => {
+        const script = completionScript("zsh")
+        expect(script).toContain("###-begin-opencode-completions-###")
+        expect(script).toContain("###-end-opencode-completions-###")
+      })
+
+      test("does not contain bash-specific syntax", () => {
+        const script = completionScript("zsh")
+        expect(script).not.toContain("COMPREPLY")
+        expect(script).not.toContain("compgen")
+      })
+
+      test("does not contain fish-specific syntax", () => {
+        const script = completionScript("zsh")
+        expect(script).not.toContain("commandline")
+        expect(script).not.toContain("complete -c opencode")
+      })
+
+      test("falls back to default completion when no matches", () => {
+        expect(completionScript("zsh")).toContain("_default")
+      })
+
+      test("passes COMP environment variables for context", () => {
+        const script = completionScript("zsh")
+        expect(script).toContain("COMP_CWORD")
+        expect(script).toContain("COMP_LINE")
+        expect(script).toContain("COMP_POINT")
+      })
+
+      test("supports autoload via loadautofunc", () => {
+        expect(completionScript("zsh")).toContain("loadautofunc")
+      })
+
+      test("starts with #compdef directive", () => {
+        expect(completionScript("zsh")).toMatch(/^#compdef opencode\n/)
+      })
+    })
+
+    test("throws for unsupported shell", () => {
+      // @ts-expect-error testing invalid input
+      expect(() => completionScript("powershell")).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1515

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add completion support for Fish shell and ZSH shell. This is using the same solution with yargs but enabling them for other shell than just bash shell. Add also autodetection.

I must admit I don't have much experience with ZSH, so someone help with the testing of the AI generated code would be great!

### How did you verify your code works?

* Added tests 
* Build of the opencode and running it on my machine for Fish and in distrobox container for bash.

### Screenshots / recordings

<img width="1782" height="357" alt="2026-05-07T16:21:54,561297466+02:00" src="https://github.com/user-attachments/assets/21f57ea6-5039-4b50-8cfe-c75f63f60a44" />
<img width="1240" height="71" alt="2026-05-07T16:22:37,698940640+02:00" src="https://github.com/user-attachments/assets/029b45d3-07d2-4f34-b765-0d6846f965ac" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
