### PR TITLE
fix(desktop): ensure Electron binary before predev via install.js

### DIFF
--- a/packages/desktop/scripts/predev.ts
+++ b/packages/desktop/scripts/predev.ts
@@ -1,4 +1,24 @@
+import path from "node:path"
+import { existsSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import { $ } from "bun"
+
+const desktopDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..")
+const electronDir = path.join(desktopDir, "node_modules", "electron")
+if (!existsSync(path.join(electronDir, "path.txt"))) {
+  console.error("Electron OS binary missing; running electron postinstall (node install.js)...")
+  const proc = Bun.spawn(["node", "install.js"], {
+    cwd: electronDir,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  })
+  const code = await proc.exited
+  if (code !== 0) {
+    console.error("electron install.js exited with code", code)
+    process.exit(code ?? 1)
+  }
+}
 
 await $`bun ./scripts/copy-icons.ts ${process.env.OPENCODE_CHANNEL ?? "dev"}`
 


### PR DESCRIPTION
### Issue for this PR

Closes #26204

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Before `predev` runs, we check whether the Electron OS binary was downloaded by looking for `path.txt` under `packages/desktop/node_modules/electron` (that file is created after a successful `install.js` / postinstall). If it is missing—e.g. fresh clone, installs with scripts skipped, or a broken partial install—we run `node install.js` in that directory to fetch the platform binary, then continue with the existing `copy-icons` and `build-node` steps. That way `predev` fails less often with “no Electron binary” errors buried in later commands.

### How did you verify your code works?

Remove or temporarily delete `node_modules/electron/path.txt` under `packages/desktop`, run whatever invokes `predev`, and confirm the script logs the missing-binary message, runs `install.js`, recreates `path.txt`, and completes the rest of predev. On a machine where Electron is already installed correctly, confirm the install path is skipped because `path.txt` exists.

### Screenshots / recordings

N/A (not a UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR