### PR TITLE
fix(permission): read uses worktree-relative path patterns

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -178,7 +178,7 @@ export const ReadTool = Tool.define(
 
       yield* ctx.ask({
         permission: "read",
-        patterns: [filepath],
+        patterns: [path.relative(instance.worktree, filepath).replaceAll("\\", "/")],
         always: ["*"],
         metadata: {},
       })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -78,7 +78,6 @@ const fail = Effect.fn("ReadToolTest.fail")(function* (
   throw new Error("expected read to fail")
 })
 
-const full = (p: string) => (process.platform === "win32" ? Filesystem.normalizePath(p) : p)
 const glob = (p: string) =>
   process.platform === "win32" ? Filesystem.normalizePathPattern(p) : p.replaceAll("\\", "/")
 const put = Effect.fn("ReadToolTest.put")(function* (p: string, content: string | Buffer | Uint8Array) {
@@ -155,7 +154,7 @@ describe("tool.read external_directory permission", () => {
         yield* exec(dir, { filePath: alt }, next)
         const read = items.find((item) => item.permission === "read")
         expect(read).toBeDefined()
-        expect(read!.patterns).toEqual([full(target)])
+        expect(read!.patterns).toEqual(["test.txt"])
       }),
     )
   }
@@ -197,6 +196,61 @@ describe("tool.read external_directory permission", () => {
       yield* exec(dir, { filePath: path.join(dir, "internal.txt") }, next)
       const ext = items.find((item) => item.permission === "external_directory")
       expect(ext).toBeUndefined()
+    }),
+  )
+})
+
+describe("tool.read permission patterns", () => {
+  it.live("emits worktree-relative pattern for files inside the project", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(dir, "src", "foo.ts"), "hello")
+
+      const { items, next } = asks()
+
+      yield* exec(dir, { filePath: path.join(dir, "src", "foo.ts") }, next)
+      const read = items.find((item) => item.permission === "read")
+      expect(read).toBeDefined()
+      expect(read!.patterns).toEqual(["src/foo.ts"])
+    }),
+  )
+
+  it.live("normalizes backslashes to forward slashes in pattern", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(dir, "a", "b", "c.txt"), "x")
+
+      const { items, next } = asks()
+
+      yield* exec(dir, { filePath: path.join(dir, "a", "b", "c.txt") }, next)
+      const read = items.find((item) => item.permission === "read")
+      expect(read).toBeDefined()
+      expect(read!.patterns[0]).not.toContain("\\")
+      expect(read!.patterns).toEqual(["a/b/c.txt"])
+    }),
+  )
+
+  it.live("relative read patterns match worktree-relative deny rules from config", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(dir, "src", "secret.ts"), "hidden")
+
+      const { items, next } = asks()
+
+      yield* exec(dir, { filePath: path.join(dir, "src", "secret.ts") }, next)
+      const read = items.find((item) => item.permission === "read")
+      expect(read).toBeDefined()
+
+      // Simulates a user-written rule: { permission: { read: { "src/**": "deny" } } }.
+      // Before this fix, `read` emitted the absolute filepath as the pattern, so
+      // worktree-relative deny rules silently failed to match. After the fix, this
+      // assertion holds — matching how `edit`/`write`/`apply_patch` already behave.
+      const ruleset = Permission.fromConfig({
+        read: { "src/**": "deny" },
+      })
+      for (const pattern of read!.patterns) {
+        expect(Permission.evaluate("read", pattern, ruleset).action).toBe("deny")
+      }
     }),
   )
 })

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -60,6 +60,10 @@ For most permissions, you can use an object to apply different actions based on 
       "rm *": "deny",
       "grep *": "allow"
     },
+    "read": {
+      "*": "allow",
+      "secrets/**": "deny"
+    },
     "edit": {
       "*": "deny",
       "packages/web/src/content/docs/*.mdx": "allow"
@@ -67,6 +71,8 @@ For most permissions, you can use an object to apply different actions based on 
   }
 }
 ```
+
+For path-based permissions (`read`, `edit`), patterns match against the file path **relative to the project worktree** with forward slashes, so `"src/**"` works the same way for both. To gate paths outside the worktree, see [External Directories](#external-directories).
 
 Rules are evaluated by pattern match, with the **last matching rule winning**. A common pattern is to put the catch-all `"*"` rule first, and more specific rules after it.
 


### PR DESCRIPTION
### Issue for this PR

Closes #26524

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`read` was evaluating permission rules against the absolute file path, while `edit` / `write` / `apply_patch` already use the worktree-relative path. So `"read": { "src/*": "deny" }` silently failed to match the same files that `"edit": { "src/*": "deny" }` would deny.

This PR aligns `read` with the other file tools — emits `path.relative(instance.worktree, filepath).replaceAll("\\", "/")` as the pattern. Same shape `apply_patch` already uses.

Out of scope (tracked as follow-ups):

- Non-git worktree edge case (`worktree === "/"` makes `path.relative` produce nearly-absolute paths). Affects all relative-path tools, not just `read`.
- Forward-slash normalization in `edit`/`write` (currently masked by `Wildcard.match` doing the same thing at match time). Will fold into a small helper-extraction refactor.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — clean
- `bun test test/tool/read.test.ts` — 40/40 pass (3 new tests for the relative-pattern behavior, 1 updated Windows assertion)
- `bun test test/permission test/tool` — 365/365 pass
- The new `"relative read patterns match worktree-relative deny rules from config"` test directly feeds a config-derived ruleset through `Permission.evaluate` against the patterns the read tool emits, asserting `deny`.
- Manual smoke test with a built `--single` binary against a temp project containing `permission: { read: { "*": "allow", "src/*": "deny" }, edit: { "*": "allow", "src/*": "deny" } }`. Before the fix, only `edit` denied `src/secret.ts`; after the fix, both `read` and `edit` deny it as configured.

### Behavior change for users

Anyone who configured `read` with absolute paths (e.g. `"read": { "/home/me/proj/secrets/**": "deny" }`) will need to rewrite as worktree-relative (`"secrets/**": "deny"`). This was the only way to make read rules match anything specific before this fix; the relative form matches the docs and how the other file tools work.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR