### PR TITLE
test(server): run httpapi exercise effect mode in test:httpapi

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsgo --noEmit",
     "test": "bun test --timeout 30000",
     "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
-    "test:httpapi": "bun run script/httpapi-exercise.ts --mode coverage --fail-on-missing --fail-on-skip && bun run script/httpapi-exercise.ts --mode auth --fail-on-missing --fail-on-skip",
+    "test:httpapi": "bun run script/httpapi-exercise.ts --mode coverage --fail-on-missing --fail-on-skip && bun run script/httpapi-exercise.ts --mode auth --fail-on-missing --fail-on-skip && bun run script/httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip",
     "build": "bun run script/build.ts",
     "fix-node-pty": "bun run script/fix-node-pty.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",


### PR DESCRIPTION
## Summary
- \`test:httpapi\` previously ran only \`coverage\` (route inventory) and \`auth\` (per-route auth declarations) — neither exercises the routes themselves.
- Appends \`bun run script/httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip\`, which dispatches a real request through the new HTTP API stack for every route in the inventory.
- Local run reports \`pass=139 fail=0 skip=0 missing=0 extra=0\`.

## Test plan
- [x] \`bun run test:httpapi\` (139 pass)