### PR TITLE
fix(ui): make markdown `<hr>` visible using --markdown-horizontal-rule token

### DIFF
--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -113,10 +113,9 @@
     font-style: normal;
   }
 
-  /* Horizontal Rule - Invisible spacing only */
   hr {
     border: none;
-    height: 0;
+    border-top: 1px solid var(--markdown-horizontal-rule);
     margin: 40px 0;
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #25116

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Having a horizontal rule is very common in markdown rendering. I changed the default `<hr>` CSS elements to make it work as expected, not a blank gap.

I also utilize the `--markdown-horizontal-rule` token for this color to make themes able to change the color of the horizontal rule.

### How did you verify your code works?

I built and ran opencode locally. All in all those CSS changes won't actually break any logic.

### Screenshots / recordings

Before
<img width="1507" height="487" alt="Without a horizontal ruler" src="https://github.com/user-attachments/assets/d5a771f9-7232-4951-ab70-d273b93e0253" />

After
<img width="1047" height="449" alt="With a horizontal ruler" src="https://github.com/user-attachments/assets/c82f2a22-8c9c-46b8-8aa2-7ada09a70343" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
