### PR TITLE
feat(acp): emit agent_error session/update when LLM call fails after retries

### DIFF
--- a/packages/opencode/src/acp/agent-error.ts
+++ b/packages/opencode/src/acp/agent-error.ts
@@ -1,0 +1,142 @@
+/**
+ * TypeScript mirror of the `agent_error` ACP `session/update` kind.
+ *
+ * The upstream `@agentclientprotocol/sdk` defines `SessionUpdate` as a
+ * closed discriminated union (a `type` alias, not an `interface`).
+ * TypeScript's declaration merging only works on interfaces, so we
+ * cannot extend `SessionUpdate` via an ambient `.d.ts` augmentation —
+ * we have to define our own extended union and use it at the emit site.
+ *
+ * This file is the local fork extension. The wire shape mirrors the
+ * canonical Python definition at:
+ *
+ *   packages/models/src/models/llm_errors.py    (tn-mono)
+ *   services/tn-claw/src/tn_claw/schemas/agent_error.py    (tn-mono)
+ *
+ * Phase chain:
+ *   - Phase 1A: Python contract (tn-mono PR #721, MERGED 2026-05-08)
+ *   - Phase 1B: this file (TS mirror in our anomalyco/opencode fork)
+ *   - Phase 4:  `session/processor.ts` `halt()` emits an `agent_error`
+ *               frame using `SessionUpdateWithAgentError` at its
+ *               `connection.sessionUpdate(...)` callsite
+ *
+ * Spec: `specs/20260508-llm-error-propagation/spec.md`
+ */
+
+import type { SessionUpdate } from "@agentclientprotocol/sdk"
+
+/**
+ * Closed vocabulary for the category of a failed LLM call.
+ *
+ * Keep in sync with `LLMErrorType` in
+ * `packages/models/src/models/llm_errors.py` (tn-mono).
+ */
+export const LLM_ERROR_TYPES = [
+  "budget", // 429 + type=budget_error — non-retriable
+  "rate_limit", // 429 + type=rate_limit_error — bounded retry
+  "provider_unavailable", // 5xx — bounded retry
+  "context_overflow", // 400 + type=invalid_request_error — non-retriable
+  "auth", // 401 — non-retriable; surfaces as connection-level via ch:"error", NOT here
+  "unknown", // wall-clock timeout / unparseable — bounded retry
+] as const
+
+export type LLMErrorType = (typeof LLM_ERROR_TYPES)[number]
+
+const NON_RETRIABLE: ReadonlySet<LLMErrorType> = new Set<LLMErrorType>([
+  "budget",
+  "context_overflow",
+  "auth",
+])
+
+/**
+ * Source-of-truth retry classification by error type.
+ *
+ * Mirrors `is_retriable()` in `packages/models/src/models/llm_errors.py`.
+ * All retry policy in opencode (`session/retry.ts`'s `retryable()`) and
+ * the frontend should derive from this function rather than maintaining
+ * their own tables.
+ */
+export function isRetriable(type: LLMErrorType): boolean {
+  return !NON_RETRIABLE.has(type)
+}
+
+/**
+ * Wire payload for a typed LLM call failure.
+ *
+ * Travels intact from origin (tn-api) through every intermediate layer
+ * to the rendered chat item. `retryable` is on-the-wire explicit so
+ * consumers do not need to keep their own derivation table.
+ *
+ * Wire shape uses snake_case field names — matches the Python
+ * `LLMErrorPayload` and the spec's wire example. Cross-language consumers
+ * (tn-claw Python, frontend) read these names verbatim; do not
+ * camelCase-alias when serializing.
+ *
+ * `auth` is included in `LLMErrorType` for completeness but is NOT
+ * valid on the `agent_error` `session/update` path — auth failures
+ * occur before a session exists; emit them as `ch:"error"` with a
+ * `WebSocketErrorCode` instead.
+ */
+export interface LLMErrorPayload {
+  type: LLMErrorType
+  message: string
+  detail?: Record<string, unknown>
+  retryable: boolean
+  retry_after_seconds?: number | null
+  reset_at_epoch_ms?: number | null
+  source?: string | null
+}
+
+/**
+ * The `agent_error` session/update envelope.
+ *
+ * Shape mirrors the SDK's other discriminated-union members
+ * (e.g. `{ sessionUpdate: "tool_call", ...ToolCall }`).
+ */
+export interface AgentErrorUpdate {
+  sessionUpdate: "agent_error"
+  error: LLMErrorPayload
+  /**
+   * Mirrors the SDK's `stopReason` field on chunk-shaped updates.
+   * Always `"error"` for this kind; included so `session/update`
+   * consumers can clear streaming state without special-casing.
+   */
+  stopReason?: "error"
+}
+
+/**
+ * Local extension of the SDK's closed `SessionUpdate` union.
+ *
+ * Phase 4's emit site (`session/processor.ts` `halt()`) should pass an
+ * `AgentErrorUpdate` to `connection.sessionUpdate(...)` typed as
+ * `SessionUpdateWithAgentError`. We intentionally do NOT cast the
+ * value to the upstream `SessionUpdate` — that would lose the typed
+ * `error` field in callers. Instead, emit code uses this superset.
+ *
+ * Once `@agentclientprotocol/sdk` adopts `agent_error` upstream, drop
+ * this type alias and import the new SDK literal directly.
+ */
+export type SessionUpdateWithAgentError = SessionUpdate | AgentErrorUpdate
+
+/**
+ * Type guard for narrowing an unknown session/update to the
+ * `agent_error` kind. Mirrors `parse_agent_error()` on the Python side.
+ *
+ * Returns `false` for any other kind, including malformed shapes;
+ * the caller does not need a try/catch around it.
+ */
+export function isAgentErrorUpdate(update: unknown): update is AgentErrorUpdate {
+  if (!update || typeof update !== "object") return false
+  const u = update as { sessionUpdate?: unknown; error?: unknown }
+  if (u.sessionUpdate !== "agent_error") return false
+  return isLLMErrorPayload(u.error)
+}
+
+function isLLMErrorPayload(value: unknown): value is LLMErrorPayload {
+  if (!value || typeof value !== "object") return false
+  const p = value as { type?: unknown; message?: unknown; retryable?: unknown }
+  if (typeof p.message !== "string") return false
+  if (typeof p.retryable !== "boolean") return false
+  if (typeof p.type !== "string") return false
+  return (LLM_ERROR_TYPES as readonly string[]).includes(p.type)
+}

