### PR TITLE
docs: add AgentDrop MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -509,3 +509,31 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### AgentDrop
+
+Add the [AgentDrop MCP server](https://docs.agent-drop.com) to send and receive encrypted files between AI agents.
+
+```json title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "agentdrop": {
+      "type": "local",
+      "command": ["npx", "agentdrop-mcp-server"],
+      "environment": {
+        "AGENTDROP_API_KEY": "{env:AGENTDROP_API_KEY}",
+        "AGENTDROP_AGENT_ID": "{env:AGENTDROP_AGENT_ID}"
+      }
+    }
+  }
+}
+```
+
+Register your agent and get your API key at [agent-drop.com](https://agent-drop.com). Once configured, you can send files between agents directly from your prompts.
+
+```txt "use agentdrop"
+Send this summary to my analysis agent. use agentdrop
+```


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an entry for AgentDrop in the MCP servers docs page (`packages/web/src/content/docs/mcp-servers.mdx`). It follows the same format as the existing entries (Linear, Bun, etc.) - short description, ready-to-paste `opencode.jsonc` snippet, and a one-line usage example.

AgentDrop is an npm-published MCP server (`agentdrop-mcp-server`) that lets agents send and receive encrypted files between each other. It is a stdio server, configured the same way as the other entries in the file.

An earlier version of this PR (#26158) was auto-closed because the description did not follow the template. This is a re-submission of the same diff with a compliant body.

### How did you verify your code works?

Verified the JSON snippet shape matches the existing entries on this docs page, and the command + env vars match the agentdrop-mcp-server v0.2.27 package on npm (no transport or env-var changes since the package was first published, so the config example is current).

The diff is markdown-only - no code, no build impact. Rendered locally to confirm headings and code blocks display correctly.

### Screenshots / recordings

N/A - markdown docs only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR