### PR TITLE
fix(app): allow opening composer image previews from filename overlay

### DIFF
--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -15,7 +15,7 @@ const imageClass =
   "size-16 rounded-md object-cover border border-border-base hover:border-border-strong-base transition-colors"
 const removeClass =
   "absolute -top-1.5 -right-1.5 size-5 rounded-full bg-surface-raised-stronger-non-alpha border border-border-base flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-surface-raised-base-hover"
-const nameClass = "absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 rounded-b-md"
+const nameClass = "pointer-events-none absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 rounded-b-md"
 
 export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (props) => {
   return (


### PR DESCRIPTION
## Summary
- Let clicks pass through the composer image filename overlay so the image preview opens from the full thumbnail area.

<img width="791" height="276" alt="image" src="https://github.com/user-attachments/assets/08503c07-e630-4a91-96be-581c96f8050f" />

## Test
- bun typecheck from packages/app
- Manually verified in desktop dev app