### PR TITLE
docs(server): explain why HTTP API PTY handler has no early-frame buffer

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
@@ -153,6 +153,12 @@ export const ptyConnectRoute = HttpRouter.use((router) =>
           return HttpServerResponse.empty()
         }
 
+        // No `pending[]`-style early-frame buffer (the legacy Hono handler had one).
+        // `request.upgrade` returns a Socket without running the WS handshake; the
+        // handshake fires inside `socket.runRaw` below, AFTER `pty.connect` resolves
+        // and the message callback is registered. The client therefore can't fire
+        // `open` and start sending until the listener is already wired. Don't move
+        // `runRaw` ahead of `pty.connect` without re-introducing a buffer.
         yield* socket
           .runRaw((message) => handlePtyInput(handler, message))
           .pipe(


### PR DESCRIPTION
## Summary
Replaces the planned ~20s behavioral regression test (closed in #26461) with a 6-line comment in the prod handler.

The legacy Hono PTY handler used a \`pending[]\` array to buffer frames between \`onOpen\` and \`pty.connect()\` resolving. The HTTP API handler doesn't, because \`request.upgrade\` returns a Socket without running the WS handshake — the handshake fires inside \`socket.runRaw\`, after \`pty.connect\` resolves and the message callback is registered. So the client can't fire \`open\` and start sending until the listener is already wired.

This invariant is non-obvious. The comment makes it explicit so a future refactor that moves \`runRaw\` ahead of \`pty.connect\` doesn't silently re-open an early-frame race.

## Test plan
- [x] Comment-only change; no behavior modified.