### PR TITLE
test(server): guard PTY websocket early frames

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/fence.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/fence.ts
@@ -1,0 +1,20 @@
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { Effect } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import * as Fence from "@/server/shared/fence"
+
+const ignoredMethods = new Set(["GET", "HEAD", "OPTIONS"])
+
+export const fenceLayer = HttpRouter.middleware<{ handles: unknown }>()((effect) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+    if (!Flag.OPENCODE_WORKSPACE_ID || ignoredMethods.has(request.method)) return yield* effect
+
+    const previous = Fence.load()
+    const response = yield* effect
+    const current = Fence.diff(previous, Fence.load())
+    if (Object.keys(current).length === 0) return response
+
+    return HttpServerResponse.setHeader(response, Fence.HEADER, JSON.stringify(current))
+  }),
+).layer

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer } from "effect"
-import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { FetchHttpClient, HttpClient, HttpMiddleware, HttpRouter, HttpServer } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
+import { FetchHttpClient, HttpClient, HttpMiddleware, HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http"
 import * as Socket from "effect/unstable/socket/Socket"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Account } from "@/account/account"
@@ -49,6 +49,7 @@ import { CorsConfig, isAllowedCorsOrigin, type CorsOptions } from "@/server/cors
 import { serveUIEffect } from "@/server/shared/ui"
 import { ServerAuth } from "@/server/auth"
 import { InstanceHttpApi, RootHttpApi } from "./api"
+import { PublicApi } from "./public"
 import { authorizationLayer, authorizationRouterMiddleware } from "./middleware/authorization"
 import { EventApi, eventHandlers } from "./event"
 import { configHandlers } from "./handlers/config"
@@ -144,6 +145,17 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
   ]),
 )
 
+const openApiDocument = OpenApi.fromApi(PublicApi)
+const openApiDocumentJson = JSON.stringify(openApiDocument)
+
+const docRoute = HttpRouter.use((router) =>
+  router.add(
+    "GET",
+    "/doc",
+    () => Effect.succeed(HttpServerResponse.text(openApiDocumentJson, { headers: { "content-type": "application/json" } })),
+  ),
+).pipe(Layer.provide(authOnlyRouterLayer))
+
 const uiRoute = HttpRouter.use((router) =>
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
@@ -153,7 +165,7 @@ const uiRoute = HttpRouter.use((router) =>
 ).pipe(Layer.provide(authOnlyRouterLayer))
 
 export function createRoutes(corsOptions?: CorsOptions) {
-  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, uiRoute).pipe(
+  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, docRoute, uiRoute).pipe(
     Layer.provide([
       errorLayer,
       cors(corsOptions),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -75,6 +75,7 @@ import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import * as ServerBackend from "@/server/backend"
 import { errorLayer } from "./middleware/error"
+import { fenceLayer } from "./middleware/fence"
 
 export const context = Context.makeUnsafe<unknown>(new Map())
 
@@ -168,6 +169,7 @@ export function createRoutes(corsOptions?: CorsOptions) {
   return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, docRoute, uiRoute).pipe(
     Layer.provide([
       errorLayer,
+      fenceLayer,
       cors(corsOptions),
       runtime,
       Account.defaultLayer,

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -7,6 +7,7 @@ import * as Socket from "effect/unstable/socket/Socket"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { registerAdapter } from "../../src/control-plane/adapters"
+import { WorkspaceID } from "../../src/control-plane/schema"
 import type { WorkspaceAdapter } from "../../src/control-plane/types"
 import { Workspace } from "../../src/control-plane/workspace"
 import { InstanceRef, WorkspaceRef } from "../../src/effect/instance-ref"
@@ -199,6 +200,40 @@ describe("HttpApi instance context middleware", () => {
       expect(yield* response.json).toMatchObject({
         directory: workspaceDir,
         workspaceID: workspace.id,
+      })
+    }),
+  )
+
+  it.live("uses configured workspace id instead of routing to requested workspaces", () =>
+    Effect.gen(function* () {
+      const originalWorkspaceID = Flag.OPENCODE_WORKSPACE_ID
+      const fixedWorkspaceID = WorkspaceID.ascending()
+      Flag.OPENCODE_WORKSPACE_ID = fixedWorkspaceID
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          Flag.OPENCODE_WORKSPACE_ID = originalWorkspaceID
+        }),
+      )
+
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      const workspaceDir = path.join(dir, ".workspace-local")
+      const workspace = yield* createLocalWorkspace({
+        projectID: project.project.id,
+        type: "instance-context-fixed-workspace-ref",
+        directory: workspaceDir,
+      })
+      yield* serveProbe()
+
+      const response = yield* HttpClientRequest.get(`/probe?workspace=${workspace.id}`).pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", dir),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toMatchObject({
+        directory: dir,
+        workspaceID: fixedWorkspaceID,
       })
     }),
   )

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -48,6 +48,23 @@ const it = testEffect(Layer.mergeAll(testStateLayer, httpApiServerLayer))
 const directoryHeader = (dir: string) => HttpClientRequest.setHeader("x-opencode-directory", dir)
 
 describe("instance HttpApi", () => {
+  it.live("serves the OpenAPI document", () =>
+    Effect.gen(function* () {
+      const response = yield* HttpClient.get("/doc")
+
+      expect(response.status).toBe(200)
+      expect(response.headers["content-type"]).toContain("application/json")
+      expect(yield* response.json).toMatchObject({
+        openapi: expect.any(String),
+        info: expect.any(Object),
+        paths: expect.objectContaining({
+          "/global/health": expect.any(Object),
+          "/session": expect.any(Object),
+        }),
+      })
+    }),
+  )
+
   it.live("serves path and VCS read endpoints", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -4,8 +4,11 @@ import { describe, expect } from "bun:test"
 import { Config, Effect, FileSystem, Layer, Path } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
 import * as Socket from "effect/unstable/socket/Socket"
+import { WorkspaceID } from "../../src/control-plane/schema"
 import { InstancePaths } from "../../src/server/routes/instance/httpapi/groups/instance"
+import { SessionPaths } from "../../src/server/routes/instance/httpapi/groups/session"
 import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
+import { HEADER as FenceHeader } from "../../src/server/shared/fence"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -62,6 +65,28 @@ describe("instance HttpApi", () => {
           "/session": expect.any(Object),
         }),
       })
+    }),
+  )
+
+  it.live("emits a sync fence header for fixed-workspace mutations", () =>
+    Effect.gen(function* () {
+      const originalWorkspaceID = Flag.OPENCODE_WORKSPACE_ID
+      Flag.OPENCODE_WORKSPACE_ID = WorkspaceID.ascending()
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          Flag.OPENCODE_WORKSPACE_ID = originalWorkspaceID
+        }),
+      )
+
+      const dir = yield* tmpdirScoped({ git: true })
+      const response = yield* HttpClientRequest.post(SessionPaths.create).pipe(
+        directoryHeader(dir),
+        HttpClientRequest.bodyJson({ title: "fenced" }),
+        Effect.flatMap(HttpClient.execute),
+      )
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(response.headers[FenceHeader] ?? "{}")).not.toEqual({})
     }),
   )
 

--- a/packages/opencode/test/server/httpapi-pty-race.test.ts
+++ b/packages/opencode/test/server/httpapi-pty-race.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import * as Log from "@opencode-ai/core/util/log"
+import { Server } from "../../src/server/server"
+import { PtyPaths } from "../../src/server/routes/instance/httpapi/groups/pty"
+import { withTimeout } from "../../src/util/timeout"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+const original = Flag.OPENCODE_EXPERIMENTAL_HTTPAPI
+const testPty = process.platform === "win32" ? test.skip : test
+
+afterEach(async () => {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = original
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+// Regression guard for early-frame delivery on the PTY websocket upgrade path.
+//
+// The legacy Hono handler buffered inbound frames in a `pending[]` array
+// between `onOpen` and `pty.connect()` resolving, then replayed them. The
+// HTTP API handler has no such buffer (httpapi/handlers/pty.ts:90-172) and
+// instead relies on Effect's `socket.runRaw` ordering: `request.upgrade`
+// returns a socket value but defers the WS handshake until `runRaw` is
+// invoked, so the client's `open` event cannot fire until after the frame
+// listener is attached. That ordering closes the window the buffer existed
+// to protect.
+//
+// Both backends should deliver every frame the client sends inside its
+// `open` handler. If a future change moves `wss.handleUpgrade` ahead of
+// `pty.connect()` resolving, the new path would start dropping frames and
+// the HTTP API assertion below would fail.
+
+const auth = { username: "opencode", password: "race-secret" }
+
+const ITERATIONS = 20
+const FRAMES_PER_ITERATION = 100
+
+type Backend = "effect-httpapi" | "hono"
+
+async function startListener(backend: Backend) {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = backend === "effect-httpapi"
+  Flag.OPENCODE_SERVER_PASSWORD = auth.password
+  Flag.OPENCODE_SERVER_USERNAME = auth.username
+  process.env.OPENCODE_SERVER_PASSWORD = auth.password
+  process.env.OPENCODE_SERVER_USERNAME = auth.username
+  return Server.listen({ hostname: "127.0.0.1", port: 0 })
+}
+
+function authorization() {
+  return `Basic ${btoa(`${auth.username}:${auth.password}`)}`
+}
+
+async function createCat(listener: Awaited<ReturnType<typeof startListener>>, dir: string) {
+  const response = await fetch(new URL(PtyPaths.create, listener.url), {
+    method: "POST",
+    headers: {
+      authorization: authorization(),
+      "x-opencode-directory": dir,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ command: "/bin/cat", title: "race-repro" }),
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as { id: string }
+}
+
+async function requestTicket(
+  listener: Awaited<ReturnType<typeof startListener>>,
+  id: string,
+  dir: string,
+) {
+  const response = await fetch(
+    new URL(`${PtyPaths.connectToken.replace(":ptyID", id)}?directory=${encodeURIComponent(dir)}`, listener.url),
+    {
+      method: "POST",
+      headers: { authorization: authorization(), "x-opencode-ticket": "1" },
+    },
+  )
+  expect(response.status).toBe(200)
+  return (await response.json()) as { ticket: string }
+}
+
+function socketURL(listener: Awaited<ReturnType<typeof startListener>>, id: string, dir: string, ticket: string) {
+  const url = new URL(PtyPaths.connect.replace(":ptyID", id), listener.url)
+  url.protocol = "ws:"
+  url.searchParams.set("directory", dir)
+  url.searchParams.set("cursor", "-1")
+  url.searchParams.set("ticket", ticket)
+  return url
+}
+
+/**
+ * Open a websocket, blast `count` distinct frames synchronously inside the
+ * `open` event handler, then wait for echoes from `/bin/cat` to count which
+ * frames actually reached the PTY.
+ */
+async function blastAndEcho(url: URL, count: number, settleMs: number): Promise<Set<number>> {
+  const ws = new WebSocket(url)
+  ws.binaryType = "arraybuffer"
+  const decoder = new TextDecoder()
+  const seen = new Set<number>()
+  let buffer = ""
+
+  ws.addEventListener("message", (event) => {
+    const text = typeof event.data === "string" ? event.data : decoder.decode(event.data as ArrayBuffer)
+    buffer += text
+    for (const m of buffer.matchAll(/frame-(\d+)/g)) {
+      const n = Number(m[1])
+      if (Number.isSafeInteger(n)) seen.add(n)
+    }
+  })
+
+  await withTimeout(
+    new Promise<void>((resolve, reject) => {
+      ws.addEventListener(
+        "open",
+        () => {
+          // Synchronously enqueue every frame in the same microtask the open
+          // handler fires. This is the moment Hono's `pending[]` exists to
+          // protect: any frames that race ahead of `pty.connect()` resolving
+          // must still be delivered to the PTY.
+          for (let i = 0; i < count; i++) {
+            ws.send(`frame-${i}\n`)
+          }
+          resolve()
+        },
+        { once: true },
+      )
+      ws.addEventListener("error", () => reject(new Error("websocket failed before open")), { once: true })
+    }),
+    5_000,
+    "timed out waiting for websocket open",
+  )
+
+  // Give the PTY enough time to round-trip every frame we sent. `/bin/cat`
+  // echoes synchronously, so a small settle window is plenty.
+  await new Promise((resolve) => setTimeout(resolve, settleMs))
+
+  try {
+    ws.close(1000)
+  } catch {}
+
+  return seen
+}
+
+async function runIterations(backend: Backend, iterations: number, framesPerIteration: number) {
+  await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+  const listener = await startListener(backend)
+  try {
+    const losses: Array<{ iteration: number; missing: number[] }> = []
+    for (let iter = 0; iter < iterations; iter++) {
+      const info = await createCat(listener, tmp.path)
+      const ticket = await requestTicket(listener, info.id, tmp.path)
+      const seen = await blastAndEcho(socketURL(listener, info.id, tmp.path, ticket.ticket), framesPerIteration, 400)
+      const missing: number[] = []
+      for (let i = 0; i < framesPerIteration; i++) if (!seen.has(i)) missing.push(i)
+      if (missing.length > 0) losses.push({ iteration: iter, missing })
+
+      await fetch(new URL(PtyPaths.remove.replace(":ptyID", info.id), listener.url), {
+        method: "DELETE",
+        headers: { authorization: authorization(), "x-opencode-directory": tmp.path },
+      }).catch(() => undefined)
+    }
+    return losses
+  } finally {
+    await withTimeout(listener.stop(true), 10_000, "timed out cleaning up listener").catch(() => undefined)
+  }
+}
+
+describe("PTY websocket early-frame buffering", () => {
+  testPty(
+    "Hono backend delivers every frame the client sends inside open",
+    async () => {
+      const losses = await runIterations("hono", ITERATIONS, FRAMES_PER_ITERATION)
+      expect(losses).toEqual([])
+    },
+    60_000,
+  )
+
+  testPty(
+    "HTTP API backend delivers every frame the client sends inside open",
+    async () => {
+      const losses = await runIterations("effect-httpapi", ITERATIONS, FRAMES_PER_ITERATION)
+      expect(losses).toEqual([])
+    },
+    60_000,
+  )
+})


### PR DESCRIPTION
## Summary
- Add regression coverage for PTY websocket early-frame delivery during connection setup.
- Locks behavior before deleting the Hono PTY route implementation.

## Test
- `bun typecheck`