### PR TITLE
fix: agents spec alignment

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -28,6 +28,7 @@ const SKILL_PATTERN = "**/SKILL.md"
 export const Info = Schema.Struct({
   name: Schema.String,
   description: Schema.optional(Schema.String),
+  disableModelInvocation: Schema.optional(Schema.Boolean),
   location: Schema.String,
   content: Schema.String,
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
@@ -93,7 +94,13 @@ const add = Effect.fnUntraced(function* (state: State, match: string, bus: Bus.I
 
   if (!md) return
 
-  const parsed = z.object({ name: z.string(), description: z.string().optional() }).safeParse(md.data)
+  const parsed = z
+    .object({
+      name: z.string(),
+      description: z.string().optional(),
+      "disable-model-invocation": z.boolean().optional(),
+    })
+    .safeParse(md.data)
   if (!parsed.success) return
 
   if (state.skills[parsed.data.name]) {
@@ -108,6 +115,7 @@ const add = Effect.fnUntraced(function* (state: State, match: string, bus: Bus.I
   state.skills[parsed.data.name] = {
     name: parsed.data.name,
     description: parsed.data.description,
+    disableModelInvocation: parsed.data["disable-model-invocation"],
     location: match,
     content: md.content,
   }
@@ -251,7 +259,9 @@ export const layer = Layer.effect(
 
     const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
       const s = yield* InstanceState.get(state)
-      const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
+      const list = Object.values(s.skills)
+        .filter((skill) => !skill.disableModelInvocation)
+        .toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list
       return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny")
     })

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -142,6 +142,46 @@ description: Second test skill.
     ),
   )
 
+  it.live("hides skills with disabled model invocation from available catalog", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".opencode", "skill", "visible-skill", "SKILL.md"),
+                `---
+name: visible-skill
+description: Visible to the model.
+---
+
+# Visible Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".opencode", "skill", "manual-skill", "SKILL.md"),
+                `---
+name: manual-skill
+description: Only load when explicitly requested.
+disable-model-invocation: true
+---
+
+# Manual Skill
+`,
+              ),
+            ]),
+          )
+
+          const skill = yield* Skill.Service
+          expect((yield* skill.all()).map((item) => item.name).toSorted()).toEqual(["manual-skill", "visible-skill"])
+          expect((yield* skill.get("manual-skill"))?.name).toBe("manual-skill")
+          expect((yield* skill.available()).map((item) => item.name)).toEqual(["visible-skill"])
+          expect(Skill.fmt(yield* skill.available(), { verbose: true })).not.toContain("manual-skill")
+        }),
+      { git: true },
+    ),
+  )
+
   it.live("skips skills with missing frontmatter", () =>
     provideTmpdirInstance(
       (dir) =>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4244,6 +4244,7 @@ export type AppSkillsResponses = {
   200: Array<{
     name: string
     description?: string
+    disableModelInvocation?: boolean
     location: string
     content: string
   }>

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -41,8 +41,12 @@ Only these fields are recognized:
 - `license` (optional)
 - `compatibility` (optional)
 - `metadata` (optional, string-to-string map)
+- `disable-model-invocation` (optional, boolean)
 
 Unknown frontmatter fields are ignored.
+
+Set `disable-model-invocation: true` to hide a skill from the model's available skills catalog.
+The skill can still be loaded when explicitly requested by name.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Fixes #11972

Related: #20474, #21793

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Supports the Agent Skills `disable-model-invocation` frontmatter field.

Per https://agentskills.io/client-implementation/adding-skills-support#filtering, skills can include metadata that controls model-facing invocation. When `disable-model-invocation: true` is present, OpenCode now excludes that skill from the model-facing available skills catalog while keeping the skill loadable by explicit name.

This lets manual/internal skills stay available without spending model context or encouraging automatic model activation.

Also updates the OpenCode skills docs and regenerates the JS SDK type.

### How did you verify your code works?

- `bun test test/skill/skill.test.ts --timeout 30000`
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/sdk/js`

### Screenshots / recordings

Not applicable. No UI changes.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR