### PR TITLE
fix(app): resync session stream after iOS PWA returns from background

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -43,11 +43,15 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     const emitter = createGlobalEmitter<{
       [key: string]: Event
     }>()
+    const reconnectEmitter = createGlobalEmitter<{
+      reconnect: { at: number }
+    }>()
 
     type Queued = { directory: string; payload: Event }
     const FLUSH_FRAME_MS = 16
     const STREAM_YIELD_MS = 8
     const RECONNECT_DELAY_MS = 250
+    const RECONNECT_DEBOUNCE_MS = 1_000
 
     let queue: Queued[] = []
     let buffer: Queued[] = []
@@ -80,6 +84,8 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       queue.length = 0
       coalesced.clear()
       staleDeltas.clear()
+      const reconnected = reconnectQueued
+      reconnectQueued = false
 
       last = Date.now()
       batch(() => {
@@ -93,6 +99,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       })
 
       buffer.length = 0
+      if (reconnected) reconnectEmitter.emit("reconnect", { at: Date.now() })
     }
 
     const schedule = () => {
@@ -109,10 +116,12 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     let run: Promise<void> | undefined
     let started = false
     const HEARTBEAT_TIMEOUT_MS = 15_000
-    let lastEventAt = Date.now()
+    let lastReconnect = 0
+    let hidden = false
+    let connected = false
+    let reconnectQueued = false
     let heartbeat: ReturnType<typeof setTimeout> | undefined
     const resetHeartbeat = () => {
-      lastEventAt = Date.now()
       if (heartbeat) clearTimeout(heartbeat)
       heartbeat = setTimeout(() => {
         attempt?.abort()
@@ -123,6 +132,14 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       clearTimeout(heartbeat)
       heartbeat = undefined
     }
+    const forceReconnect = () => {
+      if (!started) return
+      if (!attempt) return
+      const now = Date.now()
+      if (now - lastReconnect < RECONNECT_DEBOUNCE_MS) return
+      lastReconnect = now
+      attempt.abort()
+    }
 
     const start = () => {
       if (started) return run
@@ -131,7 +148,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
         // oxlint-disable-next-line no-unmodified-loop-condition -- `started` is set to false by stop() which also aborts; both flags are checked to allow graceful exit
         while (!abort.signal.aborted && started) {
           attempt = new AbortController()
-          lastEventAt = Date.now()
           const onAbort = () => {
             attempt?.abort()
           }
@@ -161,6 +177,10 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
               }
 
               const payload = event.payload as Event
+              if (directory === "global" && payload.type === "server.connected") {
+                if (connected) reconnectQueued = true
+                connected = true
+              }
 
               const k = key(directory, payload)
               if (k) {
@@ -215,10 +235,16 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
 
     onMount(() => {
       makeEventListener(document, "visibilitychange", () => {
-        if (document.visibilityState !== "visible") return
-        if (!started) return
-        if (Date.now() - lastEventAt < HEARTBEAT_TIMEOUT_MS) return
-        attempt?.abort()
+        if (document.visibilityState === "hidden") {
+          hidden = true
+          return
+        }
+        if (!hidden) return
+        hidden = false
+        forceReconnect()
+      })
+      makeEventListener(window, "pageshow", (event) => {
+        if (event.persisted) forceReconnect()
       })
     })
 
@@ -241,6 +267,8 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
         on: emitter.on.bind(emitter),
         listen: emitter.listen.bind(emitter),
         start,
+        reconnect: (handler: (event: { at: number }) => void) =>
+          reconnectEmitter.on("reconnect", handler),
       },
       createClient(opts: Omit<Parameters<typeof createSdkForServer>[0], "server" | "fetch">) {
         const s = server.current

--- a/packages/app/src/context/sync-optimistic.test.ts
+++ b/packages/app/src/context/sync-optimistic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Message, Part } from "@opencode-ai/sdk/v2/client"
-import { applyOptimisticAdd, applyOptimisticRemove, mergeOptimisticPage } from "./sync"
+import { applyOptimisticAdd, applyOptimisticRemove, mergeOptimisticPage, runInflight } from "./sync"
 
 type Text = Extract<Part, { type: "text" }>
 
@@ -20,6 +20,16 @@ const textPart = (id: string, sessionID: string, messageID: string): Text => ({
   type: "text",
   text: id,
 })
+
+const deferred = () => {
+  let resolve = () => {}
+  return {
+    promise: new Promise<void>((done) => {
+      resolve = done
+    }),
+    resolve,
+  }
+}
 
 describe("sync optimistic reducers", () => {
   test("applyOptimisticAdd inserts message in sorted order and stores parts", () => {
@@ -119,5 +129,57 @@ describe("sync optimistic reducers", () => {
       { id: "prt_1", type: "text", text: "server" },
       { id: "prt_2", type: "text", text: "prt_2" },
     ])
+  })
+})
+
+describe("runInflight", () => {
+  test("runs a forced task after an existing non-force task", async () => {
+    const pending = deferred()
+    const calls: string[] = []
+    const map = new Map<string, Promise<void>>()
+    const forced = new Set<string>()
+
+    const first = runInflight(map, "session", async () => {
+      calls.push("normal")
+      await pending.promise
+    })
+    const second = runInflight(
+      map,
+      "session",
+      async () => {
+        calls.push("force")
+      },
+      { force: true, forced },
+    )
+
+    expect(calls).toEqual(["normal"])
+    pending.resolve()
+    await Promise.all([first, second])
+    expect(calls).toEqual(["normal", "force"])
+  })
+
+  test("still runs a forced task after an existing non-force task fails", async () => {
+    const pending = deferred()
+    const calls: string[] = []
+    const map = new Map<string, Promise<void>>()
+    const forced = new Set<string>()
+
+    const first = runInflight(map, "session", async () => {
+      calls.push("normal")
+      await pending.promise
+      throw new Error("failed")
+    })
+    const second = runInflight(
+      map,
+      "session",
+      async () => {
+        calls.push("force")
+      },
+      { force: true, forced },
+    )
+
+    pending.resolve()
+    await Promise.all([first.catch(() => {}), second])
+    expect(calls).toEqual(["normal", "force"])
   })
 })

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -21,13 +21,23 @@ function sortParts(parts: Part[]) {
   return parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id))
 }
 
-function runInflight(map: Map<string, Promise<void>>, key: string, task: () => Promise<void>) {
+export function runInflight(
+  map: Map<string, Promise<void>>,
+  key: string,
+  task: () => Promise<void>,
+  options?: { force?: boolean; forced?: Set<string> },
+): Promise<void> {
   const pending = map.get(key)
-  if (pending) return pending
+  if (pending) {
+    if (!options?.force || options.forced?.has(key)) return pending
+    return pending.catch(() => {}).then(() => runInflight(map, key, task, options))
+  }
   const promise = task().finally(() => {
     map.delete(key)
+    options?.forced?.delete(key)
   })
   map.set(key, promise)
+  if (options?.force) options.forced?.add(key)
   return promise
 }
 
@@ -184,6 +194,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const initialMessagePageSize = 80
     const historyMessagePageSize = 200
     const inflight = new Map<string, Promise<void>>()
+    const inflightForce = new Set<string>()
     const inflightDiff = new Map<string, Promise<void>>()
     const inflightTodo = new Map<string, Promise<void>>()
     const optimistic = new Map<string, Map<string, OptimisticItem>>()
@@ -497,7 +508,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
                   })
 
             await Promise.all([sessionReq, messagesReq])
-          })
+          }, { force: opts?.force, forced: inflightForce })
         },
         async diff(sessionID: string, opts?: { force?: boolean }) {
           const directory = sdk.directory

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -33,6 +33,7 @@ import { useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import { useComments } from "@/context/comments"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
+import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
@@ -320,6 +321,7 @@ function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
 
 export default function Page() {
   const globalSync = useGlobalSync()
+  const globalSDK = useGlobalSDK()
   const layout = useLayout()
   const local = useLocal()
   const file = useFile()
@@ -1778,6 +1780,15 @@ export default function Page() {
 
   onMount(() => {
     makeEventListener(document, "keydown", handleKeyDown)
+  })
+
+  onMount(() => {
+    const unsub = globalSDK.event.reconnect(() => {
+      const id = params.id
+      if (!id) return
+      void sync.session.sync(id, { force: true })
+    })
+    onCleanup(unsub)
   })
 
   onCleanup(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #17769

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the web app runs as a PWA on iOS and is backgrounded, Safari suspends JS and quietly closes the SSE connection. On resume the existing visibility heuristic skipped reconnect because the last event timestamp was within the heartbeat window right before suspension, so the session UI stayed frozen until the user manually refreshed.

Changes:

- \`global-sdk.tsx\`: track the \`hidden\` flag explicitly; on \`visibilitychange\` to visible (and \`pageshow\` with \`event.persisted\` for bfcache), force-reconnect with a 1s debounce. Detect successful reconnects (\`server.connected\` arriving while already connected) and emit a new \`event.reconnect\`.
- \`session.tsx\`: subscribe to \`event.reconnect\` and force-resync the active session messages. The directory bootstrap re-fetches the session list but not message bodies, so events arriving during the gap would otherwise be lost.
- \`sync.tsx\`: extend \`runInflight\` so a \`force: true\` call still re-runs after a non-force task currently in flight (queues after success or failure). Wired into \`session.sync()\`.
- \`sync-optimistic.test.ts\`: tests for the new \`runInflight\` behavior.

### How did you verify your code works?

Manual: installed the web app to home screen on iOS, started a streaming session, switched apps for ~30s, returned — the stream resumes and the session catches up without a refresh.

Automated:

- \`bun test src/context/sync-optimistic.test.ts\` from \`packages/app\` (7 pass)
- \`bun typecheck\` from \`packages/app\`

### Screenshots / recordings

N/A — no UI surface changed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR