### PR TITLE
fix(tool/read): match permission patterns against worktree-relative path

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -178,7 +178,7 @@ export const ReadTool = Tool.define(
 
       yield* ctx.ask({
         permission: "read",
-        patterns: [filepath],
+        patterns: [path.relative(instance.worktree, filepath)],
         always: ["*"],
         metadata: {},
       })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -155,10 +155,23 @@ describe("tool.read external_directory permission", () => {
         yield* exec(dir, { filePath: alt }, next)
         const read = items.find((item) => item.permission === "read")
         expect(read).toBeDefined()
-        expect(read!.patterns).toEqual([full(target)])
+        expect(read!.patterns).toEqual([path.relative(dir, full(target))])
       }),
     )
   }
+
+  it.live("uses worktree-relative path for read permission so user rules match like edit/write", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(dir, "src", "secret.ts"), "shh")
+
+      const { items, next } = asks()
+      yield* exec(dir, { filePath: path.join(dir, "src", "secret.ts") }, next)
+      const read = items.find((item) => item.permission === "read")
+      expect(read).toBeDefined()
+      expect(read!.patterns).toEqual([path.join("src", "secret.ts")])
+    }),
+  )
 
   it.live("asks for directory-scoped external_directory permission when reading external directory", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
Closes #26524.

## Problem

`read` checked permissions with the absolute filepath. `edit`, `write`, and `apply_patch` all check against `path.relative(instance.worktree, filepath)`. So a user rule like:

\`\`\`json
{
  \"permission\": {
    \"read\":  { \"*\": \"allow\", \"src/*\": \"deny\" },
    \"edit\":  { \"*\": \"allow\", \"src/*\": \"deny\" }
  }
}
\`\`\`

denied edits to \`src/foo.ts\` (correct — the relative \`src/foo.ts\` matched \`src/*\`), but allowed reads (the absolute \`/abs/.../src/foo.ts\` did not match \`src/*\` and fell through to \`*\`). Same rule, same file, different outcome.

## Fix

\`packages/opencode/src/tool/read.ts:181\` — use \`path.relative(instance.worktree, filepath)\` like the other tools.

## Verification

- Updated \`test/tool/read.test.ts\` Windows assertion to expect the relative form (was the only test hard-coded to absolute).
- Added a regression test that asserts \`read\` patterns are worktree-relative so a \`src/*\` rule would match.
- 38/38 tests in \`test/tool/read.test.ts\` pass.