### PR TITLE
fix(session): prevent double compaction after auto-compact

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1476,9 +1476,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             continue
           }
 
+          const lastCompactionUserID = msgs.findLast(
+            (m) => m.info.role === "user" && m.parts.some((p) => p.type === "compaction"),
+          )?.info.id
           if (
             lastFinished &&
             lastFinished.summary !== true &&
+            (!lastCompactionUserID || lastFinished.id > lastCompactionUserID) &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
             yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2061,3 +2061,134 @@ it.live(
     ),
   30_000,
 )
+
+const seedDoubleCompact = Effect.fn("test.seedDoubleCompact")(function* (sessionID: SessionID) {
+  const session = yield* Session.Service
+
+  const u1 = yield* user(sessionID, "first request")
+
+  const a1: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: u1.id,
+    sessionID,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 95_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+    finish: "tool-calls",
+  }
+  yield* session.updateMessage(a1)
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: a1.id,
+    sessionID,
+    type: "text",
+    text: "pre-compact reply",
+  })
+
+  const c1 = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: c1.id,
+    sessionID,
+    type: "compaction",
+    auto: true,
+    tail_start_id: u1.id,
+  })
+
+  const s1: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: c1.id,
+    sessionID,
+    mode: "compaction",
+    agent: "compaction",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+    finish: "stop",
+    summary: true,
+  }
+  yield* session.updateMessage(s1)
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: s1.id,
+    sessionID,
+    type: "text",
+    text: "## Goal\n- summarized",
+  })
+
+  const ucont = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: ucont.id,
+    sessionID,
+    type: "text",
+    synthetic: true,
+    text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
+  })
+
+  return { u1, a1, c1, s1, ucont }
+})
+
+const compactionMarkerCount = Effect.fn("test.compactionMarkerCount")(function* (sessionID: SessionID) {
+  const all = yield* MessageV2.filterCompactedEffect(sessionID)
+  return all.filter((m) => m.info.role === "user" && m.parts.some((p) => p.type === "compaction")).length
+})
+
+it.live(
+  "loop does not double-compact after a successful auto-compaction summary",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({
+          title: "double-compact-regression",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* seedDoubleCompact(chat.id)
+        expect(yield* compactionMarkerCount(chat.id)).toBe(1)
+
+        yield* llm.text("done")
+
+        const result = yield* prompt
+          .loop({ sessionID: chat.id })
+          .pipe(Effect.timeout("8 seconds"), Effect.exit)
+
+        expect(Exit.isSuccess(result)).toBe(true)
+        if (Exit.isSuccess(result)) {
+          expect(result.value.info.role).toBe("assistant")
+          expect(result.value.parts.some((p) => p.type === "text" && p.text === "done")).toBe(true)
+        }
+
+        expect(yield* compactionMarkerCount(chat.id)).toBe(1)
+        expect(yield* llm.calls).toBe(1)
+      }),
+      { git: true, config: providerCfg },
+    ),
+  30_000,
+)


### PR DESCRIPTION
### Issue for this PR

Resolves #26230
Resolves #20621

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After auto-compaction, `filterCompacted` retains tail assistant messages that carry stale cumulative token counts (~100K). The backward scan in the prompt loop picks up these retained tails as `lastFinished`, and the overflow pre-check immediately fires a second compaction — every single time. This wastes tokens and doubles Copilot request consumption.

**Root cause:** The backward scan at `prompt.ts:1418-1426` searches from the end of `filterCompacted`'s output and breaks as soon as it finds `lastUser` + `lastFinished`. After compaction, the output is:

```
[0]  compaction_user        (COMPACTION part with tail_start_id)
[1]  compaction_summary     summary=true, finish=stop
[2-20] retained tail assistants  tokens=97K-103K, finish=tool-calls (stale)
[21] auto-continue user     tokens=0
```

The scan finds `lastUser`=[21] and `lastFinished`=[20] (a retained tail), then breaks — never reaching the compaction part at [0]. Since `tasks` is empty, the compaction task handler is skipped. The pre-check then sees `lastFinished` with stale 103K tokens, `isOverflow` returns true, and a second compaction fires.

**Fix:** Add a guard that only triggers the overflow pre-check when `lastFinished` is newer than the last compaction user message. Retained tails have IDs older than the compaction user, so they fail this check.

4-line production change in `packages/opencode/src/session/prompt.ts`.

### How did you verify your code works?

- Reproduced the bug empirically against a real session (587 messages, 19 compaction pairs — all doubled)
- Imported the actual `filterCompacted` function and traced the exact output ordering and backward scan behavior
- `bun typecheck` — clean
- `bun test test/session/prompt.test.ts --test-name-pattern "double-compact"` — 1 pass
- Regression test seeds a post-compaction state (compaction pair + auto-continue user) and asserts no second compaction is created and the model is called exactly once

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR