### PR TITLE
docs: Add new tools to docs: Onboard, Market, Paseo

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -71,7 +71,9 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
-
+| [Paseo](https://github.com/getpaseo/paseo)                                                 | Desktop and Mobile app for OpenCode and others                   |
+| [OpenCode Onboard](https://github.com/CKGrafico/opencode-onboard)                          | Prepare tour codebase to use OpenCode, OpenSpec and Ensemble     |
+| [OpenCode Market](https://github.com/CKGrafico/opencode-market)                            | A tool to install Claude or Github Copilot agents and skills     |
 ---
 
 ## Agents


### PR DESCRIPTION
Adding two of my personal tools:
Open Code Onboard
https://github.com/CKGrafico/opencode-onboard
One command to prepare any codebase for AI agent workflows with opencode, installs a universal agent team, model selection, and OpenSpec or Ensemble configurations.
<img width="1009" height="498" alt="image" src="https://raw.githubusercontent.com/CKGrafico/opencode-onboard/refs/heads/main/demo.gif" />


Open Code Market 
https://github.com/CKGrafico/opencode-market
CLI to discover, install, and manage opencode agent plugins from GitHub marketplaces. The goal of this tool is to never exist but meanwhile Opencode has no an official market 
<img width="1097" height="247" alt="image" src="https://github.com/user-attachments/assets/f23c2d49-d7fe-4232-a32b-dc1e6e36bed8" />

And also Paseo:
https://github.com/getpaseo/paseo
<img width="2048" height="1233" alt="image" src="https://github.com/user-attachments/assets/fa5e9605-f6f5-4ec7-baef-10c617ca0280" />
