### PR TITLE
feat(opencode): Add support for reading and editing files in legacy encodings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -391,6 +391,7 @@
         "ai-gateway-provider": "3.1.2",
         "bonjour-service": "1.3.0",
         "bun-pty": "0.4.8",
+        "chardet": "2.1.1",
         "chokidar": "4.0.3",
         "cli-sound": "1.1.3",
         "clipboardy": "4.0.0",
@@ -406,6 +407,7 @@
         "gray-matter": "4.0.3",
         "hono": "catalog:",
         "hono-openapi": "catalog:",
+        "iconv-lite": "0.7.2",
         "ignore": "7.0.5",
         "immer": "11.1.4",
         "jsonc-parser": "3.3.1",
@@ -2759,6 +2761,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
     "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -151,6 +151,8 @@
     "gray-matter": "4.0.3",
     "hono": "catalog:",
     "hono-openapi": "catalog:",
+    "chardet": "2.1.1",
+    "iconv-lite": "0.7.2",
     "ignore": "7.0.5",
     "immer": "11.1.4",
     "jsonc-parser": "3.3.1",

--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -1,9 +1,9 @@
 import z from "zod"
 import * as path from "path"
 import * as fs from "fs/promises"
-import { readFileSync } from "fs"
 import * as Log from "@opencode-ai/core/util/log"
 import * as Bom from "../util/bom"
+import { Encoding } from "../util/encoding"
 
 const log = Log.create({ service: "patch" })
 
@@ -307,13 +307,18 @@ interface ApplyPatchFileUpdate {
   unified_diff: string
   content: string
   bom: boolean
+  encoding: string
 }
 
 export function deriveNewContentsFromChunks(filePath: string, chunks: UpdateFileChunk[]): ApplyPatchFileUpdate {
   // Read original file content
   let originalContent: ReturnType<typeof Bom.split>
+  let encoding: string
   try {
-    originalContent = Bom.split(readFileSync(filePath, "utf-8"))
+    // Encoding.readSync strips UTF-8 BOMs so the BOM flag is derived from the encoding label.
+    const result = Encoding.readSync(filePath)
+    originalContent = { bom: result.encoding === "utf-8-bom", text: result.text }
+    encoding = result.encoding
   } catch (error) {
     throw new Error(`Failed to read file ${filePath}: ${error}`, { cause: error })
   }
@@ -343,6 +348,7 @@ export function deriveNewContentsFromChunks(filePath: string, chunks: UpdateFile
     unified_diff: unifiedDiff,
     content: newContent,
     bom: originalContent.bom || next.bom,
+    encoding,
   }
 }
 
@@ -530,13 +536,7 @@ export async function applyHunksToFiles(hunks: Hunk[]): Promise<AffectedPaths> {
   for (const hunk of hunks) {
     switch (hunk.type) {
       case "add":
-        // Create parent directories
-        const addDir = path.dirname(hunk.path)
-        if (addDir !== "." && addDir !== "/") {
-          await fs.mkdir(addDir, { recursive: true })
-        }
-
-        await fs.writeFile(hunk.path, hunk.contents, "utf-8")
+        await Encoding.write(hunk.path, hunk.contents)
         added.push(hunk.path)
         log.info(`Added file: ${hunk.path}`)
         break
@@ -552,18 +552,13 @@ export async function applyHunksToFiles(hunks: Hunk[]): Promise<AffectedPaths> {
 
         if (hunk.move_path) {
           // Handle file move
-          const moveDir = path.dirname(hunk.move_path)
-          if (moveDir !== "." && moveDir !== "/") {
-            await fs.mkdir(moveDir, { recursive: true })
-          }
-
-          await fs.writeFile(hunk.move_path, Bom.join(fileUpdate.content, fileUpdate.bom), "utf-8")
+          await Encoding.write(hunk.move_path, Bom.join(fileUpdate.content, fileUpdate.bom), fileUpdate.encoding)
           await fs.unlink(hunk.path)
           modified.push(hunk.move_path)
           log.info(`Moved file: ${hunk.path} -> ${hunk.move_path}`)
         } else {
           // Regular update
-          await fs.writeFile(hunk.path, Bom.join(fileUpdate.content, fileUpdate.bom), "utf-8")
+          await Encoding.write(hunk.path, Bom.join(fileUpdate.content, fileUpdate.bom), fileUpdate.encoding)
           modified.push(hunk.path)
           log.info(`Updated file: ${hunk.path}`)
         }
@@ -628,7 +623,7 @@ export async function maybeParseApplyPatchVerified(
             // For delete, we need to read the current content
             const deletePath = path.resolve(effectiveCwd, hunk.path)
             try {
-              const content = await fs.readFile(deletePath, "utf-8")
+              const content = (await Encoding.read(deletePath)).text
               changes.set(resolvedPath, {
                 type: "delete",
                 content,

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -14,6 +14,7 @@ import DESCRIPTION from "./apply_patch.txt"
 import { File } from "../file"
 import { Format } from "../format"
 import * as Bom from "@/util/bom"
+import { EncodedIO } from "@/util/encoded-io"
 
 export const Parameters = Schema.Struct({
   patchText: Schema.String.annotate({ description: "The full patch text that describes all changes to be made" }),
@@ -65,6 +66,7 @@ export const ApplyPatchTool = Tool.define(
         additions: number
         deletions: number
         bom: boolean
+        encoding: string
       }> = []
 
       let totalDiff = ""
@@ -97,6 +99,7 @@ export const ApplyPatchTool = Tool.define(
               additions,
               deletions,
               bom: next.bom,
+              encoding: "utf-8",
             })
 
             totalDiff += diff + "\n"
@@ -116,12 +119,14 @@ export const ApplyPatchTool = Tool.define(
             const oldContent = source.text
             let newContent = oldContent
             let bom = source.bom
+            let encoding: string
 
             // Apply the update chunks to get new content
             try {
               const fileUpdate = Patch.deriveNewContentsFromChunks(filePath, hunk.chunks)
               newContent = fileUpdate.content
               bom = fileUpdate.bom
+              encoding = fileUpdate.encoding
             } catch (error) {
               return yield* Effect.fail(new Error(`apply_patch verification failed: ${error}`))
             }
@@ -148,6 +153,7 @@ export const ApplyPatchTool = Tool.define(
               additions,
               deletions,
               bom,
+              encoding,
             })
 
             totalDiff += diff + "\n"
@@ -155,7 +161,8 @@ export const ApplyPatchTool = Tool.define(
           }
 
           case "delete": {
-            const source = yield* Bom.readFile(afs, filePath).pipe(
+            // encoding-aware read so non-UTF-8 files decode without corruption
+            const deleteRead = yield* EncodedIO.read(filePath).pipe(
               Effect.catch((error) =>
                 Effect.fail(
                   new Error(
@@ -164,7 +171,8 @@ export const ApplyPatchTool = Tool.define(
                 ),
               ),
             )
-            const contentToDelete = source.text
+            const contentToDelete = deleteRead.text
+            const source = Bom.split(contentToDelete)
             const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
 
             const deletions = contentToDelete.split("\n").length
@@ -178,6 +186,7 @@ export const ApplyPatchTool = Tool.define(
               additions: 0,
               deletions,
               bom: source.bom,
+              encoding: deleteRead.encoding,
             })
 
             totalDiff += deleteDiff + "\n"
@@ -217,22 +226,18 @@ export const ApplyPatchTool = Tool.define(
         const edited = change.type === "delete" ? undefined : (change.movePath ?? change.filePath)
         switch (change.type) {
           case "add":
-            // Create parent directories (recursive: true is safe on existing/root dirs)
-
-            yield* afs.writeWithDirs(change.filePath, Bom.join(change.newContent, change.bom))
+            yield* EncodedIO.write(change.filePath, Bom.join(change.newContent, change.bom), change.encoding)
             updates.push({ file: change.filePath, event: "add" })
             break
 
           case "update":
-            yield* afs.writeWithDirs(change.filePath, Bom.join(change.newContent, change.bom))
+            yield* EncodedIO.write(change.filePath, Bom.join(change.newContent, change.bom), change.encoding)
             updates.push({ file: change.filePath, event: "change" })
             break
 
           case "move":
             if (change.movePath) {
-              // Create parent directories (recursive: true is safe on existing/root dirs)
-
-              yield* afs.writeWithDirs(change.movePath!, Bom.join(change.newContent, change.bom))
+              yield* EncodedIO.write(change.movePath!, Bom.join(change.newContent, change.bom), change.encoding)
               yield* afs.remove(change.filePath)
               updates.push({ file: change.filePath, event: "unlink" })
               updates.push({ file: change.movePath, event: "add" })

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -115,11 +115,23 @@ export const ApplyPatchTool = Tool.define(
               )
             }
 
-            const source = yield* Bom.readFile(afs, filePath)
+            // encoding-aware read so non-UTF-8 files decode without mojibake; the
+            // resulting diff, additions/deletions counts, and permission-prompt
+            // metadata shown to the user must reflect the real file contents.
+            const read = yield* EncodedIO.read(filePath).pipe(
+              Effect.catch((error) =>
+                Effect.fail(
+                  new Error(
+                    `apply_patch verification failed: ${error instanceof Error ? error.message : String(error)}`,
+                  ),
+                ),
+              ),
+            )
+            const source = Bom.split(read.text)
             const oldContent = source.text
             let newContent = oldContent
             let bom = source.bom
-            let encoding: string
+            let encoding = read.encoding // overwritten by deriveNewContentsFromChunks below
 
             // Apply the update chunks to get new content
             try {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -18,6 +18,7 @@ import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import * as Bom from "@/util/bom"
+import { EncodedIO } from "@/util/encoded-io"
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -89,7 +90,10 @@ export const EditTool = Tool.define(
             Effect.gen(function* () {
               if (params.oldString === "") {
                 const existed = yield* afs.existsSafe(filePath)
-                const source = existed ? yield* Bom.readFile(afs, filePath) : { bom: false, text: "" }
+                // Encoding.read strips UTF-8 BOMs so derive the BOM flag from the
+                // detected encoding label instead of the decoded text.
+                const pre = existed ? yield* EncodedIO.read(filePath) : { text: "", encoding: "utf-8" }
+                const source = { bom: pre.encoding === "utf-8-bom", text: pre.text, encoding: pre.encoding }
                 const next = Bom.split(params.newString)
                 const desiredBom = source.bom || next.bom
                 contentOld = source.text
@@ -104,7 +108,7 @@ export const EditTool = Tool.define(
                     diff,
                   },
                 })
-                yield* afs.writeWithDirs(filePath, Bom.join(contentNew, desiredBom))
+                yield* EncodedIO.write(filePath, Bom.join(contentNew, desiredBom), source.encoding)
                 if (yield* format.file(filePath)) {
                   contentNew = yield* Bom.syncFile(afs, filePath, desiredBom)
                 }
@@ -119,7 +123,10 @@ export const EditTool = Tool.define(
               const info = yield* afs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)))
               if (!info) throw new Error(`File ${filePath} not found`)
               if (info.type === "Directory") throw new Error(`Path is a directory, not a file: ${filePath}`)
-              const source = yield* Bom.readFile(afs, filePath)
+              // Encoding.read strips UTF-8 BOMs so derive the BOM flag from the
+              // detected encoding label instead of the decoded text.
+              const pre = yield* EncodedIO.read(filePath)
+              const source = { bom: pre.encoding === "utf-8-bom", text: pre.text, encoding: pre.encoding }
               contentOld = source.text
 
               const ending = detectLineEnding(contentOld)
@@ -148,7 +155,7 @@ export const EditTool = Tool.define(
                 },
               })
 
-              yield* afs.writeWithDirs(filePath, Bom.join(contentNew, desiredBom))
+              yield* EncodedIO.write(filePath, Bom.join(contentNew, desiredBom), source.encoding)
               if (yield* format.file(filePath)) {
                 contentNew = yield* Bom.syncFile(afs, filePath, desiredBom)
               }

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -1,8 +1,9 @@
 import { Effect, Option, Schema, Scope } from "effect"
 import { NonNegativeInt } from "@/util/schema"
-import { createReadStream } from "fs"
 import * as path from "path"
+import { Readable } from "stream"
 import { createInterface } from "readline"
+import { Encoding } from "@/util/encoding"
 import * as Tool from "./tool"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { LSP } from "@/lsp/lsp"
@@ -138,6 +139,10 @@ export const ReadTool = Tool.define(
       }
 
       if (bytes.length === 0) return false
+
+      // UTF-16/32 BOM: NUL bytes are legitimate, skip the NUL/control-char heuristic
+      const buf = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      if (Encoding.hasUtf16Bom(buf, bytes.length) || Encoding.hasUtf32Bom(buf, bytes.length)) return false
 
       let nonPrintableCount = 0
       for (let i = 0; i < bytes.length; i++) {
@@ -295,7 +300,8 @@ export const ReadTool = Tool.define(
 )
 
 async function lines(filepath: string, opts: { limit: number; offset: number }) {
-  const stream = createReadStream(filepath, { encoding: "utf8" })
+  const encoded = await Encoding.read(filepath)
+  const stream = Readable.from([encoded.text])
   const rl = createInterface({
     input: stream,
     // Note: we use the crlfDelay option to recognize all instances of CR LF

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -1,9 +1,10 @@
 import { Effect, Option, Schema, Scope } from "effect"
 import { NonNegativeInt } from "@/util/schema"
 import * as path from "path"
-import { Readable } from "stream"
+import type { Readable } from "stream"
 import { createInterface } from "readline"
 import { Encoding } from "@/util/encoding"
+import { TextStream } from "@/util/text-stream"
 import * as Tool from "./tool"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { LSP } from "@/lsp/lsp"
@@ -299,9 +300,14 @@ export const ReadTool = Tool.define(
   }),
 )
 
+// Routed through TextStream.withFallback so plain UTF-8 files stream straight
+// from disk and stop at the line/byte cap, while non-UTF-8 files fall back to
+// a buffered iconv decode for correctness.
 async function lines(filepath: string, opts: { limit: number; offset: number }) {
-  const encoded = await Encoding.read(filepath)
-  const stream = Readable.from([encoded.text])
+  return TextStream.withFallback(filepath, (stream) => readLines(stream, opts))
+}
+
+async function readLines(stream: Readable, opts: { limit: number; offset: number }) {
   const rl = createInterface({
     input: stream,
     // Note: we use the crlfDelay option to recognize all instances of CR LF

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -14,6 +14,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import * as Bom from "@/util/bom"
+import { EncodedIO } from "@/util/encoded-io"
 
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
@@ -44,7 +45,10 @@ export const WriteTool = Tool.define(
           yield* assertExternalDirectoryEffect(ctx, filepath)
 
           const exists = yield* fs.existsSafe(filepath)
-          const source = exists ? yield* Bom.readFile(fs, filepath) : { bom: false, text: "" }
+          // Encoding.read strips UTF-8 BOMs so derive the BOM flag from the
+          // detected encoding label instead of the decoded text.
+          const pre = exists ? yield* EncodedIO.read(filepath) : { text: "", encoding: "utf-8" }
+          const source = { bom: pre.encoding === "utf-8-bom", text: pre.text, encoding: pre.encoding }
           const next = Bom.split(params.content)
           const desiredBom = source.bom || next.bom
           const contentOld = source.text
@@ -61,7 +65,7 @@ export const WriteTool = Tool.define(
             },
           })
 
-          yield* fs.writeWithDirs(filepath, Bom.join(contentNew, desiredBom))
+          yield* EncodedIO.write(filepath, Bom.join(contentNew, desiredBom), source.encoding)
           if (yield* format.file(filepath)) {
             yield* Bom.syncFile(fs, filepath, desiredBom)
           }

--- a/packages/opencode/src/util/encoded-io.ts
+++ b/packages/opencode/src/util/encoded-io.ts
@@ -1,0 +1,17 @@
+import { Effect } from "effect"
+import { Encoding } from "@/util/encoding"
+
+/**
+ * Effect wrappers around {@link Encoding.read} and {@link Encoding.write} so
+ * tool code can preserve file encoding without leaking Node/async boilerplate
+ * into each call site. Uses {@link Effect.tryPromise} so I/O failures surface
+ * as typed errors that can be recovered with `.pipe(Effect.catch(...))`.
+ */
+const wrap = (cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause)))
+
+export const read = (path: string) => Effect.tryPromise({ try: () => Encoding.read(path), catch: wrap })
+
+export const write = (path: string, text: string, encoding: string = Encoding.DEFAULT) =>
+  Effect.tryPromise({ try: () => Encoding.write(path, text, encoding), catch: wrap })
+
+export * as EncodedIO from "./encoded-io"

--- a/packages/opencode/src/util/encoding.ts
+++ b/packages/opencode/src/util/encoding.ts
@@ -1,0 +1,163 @@
+import { readFile, writeFile, mkdir } from "fs/promises"
+import { readFileSync } from "fs"
+import { dirname } from "path"
+import chardet from "chardet"
+import iconv from "iconv-lite"
+
+/**
+ * Text encoding detection and preservation for tool file I/O.
+ *
+ * Supported:
+ *  - UTF-8 (with or without BOM)
+ *  - UTF-16 LE/BE with BOM (detected by chardet)
+ *  - UTF-32 LE/BE with BOM (detected by chardet)
+ *  - Legacy Latin and CJK encodings (detected by chardet)
+ *
+ * Not supported:
+ *  - UTF-16 or UTF-32 without BOM (ambiguous, rare)
+ *
+ * Detection strategy:
+ *  1. If the bytes are valid UTF-8, treat as UTF-8 (tracking the presence of a
+ *     BOM so it can be written back).
+ *  2. Otherwise, trust chardet. chardet only reports the wide UTF variants
+ *     when a BOM is present, which aligns with the contract above.
+ *
+ * iconv-lite's UTF codecs strip BOMs on decode and do not emit them on encode,
+ * so UTF BOMs are handled explicitly in {@link encode} to round-trip cleanly.
+ */
+
+export const DEFAULT = "utf-8"
+/**
+ * Synthetic label for UTF-8 files that start with a BOM. iconv-lite's utf-8
+ * codec always strips BOMs on decode and never emits one on encode, so we
+ * track the "with BOM" case explicitly to round-trip it faithfully.
+ */
+export const UTF8_BOM = "utf-8-bom"
+const BOMS = {
+  "utf-8-bom": Buffer.from([0xef, 0xbb, 0xbf]),
+  "utf-16le": Buffer.from([0xff, 0xfe]),
+  "utf-16be": Buffer.from([0xfe, 0xff]),
+  "utf-32le": Buffer.from([0xff, 0xfe, 0x00, 0x00]),
+  "utf-32be": Buffer.from([0x00, 0x00, 0xfe, 0xff]),
+}
+
+function startsWith(bytes: Buffer, bom: Buffer, limit: number): boolean {
+  return limit >= bom.length && bytes.subarray(0, bom.length).equals(bom)
+}
+
+function hasUtf8Bom(bytes: Buffer): boolean {
+  return startsWith(bytes, BOMS["utf-8-bom"], bytes.length)
+}
+
+/** True if `bytes[0..limit]` starts with a UTF-16 LE or BE byte-order mark. */
+export function hasUtf16Bom(bytes: Buffer, limit = bytes.length): boolean {
+  // UTF-32 LE starts with FF FE 00 00, so exclude it to avoid misclassifying as UTF-16 LE.
+  if (hasUtf32Bom(bytes, limit)) return false
+  return startsWith(bytes, BOMS["utf-16le"], limit) || startsWith(bytes, BOMS["utf-16be"], limit)
+}
+
+/** True if `bytes[0..limit]` starts with a UTF-32 LE or BE byte-order mark. */
+export function hasUtf32Bom(bytes: Buffer, limit = bytes.length): boolean {
+  return startsWith(bytes, BOMS["utf-32le"], limit) || startsWith(bytes, BOMS["utf-32be"], limit)
+}
+
+/**
+ * Canonicalize chardet labels to a stable lowercase-hyphenated form.
+ *
+ * iconv-lite already accepts every label chardet emits (e.g. "UTF-16 LE",
+ * "Shift_JIS", "KOI8-R"), so this map is not required to make decode/encode
+ * work. Its job is to give the rest of the codebase a consistent label —
+ * callers compare against `"utf-16le"`, `"windows-1251"`, etc., and should
+ * not have to account for chardet's casing or whitespace conventions.
+ *
+ * ISO-2022-* is unsupported by iconv-lite under any alias and is left out
+ * of the map; those labels fall through the `encodingExists` guard in
+ * `detect()` and are rejected to UTF-8.
+ */
+function normalize(name: string): string {
+  const lower = name.toLowerCase().replace(/[^a-z0-9]/g, "")
+  const map: Record<string, string> = {
+    utf8: "utf-8",
+    utf16le: "utf-16le",
+    utf16be: "utf-16be",
+    utf32le: "utf-32le",
+    utf32be: "utf-32be",
+    iso88591: "iso-8859-1",
+    iso88592: "iso-8859-2",
+    iso88595: "iso-8859-5",
+    iso88597: "iso-8859-7",
+    iso88598: "iso-8859-8",
+    iso88599: "iso-8859-9",
+    windows1250: "windows-1250",
+    windows1251: "windows-1251",
+    windows1252: "windows-1252",
+    windows1253: "windows-1253",
+    windows1255: "windows-1255",
+    shiftjis: "Shift_JIS",
+    eucjp: "euc-jp",
+    euckr: "euc-kr",
+    big5: "big5",
+    gb18030: "gb18030",
+    koi8r: "koi8-r",
+  }
+  return map[lower] ?? name
+}
+
+function isUtf8(bytes: Buffer): boolean {
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function detect(bytes: Buffer): string {
+  if (bytes.length === 0) return DEFAULT
+  if (isUtf8(bytes)) return hasUtf8Bom(bytes) ? UTF8_BOM : DEFAULT
+  const result = chardet.detect(bytes)
+  if (!result) return DEFAULT
+  const enc = normalize(result)
+  if (!iconv.encodingExists(enc)) return DEFAULT
+  return enc
+}
+
+export function decode(bytes: Buffer, encoding: string): string {
+  if (encoding === UTF8_BOM) return iconv.decode(bytes, "utf-8")
+  return iconv.decode(bytes, encoding)
+}
+
+export function encode(text: string, encoding: string): Buffer {
+  // iconv-lite's UTF codecs strip/ignore BOMs, but we support "UTF-X with BOM"
+  // as a distinct variant. Prepend the BOM manually so round-tripping keeps
+  // the original byte signature intact. Strip a leading U+FEFF from `text`
+  // first so we never emit a double BOM when the decoded text already
+  // contains one (e.g. if a tool round-trips content verbatim).
+  const body = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text
+  const key = encoding === UTF8_BOM ? UTF8_BOM : encoding.toLowerCase()
+  const bom = BOMS[key as keyof typeof BOMS]
+  if (bom) return Buffer.concat([bom, iconv.encode(body, key === UTF8_BOM ? "utf-8" : key)])
+  return iconv.encode(text, encoding)
+}
+
+/** Read a file, detecting its encoding. */
+export async function read(path: string): Promise<{ text: string; encoding: string }> {
+  const bytes = await readFile(path)
+  const encoding = detect(bytes)
+  return { text: decode(bytes, encoding), encoding }
+}
+
+/** Synchronous read, detecting encoding. */
+export function readSync(path: string): { text: string; encoding: string } {
+  const bytes = readFileSync(path)
+  const encoding = detect(bytes)
+  return { text: decode(bytes, encoding), encoding }
+}
+
+/** Write text, ensuring parent directory exists, using the given encoding. */
+export async function write(path: string, text: string, encoding: string = DEFAULT): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, encode(text, encoding))
+}
+
+export * as Encoding from "./encoding"

--- a/packages/opencode/src/util/text-stream.ts
+++ b/packages/opencode/src/util/text-stream.ts
@@ -1,0 +1,72 @@
+import { createReadStream } from "fs"
+import { PassThrough, Readable } from "stream"
+import { Encoding } from "@/util/encoding"
+
+/**
+ * Encoding-aware text streaming for tools that walk a file line by line.
+ * Optimistically stream as UTF-8; fall back to a buffered iconv decode only
+ * when the bytes turn out not to be valid UTF-8.
+ */
+
+/** Distinct class so {@link withFallback} can tell us apart from real I/O failures. */
+export class InvalidUtf8Error extends Error {
+  constructor() {
+    super("invalid utf-8")
+  }
+}
+
+/**
+ * UTF-8 text Readable for `filepath`. A leading UTF-8 BOM passes through as
+ * U+FEFF — same as `createReadStream({ encoding: "utf8" })`.
+ */
+export function openUtf8(filepath: string): Readable {
+  const out = new PassThrough({ encoding: "utf8" })
+  const raw = createReadStream(filepath)
+  const decoder = new TextDecoder("utf-8", { fatal: true })
+  raw.on("data", (chunk) => {
+    try {
+      const text = decoder.decode(chunk as Buffer, { stream: true })
+      if (text) out.write(text)
+    } catch {
+      raw.destroy()
+      out.destroy(new InvalidUtf8Error())
+    }
+  })
+  raw.on("end", () => {
+    try {
+      const tail = decoder.decode()
+      if (tail) out.write(tail)
+      out.end()
+    } catch {
+      out.destroy(new InvalidUtf8Error())
+    }
+  })
+  raw.on("error", (err) => out.destroy(err))
+  // Propagate consumer-side teardown so early-exit (line / byte cap, fallback)
+  // stops pulling chunks from disk instead of running to EOF.
+  out.on("close", () => raw.destroy())
+  return out
+}
+
+/** Whole-file UTF-8 Readable via {@link Encoding.read}; buffers the entire decoded file. */
+export async function openDecoded(filepath: string): Promise<Readable> {
+  const decoded = await Encoding.read(filepath)
+  return Readable.from([decoded.text])
+}
+
+/**
+ * Run `fn` against an optimistic UTF-8 stream; on {@link InvalidUtf8Error}
+ * retry once against {@link openDecoded}. `fn` must be safe to retry — it is
+ * called twice on the fallback path, so any side effects must be idempotent.
+ * Other errors propagate.
+ */
+export async function withFallback<T>(filepath: string, fn: (input: Readable) => Promise<T>): Promise<T> {
+  try {
+    return await fn(openUtf8(filepath))
+  } catch (err) {
+    if (!(err instanceof InvalidUtf8Error)) throw err
+  }
+  return fn(await openDecoded(filepath))
+}
+
+export * as TextStream from "./text-stream"

--- a/packages/opencode/src/util/text-stream.ts
+++ b/packages/opencode/src/util/text-stream.ts
@@ -16,8 +16,11 @@ export class InvalidUtf8Error extends Error {
 }
 
 /**
- * UTF-8 text Readable for `filepath`. A leading UTF-8 BOM passes through as
- * U+FEFF — same as `createReadStream({ encoding: "utf8" })`.
+ * UTF-8 text Readable for `filepath`. A leading UTF-8 BOM is stripped here by
+ * `TextDecoder` (per WHATWG spec) — note this differs from
+ * `createReadStream({ encoding: "utf8" })`, whose `StringDecoder` preserves
+ * the BOM as U+FEFF. The {@link openDecoded} fallback also strips the BOM
+ * (iconv's utf-8 codec drops it), so both paths agree on BOM handling.
  */
 export function openUtf8(filepath: string): Readable {
   const out = new PassThrough({ encoding: "utf8" })

--- a/packages/opencode/test/tool/tool-encoding.test.ts
+++ b/packages/opencode/test/tool/tool-encoding.test.ts
@@ -324,6 +324,53 @@ describe("tool encoding preservation", () => {
       ),
     )
 
+    // Regression guard: the diff and additions/deletions counts surfaced to the
+    // user (and to the permission prompt) are derived from the pre-patch read
+    // of the file. A previous version reused a hard-coded UTF-8 decoder for
+    // that read, producing mojibake for any non-UTF-8 file. The bytes ended up
+    // correct because the patch helper does its own encoding-aware read, so
+    // tests that only checked final file bytes (above) missed the bug.
+    it.live("returns a non-mojibake diff for a Shift_JIS update", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "doc.txt")
+          const replacement = "日本語"
+          const original = "line1\n" + samples.shiftJis + "\nline3\n"
+          yield* putEncoded(filepath, original, "Shift_JIS")
+
+          const patch = [
+            "*** Begin Patch",
+            "*** Update File: doc.txt",
+            "@@",
+            " line1",
+            "-" + samples.shiftJis,
+            "+" + replacement,
+            " line3",
+            "*** End Patch",
+          ].join("\n")
+
+          const result = (yield* runPatch({ patchText: patch })) as {
+            metadata: {
+              diff: string
+              files: Array<{ additions: number; deletions: number }>
+            }
+          }
+
+          // The diff must contain the real decoded old/new lines, not a UTF-8
+          // misread of the Shift_JIS bytes (which would surface as U+FFFD).
+          expect(result.metadata.diff).toContain(samples.shiftJis)
+          expect(result.metadata.diff).toContain(replacement)
+          expect(result.metadata.diff).not.toContain("\uFFFD")
+
+          // Per-file stats are derived from the same diff, so a mojibake read
+          // would inflate both additions and deletions.
+          expect(result.metadata.files).toHaveLength(1)
+          expect(result.metadata.files[0].additions).toBe(1)
+          expect(result.metadata.files[0].deletions).toBe(1)
+        }),
+      ),
+    )
+
     it.live("new files added via apply_patch are UTF-8", () =>
       provideTmpdirInstance((dir) =>
         Effect.gen(function* () {

--- a/packages/opencode/test/tool/tool-encoding.test.ts
+++ b/packages/opencode/test/tool/tool-encoding.test.ts
@@ -1,0 +1,399 @@
+// Integration tests verifying that the agent file tools (read, write, edit,
+// apply_patch) detect and preserve the original encoding of files on disk.
+// Tests exercise the real tool pipeline rather than the Encoding helper
+// directly so we validate end-to-end behaviour.
+
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import fs from "fs/promises"
+import iconv from "iconv-lite"
+import { Agent } from "@/agent/agent"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { ApplyPatchTool } from "@/tool/apply_patch"
+import { Bus } from "@/bus"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { EditTool } from "@/tool/edit"
+import { Format } from "@/format"
+import { Instruction } from "@/session/instruction"
+import { LSP } from "@/lsp/lsp"
+import { MessageID, SessionID } from "@/session/schema"
+import { ReadTool } from "@/tool/read"
+import * as Tool from "@/tool/tool"
+import { Truncate } from "@/tool/truncate"
+import { WriteTool } from "@/tool/write"
+import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-encoding"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const it = testEffect(
+  Layer.mergeAll(
+    Agent.defaultLayer,
+    AppFileSystem.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Instruction.defaultLayer,
+    LSP.defaultLayer,
+    Bus.layer,
+    Format.defaultLayer,
+    Truncate.defaultLayer,
+  ),
+)
+
+const runRead = (args: Tool.InferParameters<typeof ReadTool>) =>
+  Effect.gen(function* () {
+    const info = yield* ReadTool
+    const tool = yield* info.init()
+    return yield* tool.execute(args, ctx)
+  })
+
+const runWrite = (args: Tool.InferParameters<typeof WriteTool>) =>
+  Effect.gen(function* () {
+    const info = yield* WriteTool
+    const tool = yield* info.init()
+    return yield* tool.execute(args, ctx)
+  })
+
+const runEdit = (args: Tool.InferParameters<typeof EditTool>) =>
+  Effect.gen(function* () {
+    const info = yield* EditTool
+    const tool = yield* info.init()
+    return yield* tool.execute(args, ctx)
+  })
+
+const runPatch = (args: Tool.InferParameters<typeof ApplyPatchTool>) =>
+  Effect.gen(function* () {
+    const info = yield* ApplyPatchTool
+    const tool = yield* info.init()
+    return yield* tool.execute(args, ctx)
+  })
+
+// iconv-lite's UTF codecs don't emit BOMs, but this codebase supports
+// "UTF-X with BOM" as a distinct variant. Prepend one here for fixture files
+// that are meant to have one.
+const UTF8_BOM = "utf-8-bom"
+const encodeBytes = (text: string, encoding: string): Buffer => {
+  if (encoding === UTF8_BOM) return Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), iconv.encode(text, "utf-8")])
+  const lower = encoding.toLowerCase()
+  if (lower === "utf-16le") return Buffer.concat([Buffer.from([0xff, 0xfe]), iconv.encode(text, encoding)])
+  if (lower === "utf-16be") return Buffer.concat([Buffer.from([0xfe, 0xff]), iconv.encode(text, encoding)])
+  if (lower === "utf-32le") return Buffer.concat([Buffer.from([0xff, 0xfe, 0x00, 0x00]), iconv.encode(text, encoding)])
+  if (lower === "utf-32be") return Buffer.concat([Buffer.from([0x00, 0x00, 0xfe, 0xff]), iconv.encode(text, encoding)])
+  return iconv.encode(text, encoding)
+}
+
+// Create a file with the given encoding by writing raw bytes.
+const putEncoded = (filepath: string, text: string, encoding: string) =>
+  Effect.promise(async () => {
+    await fs.mkdir(path.dirname(filepath), { recursive: true })
+    await fs.writeFile(filepath, encodeBytes(text, encoding))
+  })
+
+const loadDecoded = (filepath: string, encoding: string) =>
+  Effect.promise(async () => {
+    const bytes = await fs.readFile(filepath)
+    if (encoding === UTF8_BOM) {
+      const stripped = bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf
+      return iconv.decode(stripped ? bytes.subarray(3) : bytes, "utf-8")
+    }
+    return iconv.decode(bytes, encoding)
+  })
+
+const loadBytes = (filepath: string) => Effect.promise(() => fs.readFile(filepath))
+
+// Sample phrases chosen to exercise each encoding's characteristic byte patterns.
+const samples = {
+  utf8: "Hello, world! — £100",
+  shiftJis: "こんにちは、世界！日本語のテストです。",
+  eucJp: "日本語のEUC-JPテスト文字列です。",
+  gb2312: "你好，世界！这是简体中文测试。",
+  big5: "你好，世界！這是繁體中文測試。",
+  eucKr: "안녕하세요, 세계! 한국어 테스트입니다.",
+  windows1251: "Привет, мир! Это тест кириллицы.",
+  koi8r: "Привет, мир! КОИ-8 Р тест.",
+}
+
+describe("tool encoding preservation", () => {
+  describe("ReadTool decodes files with non-UTF-8 encodings", () => {
+    const cases: Array<[string, string, string]> = [
+      ["UTF-8", "utf-8", samples.utf8],
+      ["UTF-8 with BOM", UTF8_BOM, samples.utf8],
+      ["UTF-16 LE with BOM", "utf-16le", samples.utf8],
+      ["UTF-16 BE with BOM", "utf-16be", samples.utf8],
+      ["UTF-32 LE with BOM", "utf-32le", samples.utf8],
+      ["UTF-32 BE with BOM", "utf-32be", samples.utf8],
+      ["Shift_JIS", "Shift_JIS", samples.shiftJis],
+      ["EUC-JP", "euc-jp", samples.eucJp],
+      ["GB2312", "gb2312", samples.gb2312],
+      ["Big5", "big5", samples.big5],
+      ["EUC-KR", "euc-kr", samples.eucKr],
+      ["Windows-1251", "windows-1251", samples.windows1251],
+      ["KOI8-R", "koi8-r", samples.koi8r],
+    ]
+
+    for (const [label, encoding, text] of cases) {
+      it.live(`decodes ${label} content for the model`, () =>
+        provideEncoded(encoding, text, (filepath) =>
+          Effect.gen(function* () {
+            const result = yield* runRead({ filePath: filepath })
+            expect(result.output).toContain(text)
+          }),
+        ),
+      )
+    }
+  })
+
+  describe("ReadTool does not flag non-Latin text files as binary", () => {
+    it.live("accepts Shift_JIS", () =>
+      provideEncoded("Shift_JIS", samples.shiftJis, (filepath) =>
+        Effect.gen(function* () {
+          const result = yield* runRead({ filePath: filepath })
+          expect(result.output).toContain(samples.shiftJis)
+        }),
+      ),
+    )
+
+    it.live("accepts UTF-16 LE with BOM (contains NUL bytes)", () =>
+      provideEncoded("utf-16le", samples.utf8, (filepath) =>
+        Effect.gen(function* () {
+          const result = yield* runRead({ filePath: filepath })
+          expect(result.output).toContain(samples.utf8)
+        }),
+      ),
+    )
+
+    it.live("accepts UTF-32 LE with BOM (3 of every 4 bytes are NUL)", () =>
+      provideEncoded("utf-32le", samples.utf8, (filepath) =>
+        Effect.gen(function* () {
+          const result = yield* runRead({ filePath: filepath })
+          expect(result.output).toContain(samples.utf8)
+        }),
+      ),
+    )
+  })
+
+  describe("WriteTool preserves existing file encoding when overwriting", () => {
+    const cases: Array<[string, string, string]> = [
+      ["UTF-8 with BOM", UTF8_BOM, samples.utf8],
+      ["Shift_JIS", "Shift_JIS", samples.shiftJis],
+      ["GB2312", "gb2312", samples.gb2312],
+      ["Windows-1251", "windows-1251", samples.windows1251],
+      ["UTF-16 LE", "utf-16le", samples.utf8],
+      ["UTF-32 LE", "utf-32le", samples.utf8],
+      ["UTF-32 BE", "utf-32be", samples.utf8],
+    ]
+
+    for (const [label, encoding, original] of cases) {
+      it.live(`preserves ${label} encoding on overwrite`, () =>
+        provideTmpdirInstance((dir) =>
+          Effect.gen(function* () {
+            const filepath = path.join(dir, "file.txt")
+            yield* putEncoded(filepath, original, encoding)
+
+            const replacement = original + " updated"
+            yield* runWrite({ filePath: filepath, content: replacement })
+
+            const decoded = yield* loadDecoded(filepath, encoding)
+            expect(decoded).toBe(replacement)
+
+            // Bytes should still match the original encoding (and differ from UTF-8).
+            const bytes = yield* loadBytes(filepath)
+            expect(bytes.equals(encodeBytes(replacement, encoding))).toBe(true)
+          }),
+        ),
+      )
+    }
+
+    it.live("defaults new files to UTF-8", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "new.txt")
+          yield* runWrite({ filePath: filepath, content: samples.utf8 })
+
+          const bytes = yield* loadBytes(filepath)
+          expect(bytes.equals(Buffer.from(samples.utf8, "utf-8"))).toBe(true)
+        }),
+      ),
+    )
+
+    // Guard against double-BOM regressions: if the model ever hands back content
+    // that already starts with U+FEFF (e.g. by round-tripping literal bytes),
+    // writing it to a BOM-encoded file must still produce exactly one BOM.
+    const bomCases: Array<[string, string, Buffer]> = [
+      ["UTF-8 with BOM", UTF8_BOM, Buffer.from([0xef, 0xbb, 0xbf])],
+      ["UTF-16 LE", "utf-16le", Buffer.from([0xff, 0xfe])],
+      ["UTF-16 BE", "utf-16be", Buffer.from([0xfe, 0xff])],
+      ["UTF-32 LE", "utf-32le", Buffer.from([0xff, 0xfe, 0x00, 0x00])],
+      ["UTF-32 BE", "utf-32be", Buffer.from([0x00, 0x00, 0xfe, 0xff])],
+    ]
+    for (const [label, encoding, bom] of bomCases) {
+      it.live(`does not emit a double BOM for ${label} when content starts with U+FEFF`, () =>
+        provideTmpdirInstance((dir) =>
+          Effect.gen(function* () {
+            const filepath = path.join(dir, "file.txt")
+            yield* putEncoded(filepath, "hello", encoding)
+
+            yield* runWrite({ filePath: filepath, content: "\uFEFFgoodbye" })
+
+            const bytes = yield* loadBytes(filepath)
+            // Exactly one BOM prefix, immediately followed by encoded payload.
+            expect(bytes.subarray(0, bom.length).equals(bom)).toBe(true)
+            expect(bytes.subarray(bom.length, bom.length * 2).equals(bom)).toBe(false)
+            const decoded = yield* loadDecoded(filepath, encoding)
+            expect(decoded).toBe("goodbye")
+          }),
+        ),
+      )
+    }
+  })
+
+  describe("EditTool preserves existing file encoding across edits", () => {
+    const cases: Array<[string, string, string, string, string]> = [
+      ["UTF-8 with BOM", UTF8_BOM, samples.utf8 + "\n second line", "world", "earth"],
+      ["Shift_JIS", "Shift_JIS", samples.shiftJis, "日本語", "ニホンゴ"],
+      ["GB2312", "gb2312", samples.gb2312, "简体中文", "中文简体"],
+      ["Windows-1251", "windows-1251", samples.windows1251, "мир", "планета"],
+      ["UTF-16 LE", "utf-16le", samples.utf8 + "\n second line", "world", "earth"],
+      ["UTF-32 LE", "utf-32le", samples.utf8 + "\n second line", "world", "earth"],
+    ]
+
+    for (const [label, encoding, original, oldString, newString] of cases) {
+      it.live(`preserves ${label} through edit`, () =>
+        provideTmpdirInstance((dir) =>
+          Effect.gen(function* () {
+            const filepath = path.join(dir, "doc.txt")
+            yield* putEncoded(filepath, original, encoding)
+
+            yield* runEdit({ filePath: filepath, oldString, newString })
+
+            const decoded = yield* loadDecoded(filepath, encoding)
+            const expected = original.replace(oldString, newString)
+            expect(decoded).toBe(expected)
+
+            const bytes = yield* loadBytes(filepath)
+            expect(bytes.equals(encodeBytes(expected, encoding))).toBe(true)
+          }),
+        ),
+      )
+    }
+  })
+
+  describe("ApplyPatchTool preserves encoding", () => {
+    it.live("preserves Shift_JIS through an update hunk", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "doc.txt")
+          const replacement = "日本語"
+          const original = "line1\n" + samples.shiftJis + "\nline3\n"
+          const expected = original.replace(samples.shiftJis, replacement)
+          yield* putEncoded(filepath, original, "Shift_JIS")
+
+          const patch = [
+            "*** Begin Patch",
+            "*** Update File: doc.txt",
+            "@@",
+            " line1",
+            "-" + samples.shiftJis,
+            "+" + replacement,
+            " line3",
+            "*** End Patch",
+          ].join("\n")
+
+          yield* runPatch({ patchText: patch })
+
+          const decoded = yield* loadDecoded(filepath, "Shift_JIS")
+          expect(decoded).toBe(expected)
+
+          // Bytes must still be Shift_JIS, not silently promoted to UTF-8.
+          const bytes = yield* loadBytes(filepath)
+          expect(bytes.equals(encodeBytes(expected, "Shift_JIS"))).toBe(true)
+        }),
+      ),
+    )
+
+    it.live("new files added via apply_patch are UTF-8", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const patch = ["*** Begin Patch", "*** Add File: new.txt", "+hello world", "*** End Patch"].join("\n")
+          yield* runPatch({ patchText: patch })
+          const bytes = yield* loadBytes(path.join(dir, "new.txt"))
+          expect(bytes.equals(Buffer.from("hello world\n", "utf-8"))).toBe(true)
+        }),
+      ),
+    )
+
+    // Deletes exercise a code path in patch/index.ts that doesn't write bytes
+    // back — verify it still works when the target file is non-UTF-8, because
+    // the deletion code has to decode the old contents to confirm match.
+    it.live("deletes a Windows-1251 file without UTF-8 corruption errors", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "legacy.txt")
+          yield* putEncoded(filepath, samples.windows1251, "windows-1251")
+          const patch = ["*** Begin Patch", "*** Delete File: legacy.txt", "*** End Patch"].join("\n")
+          yield* runPatch({ patchText: patch })
+          const exists = yield* Effect.promise(() =>
+            fs
+              .access(filepath)
+              .then(() => true)
+              .catch(() => false),
+          )
+          expect(exists).toBe(false)
+        }),
+      ),
+    )
+  })
+
+  // EditTool's replaceAll path rewrites the entire buffer and re-encodes it
+  // in one shot — regression guard that re-encoding a multi-occurrence edit in
+  // a legacy encoding yields byte-exact output.
+  describe("EditTool replaceAll preserves non-UTF-8 encoding", () => {
+    it.live("replaces every occurrence in Shift_JIS", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "doc.txt")
+          // Pad with additional Shift_JIS text so chardet has enough bytes
+          // to confidently identify the encoding.
+          const pad = samples.shiftJis + "\n"
+          const original = pad + "日本語\n日本語\n日本語\n" + pad
+          yield* putEncoded(filepath, original, "Shift_JIS")
+
+          yield* runEdit({ filePath: filepath, oldString: "日本語", newString: "ニホンゴ", replaceAll: true })
+
+          const expected =
+            pad.replaceAll("日本語", "ニホンゴ") +
+            "ニホンゴ\nニホンゴ\nニホンゴ\n" +
+            pad.replaceAll("日本語", "ニホンゴ")
+          const decoded = yield* loadDecoded(filepath, "Shift_JIS")
+          expect(decoded).toBe(expected)
+          const bytes = yield* loadBytes(filepath)
+          expect(bytes.equals(encodeBytes(expected, "Shift_JIS"))).toBe(true)
+        }),
+      ),
+    )
+  })
+})
+
+// Shared helper to set up a temp instance with an encoded file at `file.txt`.
+function provideEncoded<A, E, R>(encoding: string, text: string, body: (filepath: string) => Effect.Effect<A, E, R>) {
+  return provideTmpdirInstance((dir) =>
+    Effect.gen(function* () {
+      const filepath = path.join(dir, "file.txt")
+      yield* putEncoded(filepath, text, encoding)
+      return yield* body(filepath)
+    }),
+  )
+}

