### PR TITLE
fix(provider): propagate options.extraBody for openai-compatible providers

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -100,6 +100,13 @@ export const Info = Schema.Struct({
           description:
             "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
         }),
+        extraBody: Schema.optional(Schema.Record(Schema.String, Schema.Any)).annotate({
+          description:
+            "Additional fields merged into every chat-completions request body for this provider. " +
+            "Useful for OpenAI-compatible servers that accept server-specific knobs not in the standard OpenAI schema " +
+            "(e.g. vLLM/SGLang `chat_template_kwargs`, NVIDIA NIM `chat_template_kwargs`). " +
+            "Routed through `providerOptions[<sdk-key>]` for `@ai-sdk/openai-compatible` providers; user values override hardcoded per-provider defaults.",
+        }),
       }),
       [Schema.Record(Schema.String, Schema.Any)],
     ),

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1092,6 +1092,24 @@ export function options(input: {
     }
   }
 
+  // Honor user-supplied `provider.<id>.options.extraBody`. Merging into result
+  // routes the fields through providerOptions() under the SDK-recognized key,
+  // so server-specific chat-completions body params (e.g. `chat_template_kwargs`
+  // for vLLM/SGLang, NVIDIA NIM, etc.) reach the wire without requiring a
+  // hardcoded per-provider block here. The alibaba-cn block above proves the
+  // routing works: providerOptions[providerName] entries land on the request
+  // body for `@ai-sdk/openai-compatible` providers.
+  // User config wins over the hardcoded blocks above by design — operators with
+  // custom OpenAI-compatible servers need to be able to override defaults.
+  // Closes #13584, #23995, #24264.
+  if (
+    input.providerOptions?.extraBody &&
+    typeof input.providerOptions.extraBody === "object" &&
+    !Array.isArray(input.providerOptions.extraBody)
+  ) {
+    Object.assign(result, input.providerOptions.extraBody)
+  }
+
   return result
 }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3552,3 +3552,134 @@ describe("ProviderTransform.providerOptions - ai-gateway-provider", () => {
     expect(result).toEqual({ openaiCompatible: { reasoningEffort: "high" } })
   })
 })
