### PR TITLE
test(server): cover REST API project skills

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
@@ -1,0 +1,64 @@
+import { deflateSync, gzipSync } from "node:zlib"
+import { Effect } from "effect"
+import { HttpBody, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+
+// Mirror of Hono's compressible content-type set so wire behavior matches.
+const COMPRESSIBLE_CONTENT_TYPE_REGEX =
+  /^\s*(?:text\/(?!event-stream(?:[;\s]|$))[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|x-ns-proxy-autoconfig|x-sh|x-tar|x-www-form-urlencoded)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i
+
+const NO_TRANSFORM_REGEX = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
+
+const STREAMING_PATHS = new Set(["/event", "/global/event"])
+const STREAMING_POST_REGEX = /^\/session\/[^/]+\/(?:message|prompt_async)$/
+
+const THRESHOLD_BYTES = 1024
+
+type Encoding = "gzip" | "deflate"
+
+function pickEncoding(acceptEncoding: string | undefined): Encoding | undefined {
+  if (!acceptEncoding) return undefined
+  const lower = acceptEncoding.toLowerCase()
+  if (lower.includes("gzip")) return "gzip"
+  if (lower.includes("deflate")) return "deflate"
+  return undefined
+}
+
+function pathOf(url: string): string {
+  const queryIndex = url.indexOf("?")
+  return queryIndex === -1 ? url : url.slice(0, queryIndex)
+}
+
+export const compressionLayer = HttpRouter.middleware<{ handles: unknown }>()((effect) =>
+  Effect.gen(function* () {
+    const response = yield* effect
+    const request = yield* HttpServerRequest.HttpServerRequest
+
+    if (request.method === "HEAD") return response
+    if (response.headers["content-encoding"]) return response
+    if (response.headers["transfer-encoding"]) return response
+
+    const body = response.body
+    if (body._tag !== "Uint8Array") return response
+    if (body.body.byteLength < THRESHOLD_BYTES) return response
+
+    const cacheControl = response.headers["cache-control"]
+    if (cacheControl && NO_TRANSFORM_REGEX.test(cacheControl)) return response
+
+    const path = pathOf(request.url)
+    if (STREAMING_PATHS.has(path)) return response
+    if (request.method === "POST" && STREAMING_POST_REGEX.test(path)) return response
+
+    const contentType = body.contentType
+    if (!COMPRESSIBLE_CONTENT_TYPE_REGEX.test(contentType)) return response
+
+    const encoding = pickEncoding(request.headers["accept-encoding"])
+    if (!encoding) return response
+
+    const compressed = encoding === "gzip" ? gzipSync(body.body) : deflateSync(body.body)
+    return HttpServerResponse.setHeader(
+      HttpServerResponse.setBody(response, HttpBody.uint8Array(compressed, contentType)),
+      "content-encoding",
+      encoding,
+    )
+  }),
+).layer

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/cors-vary.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/cors-vary.ts
@@ -1,0 +1,29 @@
+import { Effect } from "effect"
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
+
+// effect-smol's HttpMiddleware.cors builds OPTIONS preflight responses by
+// spreading allowOrigin() and allowHeaders() into the same record. Both set
+// the `vary` key, so allowHeaders' `Vary: Access-Control-Request-Headers`
+// overwrites allowOrigin's `Vary: Origin`. With dynamic origin echoing, the
+// missing `Vary: Origin` lets shared caches reuse a preflight cached for one
+// origin against a different origin.
+//
+// TODO: upstream a fix that merges Vary values in headersFromRequestOptions
+// (packages/effect/src/unstable/http/HttpMiddleware.ts ~line 332).
+export const corsVaryFix = HttpRouter.middleware(
+  (effect) =>
+    Effect.gen(function* () {
+      const response = yield* effect
+      const allowOrigin = response.headers["access-control-allow-origin"]
+      if (!allowOrigin || allowOrigin === "*") return response
+
+      const vary = response.headers["vary"]
+      if (!vary) return HttpServerResponse.setHeader(response, "vary", "Origin")
+
+      const tokens = vary.split(",").map((s) => s.trim().toLowerCase())
+      if (tokens.includes("origin") || tokens.includes("*")) return response
+
+      return HttpServerResponse.setHeader(response, "vary", `${vary}, Origin`)
+    }),
+  { global: true },
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/fence.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/fence.ts
@@ -1,0 +1,20 @@
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { Effect } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import * as Fence from "@/server/shared/fence"
+
+const ignoredMethods = new Set(["GET", "HEAD", "OPTIONS"])
+
+export const fenceLayer = HttpRouter.middleware<{ handles: unknown }>()((effect) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+    if (!Flag.OPENCODE_WORKSPACE_ID || ignoredMethods.has(request.method)) return yield* effect
+
+    const previous = Fence.load()
+    const response = yield* effect
+    const current = Fence.diff(previous, Fence.load())
+    if (Object.keys(current).length === 0) return response
+
+    return HttpServerResponse.setHeader(response, Fence.HEADER, JSON.stringify(current))
+  }),
+).layer

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer } from "effect"
-import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { FetchHttpClient, HttpClient, HttpMiddleware, HttpRouter, HttpServer } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
+import { FetchHttpClient, HttpClient, HttpMiddleware, HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http"
 import * as Socket from "effect/unstable/socket/Socket"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Account } from "@/account/account"
