### PR TITLE
fix(test): set OPENCODE_EXPERIMENTAL_WORKSPACES in fence header test

### DIFF
--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -14,17 +14,22 @@ import { disposeAllInstances, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 // Flip the experimental HttpApi flag so backend selection telemetry on the
-// production routes reports the right backend, and reset the database around
-// the test so per-instance state does not leak between runs. resetDatabase()
-// already calls disposeAllInstances(), so we don't repeat it.
+// production routes reports the right backend, and the experimental
+// workspaces flag so SyncEvent.run actually writes to EventSequenceTable
+// (the source of truth the fence middleware reads). Reset the database
+// around the test so per-instance state does not leak between runs.
+// resetDatabase() already calls disposeAllInstances(), so we don't repeat it.
 const testStateLayer = Layer.effectDiscard(
   Effect.gen(function* () {
     const originalHttpApi = Flag.OPENCODE_EXPERIMENTAL_HTTPAPI
+    const originalWorkspaces = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
     Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = true
+    Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
     yield* Effect.promise(() => resetDatabase())
     yield* Effect.addFinalizer(() =>
       Effect.promise(async () => {
         Flag.OPENCODE_EXPERIMENTAL_HTTPAPI = originalHttpApi
+        Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = originalWorkspaces
         await resetDatabase()
       }),
     )


### PR DESCRIPTION
## Root cause

The new test in \`packages/opencode/test/server/httpapi-instance.test.ts\` (\`emits a sync fence header for fixed-workspace mutations\`) was flaking on CI's linux unit job.

The test sets \`OPENCODE_WORKSPACE_ID\`, POSTs \`SessionPaths.create\`, and asserts the response contains a non-empty \`x-opencode-sync\` header. The fence middleware computes the header by diffing \`Fence.load()\` (a SELECT against \`EventSequenceTable\`) before and after the request. The \`EventSequenceTable\` write inside \`SyncEvent.process()\` is gated on:

\`\`\`ts
if (Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
  tx.insert(EventSequenceTable)...
\`\`\`

(see \`packages/opencode/src/sync/index.ts:287\`). Without that flag, no row is ever inserted, \`Fence.diff\` returns \`{}\`, and the middleware drops the header — failing the assertion.

The test only set \`OPENCODE_WORKSPACE_ID\`, not \`OPENCODE_EXPERIMENTAL_WORKSPACES\`. Locally it always passed because devs typically have \`OPENCODE_EXPERIMENTAL_WORKSPACES=true\` in their shell. On CI it intermittently passed only when a sibling test file (e.g. \`httpapi-session.test.ts\`) happened to load first and mutate \`Flag.OPENCODE_EXPERIMENTAL_WORKSPACES\` at module init — Bun's test-file order is non-deterministic, so it flaked.

Not actually a race in the DB or middleware; a missing test-setup flag.

## Fix

Set \`Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true\` in the test-state layer (mirroring \`httpapi-session.test.ts\` and friends) and restore the original value in the finalizer.

## Verification

Reproduced reliably by unsetting \`OPENCODE_EXPERIMENTAL_WORKSPACES\` in my shell and running the test 20 times: **0/20 pass before the fix, 20/20 after**. Full file (\`bun run test test/server/httpapi-instance.test.ts\`) passes 3/3. \`bun typecheck\` clean.