### PR TITLE
fix(run): set non-zero exit code on session error

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -685,6 +685,7 @@ export const RunCommand = effectCmd({
                 err = String(props.error.data.message)
               }
               error = error ? error + EOL + err : err
+              process.exitCode = 1
               if (emit("error", { error: props.error })) continue
               UI.error(err)
             }


### PR DESCRIPTION
### Issue for this PR

Closes #26509

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run -m <invalid-model> "<prompt>"` printed the error but exited `0`,
breaking shell scripts that key off `$?`. Without a prompt the same command
exits `1`, so the bug only hits the prompt path.

In `run.ts`, the non-interactive path runs `loop()` as fire-and-forget. When a
`session.error` event arrives, the handler stores the message locally and prints
it — but never propagates it to the process exit code. After the session goes
idle the loop breaks, the event subscription closes, the event loop drains, and
Node exits `0`.

Fix: set `process.exitCode = 1` in the `session.error` branch. Same pattern used
elsewhere in the CLI for soft-failure exits (`thread.ts:126,222`,
`attach.ts:54,81`). Using `exitCode` rather than `process.exit(1)` lets the loop
finish, the subscription tear down, and stdout flush before Node exits — relevant
for `--format json` consumers.

Refs older duplicates that were never actually closed by a fix: #15558, #17854,
#2489. PR #15787 took a different approach (await `loopDone` then `process.exit(1)`)
but was auto-closed by the template-compliance bot before any human review.

### How did you verify your code works?

Manual repro on dev tree (also reproduces on installed 1.14.41):

\`\`\`
$ bun --conditions=browser packages/opencode/src/index.ts run -m invalid-model "test"
Error: Model not found: invalid-model/
$ echo $?
1    # was 0 before the fix
\`\`\`

No-prompt path still exits \`1\` (no regression):

\`\`\`
$ bun --conditions=browser packages/opencode/src/index.ts run -m invalid-model </dev/null
Error: You must provide a message or a command
$ echo $?
1
\`\`\`

\`bun run typecheck\` passes; \`bunx oxlint\` reports no new warnings.

### Screenshots / recordings

_N/A — CLI exit code change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR