### PR TITLE
fix(opencode): make bash tool description parameter optional

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1300,6 +1300,22 @@ export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JS
   }
   */
 
+  // Ensure `required` is present when `properties` exists. Claude and other
+  // providers reject schemas that have properties but no required field.
+  const ensureRequired = (obj: unknown): unknown => {
+    if (obj === null || typeof obj !== "object" || Array.isArray(obj)) return obj
+    const node = obj as Record<string, unknown>
+    const result: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(node)) {
+      result[key] = typeof value === "object" && value !== null ? ensureRequired(value) : value
+    }
+    if (result.type === "object" && result.properties && !Array.isArray(result.required)) {
+      result.required = []
+    }
+    return result
+  }
+  schema = ensureRequired(schema) as JSONSchema.BaseSchema | JSONSchema7
+
   if (model.providerID === "moonshotai" || model.api.id.toLowerCase().includes("kimi")) {
     const sanitizeMoonshot = (obj: unknown): unknown => {
       if (obj === null || typeof obj !== "object") return obj


### PR DESCRIPTION
  ### Issue for this PR                                                                                                                                                                                              
                                          
  Closes #13618                                                                                                                                                                                                      
   
  ### Type of change                                                                                                                                                                                                 
                                          
  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  Claude and other providers reject tool schemas that have `properties` but no `required` field with: `JSON schema is invalid. It must match JSON Schema draft 2020-12`.                                             
   
  Plugin tools like `session_list` generate schemas with `properties` but no `required`. The existing code only handles this for Google/Gemini (filtering `required` in the Gemini sanitizer). Other providers get   
  the raw schema and reject it.           
                                                                                                                                                                                                                     
  The fix adds a recursive `ensureRequired` pass in `transform.ts` that sets `required: []` on any object schema missing it. Runs before any provider-specific sanitizers so all providers benefit.                  
   
  ### How did you verify your code works?                                                                                                                                                                            
                                          
  - `bun turbo typecheck` passes (12/12 packages)
  - Husky pre-push hook passes

  ### Checklist

  - [x] I have tested my changes locally                                                                                                                                                                             
  - [x] I have not included unrelated changes in this PR
