### PR TITLE
fix(desktop): await where.exe output in resolveWindowsAppPath

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -85,7 +85,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -119,7 +119,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -146,7 +146,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.48",
@@ -170,7 +170,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -194,7 +194,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -228,7 +228,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -282,7 +282,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -311,7 +311,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -327,7 +327,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -469,7 +469,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "effect": "catalog:",
@@ -504,7 +504,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -519,7 +519,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -554,7 +554,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -603,7 +603,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.14.40",
+      "version": "1.14.41",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.14.40",
+  "version": "1.14.41",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/desktop/src/main/apps.test.ts
+++ b/packages/desktop/src/main/apps.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+
+import { resolveWindowsAppPath } from "./apps"
+
+describe("desktop app resolution", () => {
+  test("resolveWindowsAppPath awaits where.exe output", async () => {
+    const path = await resolveWindowsAppPath("opencode", async () => ({
+      stdout: "C:\\Users\\test\\AppData\\Local\\Programs\\OpenCode\\OpenCode.exe\r\n",
+      stderr: "",
+    }))
+
+    expect(path).toBe("C:\\Users\\test\\AppData\\Local\\Programs\\OpenCode\\OpenCode.exe")
+  })
+})

--- a/packages/desktop/src/main/apps.ts
+++ b/packages/desktop/src/main/apps.ts
@@ -4,6 +4,8 @@ import { dirname, extname, join } from "node:path"
 import util from "node:util"
 
 const execFilePromise = util.promisify(execFile)
+type ExecFileResult = Awaited<ReturnType<typeof execFilePromise>>
+type ExecFile = (file: string, args?: readonly string[]) => Promise<ExecFileResult>
 
 const exists = (path: string) =>
   access(path)
@@ -55,10 +57,14 @@ async function checkMacosApp(appName: string) {
     .catch(() => false)
 }
 
-async function resolveWindowsAppPath(appName: string): Promise<string | null> {
+export async function resolveWindowsAppPath(
+  appName: string,
+  runExecFile: ExecFile = execFilePromise,
+): Promise<string | null> {
   let output: string
   try {
-    output = execFilePromise("where", [appName]).toString()
+    const result = await runExecFile("where", [appName])
+    output = result.stdout.toString()
   } catch {
     return null
   }

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/extensions/zed/extension.toml
+++ b/packages/extensions/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "opencode"
 name = "OpenCode"
 description = "The open source coding agent."
-version = "1.14.40"
+version = "1.14.41"
 schema_version = 1
 authors = ["Anomaly"]
 repository = "https://github.com/anomalyco/opencode"
@@ -11,26 +11,26 @@ name = "OpenCode"
 icon = "./icons/opencode.svg"
 
 [agent_servers.opencode.targets.darwin-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.40/opencode-darwin-arm64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-darwin-arm64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.darwin-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.40/opencode-darwin-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-darwin-x64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.40/opencode-linux-arm64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-linux-arm64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.40/opencode-linux-x64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-linux-x64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.windows-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.40/opencode-windows-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.41/opencode-windows-x64.zip"
 cmd = "./opencode.exe"
 args = ["acp"]

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.14.40",
+  "version": "1.14.41",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

In v1.14.41, resolveWindowsAppPath was refactored from sync to async but execFilePromise("where", [appName]).toString() was called without await. This returned "[object Promise]" instead of the resolved path, breaking app resolution (resolveAppPath) on Windows.

## Root Cause

packages/desktop/src/main/apps.ts:61 — `execFilePromise("where", [appName]).toString()`

execFilePromise (util.promisify(execFile)) returns a Promise. Calling .toString() before await yields "[object Promise]", so path parsing receives garbage.

## Fix

1. Export resolveWindowsAppPath with injectable runExecFile param for testing
2. await the result and read stdout properly
3. Regression test added with mocked execFile

## Verification

bun test packages/desktop/src/main/apps.test.ts — 1 pass, 0 fail

## Related

Issue #26278 reporter also observed sidecar exiting with code 0 seconds after Windows startup in v1.14.41. That symptom may be separate (utilityProcess.fork sidecar refactor) but this fixes a definite bug in the same release.

Commit authored as "OpenCode Contributor".
