### PR TITLE
fix(mcp): tolerate output schema ref failures

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -36,6 +36,24 @@ import { withStatics } from "@opencode-ai/core/schema"
 const log = Log.create({ service: "mcp" })
 const DEFAULT_TIMEOUT = 30_000
 
+const TolerantToolSchema = z.looseObject({
+  name: z.string(),
+  description: z.string().optional(),
+  inputSchema: z
+    .object({
+      type: z.literal("object"),
+      properties: z.record(z.string(), z.object({}).catchall(z.unknown())).optional(),
+      required: z.array(z.string()).optional(),
+    })
+    .catchall(z.unknown()),
+  outputSchema: z.unknown().optional(),
+})
+
+const TolerantListToolsResultSchema = z.looseObject({
+  tools: z.array(TolerantToolSchema),
+  nextCursor: z.string().optional(),
+})
+
 export const Resource = Schema.Struct({
   name: Schema.String,
   uri: Schema.String,
@@ -119,6 +137,30 @@ function remoteURL(key: string, value: string) {
   log.warn("invalid remote mcp url", { key })
 }
 
+function isOutputSchemaValidationError(error: Error) {
+  return /can't resolve reference|resolves to more than one schema|outputSchema|schema.*reference|reference.*schema/i.test(
+    error.message,
+  )
+}
+
+async function listTools(key: string, client: MCPClient, timeout: number) {
+  try {
+    return (await withTimeout(client.listTools(), timeout)).tools
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err))
+    if (!isOutputSchemaValidationError(error)) throw error
+
+    log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", { key, error })
+    return (
+      await withTimeout(client.request({ method: "tools/list" }, TolerantListToolsResultSchema), timeout)
+    ).tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }))
+  }
+}
+
 // Convert MCP tool definition to AI SDK Tool type
 function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Tool {
   const inputSchema = mcpTool.inputSchema
@@ -152,10 +194,10 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
 
 function defs(key: string, client: MCPClient, timeout?: number) {
   return Effect.tryPromise({
-    try: () => withTimeout(client.listTools(), timeout ?? DEFAULT_TIMEOUT),
+    try: () => listTools(key, client, timeout ?? DEFAULT_TIMEOUT),
     catch: (err) => (err instanceof Error ? err : new Error(String(err))),
   }).pipe(
-    Effect.map((result) => result.tools),
+    Effect.map((tools) => tools),
     Effect.catch((err) => {
       log.error("failed to get tools from client", { key, error: err })
       return Effect.succeed(undefined)

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -143,22 +143,42 @@ function isOutputSchemaValidationError(error: Error) {
   )
 }
 
-async function listTools(key: string, client: MCPClient, timeout: number) {
-  try {
-    return (await withTimeout(client.listTools(), timeout)).tools
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err))
-    if (!isOutputSchemaValidationError(error)) throw error
+function listTools(key: string, client: MCPClient, timeout: number) {
+  const timed = <T, E>(effect: Effect.Effect<T, E>) =>
+    effect.pipe(
+      Effect.timeoutOrElse({
+        duration: timeout,
+        orElse: () => Effect.fail(new Error(`Operation timed out after ${timeout}ms`)),
+      }),
+    )
 
-    log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", { key, error })
-    return (
-      await withTimeout(client.request({ method: "tools/list" }, TolerantListToolsResultSchema), timeout)
-    ).tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-    }))
-  }
+  return timed(
+    Effect.tryPromise({
+      try: () => client.listTools(),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }),
+  ).pipe(
+    Effect.map((result) => result.tools),
+    Effect.catch((error) => {
+      if (!isOutputSchemaValidationError(error)) return Effect.fail(error)
+
+      log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", { key, error })
+      return timed(
+        Effect.tryPromise({
+          try: () => client.request({ method: "tools/list" }, TolerantListToolsResultSchema),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }),
+      ).pipe(
+        Effect.map((result) =>
+          result.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+          })),
+        ),
+      )
+    }),
+  )
 }
 
 // Convert MCP tool definition to AI SDK Tool type
