### PR TITLE
test(server): expect null body from HTTP API authorize() with no redirect

### DIFF
--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -128,7 +128,12 @@ describe("provider HttpApi", () => {
           headers,
         })
         expect(apiLegacy).toEqual({ status: 200, body: "" })
-        expect(apiHttpApi).toEqual(apiLegacy)
+        // #26474 changed the HTTP API authorize handler to serialize an
+        // undefined service result as JSON `null` instead of an empty body
+        // so clients can `.json()` parse the response uniformly. The legacy
+        // Hono path still emits an empty body (`c.json(undefined)`); the new
+        // backend's body diverges intentionally.
+        expect(apiHttpApi).toEqual({ status: 200, body: "null" })
 
         const oauthLegacy = yield* requestAuthorize({
           app: legacy,


### PR DESCRIPTION
Followup to #26474. The parity test still asserted the HTTP API response equals Hono's empty body; #26474 changed HTTP API to serialize undefined as JSON `null` so clients can `.json()` parse uniformly. Update the assertion accordingly.