### PR TITLE
refactor(server): clarify HttpApi route auth layers

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -20,13 +20,17 @@ import { SyncApi } from "./groups/sync"
 import { TuiApi } from "./groups/tui"
 import { WorkspaceApi } from "./groups/workspace"
 import { V2Api } from "./groups/v2"
+import { Authorization } from "./middleware/authorization"
 
 // SSE event schemas built from the same BusEvent/SyncEvent registries that
 // the Hono spec uses, so both specs emit identical Event/SyncEvent components.
 const EventSchema = Schema.Union(BusEvent.effectPayloads()).annotate({ identifier: "Event" })
 const SyncEventSchemas = SyncEvent.effectPayloads()
 
-export const RootHttpApi = HttpApi.make("opencode-root").addHttpApi(ControlApi).addHttpApi(GlobalApi)
+export const RootHttpApi = HttpApi.make("opencode-root")
+  .addHttpApi(ControlApi)
+  .addHttpApi(GlobalApi)
+  .middleware(Authorization)
 
 export const InstanceHttpApi = HttpApi.make("opencode-instance")
   .addHttpApi(ConfigApi)

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -97,15 +97,11 @@ const cors = (corsOptions?: CorsOptions) =>
   )
 
 // Route tree:
-// - rootApiRoutes: /global/* and control routes; requires auth but no workspace context.
+// - protectedRootRoutes: /global/*, control routes, and UI fallback; requires auth but no workspace context.
 // - eventApiRoutes/rawInstanceRoutes: raw instance routes; auth and workspace routing happen as router middleware.
 // - instanceApiRoutes: schema routes; auth is declared on each group and workspace context is provided below.
-// - uiRoute: raw catch-all fallback; uses the same auth-only router layer as root routes.
 const rootRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
-const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(
-  Layer.provide([controlHandlers, globalHandlers]),
-  Layer.provide(rootRouterLayer),
-)
+const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(Layer.provide([controlHandlers, globalHandlers]))
 const instanceRouterLayer = authorizationRouterMiddleware
   .combine(instanceRouterMiddleware)
   .combine(workspaceRouterMiddleware)
@@ -149,10 +145,12 @@ const uiRoute = HttpRouter.use((router) =>
     const client = yield* HttpClient.HttpClient
     yield* router.add("*", "/*", (request) => serveUIEffect(request, { fs, client }))
   }),
-).pipe(Layer.provide(rootRouterLayer))
+)
+
+const protectedRootRoutes = Layer.mergeAll(rootApiRoutes, uiRoute).pipe(Layer.provide(rootRouterLayer))
 
 export function createRoutes(corsOptions?: CorsOptions) {
-  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, uiRoute).pipe(
+  return Layer.mergeAll(protectedRootRoutes, eventApiRoutes, instanceRoutes).pipe(
     Layer.provide([
       errorLayer,
       cors(corsOptions),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -96,9 +96,15 @@ const cors = (corsOptions?: CorsOptions) =>
     { global: true },
   )
 
+// Route tree:
+// - rootApiRoutes: /global/* and control routes; requires auth but no workspace context.
+// - eventApiRoutes/rawInstanceRoutes: raw instance routes; auth and workspace routing happen as router middleware.
+// - instanceApiRoutes: schema routes; auth is declared on each group and workspace context is provided below.
+// - uiRoute: raw catch-all fallback; uses the same auth-only router layer as root routes.
+const rootRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
 const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(
   Layer.provide([controlHandlers, globalHandlers]),
-  Layer.provide(authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))),
+  Layer.provide(rootRouterLayer),
 )
 const instanceRouterLayer = authorizationRouterMiddleware
   .combine(instanceRouterMiddleware)
@@ -143,7 +149,7 @@ const uiRoute = HttpRouter.use((router) =>
     const client = yield* HttpClient.HttpClient
     yield* router.add("*", "/*", (request) => serveUIEffect(request, { fs, client }))
   }),
-).pipe(Layer.provide(authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))))
+).pipe(Layer.provide(rootRouterLayer))
 
 export function createRoutes(corsOptions?: CorsOptions) {
   return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, uiRoute).pipe(

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -97,11 +97,16 @@ const cors = (corsOptions?: CorsOptions) =>
   )
 
 // Route tree:
-// - protectedRootRoutes: /global/*, control routes, and UI fallback; requires auth but no workspace context.
+// - rootApiRoutes: typed /global/* and control routes; auth is declared by RootHttpApi.
 // - eventApiRoutes/rawInstanceRoutes: raw instance routes; auth and workspace routing happen as router middleware.
 // - instanceApiRoutes: schema routes; auth is declared on each group and workspace context is provided below.
-const rootRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
-const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(Layer.provide([controlHandlers, globalHandlers]))
+// - uiRoute: raw catch-all fallback; auth is router middleware so public static assets can bypass it.
+const authOnlyRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
+const httpApiAuthLayer = authorizationLayer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
+const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(
+  Layer.provide([controlHandlers, globalHandlers]),
+  Layer.provide(httpApiAuthLayer),
+)
 const instanceRouterLayer = authorizationRouterMiddleware
   .combine(instanceRouterMiddleware)
   .combine(workspaceRouterMiddleware)
@@ -133,7 +138,7 @@ const instanceApiRoutes = HttpApiBuilder.layer(InstanceHttpApi).pipe(
 const rawInstanceRoutes = Layer.mergeAll(ptyConnectRoute).pipe(Layer.provide(instanceRouterLayer))
 const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe(
   Layer.provide([
-    authorizationLayer.pipe(Layer.provide(ServerAuth.Config.defaultLayer)),
+    httpApiAuthLayer,
     workspaceRoutingLayer.pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal)),
     instanceContextLayer,
   ]),
@@ -145,12 +150,10 @@ const uiRoute = HttpRouter.use((router) =>
     const client = yield* HttpClient.HttpClient
     yield* router.add("*", "/*", (request) => serveUIEffect(request, { fs, client }))
   }),
-)
-
-const protectedRootRoutes = Layer.mergeAll(rootApiRoutes, uiRoute).pipe(Layer.provide(rootRouterLayer))
+).pipe(Layer.provide(authOnlyRouterLayer))
 
 export function createRoutes(corsOptions?: CorsOptions) {
-  return Layer.mergeAll(protectedRootRoutes, eventApiRoutes, instanceRoutes).pipe(
+  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, uiRoute).pipe(
     Layer.provide([
       errorLayer,
       cors(corsOptions),

--- a/packages/opencode/test/server/httpapi-bridge.test.ts
+++ b/packages/opencode/test/server/httpapi-bridge.test.ts
@@ -363,12 +363,16 @@ describe("HttpApi server", () => {
     const auth = { authorization: authorization("opencode", "secret") }
     const wrongAuth = { authorization: authorization("opencode", "wrong") }
 
-    const [missingConfig, wrongConfig, goodConfig] = await Promise.all([
+    const [missingHealth, goodHealth, missingConfig, wrongConfig, goodConfig] = await Promise.all([
+      server.request(GlobalPaths.health),
+      server.request(GlobalPaths.health, { headers: auth }),
       server.request(GlobalPaths.config),
       server.request(GlobalPaths.config, { headers: wrongAuth }),
       server.request(GlobalPaths.config, { headers: auth }),
     ])
 
+    expect(missingHealth.status).toBe(401)
+    expect(goodHealth.status).toBe(200)
     expect(missingConfig.status).toBe(401)
     expect(wrongConfig.status).toBe(401)
     expect(goodConfig.status).toBe(200)


### PR DESCRIPTION
## Summary

- Declares root HttpApi auth on `RootHttpApi` with `HttpApi.middleware(Authorization)`, matching the existing typed route pattern used by instance groups.
- Keeps raw `HttpRouter` auth only for raw routes that need router-level exceptions, like the UI catch-all/public static assets.
- Names and reuses the shared `httpApiAuthLayer` so typed root and typed instance routes resolve the same auth service.
- Adds coverage that `/global/health` is protected under server auth, matching Hono's top-level `AuthMiddleware` behavior.

## Route Shape

- `rootApiRoutes`: typed `/global/*` and control routes; auth lives in the `RootHttpApi` contract.
- `eventApiRoutes` / `rawInstanceRoutes`: raw instance routes; auth and workspace routing happen as router middleware.
- `instanceApiRoutes`: typed instance routes; auth remains declared by each group and workspace context is provided by the server layer.
- `uiRoute`: raw catch-all fallback; auth remains router middleware so public static assets can bypass it.

## Verification

- `bun typecheck` from `packages/opencode`
- `bun run test -- test/server/httpapi-bridge.test.ts test/server/httpapi-ui.test.ts test/server/httpapi-authorization.test.ts test/server/auth.test.ts`