@@ -49,6 +49,7 @@ import { CorsConfig, isAllowedCorsOrigin, type CorsOptions } from "@/server/cors
 import { serveUIEffect } from "@/server/shared/ui"
 import { ServerAuth } from "@/server/auth"
 import { InstanceHttpApi, RootHttpApi } from "./api"
+import { PublicApi } from "./public"
 import { authorizationLayer, authorizationRouterMiddleware } from "./middleware/authorization"
 import { EventApi, eventHandlers } from "./event"
 import { configHandlers } from "./handlers/config"
@@ -144,6 +145,17 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
   ]),
 )
 
+const openApiDocument = OpenApi.fromApi(PublicApi)
+const openApiDocumentJson = JSON.stringify(openApiDocument)
+
+const docRoute = HttpRouter.use((router) =>
+  router.add(
+    "GET",
+    "/doc",
+    () => Effect.succeed(HttpServerResponse.text(openApiDocumentJson, { headers: { "content-type": "application/json" } })),
+  ),
+).pipe(Layer.provide(authOnlyRouterLayer))
+
 const uiRoute = HttpRouter.use((router) =>
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
@@ -153,7 +165,7 @@ const uiRoute = HttpRouter.use((router) =>
 ).pipe(Layer.provide(authOnlyRouterLayer))
 
 export function createRoutes(corsOptions?: CorsOptions) {
-  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, uiRoute).pipe(
+  return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, docRoute, uiRoute).pipe(
     Layer.provide([
       errorLayer,
       cors(corsOptions),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -74,6 +74,7 @@ import { workspaceRouterMiddleware, workspaceRoutingLayer } from "./middleware/w
 import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import * as ServerBackend from "@/server/backend"
+import { compressionLayer } from "./middleware/compression"
 import { errorLayer } from "./middleware/error"
 import { fenceLayer } from "./middleware/fence"
 
@@ -169,6 +170,7 @@ export function createRoutes(corsOptions?: CorsOptions) {
   return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, docRoute, uiRoute).pipe(
     Layer.provide([
       errorLayer,
+      compressionLayer,
       fenceLayer,
       cors(corsOptions),
       runtime,

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -75,6 +75,7 @@ import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import * as ServerBackend from "@/server/backend"
 import { errorLayer } from "./middleware/error"
+import { fenceLayer } from "./middleware/fence"
 
 export const context = Context.makeUnsafe<unknown>(new Map())
 
@@ -168,6 +169,7 @@ export function createRoutes(corsOptions?: CorsOptions) {
   return Layer.mergeAll(rootApiRoutes, eventApiRoutes, instanceRoutes, docRoute, uiRoute).pipe(
     Layer.provide([
       errorLayer,
+      fenceLayer,
       cors(corsOptions),
       runtime,
       Account.defaultLayer,

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -75,6 +75,7 @@ import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import * as ServerBackend from "@/server/backend"
 import { compressionLayer } from "./middleware/compression"
+import { corsVaryFix } from "./middleware/cors-vary"
 import { errorLayer } from "./middleware/error"
 import { fenceLayer } from "./middleware/fence"
 
@@ -171,6 +172,7 @@ export function createRoutes(corsOptions?: CorsOptions) {
     Layer.provide([
       errorLayer,
       compressionLayer,
+      corsVaryFix,
       fenceLayer,
       cors(corsOptions),
       runtime,

--- a/packages/opencode/test/server/httpapi-compression.test.ts
+++ b/packages/opencode/test/server/httpapi-compression.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { gunzipSync, inflateSync } from "node:zlib"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import * as Log from "@opencode-ai/core/util/log"
+import { Server } from "../../src/server/server"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+const original = Flag.OPENCODE_EXPERIMENTAL_HTTPAPI
+
+afterEach(async () => {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = original
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+function app() {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+  return Server.Default().app
+}
+
+// /config echoes the config back. Padding the config pushes the response body
+// well past the 1024 B threshold so we can observe compression behavior.
+function fatConfig() {
+  const instructions: string[] = []
+  for (let i = 0; i < 50; i++) {
+    instructions.push(`padding-instruction-${i}-${"x".repeat(40)}`)
+  }
+  return {
+    formatter: false,
+    lsp: false,
+    username: "compression-test-user",
+    instructions,
+  }
+}
+
+describe("HttpApi compression", () => {
+  describe("encodes responses", () => {
+    test("gzips JSON when Accept-Encoding includes gzip and body exceeds threshold", async () => {
+      await using tmp = await tmpdir({ config: fatConfig() })
+      const response = await app().request("/config", {
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "gzip" },
+      })
+      expect(response.status).toBe(200)
+      expect(response.headers.get("content-encoding")).toBe("gzip")
+      const compressed = new Uint8Array(await response.arrayBuffer())
+      const decompressed = gunzipSync(compressed)
+      const json = JSON.parse(new TextDecoder().decode(decompressed))
+      expect(json).toMatchObject({ username: "compression-test-user" })
+      expect(compressed.byteLength).toBeLessThan(decompressed.byteLength)
+    })
+
+    test("uses deflate when only deflate is acceptable", async () => {
+      await using tmp = await tmpdir({ config: fatConfig() })
+      const response = await app().request("/config", {
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "deflate" },
+      })
+      expect(response.status).toBe(200)
+      expect(response.headers.get("content-encoding")).toBe("deflate")
+      const compressed = new Uint8Array(await response.arrayBuffer())
+      const decompressed = inflateSync(compressed)
+      const json = JSON.parse(new TextDecoder().decode(decompressed))
+      expect(json).toMatchObject({ username: "compression-test-user" })
+    })
+
+    test("prefers gzip when both gzip and deflate are acceptable", async () => {
+      await using tmp = await tmpdir({ config: fatConfig() })
+      const response = await app().request("/config", {
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "gzip, deflate" },
+      })
+      expect(response.headers.get("content-encoding")).toBe("gzip")
+    })
+
+    test("does not include the original Content-Length when compressed", async () => {
+      await using tmp = await tmpdir({ config: fatConfig() })
+      const response = await app().request("/config", {
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "gzip" },
+      })
+      const compressed = new Uint8Array(await response.arrayBuffer())
+      const declared = response.headers.get("content-length")
+      // Either absent (transfer-encoding chunked) or matches the compressed length.
+      if (declared !== null) expect(Number(declared)).toBe(compressed.byteLength)
+    })
+  })
+
+  describe("skips", () => {
+    test("when no Accept-Encoding header is present", async () => {
+      await using tmp = await tmpdir({ config: fatConfig() })
+      const response = await app().request("/config", {
+        headers: { "x-opencode-directory": tmp.path },
+      })
+      expect(response.headers.get("content-encoding")).toBeNull()
+    })
+
+    test("when Accept-Encoding only allows unsupported encodings", async () => {
+      await using tmp = await tmpdir({ config: fatConfig() })
+      const response = await app().request("/config", {
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "br" },
+      })
+      expect(response.headers.get("content-encoding")).toBeNull()
+    })
+
+    test("when the response body is below the 1024-byte threshold", async () => {
+      // A bare config produces a tiny response (~few hundred bytes).
+      await using tmp = await tmpdir({ config: { formatter: false, lsp: false } })
+      const response = await app().request("/config", {
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "gzip" },
+      })
+      expect(response.status).toBe(200)
+      const body = new Uint8Array(await response.arrayBuffer())
+      expect(body.byteLength).toBeLessThan(1024)
+      expect(response.headers.get("content-encoding")).toBeNull()
+    })
+
+    test("HEAD requests", async () => {
+      await using tmp = await tmpdir({ config: fatConfig() })
+      const response = await app().request("/config", {
+        method: "HEAD",
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "gzip" },
+      })
+      expect(response.headers.get("content-encoding")).toBeNull()
+    })
+  })
+
+  describe("streaming exclusions", () => {
+    test("/event SSE is not compressed", async () => {
+      await using tmp = await tmpdir({ config: { formatter: false, lsp: false } })
+      const controller = new AbortController()
+      const response = await app().request("/event", {
+        headers: { "x-opencode-directory": tmp.path, "accept-encoding": "gzip" },
+        signal: controller.signal,
+      })
+      try {
+        expect(response.status).toBe(200)
+        expect(response.headers.get("content-encoding")).toBeNull()
+      } finally {
+        controller.abort()
+        await response.body?.cancel().catch(() => {})
+      }
+    })
+
+    test("/global/event SSE is not compressed", async () => {
+      const controller = new AbortController()
+      const response = await app().request("/global/event", {
+        headers: { "accept-encoding": "gzip" },
+        signal: controller.signal,
+      })
+      try {
+        expect(response.status).toBe(200)
+        expect(response.headers.get("content-encoding")).toBeNull()
+      } finally {
+        controller.abort()
+        await response.body?.cancel().catch(() => {})
+      }
+    })
+  })
+})

--- a/packages/opencode/test/server/httpapi-cors-vary.test.ts
+++ b/packages/opencode/test/server/httpapi-cors-vary.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import * as Log from "@opencode-ai/core/util/log"
+import { Server } from "../../src/server/server"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+const original = Flag.OPENCODE_EXPERIMENTAL_HTTPAPI
+
+afterEach(async () => {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = original
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+function app(experimental: boolean) {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = experimental
+  return experimental ? Server.Default().app : Server.Legacy().app
+}
+
+const PREFLIGHT_HEADERS = {
+  origin: "http://localhost:3000",
+  "access-control-request-method": "POST",
+  "access-control-request-headers": "content-type, x-opencode-directory",
+}
+
+// effect-smol's HttpMiddleware.cors overwrites `Vary: Origin` with
+// `Vary: Access-Control-Request-Headers` on OPTIONS preflight responses
+// (the two share the same record key during the spread). With dynamic
+// origin echoing, missing Vary: Origin lets shared caches serve a preflight
+// cached for one origin against a different origin. corsVaryFixLayer
+// restores the merged form.
+describe("CORS preflight Vary header", () => {
+  test("Hono backend preflight Vary contains Origin", async () => {
+    const response = await app(false).request("/global/config", {
+      method: "OPTIONS",
+      headers: PREFLIGHT_HEADERS,
+    })
+
+    expect([200, 204]).toContain(response.status)
+    expect(response.headers.get("access-control-allow-origin")).toBe("http://localhost:3000")
+    expect((response.headers.get("vary") ?? "").toLowerCase()).toContain("origin")
+  })
+
+  test("HTTP API backend preflight Vary contains Origin", async () => {
+    const response = await app(true).request("/global/config", {
+      method: "OPTIONS",
+      headers: PREFLIGHT_HEADERS,
+    })
+
+    expect([200, 204]).toContain(response.status)
+    expect(response.headers.get("access-control-allow-origin")).toBe("http://localhost:3000")
+    expect((response.headers.get("vary") ?? "").toLowerCase()).toContain("origin")
+  })
+
+  test("HTTP API backend preflight Vary still preserves Access-Control-Request-Headers", async () => {
+    const response = await app(true).request("/global/config", {
+      method: "OPTIONS",
+      headers: PREFLIGHT_HEADERS,
+    })
+
+    const vary = (response.headers.get("vary") ?? "").toLowerCase()
+    expect(vary).toContain("origin")
+    expect(vary).toContain("access-control-request-headers")
+  })
+
+  test("HTTP API backend does not duplicate Origin in Vary", async () => {
+    const response = await app(true).request("/global/config", {
+      method: "OPTIONS",
+      headers: PREFLIGHT_HEADERS,
+    })
+
+    const vary = response.headers.get("vary") ?? ""
+    const originCount = vary
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => s === "origin").length
+    expect(originCount).toBe(1)
+  })
+})

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -7,6 +7,7 @@ import * as Socket from "effect/unstable/socket/Socket"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { registerAdapter } from "../../src/control-plane/adapters"
+import { WorkspaceID } from "../../src/control-plane/schema"
 import type { WorkspaceAdapter } from "../../src/control-plane/types"
 import { Workspace } from "../../src/control-plane/workspace"
 import { InstanceRef, WorkspaceRef } from "../../src/effect/instance-ref"
@@ -199,6 +200,40 @@ describe("HttpApi instance context middleware", () => {
       expect(yield* response.json).toMatchObject({
         directory: workspaceDir,
         workspaceID: workspace.id,
+      })
+    }),
+  )
+
+  it.live("uses configured workspace id instead of routing to requested workspaces", () =>
+    Effect.gen(function* () {
+      const originalWorkspaceID = Flag.OPENCODE_WORKSPACE_ID
+      const fixedWorkspaceID = WorkspaceID.ascending()
+      Flag.OPENCODE_WORKSPACE_ID = fixedWorkspaceID
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          Flag.OPENCODE_WORKSPACE_ID = originalWorkspaceID
+        }),
+      )
+
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      const workspaceDir = path.join(dir, ".workspace-local")
+      const workspace = yield* createLocalWorkspace({
+        projectID: project.project.id,
+        type: "instance-context-fixed-workspace-ref",
+        directory: workspaceDir,
+      })
+      yield* serveProbe()
+
+      const response = yield* HttpClientRequest.get(`/probe?workspace=${workspace.id}`).pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", dir),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toMatchObject({
+        directory: dir,
+        workspaceID: fixedWorkspaceID,
       })
     }),
   )

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -48,6 +48,23 @@ const it = testEffect(Layer.mergeAll(testStateLayer, httpApiServerLayer))
 const directoryHeader = (dir: string) => HttpClientRequest.setHeader("x-opencode-directory", dir)
 
 describe("instance HttpApi", () => {
+  it.live("serves the OpenAPI document", () =>
+    Effect.gen(function* () {
+      const response = yield* HttpClient.get("/doc")
+
+      expect(response.status).toBe(200)
+      expect(response.headers["content-type"]).toContain("application/json")
+      expect(yield* response.json).toMatchObject({
+        openapi: expect.any(String),
+        info: expect.any(Object),
+        paths: expect.objectContaining({
+          "/global/health": expect.any(Object),
+          "/session": expect.any(Object),
+        }),
+      })
+    }),
+  )
+
   it.live("serves path and VCS read endpoints", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -4,8 +4,11 @@ import { describe, expect } from "bun:test"
 import { Config, Effect, FileSystem, Layer, Path } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
 import * as Socket from "effect/unstable/socket/Socket"
+import { WorkspaceID } from "../../src/control-plane/schema"
 import { InstancePaths } from "../../src/server/routes/instance/httpapi/groups/instance"
+import { SessionPaths } from "../../src/server/routes/instance/httpapi/groups/session"
 import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
+import { HEADER as FenceHeader } from "../../src/server/shared/fence"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -62,6 +65,28 @@ describe("instance HttpApi", () => {
           "/session": expect.any(Object),
         }),
       })
+    }),
+  )
+
+  it.live("emits a sync fence header for fixed-workspace mutations", () =>
+    Effect.gen(function* () {
+      const originalWorkspaceID = Flag.OPENCODE_WORKSPACE_ID
+      Flag.OPENCODE_WORKSPACE_ID = WorkspaceID.ascending()
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          Flag.OPENCODE_WORKSPACE_ID = originalWorkspaceID
+        }),
+      )
+
+      const dir = yield* tmpdirScoped({ git: true })
+      const response = yield* HttpClientRequest.post(SessionPaths.create).pipe(
+        directoryHeader(dir),
+        HttpClientRequest.bodyJson({ title: "fenced" }),
+        Effect.flatMap(HttpClient.execute),
+      )
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(response.headers[FenceHeader] ?? "{}")).not.toEqual({})
     }),
   )
 

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -5,6 +5,7 @@ import { Config, Effect, FileSystem, Layer, Path } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
 import * as Socket from "effect/unstable/socket/Socket"
 import { WorkspaceID } from "../../src/control-plane/schema"
+import { ControlPaths } from "../../src/server/routes/instance/httpapi/groups/control"
 import { InstancePaths } from "../../src/server/routes/instance/httpapi/groups/instance"
 import { SessionPaths } from "../../src/server/routes/instance/httpapi/groups/session"
 import { ExperimentalHttpApiServer } from "../../src/server/routes/instance/httpapi/server"
@@ -87,6 +88,31 @@ describe("instance HttpApi", () => {
 
       expect(response.status).toBe(200)
       expect(JSON.parse(response.headers[FenceHeader] ?? "{}")).not.toEqual({})
+    }),
+  )
+
+  it.live("does not emit sync fence headers for fixed-workspace reads or no-op mutations", () =>
+    Effect.gen(function* () {
+      const originalWorkspaceID = Flag.OPENCODE_WORKSPACE_ID
+      Flag.OPENCODE_WORKSPACE_ID = WorkspaceID.ascending()
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          Flag.OPENCODE_WORKSPACE_ID = originalWorkspaceID
+        }),
+      )
+
+      const dir = yield* tmpdirScoped({ git: true })
+      const read = yield* HttpClientRequest.get(InstancePaths.path).pipe(directoryHeader(dir), HttpClient.execute)
+      const log = yield* HttpClientRequest.post(ControlPaths.log).pipe(
+        directoryHeader(dir),
+        HttpClientRequest.bodyJson({ service: "fence-test", level: "info", message: "noop" }),
+        Effect.flatMap(HttpClient.execute),
+      )
+
+      expect(read.status).toBe(200)
+      expect(read.headers[FenceHeader]).toBeUndefined()
+      expect(log.status).toBe(200)
+      expect(log.headers[FenceHeader]).toBeUndefined()
     }),
   )
 

--- a/packages/opencode/test/server/httpapi-pty-race.test.ts
+++ b/packages/opencode/test/server/httpapi-pty-race.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import * as Log from "@opencode-ai/core/util/log"
+import { Server } from "../../src/server/server"
+import { PtyPaths } from "../../src/server/routes/instance/httpapi/groups/pty"
+import { withTimeout } from "../../src/util/timeout"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+const original = Flag.OPENCODE_EXPERIMENTAL_HTTPAPI
+const testPty = process.platform === "win32" ? test.skip : test
+
+afterEach(async () => {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = original
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+// Regression guard for early-frame delivery on the PTY websocket upgrade path.
+//
+// The legacy Hono handler buffered inbound frames in a `pending[]` array
+// between `onOpen` and `pty.connect()` resolving, then replayed them. The
+// HTTP API handler has no such buffer (httpapi/handlers/pty.ts:90-172) and
+// instead relies on Effect's `socket.runRaw` ordering: `request.upgrade`
+// returns a socket value but defers the WS handshake until `runRaw` is
+// invoked, so the client's `open` event cannot fire until after the frame
+// listener is attached. That ordering closes the window the buffer existed
+// to protect.
+//
+// Both backends should deliver every frame the client sends inside its
+// `open` handler. If a future change moves `wss.handleUpgrade` ahead of
+// `pty.connect()` resolving, the new path would start dropping frames and
+// the HTTP API assertion below would fail.
+
+const auth = { username: "opencode", password: "race-secret" }
+
+const ITERATIONS = 20
+const FRAMES_PER_ITERATION = 100
+
+type Backend = "effect-httpapi" | "hono"
+
+async function startListener(backend: Backend) {
+  Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = backend === "effect-httpapi"
+  Flag.OPENCODE_SERVER_PASSWORD = auth.password
+  Flag.OPENCODE_SERVER_USERNAME = auth.username
+  process.env.OPENCODE_SERVER_PASSWORD = auth.password
+  process.env.OPENCODE_SERVER_USERNAME = auth.username
+  return Server.listen({ hostname: "127.0.0.1", port: 0 })
+}
+
+function authorization() {
+  return `Basic ${btoa(`${auth.username}:${auth.password}`)}`
+}
+
+async function createCat(listener: Awaited<ReturnType<typeof startListener>>, dir: string) {
+  const response = await fetch(new URL(PtyPaths.create, listener.url), {
+    method: "POST",
+    headers: {
+      authorization: authorization(),
+      "x-opencode-directory": dir,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ command: "/bin/cat", title: "race-repro" }),
+  })
+  expect(response.status).toBe(200)
+  return (await response.json()) as { id: string }
+}
+
+async function requestTicket(
+  listener: Awaited<ReturnType<typeof startListener>>,
+  id: string,
+  dir: string,
+) {
+  const response = await fetch(
+    new URL(`${PtyPaths.connectToken.replace(":ptyID", id)}?directory=${encodeURIComponent(dir)}`, listener.url),
+    {
+      method: "POST",
+      headers: { authorization: authorization(), "x-opencode-ticket": "1" },
+    },
+  )
+  expect(response.status).toBe(200)
+  return (await response.json()) as { ticket: string }
+}
+
+function socketURL(listener: Awaited<ReturnType<typeof startListener>>, id: string, dir: string, ticket: string) {
+  const url = new URL(PtyPaths.connect.replace(":ptyID", id), listener.url)
+  url.protocol = "ws:"
+  url.searchParams.set("directory", dir)
+  url.searchParams.set("cursor", "-1")
+  url.searchParams.set("ticket", ticket)
+  return url
+}
+
+/**
+ * Open a websocket, blast `count` distinct frames synchronously inside the
+ * `open` event handler, then wait for echoes from `/bin/cat` to count which
+ * frames actually reached the PTY.
+ */
+async function blastAndEcho(url: URL, count: number, settleMs: number): Promise<Set<number>> {
+  const ws = new WebSocket(url)
+  ws.binaryType = "arraybuffer"
+  const decoder = new TextDecoder()
+  const seen = new Set<number>()
+  let buffer = ""
+
+  ws.addEventListener("message", (event) => {
+    const text = typeof event.data === "string" ? event.data : decoder.decode(event.data as ArrayBuffer)
+    buffer += text
+    for (const m of buffer.matchAll(/frame-(\d+)/g)) {
+      const n = Number(m[1])
+      if (Number.isSafeInteger(n)) seen.add(n)
+    }
+  })
+
+  await withTimeout(
+    new Promise<void>((resolve, reject) => {
+      ws.addEventListener(
+        "open",
+        () => {
+          // Synchronously enqueue every frame in the same microtask the open
+          // handler fires. This is the moment Hono's `pending[]` exists to
+          // protect: any frames that race ahead of `pty.connect()` resolving
+          // must still be delivered to the PTY.
+          for (let i = 0; i < count; i++) {
+            ws.send(`frame-${i}\n`)
+          }
+          resolve()
+        },
+        { once: true },
+      )
+      ws.addEventListener("error", () => reject(new Error("websocket failed before open")), { once: true })
+    }),
+    5_000,
+    "timed out waiting for websocket open",
+  )
+
+  // Give the PTY enough time to round-trip every frame we sent. `/bin/cat`
+  // echoes synchronously, so a small settle window is plenty.
+  await new Promise((resolve) => setTimeout(resolve, settleMs))
+
+  try {
+    ws.close(1000)
+  } catch {}
+
+  return seen
+}
+
+async function runIterations(backend: Backend, iterations: number, framesPerIteration: number) {
+  await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+  const listener = await startListener(backend)
+  try {
+    const losses: Array<{ iteration: number; missing: number[] }> = []
+    for (let iter = 0; iter < iterations; iter++) {
+      const info = await createCat(listener, tmp.path)
+      const ticket = await requestTicket(listener, info.id, tmp.path)
+      const seen = await blastAndEcho(socketURL(listener, info.id, tmp.path, ticket.ticket), framesPerIteration, 400)
+      const missing: number[] = []
+      for (let i = 0; i < framesPerIteration; i++) if (!seen.has(i)) missing.push(i)
+      if (missing.length > 0) losses.push({ iteration: iter, missing })
+
+      await fetch(new URL(PtyPaths.remove.replace(":ptyID", info.id), listener.url), {
+        method: "DELETE",
+        headers: { authorization: authorization(), "x-opencode-directory": tmp.path },
+      }).catch(() => undefined)
+    }
+    return losses
+  } finally {
+    await withTimeout(listener.stop(true), 10_000, "timed out cleaning up listener").catch(() => undefined)
+  }
+}
+
+describe("PTY websocket early-frame buffering", () => {
+  testPty(
+    "Hono backend delivers every frame the client sends inside open",
+    async () => {
+      const losses = await runIterations("hono", ITERATIONS, FRAMES_PER_ITERATION)
+      expect(losses).toEqual([])
+    },
+    60_000,
+  )
+
+  testPty(
+    "HTTP API backend delivers every frame the client sends inside open",
+    async () => {
+      const losses = await runIterations("effect-httpapi", ITERATIONS, FRAMES_PER_ITERATION)
+      expect(losses).toEqual([])
+    },
+    60_000,
+  )
+})

--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -231,11 +231,44 @@ function withFakeLlm<A, E, R>(backend: Backend, run: (input: LlmProjectFixture) 
   }).pipe(Effect.provide(TestLLMServer.layer))
 }
 
+function withFakeLlmProject<A, E, R>(
+  backend: Backend,
+  options: { setup?: (dir: string) => Effect.Effect<void> },
+  run: (input: LlmProjectFixture) => Effect.Effect<A, E, R>,
+) {
+  return Effect.gen(function* () {
+    const llm = yield* TestLLMServer
+    return yield* withProject(
+      backend,
+      {
+        config: providerConfig(llm.url),
+        setup: options.setup,
+      },
+      (input) => run({ ...input, llm }),
+    )
+  }).pipe(Effect.provide(TestLLMServer.layer))
+}
+
 function writeStandardFiles(dir: string) {
   return Effect.all([
     call(() => Bun.write(path.join(dir, "hello.txt"), "hello")),
     call(() => Bun.write(path.join(dir, "needle.ts"), "export const needle = 'sdk-parity'\n")),
   ]).pipe(Effect.asVoid)
+}
+
+function writeProjectSkill(dir: string) {
+  return call(() =>
+    Bun.write(
+      path.join(dir, ".opencode", "skills", "project-rest-skill", "SKILL.md"),
+      `---
+name: project-rest-skill
+description: A project skill visible to REST API prompts.
+---
+
+# Project REST Skill
+`,
+    ),
+  ).pipe(Effect.asVoid)
 }
 
 function seedMessage(directory: string, sessionID: string) {
@@ -643,6 +676,36 @@ describe("HttpApi SDK", () => {
           persistedText: JSON.stringify(messages.data).includes("fake world"),
           userText: JSON.stringify(messages.data).includes("hello llm"),
         }
+      }),
+    ),
+  )
+
+  httpapi(
+    "includes project skills in REST API async prompt context",
+    withFakeLlmProject("httpapi", { setup: writeProjectSkill }, ({ sdk, llm }) =>
+      Effect.gen(function* () {
+        yield* llm.text("skill context ok", { usage: { input: 11, output: 7 } })
+        const session = yield* capture(() =>
+          sdk.session.create({
+            title: "project skill prompt",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          }),
+        )
+        const sessionID = String(record(session.data).id)
+        const prompt = yield* capture(() =>
+          sdk.session.promptAsync({
+            sessionID,
+            agent: "build",
+            model: { providerID: "test", modelID: "test-model" },
+            parts: [{ type: "text", text: "hello skill context" }],
+          }),
+        )
+        yield* llm.wait(1)
+        const inputs = yield* llm.inputs
+
+        expect(session.status).toBe(200)
+        expect(prompt.status).toBe(204)
+        expect(JSON.stringify(inputs[0])).toContain("project-rest-skill")
       }),
     ),
   )

--- a/packages/opencode/test/server/httpapi-workspace-routing.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace-routing.test.ts
@@ -310,6 +310,7 @@ describe("HttpApi workspace routing middleware", () => {
         create: () => Effect.die("unused"),
         sessionWarp: () => Effect.die("unused"),
         list: () => Effect.die("unused"),
+        syncList: () => Effect.die("unused"),
         get: (id) =>
           Effect.succeed(
             id === workspaceID

--- a/packages/opencode/test/server/httpapi-workspace-routing.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace-routing.test.ts
@@ -317,7 +317,7 @@ describe("HttpApi workspace routing middleware", () => {
                   id: workspaceID,
                   type,
                   branch: null,
-                  name: null,
+                  name: "remote-http-fence-target",
                   directory: null,
                   extra: null,
                   projectID: project.project.id,

--- a/packages/opencode/test/server/httpapi-workspace-routing.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace-routing.test.ts
@@ -1,7 +1,7 @@
 import { NodeHttpServer, NodeServices } from "@effect/platform-node"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { describe, expect } from "bun:test"
-import { Context, Effect, Layer, Queue } from "effect"
+import { Context, Effect, Layer, Queue, Ref } from "effect"
 import {
   FetchHttpClient,
   HttpClient,
@@ -28,6 +28,7 @@ import {
   WorkspaceRouteContext,
   workspaceRouterMiddleware,
 } from "../../src/server/routes/instance/httpapi/middleware/workspace-routing"
+import { HEADER as FenceHeader } from "../../src/server/shared/fence"
 import { Database } from "../../src/storage/db"
 import { resetDatabase } from "../fixture/db"
 import { tmpdirScoped } from "../fixture/fixture"
@@ -286,6 +287,63 @@ describe("HttpApi workspace routing middleware", () => {
       expect(forwarded?.headers["x-target-auth"]).toBe("secret")
       expect(forwarded?.headers["x-opencode-directory"]).toBeUndefined()
       expect(forwarded?.headers["x-opencode-workspace"]).toBeUndefined()
+    }),
+  )
+
+  it.live("waits for sync fence headers from remote workspace HTTP responses", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      const workspaceID = WorkspaceID.ascending()
+      const type = "remote-http-fence-target"
+      const waited = yield* Ref.make<{ workspaceID: WorkspaceID; state: Record<string, number> } | undefined>(undefined)
+
+      const remoteUrl = yield* startRemoteWorkspaceHttpServer(() =>
+        HttpServerResponse.json(
+          { proxied: true },
+          { status: 202, headers: { [FenceHeader]: JSON.stringify({ aggregate: 3 }) } },
+        ),
+      )
+      registerAdapter(project.project.id, type, remoteAdapter(path.join(dir, `.${type}`), `${remoteUrl}/base`))
+
+      const workspace = Workspace.Service.of({
+        create: () => Effect.die("unused"),
+        sessionWarp: () => Effect.die("unused"),
+        list: () => Effect.die("unused"),
+        get: (id) =>
+          Effect.succeed(
+            id === workspaceID
+              ? {
+                  id: workspaceID,
+                  type,
+                  branch: null,
+                  name: null,
+                  directory: null,
+                  extra: null,
+                  projectID: project.project.id,
+                  timeUsed: Date.now(),
+                }
+              : undefined,
+          ),
+        remove: () => Effect.die("unused"),
+        status: () => Effect.die("unused"),
+        isSyncing: () => Effect.succeed(true),
+        waitForSync: (id, state) => Ref.set(waited, { workspaceID: id, state }),
+        startWorkspaceSyncing: () => Effect.die("unused"),
+      })
+
+      yield* HttpRouter.add("PATCH", "/probe", HttpServerResponse.text("route called")).pipe(
+        Layer.provide(workspaceRoutingTestLayer),
+        Layer.provide(Layer.succeed(Workspace.Service, workspace)),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.patch(`/probe?workspace=${workspaceID}`).pipe(HttpClient.execute)
+
+      expect(response.status).toBe(202)
+      expect(yield* response.json).toEqual({ proxied: true })
+      expect(yield* Ref.get(waited)).toEqual({ workspaceID, state: { aggregate: 3 } })
     }),
   )
 


### PR DESCRIPTION
## Summary
- Add a focused HttpApi SDK regression test for project-local skills in REST API async prompt context.
- The test creates a `.opencode/skills` skill, sends `promptAsync`, waits for the fake LLM call, and asserts the skill is present in the model request.

## Verification
- `bun test --timeout 10000 test/server/httpapi-sdk.test.ts --grep "includes project skills"`

## Notes
- This was investigated for #25686. Current HEAD passes the reproducer, so this PR preserves that behavior before Hono deletion.
- `bun oxlint packages/opencode/test/server/httpapi-sdk.test.ts` reports existing warnings in the file unrelated to this change.
- `bun typecheck` could not be trusted in the temp worktree because dependencies were symlinked from the main checkout after a native install failure, causing duplicate absolute package identities.