### PR TITLE
feat(httpapi-exercise): add .viaSdk() to drive scenarios through real SDK

### DIFF
--- a/packages/opencode/config.json
+++ b/packages/opencode/config.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+}

--- a/packages/opencode/config.json
+++ b/packages/opencode/config.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://opencode.ai/config.json"
-}

--- a/packages/opencode/test/server/httpapi-exercise/backend.ts
+++ b/packages/opencode/test/server/httpapi-exercise/backend.ts
@@ -1,5 +1,6 @@
 import { ConfigProvider, Effect, Layer } from "effect"
 import { HttpRouter } from "effect/unstable/http"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { parse } from "./assertions"
 import { runtime, type Runtime } from "./runtime"
 import type { ActiveScenario, Backend, BackendApp, CallResult, CaptureMode, SeededContext } from "./types"
@@ -17,9 +18,47 @@ export function call(
   ctx: SeededContext<unknown>,
   options: CallOptions = {},
 ) {
-  return Effect.promise(async () =>
-    capture(await app(await runtime(), backend, options).request(toRequest(scenario, ctx)), scenario.capture),
-  )
+  return Effect.promise(async () => {
+    const handler = app(await runtime(), backend, options)
+    if (scenario.sdkCall) return callViaSdk(handler, scenario, ctx)
+    return capture(await handler.request(toRequest(scenario, ctx)), scenario.capture)
+  })
+}
+
+/**
+ * Run the scenario through a real `createOpencodeClient` wired to the
+ * in-process exerciser router. The SDK applies its real request transforms
+ * (auto-injected `?directory=...` / `?workspace=...` on GETs, header
+ * rewrites, etc.), so any drift between what the SDK sends and what the
+ * server's typed query schemas accept fails the scenario at write time.
+ */
+async function callViaSdk(handler: BackendApp, scenario: ActiveScenario, ctx: SeededContext<unknown>) {
+  const sdk = createOpencodeClient({
+    baseUrl: "http://localhost",
+    directory: ctx.directory,
+    fetch: ((input: Request | URL | string, init?: RequestInit) => handler.request(input, init)) as unknown as typeof fetch,
+  })
+  let result: unknown
+  let thrown: unknown
+  try {
+    result = await scenario.sdkCall!(sdk, ctx)
+  } catch (err) {
+    thrown = err
+  }
+  return normalizeSdkResult(result, thrown)
+}
+
+function normalizeSdkResult(result: unknown, thrown: unknown): CallResult {
+  // SDK returns either { data, error, response } when not throwing, or
+  // throws an Error with `.cause = { body, status }` when throwOnError: true.
+  const tuple = result as { data?: unknown; error?: unknown; response?: Response } | undefined
+  const cause = (thrown as { cause?: { status?: number; body?: unknown } } | undefined)?.cause
+  const response = tuple?.response
+  const status = response?.status ?? cause?.status ?? (thrown ? 0 : 200)
+  const contentType = response?.headers.get("content-type") ?? "application/json"
+  const body = tuple?.data ?? tuple?.error ?? cause?.body ?? thrown
+  const text = typeof body === "string" ? body : JSON.stringify(body ?? null)
+  return { status, contentType, body, text, timedOut: false }
 }
 
 export function callAuthProbe(

--- a/packages/opencode/test/server/httpapi-exercise/dsl.ts
+++ b/packages/opencode/test/server/httpapi-exercise/dsl.ts
@@ -10,6 +10,7 @@ import type {
   ProjectOptions,
   RequestSpec,
   ScenarioContext,
+  Sdk,
   SeededContext,
   TodoScenario,
 } from "./types"
@@ -48,6 +49,22 @@ class ScenarioBuilder<S = undefined> {
 
   at(request: BuilderState<S>["request"]) {
     return this.clone({ request })
+  }
+
+  /**
+   * Run the scenario through the real SDK client wired to the in-process
+   * exerciser router. The SDK applies its real request transforms (for example,
+   * auto-injecting `?directory=...` on GETs when a directory is set) so route
+   * tests catch the SDK-vs-server-shape drift class at write time instead of
+   * regression time. Existing `.at(...)` scenarios are unchanged.
+   *
+   * The callback may return either an SDK result tuple (`{ data, error,
+   * response }`) or throw (use `{ throwOnError: true }`); the runner
+   * normalizes both into the same `CallResult` shape that `.json()` /
+   * `.status()` / `.ok()` already understand.
+   */
+  viaSdk(sdkCall: (sdk: Sdk, ctx: SeededContext<S>) => Promise<unknown>) {
+    return this.clone({ sdkCall })
   }
 
   probe(authProbe: RequestSpec) {
@@ -167,6 +184,8 @@ class ScenarioBuilder<S = undefined> {
       mutates: state.mutates,
       reset: state.reset,
       auth: state.auth,
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- `.seeded(...)` preserves the paired sdkCall/state type inside the builder.
+      sdkCall: state.sdkCall as ActiveScenario["sdkCall"],
     }
   }
 }

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -123,6 +123,19 @@ const scenarios: Scenario[] = [
   http.protected.get("/command", "command.list").json(200, array, "status"),
   http.protected.get("/agent", "app.agents").json(200, array, "status"),
   http.protected.get("/skill", "app.skills").json(200, array, "status"),
+  // Same /agent route exercised through the real SDK client. Catches the
+  // SDK-injection class of regressions (`?directory=...` auto-added on GETs)
+  // that the direct-Request path is structurally blind to. See #26569.
+  http.protected
+    .get("/agent", "app.agents.via_sdk")
+    .viaSdk((sdk) => sdk.app.agents({}, { throwOnError: true }))
+    .json(200, array, "status"),
+  // Same /command route via SDK — second proof that the directory injection
+  // works for any GET under workspace routing.
+  http.protected
+    .get("/command", "command.list.via_sdk")
+    .viaSdk((sdk) => sdk.command.list({}, { throwOnError: true }))
+    .json(200, array, "status"),
   http.protected.get("/lsp", "lsp.status").json(200, array),
   http.protected.get("/formatter", "formatter.status").json(200, array),
   http.protected.get("/config", "config.get").json(200, undefined, "status"),

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -1,9 +1,19 @@
 import type { Duration, Effect } from "effect"
+import type { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import type { Config } from "../../../src/config/config"
 import type { Project } from "../../../src/project/project"
 import type { Worktree } from "../../../src/worktree"
 import type { MessageV2 } from "../../../src/session/message-v2"
 import type { SessionID } from "../../../src/session/schema"
+
+/**
+ * The real generated SDK client used by every consumer (TUI, Desktop, plugins).
+ * Scenarios that opt into `.viaSdk(...)` get one of these wired to the in-process
+ * exerciser router so SDK request transforms (auto-injected `?directory=...`,
+ * header rewrites, etc.) are exercised against real handlers — that's what
+ * catches the #26569 family.
+ */
+export type Sdk = ReturnType<typeof createOpencodeClient>
 
 export const OpenApiMethods = ["get", "post", "put", "delete", "patch"] as const
 export const Methods = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const
@@ -88,6 +98,7 @@ export type ActiveScenario = {
   mutates: boolean
   reset: boolean
   auth: AuthPolicy
+  sdkCall?: (sdk: Sdk, ctx: SeededContext<unknown>) => Promise<unknown>
 }
 
 export type BuilderState<S> = {
@@ -102,6 +113,7 @@ export type BuilderState<S> = {
   mutates: boolean
   reset: boolean
   auth: AuthPolicy
+  sdkCall?: (sdk: Sdk, ctx: SeededContext<S>) => Promise<unknown>
 }
 
 export type TodoScenario = {


### PR DESCRIPTION
## Why

The exerciser harness builds requests directly as \`Request\` objects, so it never exercises the SDK client's auto-injection of \`?directory=...\` / \`?workspace=...\` on GETs. That's structurally how the entire #26569 / #26581 family slipped through — the SDK was sending requests the typed query schemas didn't accept, but the harness sent requests directly. The retroactive guard at \`httpapi-query-schema-drift.test.ts\` only covers the 8 routes that broke; new endpoints added without \`WorkspaceRoutingQueryFields\` would still slip past it.

## What this PR does

Adds an opt-in \`.viaSdk((sdk, ctx) => sdk.X.Y(...))\` builder method to the exerciser DSL. Scenarios that use it run through a real \`createOpencodeClient\` wired to the in-process router. The SDK applies its real request transforms (auto-injected routing query params, header rewrites, etc.) so route tests catch the SDK-vs-server-shape drift class at write time.

The runner normalizes the SDK's \`{data, error, response}\` (or thrown \`Error\` with \`.cause = {body, status}\`) back into the existing \`CallResult\` shape, so all current assertions (\`.json()\`, \`.status()\`, \`.ok()\`) work unchanged on \`.viaSdk()\` scenarios.

## What this PR does NOT change

- Existing \`.at(...)\` scenarios are byte-for-byte unchanged. \`.viaSdk(...)\` is a new opt-in path.
- No drift-test files removed yet; that's a follow-up once enough scenarios are converted.
- WebSocket / raw routes the SDK doesn't expose stay on \`.at(...)\` permanently.

## Proof

Two new SDK-based scenarios converted as proof: \`app.agents.via_sdk\` and \`command.list.via_sdk\`. Full exerciser passes 141/141 (139 existing + 2 new).

## Migration plan (subsequent PRs)

1. Migrate the 8 standalone scenarios in \`httpapi-query-schema-drift.test.ts\` into the exerciser as \`.viaSdk(...)\` scenarios.
2. Delete \`httpapi-query-schema-drift.test.ts\` once all 8 are in.
3. Add \`.viaSdk(...)\` siblings opportunistically to existing routing-aware route scenarios so the SDK-injection bug class is structurally guaranteed for those routes.
4. Document in the exerciser header that new routing-aware scenarios should default to \`.viaSdk(...)\`.

## Test

- \`bun run script/httpapi-exercise.ts --include via_sdk\` — 2/2 PASS
- \`bun run test:httpapi\` — 141/141 PASS, no regression in existing scenarios
- \`bun run typecheck\` — clean