### PR TITLE
test(session): update go retry fixture

### DIFF
--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -263,6 +263,9 @@ describe("session.retry.retryable", () => {
         message: "Subscription quota exceeded. You can continue using free models.",
         isRetryable: true,
         statusCode: 429,
+        responseHeaders: {
+          "retry-after": "19380",
+        },
         responseBody: JSON.stringify({
           type: "error",
           error: {
@@ -271,8 +274,7 @@ describe("session.retry.retryable", () => {
           },
           metadata: {
             workspace: "wrk_01K6XGM22R6FM8JVABE9XDQXGH",
-            limit: "5 hour",
-            resetAt: 19_380,
+            limitName: "5 hour",
           },
         }),
       }).toObject(),


### PR DESCRIPTION
## summary
- update the Go subscription limit retry fixture to match the current response shape
- keep the expected PAYG upsell message assertion unchanged

## testing
- bun test test/session/retry.test.ts