### PR TITLE
fix: preserve instance context for async prompts

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -278,7 +278,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID }
       payload: typeof PromptPayload.Type
     }) {
+      const instance = yield* InstanceState.context
+      const workspace = yield* InstanceState.workspaceID
       yield* promptSvc.prompt({ ...ctx.payload, sessionID: ctx.params.sessionID }).pipe(
+        Effect.provideService(InstanceRef, instance),
+        Effect.provideService(WorkspaceRef, workspace),
         Effect.catchCause((cause) =>
           Effect.gen(function* () {
             yield* Effect.logError("prompt_async failed", { sessionID: ctx.params.sessionID, cause })


### PR DESCRIPTION
### Issue for this PR

Closes #26526

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`promptAsync` starts prompt work in a forked background effect after returning `204`.

This change captures the request's `InstanceRef` and `WorkspaceRef` before forking, then provides them to the background prompt effect. That keeps async prompt execution on the same instance/workspace context as the HTTP request, so project-specific config such as custom agents remains available.

### How did you verify your code works?

- Confirmed the patch is limited to `packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts`.
- Ran `git diff --check` successfully.
- Ran `bun typecheck` from `packages/opencode`; it starts successfully but currently fails on upstream `dev` with an unrelated existing error in `src/bus/global.ts` (`GlobalBusEmitter.emit` signature mismatch). This change does not touch that file.

### Screenshots / recordings

Not applicable. This is a server-side context propagation fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
