### PR TITLE
fix(tui): respect current model config when continuing a session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -398,10 +398,11 @@ export function Prompt(props: PromptProps) {
       if (msg.agent && isPrimaryAgent) {
         // Keep command line --agent if specified.
         if (!args.agent) local.agent.set(msg.agent)
-        if (msg.model) {
-          local.model.set(msg.model)
-          local.model.variant.set(msg.model.variant)
-        }
+        // NOTE: uncomment to also restore model/variant from session history
+        // if (msg.model) {
+        //   local.model.set(msg.model)
+        //   local.model.variant.set(msg.model.variant)
+        // }
       }
     }
   })


### PR DESCRIPTION
### Issue for this PR

- Closes:  sst/opencode#26351
- Relates to: sst/opencode#23369

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Continuing an old session restores the model from the last user message, overriding the current agent config. After changing models between sessions, the old model is still sent to the API.

This removes the model/variant restoration from the session-switch effect. After the fix:
- the config model is always used when continuing a session
- the agent is still restored from session history (intentional)
- `/models` manual picks still work (they write directly to the model store)

### How did you verify your code works?

- built from source and confirmed the correct model is used after changing config and continuing a session
- verified `/models` picks still override correctly
- checked that subagents are unaffected (they read from agent state, not the model store)

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally, see: [#comment-4407725787](https://github.com/anomalyco/opencode/pull/26355#issuecomment-4407725787)
- [x] I have not included unrelated changes in this PR