### PR TITLE
fix(tui): always capture navigate keys in prompt normal mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/traits.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/traits.ts
@@ -15,13 +15,21 @@ export interface PromptTraitsInput {
  * delete-word, arrow movement, undo/redo, etc.). Shell mode is an active
  * editing mode — only `disabled` should suspend the textarea, otherwise
  * users can type in shell mode but cannot delete or move the cursor.
+ *
+ * `traits.capture` prevents key categories from propagating to session-level
+ * global handlers while the textarea is focused. "navigate" must always be
+ * captured in normal mode so that Home/End move the cursor instead of
+ * triggering the session's messages_first/messages_last scroll handlers.
+ * When autocomplete is visible, "escape" and "submit" are also captured so
+ * Escape closes the dropdown and Enter selects a completion item rather than
+ * bubbling up.
  */
 export function computePromptTraits(input: PromptTraitsInput): EditorTraits {
   const capture =
     input.mode === "normal"
       ? input.autocompleteVisible
         ? (["escape", "navigate", "submit", "tab"] as const)
-        : (["tab"] as const)
+        : (["navigate", "tab"] as const)
       : undefined
   return {
     capture,

--- a/packages/opencode/test/cli/cmd/tui/prompt-traits.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-traits.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test"
 import { computePromptTraits } from "../../../../src/cli/cmd/tui/component/prompt/traits"
 
 describe("computePromptTraits", () => {
-  test("normal mode without autocomplete only captures tab", () => {
+  test("normal mode without autocomplete captures navigate and tab", () => {
     const traits = computePromptTraits({ mode: "normal", disabled: false, autocompleteVisible: false })
-    expect(traits.capture).toEqual(["tab"])
+    expect(traits.capture).toEqual(["navigate", "tab"])
     expect(traits.suspend).toBe(false)
     expect(traits.status).toBeUndefined()
   })


### PR DESCRIPTION
## Summary

- **Home/End keys** stop working in the chat input after the first message is sent — they scroll the message list instead of moving the cursor.
- They worked correctly on the Home screen (before any message was sent).

## Root cause

`computePromptTraits` returned `capture = ["tab"]` when autocomplete was not visible. This tells @opentui the textarea only owns the Tab key — all other key categories propagate to parent/session-level handlers.

In the Session route, `messages_first` is bound to `"ctrl+g,home"` (comma = OR, so plain `home` alone matches), and `messages_last` to `"ctrl+alt+g,end"` (plain `end` matches). With `capture = ["tab"]`, those global handlers intercept `Home`/`End` before the textarea acts. The Home screen has no session handlers yet, which is why the behavior differed before vs. after the first message.

## Fix

Always include `"navigate"` in the capture list when in normal mode, not only when autocomplete is visible:

```diff
- : (["tab"] as const)
+ : (["navigate", "tab"] as const)
```

`"escape"` and `"submit"` remain autocomplete-only — outside autocomplete they should propagate so parent handlers can act on them.

Updated the unit test in `prompt-traits.test.ts` to reflect the new expected capture set.

## Testing

Reproduce before the fix:
1. Open opencode, type a message and send it
2. In the follow-up input, press `Home` or `End` → message list scrolls instead of cursor moving

After the fix, `Home` and `End` move the cursor within the input on both the Home screen and the Session screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)