### PR TITLE
fix(session): prevent double compaction when task already pending

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1476,7 +1476,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             continue
           }
 
+          const hasCompactionTask = tasks.some((t) => t.type === "compaction")
           if (
+            !hasCompactionTask &&
             lastFinished &&
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))


### PR DESCRIPTION
### Issue for this PR

Closes #26230

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes double compaction issue where sessions would compact twice consecutively when using Opus 4.7 through Copilot.

**The Problem:** After a recent token calculation change (commit 38af0dc6f, Apr 27 2026), the overflow check started triggering incorrectly due to double-counting cache tokens. Combined with a structural bug from the Nov 2025 refactor (a1214fff2), this caused compaction tasks to be created twice.

**The Fix:** Added a guard to prevent creating a new compaction task when one is already pending in the queue:

```typescript
const hasCompactionTask = tasks.some((t) => t.type === "compaction")
if (!hasCompactionTask && ...) { /* create compaction */ }
```

This prevents duplicate compaction regardless of token calculation issues.

Changed file: `packages/opencode/src/session/prompt.ts:1478`

### How did you verify your code works?

- Ran `bun typecheck` - no new type errors introduced
- Existing test suite passes
- The fix addresses the root cause: prevents queue from having multiple pending compaction tasks

### Screenshots / recordings

N/A - backend fix

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR