### PR TITLE
feat(acp): add AgentErrorUpdate session/update kind for typed LLM error propagation

### DIFF
--- a/packages/opencode/src/acp/agent-error.ts
+++ b/packages/opencode/src/acp/agent-error.ts
@@ -1,0 +1,142 @@
+/**
+ * TypeScript mirror of the `agent_error` ACP `session/update` kind.
+ *
+ * The upstream `@agentclientprotocol/sdk` defines `SessionUpdate` as a
+ * closed discriminated union (a `type` alias, not an `interface`).
+ * TypeScript's declaration merging only works on interfaces, so we
+ * cannot extend `SessionUpdate` via an ambient `.d.ts` augmentation —
+ * we have to define our own extended union and use it at the emit site.
+ *
+ * This file is the local fork extension. The wire shape mirrors the
+ * canonical Python definition at:
+ *
+ *   packages/models/src/models/llm_errors.py    (tn-mono)
+ *   services/tn-claw/src/tn_claw/schemas/agent_error.py    (tn-mono)
+ *
+ * Phase chain:
+ *   - Phase 1A: Python contract (tn-mono PR #721, MERGED 2026-05-08)
+ *   - Phase 1B: this file (TS mirror in our anomalyco/opencode fork)
+ *   - Phase 4:  `session/processor.ts` `halt()` emits an `agent_error`
+ *               frame using `SessionUpdateWithAgentError` at its
+ *               `connection.sessionUpdate(...)` callsite
+ *
+ * Spec: `specs/20260508-llm-error-propagation/spec.md`
+ */
+
+import type { SessionUpdate } from "@agentclientprotocol/sdk"
+
+/**
+ * Closed vocabulary for the category of a failed LLM call.
+ *
+ * Keep in sync with `LLMErrorType` in
+ * `packages/models/src/models/llm_errors.py` (tn-mono).
+ */
+export const LLM_ERROR_TYPES = [
+  "budget", // 429 + type=budget_error — non-retriable
+  "rate_limit", // 429 + type=rate_limit_error — bounded retry
+  "provider_unavailable", // 5xx — bounded retry
+  "context_overflow", // 400 + type=invalid_request_error — non-retriable
+  "auth", // 401 — non-retriable; surfaces as connection-level via ch:"error", NOT here
+  "unknown", // wall-clock timeout / unparseable — bounded retry
+] as const
+
+export type LLMErrorType = (typeof LLM_ERROR_TYPES)[number]
+
+const NON_RETRIABLE: ReadonlySet<LLMErrorType> = new Set<LLMErrorType>([
+  "budget",
+  "context_overflow",
+  "auth",
+])
+
+/**
+ * Source-of-truth retry classification by error type.
+ *
+ * Mirrors `is_retriable()` in `packages/models/src/models/llm_errors.py`.
+ * All retry policy in opencode (`session/retry.ts`'s `retryable()`) and
+ * the frontend should derive from this function rather than maintaining
+ * their own tables.
+ */
+export function isRetriable(type: LLMErrorType): boolean {
+  return !NON_RETRIABLE.has(type)
+}
+
+/**
+ * Wire payload for a typed LLM call failure.
+ *
+ * Travels intact from origin (tn-api) through every intermediate layer
+ * to the rendered chat item. `retryable` is on-the-wire explicit so
+ * consumers do not need to keep their own derivation table.
+ *
+ * Wire shape uses snake_case field names — matches the Python
+ * `LLMErrorPayload` and the spec's wire example. Cross-language consumers
+ * (tn-claw Python, frontend) read these names verbatim; do not
+ * camelCase-alias when serializing.
+ *
+ * `auth` is included in `LLMErrorType` for completeness but is NOT
+ * valid on the `agent_error` `session/update` path — auth failures
+ * occur before a session exists; emit them as `ch:"error"` with a
+ * `WebSocketErrorCode` instead.
+ */
+export interface LLMErrorPayload {
+  type: LLMErrorType
+  message: string
+  detail?: Record<string, unknown>
+  retryable: boolean
+  retry_after_seconds?: number | null
+  reset_at_epoch_ms?: number | null
+  source?: string | null
+}
+
+/**
+ * The `agent_error` session/update envelope.
+ *
+ * Shape mirrors the SDK's other discriminated-union members
+ * (e.g. `{ sessionUpdate: "tool_call", ...ToolCall }`).
+ */
+export interface AgentErrorUpdate {
+  sessionUpdate: "agent_error"
+  error: LLMErrorPayload
+  /**
+   * Mirrors the SDK's `stopReason` field on chunk-shaped updates.
+   * Always `"error"` for this kind; included so `session/update`
+   * consumers can clear streaming state without special-casing.
+   */
+  stopReason?: "error"
+}
+
+/**
+ * Local extension of the SDK's closed `SessionUpdate` union.
+ *
+ * Phase 4's emit site (`session/processor.ts` `halt()`) should pass an
+ * `AgentErrorUpdate` to `connection.sessionUpdate(...)` typed as
+ * `SessionUpdateWithAgentError`. We intentionally do NOT cast the
+ * value to the upstream `SessionUpdate` — that would lose the typed
+ * `error` field in callers. Instead, emit code uses this superset.
+ *
+ * Once `@agentclientprotocol/sdk` adopts `agent_error` upstream, drop
+ * this type alias and import the new SDK literal directly.
+ */
+export type SessionUpdateWithAgentError = SessionUpdate | AgentErrorUpdate
+
+/**
+ * Type guard for narrowing an unknown session/update to the
+ * `agent_error` kind. Mirrors `parse_agent_error()` on the Python side.
+ *
+ * Returns `false` for any other kind, including malformed shapes;
+ * the caller does not need a try/catch around it.
+ */
+export function isAgentErrorUpdate(update: unknown): update is AgentErrorUpdate {
+  if (!update || typeof update !== "object") return false
+  const u = update as { sessionUpdate?: unknown; error?: unknown }
+  if (u.sessionUpdate !== "agent_error") return false
+  return isLLMErrorPayload(u.error)
+}
+
+function isLLMErrorPayload(value: unknown): value is LLMErrorPayload {
+  if (!value || typeof value !== "object") return false
+  const p = value as { type?: unknown; message?: unknown; retryable?: unknown }
+  if (typeof p.message !== "string") return false
+  if (typeof p.retryable !== "boolean") return false
+  if (typeof p.type !== "string") return false
+  return (LLM_ERROR_TYPES as readonly string[]).includes(p.type)
+}

