### PR TITLE
Fix GitHub action share links

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -120,7 +120,7 @@ let octoGraph: typeof graphql
 let commentId: number
 let gitConfig: string
 let session: { id: string; title: string; version: string }
-let shareId: string | undefined
+let shareInfo: { id: string; url: string } | undefined
 let exitCode = 0
 type PromptFiles = Awaited<ReturnType<typeof getUserPrompt>>["promptFiles"]
 
@@ -146,15 +146,17 @@ try {
   const repoData = await fetchRepo()
   session = await client.session.create<true>().then((r) => r.data)
   await subscribeSessionEvents()
-  shareId = await (async () => {
+  shareInfo = await (async () => {
     if (useEnvShare() === false) return
     if (!useEnvShare() && repoData.data.private) return
-    await client.session.share<true>({ path: session })
-    return session.id.slice(-8)
+    const response = await client.session.share<true>({ path: session })
+    const url = response.data.share?.url
+    if (!url) return
+    return { id: parseShareId(url), url }
   })()
   console.log("opencode session", session.id)
-  if (shareId) {
-    console.log("Share link:", `${useShareUrl()}/s/${shareId}`)
+  if (shareInfo?.url) {
+    console.log("Share link:", shareInfo.url)
   }
 
   // Handle 3 cases
@@ -172,7 +174,8 @@ try {
         const summary = await summarize(response)
         await pushToLocalBranch(summary)
       }
-      const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${useShareUrl()}/s/${shareId}`))
+      const shareUrl = shareInfo?.url
+      const hasShared = shareUrl ? prData.comments.nodes.some((c) => c.body.includes(shareUrl)) : false
       await updateComment(`${response}${footer({ image: !hasShared })}`)
     }
     // Fork PR
@@ -184,7 +187,8 @@ try {
         const summary = await summarize(response)
         await pushToForkBranch(summary, prData)
       }
-      const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${useShareUrl()}/s/${shareId}`))
+      const shareUrl = shareInfo?.url
+      const hasShared = shareUrl ? prData.comments.nodes.some((c) => c.body.includes(shareUrl)) : false
       await updateComment(`${response}${footer({ image: !hasShared })}`)
     }
   }
@@ -360,10 +364,6 @@ function useContext() {
 function useIssueId() {
   const payload = useContext().payload as IssueCommentEvent
   return payload.issue.number
-}
-
-function useShareUrl() {
-  return isMock() ? "https://dev.opencode.ai" : "https://opencode.ai"
 }
 
 async function getAccessToken() {
@@ -815,16 +815,23 @@ function footer(opts?: { image?: boolean }) {
   const { providerID, modelID } = useEnvModel()
 
   const image = (() => {
-    if (!shareId) return ""
+    if (!shareInfo?.url) return ""
+    if (!shareInfo.id) return ""
     if (!opts?.image) return ""
 
     const titleAlt = encodeURIComponent(session.title.substring(0, 50))
     const title64 = Buffer.from(session.title.substring(0, 700), "utf8").toString("base64")
 
-    return `<a href="${useShareUrl()}/s/${shareId}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${providerID}/${modelID}&version=${session.version}&id=${shareId}" /></a>\n`
+    return `<a href="${shareInfo.url}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${providerID}/${modelID}&version=${session.version}&id=${shareInfo.id}" /></a>\n`
   })()
-  const shareUrl = shareId ? `[opencode session](${useShareUrl()}/s/${shareId})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
+  const shareUrl = shareInfo?.url ? `[opencode session](${shareInfo.url})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
   return `\n\n${image}${shareUrl}[github run](${useEnvRunUrl()})`
+}
+
+function parseShareId(url: string) {
+  const pathname = url.split("?").at(0)
+  if (!pathname) return ""
+  return pathname.split("/").filter(Boolean).at(-1) ?? ""
 }
 
 async function fetchRepo() {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -181,6 +181,35 @@ export function formatPromptTooLargeError(files: { filename: string; content: st
   return `PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.${fileDetails}`
 }
 
+export function formatGithubFooter(input: {
+  runUrl: string
+  share?: { id: string; url: string } | undefined
+  image?: boolean | undefined
+  session?: { title: string; version: string } | undefined
+  providerID?: string | undefined
+  modelID?: string | undefined
+}) {
+  const image = (() => {
+    if (!input.share?.url) return ""
+    if (!input.share.id) return ""
+    if (!input.image) return ""
+    if (!input.session || !input.providerID || !input.modelID) return ""
+
+    const titleAlt = encodeURIComponent(input.session.title.substring(0, 50))
+    const title64 = Buffer.from(input.session.title.substring(0, 700), "utf8").toString("base64")
+
+    return `<a href="${input.share.url}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${input.providerID}/${input.modelID}&version=${input.session.version}&id=${input.share.id}" /></a>\n`
+  })()
+  const shareUrl = input.share?.url ? `[opencode session](${input.share.url})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
+  return `\n\n${image}${shareUrl}[github run](${input.runUrl})`
+}
+
+function parseShareId(url: string) {
+  const pathname = url.split("?").at(0)
+  if (!pathname) return ""
+  return pathname.split("/").filter(Boolean).at(-1) ?? ""
+}
+
 export const GithubCommand = cmd({
   command: "github",
   describe: "manage GitHub agent",
@@ -478,14 +507,13 @@ export const GithubRunCommand = effectCmd({
           ? (payload as IssueCommentEvent | IssuesEvent).issue.number
           : (payload as PullRequestEvent | PullRequestReviewCommentEvent).pull_request.number
       const runUrl = `/${owner}/${repo}/actions/runs/${runId}`
-      const shareBaseUrl = isMock ? "https://dev.opencode.ai" : "https://opencode.ai"
 
       let appToken: string
       let octoRest: Octokit
       let octoGraph: typeof graphql
       let gitConfig: string
       let session: { id: SessionID; title: string; version: string }
-      let shareId: string | undefined
+      let shareInfo: { id: string; url: string } | undefined
       let exitCode = 0
       type PromptFiles = Awaited<ReturnType<typeof getUserPrompt>>["promptFiles"]
       const triggerCommentId = isCommentEvent
@@ -560,13 +588,17 @@ export const GithubRunCommand = effectCmd({
           }),
         )
         subscribeSessionEvents()
-        shareId = await (async () => {
+        shareInfo = await (async () => {
           if (share === false) return
           if (!share && repoData.data.private) return
-          await Effect.runPromise(sessionShare.share(session.id))
-          return session.id.slice(-8)
+          const result = await Effect.runPromise(sessionShare.share(session.id))
+          if (!result.url) return
+          return { id: parseShareId(result.url), url: result.url }
         })()
         console.log("opencode session", session.id)
+        if (shareInfo?.url) {
+          console.log("Share link:", shareInfo.url)
+        }
 
         // Handle event types:
         // REPO_EVENTS (schedule, workflow_dispatch): no issue/PR context, output to logs/PR only
@@ -624,7 +656,8 @@ export const GithubRunCommand = effectCmd({
               const summary = await summarize(response)
               await pushToLocalBranch(summary, uncommittedChanges)
             }
-            const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+            const shareUrl = shareInfo?.url
+            const hasShared = shareUrl ? prData.comments.nodes.some((c) => c.body.includes(shareUrl)) : false
             await createComment(`${response}${footer({ image: !hasShared })}`)
             await removeReaction(commentType)
           }
@@ -642,7 +675,8 @@ export const GithubRunCommand = effectCmd({
               const summary = await summarize(response)
               await pushToForkBranch(summary, prData, uncommittedChanges)
             }
-            const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+            const shareUrl = shareInfo?.url
+            const hasShared = shareUrl ? prData.comments.nodes.some((c) => c.body.includes(shareUrl)) : false
             await createComment(`${response}${footer({ image: !hasShared })}`)
             await removeReaction(commentType)
           }
@@ -1392,17 +1426,14 @@ export const GithubRunCommand = effectCmd({
       }
 
       function footer(opts?: { image?: boolean }) {
-        const image = (() => {
-          if (!shareId) return ""
-          if (!opts?.image) return ""
-
-          const titleAlt = encodeURIComponent(session.title.substring(0, 50))
-          const title64 = Buffer.from(session.title.substring(0, 700), "utf8").toString("base64")
-
-          return `<a href="${shareBaseUrl}/s/${shareId}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${providerID}/${modelID}&version=${session.version}&id=${shareId}" /></a>\n`
-        })()
-        const shareUrl = shareId ? `[opencode session](${shareBaseUrl}/s/${shareId})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
-        return `\n\n${image}${shareUrl}[github run](${runUrl})`
+        return formatGithubFooter({
+          runUrl,
+          share: shareInfo,
+          image: opts?.image,
+          session,
+          providerID,
+          modelID,
+        })
       }
 
       async function fetchRepo() {

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { extractResponseText, formatPromptTooLargeError } from "../../src/cli/cmd/github"
+import { extractResponseText, formatGithubFooter, formatPromptTooLargeError } from "../../src/cli/cmd/github"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 
@@ -194,5 +194,30 @@ describe("formatPromptTooLargeError", () => {
     expect(result).toInclude("img1.png (3 KB)")
     expect(result).toInclude("img2.jpg (6 KB)")
     expect(result).toInclude("img3.gif (9 KB)")
+  })
+})
+
+describe("formatGithubFooter", () => {
+  test("uses canonical share URL returned by share service", () => {
+    const result = formatGithubFooter({
+      runUrl: "/anomalyco/opencode/actions/runs/123",
+      share: { id: "uaFpXIla", url: "https://opncd.ai/share/uaFpXIla" },
+      image: true,
+      session: { title: "Fix GitHub share links", version: "1.2.3" },
+      providerID: "openai",
+      modelID: "gpt-5",
+    })
+
+    expect(result).toContain("[opencode session](https://opncd.ai/share/uaFpXIla)")
+    expect(result).toContain('<a href="https://opncd.ai/share/uaFpXIla">')
+    expect(result).toContain("id=uaFpXIla")
+    expect(result).not.toContain("https://opencode.ai/s/")
+    expect(result).not.toContain("/s/uaFpXIla")
+  })
+
+  test("omits share link when sharing is unavailable", () => {
+    const result = formatGithubFooter({ runUrl: "/anomalyco/opencode/actions/runs/123" })
+
+    expect(result).toBe("\n\n[github run](/anomalyco/opencode/actions/runs/123)")
   })
 })


### PR DESCRIPTION
## Summary
- Use the canonical share URL returned by the share service in GitHub action comments.
- Stop constructing stale `opencode.ai/s/<id>` links in the active CLI action path and legacy action entrypoint.
- Add focused footer coverage for `opncd.ai/share/<id>` links.

## Verification
- `bun test test/cli/github-action.test.ts test/cli/import.test.ts test/share/share-next.test.ts`
- `bun typecheck`
- pre-push hook: `bun turbo typecheck`

Closes #26417