+
+describe("ProviderTransform.options - extraBody propagation", () => {
+  // Regression coverage for #13584 / #23995 / #24264: users of OpenAI-compatible
+  // servers (vLLM, SGLang, NVIDIA NIM, direct DashScope) must be able to set
+  // server-specific chat-completions body fields (e.g. `chat_template_kwargs`)
+  // via `provider.<id>.options.extraBody` in opencode.json. Until this fix,
+  // the field was permitted by the rest record on the schema but never read.
+  const sessionID = "test-session-extra-body"
+
+  const vllmModel = {
+    id: "vllm-local/qwen3.6-35b",
+    providerID: "vllm-local",
+    api: {
+      id: "qwen3.6-35b",
+      url: "http://localhost:8000/v1",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "Qwen3.6-35B (vLLM)",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 200_000, output: 32_000 },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("merges extraBody fields into the result (qwen3 vLLM enable_thinking case)", () => {
+    const result = ProviderTransform.options({
+      model: vllmModel,
+      sessionID,
+      providerOptions: {
+        extraBody: { chat_template_kwargs: { enable_thinking: false } },
+      },
+    })
+    expect(result.chat_template_kwargs).toEqual({ enable_thinking: false })
+  })
+
+  test("preserves nested objects in extraBody intact", () => {
+    const result = ProviderTransform.options({
+      model: vllmModel,
+      sessionID,
+      providerOptions: {
+        extraBody: {
+          chat_template_kwargs: { enable_thinking: true, deep: { tool: "ok" } },
+          guided_json: { type: "object" },
+        },
+      },
+    })
+    expect(result.chat_template_kwargs).toEqual({ enable_thinking: true, deep: { tool: "ok" } })
+    expect(result.guided_json).toEqual({ type: "object" })
+  })
+
+  test("undefined extraBody is a no-op", () => {
+    const result = ProviderTransform.options({
+      model: vllmModel,
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.chat_template_kwargs).toBeUndefined()
+  })
+
+  test("null extraBody does not crash and is treated as a no-op", () => {
+    const result = ProviderTransform.options({
+      model: vllmModel,
+      sessionID,
+      providerOptions: { extraBody: null as any },
+    })
+    expect(result.chat_template_kwargs).toBeUndefined()
+  })
+
+  test("array extraBody is rejected (must be a plain object)", () => {
+    const result = ProviderTransform.options({
+      model: vllmModel,
+      sessionID,
+      providerOptions: { extraBody: ["chat_template_kwargs"] as any },
+    })
+    expect(result["0"]).toBeUndefined()
+    expect(result.chat_template_kwargs).toBeUndefined()
+  })
+
+  test("extraBody preserves non-overlapping fields set by other blocks", () => {
+    // Use a model that triggers an existing block (alibaba-cn enable_thinking).
+    const alibabaModel = {
+      ...vllmModel,
+      id: "alibaba-cn/qwen3-235b",
+      providerID: "alibaba-cn",
+      api: {
+        id: "qwen3-235b",
+        url: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: { ...vllmModel.capabilities, reasoning: true },
+    }
+    const result = ProviderTransform.options({
+      model: alibabaModel as any,
+      sessionID,
+      providerOptions: { extraBody: { foo: "bar" } },
+    })
+    expect(result.enable_thinking).toBe(true) // set by alibaba-cn block
+    expect(result.foo).toBe("bar") // added by extraBody
+  })
+
+  test("extraBody overrides hardcoded fields by design (user config wins)", () => {
+    const alibabaModel = {
+      ...vllmModel,
+      id: "alibaba-cn/qwen3-235b",
+      providerID: "alibaba-cn",
+      api: {
+        id: "qwen3-235b",
+        url: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: { ...vllmModel.capabilities, reasoning: true },
+    }
+    const result = ProviderTransform.options({
+      model: alibabaModel as any,
+      sessionID,
+      providerOptions: { extraBody: { enable_thinking: false } },
+    })
+    // Hardcoded block sets enable_thinking=true; user explicit override wins.
+    expect(result.enable_thinking).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #13584
Closes #23995
Closes #24264

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`provider.<id>.options.extraBody` from `opencode.json` is silently dropped — `extraBody` is permitted by the schema's rest record but never read. Users of OpenAI-compatible servers (vLLM, NVIDIA NIM, SGLang, direct DashScope) can't pass server-specific body fields like `chat_template_kwargs` that those endpoints need.

The fix: read `input.providerOptions.extraBody` in `ProviderTransform.options()` and `Object.assign` it into `result`. Routing then matches the existing `alibaba-cn` `enable_thinking=true` block at `transform.ts:1040` — which is proof the path reaches the wire (DashScope users rely on it). Also adds a typed `extraBody` field to `Info.options` for IDE completion.

Pattern matches #25573 (cf-ai-gateway fix); avoids the larger surface change in #6761 (closed without merge).

### How did you verify your code works?

7 new unit tests in `transform.test.ts`: positive case, nested objects, `undefined`/`null`/array no-ops, non-clobbering of unrelated fields, explicit precedence (user `extraBody` overrides hardcoded blocks). Full provider suite passes (291/291).

End-to-end against vLLM serving `Qwen3.6-35B-A3B` (`--reasoning-parser qwen3 --tool-call-parser qwen3_coder`):

- **Vanilla v1.14.39** with `extraBody.chat_template_kwargs.enable_thinking=false` in `opencode.json`: agent loop dies — model emits EOS without finishing tool calls because `enable_thinking=false` never reaches vLLM and qwen3 produces runaway reasoning.
- **Same config + this patch**: agent run finishes cleanly (537s, 5 commits in a multi-feature run, no hallucinations). Direct routing to vLLM verified — no proxy in the path.

### Screenshots / recordings

_n/a — not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
