### PR TITLE
fix(cli): respawn the invoked binary in pr.ts via process.argv

### DIFF
--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -4,10 +4,11 @@ import { effectCmd, fail } from "../effect-cmd"
 import { Git } from "@/git"
 import { InstanceRef } from "@/effect/instance-ref"
 import { Process } from "@/util/process"
+import { selfDisplayName, selfRespawnArgv } from "@/util/self-respawn"
 
 export const PrCommand = effectCmd({
   command: "pr <number>",
-  describe: "fetch and checkout a GitHub PR branch, then run opencode",
+  describe: `fetch and checkout a GitHub PR branch, then run ${selfDisplayName()}`,
   builder: (yargs) =>
     yargs.positional("number", {
       type: "number",
@@ -76,11 +77,12 @@ export const PrCommand = effectCmd({
         const sessionMatch = prInfo.body.match(/https:\/\/opncd\.ai\/s\/([a-zA-Z0-9_-]+)/)
         if (sessionMatch) {
           const sessionUrl = sessionMatch[0]
-          UI.println(`Found opencode session: ${sessionUrl}`)
+          const self = selfRespawnArgv()
+          UI.println(`Found ${selfDisplayName()} session: ${sessionUrl}`)
           UI.println(`Importing session...`)
 
           const importResult = yield* Effect.promise(() =>
-            Process.text(["opencode", "import", sessionUrl], { nothrow: true }),
+            Process.text([...self, "import", sessionUrl], { nothrow: true }),
           )
           if (importResult.code === 0) {
             const sessionIdMatch = importResult.text.trim().match(/Imported session: ([a-zA-Z0-9_-]+)/)
@@ -95,13 +97,14 @@ export const PrCommand = effectCmd({
 
     UI.println(`Successfully checked out PR #${prNumber} as branch '${localBranchName}'`)
     UI.println()
-    UI.println("Starting opencode...")
+    UI.println(`Starting ${selfDisplayName()}...`)
     UI.println()
 
-    const opencodeArgs = sessionId ? ["-s", sessionId] : []
+    const self = selfRespawnArgv()
+    const sessionArgs = sessionId ? ["-s", sessionId] : []
     const code = yield* Effect.promise(
       () =>
-        Process.spawn(["opencode", ...opencodeArgs], {
+        Process.spawn([...self, ...sessionArgs], {
           stdin: "inherit",
           stdout: "inherit",
           stderr: "inherit",
@@ -110,6 +113,6 @@ export const PrCommand = effectCmd({
     )
     // Match legacy throw semantics — propagate as a defect so the top-level
     // index.ts catch handles it identically (exit 1, "Unexpected error" banner).
-    if (code !== 0) return yield* Effect.die(new Error(`opencode exited with code ${code}`))
+    if (code !== 0) return yield* Effect.die(new Error(`${selfDisplayName()} exited with code ${code}`))
   }),
 })

--- a/packages/opencode/src/util/self-respawn.ts
+++ b/packages/opencode/src/util/self-respawn.ts
@@ -1,0 +1,55 @@
+/**
+ * Cross-platform basename that recognises both `/` and `\` as separators so
+ * paths from cross-built environments (Windows argv on a POSIX test runner,
+ * cygwin tools, etc.) produce the same answer as the host's `path.basename`
+ * would.
+ */
+function basename(p: string): string {
+  const m = p.match(/[^/\\]+$/)
+  return m ? m[0] : p
+}
+
+/**
+ * Argv prefix to spawn the same CLI that produced this process.
+ *
+ * - Compiled binary mode (production opencode binary): returns `[binaryPath]`
+ *   so children inherit the same compiled binary.
+ * - Bun-run mode (`bun src/index.ts ...`): returns `[bunPath, scriptPath]`
+ *   so children re-enter the same script under the same Bun runtime.
+ *
+ * Replaces hardcoded `"opencode"` strings on self-spawn paths so the binary
+ * the user actually invoked is what gets respawned. The literal `"opencode"`
+ * in `pr.ts`'s spawn path routes children to whichever `opencode` `$PATH`
+ * happens to resolve, regardless of how the parent was launched — that
+ * misroutes under symlinks (`oc -> opencode`), side-by-side installs
+ * (`opencode-canary` should respawn itself), `bun src/index.ts` dev runs
+ * (the script path is needed in addition to the bun binary), and any
+ * rename or wrapper script.
+ */
+export function selfRespawnArgv(argv: readonly string[] = process.argv): readonly string[] {
+  const exe = argv[0]
+  if (!exe) throw new Error("argv[0] is missing; cannot determine self binary")
+  if (!isBunInterpreter(exe)) return [exe]
+  const script = argv[1]
+  if (!script) throw new Error("Bun runtime detected but argv[1] (script path) is missing")
+  return [exe, script]
+}
+
+/**
+ * Display name of the current binary, suitable for user-facing messages such
+ * as "Starting <name>...". Returns the binary's basename (`opencode`,
+ * `securecode`, etc.) for compiled binaries and `bun` for `bun src/...` dev
+ * runs. Falls back to `"opencode"` if argv[0] is unexpectedly missing.
+ */
+export function selfDisplayName(argv: readonly string[] = process.argv): string {
+  const exe = argv[0]
+  if (!exe) return "opencode"
+  return basename(exe)
+}
+
+function isBunInterpreter(exe: string): boolean {
+  // Match the Bun runtime regardless of platform (`bun`, `bun-debug`, `bun.exe`,
+  // `bun-canary` distros etc. all start with `bun` after the directory part).
+  const base = basename(exe).toLowerCase()
+  return /^bun(\b|[-_.])/.test(base)
+}

--- a/packages/opencode/test/util/self-respawn.test.ts
+++ b/packages/opencode/test/util/self-respawn.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import { selfDisplayName, selfRespawnArgv } from "../../src/util/self-respawn"
+
+describe("selfRespawnArgv", () => {
+  test("compiled binary mode returns [binaryPath] only", () => {
+    expect(selfRespawnArgv(["/usr/local/bin/opencode", "pr", "123"])).toEqual(["/usr/local/bin/opencode"])
+  })
+
+  test("compiled binary mode works for renamed / aliased binaries", () => {
+    // Symlink, canary build, downstream rename — selfRespawnArgv should
+    // honour whatever process.argv[0] resolves to at invocation time.
+    expect(selfRespawnArgv(["/usr/local/bin/opencode-canary", "pr", "123"])).toEqual([
+      "/usr/local/bin/opencode-canary",
+    ])
+    expect(selfRespawnArgv(["/Users/x/.local/bin/oc", "pr", "123"])).toEqual(["/Users/x/.local/bin/oc"])
+  })
+
+  test("bun-run mode returns [bunPath, scriptPath]", () => {
+    expect(selfRespawnArgv(["/Users/x/.bun/bin/bun", "/repo/src/index.ts", "pr", "123"])).toEqual([
+      "/Users/x/.bun/bin/bun",
+      "/repo/src/index.ts",
+    ])
+  })
+
+  test("bun-run mode handles bun-debug / bun-canary distros", () => {
+    expect(selfRespawnArgv(["/Users/x/.bun/bin/bun-debug", "/repo/src/index.ts"])).toEqual([
+      "/Users/x/.bun/bin/bun-debug",
+      "/repo/src/index.ts",
+    ])
+  })
+
+  test("bun-run mode handles bun.exe on Windows", () => {
+    expect(selfRespawnArgv(["C:\\Tools\\bun.exe", "C:\\repo\\src\\index.ts"])).toEqual([
+      "C:\\Tools\\bun.exe",
+      "C:\\repo\\src\\index.ts",
+    ])
+  })
+
+  test("does not match binaries that merely contain 'bun'", () => {
+    // Defensive: a hypothetical `tribune` binary should not be treated as Bun.
+    expect(selfRespawnArgv(["/usr/local/bin/tribune", "pr", "123"])).toEqual(["/usr/local/bin/tribune"])
+  })
+
+  test("throws when argv[0] is missing", () => {
+    expect(() => selfRespawnArgv([])).toThrow(/argv\[0\] is missing/)
+  })
+
+  test("throws when bun runtime detected but argv[1] is missing", () => {
+    expect(() => selfRespawnArgv(["/usr/local/bin/bun"])).toThrow(/argv\[1\].*missing/)
+  })
+})
+
+describe("selfDisplayName", () => {
+  test("returns binary basename for compiled binaries", () => {
+    expect(selfDisplayName(["/usr/local/bin/opencode"])).toBe("opencode")
+    expect(selfDisplayName(["/usr/local/bin/opencode-canary"])).toBe("opencode-canary")
+  })
+
+  test("returns 'bun' under bun-run mode", () => {
+    expect(selfDisplayName(["/Users/x/.bun/bin/bun", "/repo/src/index.ts"])).toBe("bun")
+  })
+
+  test("returns 'bun.exe' under bun-run mode on Windows", () => {
+    expect(selfDisplayName(["C:\\Tools\\bun.exe"])).toBe("bun.exe")
+  })
+
+  test("falls back to 'opencode' when argv[0] is missing", () => {
+    expect(selfDisplayName([])).toBe("opencode")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #26335

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/opencode/src/cli/cmd/pr.ts` hardcodes the literal string `"opencode"` when launching a child session after checkout (two `Process.text` / `Process.spawn` calls, the "Starting opencode..." line, and the exit-code error). That string routes children through whichever `opencode` happens to come first on `$PATH`, ignoring how the parent was launched. So all of the following misroute:

- Compiled-binary symlinks (`oc -> opencode`; `oc pr 123` should keep using `oc`'s install path)
- Side-by-side installs (`opencode-canary pr 123` should respawn the canary, not stable)
- `bun src/index.ts pr 123` dev mode (the literal `"opencode"` is not on the dev shell's `$PATH`; the child needs `[bunPath, scriptPath]`)
- Wrapper scripts that retitle the binary (sudo, custom names, etc.)

Replace the four hardcoded sites with a tiny `process.argv`-driven helper at `packages/opencode/src/util/self-respawn.ts`:

- `selfRespawnArgv(argv)` returns `[binaryPath]` for compiled binaries and `[bunPath, scriptPath]` when invoked under the Bun interpreter. Detection is `^bun(\b|[-_.])` against the basename, with a cross-platform basename so Windows-style paths supplied via tests don't break the regex.
- `selfDisplayName(argv)` returns the basename for the "Starting `<name>`..." message, the exit-code error, and the yargs `describe` text — so `--help` matches whatever binary is actually running.

`pr.ts` then becomes a thin call site for those helpers. No new public API, no behavior change for the default invocation path; only the misrouted paths above gain correct behavior. Same theme as #18611 (hardcoded `"opencode"` in `attach.ts`), different file.

### How did you verify your code works?

- `bun test packages/opencode/test/util/self-respawn.test.ts` — 12 unit cases covering compiled-binary mode, bun-run mode, bun-debug / bun-canary distros, Windows path basenames, defensive non-bun binaries (e.g. `tribune` shouldn't match the bun regex), and the two error paths
- `bun turbo typecheck --filter=opencode` — clean
- `bun src/index.ts pr --help` shows the `pr` describe text reflecting the running binary

### Screenshots / recordings

_CLI message text only — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR