### PR TITLE
fix: add trailing newline to help output

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -60,7 +60,7 @@ function show(out: string) {
   const text = out.trimStart()
   if (!text.startsWith("opencode ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text)
+    process.stderr.write(text.endsWith(EOL) ? text : text + EOL)
     return
   }
   process.stderr.write(out.endsWith(EOL) ? out : out + EOL)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -63,7 +63,7 @@ function show(out: string) {
     process.stderr.write(text)
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(out.endsWith(EOL) ? out : out + EOL)
 }
 
 const cli = yargs(args)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -58,12 +58,13 @@ const args = hideBin(process.argv)
 
 function show(out: string) {
   const text = out.trimStart()
+  const content = out.endsWith(EOL) ? out : out + EOL
   if (!text.startsWith("opencode ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text.endsWith(EOL) ? text : text + EOL)
+    process.stderr.write(content.trimStart())
     return
   }
-  process.stderr.write(out.endsWith(EOL) ? out : out + EOL)
+  process.stderr.write(content)
 }
 
 const cli = yargs(args)


### PR DESCRIPTION
### Issue for this PR

Closes #24813

### Type of change

- [x] Bug fix

### What does this PR do?

When `opencode auth` is run without a subcommand, yargs' `demandCommand` fires and the help text is printed via the `show()` callback in `packages/opencode/src/index.ts`. yargs hands the callback help text without a final newline, so the shell prompt ends up glued to the last help line.

This patches both branches of `show()` to ensure trailing EOL:

- the logo-prefixed branch (subcommand help, prints `UI.logo()` then the help body)
- the bare-`opencode` branch (top-level help)

#22125 contains the same fix bundled with a much larger LSP/compaction/i18n change set; this PR is a focused, mergeable extraction so the trailing-newline issue can land independently.

### How did you verify your code works?

- `bun typecheck` clean across all 12 workspace packages.
- `bun test --timeout 30000` from `packages/opencode/` runs cleanly on the affected file (no test exists for the `show()` callback specifically; the change is mechanical).
- Manually confirmed the original bug reproduces on `dev` and is resolved on this branch by running `opencode auth` and observing the prompt now appears on its own line.

### Screenshots / recordings

N/A — terminal-output behavior; not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
