### PR TITLE
fix(sdk): honor custom fetch option in SSE client (event.subscribe)

### DIFF
--- a/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
@@ -5,6 +5,13 @@ import type { Config } from "./types.gen.js"
 export type ServerSentEventsOptions<TData = unknown> = Omit<RequestInit, "method"> &
   Pick<Config, "method" | "responseTransformer" | "responseValidator"> & {
     /**
+     * Fetch API implementation. You can use this option to provide a custom
+     * fetch instance.
+     *
+     * @default globalThis.fetch
+     */
+    fetch?: (request: Request) => ReturnType<typeof fetch>
+    /**
      * Callback invoked when a network or parsing error occurs during streaming.
      *
      * This option applies only if the endpoint returns a stream of events.
@@ -64,6 +71,7 @@ export type ServerSentEventsResult<TData = unknown, TReturn = void, TNext = unkn
 }
 
 export const createSseClient = <TData = unknown>({
+  fetch: fetchFn,
   onSseError,
   onSseEvent,
   responseTransformer,
@@ -75,6 +83,9 @@ export const createSseClient = <TData = unknown>({
   url,
   ...options
 }: ServerSentEventsOptions): ServerSentEventsResult<TData> => {
+  // fetch must be assigned to a local variable, otherwise it would throw the error:
+  // TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
+  const _fetch = fetchFn ?? globalThis.fetch
   let lastEventId: string | undefined
 
   const sleep = sseSleepFn ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)))
@@ -99,7 +110,7 @@ export const createSseClient = <TData = unknown>({
       }
 
       try {
-        const response = await fetch(url, { ...options, headers, signal })
+        const response = await _fetch(new Request(url, { ...options, headers, signal }))
 
         if (!response.ok) throw new Error(`SSE failed: ${response.status} ${response.statusText}`)
 


### PR DESCRIPTION
### Issue for this PR

Fixes #28180

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`createSseClient` in `packages/sdk/js/src/gen/core/serverSentEvents.gen.ts` called the bare global `fetch` instead of the `fetch` passed in via `createOpencodeClient({ fetch })`. The `client.gen.ts` `makeMethod(...).sse` path already forwards `opts.fetch` into `createSseClient`, but the SSE client never read it.

Effect: any custom fetch wrapper (Basic Auth, Bearer tokens, signing, custom headers) is silently dropped on SSE endpoints like `client.event.subscribe()`. The unauthenticated request gets a 401 and the SSE loop retries forever without surfacing the failure.

Fix:
- Add a `fetch` field to `ServerSentEventsOptions`, typed `(request: Request) => ReturnType<typeof fetch>` so it matches the `Config["fetch"]` signature in `client/types.gen.ts`.
- Destructure it in `createSseClient`, store it in a local (`const _fetch = fetchFn ?? globalThis.fetch`) to avoid the `Illegal invocation` TypeError, and call `_fetch(new Request(url, { ...options, headers, signal }))`.

Note on the generated-file header: `script/build.ts` only regenerates `src/v2/gen`, never `src/gen`, so this edit persists. The v2 SSE client (`src/v2/gen/core/serverSentEvents.gen.ts`) already handles this correctly; this PR brings v1 to parity.

### How did you verify your code works?

- `bun typecheck` passes in `packages/sdk/js` and `packages/opencode`.
- Reproduced against a local opencode server behind Basic Auth:
  - Before: `client.session.list()` works (custom fetch honored), `client.event.subscribe()` hits 401 and reconnects silently.
  - After: both work; the SSE request carries the `Authorization` header from the user's fetch wrapper.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR