### PR TITLE
fix(tui): request root sessions in session dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -18,6 +18,20 @@ import { DialogSessionDeleteFailed } from "./dialog-session-delete-failed"
 import { WorkspaceLabel } from "./workspace-label"
 import { useCommandShortcut } from "../keymap"
 
+type SessionListFilter = {
+  scope?: "project"
+  path?: string
+}
+
+export function createDialogSessionListQuery(input: { query: string; filter: SessionListFilter }) {
+  return {
+    ...input.filter,
+    roots: true,
+    limit: input.query ? 30 : 100,
+    ...(input.query ? { search: input.query } : {}),
+  }
+}
+
 export function DialogSessionList() {
   const dialog = useDialog()
   const route = useRoute()
@@ -30,17 +44,16 @@ export function DialogSessionList() {
   const [search, setSearch] = createDebouncedSignal("", 150)
   const deleteHint = useCommandShortcut("session.delete")
 
-  const [searchResults, { refetch }] = createResource(
+  const [rootSessions, { refetch }] = createResource(
     () => ({ query: search(), filter: sync.session.query() }),
     async (input) => {
-      if (!input.query) return undefined
-      const result = await sdk.client.session.list({ search: input.query, limit: 30, ...input.filter })
+      const result = await sdk.client.session.list(createDialogSessionListQuery(input))
       return result.data ?? []
     },
   )
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
-  const sessions = createMemo(() => searchResults() ?? sync.data.session)
+  const sessions = createMemo(() => rootSessions() ?? sync.data.session.filter((x) => x.parentID === undefined))
 
   function recover(session: NonNullable<ReturnType<typeof sessions>[number]>) {
     const workspace = project.workspace.get(session.workspaceID!)
@@ -96,7 +109,7 @@ export function DialogSessionList() {
           }
           await project.workspace.sync()
           await sync.session.refresh()
-          if (search()) await refetch()
+          await refetch()
           if (info?.workspaceID === session.workspaceID) {
             route.navigate({ type: "home" })
           }
@@ -230,7 +243,7 @@ export function DialogSessionList() {
               if (status && status !== "connected") {
                 await sync.session.refresh()
               }
-              if (search()) await refetch()
+              await refetch()
               setToDelete(undefined)
               return
             }

--- a/packages/opencode/test/cli/tui/dialog-session-list.test.ts
+++ b/packages/opencode/test/cli/tui/dialog-session-list.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { createDialogSessionListQuery } from "@/cli/cmd/tui/component/dialog-session-list"
+
+test("dialog session list requests root sessions for the default picker", () => {
+  const query = createDialogSessionListQuery({ query: "", filter: { scope: "project" } })
+
+  expect(query).toEqual({ scope: "project", roots: true, limit: 100 })
+  expect("start" in query).toBe(false)
+  expect("search" in query).toBe(false)
+})
+
+test("dialog session search preserves scope filters while requesting root sessions", () => {
+  const query = createDialogSessionListQuery({ query: "deploy", filter: { path: "packages/opencode" } })
+
+  expect(query).toEqual({ path: "packages/opencode", roots: true, limit: 30, search: "deploy" })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #16270
Related: #13877, #25897, #23276

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The session switch dialog was rendering root sessions from the shared mixed session bootstrap list. In projects with many recent child/subagent sessions, the server-side limit can be filled before the dialog filters out child sessions, so root sessions disappear from `/sessions` even though `opencode session list` can still show them.

This keeps the shared `sync.data.session` bootstrap unchanged, because other TUI flows use it for parent/child navigation. The dialog now has its own root-session query for both the default picker and search results, preserving the current scope/path filter while passing `roots: true`.

The default dialog query asks for the latest 100 root sessions instead of reusing the bootstrap 30-day window. Search asks for the latest 30 matching root sessions. Delete and workspace recovery paths refetch the dialog root-session resource so the picker stays current.

### How did you verify your code works?

- `bun test test/cli/tui/dialog-session-list.test.ts test/server/session-list.test.ts test/server/httpapi-sdk.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run build`
- Manual driver: imported `createDialogSessionListQuery` and verified the default picker query is `{ scope: "project", roots: true, limit: 100 }` with no `start`/`search`, and the search query preserves path filters with `roots: true`, `limit: 30`, and `search`.

### Screenshots / recordings

N/A. This changes the session query used by the TUI dialog, not the rendered UI layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Authorship disclosure: prepared with AI assistance.
