### PR TITLE
fix(config): allow active provider model status

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -49,7 +49,7 @@ export const Model = Schema.Struct({
     }),
   ),
   experimental: Schema.optional(Schema.Boolean),
-  status: Schema.optional(Schema.Literals(["alpha", "beta", "deprecated"])),
+  status: Schema.optional(Schema.Literals(["alpha", "beta", "deprecated", "active"])),
   provider: Schema.optional(
     Schema.Struct({ npm: Schema.optional(Schema.String), api: Schema.optional(Schema.String) }),
   ),

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -71,7 +71,7 @@ export const Model = Schema.Struct({
       ),
     }),
   ),
-  status: Schema.optional(Schema.Literals(["alpha", "beta", "deprecated"])),
+  status: Schema.optional(Schema.Literals(["alpha", "beta", "deprecated", "active"])),
   provider: Schema.optional(
     Schema.Struct({ npm: Schema.optional(Schema.String), api: Schema.optional(Schema.String) }),
   ),

--- a/packages/opencode/test/server/httpapi-config.test.ts
+++ b/packages/opencode/test/server/httpapi-config.test.ts
@@ -47,4 +47,41 @@ describe("config HttpApi", () => {
       lsp: false,
     })
   })
+
+  test("serves config with active provider model status", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        formatter: false,
+        lsp: false,
+        provider: {
+          omniroute: {
+            models: {
+              "gpt-4o": {
+                status: "active",
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const response = await app().request("/config", {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      provider: {
+        omniroute: {
+          models: {
+            "gpt-4o": {
+              status: "active",
+            },
+          },
+        },
+      },
+    })
+  })
 })

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1065,7 +1065,7 @@ export type ProviderConfig = {
         output: Array<"text" | "audio" | "image" | "video" | "pdf">
       }
       experimental?: boolean
-      status?: "alpha" | "beta" | "deprecated"
+      status?: "alpha" | "beta" | "deprecated" | "active"
       options?: {
         [key: string]: unknown
       }
@@ -3012,7 +3012,7 @@ export type ProviderListResponses = {
             output: Array<"text" | "audio" | "image" | "video" | "pdf">
           }
           experimental?: boolean
-          status?: "alpha" | "beta" | "deprecated"
+          status?: "alpha" | "beta" | "deprecated" | "active"
           options: {
             [key: string]: unknown
           }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1060,7 +1060,7 @@ export type ProviderConfig = {
         output: Array<"text" | "audio" | "image" | "video" | "pdf">
       }
       experimental?: boolean
-      status?: "alpha" | "beta" | "deprecated"
+      status?: "alpha" | "beta" | "deprecated" | "active"
       provider?: {
         npm?: string
         api?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11725,7 +11725,7 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["alpha", "beta", "deprecated"]
+                  "enum": ["alpha", "beta", "deprecated", "active"]
                 },
                 "provider": {
                   "type": "object",


### PR DESCRIPTION
## Summary
- Allow `status: \"active\"` in provider model config and models.dev schemas.
- Update SDK/OpenAPI generated status enums to include `active`.
- Add an HTTP `/config` regression test covering provider model overrides with active status.

## Testing
- `bun test --timeout 5000 test/server/httpapi-config.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun typecheck` from `packages/sdk/js`
- `bun oxlint packages/opencode/src/config/provider.ts packages/opencode/src/provider/models.ts packages/opencode/test/server/httpapi-config.test.ts` (warnings only from existing assertions in `provider/models.ts`)

Fixes #26589