### PR TITLE
fix: add DeepSeek tool calling prompt

### DIFF
--- a/packages/opencode/src/session/prompt/deepseek.txt
+++ b/packages/opencode/src/session/prompt/deepseek.txt
@@ -1,0 +1,35 @@
+# Tool Calling Rules
+
+When calling tools, follow these rules strictly. They override any conflicting habits from chat training.
+
+## Argument Formatting
+
+1. Omit optional fields you don't need. Do not send `null`, `""`, `{}`, or `[]` as a placeholder. If a field is optional and you have no value, leave it out of the JSON entirely.
+2. Match the container type exactly.
+- Array fields take JSON arrays: `["a", "b"]`, never `"[\"a\",\"b\"]"` as a string, never `{}`, never `"foo"`.
+- Single-element arrays still need brackets: `["foo"]`, not `"foo"`.
+- Object fields take JSON objects, not arrays or strings.
+3. Strings are raw strings. Do not wrap values in extra quotes, code fences, or markdown.
+4. Numbers and booleans are unquoted: `30`, not `"30"`. `true`, not `"true"`.
+
+## Paths And Identifiers
+
+5. File paths, URLs, IDs, and similar fields go to system functions, not chat output. Never format them as markdown links, never wrap them in backticks, never add explanatory parentheses.
+- Correct: `/Users/me/notes.md`
+- Wrong: `[notes.md](notes.md)`
+- Wrong: `` `/Users/me/notes.md` ``
+- Wrong: `/Users/me/notes.md (the notes file)`
+6. If a tool description says "path", treat it as input to a filesystem call. No formatting, no decoration.
+
+## Related Parameters
+
+7. When a tool has paired parameters such as offset + limit, start + end, or from + to, provide both or neither. Read the description because half the pair often produces an error.
+
+## Recovery
+
+8. If a tool returns a validation error, read the error message carefully and fix only what it complains about. Do not rewrite the whole call. Do not retry the same arguments.
+9. If a tool returns a "Note:" with a defaulted value, that's informational, not an error. Continue the task. If the default is wrong, retry with the correct explicit value.
+
+## Tool Selection
+
+10. Use the tool whose description matches your intent most specifically. Don't reach for shellCommand if a dedicated tool exists. Don't reach for execute_code for things a single tool call can handle.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -8,6 +8,7 @@ import PROMPT_BEAST from "./prompt/beast.txt"
 import PROMPT_GEMINI from "./prompt/gemini.txt"
 import PROMPT_GPT from "./prompt/gpt.txt"
 import PROMPT_KIMI from "./prompt/kimi.txt"
+import PROMPT_DEEPSEEK from "./prompt/deepseek.txt"
 
 import PROMPT_CODEX from "./prompt/codex.txt"
 import PROMPT_TRINITY from "./prompt/trinity.txt"
@@ -29,6 +30,7 @@ export function provider(model: Provider.Model) {
   if (model.api.id.includes("claude")) return [PROMPT_ANTHROPIC]
   if (model.api.id.toLowerCase().includes("trinity")) return [PROMPT_TRINITY]
   if (model.api.id.toLowerCase().includes("kimi")) return [PROMPT_KIMI]
+  if (model.api.id.toLowerCase().includes("deepseek")) return [PROMPT_DEFAULT, PROMPT_DEEPSEEK]
   return [PROMPT_DEFAULT]
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #26498

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a DeepSeek-specific prompt section for tool-call argument formatting.

DeepSeek models can be sensitive to JSON argument shape. The new prompt makes optional-field omission, array/object types, raw path values, paired parameters, validation-error recovery, and tool selection explicit.

The prompt is only appended when `model.api.id` contains `deepseek`, so other providers keep the existing behavior.

### How did you verify your code works?

- `bun install --frozen-lockfile`
- `bun run typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR