### PR TITLE
fix(desktop): await Windows app path lookup

### DIFF
--- a/packages/desktop/src/main/apps.ts
+++ b/packages/desktop/src/main/apps.ts
@@ -58,7 +58,7 @@ async function checkMacosApp(appName: string) {
 async function resolveWindowsAppPath(appName: string): Promise<string | null> {
   let output: string
   try {
-    output = execFilePromise("where", [appName]).toString()
+    output = (await execFilePromise("where", [appName])).stdout
   } catch {
     return null
   }


### PR DESCRIPTION
### Issue for this PR

Closes #26287 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a Windows Desktop bug where opening a project with VS Code could fail with:

`spawn [object Promise] ENOENT`

The issue was caused by the Windows application path lookup returning a Promise-shaped result that was not being resolved to the actual executable path before being used by the process launch code. As a result, `spawn()` received `[object Promise]` instead of a valid command path, causing Windows to report `ENOENT`.

### How did you verify your code works?

I verified this by clicking the "Open with VS Code" button in the top-right corner and confirming that the project opens successfully in VS Code.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