--- a/packages/opencode/src/acp/agent-error.ts
+++ b/packages/opencode/src/acp/agent-error.ts
@@ -24,6 +24,15 @@
  */
 
 import type { SessionUpdate } from "@agentclientprotocol/sdk"
+import type {
+  ApiError,
+  ContextOverflowError,
+  MessageAbortedError,
+  MessageOutputLengthError,
+  ProviderAuthError,
+  StructuredOutputError,
+  UnknownError,
+} from "@opencode-ai/sdk/v2"
 
 /**
  * Closed vocabulary for the category of a failed LLM call.
@@ -139,4 +148,121 @@ function isLLMErrorPayload(value: unknown): value is LLMErrorPayload {
   if (typeof p.retryable !== "boolean") return false
   if (typeof p.type !== "string") return false
   return (LLM_ERROR_TYPES as readonly string[]).includes(p.type)
+}
+
+/**
+ * Discriminated union of every error variant `EventSessionError.properties.error`
+ * may carry, mirroring the SDK definition in
+ * `@opencode-ai/sdk/v2`'s generated types.
+ */
+export type SDKSessionError =
+  | ApiError
+  | ContextOverflowError
+  | ProviderAuthError
+  | UnknownError
+  | MessageOutputLengthError
+  | MessageAbortedError
+  | StructuredOutputError
+
+/**
+ * Convert an SDK `EventSessionError.properties.error` payload into the
+ * typed `LLMErrorPayload` carried on the `agent_error` `session/update`
+ * wire shape.
+ *
+ * Lookup priority:
+ *  1. `APIError.responseHeaders["x-llm-error-type"]` — when the upstream
+ *     proxy classifies the failure (e.g. `budget`, `rate_limit`) it sets
+ *     this header. Highest fidelity.
+ *  2. Variant name (`ProviderAuthError` → `auth`, `ContextOverflowError`
+ *     → `context_overflow`).
+ *  3. Status-code heuristic on `APIError` (401 → `auth`, 5xx → `provider_unavailable`).
+ *  4. Fallback to `unknown`.
+ *
+ * The `retryable` flag is derived from the resulting type via
+ * `isRetriable()`, then overridden by the explicit
+ * `x-llm-error-retryable` header when present (so a proxy that knows
+ * better than the type table — e.g. a temporarily-disabled budget that
+ * should not be retried even though `unknown` would normally be — wins).
+ */
+export function llmErrorPayloadFromSDK(error: SDKSessionError): LLMErrorPayload {
+  if (error.name === "ProviderAuthError") {
+    return {
+      type: "auth",
+      message: error.data.message,
+      retryable: false,
+    }
+  }
+
+  if (error.name === "ContextOverflowError") {
+    return {
+      type: "context_overflow",
+      message: error.data.message,
+      retryable: false,
+    }
+  }
+
+  if (error.name === "APIError") {
+    return llmErrorPayloadFromApiError(error)
+  }
+
+  // MessageOutputLengthError / MessageAbortedError / StructuredOutputError /
+  // UnknownError — no proxy classification available; treat as a transient
+  // unknown failure.
+  const message = "data" in error && "message" in error.data ? (error.data as { message: string }).message : error.name
+  return {
+    type: "unknown",
+    message: message || "Unknown error",
+    retryable: true,
+  }
+}
+
+function llmErrorPayloadFromApiError(error: ApiError): LLMErrorPayload {
+  const headers = error.data.responseHeaders ?? {}
+  const headerType = readHeader(headers, "x-llm-error-type")
+  const headerRetryable = readHeader(headers, "x-llm-error-retryable")
+  const resolvedType = resolveTypeFromHeaders(headerType) ?? resolveTypeFromStatus(error.data.statusCode)
+
+  const retryable = (() => {
+    if (headerRetryable === "true") return true
+    if (headerRetryable === "false") return false
+    return isRetriable(resolvedType)
+  })()
+
+  const payload: LLMErrorPayload = {
+    type: resolvedType,
+    message: error.data.message,
+    retryable,
+  }
+
+  const resetAt = readHeader(headers, "x-llm-error-reset-at")
+  if (resetAt !== undefined) {
+    const parsed = Number.parseInt(resetAt, 10)
+    if (Number.isFinite(parsed)) payload.reset_at_epoch_ms = parsed
+  }
+
+  const retryAfter = readHeader(headers, "retry-after")
+  if (retryAfter !== undefined) {
+    const parsed = Number.parseInt(retryAfter, 10)
+    if (Number.isFinite(parsed)) payload.retry_after_seconds = parsed
+  }
+
+  return payload
+}
+
+function readHeader(headers: Record<string, string>, name: string): string | undefined {
+  // Header keys are typically lowercased by fetch / undici / Bun, but
+  // accept either casing defensively for non-Bun callers.
+  return headers[name] ?? headers[name.toLowerCase()] ?? headers[name.toUpperCase()]
+}
+
+function resolveTypeFromHeaders(value: string | undefined): LLMErrorType | undefined {
+  if (!value) return undefined
+  return (LLM_ERROR_TYPES as readonly string[]).includes(value) ? (value as LLMErrorType) : undefined
+}
+
+function resolveTypeFromStatus(status: number | undefined): LLMErrorType {
+  if (status === undefined) return "unknown"
+  if (status === 401) return "auth"
+  if (status >= 500) return "provider_unavailable"
+  return "unknown"
 }

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -39,6 +39,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { ACPSessionManager } from "./session"
 import type { ACPConfig } from "./types"