@@ -193,11 +213,7 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
 }
 
 function defs(key: string, client: MCPClient, timeout?: number) {
-  return Effect.tryPromise({
-    try: () => listTools(key, client, timeout ?? DEFAULT_TIMEOUT),
-    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-  }).pipe(
-    Effect.map((tools) => tools),
+  return listTools(key, client, timeout ?? DEFAULT_TIMEOUT).pipe(
     Effect.catch((err) => {
       log.error("failed to get tools from client", { key, error: err })
       return Effect.succeed(undefined)

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -6,6 +6,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,
+  ToolSchema,
   type Tool as MCPToolDef,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
@@ -36,16 +37,7 @@ import { withStatics } from "@opencode-ai/core/schema"
 const log = Log.create({ service: "mcp" })
 const DEFAULT_TIMEOUT = 30_000
 
-const TolerantToolSchema = z.looseObject({
-  name: z.string(),
-  description: z.string().optional(),
-  inputSchema: z
-    .object({
-      type: z.literal("object"),
-      properties: z.record(z.string(), z.object({}).catchall(z.unknown())).optional(),
-      required: z.array(z.string()).optional(),
-    })
-    .catchall(z.unknown()),
+const TolerantToolSchema = ToolSchema.extend({
   outputSchema: z.unknown().optional(),
 })
 
@@ -144,31 +136,19 @@ function isOutputSchemaValidationError(error: Error) {
 }
 
 function listTools(key: string, client: MCPClient, timeout: number) {
-  const timed = <T, E>(effect: Effect.Effect<T, E>) =>
-    effect.pipe(
-      Effect.timeoutOrElse({
-        duration: timeout,
-        orElse: () => Effect.fail(new Error(`Operation timed out after ${timeout}ms`)),
-      }),
-    )
-
-  return timed(
-    Effect.tryPromise({
-      try: () => client.listTools(),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    }),
-  ).pipe(
+  return Effect.tryPromise({
+    try: () => client.listTools(undefined, { timeout }),
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+  }).pipe(
     Effect.map((result) => result.tools),
     Effect.catch((error) => {
       if (!isOutputSchemaValidationError(error)) return Effect.fail(error)
 
       log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", { key, error })
-      return timed(
-        Effect.tryPromise({
-          try: () => client.request({ method: "tools/list" }, TolerantListToolsResultSchema),
-          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-        }),
-      ).pipe(
+      return Effect.tryPromise({
+        try: () => client.request({ method: "tools/list" }, TolerantListToolsResultSchema, { timeout }),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
         Effect.map((result) =>
           result.tools.map((tool) => ({
             name: tool.name,

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -7,8 +7,9 @@ import type { MCP as MCPNS } from "../../src/mcp/index"
 
 // Per-client state for controlling mock behavior
 interface MockClientState {
-  tools: Array<{ name: string; description?: string; inputSchema: object }>
+  tools: Array<{ name: string; description?: string; inputSchema: object; outputSchema?: object }>
   listToolsCalls: number
+  requestCalls: number
   listToolsShouldFail: boolean
   listToolsError: string
   listPromptsShouldFail: boolean
@@ -36,6 +37,7 @@ function getOrCreateClientState(name?: string): MockClientState {
     state = {
       tools: [{ name: "test_tool", description: "A test tool", inputSchema: { type: "object", properties: {} } }],
       listToolsCalls: 0,
+      requestCalls: 0,
       listToolsShouldFail: false,
       listToolsError: "listTools failed",
       listPromptsShouldFail: false,
@@ -139,6 +141,12 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return { tools: this._state?.tools ?? [] }
     }
 
+    async request(request: { method: string }) {
+      if (this._state) this._state.requestCalls++
+      if (request.method === "tools/list") return { tools: this._state?.tools ?? [] }
+      throw new Error(`unsupported request: ${request.method}`)
+    }
+
     async listPrompts() {
       if (this._state?.listPromptsShouldFail) {
         throw new Error("listPrompts failed")
@@ -203,6 +211,11 @@ function withInstance(
       },
     })
   }
+}
+
+function statusName(status: Record<string, MCPNS.Status> | MCPNS.Status, server: string) {
+  if ("status" in status) return status.status
+  return status[server]?.status
 }
 
 // ========================================================================
@@ -430,6 +443,59 @@ test(
         const tools = yield* mcp.tools()
         expect(Object.keys(tools).some((k) => k.includes("good_tool"))).toBe(true)
       }),
+  ),
+)
+
+test(
+  "falls back when MCP output schema refs fail SDK tool discovery",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "stitch-like-server"
+      const serverState = getOrCreateClientState("stitch-like-server")
+      serverState.listToolsShouldFail = true
+      serverState.listToolsError = "can't resolve reference #/$defs/ScreenInstance from id #"
+      serverState.tools = [
+        {
+          name: "render_screen",
+          description: "renders a screen",
+          inputSchema: { type: "object", properties: { prompt: { type: "string" } }, required: ["prompt"] },
+          outputSchema: { type: "object", properties: { screen: { $ref: "#/$defs/ScreenInstance" } } },
+        },
+      ]
+
+      const addResult = yield* mcp.add("stitch-like-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      expect(statusName(addResult.status, "stitch-like-server")).toBe("connected")
+
+      const tools = yield* mcp.tools()
+      expect(Object.keys(tools).some((key) => key.includes("render_screen"))).toBe(true)
+      expect(serverState.listToolsCalls).toBe(1)
+      expect(serverState.requestCalls).toBe(1)
+    }),
+  ),
+)
+
+test(
+  "does not fall back for non-schema MCP tool discovery errors",
+  withInstance({}, (mcp) =>
+    Effect.gen(function* () {
+      lastCreatedClientName = "broken-server"
+      const serverState = getOrCreateClientState("broken-server")
+      serverState.listToolsShouldFail = true
+      serverState.listToolsError = "transport closed"
+
+      const addResult = yield* mcp.add("broken-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      expect(statusName(addResult.status, "broken-server")).toBe("failed")
+      expect(serverState.listToolsCalls).toBe(1)
+      expect(serverState.requestCalls).toBe(0)
+    }),
   ),
 )
 

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -141,9 +141,9 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return { tools: this._state?.tools ?? [] }
     }
 
-    async request(request: { method: string }) {
+    async request(request: { method: string }, schema: { parse: (value: unknown) => unknown }) {
       if (this._state) this._state.requestCalls++
-      if (request.method === "tools/list") return { tools: this._state?.tools ?? [] }
+      if (request.method === "tools/list") return schema.parse({ tools: this._state?.tools ?? [] })
       throw new Error(`unsupported request: ${request.method}`)
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #26529
Closes #26260
Closes #26382

Based on the approach from #26530 by @nicolascancino, with cleanup and additional regression coverage.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps the normal MCP SDK `listTools()` path for tool discovery. If that path fails with an output-schema/reference validation error, retries raw `tools/list` with a tolerant result schema that preserves `inputSchema` while treating `outputSchema` as opaque.

This prevents one invalid or unresolved MCP tool output schema from marking the entire server as failed, while still preserving normal behavior for transport/auth/listTools failures.

### How did you verify your code works?

```bash
cd packages/opencode
bun test test/mcp/lifecycle.test.ts --timeout 30000
bun typecheck
```

Also ran:

```bash
bunx prettier --write src/mcp/index.ts test/mcp/lifecycle.test.ts
bunx oxlint packages/opencode/src/mcp/index.ts packages/opencode/test/mcp/lifecycle.test.ts
```

`oxlint` reported existing warnings in these files and no errors.

The pre-push hook also ran full workspace typecheck successfully.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR