### PR TITLE
fix(opencode): plugin auto-update with temp residue cleanup

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -35,6 +35,19 @@ export interface Interface {
   readonly which: (pkg: string, bin?: string) => Effect.Effect<Option.Option<string>>
 }
 
+async function fetchRegistryVersion(name: string): Promise<string | undefined> {
+  const encoded = name.replace("/", "%2F")
+  const url = `https://registry.npmjs.org/${encoded}`
+  try {
+    const response = await fetch(url, { headers: { Accept: "application/json" } })
+    if (!response.ok) return undefined
+    const data = (await response.json()) as any
+    return data?.["dist-tags"]?.latest as string | undefined
+  } catch {
+    return undefined
+  }
+}
+
 export class Service extends Context.Service<Service, Interface>()("@opencode/Npm") {}
 
 const illegal = process.platform === "win32" ? new Set(["<", ">", ":", '"', "|", "?", "*"]) : undefined
@@ -75,6 +88,20 @@ export const layer = Layer.effect(
     const fs = yield* FileSystem.FileSystem
     const flock = yield* EffectFlock.Service
     const directory = (pkg: string) => path.join(global.cache, "packages", sanitize(pkg))
+    const cleanupTempResidues = Effect.fnUntraced(function* (nodeModulesPath: string) {
+      const entries = yield* fs.readDirectory(nodeModulesPath).pipe(Effect.catch(() => Effect.succeed([] as string[])))
+      const tempPattern = /^\.[a-z0-9-]+-[a-zA-Z0-9]{8,}$/
+      for (const entry of entries) {
+        if (tempPattern.test(entry)) {
+          const fullPath = path.join(nodeModulesPath, entry)
+          const stat = yield* fs.stat(fullPath).pipe(Effect.catch(() => Effect.succeed(undefined)))
+          if (stat?.type === "Directory") {
+            yield* fs.remove(fullPath, { recursive: true }).pipe(Effect.ignore)
+          }
+        }
+      }
+    })
+
     const reify = (input: { dir: string; add?: string[] }) =>
       Effect.gen(function* () {
         yield* flock.acquire(`npm-install:${input.dir}`)
@@ -120,11 +147,29 @@ export const layer = Layer.effect(
         }
       })()
 
+      const isLatest = pkg.includes("@latest")
+
       if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
-        return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        const installed = yield* afs.readJson(path.join(dir, "node_modules", name, "package.json")).pipe(Effect.option)
+        if (isLatest && Option.isSome(installed)) {
+          const current = (installed.value as any)?.version as string | undefined
+          if (current) {
+            const registryVersion = yield* Effect.tryPromise({
+              try: () => fetchRegistryVersion(name),
+              catch: () => Option.none<string>(),
+            }).pipe(Effect.option)
+            if (Option.isSome(registryVersion) && registryVersion.value !== current) {
+              yield* fs.remove(dir, { recursive: true }).pipe(Effect.ignore)
+            }
+          }
+        }
+        if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
+          return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        }
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
+      yield* cleanupTempResidues(path.join(dir, "node_modules")).pipe(Effect.ignore)
       const first = tree.edgesOut.values().next().value?.to
       if (!first) {
         const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -62,6 +62,34 @@ describe("Npm.add", () => {
 
     expect(Option.isSome(entry.entrypoint)).toBe(true)
   })
+
+  test("cleans up npm temp residues after install", async () => {
+    await using tmp = await tmpdir()
+    await fs.mkdir(path.join(tmp.path, "fixture-provider"))
+    await writePackage(path.join(tmp.path, "fixture-provider"), {
+      name: "fixture-provider",
+      main: "index.js",
+    })
+    await Bun.write(path.join(tmp.path, "fixture-provider", "index.js"), "export const fixture = true\n")
+
+    const spec = `fixture-provider@file:${path.join(tmp.path, "fixture-provider")}`
+    const cacheDir = path.join(tmp.path, "cache", "packages", Npm.sanitize(spec))
+    const nodeModulesDir = path.join(cacheDir, "node_modules")
+    await fs.mkdir(nodeModulesDir, { recursive: true })
+
+    // Create fake temp directories that match npm's temp naming pattern
+    await fs.mkdir(path.join(nodeModulesDir, ".tmp-abc12345678"))
+    await fs.mkdir(path.join(nodeModulesDir, ".tmp-def98765432"))
+
+    await Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      return yield* npm.add(spec)
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+
+    const entries = await fs.readdir(nodeModulesDir)
+    expect(entries).not.toContain(".tmp-abc12345678")
+    expect(entries).not.toContain(".tmp-def98765432")
+  })
 })
 
 describe("Npm.install", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #16608

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes plugin `@latest` auto-update stall and adds temp residue cleanup after npm install.

- Added `fetchRegistryVersion()` to fetch `dist-tags.latest` directly from registry.npmjs.org, bypassing local npm cache
- Modified `Npm.add()` to detect when a cached plugin is `@latest` but stale. When cache exists and version differs from registry, it deletes the cache and reinstalls
- Added `cleanupTempResidues()` that removes `.tmp-XXXX` directories npm leaves behind in `node_modules` after install

### How did you verify your code works?

- `bun test packages/core/test/npm.test.ts` — 5/5 tests pass including new temp cleanup test
- `bun typecheck` — clean, no errors
- Manual QA: installed a plugin with `@latest`, verified temp residues are cleaned from `node_modules/`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR