### PR TITLE
fix(provider): align Anthropic Opus 4.5 efforts

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -811,6 +811,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         )
       }
 
+      if (["opus-4-5", "opus-4.5"].some((v) => model.api.id.includes(v))) {
+        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { effort }]))
+      }
+
       return {
         high: {
           thinking: {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3128,69 +3128,50 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@ai-sdk/anthropic", () => {
-    test("sonnet 4.6 returns adaptive thinking options", () => {
-      const model = createMockModel({
-        id: "anthropic/claude-sonnet-4-6",
-        providerID: "anthropic",
-        api: {
-          id: "claude-sonnet-4-6",
-          url: "https://api.anthropic.com",
-          npm: "@ai-sdk/anthropic",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
-      expect(result.high).toEqual({
-        thinking: {
-          type: "adaptive",
-        },
-        effort: "high",
-      })
-    })
-
-    test("opus 4.7 returns adaptive thinking options with xhigh", () => {
-      const model = createMockModel({
-        id: "anthropic/claude-opus-4-7",
-        providerID: "anthropic",
-        api: {
-          id: "claude-opus-4-7",
-          url: "https://api.anthropic.com",
-          npm: "@ai-sdk/anthropic",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
-      expect(result.xhigh).toEqual({
-        thinking: {
-          type: "adaptive",
-          display: "summarized",
-        },
-        effort: "xhigh",
-      })
-      expect(result.max).toEqual({
-        thinking: {
-          type: "adaptive",
-          display: "summarized",
-        },
-        effort: "max",
-      })
-    })
-
-    test("opus 4.5 returns effort options without max", () => {
-      const model = createMockModel({
-        id: "anthropic/claude-opus-4-5",
-        providerID: "anthropic",
-        api: {
-          id: "claude-opus-4-5-20251101",
-          url: "https://api.anthropic.com",
-          npm: "@ai-sdk/anthropic",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
-      expect(result.low).toEqual({ effort: "low" })
-      expect(result.high).toEqual({ effort: "high" })
-    })
+    for (const testCase of [
+      {
+        name: "opus 4.5",
+        apiIds: ["claude-opus-4-5-20251101", "claude-opus-4.5-20251101"],
+        efforts: ["low", "medium", "high"],
+        expectedHigh: { effort: "high" },
+      },
+      {
+        name: "sonnet 4.6",
+        apiIds: ["claude-sonnet-4-6", "claude-sonnet-4.6"],
+        efforts: ["low", "medium", "high", "max"],
+        expectedHigh: { thinking: { type: "adaptive" }, effort: "high" },
+      },
+      {
+        name: "opus 4.6",
+        apiIds: ["claude-opus-4-6", "claude-opus-4.6"],
+        efforts: ["low", "medium", "high", "max"],
+        expectedHigh: { thinking: { type: "adaptive" }, effort: "high" },
+      },
+      {
+        name: "opus 4.7",
+        apiIds: ["claude-opus-4-7", "claude-opus-4.7"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      },
+    ]) {
+      for (const apiId of testCase.apiIds) {
+        test(`${testCase.name} ${apiId} returns supported reasoning efforts`, () => {
+          const result = ProviderTransform.variants(
+            createMockModel({
+              id: `anthropic/${apiId}`,
+              providerID: "anthropic",
+              api: {
+                id: apiId,
+                url: "https://api.anthropic.com",
+                npm: "@ai-sdk/anthropic",
+              },
+            }),
+          )
+          expect(Object.keys(result)).toEqual(testCase.efforts)
+          expect(result.high).toEqual(testCase.expectedHigh)
+        })
+      }
+    }
 
     test("github copilot opus 4.7 returns only medium reasoning effort", () => {
       const model = createMockModel({

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3176,6 +3176,22 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
+    test("opus 4.5 returns effort options without max", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-5",
+        providerID: "anthropic",
+        api: {
+          id: "claude-opus-4-5-20251101",
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      expect(result.low).toEqual({ effort: "low" })
+      expect(result.high).toEqual({ effort: "high" })
+    })
+
     test("github copilot opus 4.7 returns only medium reasoning effort", () => {
       const model = createMockModel({
         id: "claude-opus-4.7",


### PR DESCRIPTION
## Summary
- Align Anthropic Opus 4.5 reasoning variants with the provider-supported `output_config.effort` values.
- Add `low` and `medium` options and remove invalid `max` for `claude-opus-4-5-20251101`.
- Cover the Opus 4.5 variant mapping with a regression test.

## Support Matrix
| Model | Before | After |
| --- | --- | --- |
| `claude-opus-4-5-20251101` | `high`, `max` | `low`, `medium`, `high` |

## Validation
- Live Anthropic validation rejects `max`/`xhigh` for `claude-opus-4-5-20251101` and accepts `low`, `medium`, `high` via `output_config.effort`.

## Testing
- `bun run test test/provider/transform.test.ts`
- `bun typecheck`
- `bunx oxlint "packages/opencode/src/provider/transform.ts" "packages/opencode/test/provider/transform.test.ts"` (114 existing warnings, 0 errors)