### PR TITLE
feat(tui): add nvim editor context polling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/editor-nvim.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor-nvim.ts
@@ -1,0 +1,267 @@
+import { readdirSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import z from "zod"
+import type { EditorSelection } from "./editor"
+
+const NvimPositionSchema = z.object({
+  line: z.number(),
+  column: z.number(),
+  offset: z.number(),
+})
+
+const NvimProbeSchema = z.object({
+  cwd: z.string(),
+  file: z.string(),
+  mode: z.string(),
+  cursor: NvimPositionSchema,
+  visual_start: NvimPositionSchema,
+  visual_end: NvimPositionSchema,
+  current_line: z.string(),
+  selected_lines: z.array(z.string()),
+  buffers: z.array(z.string()),
+})
+
+const nvimProbeExpression = String.raw`luaeval('vim.json.encode((function()
+  local function pos(mark)
+    local value = vim.fn.getpos(mark)
+    return { line = value[2], column = value[3], offset = value[4] }
+  end
+
+  local function listed_buffers()
+    local buffers = {}
+    for _, buffer in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_loaded(buffer) then
+        local name = vim.api.nvim_buf_get_name(buffer)
+        if name ~= "" then
+          table.insert(buffers, name)
+        end
+      end
+    end
+    return buffers
+  end
+
+  local mode = vim.api.nvim_get_mode().mode
+  local active_selection = mode == "v" or mode == "V" or mode == "s" or mode == "S"
+  local visual_start = active_selection and pos("v") or pos("''<")
+  local visual_end = active_selection and pos(".") or pos("''>")
+  local selected_lines = {}
+  if visual_start.line > 0 and visual_end.line > 0 then
+    local start_line = math.min(visual_start.line, visual_end.line)
+    local end_line = math.max(visual_start.line, visual_end.line)
+    selected_lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
+  end
+
+  return {
+    cwd = vim.fn.getcwd(),
+    file = vim.api.nvim_buf_get_name(0),
+    mode = mode,
+    cursor = pos("."),
+    visual_start = visual_start,
+    visual_end = visual_end,
+    current_line = vim.api.nvim_get_current_line(),
+    selected_lines = selected_lines,
+    buffers = listed_buffers(),
+  }
+end)())')`
+
+type NvimProbe = z.infer<typeof NvimProbeSchema>
+
+export type NvimSelectionResult =
+  | { type: "selection"; selection: EditorSelection }
+  | { type: "empty" }
+  | { type: "unavailable" }
+
+export async function resolveNvimSelection(cwd = process.cwd()): Promise<NvimSelectionResult> {
+  const sockets = resolveNvimSockets()
+  if (sockets.length === 0) return { type: "empty" }
+
+  const probes = (await Promise.all(sockets.map(queryNvimSocket))).flatMap((result) => {
+    if (result.type !== "probe") return []
+    const score = scoreNvimWorkspace(result.probe, cwd)
+    if (score === 0) return []
+    return [{ socket: result.socket, probe: result.probe, score }]
+  })
+
+  const match = probes.sort((left, right) => right.score - left.score)[0]
+  if (!match) return { type: "empty" }
+
+  const selection = nvimProbeToSelection(match.probe)
+  if (!selection) return { type: "empty" }
+
+  return { type: "selection", selection }
+}
+
+export function resolveNvimSockets() {
+  if (process.platform !== "linux") return []
+
+  return Array.from(
+    new Set(
+      [
+        process.env.NVIM_LISTEN_ADDRESS,
+        ...scanSocketDirectory(process.env.XDG_RUNTIME_DIR),
+        ...scanSocketDirectory(path.join("/run/user", String(process.getuid?.() ?? os.userInfo().uid))),
+      ].filter((item): item is string => Boolean(item)),
+    ),
+  )
+}
+
+async function queryNvimSocket(socket: string) {
+  try {
+    const proc = Bun.spawn(["nvim", "--server", socket, "--remote-expr", nvimProbeExpression], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const timeout = setTimeout(() => proc.kill(), 750)
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]).finally(() => {
+      clearTimeout(timeout)
+    })
+    if (exitCode !== 0) return { type: "unavailable" as const }
+
+    const parsed = NvimProbeSchema.safeParse(JSON.parse(stdout) as unknown)
+    if (!parsed.success) return { type: "unavailable" as const }
+    return { type: "probe" as const, socket, probe: parsed.data }
+  } catch {
+    return { type: "unavailable" as const }
+  }
+}
+
+function nvimProbeToSelection(probe: NvimProbe): EditorSelection | undefined {
+  if (!isFilePath(probe.file)) return undefined
+
+  const range = nvimSelectedRange(probe) ?? nvimCursorRange(probe)
+  if (!range) return undefined
+
+  return {
+    filePath: probe.file,
+    source: "nvim",
+    ranges: [range],
+  }
+}
+
+function nvimSelectedRange(probe: NvimProbe): EditorSelection["ranges"][number] | undefined {
+  if (!isNvimSelectionMode(probe.mode)) return undefined
+  if (probe.visual_start.line <= 0 || probe.visual_end.line <= 0 || probe.selected_lines.length === 0) return undefined
+
+  const start = compareNvimPosition(probe.visual_start, probe.visual_end) <= 0 ? probe.visual_start : probe.visual_end
+  const end = start === probe.visual_start ? probe.visual_end : probe.visual_start
+  if (start.line === end.line && start.column === end.column) return undefined
+
+  if (probe.mode === "V" || probe.mode === "S") {
+    return {
+      text: probe.selected_lines.join("\n"),
+      selection: {
+        start: { line: start.line, character: 1 },
+        end: {
+          line: end.line,
+          character: (probe.selected_lines[probe.selected_lines.length - 1] ?? "").length + 1,
+        },
+      },
+    }
+  }
+
+  const text = probe.selected_lines
+    .map((line, index) => {
+      if (probe.selected_lines.length === 1) return sliceNvimLine(line, start.column, end.column, true)
+      if (index === 0) return sliceNvimLine(line, start.column)
+      if (index === probe.selected_lines.length - 1) return sliceNvimLine(line, 1, end.column, true)
+      return line
+    })
+    .join("\n")
+
+  return {
+    text,
+    selection: {
+      start: { line: start.line, character: nvimColumnToCharacter(probe.selected_lines[0] ?? "", start.column) },
+      end: {
+        line: end.line,
+        character: nvimColumnToCharacter(probe.selected_lines[probe.selected_lines.length - 1] ?? "", end.column, true),
+      },
+    },
+  }
+}
+
+function nvimCursorRange(probe: NvimProbe): EditorSelection["ranges"][number] | undefined {
+  if (probe.cursor.line <= 0 || probe.cursor.column <= 0) return undefined
+
+  return {
+    text: "",
+    selection: {
+      start: { line: probe.cursor.line, character: nvimColumnToCharacter(probe.current_line, probe.cursor.column) },
+      end: { line: probe.cursor.line, character: nvimColumnToCharacter(probe.current_line, probe.cursor.column) },
+    },
+  }
+}
+
+function scanSocketDirectory(directory: string | undefined): string[] {
+  if (!directory) return []
+
+  try {
+    const entries = readdirSync(directory, { withFileTypes: true })
+    return [
+      ...entries
+        .filter((entry) => entry.isSocket() && entry.name.toLowerCase().includes("nvim"))
+        .map((entry) => path.join(directory, entry.name)),
+      ...entries
+        .filter((entry) => entry.isDirectory() && entry.name.toLowerCase().includes("nvim"))
+        .flatMap((entry) => scanSocketDirectory(path.join(directory, entry.name))),
+    ]
+  } catch {
+    return []
+  }
+}
+
+function scoreNvimWorkspace(probe: NvimProbe, cwd: string) {
+  return Math.max(
+    pathContainsLength(probe.cwd, cwd),
+    isFilePath(probe.file) ? pathContainsLength(path.dirname(probe.file), cwd) : 0,
+    ...probe.buffers.map((buffer) => (isFilePath(buffer) ? pathContainsLength(path.dirname(buffer), cwd) : 0)),
+  )
+}
+
+function compareNvimPosition(left: z.infer<typeof NvimPositionSchema>, right: z.infer<typeof NvimPositionSchema>) {
+  return left.line - right.line || left.column - right.column
+}
+
+function sliceNvimLine(line: string, startColumn: number, endColumn?: number, includeEnd?: boolean) {
+  return line.slice(
+    utf8ByteOffsetToStringIndex(line, Math.max(startColumn - 1, 0)),
+    endColumn == null ? undefined : utf8ByteOffsetToStringIndex(line, Math.max(endColumn - (includeEnd ? 0 : 1), 0)),
+  )
+}
+
+function nvimColumnToCharacter(line: string, column: number, includeEnd?: boolean) {
+  return utf8ByteOffsetToStringIndex(line, Math.max(column - (includeEnd ? 0 : 1), 0)) + 1
+}
+
+function utf8ByteOffsetToStringIndex(text: string, byteOffset: number) {
+  if (byteOffset <= 0) return 0
+
+  const utf8 = new TextEncoder()
+  let bytes = 0
+  for (let index = 0; index < text.length; ) {
+    const codePoint = text.codePointAt(index)
+    if (codePoint === undefined) return text.length
+
+    const nextIndex = index + (codePoint > 0xffff ? 2 : 1)
+    bytes += utf8.encode(text.slice(index, nextIndex)).length
+    if (bytes >= byteOffset) return nextIndex
+    index = nextIndex
+  }
+
+  return text.length
+}
+
+function pathContainsLength(parent: string, child: string) {
+  const resolved = path.resolve(parent)
+  const relative = path.relative(resolved, path.resolve(child))
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative)) ? resolved.length : 0
+}
+
+function isFilePath(value: string) {
+  return path.isAbsolute(value) && !value.includes("://")
+}
+
+function isNvimSelectionMode(mode: string) {
+  return mode === "v" || mode === "V" || mode === "s" || mode === "S"
+}

