### PR TITLE
test(server): expand workspace routing fixed-id coverage

### DIFF
--- a/packages/opencode/test/fixture/flag.ts
+++ b/packages/opencode/test/fixture/flag.ts
@@ -1,0 +1,20 @@
+import type { WorkspaceID } from "@/control-plane/schema"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { Effect, Scope } from "effect"
+
+/**
+ * Scoped override for `Flag.OPENCODE_WORKSPACE_ID`. Saves the previous value
+ * on entry and restores it via finalizer when the surrounding scope closes —
+ * preserves the original try/finally semantics regardless of test outcome.
+ */
+export function withFixedWorkspaceID(id: WorkspaceID): Effect.Effect<void, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const previous = Flag.OPENCODE_WORKSPACE_ID
+    Flag.OPENCODE_WORKSPACE_ID = id
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        Flag.OPENCODE_WORKSPACE_ID = previous
+      }),
+    )
+  })
+}

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -21,6 +21,7 @@ import { instanceRouterMiddleware } from "../../src/server/routes/instance/httpa
 import { workspaceRouterMiddleware } from "../../src/server/routes/instance/httpapi/middleware/workspace-routing"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, tmpdirScoped } from "../fixture/fixture"
+import { withFixedWorkspaceID } from "../fixture/flag"
 import { waitGlobalBusEvent } from "./global-bus"
 import { testEffect } from "../lib/effect"
 
@@ -204,16 +205,10 @@ describe("HttpApi instance context middleware", () => {
     }),
   )
 
-  it.live("uses configured workspace id instead of routing to requested workspaces", () =>
+  it.live("uses configured workspace id instead of routing to the requested workspace", () =>
     Effect.gen(function* () {
-      const originalWorkspaceID = Flag.OPENCODE_WORKSPACE_ID
       const fixedWorkspaceID = WorkspaceID.ascending()
-      Flag.OPENCODE_WORKSPACE_ID = fixedWorkspaceID
-      yield* Effect.addFinalizer(() =>
-        Effect.sync(() => {
-          Flag.OPENCODE_WORKSPACE_ID = originalWorkspaceID
-        }),
-      )
+      yield* withFixedWorkspaceID(fixedWorkspaceID)
 
       const dir = yield* tmpdirScoped({ git: true })
       const project = yield* Project.use.fromDirectory(dir)
@@ -226,6 +221,66 @@ describe("HttpApi instance context middleware", () => {
       yield* serveProbe()
 
       const response = yield* HttpClientRequest.get(`/probe?workspace=${workspace.id}`).pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", dir),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toMatchObject({
+        directory: dir,
+        workspaceID: fixedWorkspaceID,
+      })
+    }),
+  )
+
+  it.live("falls through to local instead of MissingWorkspace when configured workspace id is set", () =>
+    Effect.gen(function* () {
+      const fixedWorkspaceID = WorkspaceID.ascending()
+      yield* withFixedWorkspaceID(fixedWorkspaceID)
+
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* Project.use.fromDirectory(dir)
+      yield* serveProbe()
+
+      // Reference a workspace id that is not registered locally. Without the
+      // configured env override, this would short-circuit to a 500
+      // MissingWorkspace response. With the env set, planRequest must skip the
+      // MissingWorkspace branch and fall through to Local with the configured
+      // workspace id.
+      const unknownWorkspaceID = WorkspaceID.ascending()
+      const response = yield* HttpClientRequest.get(`/probe?workspace=${unknownWorkspaceID}`).pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", dir),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toMatchObject({
+        directory: dir,
+        workspaceID: fixedWorkspaceID,
+      })
+    }),
+  )
+
+  it.live("keeps configured workspace id on control-plane routes without remote routing", () =>
+    Effect.gen(function* () {
+      const fixedWorkspaceID = WorkspaceID.ascending()
+      yield* withFixedWorkspaceID(fixedWorkspaceID)
+
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      const workspaceDir = path.join(dir, ".workspace-local")
+      const workspace = yield* createLocalWorkspace({
+        projectID: project.project.id,
+        type: "instance-context-fixed-workspace-control-plane",
+        directory: workspaceDir,
+      })
+      // /session is matched by isLocalWorkspaceRoute, so shouldStayOnControlPlane
+      // is true. Combined with the env override, the route must stay Local with
+      // the configured workspace id (not divert to the requested workspace's
+      // local directory).
+      yield* serveProbe("/session")
+
+      const response = yield* HttpClientRequest.get(`/session?workspace=${workspace.id}`).pipe(
         HttpClientRequest.setHeader("x-opencode-directory", dir),
         HttpClient.execute,
       )


### PR DESCRIPTION
## Summary

Follow-up to #26454, which locked one invariant of the `OPENCODE_WORKSPACE_ID` env override on the HttpApi workspace routing middleware. This PR tightens the surrounding coverage of `planRequest` in `packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts` and removes the small amount of duplication introduced by the original test.

Tests-only — no production code is touched.

### Changes

- **New test: MissingWorkspace short-circuit suppression.** When `OPENCODE_WORKSPACE_ID` is set and the request references an unknown `?workspace=...` id, `planRequest` must skip the `RequestPlan.MissingWorkspace` branch and fall through to `Local` with the configured id (covers `planRequest` line 145's `!envWorkspaceID` guard — without it the route would 500).
- **New test: control-plane interaction.** When env is set and the path matches `isLocalWorkspaceRoute` (e.g. `GET /session`), the route must stay `Local` with the configured id rather than diverting to the requested workspace's local directory (covers the `shouldStayOnControlPlane` interaction with the env-set Local fallthrough at line 153).
- **Title tightening.** Existing test renamed from "to requested workspaces" → "to the requested workspace" (singular).
- **Helper extraction.** The save-then-restore-via-finalizer pattern for `Flag.OPENCODE_WORKSPACE_ID` is extracted into `test/fixture/flag.ts` as `withFixedWorkspaceID(id)` and adopted by all three sites in `httpapi-instance-context.test.ts`. The original try/finally semantics are preserved via `Effect.addFinalizer` on the test's scope.

## Test plan

- [x] `cd packages/opencode && bun run test test/server/httpapi-instance-context.test.ts test/server/httpapi-instance.test.ts` — 10 pass, 0 fail
- [x] `cd packages/opencode && bun run typecheck`