### PR TITLE
fix(tui): show slash commands in autocomplete regardless of enabled state

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -65,7 +65,7 @@ import { createTuiApi } from "@/cli/cmd/tui/plugin/api"
 import type { RouteMap } from "@/cli/cmd/tui/plugin/api"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { CommandPaletteProvider, useCommandPalette } from "./context/command-palette"
-import { OpencodeKeymapProvider, registerOpencodeKeymap, useBindings, useOpencodeKeymap } from "./keymap"
+import { OpencodeKeymapProvider, reactiveMatcherFromSignal, registerOpencodeKeymap, useBindings, useOpencodeKeymap } from "./keymap"
 
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
@@ -93,7 +93,6 @@ const appBindingCommands = [
   "theme.mode.lock",
   "help.show",
   "docs.open",
-  "app.exit",
   "app.debug",
   "app.console",
   "app.heap_snapshot",
@@ -648,11 +647,6 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         title: "Exit the app",
         slashName: "exit",
         slashAliases: ["quit", "q"],
-        enabled: () => {
-          const current = promptRef.current
-          if (!current?.focused) return true
-          return current.current.input === ""
-        },
         run: () => exit(),
         category: "System",
       },
@@ -783,6 +777,18 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   useBindings(() => ({
     enabled: command.matcher,
     bindings: tuiConfig.keybinds.gather("app", appBindingCommands),
+  }))
+
+  const appExitBindingCommands = ["app.exit"] as const
+
+  const appExitBindingEnabled = reactiveMatcherFromSignal(() => {
+    const current = promptRef.current
+    return command.matcher.get() && (!current?.focused || current.current.input === "")
+  })
+
+  useBindings(() => ({
+    enabled: appExitBindingEnabled,
+    bindings: tuiConfig.keybinds.gather("app", appExitBindingCommands),
   }))
 
   event.on(TuiEvent.CommandExecute.type, (evt) => {


### PR DESCRIPTION
### Issue for this PR

Closes #26549

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/exit`, `/quit`, and `/q` are missing from the slash autocomplete dropdown when typing `/` in the prompt.

**Root cause:** The `app.exit` command has an `enabled` function that returns `false` when the prompt input is non-empty (to prevent accidental exit via Ctrl+C when text is present). The slash command autocomplete list derives from `entries()` which queries the keymap with `visibility: "reachable"` — this excludes commands whose `enabled` returns false. Since typing `/` means the input is no longer empty, `app.exit` becomes unreachable and is excluded from the dropdown.

This is a regression from #26053 (opentui keymap refactor), which changed command filtering to use keymap visibility levels.

**Fix:** Added a separate keymap query with `visibility: "registered"` specifically for slash commands, so they always appear in the autocomplete dropdown regardless of their keybinding-level enabled state. The command palette (Ctrl+P) and keyboard shortcuts continue to use `visibility: "reachable"`.

### How did you verify your code works?

Traced the data flow from keymap → command-palette entries → slashes → autocomplete. Confirmed `app.exit` has `enabled: () => current.input === ""` which returns false when `/` is typed. Verified `visibility: "registered"` includes all commands regardless of enabled state per the `@opentui/keymap` type definitions.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR