### PR TITLE
refactor(server): use JSON response for OpenAPI doc route

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -156,11 +156,12 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
 )
 
 const openApiDocument = OpenApi.fromApi(PublicApi)
-const openApiDocumentJson = JSON.stringify(openApiDocument)
 
 const docRoute = HttpRouter.use((router) =>
-  router.add("GET", "/doc", () =>
-    Effect.succeed(HttpServerResponse.text(openApiDocumentJson, { headers: { "content-type": "application/json" } })),
+  router.add(
+    "GET",
+    "/doc",
+    () => Effect.succeed(HttpServerResponse.jsonUnsafe(openApiDocument)),
   ),
 ).pipe(Layer.provide(authOnlyRouterLayer))
 

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -155,14 +155,15 @@ const instanceRoutes = Layer.mergeAll(rawInstanceRoutes, instanceApiRoutes).pipe
   ]),
 )
 
-const openApiDocument = OpenApi.fromApi(PublicApi)
+// `OpenApi.fromApi` is non-trivial; defer until /doc is actually hit so
+// processes that never serve it (CLI, scripts) don't pay at module load.
+// `HttpServerResponse.jsonUnsafe` runs JSON.stringify eagerly, so caching
+// the response also caches the serialized body — every /doc request reuses
+// the same Uint8Array instead of re-stringifying the spec.
+const docResponse = lazy(() => HttpServerResponse.jsonUnsafe(OpenApi.fromApi(PublicApi)))
 
 const docRoute = HttpRouter.use((router) =>
-  router.add(
-    "GET",
-    "/doc",
-    () => Effect.succeed(HttpServerResponse.jsonUnsafe(openApiDocument)),
-  ),
+  router.add("GET", "/doc", () => Effect.succeed(docResponse())),
 ).pipe(Layer.provide(authOnlyRouterLayer))
 
 const uiRoute = HttpRouter.use((router) =>


### PR DESCRIPTION
## Summary
- Replaces \`HttpServerResponse.text(JSON.stringify(openApiDocument), { headers: { \"content-type\": \"application/json\" } })\` with \`HttpServerResponse.jsonUnsafe(openApiDocument)\` on the \`/doc\` route.
- Drops the manual content-type wiring and the precomputed \`openApiDocumentJson\` since \`jsonUnsafe\` handles both.

## Test plan
- [x] No behavior change; existing \`/doc\` coverage still applies.