+import { llmErrorPayloadFromSDK, type SessionUpdateWithAgentError } from "./agent-error"
 import { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
 import { Agent as AgentModule } from "../agent/agent"
@@ -270,6 +271,45 @@ export class Agent implements ACPAgent {
             }
           })
         this.permissionQueues.set(permission.sessionID, next)
+        return
+      }
+
+      case "session.error": {
+        const props = event.properties
+        const sessionID = props.sessionID
+        const error = props.error
+        if (!sessionID || !error) return
+
+        // ContextOverflowError triggers in-process compaction and the turn
+        // continues; do not surface it as a turn-ending error. Non-overflow
+        // errors fall through to the agent_error emit below.
+        if (error.name === "ContextOverflowError") return
+
+        const session = this.sessionManager.tryGet(sessionID)
+        if (!session) return
+
+        const payload = llmErrorPayloadFromSDK(error)
+        const update: SessionUpdateWithAgentError = {
+          sessionUpdate: "agent_error",
+          error: payload,
+          stopReason: "error",
+        }
+        await this.connection
+          .sessionUpdate({
+            sessionId: session.id,
+            // Cast: the upstream `@agentclientprotocol/sdk` `SessionUpdate`
+            // union is closed and does not yet include `agent_error`. Until
+            // that PR lands the local `SessionUpdateWithAgentError` superset
+            // carries the typed payload at the emit site; the runtime wire
+            // shape is independent of the typing.
+            update: update as unknown as Parameters<typeof this.connection.sessionUpdate>[0]["update"],
+          })
+          .catch((err) => {
+            log.error("failed to emit agent_error session/update", {
+              error: err,
+              sessionID,
+            })
+          })
         return
       }
 

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -285,6 +285,11 @@ export class Agent implements ACPAgent {
         // errors fall through to the agent_error emit below.
         if (error.name === "ContextOverflowError") return
 
+        // MessageAbortedError is the normal user-stop path triggered by
+        // session/cancel. The prompt RPC reports stopReason=cancelled, so an
+        // agent_error update here would make an intentional stop look failed.
+        if (error.name === "MessageAbortedError") return
+
         const session = this.sessionManager.tryGet(sessionID)
         if (!session) return
 

--- a/packages/opencode/test/acp/agent-error.test.ts
+++ b/packages/opencode/test/acp/agent-error.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test"
+import {
+  LLM_ERROR_TYPES,
+  type LLMErrorPayload,
+  type SessionUpdateWithAgentError,
+  isAgentErrorUpdate,
+  isRetriable,
+} from "../../src/acp/agent-error"
+
+describe("isRetriable", () => {
+  test.each([
+    ["budget", false],
+    ["context_overflow", false],
+    ["auth", false],
+    ["rate_limit", true],
+    ["provider_unavailable", true],
+    ["unknown", true],
+  ] as const)("classifies %s as retriable=%s", (type, expected) => {
+    expect(isRetriable(type)).toBe(expected)
+  })
+
+  test("LLM_ERROR_TYPES is the closed vocabulary", () => {
+    expect(LLM_ERROR_TYPES).toEqual([
+      "budget",
+      "rate_limit",
+      "provider_unavailable",
+      "context_overflow",
+      "auth",
+      "unknown",
+    ])
+  })
+})
+
+describe("isAgentErrorUpdate", () => {
+  const validBudgetPayload: LLMErrorPayload = {
+    type: "budget",
+    message: "Weekly budget exceeded",
+    retryable: false,
+    detail: { limitUsd: "1.0", consumedUsd: "1.004" },
+    reset_at_epoch_ms: 1778457600000,
+    source: "global",
+  }
+
+  test("narrows valid agent_error frames", () => {
+    const update: unknown = {
+      sessionUpdate: "agent_error",
+      error: validBudgetPayload,
+    }
+    expect(isAgentErrorUpdate(update)).toBe(true)
+    if (isAgentErrorUpdate(update)) {
+      // Compile-time narrowing check: both fields are typed.
+      expect(update.error.type).toBe("budget")
+      expect(update.error.retryable).toBe(false)
+    }
+  })
+
+  test("rejects other session/update kinds", () => {
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } })).toBe(
+      false,
+    )
+    expect(isAgentErrorUpdate({ sessionUpdate: "tool_call_update" })).toBe(false)
+  })
+
+  test("rejects missing or malformed payloads", () => {
+    expect(isAgentErrorUpdate(undefined)).toBe(false)
+    expect(isAgentErrorUpdate(null)).toBe(false)
+    expect(isAgentErrorUpdate("agent_error")).toBe(false)
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_error" })).toBe(false)
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_error", error: null })).toBe(false)
+    expect(isAgentErrorUpdate({ sessionUpdate: "agent_error", error: { type: "budget" } })).toBe(false)
+    expect(
+      isAgentErrorUpdate({
+        sessionUpdate: "agent_error",
+        error: { type: "not_a_real_type", message: "x", retryable: false },
+      }),
+    ).toBe(false)
+  })
+
+  test("JSON round-trip preserves shape", () => {
+    const frame: SessionUpdateWithAgentError = {
+      sessionUpdate: "agent_error",
+      error: validBudgetPayload,
+      stopReason: "error",
+    }
+    const decoded = JSON.parse(JSON.stringify(frame))
+    expect(isAgentErrorUpdate(decoded)).toBe(true)
+    if (isAgentErrorUpdate(decoded)) {
+      expect(decoded.error.reset_at_epoch_ms).toBe(1778457600000)
+      expect(decoded.error.source).toBe("global")
+    }
+  })
+})
+
+describe("SessionUpdateWithAgentError compile-time narrowing", () => {
+  test("discriminated union narrows to AgentErrorUpdate by sessionUpdate literal", () => {
+    const update: SessionUpdateWithAgentError = {
+      sessionUpdate: "agent_error",
+      error: {
+        type: "rate_limit",
+        message: "Slow down",
+        retryable: true,
+        retry_after_seconds: 12,
+      },
+    }
+    if (update.sessionUpdate === "agent_error") {
+      // This block must compile — i.e. update.error is typed as LLMErrorPayload.
+      const _typeCheck: number | null | undefined = update.error.retry_after_seconds
+      expect(_typeCheck).toBe(12)
+    } else {
+      throw new Error("union narrowing failed")
+    }
+  })
+})

--- a/packages/opencode/test/acp/halt-emits-agent-error.test.ts
+++ b/packages/opencode/test/acp/halt-emits-agent-error.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, test } from "bun:test"
+import { ACP } from "../../src/acp/agent"
+import { llmErrorPayloadFromSDK } from "../../src/acp/agent-error"
+import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import type { ApiError, ContextOverflowError, Event, ProviderAuthError } from "@opencode-ai/sdk/v2"
+import { WithInstance } from "../../src/project/with-instance"
+import { tmpdir } from "../fixture/fixture"
+
+type SessionUpdateParams = Parameters<AgentSideConnection["sessionUpdate"]>[0]
+type RequestPermissionParams = Parameters<AgentSideConnection["requestPermission"]>[0]
+type RequestPermissionResult = Awaited<ReturnType<AgentSideConnection["requestPermission"]>>
+
+type GlobalEventEnvelope = {
+  directory?: string
+  payload?: Event
+}
+
+function createEventStream() {
+  const queue: GlobalEventEnvelope[] = []
+  const waiters: Array<(value: GlobalEventEnvelope | undefined) => void> = []
+  const state = { closed: false }
+
+  const push = (event: GlobalEventEnvelope) => {
+    const waiter = waiters.shift()
+    if (waiter) {
+      waiter(event)
+      return
+    }
+    queue.push(event)
+  }
+
+  const close = () => {
+    state.closed = true
+    for (const waiter of waiters.splice(0)) waiter(undefined)
+  }
+
+  const stream = async function* (signal?: AbortSignal) {
+    while (true) {
+      if (signal?.aborted) return
+      const next = queue.shift()
+      if (next) {
+        yield next
+        continue
+      }
+      if (state.closed) return
+      const value = await new Promise<GlobalEventEnvelope | undefined>((resolve) => {
+        waiters.push(resolve)
+        if (!signal) return
+        signal.addEventListener("abort", () => resolve(undefined), { once: true })
+      })
+      if (!value) return
+      yield value
+    }
+  }
+
+  return { controller: { push, close }, stream }
+}
+
+function createFakeAgent() {
+  const sessionUpdates: SessionUpdateParams[] = []
+  const connection = {
+    async sessionUpdate(params: SessionUpdateParams) {
+      sessionUpdates.push(params)
+    },
+    async requestPermission(_params: RequestPermissionParams): Promise<RequestPermissionResult> {
+      return { outcome: { outcome: "selected", optionId: "once" } } as RequestPermissionResult
+    },
+  } as unknown as AgentSideConnection
+
+  const { controller, stream } = createEventStream()
+  let sessionCount = 0
+
+  const sdk = {
+    global: {
+      event: async (opts?: { signal?: AbortSignal }) => ({ stream: stream(opts?.signal) }),
+    },
+    session: {
+      create: async () => {
+        sessionCount++
+        return { data: { id: `ses_${sessionCount}`, time: { created: new Date().toISOString() } } }
+      },
+      get: async () => ({ data: { id: "ses_1", time: { created: new Date().toISOString() } } }),
+      messages: async () => ({ data: [] }),
+      message: async () => ({
+        data: { info: { role: "assistant" }, parts: [{ id: "part_1", type: "text", text: "" }] },
+      }),
+    },
+    permission: { respond: async () => ({ data: true }) },
+    config: {
+      providers: async () => ({
+        data: {
+          providers: [
+            {
+              id: "opencode",
+              name: "opencode",
+              models: { "big-pickle": { id: "big-pickle", name: "big-pickle" } },
+            },
+          ],
+        },
+      }),
+    },
+    app: { agents: async () => ({ data: [{ name: "build", description: "build", mode: "agent" }] }) },
+    command: { list: async () => ({ data: [] }) },
+    mcp: { add: async () => ({ data: true }) },
+  } as any
+
+  const agent = new ACP.Agent(connection, {
+    sdk,
+    defaultModel: { providerID: "opencode", modelID: "big-pickle" },
+  } as any)
+
+  const stop = () => {
+    controller.close()
+    ;(agent as any).eventAbort.abort()
+  }
+
+  return { agent, controller, sessionUpdates, stop }
+}
+
+describe("llmErrorPayloadFromSDK", () => {
+  test("APIError with x-llm-error-type=budget header → typed budget payload", () => {
+    const error: ApiError = {
+      name: "APIError",
+      data: {
+        message: "Weekly budget exhausted",
+        statusCode: 402,
+        isRetryable: false,
+        responseHeaders: {
+          "x-llm-error-type": "budget",
+          "x-llm-error-retryable": "false",
+          "x-llm-error-reset-at": "1746748800000",
+        },
+      },
+    }
+    const payload = llmErrorPayloadFromSDK(error)
+    expect(payload.type).toBe("budget")
+    expect(payload.retryable).toBe(false)
+    expect(payload.reset_at_epoch_ms).toBe(1746748800000)
+    expect(payload.message).toBe("Weekly budget exhausted")
+  })
+
+  test("APIError with x-llm-error-type=rate_limit + retry-after → retry_after_seconds", () => {
+    const error: ApiError = {
+      name: "APIError",
+      data: {
+        message: "Rate limited",
+        statusCode: 429,
+        isRetryable: true,
+        responseHeaders: {
+          "x-llm-error-type": "rate_limit",
+          "x-llm-error-retryable": "true",
+          "retry-after": "30",
+        },
+      },
+    }
+    const payload = llmErrorPayloadFromSDK(error)
+    expect(payload.type).toBe("rate_limit")
+    expect(payload.retryable).toBe(true)
+    expect(payload.retry_after_seconds).toBe(30)
+  })
+
+  test("APIError without classification headers, status 503 → provider_unavailable", () => {
+    const error: ApiError = {
+      name: "APIError",
+      data: { message: "service unavailable", statusCode: 503, isRetryable: true },
+    }
+    const payload = llmErrorPayloadFromSDK(error)
+    expect(payload.type).toBe("provider_unavailable")
+    expect(payload.retryable).toBe(true)
+  })
+
+  test("APIError without classification headers, status 401 → auth", () => {
+    const error: ApiError = {
+      name: "APIError",
+      data: { message: "unauthorized", statusCode: 401, isRetryable: false },
+    }
+    const payload = llmErrorPayloadFromSDK(error)
+    expect(payload.type).toBe("auth")
+    expect(payload.retryable).toBe(false)
+  })
+
+  test("ContextOverflowError → context_overflow non-retriable", () => {
+    const error: ContextOverflowError = {
+      name: "ContextOverflowError",
+      data: { message: "exceeded context window" },
+    }
+    const payload = llmErrorPayloadFromSDK(error)
+    expect(payload.type).toBe("context_overflow")
+    expect(payload.retryable).toBe(false)
+  })
+
+  test("ProviderAuthError → auth non-retriable", () => {
+    const error: ProviderAuthError = {
+      name: "ProviderAuthError",
+      data: { providerID: "openai", message: "missing api key" },
+    }
+    const payload = llmErrorPayloadFromSDK(error)
+    expect(payload.type).toBe("auth")
+    expect(payload.retryable).toBe(false)
+  })
+
+  test("explicit x-llm-error-retryable header overrides type-derived retryable", () => {
+    // unknown is normally retryable; header forces non-retriable
+    const error: ApiError = {
+      name: "APIError",
+      data: {
+        message: "weird error",
+        statusCode: 500,
+        isRetryable: true,
+        responseHeaders: { "x-llm-error-retryable": "false" },
+      },
+    }
+    const payload = llmErrorPayloadFromSDK(error)
+    expect(payload.retryable).toBe(false)
+  })
+})
+
+describe("acp.agent session.error handling", () => {
+  test("emits agent_error session/update for APIError carrying X-Llm-Error-* headers", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            id: "evt_err_1",
+            type: "session.error",
+            properties: {
+              sessionID: sessionId,
+              error: {
+                name: "APIError",
+                data: {
+                  message: "Weekly budget exhausted",
+                  statusCode: 402,
+                  isRetryable: false,
+                  responseHeaders: {
+                    "x-llm-error-type": "budget",
+                    "x-llm-error-retryable": "false",
+                    "x-llm-error-reset-at": "1746748800000",
+                  },
+                },
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        const errorUpdates = sessionUpdates.filter(
+          (u) => u.sessionId === sessionId && (u.update as any).sessionUpdate === "agent_error",
+        )
+        expect(errorUpdates.length).toBe(1)
+        const update = errorUpdates[0].update as any
+        expect(update.error.type).toBe("budget")
+        expect(update.error.retryable).toBe(false)
+        expect(update.error.reset_at_epoch_ms).toBe(1746748800000)
+        expect(update.stopReason).toBe("error")
+
+        stop()
+      },
+    })
+  })
+
+  test("does NOT emit agent_error for ContextOverflowError (compaction handles it)", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            id: "evt_err_2",
+            type: "session.error",
+            properties: {
+              sessionID: sessionId,
+              error: {
+                name: "ContextOverflowError",
+                data: { message: "context window exceeded" },
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        const errorUpdates = sessionUpdates.filter(
+          (u) => u.sessionId === sessionId && (u.update as any).sessionUpdate === "agent_error",
+        )
+        expect(errorUpdates.length).toBe(0)
+
+        stop()
+      },
+    })
+  })
+
+  test("ignores session.error for unknown sessions (no emit)", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { controller, sessionUpdates, stop } = createFakeAgent()
+
+        controller.push({
+          directory: "/tmp/opencode-acp-test",
+          payload: {
+            id: "evt_err_3",
+            type: "session.error",
+            properties: {
+              sessionID: "ses_does_not_exist",
+              error: {
+                name: "APIError",
+                data: { message: "boom", statusCode: 500, isRetryable: true },
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(sessionUpdates.length).toBe(0)
+        stop()
+      },
+    })
+  })
+})

--- a/packages/opencode/test/acp/halt-emits-agent-error.test.ts
+++ b/packages/opencode/test/acp/halt-emits-agent-error.test.ts
@@ -302,6 +302,42 @@ describe("acp.agent session.error handling", () => {
     })
   })
 
+  test("does NOT emit agent_error for MessageAbortedError (user cancellation)", async () => {
+    await using tmp = await tmpdir()
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            id: "evt_err_3",
+            type: "session.error",
+            properties: {
+              sessionID: sessionId,
+              error: {
+                name: "MessageAbortedError",
+                data: { message: "Aborted" },
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        const errorUpdates = sessionUpdates.filter(
+          (u) => u.sessionId === sessionId && (u.update as any).sessionUpdate === "agent_error",
+        )
+        expect(errorUpdates.length).toBe(0)
+
+        stop()
+      },
+    })
+  })
+
   test("ignores session.error for unknown sessions (no emit)", async () => {
     await using tmp = await tmpdir()
     await WithInstance.provide({
@@ -312,7 +348,7 @@ describe("acp.agent session.error handling", () => {
         controller.push({
           directory: "/tmp/opencode-acp-test",
           payload: {
-            id: "evt_err_3",
+            id: "evt_err_4",
             type: "session.error",
             properties: {
               sessionID: "ses_does_not_exist",


### PR DESCRIPTION
### Issue for this PR

Closes #24494
Closes #28453

Stacks on #26306, which adds the `agent_error` `SessionUpdate` kind and the `LLMErrorPayload` shape this PR uses. Diffs from that PR are included here until it merges.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement / new feature (non-breaking change which adds functionality)

### What does this PR do?

When the retry policy in `session/retry.ts` is exhausted, `session/processor.ts halt()` records the failure internally but does not emit an ACP frame to the connected client. From an ACP client perspective, the turn can look silently stuck: no final error notification and no `stopReason`.

This PR adds a `case "session.error":` branch in `packages/opencode/src/acp/agent.ts` that translates the SDK error variant into an `LLMErrorPayload` and emits the new `agent_error` `session/update` kind with `stopReason: "error"`.

The payload extraction prefers classification headers when present:

- `x-llm-error-type`: `budget` | `rate_limit` | `provider_unavailable` | `context_overflow` | `auth` | `unknown`
- `x-llm-error-retryable`: `"true"` / `"false"` (overrides type-derived `retryable`)
- `x-llm-error-reset-at`: epoch ms - populates `reset_at_epoch_ms`
- `retry-after`: seconds - populates `retry_after_seconds`

It falls back to status-code heuristics when headers are absent (`401` -> `auth`, `5xx` -> `provider_unavailable`, else -> `unknown`). `ProviderAuthError` and `ContextOverflowError` SDK variants are mapped by name.

Two `session.error` variants are intentionally not emitted as `agent_error`:

- `ContextOverflowError`: compaction handles this path and the turn can continue on a smaller context window.
- `MessageAbortedError`: this is the normal user-stop path triggered by `session/cancel`; the prompt RPC reports cancellation via `stopReason: "cancelled"`, so emitting `agent_error` would make one user action look like both an error and a cancellation.

The existing event subscription already receives `session.error` events through the SDK event stream. No bus, SDK, or event-stream wiring changes are required.

### How did you verify your code works?

`packages/opencode/test/acp/halt-emits-agent-error.test.ts` covers:

- `APIError` classification headers -> typed payload fields preserved
- fallback status-code classification for `503` and `401`
- `ContextOverflowError` and `ProviderAuthError` mapping
- explicit retryability override from headers
- `session.error` emits exactly one `agent_error` update for a classified API error
- `ContextOverflowError` emits no `agent_error`
- `MessageAbortedError` emits no `agent_error`
- unknown session IDs emit no update

```
$ bun test test/acp/halt-emits-agent-error.test.ts
 11 pass
 0 fail
 24 expect() calls

$ bun run typecheck
# clean

# push hook
$ bun turbo typecheck
 Tasks:    12 successful, 12 total
```

### Screenshots / recordings

N/A - backend / ACP wire change. Client rendering of the `agent_error` frame is downstream consumer work.

### Checklist

- [x] All tests pass locally
- [x] Code follows the existing event-handling style
- [x] Diff is confined to ACP error mapping / event handling and tests
- [x] No new dependencies, schema migrations, or breaking protocol changes
- [x] `bun run typecheck` clean
