### PR TITLE
docs: add OpenCode Ensemble to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                         |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                             |
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)              | Claude Code-style background agents with async delegation and context persistence                 |
+| [OpenCode Ensemble](https://github.com/hueyexe/opencode-ensemble)                                  | Coordinate parallel OpenCode agents with team messaging, shared tasks, and worktree isolation     |
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |


### PR DESCRIPTION
### Issue for this PR

N/A - documentation-only ecosystem listing.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds OpenCode Ensemble to the ecosystem docs plugin table.

OpenCode Ensemble is a public npm plugin for coordinating parallel OpenCode agents with team messaging, shared tasks, and worktree isolation. This change only adds the listing and link.

### How did you verify your code works?

- Ran `git diff origin/dev...HEAD --check`

### Screenshots / recordings

N/A - documentation table entry only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR