### PR TITLE
Source workspace path pattern

### DIFF
--- a/packages/opencode/specs/openapi-translation-cleanup.md
+++ b/packages/opencode/specs/openapi-translation-cleanup.md
@@ -111,7 +111,7 @@ Concrete first targets:
 - `[x]` `permissionID`
 - `[x]` `ptyID`
 
-Leave ambiguous route-local `id` overrides for workspace routes until they are renamed or explicitly typed in endpoint params.
+- `[x]` Remove ambiguous workspace `id` path overrides once the endpoint source schema emits the `wrk` pattern.
 
 Verification:
 

--- a/packages/opencode/src/control-plane/schema.ts
+++ b/packages/opencode/src/control-plane/schema.ts
@@ -4,9 +4,9 @@ import { Identifier } from "@/id/id"
 import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
-const workspaceIdSchema = Schema.String.annotate({ [ZodOverride]: Identifier.schema("workspace") }).pipe(
-  Schema.brand("WorkspaceID"),
-)
+const workspaceIdSchema = Schema.String.check(Schema.isStartsWith("wrk"))
+  .annotate({ [ZodOverride]: Identifier.schema("workspace") })
+  .pipe(Schema.brand("WorkspaceID"))
 
 export type WorkspaceID = typeof workspaceIdSchema.Type
 

--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -478,7 +478,7 @@ function flattenOptions(options: OpenApiSchema[] | undefined): OpenApiSchema[] |
 function normalizeParameter(param: OpenApiParameter, route: string) {
   if (!param.schema || typeof param.schema !== "object") return
   if (param.in === "path") {
-    param.schema = pathParameterSchema(route, param.name) ?? stripOptionalNull(param.schema)
+    param.schema = stripOptionalNull(param.schema)
     return
   }
   if (param.in === "query") {
@@ -495,12 +495,6 @@ function normalizeParameter(param: OpenApiParameter, route: string) {
     }
   }
   param.schema = stripOptionalNull(param.schema)
-}
-
-function pathParameterSchema(route: string, name: string) {
-  if (name === "id" && route.startsWith("DELETE /experimental/workspace/")) return { type: "string", pattern: "^wrk.*" }
-  if (name === "id" && route.startsWith("POST /experimental/workspace/")) return { type: "string", pattern: "^wrk.*" }
-  return undefined
 }
 
 export const PublicApi = OpenCodeHttpApi.annotateMerge(

--- a/packages/opencode/test/server/httpapi-query-schema-drift.test.ts
+++ b/packages/opencode/test/server/httpapi-query-schema-drift.test.ts
@@ -17,6 +17,7 @@ import {
   ToolListQuery,
 } from "../../src/server/routes/instance/httpapi/groups/experimental"
 import { InstancePaths, VcsDiffQuery } from "../../src/server/routes/instance/httpapi/groups/instance"
+import { WorkspacePaths } from "../../src/server/routes/instance/httpapi/groups/workspace"
 import {
   ListQuery as SessionListQuery,
   MessagesQuery,
@@ -82,6 +83,7 @@ const pathParamPatterns = [
   { method: "post", path: "/permission/:requestID/reply", name: "requestID", pattern: "^per" },
   { method: "post", path: "/question/:requestID/reply", name: "requestID", pattern: "^que" },
   { method: "put", path: PtyPaths.update, name: "ptyID", pattern: "^pty" },
+  { method: "delete", path: WorkspacePaths.remove, name: "id", pattern: "^wrk" },
 ] satisfies Array<{ method: Method; path: string; name: string; pattern: string }>
 
 function app() {


### PR DESCRIPTION
## Summary
- Add the `wrk` prefix pattern to the `WorkspaceID` runtime schema.
- Remove the remaining workspace path parameter special-case from `public.ts`.
- Extend path parameter OpenAPI coverage for the workspace removal route.

## Testing
- `./packages/sdk/js/script/build.ts`
- `bun dev generate > /tmp/opencode-openapi-workspace-path-pattern.json`
- `bun test --timeout 5000 test/server/httpapi-query-schema-drift.test.ts`
- `bunx prettier --check src/control-plane/schema.ts src/server/routes/instance/httpapi/public.ts specs/openapi-translation-cleanup.md test/server/httpapi-query-schema-drift.test.ts`
- `bunx oxlint packages/opencode/src/control-plane/schema.ts packages/opencode/src/server/routes/instance/httpapi/public.ts packages/opencode/test/server/httpapi-query-schema-drift.test.ts`
- `bun typecheck`
- pre-push `bun turbo typecheck`

<!-- stack:links:start -->
### Stack

- [ ] #26623
- [ ] **#26624** 👈 current
<!-- stack:links:end -->