### PR TITLE
fix(installation): detect install method from invoked CLI path

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -171,9 +171,9 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
           }
         }),
         method: Effect.fn("Installation.method")(function* () {
-          if (process.execPath.includes(path.join(".opencode", "bin"))) return "curl" as Method
-          if (process.execPath.includes(path.join(".local", "bin"))) return "curl" as Method
-          const exec = process.execPath.toLowerCase()
+          const invoked = (process.argv[1] || process.env._ || process.execPath).toLowerCase()
+          if (invoked.includes(path.join(".opencode", "bin"))) return "curl" as Method
+          if (invoked.includes(path.join(".local", "bin"))) return "curl" as Method
 
           const checks: Array<{ name: Method; command: () => Effect.Effect<string> }> = [
             { name: "npm", command: () => text(["npm", "list", "-g", "--depth=0"]) },
@@ -186,8 +186,8 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | ChildPro
           ]
 
           checks.sort((a, b) => {
-            const aMatches = exec.includes(a.name)
-            const bMatches = exec.includes(b.name)
+            const aMatches = invoked.includes(a.name)
+            const bMatches = invoked.includes(b.name)
             if (aMatches && !bMatches) return -1
             if (!aMatches && bMatches) return 1
             return 0


### PR DESCRIPTION
### Issue for this PR

Closes #26479

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes installation-method detection used by auto-upgrade. Previously the code used `process.execPath` (runtime executable like node/bun) as the primary signal, which can differ from the actual invoked `opencode` command path. In some local setups that can choose the wrong installer path during upgrade and leave the command unavailable after exiting.

The change switches method heuristics to inspect the invoked CLI path (`process.argv[1]` fallback chain) and keeps the existing curl path checks and package-manager prioritization behavior.

### How did you verify your code works?

- Reproduced and analyzed the failing behavior path where runtime executable path mismatches command installation path.
- Validated the diff is scoped to install-method detection only.
- Attempted local typecheck in `packages/opencode`; environment is missing `tsgo`, so full typecheck could not run here.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