--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -6,6 +6,7 @@ import { createStore } from "solid-js/store"
 import z from "zod"
 import { isRecord } from "@/util/record"
 import { createSimpleContext } from "./helper"
+import { resolveNvimSelection, resolveNvimSockets } from "./editor-nvim"
 import { resolveZedDbPath, resolveZedSelection } from "./editor-zed"
 
 const MCP_PROTOCOL_VERSION = "2025-11-25"
@@ -40,13 +41,13 @@ const EditorSelectionSchema = z
   .union([
     z.object({
       filePath: z.string(),
-      source: z.enum(["websocket", "zed"]).optional(),
+      source: z.enum(["websocket", "zed", "nvim"]).optional(),
       ranges: z.array(EditorSelectionRangeSchema).min(1),
     }),
     z.object({
       text: z.string(),
       filePath: z.string(),
-      source: z.enum(["websocket", "zed"]).optional(),
+      source: z.enum(["websocket", "zed", "nvim"]).optional(),
       selection: z.object({
         start: PositionSchema,
         end: PositionSchema,
@@ -104,6 +105,11 @@ type EditorLockFile = {
   mtimeMs: number
 }
 
+type PolledEditorSelectionResult =
+  | { type: "selection"; selection: EditorSelection }
+  | { type: "empty" }
+  | { type: "unavailable" }
+
 export const { use: useEditorContext, provider: EditorContextProvider } = createSimpleContext({
   name: "EditorContext",
   init: (props: { WebSocketImpl?: typeof WebSocket }) => {
@@ -126,8 +132,8 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
     let reconnect: ReturnType<typeof setTimeout> | undefined
     let attempt = 0
     let requestID = 0
-    let zedSelection: Promise<void> | undefined
-    let lastZedSelectionKey: string | undefined
+    let polledSelection: Promise<void> | undefined
+    let lastPolledSelectionKey: string | undefined
     let directory = process.cwd()
     let preserveSelectionOnReconnect = false
     const pending = new Map<number, string>()
@@ -138,12 +144,12 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
       if (changed) setStore("selectionSent", false)
     }
 
-    const clearSelectionForReconnect = (options?: { resetZedSelectionKey?: boolean }) => {
+    const clearSelectionForReconnect = (options?: { resetPolledSelectionKey?: boolean }) => {
       if (preserveSelectionOnReconnect) {
         preserveSelectionOnReconnect = false
         return
       }
-      if (options?.resetZedSelectionKey) lastZedSelectionKey = undefined
+      if (options?.resetPolledSelectionKey) lastPolledSelectionKey = undefined
       setSelection(undefined)
     }
 
@@ -163,31 +169,31 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
 
       const connection = resolveEditorConnection(directory)
       if (!connection) {
-        const dbPath = resolveZedDbPath()
-        if (!dbPath) {
+        if (!hasPolledEditorSelectionSource()) {
           setStore("status", "disabled")
           scheduleReconnect()
           return
         }
-        zedSelection ??= resolveZedSelection(dbPath, directory)
+
+        polledSelection ??= resolvePolledEditorSelection(directory)
           .then((result) => {
             if (closed || socket) return
             if (result.type === "unavailable") return
             const selection = result.type === "selection" ? result.selection : undefined
             const key = editorSelectionKey(selection)
-            if (key !== lastZedSelectionKey) {
-              lastZedSelectionKey = key
+            if (key !== lastPolledSelectionKey) {
+              lastPolledSelectionKey = key
               setSelection(selection)
               setStore("status", selection ? "connected" : "disabled")
             }
           })
           .catch(() => {
-            // Keep the last known Zed selection for transient polling failures.
+            // Keep the last known editor selection for transient polling failures.
           })
           .finally(() => {
-            zedSelection = undefined
+            polledSelection = undefined
           })
-        scheduleZedPoll()
+        schedulePolledEditorSelection()
         return
       }
 
@@ -263,7 +269,7 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
       reconnect = setTimeout(connect, delay)
     }
 
-    const scheduleZedPoll = () => {
+    const schedulePolledEditorSelection = () => {
       if (closed) return
       if (reconnect) clearTimeout(reconnect)
       reconnect = setTimeout(connect, 1000)
@@ -272,7 +278,7 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
     const reconnectWithDirectory = (nextDirectory?: string) => {
       const resolved = nextDirectory || process.cwd()
       const sameDirectory = directory === resolved
-      clearSelectionForReconnect({ resetZedSelectionKey: !sameDirectory })
+      clearSelectionForReconnect({ resetPolledSelectionKey: !sameDirectory })
       if (sameDirectory) return
 
       directory = resolved
@@ -302,7 +308,7 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
 
     return {
       enabled() {
-        return Boolean(resolveEditorConnection(directory) || resolveZedDbPath())
+        return Boolean(resolveEditorConnection(directory) || hasPolledEditorSelectionSource())
       },
       connected() {
         return store.status === "connected"
@@ -311,8 +317,8 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
         return store.selection
       },
       clearSelection() {
-        lastZedSelectionKey = undefined
-        zedSelection = undefined
+        lastPolledSelectionKey = undefined
+        polledSelection = undefined
         setSelection(undefined)
       },
       preserveSelectionFromNewSession() {
@@ -365,6 +371,21 @@ function resolveEditorConnection(directory: string): EditorConnection | undefine
       source: `lock:${lock.port}`,
     }
   }
+}
+
+async function resolvePolledEditorSelection(directory: string): Promise<PolledEditorSelectionResult> {
+  const dbPath = resolveZedDbPath()
+  const zed = dbPath ? await resolveZedSelection(dbPath, directory) : { type: "empty" as const }
+  if (zed.type === "selection") return zed
+
+  const nvim = await resolveNvimSelection(directory)
+  if (nvim.type !== "empty") return nvim
+  if (zed.type === "unavailable") return zed
+  return nvim
+}
+
+function hasPolledEditorSelectionSource() {
+  return Boolean(resolveZedDbPath() || resolveNvimSockets().length > 0)
 }
 
 function resolveEditorLockFile(activeDirectory: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #26232 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Adds support for the neovim editor context to the TUI. We use the nvim rpc support to probe for running nvim instances on the user's machine, find the open editors and find the currently open file by the user in the current workspace.

### Few things to note
- works on linux only right now as I don't have access to a mac at the current moment.
- spawns the nvim process every request instead of directly using the msgpack rpc over pipes as i didn't want to add an additional dependency just for this simple feature.

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
- tested on my local machine and a docker container to make sure it works. 
- no integration tests were added as i wasn't sure if requiring nvim installed on ci is a good idea and seems like a bad idea imo
- no unit tests added either but not sure what i'd test here. (open to suggestions)

### Screenshots / recordings

https://github.com/user-attachments/assets/07839331-beb4-4adf-a5a4-f8f707cff3a8

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
