### PR TITLE
fix(sessions): allow optional patch field in diff for migrated sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -23,11 +23,12 @@ function span(id: string, value: { value: string; start: number; end: number }) 
   }
 }
 
-function diff(kind: string, diffs: { file: string; patch: string }[] | undefined) {
+function diff(kind: string, diffs: { file: string; patch?: string }[] | undefined) {
   return diffs?.map((item, i) => ({
     ...item,
     file: redact(`${kind}-file`, String(i), item.file),
-    patch: redact(`${kind}-patch`, String(i), item.patch),
+    patch:
+      item.patch === undefined ? undefined : redact(`${kind}-patch`, String(i), item.patch),
   }))
 }
 

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -21,7 +21,8 @@ export type Patch = typeof Patch.Type
 
 export const FileDiff = Schema.Struct({
   file: Schema.String,
-  patch: Schema.String,
+  /** Older sessions (e.g. migrated summaries) may omit full patch text. */
+  patch: Schema.optional(Schema.String),
   additions: NonNegativeInt,
   deletions: NonNegativeInt,
   status: Schema.optional(Schema.Literals(["added", "deleted", "modified"])),

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -21,7 +21,6 @@ export type Patch = typeof Patch.Type
 
 export const FileDiff = Schema.Struct({
   file: Schema.String,
-  /** Older sessions (e.g. migrated summaries) may omit full patch text. */
   patch: Schema.optional(Schema.String),
   additions: NonNegativeInt,
   deletions: NonNegativeInt,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -120,7 +120,7 @@ export type PermissionRequest = {
 
 export type SnapshotFileDiff = {
   file: string
-  patch: string
+  patch?: string
   additions: number
   deletions: number
   status?: "added" | "deleted" | "modified"


### PR DESCRIPTION
### Issue for this PR

Closes #16906

Just added random issue to get the PR out.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows sessions without a proper diff patch to still be loaded by making it an optional value. This prevents the block on the desktop app.

### How did you verify your code works?

Tested the endpoint that fails, and gives 400, now returns as it should.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR