### PR TITLE
feat(opencode): add model parameter to task tool for subagent model override

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -99,6 +99,7 @@ export const layer = Layer.effect(
         const defaults = Permission.fromConfig({
           "*": "allow",
           doom_loop: "ask",
+          model_override: "deny",
           external_directory: {
             "*": "ask",
             ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),

--- a/packages/opencode/src/config/permission.ts
+++ b/packages/opencode/src/config/permission.ts
@@ -38,6 +38,7 @@ const InputObject = Schema.StructWithRest(
     codesearch: Schema.optional(Action),
     repo_clone: Schema.optional(Rule),
     repo_overview: Schema.optional(Rule),
+    model_override: Schema.optional(Rule),
     lsp: Schema.optional(Rule),
     doom_loop: Schema.optional(Action),
     skill: Schema.optional(Rule),

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -6,6 +6,7 @@ import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
+import { ModelID, ProviderID } from "../provider/schema"
 import { Effect, Exit, Schema } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 
@@ -21,6 +22,10 @@ export const Parameters = Schema.Struct({
   description: Schema.String.annotate({ description: "A short (3-5 words) description of the task" }),
   prompt: Schema.String.annotate({ description: "The task for the agent to perform" }),
   subagent_type: Schema.String.annotate({ description: "The type of specialized agent to use for this task" }),
+  model: Schema.optional(Schema.String).annotate({
+    description:
+      "Override the model for this subagent. Format: provider/model (e.g. anthropic/claude-sonnet-4, openai/gpt-4o). Takes precedence over the agent's configured model.",
+  }),
   task_id: Schema.optional(Schema.String).annotate({
     description:
       "This should only be set if you mean to resume a previous task (you can pass a prior task_id and the task will continue the same subagent session as before instead of creating a fresh one)",
@@ -104,9 +109,35 @@ export const TaskTool = Tool.define(
       const msg = yield* Effect.sync(() => MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }))
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
 
-      const model = next.model ?? {
-        modelID: msg.info.modelID,
-        providerID: msg.info.providerID,
+      let model: { modelID: ModelID; providerID: ProviderID }
+      if (params.model) {
+        const slash = params.model.indexOf("/")
+        if (slash <= 0 || slash === params.model.length - 1) {
+          return yield* Effect.fail(
+            new Error(
+              `Invalid model format: "${params.model}". Expected provider/model (e.g. anthropic/claude-sonnet-4)`,
+            ),
+          )
+        }
+        yield* ctx.ask({
+          permission: "model_override",
+          patterns: [params.model],
+          always: [params.model.slice(0, slash + 1) + "*"],
+          metadata: {
+            description: params.description,
+            subagent_type: params.subagent_type,
+            model: params.model,
+          },
+        })
+        model = {
+          providerID: ProviderID.make(params.model.slice(0, slash)),
+          modelID: ModelID.make(params.model.slice(slash + 1)),
+        }
+      } else {
+        model = next.model ?? {
+          modelID: msg.info.modelID,
+          providerID: msg.info.providerID,
+        }
       }
 
       yield* ctx.metadata({

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -11,6 +11,11 @@ When NOT to use the Task tool:
 - If you are searching for code within a specific file or set of 2-3 files, use the Read tool instead of the Task tool, to find the match more quickly
 - Other tasks that are not related to the agent descriptions above
 
+Model selection:
+- Each agent has a default model (usually inherited from the parent session).
+- You can override the model by passing the `model` parameter in `provider/model` format (e.g. `anthropic/claude-sonnet-4`, `openai/gpt-4o`, `google/gemini-2.5-pro`).
+- Model overrides require the `model_override` permission. By default this permission is denied and the user will be asked to approve. The user can allow specific models or providers in their config (e.g. `"model_override": { "anthropic/*": "allow" }`).
+- Use the `model` parameter to run a subagent on a different model than the parent session. This is useful for leveraging different model strengths (e.g., sending research tasks to a faster/cheaper model, or routing code generation to a more capable model).
 
 Usage notes:
 1. Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -432,4 +432,38 @@ describe("tool.task", () => {
       },
     },
   )
+
+  it.instance("execute uses model parameter to override subagent model", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      let seen: SessionPrompt.PromptInput | undefined
+      const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          model: "anthropic/claude-sonnet-4",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.metadata.model.providerID as string).toBe("anthropic")
+      expect(result.metadata.model.modelID as string).toBe("claude-sonnet-4")
+      expect((seen?.model?.providerID ?? "") as string).toBe("anthropic")
+      expect((seen?.model?.modelID ?? "") as string).toBe("claude-sonnet-4")
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #17595

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `model` parameter to the task tool, allowing callers to override which model a subagent uses at runtime. Accepts `provider/model` format (e.g. `anthropic/claude-sonnet-4`, `openai/gpt-4o`).

**Model priority:** `params.model` (task tool call) -> `agent.model` (agent config) -> parent session model (inherit)

**Security:** Model overrides are gated by `model_override` permission -- **denied by default**. Users must explicitly opt in via config. This prevents prompt injection from escalating to expensive models.

Example config:

```json
{
  "permission": {
    "model_override": {
      "anthropic/*": "allow",
      "openai/gpt-4o": "allow"
    }
  }
}
```

### Relationship to prior PRs

This PR addresses the same issue (#17595) as several other open PRs, with different tradeoffs:

| PR | Approach | Status | Key difference |
|---|---|---|---|
| **#18528** | `model` param + `model_override` permission | Open, stalled | Nearly identical approach. Uses zod schema and `iife()` helper; this PR uses Effect Schema and inline parsing. Both have the same permission gate. |
| **#11217** | `@agent:provider/model` syntax in prompt + TUI autocomplete + `permission.model` | Open | UI-driven approach with `@` mention syntax. Much larger scope -- includes TUI and web UI changes. |
| **#11377** | `model_tier` param (quick/standard/advanced) + configurable tier-to-model mapping | Open | Tier abstraction layer rather than direct model selection. Adds a tier config system. |
| **#17570** | Config/UI-based agent-to-model assignment (`assign-model` command) | Open | Static config-only approach. No runtime model selection. |

This PR takes the minimal, permission-gated approach from #18528 (which appears stalled since early May) with an Effect Schema implementation matching current codebase patterns.

### Changes

**`packages/opencode/src/tool/task.ts`** -- Added `model` optional string param to `Parameters` schema. When provided:
1. Validates the `provider/model` format (rejects missing `/` or empty parts with a clear error message)
2. Asks `model_override` permission with the model and provider wildcard as patterns
3. Parses into `ProviderID`/`ModelID` branded types using lightweight imports from `provider/schema.ts`
4. Falls through to `agent.model` or parent session model when not provided

**`packages/opencode/src/tool/task.txt`** -- Added "Model selection" section documenting the new parameter and permission requirement.

**`packages/opencode/src/agent/agent.ts`** -- Added `model_override: "deny"` to default permission set for all agents.

**`packages/opencode/src/config/permission.ts`** -- Added `model_override` to the config permission schema so users can configure it in `opencode.json`.

**`packages/opencode/test/tool/task.test.ts`** -- Added 1 test verifying `model` param correctly overrides the model passed to the child session and prompt payload.

### How did you verify your code works?

```bash
cd packages/opencode
bun test test/tool/task.test.ts   # 8 pass, 0 fail, 28 expect() calls
bun test test/permission/          # 85 pass, 0 fail, 130 expect() calls
bun typecheck                      # clean
bun run build                      # succeeds
```

### Behavior change for users

Purely additive. The `model` parameter is optional and requires explicit permission. When omitted or denied, behavior is identical to before -- subagents inherit their model from agent config or the parent session.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR