### PR TITLE
fix(session): accept routing params in message list

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -36,6 +36,8 @@ export const ListQuery = Schema.Struct({
 })
 export const DiffQuery = Schema.Struct(Struct.omit(SessionSummary.DiffInput.fields, ["sessionID"]))
 export const MessagesQuery = Schema.Struct({
+  directory: Schema.optional(Schema.String),
+  workspace: Schema.optional(Schema.String),
   limit: Schema.optional(Schema.NumberFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
   before: Schema.optional(Schema.String),
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -25,8 +25,12 @@ const QueryBoolean = Schema.Literals(["true", "false"]).pipe(
     encode: SchemaGetter.transform((value) => (value ? "true" : "false")),
   }),
 )
-export const ListQuery = Schema.Struct({
+const WorkspaceRoutingQuery = {
   directory: Schema.optional(Schema.String),
+  workspace: Schema.optional(Schema.String),
+}
+export const ListQuery = Schema.Struct({
+  ...WorkspaceRoutingQuery,
   scope: Schema.optional(Schema.Literals(["project"])),
   path: Schema.optional(Schema.String),
   roots: Schema.optional(QueryBoolean),
@@ -36,8 +40,7 @@ export const ListQuery = Schema.Struct({
 })
 export const DiffQuery = Schema.Struct(Struct.omit(SessionSummary.DiffInput.fields, ["sessionID"]))
 export const MessagesQuery = Schema.Struct({
-  directory: Schema.optional(Schema.String),
-  workspace: Schema.optional(Schema.String),
+  ...WorkspaceRoutingQuery,
   limit: Schema.optional(Schema.NumberFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
   before: Schema.optional(Schema.String),
 })

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
-import { Instance } from "../../src/project/instance"
 import { WithInstance } from "../../src/project/with-instance"
 import { Server } from "../../src/server/server"
 import { Session as SessionNs } from "@/session/session"
@@ -159,6 +158,30 @@ describe("session messages endpoint", () => {
           expect(res.status).toBe(200)
           const body = (await res.json()) as MessageV2.WithParts[]
           expect(body).toHaveLength(510)
+
+          await svc.remove(session.id)
+        },
+      }),
+    )
+  })
+
+  test("accepts directory query used by workspace routing", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await svc.create({})
+          await fill(session.id, 1)
+          const app = Server.Default().app
+
+          const res = await app.request(
+            `/session/${session.id}/message?limit=80&directory=${encodeURIComponent(tmp.path)}`,
+          )
+          expect(res.status).toBe(200)
+          const body = await res.json()
+          expect(Array.isArray(body)).toBe(true)
+          expect(body).toHaveLength(1)
 
           await svc.remove(session.id)
         },


### PR DESCRIPTION
## Summary
- Allow `directory`/`workspace` query params on `GET /session/{sessionID}/message` so generated app/SDK calls used for workspace routing are accepted by the typed HttpApi decoder.
- Add a regression for the Electron/app request shape: `/session/{id}/message?limit=80&directory=...`.

## Verification
- `bun run test test/server/session-messages.test.ts`
- `bun typecheck`
- `bunx oxlint packages/opencode/src/server/routes/instance/httpapi/groups/session.ts packages/opencode/test/server/session-messages.test.ts` (existing warnings in `session-messages.test.ts` only)
- `git push` pre-push hook: `bun turbo typecheck`

Related: #26257