### PR TITLE
fix(provider): constrain OpenAI deep research efforts

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -554,6 +554,7 @@ function gpt5ChatReasoningEfforts(apiId: string) {
 // to strongest.
 function openaiReasoningEfforts(apiId: string, releaseDate: string) {
   const id = apiId.toLowerCase()
+  if (id.includes("deep-research")) return ["medium"]
   const chatEfforts = gpt5ChatReasoningEfforts(id)
   if (chatEfforts) return chatEfforts
   if (GPT5_PRO_RE.test(id)) return OPENAI_GPT5_PRO_EFFORTS

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3066,6 +3066,14 @@ describe("ProviderTransform.variants", () => {
     })
 
     for (const testCase of [
+      { id: "o1", releaseDate: "2024-12-17", efforts: ["low", "medium", "high"] },
+      { id: "o1-pro", releaseDate: "2025-03-19", efforts: ["low", "medium", "high"] },
+      { id: "o3", releaseDate: "2025-04-16", efforts: ["low", "medium", "high"] },
+      { id: "o3-mini", releaseDate: "2025-01-31", efforts: ["low", "medium", "high"] },
+      { id: "o3-pro", releaseDate: "2025-06-10", efforts: ["low", "medium", "high"] },
+      { id: "o4-mini", releaseDate: "2025-04-16", efforts: ["low", "medium", "high"] },
+      { id: "o3-deep-research", releaseDate: "2025-06-26", efforts: ["medium"] },
+      { id: "o4-mini-deep-research", releaseDate: "2025-06-26", efforts: ["medium"] },
       { id: "gpt-5.1", releaseDate: "2025-11-13", efforts: ["none", "low", "medium", "high"] },
       { id: "gpt-5.4", releaseDate: "2026-03-05", efforts: ["none", "low", "medium", "high", "xhigh"] },
       { id: "gpt-5.5", modelID: "gpt-5-5", releaseDate: "2026-04-23", efforts: ["none", "low", "medium", "high", "xhigh"] },


### PR DESCRIPTION
## Summary
- Document verified OpenAI o-series reasoning effort variants in provider transform tests.
- Constrain OpenAI deep-research models to their only supported effort, `medium`.

## What Was Wrong
OpenCode used the generic OpenAI fallback for all o-series models. That was correct for standard o-series models, but too broad for deep-research models.

| Model family | OpenCode before | OpenAI supports | Change |
| --- | --- | --- | --- |
| `o1`, `o1-pro`, `o3`, `o3-mini`, `o3-pro`, `o4-mini` | `low`, `medium`, `high` | `low`, `medium`, `high` | Documented in tests; no behavior change |
| `o3-deep-research` | `low`, `medium`, `high` | `medium` | Remove invalid `low` and `high` variants |
| `o4-mini-deep-research` | `low`, `medium`, `high` | `medium` | Remove invalid `low` and `high` variants |

## Validation
- Verified with live OpenAI Responses API validation errors using unsupported `reasoning.effort: "none"`.
- Validation returned `usage: null`, so no generation tokens were consumed.

## Testing
- `bun run test test/provider/transform.test.ts`
- `bun typecheck`
- `bunx oxlint "packages/opencode/src/provider/transform.ts" "packages/opencode/test/provider/transform.test.ts"` (existing warnings only)
- push hook: `bun turbo typecheck`