### PR TITLE
fix(ui): normalize shell output carriage returns

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1810,7 +1810,7 @@ ToolRegistry.register({
     const sawPending = pending()
     const text = createMemo(() => {
       const cmd = props.input.command ?? props.metadata.command ?? ""
-      const out = stripAnsi(props.output || props.metadata.output || "")
+      const out = stripAnsi(props.output || props.metadata.output || "").replace(/\r\n?/g, "\n")
       return `$ ${cmd}${out ? "\n\n" + out : ""}`
     })
     const [copied, setCopied] = createSignal(false)


### PR DESCRIPTION
## Summary
- Normalize carriage returns in web shell output so progress-style command output renders as separate lines.
- Matches the TUI-style display path without adding terminal emulation.

## Test
- `bun typecheck` from `packages/ui` in the main worktree