--- a/packages/opencode/test/acp/agent-error.test.ts
+++ b/packages/opencode/test/acp/agent-error.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test"
+import {
+  LLM_ERROR_TYPES,
+  type LLMErrorPayload,
+  type SessionUpdateWithAgentError,
+  isAgentErrorUpdate,
+  isRetriable,
+} from "../../src/acp/agent-error"
+
+describe("isRetriable", () => {
+  test.each([
+    ["budget", false],
+    ["context_overflow", false],
+    ["auth", false],
+    ["rate_limit", true],
+    ["provider_unavailable", true],
+    ["unknown", true],
+  ] as const)("classifies %s as retriable=%s", (type, expected) => {
+    expect(isRetriable(type)).toBe(expected)
+  })
+
+  test("LLM_ERROR_TYPES is the closed vocabulary", () => {
+    expect(LLM_ERROR_TYPES).toEqual([
+      "budget",
+      "rate_limit",
+      "provider_unavailable",
+      "context_overflow",
+      "auth",
+      "unknown",
+    ])
+  })
+})
+
+describe("isAgentErrorUpdate", () => {
+  const validBudgetPayload: LLMErrorPayload = {
+    type: "budget",
+    message: "Weekly budget exceeded",
+    retryable: false,
+    detail: { limitUsd: "1.0", consumedUsd: "1.004" },
+    reset_at_epoch_ms: 1778457600000,
+    source: "global",
+  }
+
+  test("narrows valid agent_error frames", () => {
+    const update: unknown = {
+      sessionUpdate: "agent_error",
+      error: validBudgetPayload,
+    }
+    expect(isAgentErrorUpdate(update)).toBe(true)
+    if (isAgentErrorUpdate(update)) {
+      // Compile-time narrowing check: both fields are typed.
+      expect(update.error.type).toBe("budget")
+      expect(update.error.retryable).toBe(false)
+    }
+  })
+
+  test("rejects other session/update kinds", () => {
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } })).toBe(
+      false,
+    )
+    expect(isAgentErrorUpdate({ sessionUpdate: "tool_call_update" })).toBe(false)
+  })
+
+  test("rejects missing or malformed payloads", () => {
+    expect(isAgentErrorUpdate(undefined)).toBe(false)
+    expect(isAgentErrorUpdate(null)).toBe(false)
+    expect(isAgentErrorUpdate("agent_error")).toBe(false)
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_error" })).toBe(false)
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_error", error: null })).toBe(false)
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_error", error: { type: "budget" } })).toBe(false)
+    expect(
+      isAgentErrorUpdate({
+        sessionUpdate: "agent_error",
+        error: { type: "not_a_real_type", message: "x", retryable: false },
+      }),
+    ).toBe(false)
+  })
+
+  test("JSON round-trip preserves shape", () => {
+    const frame: SessionUpdateWithAgentError = {
+      sessionUpdate: "agent_error",
+      error: validBudgetPayload,
+      stopReason: "error",
+    }
+    const decoded = JSON.parse(JSON.stringify(frame))
+    expect(isAgentErrorUpdate(decoded)).toBe(true)
+    if (isAgentErrorUpdate(decoded)) {
+      expect(decoded.error.reset_at_epoch_ms).toBe(1778457600000)
+      expect(decoded.error.source).toBe("global")
+    }
+  })
+})
+
+describe("SessionUpdateWithAgentError compile-time narrowing", () => {
+  test("discriminated union narrows to AgentErrorUpdate by sessionUpdate literal", () => {
+    const update: SessionUpdateWithAgentError = {
+      sessionUpdate: "agent_error",
+      error: {
+        type: "rate_limit",
+        message: "Slow down",
+        retryable: true,
+        retry_after_seconds: 12,
+      },
+    }
+    if (update.sessionUpdate === "agent_error") {
+      // This block must compile — i.e. update.error is typed as LLMErrorPayload.
+      const _typeCheck: number | null | undefined = update.error.retry_after_seconds
+      expect(_typeCheck).toBe(12)
+    } else {
+      throw new Error("union narrowing failed")
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #26378

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a non-tool LLM call exhausts retries (`AI_RetryError: maxRetriesExceeded` or any unhandled error from the model stream), `session/processor.ts` `halt()` writes the failure to the local logfile and updates the assistant message's internal `error` field, but it never emits an ACP frame back to the client. The result on the wire is silence — the assistant message persists with `parts: []` and no `stopReason`, and a connected ACP client has no way to distinguish "still streaming" from "the call failed". Tool-call failures don't have this problem because they ride `tool_call` / `tool_call_update` shapes, but turn-level errors (rate limits, provider 5xx, context-overflow rejections, budget gates, etc.) do.

This PR adds the type-only half of fixing that: a new `session/update` kind `agent_error` whose payload carries a small closed vocabulary of error categories (`budget`, `rate_limit`, `provider_unavailable`, `context_overflow`, `auth`, `unknown`), a human-readable message, and structured retry metadata. The actual emit at `halt()` is intentionally a separate change so the contract can land first; this PR introduces no behaviour change and nothing in the codebase imports the new module yet.

**Why a new file rather than augmenting `@agentclientprotocol/sdk` directly:** the SDK's `SessionUpdate` is a closed `type` alias (discriminated union), not an `interface`. TypeScript's declaration merging only works on interfaces, so the union can't be extended via an ambient `.d.ts` patch. The clean TS-native approach is a local extended union `SessionUpdateWithAgentError = SessionUpdate | AgentErrorUpdate` that the (future) emit site opts into. If the upstream SDK ever adopts `agent_error` as a first-class kind, this local alias can be deleted and the SDK literal imported directly — no other code needs to change.

The shape:

```ts
interface AgentErrorUpdate {
  sessionUpdate: "agent_error"
  error: {
    type: "budget" | "rate_limit" | "provider_unavailable" | "context_overflow" | "auth" | "unknown"
    message: string
    retryable: boolean
    detail?: Record<string, unknown>
    retry_after_seconds?: number | null
    reset_at_epoch_ms?: number | null
    source?: string | null
  }
  stopReason?: "error"
}
```

`retryable` is on-the-wire explicit (rather than only derived from `type`) so consumers don't have to maintain a parallel classification table; an `isRetriable(type)` helper is exported as the source of truth, and a structural type guard `isAgentErrorUpdate(value)` is provided for narrowing unknown payloads. Snake-case field names are deliberate — they match the producer side of the wire (a service upstream of opencode that emits the frames) and avoid an alias-mapping layer.

`auth` is in the vocabulary for completeness but should not be emitted on the `agent_error` path: auth failures occur before a session exists, so they belong on a connection-scoped error channel, not a session/update. The module docstring states this so a future emit-site change can't accidentally produce an invalid frame.

### How did you verify your code works?

- `bun run typecheck` (`tsgo --noEmit`) — clean, 0 errors
- `bun test test/acp/agent-error.test.ts` — 12 pass / 0 fail / 23 expect() calls
  - Parametric coverage of `isRetriable` for all six categories
  - `isAgentErrorUpdate` rejects null / undefined / wrong-kind / missing-error / malformed-payload / unknown-type
  - JSON `stringify` ↔ `parse` round-trip preserves shape
  - Compile-time assertion that `SessionUpdateWithAgentError` narrows correctly via the `sessionUpdate` discriminant
  - Vocabulary-stability check catches accidental enum reordering

No integration / e2e impact since nothing imports the module yet.

### Screenshots / recordings

_N/A — type-only / additive; no UI surface._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


