### PR TITLE
chore(husky): add bun to PATH in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -e
+# Hooks run with a minimal PATH; default bun install lives here
+export PATH="$HOME/.bun/bin:$PATH"
 # Check if bun version matches package.json
 # keep in sync with packages/script/src/index.ts semver qualifier
 bun -e '


### PR DESCRIPTION
### Issue for this PR

Closes #26206

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Git hook processes often inherit a **minimal PATH** that does not include `~/.bun/bin`. The `.husky/pre-push` hook calls `bun` directly for the Bun version check and `bun typecheck`, so contributors could see `git push` fail with “bun not found” while `bun` works in their normal shell.

Prepends `HOME/.bun/bin` to `PATH` at the top of `.husky/pre-push` before any `bun` invocation.

### How did you verify your code works?

Ran `git push` for this branch: the husky hook ran successfully (`bun` version check + `bun turbo typecheck`). Also confirmed behavior with the PATH change versus the upstream hook on a PATH where Bun is only visible via `~/.bun/bin`.

### Screenshots / recordings

_N/A — shell hook change only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Made with [Cursor](https://cursor.com)