### PR TITLE
fix(provider): align GPT-5 reasoning variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -513,6 +513,11 @@ const OPENAI_XHIGH_EFFORT_RELEASE_DATE = "2025-12-04"
 //   "gpt-5", "gpt-5-nano", "gpt-5.4", "openai/gpt-5.4-codex".
 // Anchored to start-of-string or "/" so it doesn't false-match "gpt-50" or "gpt-5o".
 const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
+const GPT5_VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
+
+function gpt5Version(apiId: string) {
+  return Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined
+}
 
 // Computes the reasoning_effort tiers an OpenAI (or OpenAI-compatible upstream
 // routed through it, e.g. cf-ai-gateway) model exposes. Returns null for models
@@ -524,11 +529,26 @@ function openaiReasoningEfforts(apiId: string, releaseDate: string): string[] | 
     if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
     return [...WIDELY_SUPPORTED_EFFORTS]
   }
+  const version = gpt5Version(id)
+  if (version !== undefined) {
+    // GPT-5.1 replaced GPT-5's `minimal` effort with `none`; GPT-5.2+
+    // additionally accepts `xhigh`. Model pages list the supported subset.
+    const efforts = ["none", ...WIDELY_SUPPORTED_EFFORTS]
+    if (version >= 2) efforts.push("xhigh")
+    return efforts
+  }
   const efforts = [...WIDELY_SUPPORTED_EFFORTS]
   if (GPT5_FAMILY_RE.test(id)) efforts.unshift("minimal")
   if (releaseDate >= OPENAI_NONE_EFFORT_RELEASE_DATE) efforts.unshift("none")
   if (releaseDate >= OPENAI_XHIGH_EFFORT_RELEASE_DATE) efforts.push("xhigh")
   return efforts
+}
+
+function openaiCompatibleReasoningEfforts(id: string) {
+  const version = gpt5Version(id.toLowerCase())
+  if (version === undefined) return OPENAI_EFFORTS
+  if (version === 1) return ["none", ...WIDELY_SUPPORTED_EFFORTS]
+  return ["none", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 }
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
@@ -577,8 +597,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
   switch (model.api.npm) {
     case "@openrouter/ai-sdk-provider":
-      if (!model.id.includes("gpt") && !model.id.includes("gemini-3") && !model.id.includes("claude")) return {}
-      return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))
+      if (!id.includes("gpt") && !id.includes("gemini-3") && !id.includes("claude")) return {}
+      return Object.fromEntries(
+        (id.includes("gpt") ? openaiCompatibleReasoningEfforts(id) : OPENAI_EFFORTS).map((effort) => [
+          effort,
+          { reasoning: { effort } },
+        ]),
+      )
 
     case "ai-gateway-provider": {
       // Cloudflare AI Gateway routes every upstream through its OpenAI-compatible
@@ -652,7 +677,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           ]),
         )
       }
-      return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      return Object.fromEntries(
+        openaiCompatibleReasoningEfforts(model.api.id).map((effort) => [effort, { reasoningEffort: effort }]),
+      )
 
     case "@ai-sdk/github-copilot":
       if (model.id.includes("gemini")) {
@@ -701,7 +728,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
       const azureEfforts = ["low", "medium", "high"]
-      if (id.includes("gpt-5-") || id === "gpt-5") {
+      if ((id.includes("gpt-5-") || id === "gpt-5") && gpt5Version(id) === undefined) {
         azureEfforts.unshift("minimal")
       }
       return Object.fromEntries(

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -500,6 +500,9 @@ export function topK(model: Provider.Model) {
 
 const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+const OPENAI_GPT5_1_EFFORTS = ["none", ...WIDELY_SUPPORTED_EFFORTS]
+const OPENAI_GPT5_2_PLUS_EFFORTS = [...OPENAI_GPT5_1_EFFORTS, "xhigh"]
+const OPENAI_GPT5_CODEX_2_PLUS_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 
 // OpenAI rolled out the `none` reasoning_effort tier on this date (Responses API).
 // Models released before it 400 on `reasoning_effort: "none"`, so we only expose
@@ -519,24 +522,28 @@ function gpt5Version(apiId: string) {
   return Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined
 }
 
+function versionedGpt5ReasoningEfforts(apiId: string) {
+  const version = gpt5Version(apiId)
+  if (version === undefined) return undefined
+  if (version === 1) return OPENAI_GPT5_1_EFFORTS
+  return OPENAI_GPT5_2_PLUS_EFFORTS
+}
+
 // Computes the reasoning_effort tiers an OpenAI (or OpenAI-compatible upstream
 // routed through it, e.g. cf-ai-gateway) model exposes. Returns null for models
 // with no tunable effort knob (gpt-5-pro). Effort order: weakest to strongest.
 function openaiReasoningEfforts(apiId: string, releaseDate: string): string[] | null {
   const id = apiId.toLowerCase()
   if (id === "gpt-5-pro" || id === "openai/gpt-5-pro") return null
-  if (id.includes("codex")) {
-    if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
-    return [...WIDELY_SUPPORTED_EFFORTS]
-  }
   const version = gpt5Version(id)
-  if (version !== undefined) {
-    // GPT-5.1 replaced GPT-5's `minimal` effort with `none`; GPT-5.2+
-    // additionally accepts `xhigh`. Model pages list the supported subset.
-    const efforts = ["none", ...WIDELY_SUPPORTED_EFFORTS]
-    if (version >= 2) efforts.push("xhigh")
-    return efforts
+  if (id.includes("codex")) {
+    if (version !== undefined && version >= 2) return OPENAI_GPT5_CODEX_2_PLUS_EFFORTS
+    return WIDELY_SUPPORTED_EFFORTS
   }
+  const versionedEfforts = versionedGpt5ReasoningEfforts(id)
+  // GPT-5.1 replaced GPT-5's `minimal` effort with `none`; GPT-5.2+
+  // additionally accepts `xhigh`. Model pages list the supported subset.
+  if (versionedEfforts) return versionedEfforts
   const efforts = [...WIDELY_SUPPORTED_EFFORTS]
   if (GPT5_FAMILY_RE.test(id)) efforts.unshift("minimal")
   if (releaseDate >= OPENAI_NONE_EFFORT_RELEASE_DATE) efforts.unshift("none")
@@ -545,10 +552,7 @@ function openaiReasoningEfforts(apiId: string, releaseDate: string): string[] | 
 }
 
 function openaiCompatibleReasoningEfforts(id: string) {
-  const version = gpt5Version(id.toLowerCase())
-  if (version === undefined) return OPENAI_EFFORTS
-  if (version === 1) return ["none", ...WIDELY_SUPPORTED_EFFORTS]
-  return ["none", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+  return versionedGpt5ReasoningEfforts(id.toLowerCase()) ?? OPENAI_EFFORTS
 }
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
@@ -727,12 +731,11 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/azure":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
-      const azureEfforts = ["low", "medium", "high"]
-      if ((id.includes("gpt-5-") || id === "gpt-5") && gpt5Version(id) === undefined) {
-        azureEfforts.unshift("minimal")
-      }
       return Object.fromEntries(
-        azureEfforts.map((effort) => [
+        (GPT5_FAMILY_RE.test(id) && gpt5Version(id) === undefined
+          ? ["minimal", ...WIDELY_SUPPORTED_EFFORTS]
+          : WIDELY_SUPPORTED_EFFORTS
+        ).map((effort) => [
           effort,
           {
             reasoningEffort: effort,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -502,6 +502,7 @@ const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_1_EFFORTS = ["none", ...WIDELY_SUPPORTED_EFFORTS]
 const OPENAI_GPT5_2_PLUS_EFFORTS = [...OPENAI_GPT5_1_EFFORTS, "xhigh"]
+const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
 const OPENAI_GPT5_CODEX_2_PLUS_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 
 // OpenAI rolled out the `none` reasoning_effort tier on this date (Responses API).
@@ -517,12 +518,14 @@ const OPENAI_XHIGH_EFFORT_RELEASE_DATE = "2025-12-04"
 // Anchored to start-of-string or "/" so it doesn't false-match "gpt-50" or "gpt-5o".
 const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
 const GPT5_VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
+const GPT5_VERSIONED_PRO_RE = /(?:^|\/)gpt-5[.-]\d+[.-]pro(?:[.-]|$)/
 
 function gpt5Version(apiId: string) {
   return Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined
 }
 
 function versionedGpt5ReasoningEfforts(apiId: string) {
+  if (GPT5_VERSIONED_PRO_RE.test(apiId)) return OPENAI_GPT5_PRO_2_PLUS_EFFORTS
   const version = gpt5Version(apiId)
   if (version === undefined) return undefined
   if (version === 1) return OPENAI_GPT5_1_EFFORTS

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -504,6 +504,7 @@ const OPENAI_GPT5_1_EFFORTS = ["none", ...WIDELY_SUPPORTED_EFFORTS]
 const OPENAI_GPT5_2_PLUS_EFFORTS = [...OPENAI_GPT5_1_EFFORTS, "xhigh"]
 const OPENAI_GPT5_PRO_EFFORTS = ["high"]
 const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
+const OPENAI_GPT5_CHAT_EFFORTS = ["medium"]
 const OPENAI_GPT5_CODEX_XHIGH_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_CODEX_3_PLUS_EFFORTS = ["none", ...OPENAI_GPT5_CODEX_XHIGH_EFFORTS]
 
@@ -543,11 +544,18 @@ function gpt5CodexReasoningEfforts(apiId: string) {
   return WIDELY_SUPPORTED_EFFORTS
 }
 
+function gpt5ChatReasoningEfforts(apiId: string) {
+  if (!GPT5_FAMILY_RE.test(apiId) || !apiId.includes("-chat")) return undefined
+  return gpt5Version(apiId) === undefined ? [] : OPENAI_GPT5_CHAT_EFFORTS
+}
+
 // Computes the reasoning_effort tiers an OpenAI (or OpenAI-compatible upstream
 // routed through it, e.g. cf-ai-gateway) model exposes. Effort order: weakest
 // to strongest.
 function openaiReasoningEfforts(apiId: string, releaseDate: string) {
   const id = apiId.toLowerCase()
+  const chatEfforts = gpt5ChatReasoningEfforts(id)
+  if (chatEfforts) return chatEfforts
   if (GPT5_PRO_RE.test(id)) return OPENAI_GPT5_PRO_EFFORTS
   const codexEfforts = gpt5CodexReasoningEfforts(id)
   if (codexEfforts) return codexEfforts
@@ -564,6 +572,8 @@ function openaiReasoningEfforts(apiId: string, releaseDate: string) {
 
 function openaiCompatibleReasoningEfforts(id: string) {
   const apiId = id.toLowerCase()
+  const chatEfforts = gpt5ChatReasoningEfforts(apiId)
+  if (chatEfforts) return chatEfforts
   if (GPT5_PRO_RE.test(apiId)) return OPENAI_GPT5_PRO_EFFORTS
   return gpt5CodexReasoningEfforts(apiId) ?? versionedGpt5ReasoningEfforts(apiId) ?? OPENAI_EFFORTS
 }
@@ -1143,6 +1153,11 @@ export function smallOptions(model: Provider.Model) {
     model.api.npm === "@ai-sdk/github-copilot"
   ) {
     if (model.api.id.includes("gpt-5")) {
+      if (model.api.id.includes("-chat")) {
+        if (gpt5Version(model.api.id) === undefined) return { store: false }
+        return { store: false, reasoningEffort: "medium" }
+      }
+      if (model.api.id.includes("search-api")) return { store: false }
       if (model.api.id.includes("5.") || model.api.id.includes("5-mini")) {
         return { store: false, reasoningEffort: "low" }
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -502,8 +502,10 @@ const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_1_EFFORTS = ["none", ...WIDELY_SUPPORTED_EFFORTS]
 const OPENAI_GPT5_2_PLUS_EFFORTS = [...OPENAI_GPT5_1_EFFORTS, "xhigh"]
+const OPENAI_GPT5_PRO_EFFORTS = ["high"]
 const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
-const OPENAI_GPT5_CODEX_2_PLUS_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+const OPENAI_GPT5_CODEX_XHIGH_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+const OPENAI_GPT5_CODEX_3_PLUS_EFFORTS = ["none", ...OPENAI_GPT5_CODEX_XHIGH_EFFORTS]
 
 // OpenAI rolled out the `none` reasoning_effort tier on this date (Responses API).
 // Models released before it 400 on `reasoning_effort: "none"`, so we only expose
@@ -518,6 +520,7 @@ const OPENAI_XHIGH_EFFORT_RELEASE_DATE = "2025-12-04"
 // Anchored to start-of-string or "/" so it doesn't false-match "gpt-50" or "gpt-5o".
 const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
 const GPT5_VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
+const GPT5_PRO_RE = /(?:^|\/)gpt-5[.-]?pro(?:[.-]|$)/
 const GPT5_VERSIONED_PRO_RE = /(?:^|\/)gpt-5[.-]\d+[.-]pro(?:[.-]|$)/
 
 function gpt5Version(apiId: string) {
@@ -532,17 +535,22 @@ function versionedGpt5ReasoningEfforts(apiId: string) {
   return OPENAI_GPT5_2_PLUS_EFFORTS
 }
 
+function gpt5CodexReasoningEfforts(apiId: string) {
+  if (!GPT5_FAMILY_RE.test(apiId) || !apiId.includes("codex")) return undefined
+  const version = gpt5Version(apiId)
+  if (version !== undefined && version >= 3) return OPENAI_GPT5_CODEX_3_PLUS_EFFORTS
+  if (apiId.includes("codex-max") || (version !== undefined && version >= 2)) return OPENAI_GPT5_CODEX_XHIGH_EFFORTS
+  return WIDELY_SUPPORTED_EFFORTS
+}
+
 // Computes the reasoning_effort tiers an OpenAI (or OpenAI-compatible upstream
-// routed through it, e.g. cf-ai-gateway) model exposes. Returns null for models
-// with no tunable effort knob (gpt-5-pro). Effort order: weakest to strongest.
-function openaiReasoningEfforts(apiId: string, releaseDate: string): string[] | null {
+// routed through it, e.g. cf-ai-gateway) model exposes. Effort order: weakest
+// to strongest.
+function openaiReasoningEfforts(apiId: string, releaseDate: string) {
   const id = apiId.toLowerCase()
-  if (id === "gpt-5-pro" || id === "openai/gpt-5-pro") return null
-  const version = gpt5Version(id)
-  if (id.includes("codex")) {
-    if (version !== undefined && version >= 2) return OPENAI_GPT5_CODEX_2_PLUS_EFFORTS
-    return WIDELY_SUPPORTED_EFFORTS
-  }
+  if (GPT5_PRO_RE.test(id)) return OPENAI_GPT5_PRO_EFFORTS
+  const codexEfforts = gpt5CodexReasoningEfforts(id)
+  if (codexEfforts) return codexEfforts
   const versionedEfforts = versionedGpt5ReasoningEfforts(id)
   // GPT-5.1 replaced GPT-5's `minimal` effort with `none`; GPT-5.2+
   // additionally accepts `xhigh`. Model pages list the supported subset.
@@ -555,7 +563,9 @@ function openaiReasoningEfforts(apiId: string, releaseDate: string): string[] | 
 }
 
 function openaiCompatibleReasoningEfforts(id: string) {
-  return versionedGpt5ReasoningEfforts(id.toLowerCase()) ?? OPENAI_EFFORTS
+  const apiId = id.toLowerCase()
+  if (GPT5_PRO_RE.test(apiId)) return OPENAI_GPT5_PRO_EFFORTS
+  return gpt5CodexReasoningEfforts(apiId) ?? versionedGpt5ReasoningEfforts(apiId) ?? OPENAI_EFFORTS
 }
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
@@ -621,7 +631,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // models that support it.
       if (model.api.id.startsWith("openai/")) {
         const efforts = openaiReasoningEfforts(model.api.id, model.release_date)
-        if (!efforts) return {}
         return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
       }
       return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
@@ -750,7 +759,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/openai": {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
       const efforts = openaiReasoningEfforts(model.api.id, model.release_date)
-      if (!efforts) return {}
       return Object.fromEntries(
         efforts.map((effort) => [
           effort,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2466,7 +2466,11 @@ describe("ProviderTransform.variants", () => {
 
     for (const testCase of [
       { id: "openai/gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-pro", efforts: ["high"] },
       { id: "openai/gpt-5.5-pro", efforts: ["medium", "high", "xhigh"] },
+      { id: "openai/gpt-5.2-codex", efforts: ["low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5.3-codex", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5.3-codex-max", efforts: ["none", "low", "medium", "high", "xhigh"] },
     ]) {
       test(`${testCase.id} returns supported OpenAI reasoning efforts`, () => {
         const result = ProviderTransform.variants(
@@ -2674,7 +2678,11 @@ describe("ProviderTransform.variants", () => {
 
     for (const testCase of [
       { id: "openai/gpt-5-5", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-pro", efforts: ["high"] },
       { id: "openai/gpt-5-5-pro", efforts: ["medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-2-codex", efforts: ["low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-3-codex", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-3-codex-max", efforts: ["none", "low", "medium", "high", "xhigh"] },
     ]) {
       test(`${testCase.id} returns supported OpenAI reasoning efforts`, () => {
         const result = ProviderTransform.variants(
@@ -2989,7 +2997,7 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@ai-sdk/openai", () => {
-    test("gpt-5-pro returns empty object", () => {
+    test("gpt-5-pro returns only high effort", () => {
       const model = createMockModel({
         id: "gpt-5-pro",
         providerID: "openai",
@@ -3000,7 +3008,7 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
+      expect(Object.keys(result)).toEqual(["high"])
     })
 
     test("standard openai models return custom efforts with reasoningSummary", () => {
@@ -3058,6 +3066,13 @@ describe("ProviderTransform.variants", () => {
       { id: "gpt-5.4", releaseDate: "2026-03-05", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "gpt-5.5", modelID: "gpt-5-5", releaseDate: "2026-04-23", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "gpt-5.4-pro", releaseDate: "2026-03-05", efforts: ["medium", "high", "xhigh"] },
+      { id: "gpt-5.5-pro", releaseDate: "2026-04-23", efforts: ["medium", "high", "xhigh"] },
+      { id: "gpt-5-codex", releaseDate: "2025-09-23", efforts: ["low", "medium", "high"] },
+      { id: "gpt-5.1-codex", releaseDate: "2025-11-13", efforts: ["low", "medium", "high"] },
+      { id: "gpt-5.1-codex-max", releaseDate: "2025-11-13", efforts: ["low", "medium", "high", "xhigh"] },
+      { id: "gpt-5.2-codex", releaseDate: "2025-12-11", efforts: ["low", "medium", "high", "xhigh"] },
+      { id: "gpt-5.3-codex", releaseDate: "2026-01-22", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5.3-codex-max", releaseDate: "2026-01-22", efforts: ["none", "low", "medium", "high", "xhigh"] },
     ]) {
       test(`${testCase.id} returns supported reasoning efforts`, () => {
         const result = ProviderTransform.variants(
@@ -3554,6 +3569,8 @@ describe("ProviderTransform.variants", () => {
     for (const testCase of [
       { id: "openai/gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5.2-codex", efforts: ["low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5.3-codex", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-pro", efforts: ["high"] },
       { id: "openai/gpt-5.2-pro", efforts: ["medium", "high", "xhigh"] },
     ]) {
       test(`${testCase.id} returns supported reasoning efforts`, () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2471,6 +2471,8 @@ describe("ProviderTransform.variants", () => {
       { id: "openai/gpt-5.2-codex", efforts: ["low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5.3-codex", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5.3-codex-max", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-chat-latest", efforts: [] },
+      { id: "openai/gpt-5.2-chat-latest", efforts: ["medium"] },
     ]) {
       test(`${testCase.id} returns supported OpenAI reasoning efforts`, () => {
         const result = ProviderTransform.variants(
@@ -2683,6 +2685,8 @@ describe("ProviderTransform.variants", () => {
       { id: "openai/gpt-5-2-codex", efforts: ["low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5-3-codex", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5-3-codex-max", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-chat-latest", efforts: [] },
+      { id: "openai/gpt-5-2-chat-latest", efforts: ["medium"] },
     ]) {
       test(`${testCase.id} returns supported OpenAI reasoning efforts`, () => {
         const result = ProviderTransform.variants(
@@ -3048,10 +3052,10 @@ describe("ProviderTransform.variants", () => {
 
     test("models after 2025-12-04 include 'xhigh' effort", () => {
       const model = createMockModel({
-        id: "openai/gpt-5-chat",
+        id: "openai/gpt-5-reasoning",
         providerID: "openai",
         api: {
-          id: "gpt-5-chat",
+          id: "gpt-5-reasoning",
           url: "https://api.openai.com",
           npm: "@ai-sdk/openai",
         },
@@ -3073,6 +3077,9 @@ describe("ProviderTransform.variants", () => {
       { id: "gpt-5.2-codex", releaseDate: "2025-12-11", efforts: ["low", "medium", "high", "xhigh"] },
       { id: "gpt-5.3-codex", releaseDate: "2026-01-22", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "gpt-5.3-codex-max", releaseDate: "2026-01-22", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5-chat-latest", releaseDate: "2025-08-07", efforts: [] },
+      { id: "gpt-5.1-chat-latest", releaseDate: "2025-11-13", efforts: ["medium"] },
+      { id: "gpt-5.2-chat-latest", releaseDate: "2025-12-11", efforts: ["medium"] },
     ]) {
       test(`${testCase.id} returns supported reasoning efforts`, () => {
         const result = ProviderTransform.variants(
@@ -3572,6 +3579,8 @@ describe("ProviderTransform.variants", () => {
       { id: "openai/gpt-5.3-codex", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "openai/gpt-5-pro", efforts: ["high"] },
       { id: "openai/gpt-5.2-pro", efforts: ["medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-chat-latest", efforts: [] },
+      { id: "openai/gpt-5.2-chat-latest", efforts: ["medium"] },
     ]) {
       test(`${testCase.id} returns supported reasoning efforts`, () => {
         const result = ProviderTransform.variants(cfModel(testCase.id, "2026-03-05"))
@@ -3595,6 +3604,30 @@ describe("ProviderTransform.variants", () => {
       })
     })
   })
+})
+
+describe("ProviderTransform.smallOptions - gpt-5 chat/search", () => {
+  const createModel = (apiId: string) =>
+    ({
+      id: `openai/${apiId}`,
+      providerID: "openai",
+      api: {
+        id: apiId,
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+    }) as any
+
+  for (const testCase of [
+    { id: "gpt-5-chat-latest", options: { store: false } },
+    { id: "gpt-5.1-chat-latest", options: { store: false, reasoningEffort: "medium" } },
+    { id: "gpt-5.2-chat-latest", options: { store: false, reasoningEffort: "medium" } },
+    { id: "gpt-5-search-api", options: { store: false } },
+  ]) {
+    test(`${testCase.id} returns only supported small options`, () => {
+      expect(ProviderTransform.smallOptions(createModel(testCase.id))).toEqual(testCase.options)
+    })
+  }
 })
 
 describe("ProviderTransform.providerOptions - ai-gateway-provider", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2478,6 +2478,20 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
     })
 
+    test("gpt-5.5-pro models use pro effort levels", () => {
+      const model = createMockModel({
+        id: "openai/gpt-5.5-pro",
+        providerID: "openrouter",
+        api: {
+          id: "openai/gpt-5.5-pro",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
+    })
+
     test("gemini-3 returns OPENAI_EFFORTS with reasoning", () => {
       const model = createMockModel({
         id: "openrouter/gemini-3-5-pro",
@@ -2678,6 +2692,20 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+    })
+
+    test("gpt-5.5-pro models use pro effort levels", () => {
+      const model = createMockModel({
+        id: "openai/gpt-5-5-pro",
+        providerID: "gateway",
+        api: {
+          id: "openai/gpt-5-5-pro",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
     })
   })
 
@@ -3095,6 +3123,21 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+    })
+
+    test("gpt-5.4-pro uses pro effort levels", () => {
+      const model = createMockModel({
+        id: "gpt-5.4-pro",
+        providerID: "openai",
+        api: {
+          id: "gpt-5.4-pro",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2026-03-05",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
     })
 
     test("gpt-50 (lookalike) does not get gpt-5 family treatment", () => {
@@ -3583,6 +3626,11 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(cfModel("openai/gpt-5.2-codex", "2025-12-11"))
       expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
       expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh"])
+    })
+
+    test("openai gpt-5.2-pro uses pro effort levels", () => {
+      const result = ProviderTransform.variants(cfModel("openai/gpt-5.2-pro", "2025-12-11"))
+      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
     })
 
     test("openai gpt-4o (no reasoning) returns empty", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2464,33 +2464,25 @@ describe("ProviderTransform.variants", () => {
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
 
-    test("gpt-5.4 models do not include minimal effort", () => {
-      const model = createMockModel({
-        id: "openai/gpt-5.4",
-        providerID: "openrouter",
-        api: {
-          id: "openai/gpt-5.4",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
+    for (const testCase of [
+      { id: "openai/gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5.5-pro", efforts: ["medium", "high", "xhigh"] },
+    ]) {
+      test(`${testCase.id} returns supported OpenAI reasoning efforts`, () => {
+        const result = ProviderTransform.variants(
+          createMockModel({
+            id: testCase.id,
+            providerID: "openrouter",
+            api: {
+              id: testCase.id,
+              url: "https://openrouter.ai",
+              npm: "@openrouter/ai-sdk-provider",
+            },
+          }),
+        )
+        expect(Object.keys(result)).toEqual(testCase.efforts)
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
-    })
-
-    test("gpt-5.5-pro models use pro effort levels", () => {
-      const model = createMockModel({
-        id: "openai/gpt-5.5-pro",
-        providerID: "openrouter",
-        api: {
-          id: "openai/gpt-5.5-pro",
-          url: "https://openrouter.ai",
-          npm: "@openrouter/ai-sdk-provider",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
-    })
+    }
 
     test("gemini-3 returns OPENAI_EFFORTS with reasoning", () => {
       const model = createMockModel({
@@ -2680,33 +2672,25 @@ describe("ProviderTransform.variants", () => {
       expect(result.high).toEqual({ reasoningEffort: "high" })
     })
 
-    test("gpt-5.5 models do not include minimal effort", () => {
-      const model = createMockModel({
-        id: "openai/gpt-5-5",
-        providerID: "gateway",
-        api: {
-          id: "openai/gpt-5-5",
-          url: "https://gateway.ai",
-          npm: "@ai-sdk/gateway",
-        },
+    for (const testCase of [
+      { id: "openai/gpt-5-5", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5-5-pro", efforts: ["medium", "high", "xhigh"] },
+    ]) {
+      test(`${testCase.id} returns supported OpenAI reasoning efforts`, () => {
+        const result = ProviderTransform.variants(
+          createMockModel({
+            id: testCase.id,
+            providerID: "gateway",
+            api: {
+              id: testCase.id,
+              url: "https://gateway.ai",
+              npm: "@ai-sdk/gateway",
+            },
+          }),
+        )
+        expect(Object.keys(result)).toEqual(testCase.efforts)
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
-    })
-
-    test("gpt-5.5-pro models use pro effort levels", () => {
-      const model = createMockModel({
-        id: "openai/gpt-5-5-pro",
-        providerID: "gateway",
-        api: {
-          id: "openai/gpt-5-5-pro",
-          url: "https://gateway.ai",
-          npm: "@ai-sdk/gateway",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
-    })
+    }
   })
 
   describe("@ai-sdk/github-copilot", () => {
@@ -2986,33 +2970,22 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
 
-    test("gpt-5.5 does not add minimal effort", () => {
-      const model = createMockModel({
-        id: "gpt-5-5",
-        providerID: "azure",
-        api: {
-          id: "gpt-5-5",
-          url: "https://azure.com",
-          npm: "@ai-sdk/azure",
-        },
+    for (const id of ["gpt-5-4", "gpt-5-5"]) {
+      test(`${id} does not add minimal effort`, () => {
+        const result = ProviderTransform.variants(
+          createMockModel({
+            id,
+            providerID: "azure",
+            api: {
+              id,
+              url: "https://azure.com",
+              npm: "@ai-sdk/azure",
+            },
+          }),
+        )
+        expect(Object.keys(result)).toEqual(["low", "medium", "high"])
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
-    })
-
-    test("gpt-5.4 does not add minimal effort", () => {
-      const model = createMockModel({
-        id: "gpt-5-4",
-        providerID: "azure",
-        api: {
-          id: "gpt-5-4",
-          url: "https://azure.com",
-          npm: "@ai-sdk/azure",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
-    })
+    }
   })
 
   describe("@ai-sdk/openai", () => {
@@ -3080,65 +3053,28 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
     })
 
-    test("gpt-5.1 uses none instead of minimal", () => {
-      const model = createMockModel({
-        id: "gpt-5.1",
-        providerID: "openai",
-        api: {
-          id: "gpt-5.1",
-          url: "https://api.openai.com",
-          npm: "@ai-sdk/openai",
-        },
-        release_date: "2025-11-13",
+    for (const testCase of [
+      { id: "gpt-5.1", releaseDate: "2025-11-13", efforts: ["none", "low", "medium", "high"] },
+      { id: "gpt-5.4", releaseDate: "2026-03-05", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5.5", modelID: "gpt-5-5", releaseDate: "2026-04-23", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5.4-pro", releaseDate: "2026-03-05", efforts: ["medium", "high", "xhigh"] },
+    ]) {
+      test(`${testCase.id} returns supported reasoning efforts`, () => {
+        const result = ProviderTransform.variants(
+          createMockModel({
+            id: testCase.modelID ?? testCase.id,
+            providerID: "openai",
+            api: {
+              id: testCase.id,
+              url: "https://api.openai.com",
+              npm: "@ai-sdk/openai",
+            },
+            release_date: testCase.releaseDate,
+          }),
+        )
+        expect(Object.keys(result)).toEqual(testCase.efforts)
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
-    })
-
-    test("dotted gpt-5.4 ids do not include 'minimal'", () => {
-      const model = createMockModel({
-        id: "gpt-5.4",
-        providerID: "openai",
-        api: {
-          id: "gpt-5.4",
-          url: "https://api.openai.com",
-          npm: "@ai-sdk/openai",
-        },
-        release_date: "2026-03-05",
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
-    })
-
-    test("gpt-5.5 ids do not include 'minimal'", () => {
-      const model = createMockModel({
-        id: "gpt-5-5",
-        providerID: "openai",
-        api: {
-          id: "gpt-5.5",
-          url: "https://api.openai.com",
-          npm: "@ai-sdk/openai",
-        },
-        release_date: "2026-04-23",
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
-    })
-
-    test("gpt-5.4-pro uses pro effort levels", () => {
-      const model = createMockModel({
-        id: "gpt-5.4-pro",
-        providerID: "openai",
-        api: {
-          id: "gpt-5.4-pro",
-          url: "https://api.openai.com",
-          npm: "@ai-sdk/openai",
-        },
-        release_date: "2026-03-05",
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
-    })
+    }
 
     test("gpt-50 (lookalike) does not get gpt-5 family treatment", () => {
       const model = createMockModel({
@@ -3615,23 +3551,16 @@ describe("ProviderTransform.variants", () => {
         release_date: releaseDate,
       })
 
-    test("openai gpt-5.4 includes xhigh effort without minimal", () => {
-      const result = ProviderTransform.variants(cfModel("openai/gpt-5.4", "2026-03-05"))
-      expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
-      expect(result.high).toEqual({ reasoningEffort: "high" })
-      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
-    })
-
-    test("openai gpt-5.2-codex includes xhigh", () => {
-      const result = ProviderTransform.variants(cfModel("openai/gpt-5.2-codex", "2025-12-11"))
-      expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh"])
-    })
-
-    test("openai gpt-5.2-pro uses pro effort levels", () => {
-      const result = ProviderTransform.variants(cfModel("openai/gpt-5.2-pro", "2025-12-11"))
-      expect(Object.keys(result)).toEqual(["medium", "high", "xhigh"])
-    })
+    for (const testCase of [
+      { id: "openai/gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5.2-codex", efforts: ["low", "medium", "high", "xhigh"] },
+      { id: "openai/gpt-5.2-pro", efforts: ["medium", "high", "xhigh"] },
+    ]) {
+      test(`${testCase.id} returns supported reasoning efforts`, () => {
+        const result = ProviderTransform.variants(cfModel(testCase.id, "2026-03-05"))
+        expect(Object.keys(result)).toEqual(testCase.efforts)
+      })
+    }
 
     test("openai gpt-4o (no reasoning) returns empty", () => {
       const model = cfModel("openai/gpt-4o")

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2464,6 +2464,20 @@ describe("ProviderTransform.variants", () => {
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
 
+    test("gpt-5.4 models do not include minimal effort", () => {
+      const model = createMockModel({
+        id: "openai/gpt-5.4",
+        providerID: "openrouter",
+        api: {
+          id: "openai/gpt-5.4",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+    })
+
     test("gemini-3 returns OPENAI_EFFORTS with reasoning", () => {
       const model = createMockModel({
         id: "openrouter/gemini-3-5-pro",
@@ -2650,6 +2664,20 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
       expect(result.low).toEqual({ reasoningEffort: "low" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
+    })
+
+    test("gpt-5.5 models do not include minimal effort", () => {
+      const model = createMockModel({
+        id: "openai/gpt-5-5",
+        providerID: "gateway",
+        api: {
+          id: "openai/gpt-5-5",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
     })
   })
 
@@ -2929,6 +2957,34 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
+
+    test("gpt-5.5 does not add minimal effort", () => {
+      const model = createMockModel({
+        id: "gpt-5-5",
+        providerID: "azure",
+        api: {
+          id: "gpt-5-5",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    })
+
+    test("gpt-5.4 does not add minimal effort", () => {
+      const model = createMockModel({
+        id: "gpt-5-4",
+        providerID: "azure",
+        api: {
+          id: "gpt-5-4",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    })
   })
 
   describe("@ai-sdk/openai", () => {
@@ -2996,7 +3052,22 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
     })
 
-    test("dotted gpt-5.x ids include 'minimal' (regression: matcher used to miss gpt-5.4)", () => {
+    test("gpt-5.1 uses none instead of minimal", () => {
+      const model = createMockModel({
+        id: "gpt-5.1",
+        providerID: "openai",
+        api: {
+          id: "gpt-5.1",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2025-11-13",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high"])
+    })
+
+    test("dotted gpt-5.4 ids do not include 'minimal'", () => {
       const model = createMockModel({
         id: "gpt-5.4",
         providerID: "openai",
@@ -3008,7 +3079,22 @@ describe("ProviderTransform.variants", () => {
         release_date: "2026-03-05",
       })
       const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
+    })
+
+    test("gpt-5.5 ids do not include 'minimal'", () => {
+      const model = createMockModel({
+        id: "gpt-5-5",
+        providerID: "openai",
+        api: {
+          id: "gpt-5.5",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2026-04-23",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
     })
 
     test("gpt-50 (lookalike) does not get gpt-5 family treatment", () => {
@@ -3486,11 +3572,11 @@ describe("ProviderTransform.variants", () => {
         release_date: releaseDate,
       })
 
-    test("openai gpt-5.4 includes xhigh effort (regression: variant=xhigh used to be silently ignored)", () => {
+    test("openai gpt-5.4 includes xhigh effort without minimal", () => {
       const result = ProviderTransform.variants(cfModel("openai/gpt-5.4", "2026-03-05"))
       expect(result.xhigh).toEqual({ reasoningEffort: "xhigh" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
-      expect(Object.keys(result)).toContain("minimal")
+      expect(Object.keys(result)).toEqual(["none", "low", "medium", "high", "xhigh"])
     })
 
     test("openai gpt-5.2-codex includes xhigh", () => {


### PR DESCRIPTION
## Summary
- Align GPT-5 reasoning variants with current OpenAI support so GPT-5.1+ and GPT-5.5 no longer expose unsupported `minimal`.
- Preserve valid `xhigh` support for GPT-5.2+ standard models and handle Pro/Codex/Chat effort differences.
- Apply the version-aware mapping across OpenAI, OpenRouter, AI SDK Gateway, and Cloudflare AI Gateway paths, with regression coverage.

## What Was Wrong
- OpenCode exposed `minimal` for newer GPT-5.x models, including GPT-5.5, even though OpenAI rejects `minimal` for those models.
- Selecting that variant caused an immediate provider-side `400` before generation. For GPT-5.5, OpenAI reports the supported values as `none`, `low`, `medium`, `high`, and `xhigh`.
- Related GPT-5 family variants also needed tighter handling: bare `gpt-5-pro` only supports `high`, versioned Pro models support a different set, Codex models do not all share the standard GPT-5.x effort matrix, and Chat models either do not support `reasoning.effort` or only support `medium`.
- `models.dev` currently only tells OpenCode whether reasoning exists (`reasoning = true`), not which exact effort values are valid, so this mapping has to live in OpenCode for now.

## Validation
- Confirmed the supported values against live OpenAI Responses API validation errors.
- Used intentionally unsupported effort values so OpenAI rejected the request during validation with `usage: null`, returning the supported values without generating tokens.

## Supported Efforts
All values below come from live OpenAI validation errors.

| Model family | Supported `reasoning.effort` values |
| --- | --- |
| `gpt-5`, `gpt-5-mini`, `gpt-5-nano` | `minimal`, `low`, `medium`, `high` |
| `gpt-5.1` | `none`, `low`, `medium`, `high` |
| `gpt-5.2+`, `gpt-5.4`, `gpt-5.5` | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5-pro` | `high` |
| Versioned GPT-5 Pro, e.g. `gpt-5.2-pro`, `gpt-5.4-pro`, `gpt-5.5-pro` | `medium`, `high`, `xhigh` |
| GPT-5 Codex / GPT-5.1 Codex | `low`, `medium`, `high` |
| GPT-5.1 Codex Max / GPT-5.2 Codex | `low`, `medium`, `high`, `xhigh` |
| GPT-5.3 Codex | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5-chat-latest` | no `reasoning.effort` support |
| Versioned GPT-5 Chat latest, e.g. `gpt-5.1-chat-latest`, `gpt-5.2-chat-latest`, `gpt-5.3-chat-latest` | `medium` |
| GPT-5 Search API | no `reasoning.effort` support |

## Testing
- `bun run test test/provider/transform.test.ts`
- `bun typecheck`
- `bunx oxlint "packages/opencode/src/provider/transform.ts" "packages/opencode/test/provider/transform.test.ts"` (existing warnings only)
- push hook: `bun turbo typecheck`