### PR TITLE
fix(storage): default workspace time migration

### DIFF
--- a/packages/opencode/migration/20260507164347_add_workspace_time/migration.sql
+++ b/packages/opencode/migration/20260507164347_add_workspace_time/migration.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `workspace` ADD `time_used` integer NOT NULL;
+ALTER TABLE `workspace` ADD `time_used` integer NOT NULL DEFAULT 0;

--- a/packages/opencode/test/storage/workspace-time-migration.test.ts
+++ b/packages/opencode/test/storage/workspace-time-migration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+import { drizzle } from "drizzle-orm/bun-sqlite"
+import { migrate } from "drizzle-orm/bun-sqlite/migrator"
+import { readFileSync, readdirSync } from "fs"
+import path from "path"
+
+const target = "20260507164347_add_workspace_time"
+
+function migrations() {
+  return readdirSync(path.join(import.meta.dirname, "../../migration"), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      name: entry.name,
+      timestamp: Number(entry.name.split("_")[0]),
+      sql: readFileSync(path.join(import.meta.dirname, "../../migration", entry.name, "migration.sql"), "utf-8"),
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp)
+}
+
+describe("workspace time migration", () => {
+  test("migrates existing workspace rows", () => {
+    const sqlite = new Database(":memory:")
+    const db = drizzle({ client: sqlite })
+    const entries = migrations()
+    const index = entries.findIndex((entry) => entry.name === target)
+
+    expect(index).toBeGreaterThan(0)
+
+    migrate(db, entries.slice(0, index))
+    sqlite.run(
+      "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ["project_1", "/tmp/project", "git", "project", 1, 1, "[]"],
+    )
+    sqlite.run(
+      "INSERT INTO workspace (id, type, name, branch, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ["workspace_1", "local", "main", "main", "/tmp/project", null, "project_1"],
+    )
+
+    expect(() => migrate(db, entries.slice(index))).not.toThrow()
+    expect(sqlite.query("SELECT time_used FROM workspace WHERE id = ?").get("workspace_1")).toEqual({ time_used: 0 })
+  })
+})


### PR DESCRIPTION
## Summary
- Add a SQL default to the `workspace.time_used` migration so existing workspace rows can migrate on SQLite.
- Add a focused reproducer that applies migrations up to the bad migration, inserts an existing workspace row, and verifies the remaining migrations preserve it with `time_used = 0`.

## Verification
- `bun test --timeout 5000 test/storage/workspace-time-migration.test.ts`
- `bun typecheck`

Note: file-scoped `oxlint` is currently blocked by the repo `.oxlintrc` error: `options.typeAware` is only supported in the root config.