### PR TITLE
fix: flush `debug skill` stdout

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/skill.ts
+++ b/packages/opencode/src/cli/cmd/debug/skill.ts
@@ -10,6 +10,10 @@ export const SkillCommand = effectCmd({
   handler: Effect.fn("Cli.debug.skill")(function* () {
     const skill = yield* Skill.Service
     const skills = yield* skill.all()
-    process.stdout.write(JSON.stringify(skills, null, 2) + EOL)
+    yield* Effect.callback<void>((resume) => {
+      process.stdout.write(JSON.stringify(skills, null, 2) + EOL, (err) => {
+        resume(err ? Effect.die(err) : Effect.void)
+      })
+    })
   }),
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #26399

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode debug skill | jq '.[].name'` was failing for me with invalid JSON errors. The JSON was being truncated.

`opencode debug skill` was writing a large JSON payload to stdout and returning before the piped output was fully flushed. This would happen only with larger lists of skills.

**Fix**
The command now awaits the `process.stdout.write` callback before exiting.

### How did you verify your code works?

Successfully ran `opencode debug skill | jq empty` from directory with a bunch of local skills, which previously failed.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._