### PR TITLE
fix(cli): forward signals from npm shim

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -5,7 +5,7 @@ const fs = require("fs")
 const path = require("path")
 const os = require("os")
 
-const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT", "SIGUSR1", "SIGUSR2"]
+const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP"]
 
 function run(target) {
   const child = childProcess.spawn(target, process.argv.slice(2), {
@@ -44,18 +44,12 @@ function run(target) {
 }
 
 const envPath = process.env.OPENCODE_BIN_PATH
-if (envPath) {
-  run(envPath)
-}
 
 const scriptPath = fs.realpathSync(__filename)
 const scriptDir = path.dirname(scriptPath)
 
 //
 const cached = path.join(scriptDir, ".opencode")
-if (fs.existsSync(cached)) {
-  run(cached)
-}
 
 const platformMap = {
   darwin: "darwin",
@@ -192,7 +186,7 @@ function findBinary(startDir) {
   }
 }
 
-const resolved = findBinary(scriptDir)
+const resolved = envPath || (fs.existsSync(cached) ? cached : findBinary(scriptDir))
 if (!resolved) {
   console.error(
     "It seems that your package manager failed to install the right version of the opencode CLI for your platform. You can try manually installing " +

--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -5,16 +5,42 @@ const fs = require("fs")
 const path = require("path")
 const os = require("os")
 
+const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT", "SIGUSR1", "SIGUSR2"]
+
 function run(target) {
-  const result = childProcess.spawnSync(target, process.argv.slice(2), {
+  const child = childProcess.spawn(target, process.argv.slice(2), {
     stdio: "inherit",
   })
-  if (result.error) {
-    console.error(result.error.message)
+
+  child.on("error", (error) => {
+    console.error(error.message)
     process.exit(1)
+  })
+
+  const forwarders = {}
+  for (const signal of forwardedSignals) {
+    forwarders[signal] = () => {
+      try {
+        child.kill(signal)
+      } catch {
+        // The child may have already exited.
+      }
+    }
+    process.on(signal, forwarders[signal])
   }
-  const code = typeof result.status === "number" ? result.status : 0
-  process.exit(code)
+
+  child.on("exit", (code, signal) => {
+    for (const forwardedSignal of forwardedSignals) {
+      process.removeListener(forwardedSignal, forwarders[forwardedSignal])
+    }
+
+    if (signal) {
+      process.kill(process.pid, signal)
+      return
+    }
+
+    process.exit(typeof code === "number" ? code : 0)
+  })
 }
 
 const envPath = process.env.OPENCODE_BIN_PATH


### PR DESCRIPTION
### Issue for this PR

Closes #20899
Closes #17978

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The npm wrapper currently runs the real opencode binary with `spawnSync()`. If a supervisor sends `SIGTERM`, `SIGINT`, or `SIGHUP` to the wrapper while `opencode serve` is running, the wrapper can die without forwarding the signal to the child. The child then survives as a PID-1 orphan.

This switches the wrapper to async `spawn()`, forwards common termination signals to the child, and preserves signal exits by re-raising the child's signal on the wrapper process. That also fixes the wrapper's signal-exit-to-code-0 behavior from #17978.

### How did you verify your code works?

I used a deterministic repro that runs `opencode serve`, sends `SIGTERM`, `SIGINT`, and `SIGHUP` to the npm wrapper, then checks whether the real `.opencode serve` child is still alive with `PPID=1`.

Homeboy observe A/B evidence:

| Case | Homeboy run | Result |
|---|---:|---|
| Stock upstream wrapper | `8d26c4f6-4e90-459b-a15d-49e76cc0f9da` | 3/3 orphans |
| Patched wrapper from this PR | `bdc45e95-2ec3-44bf-b50a-c7daee37552e` | 0/3 orphans |

### Screenshots / recordings

N/A — CLI process lifecycle fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause analysis, deterministic repro construction, Homeboy A/B evidence capture, and drafting the patch. Chris reviewed the behavior and evidence.