### PR TITLE
fix(sdk): add missing format field to SessionPromptData type

### DIFF
--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1401,6 +1401,18 @@ export type VcsInfo = {
   branch: string
 }
 
+export type OutputFormatText = {
+  type: "text"
+}
+
+export type OutputFormatJsonSchema = {
+  type: "json_schema"
+  schema: Record<string, unknown>
+  retryCount?: number
+}
+
+export type OutputFormat = OutputFormatText | OutputFormatJsonSchema
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -2595,6 +2607,7 @@ export type SessionPromptData = {
     tools?: {
       [key: string]: boolean
     }
+    format?: OutputFormat
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {


### PR DESCRIPTION
## Summary

Fixes a TypeScript type definition issue where the `format` field is missing from `SessionPromptData`, even though it exists in the OpenAPI spec and works at runtime.

## Problem

Users trying to use structured output with the SDK get TypeScript errors:

```typescript
const result = await client.session.prompt({
  path: { id: session.data?.id! },
  body: {
    parts: [{ type: "text", text: "Research Anthropic" }],
    format: {  // ❌ TypeScript error: format does not exist
      type: "json_schema",
      schema: { /* ... */ }
    }
  }
});
```

The OpenAPI spec (line 5254-5256 in `packages/sdk/openapi.json`) **does** include the `format` field:
```json
"format": {
  "$ref": "#/components/schemas/OutputFormat"
}
```

But the generated TypeScript types in `packages/sdk/js/src/gen/types.gen.ts` are missing:
- `OutputFormat` type
- `OutputFormatText` type  
- `OutputFormatJsonSchema` type
- `format` field in `SessionPromptData.body`

## Root Cause

The types are auto-generated from the OpenAPI spec, but the generation appears to have skipped these definitions. This could be:
1. A bug in the type generation tool (`@hey-api/openapi-ts`)
2. The generated types were not committed after a recent spec update
3. A configuration issue in the generation script

## Solution

Manually added the missing type definitions based on the OpenAPI spec:

```typescript
export type OutputFormatText = {
  type: "text"
}

export type OutputFormatJsonSchema = {
  type: "json_schema"
  schema: Record<string, unknown>
  retryCount?: number
}

export type OutputFormat = OutputFormatText | OutputFormatJsonSchema
```

And added the `format` field to `SessionPromptData.body`:
```typescript
body?: {
  // ... other fields
  format?: OutputFormat
  parts: Array<...>
}
```

## Changes

- **packages/sdk/js/src/gen/types.gen.ts**:
  - Added `OutputFormatText` type
  - Added `OutputFormatJsonSchema` type
  - Added `OutputFormat` union type
  - Added `format?: OutputFormat` field to `SessionPromptData.body`

## Testing

- The types match the OpenAPI spec definitions
- TypeScript users can now use the `format` parameter without type errors
- No runtime behavior changes (the API already supported this field)

## Notes

This is a manual fix. The proper long-term solution would be to:
1. Investigate why the type generation skipped these definitions
2. Re-run the generation script (`./packages/sdk/js/script/build.ts`) after fixing the root cause
3. Commit the regenerated types

However, since the generation script requires Bun and a full build environment, this manual fix provides immediate relief for users hitting this issue.

Fixes #26408