### PR TITLE
fix(tool/write): don't fail tool when post-write side-effects throw

### DIFF
--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -3,6 +3,7 @@ import * as path from "path"
 import { Effect } from "effect"
 import * as Tool from "./tool"
 import { LSP } from "@/lsp/lsp"
+import * as LSPClient from "@/lsp/client"
 import { createTwoFilesPatch } from "diff"
 import DESCRIPTION from "./write.txt"
 import { Bus } from "../bus"
@@ -62,18 +63,49 @@ export const WriteTool = Tool.define(
           })
 
           yield* fs.writeWithDirs(filepath, Bom.join(contentNew, desiredBom))
-          if (yield* format.file(filepath)) {
-            yield* Bom.syncFile(fs, filepath, desiredBom)
-          }
-          yield* bus.publish(File.Event.Edited, { file: filepath })
-          yield* bus.publish(FileWatcher.Event.Updated, {
-            file: filepath,
-            event: exists ? "change" : "add",
-          })
+
+          // Post-write side-effects: format, BOM sync, bus publish, LSP.
+          // These must NOT fail the tool — the bytes are already on disk and
+          // the model needs to know that. Previously a throw in any of these
+          // (e.g. LSP server stalling on a large file, formatter OOM, BOM
+          // re-read race) would propagate through `Effect.orDie` and surface
+          // to the user as a silent abort with no error message.
+          // See: https://github.com/anomalyco/opencode/issues/19604
+          yield* Effect.gen(function* () {
+            if (yield* format.file(filepath)) {
+              yield* Bom.syncFile(fs, filepath, desiredBom)
+            }
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("write: post-write format/BOM step failed (file already written)", { cause }),
+            ),
+          )
+          yield* bus
+            .publish(File.Event.Edited, { file: filepath })
+            .pipe(Effect.catchCause((cause) => Effect.logWarning("write: bus publish File.Edited failed", { cause })))
+          yield* bus
+            .publish(FileWatcher.Event.Updated, {
+              file: filepath,
+              event: exists ? "change" : "add",
+            })
+            .pipe(
+              Effect.catchCause((cause) =>
+                Effect.logWarning("write: bus publish FileWatcher.Updated failed", { cause }),
+              ),
+            )
 
           let output = "Wrote file successfully."
-          yield* lsp.touchFile(filepath, "document")
-          const diagnostics = yield* lsp.diagnostics()
+          yield* lsp
+            .touchFile(filepath, "document")
+            .pipe(Effect.catchCause((cause) => Effect.logWarning("write: lsp.touchFile failed", { cause })))
+          const diagnostics: Record<string, LSPClient.Diagnostic[]> = yield* lsp.diagnostics().pipe(
+            Effect.catchCause((cause) =>
+              Effect.gen(function* () {
+                yield* Effect.logWarning("write: lsp.diagnostics failed", { cause })
+                return {} as Record<string, LSPClient.Diagnostic[]>
+              }),
+            ),
+          )
           const normalizedFilepath = AppFileSystem.normalizePath(filepath)
           let projectDiagnosticsCount = 0
           for (const [file, issues] of Object.entries(diagnostics)) {

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -249,6 +249,47 @@ describe("tool.write", () => {
     )
   })
 
+  describe("large files", () => {
+    it.instance("writes a ~1500-line file successfully (regression: #19604)", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "large.md")
+        const lines = Array.from({ length: 1500 }, (_, i) => `Line ${i + 1}: ${"x".repeat(60)}`)
+        const content = lines.join("\n") + "\n"
+
+        const result = yield* run({ filePath: filepath, content })
+        expect(result.output).toContain("Wrote file successfully")
+
+        const written = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+        expect(written).toBe(content)
+      }),
+    )
+
+    it.instance(
+      "succeeds even when formatter exits non-zero (post-write side-effect failure must not abort)",
+      () =>
+        Effect.gen(function* () {
+          const test = yield* TestInstance
+          const filepath = path.join(test.directory, "boom.fail")
+          const result = yield* run({ filePath: filepath, content: "payload\n" })
+
+          expect(result.output).toContain("Wrote file successfully")
+          const written = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(written).toBe("payload\n")
+        }),
+      {
+        config: {
+          formatter: {
+            alwaysfail: {
+              extensions: [".fail"],
+              command: ["node", "-e", "process.exit(2)"],
+            },
+          },
+        },
+      },
+    )
+  })
+
   describe("error handling", () => {
     it.instance("throws error when OS denies write access", () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Fixes #19604.

The `Write` tool currently runs format / BOM-sync / bus events / LSP touch / LSP diagnostics inline with the actual disk write, then pipes the whole `Effect` through `Effect.orDie`. Any throw from the post-write steps becomes an unhandled defect and surfaces to the user as a silent abort with no error message — even though the bytes have already been written to disk successfully.

This matches the symptoms in #19604 (and the related #11112, #11630, #16816):
- "tool call appears to execute but returns a failure/abort with no error message"
- A 574-line file fails — not because of content size per se, but because LSP / format / BOM-sync chokes on whatever is happening in the project at that moment
- Workaround (split into smaller writes) works → less per-write LSP/format work, less likelihood of a downstream throw

## Fix

Wrap each post-write side-effect in `Effect.catchCause` and emit a warning instead of dying:

```ts
yield* fs.writeWithDirs(filepath, Bom.join(contentNew, desiredBom))

// Post-write side-effects: format, BOM sync, bus publish, LSP.
// These must NOT fail the tool — the bytes are already on disk.
yield* Effect.gen(function* () {
  if (yield* format.file(filepath)) {
    yield* Bom.syncFile(fs, filepath, desiredBom)
  }
}).pipe(
  Effect.catchCause((cause) =>
    Effect.logWarning("write: post-write format/BOM step failed (file already written)", { cause }),
  ),
)
// ...same for bus.publish, lsp.touchFile, lsp.diagnostics
```

The actual write itself (`fs.writeWithDirs`) still propagates its errors, so OS-level failures (EACCES, ENOSPC, EISDIR, etc.) continue to fail the tool as before — verified by the existing `throws error when OS denies write access` test, which still passes.

The permission gate (`ctx.ask`) also remains outside the catch, so denials still abort cleanly.

## Tests

All 15 existing write tests still pass, plus 2 new regression tests:

1. `writes a ~1500-line file successfully (regression: #19604)` — covers the size band reported in the issue.
2. `succeeds even when formatter exits non-zero (post-write side-effect failure must not abort)` — registers a formatter that always exits 2, asserts the write still reports success and the bytes are on disk.

```
17 pass
 0 fail
27 expect() calls
Ran 17 tests across 1 file. [14.38s]
```

`tsc --noEmit` for `packages/opencode` is clean for the touched files (one pre-existing error in `src/server/routes/ui.ts` about `fs.exists` is unrelated).

## Notes

- `LSP.touchFile` already catches its own errors internally, but I added a defensive outer catch anyway in case the surrounding `runAll` / promise machinery throws synchronously.
- I used `Effect.logWarning(msg, { cause })` to match the style already used in `packages/opencode/src/project/bootstrap.ts:47` and `instance-store.ts:159`.
- Did not touch `edit.ts` even though it uses the same `Effect.orDie` pattern — the symptoms in the linked issues are write-specific, and #24529 / #24537 already track an edit-tool variant. Happy to apply the same treatment to `edit.ts` in a follow-up if maintainers want symmetry.