--- a/packages/opencode/test/util/encoding.test.ts
+++ b/packages/opencode/test/util/encoding.test.ts
@@ -1,0 +1,342 @@
+// Unit tests for the Encoding module. These complement tool-encoding.test.ts
+// by exercising detect/decode/encode/read/write/readSync directly, without
+// going through the Effect runtime, agent harness, or tool pipeline. They are
+// cheap, fast, and cover the internal branches (BOM handling, ASCII/UTF-8
+// normalization, chardet fallback, unsupported encoding rejection) that the
+// integration tests cannot hit deterministically.
+
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import iconv from "iconv-lite"
+import { Encoding } from "@/util/encoding"
+
+const BOM = {
+  utf8: Buffer.from([0xef, 0xbb, 0xbf]),
+  utf16le: Buffer.from([0xff, 0xfe]),
+  utf16be: Buffer.from([0xfe, 0xff]),
+  utf32le: Buffer.from([0xff, 0xfe, 0x00, 0x00]),
+  utf32be: Buffer.from([0x00, 0x00, 0xfe, 0xff]),
+}
+
+async function tmp<T>(body: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-encoding-"))
+  try {
+    return await body(dir)
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true })
+  }
+}
+
+describe("Encoding.detect", () => {
+  test("empty buffer falls back to utf-8", () => {
+    expect(Encoding.detect(Buffer.alloc(0))).toBe(Encoding.DEFAULT)
+  })
+
+  test("plain ASCII is reported as utf-8", () => {
+    // Plain ASCII is valid UTF-8, so the detector short-circuits on the
+    // isUtf8 check and never reaches chardet. UTF-8 is an ASCII superset,
+    // so this label round-trips identically through iconv-lite.
+    expect(Encoding.detect(Buffer.from("plain ascii text\n"))).toBe("utf-8")
+  })
+
+  test("valid UTF-8 without BOM detects as utf-8", () => {
+    expect(Encoding.detect(Buffer.from("Hello — 世界", "utf-8"))).toBe("utf-8")
+  })
+
+  test("UTF-8 with BOM is reported as the distinct utf-8-bom variant", () => {
+    const bytes = Buffer.concat([BOM.utf8, Buffer.from("hello", "utf-8")])
+    expect(Encoding.detect(bytes)).toBe(Encoding.UTF8_BOM)
+  })
+
+  test("BOM-less UTF-8 containing multi-byte chars is not misdetected", () => {
+    // Regression guard: bytes that are valid UTF-8 must skip the chardet
+    // branch. Encoding detectors have been known to misfire on short CJK samples.
+    expect(Encoding.detect(Buffer.from("한글 テスト 中文", "utf-8"))).toBe("utf-8")
+  })
+
+  test("UTF-16 LE with BOM detects as utf-16le", () => {
+    const bytes = Buffer.concat([BOM.utf16le, iconv.encode("hello world", "utf-16le")])
+    expect(Encoding.detect(bytes)).toBe("utf-16le")
+  })
+
+  test("UTF-16 BE with BOM detects as utf-16be", () => {
+    const bytes = Buffer.concat([BOM.utf16be, iconv.encode("hello world", "utf-16be")])
+    expect(Encoding.detect(bytes)).toBe("utf-16be")
+  })
+
+  test("UTF-32 LE with BOM detects as utf-32le", () => {
+    const bytes = Buffer.concat([BOM.utf32le, iconv.encode("hello world", "utf-32le")])
+    expect(Encoding.detect(bytes)).toBe("utf-32le")
+  })
+
+  test("UTF-32 BE with BOM detects as utf-32be", () => {
+    const bytes = Buffer.concat([BOM.utf32be, iconv.encode("hello world", "utf-32be")])
+    expect(Encoding.detect(bytes)).toBe("utf-32be")
+  })
+
+  test("UTF-32 LE BOM is not misdetected as UTF-16 LE (shared FF FE prefix)", () => {
+    // UTF-32 LE BOM is FF FE 00 00; its first two bytes are identical to the
+    // UTF-16 LE BOM, so the order of BOM checks matters.
+    const bytes = Buffer.concat([BOM.utf32le, iconv.encode("hi", "utf-32le")])
+    expect(Encoding.detect(bytes)).toBe("utf-32le")
+  })
+
+  test("Shift_JIS bytes detect as Shift_JIS (case-insensitive, iconv-compatible label)", () => {
+    const bytes = iconv.encode("こんにちは、世界！日本語のテストです。", "Shift_JIS")
+    const detected = Encoding.detect(bytes)
+    expect(detected.toLowerCase()).toBe("shift_jis")
+    // The returned label must be accepted by iconv-lite so downstream decode
+    // works without a second normalization step.
+    expect(iconv.encodingExists(detected)).toBe(true)
+  })
+
+  test("Windows-1251 bytes detect as windows-1251", () => {
+    const bytes = iconv.encode("Привет, мир! Это тест кириллицы.", "windows-1251")
+    expect(Encoding.detect(bytes)).toBe("windows-1251")
+  })
+})
+
+describe("Encoding.decode / Encoding.encode", () => {
+  const cases: Array<[string, string, string]> = [
+    ["utf-8", "utf-8", "Hello — £100"],
+    ["utf-8-bom synthetic label", Encoding.UTF8_BOM, "hello"],
+    ["utf-16le", "utf-16le", "Hello 世界"],
+    ["utf-16be", "utf-16be", "Hello 世界"],
+    ["utf-32le", "utf-32le", "Hello 世界"],
+    ["utf-32be", "utf-32be", "Hello 世界"],
+    ["Shift_JIS", "Shift_JIS", "日本語"],
+    ["windows-1251", "windows-1251", "Привет"],
+    ["gb2312", "gb2312", "你好"],
+    ["big5", "big5", "繁體"],
+    ["euc-kr", "euc-kr", "한국어"],
+    ["koi8-r", "koi8-r", "Привет"],
+    ["iso-8859-1", "iso-8859-1", "Hëllo Wörld"],
+  ]
+
+  for (const [label, encoding, text] of cases) {
+    test(`round-trips ${label}`, () => {
+      const bytes = Encoding.encode(text, encoding)
+      expect(Encoding.decode(bytes, encoding)).toBe(text)
+    })
+  }
+
+  test("utf-8-bom encode emits exactly one BOM even if input starts with U+FEFF", () => {
+    // Regression guard: writers may hand us text that was previously decoded
+    // and still carries U+FEFF. The encoder must strip it to avoid doubling.
+    const bytes = Encoding.encode("\uFEFFhello", Encoding.UTF8_BOM)
+    expect(bytes.subarray(0, 3).equals(BOM.utf8)).toBe(true)
+    expect(bytes.subarray(3, 6).equals(BOM.utf8)).toBe(false)
+    expect(Encoding.decode(bytes, Encoding.UTF8_BOM)).toBe("hello")
+  })
+
+  test("utf-16le encode emits exactly one BOM even if input starts with U+FEFF", () => {
+    const bytes = Encoding.encode("\uFEFFhi", "utf-16le")
+    expect(bytes.subarray(0, 2).equals(BOM.utf16le)).toBe(true)
+    // Next two bytes must be the 'h' code unit (0x68 0x00), not another BOM.
+    expect(bytes[2]).toBe(0x68)
+    expect(bytes[3]).toBe(0x00)
+  })
+
+  test("utf-16be encode emits exactly one BOM even if input starts with U+FEFF", () => {
+    const bytes = Encoding.encode("\uFEFFhi", "utf-16be")
+    expect(bytes.subarray(0, 2).equals(BOM.utf16be)).toBe(true)
+    expect(bytes[2]).toBe(0x00)
+    expect(bytes[3]).toBe(0x68)
+  })
+
+  test("utf-32le encode emits exactly one BOM even if input starts with U+FEFF", () => {
+    const bytes = Encoding.encode("\uFEFFhi", "utf-32le")
+    expect(bytes.subarray(0, 4).equals(BOM.utf32le)).toBe(true)
+    // Next four bytes must be the 'h' code point (0x68 0x00 0x00 0x00), not another BOM.
+    expect(bytes[4]).toBe(0x68)
+    expect(bytes[5]).toBe(0x00)
+    expect(bytes[6]).toBe(0x00)
+    expect(bytes[7]).toBe(0x00)
+  })
+
+  test("utf-32be encode emits exactly one BOM even if input starts with U+FEFF", () => {
+    const bytes = Encoding.encode("\uFEFFhi", "utf-32be")
+    expect(bytes.subarray(0, 4).equals(BOM.utf32be)).toBe(true)
+    expect(bytes[4]).toBe(0x00)
+    expect(bytes[5]).toBe(0x00)
+    expect(bytes[6]).toBe(0x00)
+    expect(bytes[7]).toBe(0x68)
+  })
+
+  test("decode of utf-8-bom produces text without leading U+FEFF", () => {
+    // iconv-lite's utf-8 codec is documented to strip BOMs; guard against
+    // regressions if the underlying behaviour changes.
+    const bytes = Buffer.concat([BOM.utf8, Buffer.from("abc", "utf-8")])
+    expect(Encoding.decode(bytes, Encoding.UTF8_BOM)).toBe("abc")
+  })
+})
+
+describe("Encoding.hasUtf16Bom", () => {
+  test("detects LE BOM", () => {
+    expect(Encoding.hasUtf16Bom(BOM.utf16le)).toBe(true)
+  })
+  test("detects BE BOM", () => {
+    expect(Encoding.hasUtf16Bom(BOM.utf16be)).toBe(true)
+  })
+  test("returns false for UTF-8 BOM", () => {
+    expect(Encoding.hasUtf16Bom(BOM.utf8)).toBe(false)
+  })
+  test("returns false for plain ASCII", () => {
+    expect(Encoding.hasUtf16Bom(Buffer.from("ab"))).toBe(false)
+  })
+  test("respects an explicit limit smaller than the buffer", () => {
+    // Passing limit<2 must treat the sample as too short to contain a BOM,
+    // even if the underlying buffer starts with one. This matches the binary
+    // detection call site which reads a bounded sample.
+    expect(Encoding.hasUtf16Bom(BOM.utf16le, 1)).toBe(false)
+    expect(Encoding.hasUtf16Bom(BOM.utf16le, 2)).toBe(true)
+  })
+  test("returns false for a one-byte buffer", () => {
+    expect(Encoding.hasUtf16Bom(Buffer.from([0xff]))).toBe(false)
+  })
+  test("returns false for a UTF-32 LE BOM (distinct encoding)", () => {
+    // UTF-32 LE starts with FF FE 00 00; a naive check on the first two bytes
+    // would misclassify it as UTF-16 LE. hasUtf16Bom must reject it so the
+    // caller can disambiguate.
+    expect(Encoding.hasUtf16Bom(BOM.utf32le)).toBe(false)
+  })
+})
+
+describe("Encoding.hasUtf32Bom", () => {
+  test("detects LE BOM (FF FE 00 00)", () => {
+    expect(Encoding.hasUtf32Bom(BOM.utf32le)).toBe(true)
+  })
+  test("detects BE BOM (00 00 FE FF)", () => {
+    expect(Encoding.hasUtf32Bom(BOM.utf32be)).toBe(true)
+  })
+  test("returns false for UTF-16 LE BOM (shorter, distinct encoding)", () => {
+    expect(Encoding.hasUtf32Bom(BOM.utf16le)).toBe(false)
+  })
+  test("returns false for UTF-16 BE BOM", () => {
+    expect(Encoding.hasUtf32Bom(BOM.utf16be)).toBe(false)
+  })
+  test("returns false for UTF-8 BOM", () => {
+    expect(Encoding.hasUtf32Bom(BOM.utf8)).toBe(false)
+  })
+  test("returns false for a three-byte buffer (too short)", () => {
+    expect(Encoding.hasUtf32Bom(Buffer.from([0xff, 0xfe, 0x00]))).toBe(false)
+  })
+  test("respects an explicit limit smaller than the buffer", () => {
+    expect(Encoding.hasUtf32Bom(BOM.utf32le, 3)).toBe(false)
+    expect(Encoding.hasUtf32Bom(BOM.utf32le, 4)).toBe(true)
+  })
+})
+
+describe("Encoding.read / Encoding.readSync / Encoding.write", () => {
+  // chardet is noticeably more conservative than other detectors (jschardet,
+  // ICU) on tiny samples: a 12-byte Shift_JIS phrase collides with the
+  // windows-1252 profile and is misclassified. In practice this is fine,
+  // because the tool pipeline only runs detection on files the agent is about
+  // to read or patch — real source files and documents carry far more than 12
+  // bytes of characteristic content, which is plenty for chardet to lock
+  // onto the right encoding. The short-sample cliff only matters for
+  // synthetic fixtures like this one, so we pad the sample to the same body
+  // of Japanese text the rest of the suite already relies on.
+  const shiftJisSample = "こんにちは、世界！日本語のテストです。"
+
+  test("read detects and decodes Shift_JIS asynchronously", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "sj.txt")
+      await fs.writeFile(filepath, iconv.encode(shiftJisSample, "Shift_JIS"))
+      const result = await Encoding.read(filepath)
+      expect(result.text).toBe(shiftJisSample)
+      expect(result.encoding.toLowerCase()).toBe("shift_jis")
+    })
+  })
+
+  test("readSync mirrors read for the same input", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "sj.txt")
+      await fs.writeFile(filepath, iconv.encode(shiftJisSample, "Shift_JIS"))
+      const sync = Encoding.readSync(filepath)
+      const async_ = await Encoding.read(filepath)
+      expect(sync).toEqual(async_)
+    })
+  })
+
+  test("read preserves UTF-8 BOM as a distinct encoding label", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "bom.txt")
+      await fs.writeFile(filepath, Buffer.concat([BOM.utf8, Buffer.from("hi", "utf-8")]))
+      const result = await Encoding.read(filepath)
+      expect(result.encoding).toBe(Encoding.UTF8_BOM)
+      expect(result.text).toBe("hi")
+    })
+  })
+
+  test("write creates missing parent directories", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "nested", "deeply", "file.txt")
+      await Encoding.write(filepath, "hello", "utf-8")
+      const bytes = await fs.readFile(filepath)
+      expect(bytes.equals(Buffer.from("hello", "utf-8"))).toBe(true)
+    })
+  })
+
+  test("write defaults to utf-8 when encoding is omitted", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "default.txt")
+      await Encoding.write(filepath, "héllo")
+      const bytes = await fs.readFile(filepath)
+      expect(bytes.equals(Buffer.from("héllo", "utf-8"))).toBe(true)
+    })
+  })
+
+  test("write round-trips Shift_JIS bytes exactly", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "sj.txt")
+      const text = "日本語"
+      await Encoding.write(filepath, text, "Shift_JIS")
+      const bytes = await fs.readFile(filepath)
+      expect(bytes.equals(iconv.encode(text, "Shift_JIS"))).toBe(true)
+      // Must not be UTF-8 — regression guard against silent promotion.
+      expect(bytes.equals(Buffer.from(text, "utf-8"))).toBe(false)
+    })
+  })
+
+  test("write + read round-trips utf-16le with BOM", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "u16.txt")
+      const text = "Hello 世界"
+      await Encoding.write(filepath, text, "utf-16le")
+      const bytes = await fs.readFile(filepath)
+      expect(bytes.subarray(0, 2).equals(BOM.utf16le)).toBe(true)
+      const result = await Encoding.read(filepath)
+      expect(result.encoding).toBe("utf-16le")
+      expect(result.text).toBe(text)
+    })
+  })
+
+  test("write + read round-trips utf-32le with BOM", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "u32.txt")
+      const text = "Hello 世界"
+      await Encoding.write(filepath, text, "utf-32le")
+      const bytes = await fs.readFile(filepath)
+      expect(bytes.subarray(0, 4).equals(BOM.utf32le)).toBe(true)
+      const result = await Encoding.read(filepath)
+      expect(result.encoding).toBe("utf-32le")
+      expect(result.text).toBe(text)
+    })
+  })
+
+  test("write + read round-trips utf-32be with BOM", async () => {
+    await tmp(async (dir) => {
+      const filepath = path.join(dir, "u32be.txt")
+      const text = "Hello 世界"
+      await Encoding.write(filepath, text, "utf-32be")
+      const bytes = await fs.readFile(filepath)
+      expect(bytes.subarray(0, 4).equals(BOM.utf32be)).toBe(true)
+      const result = await Encoding.read(filepath)
+      expect(result.encoding).toBe("utf-32be")
+      expect(result.text).toBe(text)
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #7933

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support for reading and editing files in legacy encodings (i.e. encodings other than UTF-8), including legacy Latin and CJK such as Windows-1251, Shift_JIS and in theory anything that can be detected by chardet and converted by iconv-lite.

UTF-8 is still the default encoding for new files and behavior should be completely unchanged when files are valid UTF-8. Legacy encoding detection only kicks in when files are invalid UTF-8. There is a small chance that files that happen to be valid UTF-8 are misdetected or that chardet detects the wrong encoding, but this is likely acceptable as it should not regress the default UTF-8 path.

UTF-16 and UTF-32 are deliberately only supported when a byte order mark is present. Without these encodings are ambiguous and will likely trigger the pre-existing binary file detection. These encodings are not commonly used as file encodings.

#### New dependencies:

chardet 2.1.1
iconv-lite 0.7.2 (already pulled in transitively)

### How did you verify your code works?

Several integration level tests were adding to verify the whole pipeline works with some common legacy encodings.

Some manually testing was done by having the agent read a few files in legacy CJK encodings, verifying its summary makes sense and whether it could write more CJK characters to it without corrupting the file. Models may be skeptical their harness supports legacy encodings so you may have to explicitly tell it to use the relevant tool so it doesn't fall back to writing a python script instead.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Disclosures

I am a Kilo employee, PR is based on downstream https://github.com/Kilo-Org/kilocode/pull/8587