### PR TITLE
test(session): cover workspace-routed messages

### DIFF
--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -364,8 +364,15 @@ describe("session HttpApi", () => {
           headers: { "x-opencode-directory": tmp.path, "content-type": "application/json" },
           body: JSON.stringify({ title: "workspace session" }),
         })
+        const messages = yield* request(
+          `${pathFor(SessionPaths.messages, { sessionID: created.id })}?workspace=${workspace.id}`,
+          {
+            headers: { "x-opencode-directory": tmp.path },
+          },
+        )
 
         expect(created).toMatchObject({ id: created.id, workspaceID: workspace.id })
+        expect(messages.status).toBe(200)
         expect(
           yield* Effect.sync(() =>
             Database.use((db) =>


### PR DESCRIPTION
## Summary
- Add regression coverage for listing session messages with a valid `workspace` routing query param.
- Keep the follow-up scoped to the verified #26569 gap instead of the broader unproven query-schema changes from #26575.

## Verification
- `bun run test test/server/httpapi-session.test.ts -t "persists selected workspace id"`
- `bun typecheck`
- `bunx prettier --check test/server/httpapi-session.test.ts`
- `bunx oxlint packages/opencode/test/server/httpapi-session.test.ts` (existing warnings only)