### PR TITLE
fix(opencode): adjust newString indentation when fallback replacers fire

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -635,6 +635,25 @@ export const ContextAwareReplacer: Replacer = function* (content, find) {
   }
 }
 
+function computeBaseIndentLength(text: string): number {
+  const nonEmptyLines = text.split("\n").filter((l) => l.trim().length > 0)
+  if (nonEmptyLines.length === 0) return 0
+  return Math.min(...nonEmptyLines.map((l) => l.match(/^(\s*)/)?.[1].length ?? 0))
+}
+
+function applyIndentDelta(text: string, delta: number): string {
+  if (delta === 0) return text
+  return text
+    .split("\n")
+    .map((l) => {
+      if (l.trim().length === 0) return l
+      if (delta > 0) return " ".repeat(delta) + l
+      const indent = l.match(/^(\s*)/)?.[1].length ?? 0
+      return l.slice(Math.min(-delta, indent))
+    })
+    .join("\n")
+}
+
 export function trimDiff(diff: string): string {
   const lines = diff.split("\n")
   const contentLines = lines.filter(
@@ -677,6 +696,7 @@ export function replace(content: string, oldString: string, newString: string, r
   }
 
   let notFound = true
+  let isExactReplacer = true
 
   for (const replacer of [
     SimpleReplacer,
@@ -693,13 +713,19 @@ export function replace(content: string, oldString: string, newString: string, r
       const index = content.indexOf(search)
       if (index === -1) continue
       notFound = false
+      // When a fallback replacer fires, the LLM's oldString had wrong indentation.
+      // Adjust newString to match the indentation level of the matched file block.
+      const replacement = isExactReplacer
+        ? newString
+        : applyIndentDelta(newString, computeBaseIndentLength(search) - computeBaseIndentLength(newString))
       if (replaceAll) {
-        return content.replaceAll(search, newString)
+        return content.replaceAll(search, replacement)
       }
       const lastIndex = content.lastIndexOf(search)
       if (index !== lastIndex) continue
-      return content.substring(0, index) + newString + content.substring(index + search.length)
+      return content.substring(0, index) + replacement + content.substring(index + search.length)
     }
+    isExactReplacer = false
   }
 
   if (notFound) {

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
 import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
-import { EditTool } from "../../src/tool/edit"
+import { EditTool, replace } from "../../src/tool/edit"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { LSP } from "@/lsp/lsp"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -529,5 +529,56 @@ describe("tool.edit", () => {
         expect(yield* load(filepath)).toBe("top = 1\nmiddle = keep\nbottom = 2\n")
       }),
     )
+  })
+})
+
+describe("replace() indentation adjustment", () => {
+  test("corrects 3-space newString to 2-space when IndentationFlexibleReplacer fires", () => {
+    const content = 'source "amazon-ebs" "base" {\n  ami_name = "base"\n  instance_type = "t3.micro"\n}'
+    // oldString has 3-space indent (wrong) — SimpleReplacer will miss, fallback fires
+    const oldString = '   ami_name = "base"\n   instance_type = "t3.micro"'
+    // newString also has 3-space indent (wrong)
+    const newString = '   ami_name = "new-base"\n   instance_type = "t3.micro"\n   ssh_username = "ubuntu"'
+    const result = replace(content, oldString, newString)
+    // Expect 2-space indentation (matching the file)
+    expect(result).toBe(
+      'source "amazon-ebs" "base" {\n  ami_name = "new-base"\n  instance_type = "t3.micro"\n  ssh_username = "ubuntu"\n}',
+    )
+  })
+
+  test("corrects 4-space newString to 2-space when LineTrimmedReplacer fires", () => {
+    const content = "block {\n  key = old\n}"
+    const oldString = "    key = old" // 4-space (wrong), trimmed match fires
+    const newString = "    key = new\n    extra = val" // 4-space (wrong)
+    const result = replace(content, oldString, newString)
+    expect(result).toBe("block {\n  key = new\n  extra = val\n}")
+  })
+
+  test("does not adjust newString when SimpleReplacer matches (exact oldString)", () => {
+    // LLM intentionally de-indents — trust newString as-is
+    const content = "outer {\n  inner = old\n}"
+    const oldString = "  inner = old" // exact match
+    const newString = "inner = moved" // intentionally de-indented to 0
+    const result = replace(content, oldString, newString)
+    expect(result).toBe("outer {\ninner = moved\n}")
+  })
+
+  test("is a no-op when newString indentation already matches file", () => {
+    const content = "block {\n  key = old\n}"
+    const oldString = "   key = old" // 3-space (wrong), fallback fires
+    const newString = "  key = new" // 2-space (already correct)
+    const result = replace(content, oldString, newString)
+    expect(result).toBe("block {\n  key = new\n}")
+  })
+
+  test("preserves relative indentation within newString after adjustment", () => {
+    const content = "source {\n  block {\n    key = old\n  }\n}"
+    // oldString at 6-space (wrong; file has 4-space for inner block)
+    const oldString = "      key = old"
+    // newString at 6-space with nested deeper line at 8-space
+    const newString = "      key = new\n        nested = val"
+    const result = replace(content, oldString, newString)
+    // delta is -2 (6→4); relative 2-space offset between lines is preserved
+    expect(result).toBe("source {\n  block {\n    key = new\n      nested = val\n  }\n}")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #25953
Closes #14612

### Type of change

- [x] Bug fix

### What does this PR do?

The edit tool's fallback replacers (`LineTrimmedReplacer`, `IndentationFlexibleReplacer`, etc.) tolerate indentation mismatches in `oldString` by comparing trimmed/de-indented forms. However, `newString` was always substituted verbatim regardless of which replacer fired, silently introducing wrong indentation into the file. Because the diff display trims common leading whitespace, the corruption was invisible in the UI — which is exactly the behaviour described in #25953 and #14612.

The fix adds two helpers (`computeBaseIndentLength`, `applyIndentDelta`) and threads an `isExactReplacer` flag through the `replace()` loop. When a fallback replacer fires (meaning the LLM's `oldString` had wrong indentation), `newString`'s base indentation is adjusted to match the indentation level of the matched file block before substitution. `SimpleReplacer` (exact `oldString` match) is left untouched so intentional indentation changes still work.

```ts
const replacement = isExactReplacer
  ? newString
  : applyIndentDelta(newString, computeBaseIndentLength(search) - computeBaseIndentLength(newString))
```

This is a targeted fix at the substitution site — it does not change how any replacer finds its match, only what gets written when a fallback match is used.

### How did you verify your code works?

Five unit tests added to `test/tool/edit.test.ts`:

1. `IndentationFlexibleReplacer` path: 3-space LLM output corrected to file's 2-space (the HCL/Python case from #25953)
2. `LineTrimmedReplacer` path: 4-space LLM output corrected to file's 2-space
3. `SimpleReplacer` path: intentional de-indent is preserved (no regression)
4. No-op: `newString` already has correct indentation (delta = 0, no change)
5. Relative indentation within `newString` is preserved after base adjustment

All five pass. Verified by tracing the exact execution path through the replacer cascade.

### Screenshots / recordings

_Not applicable — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR