### PR TITLE
feat(desktop): allow silent install and only user-wide scope

### DIFF
--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -68,7 +68,6 @@ const getBase = (): Configuration => ({
   nsis: {
     oneClick: true,
     perMachine: false,
-    include: "resources/installer.nsh",
     installerIcon: `resources/icons/icon.ico`,
     installerHeaderIcon: `resources/icons/icon.ico`,
   },

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -66,8 +66,9 @@ const getBase = (): Configuration => ({
     verifyUpdateCodeSignature: false,
   },
   nsis: {
-    oneClick: false,
-    allowToChangeInstallationDirectory: true,
+    oneClick: true,
+    perMachine: false,
+    include: "resources/installer.nsh",
     installerIcon: `resources/icons/icon.ico`,
     installerHeaderIcon: `resources/icons/icon.ico`,
   },

--- a/packages/desktop/resources/installer.nsh
+++ b/packages/desktop/resources/installer.nsh
@@ -1,3 +1,0 @@
-!macro customInstall
-  !insertmacro uninstallOldVersion HKEY_LOCAL_MACHINE
-!macroend

--- a/packages/desktop/resources/installer.nsh
+++ b/packages/desktop/resources/installer.nsh
@@ -1,0 +1,3 @@
+!macro customInstall
+  !insertmacro uninstallOldVersion HKEY_LOCAL_MACHINE
+!macroend

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -444,7 +444,7 @@ async function installUpdate() {
     version: downloadedUpdateVersion,
   })
   await killSidecar()
-  autoUpdater.quitAndInstall()
+  autoUpdater.quitAndInstall(true, true)
 }
 
 async function checkForUpdates(alertOnFail: boolean) {


### PR DESCRIPTION
## Summary
- switch the Windows NSIS installer to one-click per-user installs with no install mode or directory prompts
- run downloaded updates silently and relaunch after install

## Testing
- `bun typecheck` from `packages/desktop`
- `bun run build && bun package:win --publish never` from `packages/desktop`
- push hook ran `bun turbo typecheck`

## Notes
- Existing system-wide installs are not explicitly uninstalled in this PR. The earlier HKLM uninstall hook was removed because it was unverified migration logic and should be handled separately with a full system-install repro.