### PR TITLE
fix(lsp): load C# server on .razor and .cshtml

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -703,7 +703,7 @@ export const Zls: Info = {
 export const CSharp: Info = {
   id: "csharp",
   root: NearestRoot([".slnx", ".sln", ".csproj", "global.json"]),
-  extensions: [".cs", ".csx"],
+  extensions: [".cs", ".csx", ".cshtml", ".razor"],
   async spawn(root) {
     const bin = await getRoslynLanguageServer()
     if (!bin) return


### PR DESCRIPTION
### Issue for this PR

Closes #26247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `.razor` and `.cshtml` to the `CSharp` LSP server's `extensions` list in `packages/opencode/src/lsp/server.ts`.

The dedicated `Razor` server already claims those extensions, but it requires the VSCode C# extension to be installed locally — when `findVscodeRazorExtension()` returns nothing, it bails with `"VS Code C# extension with Razor support not found, skipping Razor LSP"`. So Blazor users without VSCode currently get zero LSP coverage on Razor files.

Adding the extensions to `CSharp` makes the LSP dispatcher (`packages/opencode/src/lsp/lsp.ts:271`) also select the plain Roslyn server for those files. The dispatcher already supports multiple servers per extension, so `Razor` continues to attach alongside `csharp` when VSCode is present.

`.resx` (also mentioned in the issue) was deliberately left out — Roslyn doesn't analyze resource files and there's no XML LSP registered to fall back to. Adding it would either be a no-op or generate noise. Happy to file a follow-up if a maintainer wants one.

### How did you verify your code works?

I don't have .NET 8+ locally to install `roslyn-language-server` for an end-to-end Blazor smoke test, so I verified the dispatcher selection logic by replicating the matching in `lsp.ts` against `Object.values(LSPServer)`:

- Before: `Component.razor` → `[razor]`, `Page.cshtml` → `[razor]`
- After: `Component.razor` → `[csharp, razor]`, `Page.cshtml` → `[csharp, razor]`
- `.cs` / `.csx` behavior unchanged.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR