### PR TITLE
fix(opencode): make bash tool description parameter optional

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -620,7 +620,7 @@ export const ShellTool = Tool.define(
                   cwd,
                   env: yield* shellEnv(ctx, cwd),
                   timeout,
-                  description: params.description,
+                  description: params.description ?? "",
                 },
                 ctx,
               )

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -26,7 +26,7 @@ export function parameterSchema(description: string) {
     workdir: Schema.optional(Schema.String).annotate({
       description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
     }),
-    description: Schema.String.annotate({ description }),
+    description: Schema.optional(Schema.String).annotate({ description }),
   })
 }
 


### PR DESCRIPTION
  ### Issue for this PR                                                                                                                                                                                              
   
  Closes #20669                                                                                                                                                                                                      
                       
  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement                                                                                                                                                                                  
  - [ ] Documentation
                                                                                                                                                                                                                     
  ### What does this PR do?

  The bash tool's `description` parameter is defined as `Schema.String` (required) in `prompt.ts`. Local OpenAI-compatible backends like llama.cpp, LM Studio, and LiteLLM sometimes omit this field when calling the
   tool. This causes validation to fail with `expected string, received undefined`, killing the agent loop.
                                                                                                                                                                                                                     
  The fix:                                                                                                                                                                                                           
  - `prompt.ts`: Changed `Schema.String` to `Schema.optional(Schema.String)` for the `description` parameter
  - `shell.ts`: Added `?? ""` fallback where `params.description` is passed downstream, since the type is now `string | undefined`                                                                                   
                                                                                                                                                                                                                     
  The prompt text already says "it is very helpful if you write a clear, concise description" which implies optional behavior. This aligns the schema with that intent.                                              
                                                                                                                                                                                                                     
  ### How did you verify your code works?                                                                                                                                                                            
                                          
  - `bun turbo typecheck` passes (12/12 packages)                                                                                                                                                                    
  - Husky pre-push hook passes
                                                                                                                                                                                                                     
  ### Checklist                                                                                                                                                                                                      
   
  - [x] I have tested my changes locally                                                                                                                                                                             
  - [x] I have not included unrelated changes in this PR
