### PR TITLE
fix(nix): use OPENCODE_CHANNEL=prod for stable builds

### DIFF
--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   env.MODELS_DEV_API_JSON = "${models-dev}/dist/_api.json";
   env.OPENCODE_DISABLE_MODELS_FETCH = true;
   env.OPENCODE_VERSION = finalAttrs.version;
-  env.OPENCODE_CHANNEL = "local";
+  env.OPENCODE_CHANNEL = "prod";
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
### Issue for this PR

Closes #25790

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes opencode on NixOS by setting `OPENCODE_CHANNEL=prod` in the Nix derivation. The `"local"` channel was silently enabling the experimental Effect HttpApi backend (via the channel-aware default added in e709dc34f), which returns 400 on the `/provider` route when the client sends a `directory` query parameter.

### How did you verify your code works?

Confirmed by building opencode v1.14.34 on NixOS with the fix.

### Screenshots / recordings

N/A — configuration-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR