### PR TITLE
fix(session): tolerate pre-#24512 model JSON shape in fromRow

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -81,7 +81,9 @@ export function fromRow(row: SessionRow): Info {
     agent: row.agent ?? undefined,
     model: row.model
       ? {
-          id: ModelID.make(row.model.id),
+          // Pre-#24512 rows store `modelID` instead of `id`; fall back so
+          // sessions created before 2026-05-02 don't crash `fromRow`.
+          id: ModelID.make(row.model.id ?? (row.model as { modelID?: string }).modelID ?? ""),
           providerID: ProviderID.make(row.model.providerID),
           variant: row.model.variant,
         }

--- a/packages/opencode/test/session/session-legacy-model-shape.test.ts
+++ b/packages/opencode/test/session/session-legacy-model-shape.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Reproducer for #26435 — `session list` crashes when the DB contains
+ * a legacy-shape `model` column.
+ *
+ * On 2026-05-02 #24512 renamed the JSON shape stored in `session.model`
+ * from `{ providerID, modelID }` to `{ id, providerID, variant }`.
+ * The Drizzle column type was updated but no data migration rewrote
+ * existing rows. `fromRow` now reads `row.model.id`; on legacy rows
+ * that field is undefined and `ModelID.make(undefined)` throws,
+ * killing the entire list (no per-row containment).
+ */
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { eq } from "drizzle-orm"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Database } from "@/storage/db"
+import { Session as SessionNs } from "@/session/session"
+import { SessionTable } from "@/session/session.sql"
+import { WithInstance } from "@/project/with-instance"
+import * as Log from "@opencode-ai/core/util/log"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+void Log.init({ print: false })
+
+const it = testEffect(Layer.mergeAll(SessionNs.defaultLayer, CrossSpawnSpawner.defaultLayer))
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+describe("session list with legacy model shape (#26435)", () => {
+  it.live("does not crash when a row has the pre-#24512 {providerID, modelID} shape", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir({ git: true, config: { formatter: false, lsp: false } })),
+        (t) => Effect.promise(() => t[Symbol.asyncDispose]()),
+      )
+      yield* Effect.promise(() =>
+        WithInstance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            const svc = SessionNs.Service
+            // Create two valid sessions so we can prove the list still
+            // returns the good ones after the legacy row is patched.
+            const legacy = await Effect.runPromise(
+              Effect.provide(svc.use((s) => s.create({ title: "legacy" })), SessionNs.defaultLayer),
+            )
+            const ok = await Effect.runPromise(
+              Effect.provide(svc.use((s) => s.create({ title: "ok" })), SessionNs.defaultLayer),
+            )
+
+            // Replace the legacy row's model JSON with the pre-#24512
+            // shape that's still on disk for users who upgraded.
+            Database.use((db) =>
+              db
+                .update(SessionTable)
+                .set({ model: { providerID: "opencode", modelID: "big-pickle" } as any })
+                .where(eq(SessionTable.id, legacy.id))
+                .run(),
+            )
+
+            // Pre-fix this throws inside `fromRow` and the whole list
+            // call rejects, hiding `ok` along with `legacy`.
+            const list = await Effect.runPromise(
+              Effect.provide(svc.use((s) => s.list()), SessionNs.defaultLayer),
+            )
+            const ids = list.map((s) => s.id)
+            expect(ids).toContain(ok.id)
+            expect(ids).toContain(legacy.id)
+
+            const legacyEntry = list.find((s) => s.id === legacy.id)!
+            // Post-fix the legacy row resolves cleanly with the
+            // recovered modelID surfaced as `id`.
+            expect(legacyEntry.model?.id).toBe("big-pickle")
+            expect(legacyEntry.model?.providerID).toBe("opencode")
+          },
+        }),
+      )
+    }),
+  )
+})


### PR DESCRIPTION
Closes #26435.

## What broke

Sessions store their selected model as a JSON-typed SQLite column. On **2026-05-02**, commit [`a3bc5d35b`](https://github.com/anomalyco/opencode/commit/a3bc5d35b) (PR #24512 *"Refactor v2 session events as schemas"* by @thdxr) renamed the JSON shape:

| Before May 2 | After May 2 |
| --- | --- |
| `{ "providerID": "opencode", "modelID": "big-pickle" }` | `{ "id": "big-pickle", "providerID": "opencode", "variant": "..." }` |

The PR updated:
- the Drizzle column annotation in `session.sql.ts` from `$type<{ providerID, modelID }>()` to `$type<{ id, providerID, variant }>()`
- `fromRow` in `session.ts` to read `row.model.id`

But `$type<>()` is a **compile-time-only TypeScript cast**. It does not transform, validate, or migrate the underlying JSON bytes. **No data migration was added**, so existing on-disk rows still contain `{ providerID, modelID }`.

When `fromRow` reads one of those legacy rows it computes `ModelID.make(row.model.id)` — `row.model.id` is `undefined`, the `Schema.brand("ModelID")` decoder throws `Expected string, got undefined`, and the whole `Session.list` call rejects (no per-row containment in `listByProject`). One bad row hides every other valid session.

## Why this slipped through review

- **The TypeScript type changed; the storage shape didn't** — the PR's diff looked self-consistent at the type level. CI tests use freshly-created rows, which already use the new shape, so they all pass.
- **Read-only paths that fetch a session by ID** (the common case during a normal chat session) don't necessarily read legacy rows.
- **The crash only fires for users who: (a) had at least one session created before 2026-05-02, AND (b) ran `opencode session list` or anything else that hits `listByProject`.** Many users create a fresh session each chat and never trigger `list`.
- The bug surfaced the moment someone with old rows ran the list command on Windows (#26435).

## The fix

`fromRow` reads `row.model.id ?? row.model.modelID` so legacy rows decode using the old field name. Newly-written rows still use the new shape; this is read-side compatibility, not a write-side change. No data migration needed; no risk of corrupting existing data.

## Reproducer

`packages/opencode/test/session/session-legacy-model-shape.test.ts` creates a session through the normal API, then directly mutates its `model` column to the legacy shape, then asserts `Session.list` returns it (and a sibling valid session) without crashing.

Verified red → green → red → green: pre-fix the test fails with the exact `Expected string, got undefined` error; post-fix it passes; reverting the fix makes it fail again.

## Follow-up worth considering (not in this PR)

- Per-row containment in `listByProject` so a corrupt row never tanks the whole list, regardless of shape.
- A one-time migration that walks `SessionTable` and rewrites legacy `model` JSON to the new shape, eventually letting us drop this fallback.