### PR TITLE
fix: normalize Windows session directory filters

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -42,6 +42,19 @@ import { NonNegativeInt, optionalOmitUndefined, withStatics } from "@/util/schem
 
 const log = Log.create({ service: "session" })
 
+function windowsDirectoryVariants(directory: string) {
+  if (!/^[a-zA-Z]:[\\/]/.test(directory) && !directory.startsWith("\\\\") && !directory.startsWith("//")) {
+    return [directory]
+  }
+  return Array.from(new Set([directory, directory.replaceAll("/", "\\"), directory.replaceAll("\\", "/")]))
+}
+
+function directoryCondition(directory: string) {
+  const variants = windowsDirectoryVariants(directory)
+  if (variants.length === 1) return eq(SessionTable.directory, directory)
+  return or(...variants.map((item) => eq(SessionTable.directory, item)))!
+}
+
 const parentTitlePrefix = "New session - "
 const childTitlePrefix = "Child session - "
 
@@ -829,13 +842,13 @@ function* listByProject(
 
       conditions.push(
         input.directory
-          ? or(...conds, and(isNull(SessionTable.path), eq(SessionTable.directory, input.directory))!)!
+          ? or(...conds, and(isNull(SessionTable.path), directoryCondition(input.directory))!)!
           : or(...conds)!,
       )
     }
   } else if (input.scope !== "project" && !Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
     if (input.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
+      conditions.push(directoryCondition(input.directory))
     }
   }
   if (input.roots) {
@@ -876,7 +889,7 @@ export function* listGlobal(input?: {
   const conditions: SQL[] = []
 
   if (input?.directory) {
-    conditions.push(eq(SessionTable.directory, input.directory))
+    conditions.push(directoryCondition(input.directory))
   }
   if (input?.roots) {
     conditions.push(isNull(SessionTable.parent_id))

--- a/packages/opencode/src/v2/session.ts
+++ b/packages/opencode/src/v2/session.ts
@@ -20,6 +20,19 @@ export type Delivery = Schema.Schema.Type<typeof Delivery>
 
 export const DefaultDelivery = "immediate" satisfies Delivery
 
+function windowsDirectoryVariants(directory: string) {
+  if (!/^[a-zA-Z]:[\\/]/.test(directory) && !directory.startsWith("\\\\") && !directory.startsWith("//")) {
+    return [directory]
+  }
+  return Array.from(new Set([directory, directory.replaceAll("/", "\\"), directory.replaceAll("\\", "/")]))
+}
+
+function directoryCondition(directory: string) {
+  const variants = windowsDirectoryVariants(directory)
+  if (variants.length === 1) return eq(SessionTable.directory, directory)
+  return or(...variants.map((item) => eq(SessionTable.directory, item)))!
+}
+
 export class Info extends Schema.Class<Info>("Session.Info")({
   id: SessionID,
   parentID: optionalOmitUndefined(SessionID),
@@ -158,7 +171,7 @@ export const layer = Layer.effect(
         if (direction === "previous" && order === "asc") order = "desc"
         if (direction === "previous" && order === "desc") order = "asc"
         const conditions: SQL[] = []
-        if (input.directory) conditions.push(eq(SessionTable.directory, input.directory))
+        if (input.directory) conditions.push(directoryCondition(input.directory))
         if (input.path)
           conditions.push(or(eq(SessionTable.path, input.path), like(SessionTable.path, `${input.path}/%`))!)
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))


### PR DESCRIPTION
### Issue for this PR

Fixes #23864

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, session rows can be stored with native backslashes while the web client requests the same directory with forward slashes. The session list endpoint currently does an exact directory match, so valid sessions can disappear from the web sidebar.

This adds a small helper for session directory filters. When the input looks like a Windows drive or UNC path, the query accepts both slash variants. Non-Windows-looking paths keep the previous exact-match behavior.

The change is applied to both current session listing implementations:

- `packages/opencode/src/session/session.ts`
- `packages/opencode/src/v2/session.ts`

This is server-side because direct API requests like `/session?directory=C:/Users/...` still miss rows stored as `C:\Users\...`, even if client-side cache keys are normalized.

### How did you verify your code works?

Verified the failing behavior locally on Windows 11 with OpenCode `1.14.41`:

```text
GET /session?directory=C%3A%5CUsers%5Czhangqianfeng%5Cplayground&roots=true&limit=55
=> returns 9 sessions

GET /session?directory=C%3A%2FUsers%2Fzhangqianfeng%2Fplayground&roots=true&limit=55
=> returns 0 sessions before normalization
```

A temporary local proxy that only rewrites the directory query/header from `C:/Users/...` to `C:\Users\...` makes the web UI show the full session list again, confirming the server-side exact-match mismatch.

### Screenshots / recordings

N/A. This is an API/session-listing fix; the bug is visible as missing sidebar rows rather than a visual rendering change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
