### PR TITLE
refactor(desktop): use electron-log in shell-env and simplify env merging

### DIFF
--- a/packages/desktop/src/main/logging.ts
+++ b/packages/desktop/src/main/logging.ts
@@ -1,3 +1,4 @@
+import { MainLogger } from "electron-log"
 import log from "electron-log/main.js"
 import { readFileSync, readdirSync, statSync, unlinkSync } from "node:fs"
 import { dirname, join } from "node:path"
@@ -5,11 +6,14 @@ import { dirname, join } from "node:path"
 const MAX_LOG_AGE_DAYS = 7
 const TAIL_LINES = 1000
 
+let logger: MainLogger
+export const getLogger = () => logger
+
 export function initLogging() {
   log.transports.file.maxSize = 5 * 1024 * 1024
   initConsoleTransport()
   cleanup()
-  return log
+  return (logger = log)
 }
 
 export function tail(): string {

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url"
 import { app, utilityProcess } from "electron"
 import type { Details } from "electron"
 import { DEFAULT_SERVER_URL_KEY, WSL_ENABLED_KEY } from "./constants"
-import { getUserShell, loadShellEnv, mergeShellEnv } from "./shell-env"
+import { getUserShell, loadShellEnv } from "./shell-env"
 import { getStore } from "./store"
 import type { SqliteMigrationProgress } from "../preload/types"
 
@@ -57,16 +57,13 @@ export function setWslConfig(config: WslConfig) {
 
 export function preferAppEnv(userDataPath: string) {
   const shell = process.platform === "win32" ? null : getUserShell()
-  Object.assign(
-    process.env,
-    mergeShellEnv(shell ? loadShellEnv(shell) : null, {
-      ...process.env,
-      OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",
-      OPENCODE_EXPERIMENTAL_FILEWATCHER: "true",
-      OPENCODE_CLIENT: "desktop",
-      XDG_STATE_HOME: process.env.XDG_STATE_HOME ?? userDataPath,
-    }),
-  )
+  Object.assign(process.env, {
+    ...(shell ? loadShellEnv(shell) : null),
+    OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",
+    OPENCODE_EXPERIMENTAL_FILEWATCHER: "true",
+    OPENCODE_CLIENT: "desktop",
+    XDG_STATE_HOME: process.env.XDG_STATE_HOME ?? userDataPath,
+  })
 }
 
 export async function spawnLocalServer(

--- a/packages/desktop/src/main/shell-env.ts
+++ b/packages/desktop/src/main/shell-env.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process"
 import { basename } from "node:path"
+import { getLogger } from "./logging";
 
 const TIMEOUT = 5_000
 
@@ -55,28 +56,29 @@ export function isNushell(shell: string) {
 }
 
 export function loadShellEnv(shell: string) {
+  const logger = getLogger()
   if (isNushell(shell)) {
-    console.log(`[server] Skipping shell env probe for nushell: ${shell}`)
+    logger.log(`[server] Skipping shell env probe for nushell: ${shell}`)
     return null
   }
 
   const interactive = probe(shell, "-il")
   if (interactive.type === "Loaded") {
-    console.log(`[server] Loaded shell environment with -il (${Object.keys(interactive.value).length} vars)`)
+    logger.log(`[server] Loaded shell environment with -il (${Object.keys(interactive.value).length} vars)`)
     return interactive.value
   }
   if (interactive.type === "Timeout") {
-    console.warn(`[server] Interactive shell env probe timed out: ${shell}`)
+    logger.log(`[server] Interactive shell env probe timed out: ${shell}`)
     return null
   }
 
   const login = probe(shell, "-l")
   if (login.type === "Loaded") {
-    console.log(`[server] Loaded shell environment with -l (${Object.keys(login.value).length} vars)`)
+    logger.log(`[server] Loaded shell environment with -l (${Object.keys(login.value).length} vars)`)
     return login.value
   }
 
-  console.warn(`[server] Falling back to app environment: ${shell}`)
+  logger.log(`[server] Falling back to app environment: ${shell}`)
   return null
 }
 


### PR DESCRIPTION
## Summary
- Replaces `console.log`/`console.warn` usage in `shell-env.ts` with `electron-log` via a new `getLogger()` export from `logging.ts`
- Removes the `mergeShellEnv` utility and simplifies `preferAppEnv` in `server.ts` to use plain `Object.assign` instead