### PR TITLE
fix: preserve instance context for async prompts

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -278,7 +278,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID }
       payload: typeof PromptPayload.Type
     }) {
+      const instance = yield* InstanceState.context
+      const workspace = yield* InstanceState.workspaceID
       yield* promptSvc.prompt({ ...ctx.payload, sessionID: ctx.params.sessionID }).pipe(
+        Effect.provideService(InstanceRef, instance),
+        Effect.provideService(WorkspaceRef, workspace),
         Effect.catchCause((cause) =>
           Effect.gen(function* () {
             yield* Effect.logError("prompt_async failed", { sessionID: ctx.params.sessionID, cause })


### PR DESCRIPTION
## Summary
Preserve the request instance/workspace context when `promptAsync` starts background prompt work.

`promptAsync` returns `204` immediately and continues the prompt in a forked effect. Without explicitly providing the request's `InstanceRef` / `WorkspaceRef` to that forked effect, later async work can fall back to the default instance context and miss project-specific configuration such as custom agents.

Closes #26526

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## How did you verify your code works?

- Confirmed the patch is limited to `packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts`.
- Ran `git diff --check` successfully.
- Ran `bun typecheck` from `packages/opencode`; it starts successfully but currently fails on upstream `dev` with an unrelated existing error in `src/bus/global.ts` (`GlobalBusEmitter.emit` signature mismatch). This change does not touch that file.

## Checklist

- [x] I have tested locally as described above.
- [x] I have not included unrelated changes.
- [x] I have linked the relevant issue above.
