### PR TITLE
Remove redundant ID Zod overrides

### DIFF
--- a/packages/opencode/src/control-plane/schema.ts
+++ b/packages/opencode/src/control-plane/schema.ts
@@ -1,12 +1,10 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
+import { zod } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
-const workspaceIdSchema = Schema.String.check(Schema.isStartsWith("wrk"))
-  .annotate({ [ZodOverride]: Identifier.schema("workspace") })
-  .pipe(Schema.brand("WorkspaceID"))
+const workspaceIdSchema = Schema.String.check(Schema.isStartsWith("wrk")).pipe(Schema.brand("WorkspaceID"))
 
 export type WorkspaceID = typeof workspaceIdSchema.Type
 

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -1,4 +1,3 @@
-import z from "zod"
 import { randomBytes } from "crypto"
 
 const prefixes = {
@@ -7,18 +6,11 @@ const prefixes = {
   message: "msg",
   permission: "per",
   question: "que",
-  user: "usr",
   part: "prt",
   pty: "pty",
   tool: "tool",
   workspace: "wrk",
-  entry: "ent",
-  account: "act",
 } as const
-
-export function schema(prefix: keyof typeof prefixes) {
-  return z.string().startsWith(prefixes[prefix])
-}
 
 const LENGTH = 26
 

--- a/packages/opencode/src/permission/schema.ts
+++ b/packages/opencode/src/permission/schema.ts
@@ -1,12 +1,12 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
+import { zod } from "@opencode-ai/core/effect-zod"
 import { Newtype } from "@opencode-ai/core/schema"
 
 export class PermissionID extends Newtype<PermissionID>()(
   "PermissionID",
-  Schema.String.check(Schema.isStartsWith("per")).annotate({ [ZodOverride]: Identifier.schema("permission") }),
+  Schema.String.check(Schema.isStartsWith("per")),
 ) {
   static ascending(id?: string): PermissionID {
     return this.make(Identifier.ascending("permission", id))

--- a/packages/opencode/src/pty/schema.ts
+++ b/packages/opencode/src/pty/schema.ts
@@ -1,12 +1,10 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
+import { zod } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
-const ptyIdSchema = Schema.String.check(Schema.isStartsWith("pty"))
-  .annotate({ [ZodOverride]: Identifier.schema("pty") })
-  .pipe(Schema.brand("PtyID"))
+const ptyIdSchema = Schema.String.check(Schema.isStartsWith("pty")).pipe(Schema.brand("PtyID"))
 
 export type PtyID = typeof ptyIdSchema.Type
 

--- a/packages/opencode/src/question/schema.ts
+++ b/packages/opencode/src/question/schema.ts
@@ -1,13 +1,10 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
+import { zod } from "@opencode-ai/core/effect-zod"
 import { Newtype } from "@opencode-ai/core/schema"
 
-export class QuestionID extends Newtype<QuestionID>()(
-  "QuestionID",
-  Schema.String.check(Schema.isStartsWith("que")).annotate({ [ZodOverride]: Identifier.schema("question") }),
-) {
+export class QuestionID extends Newtype<QuestionID>()("QuestionID", Schema.String.check(Schema.isStartsWith("que"))) {
   static ascending(id?: string): QuestionID {
     return this.make(Identifier.ascending("question", id))
   }

--- a/packages/opencode/src/session/schema.ts
+++ b/packages/opencode/src/session/schema.ts
@@ -1,47 +1,35 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
+import { zod } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
-export const SessionID = Schema.String.check(Schema.isStartsWith("ses"))
-  .annotate({
-    [ZodOverride]: Identifier.schema("session"),
-  })
-  .pipe(
-    Schema.brand("SessionID"),
-    withStatics((s) => ({
-      descending: (id?: string) => s.make(Identifier.descending("session", id)),
-      zod: zod(s),
-    })),
-  )
+export const SessionID = Schema.String.check(Schema.isStartsWith("ses")).pipe(
+  Schema.brand("SessionID"),
+  withStatics((s) => ({
+    descending: (id?: string) => s.make(Identifier.descending("session", id)),
+    zod: zod(s),
+  })),
+)
 
 export type SessionID = Schema.Schema.Type<typeof SessionID>
 
-export const MessageID = Schema.String.check(Schema.isStartsWith("msg"))
-  .annotate({
-    [ZodOverride]: Identifier.schema("message"),
-  })
-  .pipe(
-    Schema.brand("MessageID"),
-    withStatics((s) => ({
-      ascending: (id?: string) => s.make(Identifier.ascending("message", id)),
-      zod: zod(s),
-    })),
-  )
+export const MessageID = Schema.String.check(Schema.isStartsWith("msg")).pipe(
+  Schema.brand("MessageID"),
+  withStatics((s) => ({
+    ascending: (id?: string) => s.make(Identifier.ascending("message", id)),
+    zod: zod(s),
+  })),
+)
 
 export type MessageID = Schema.Schema.Type<typeof MessageID>
 
-export const PartID = Schema.String.check(Schema.isStartsWith("prt"))
-  .annotate({
-    [ZodOverride]: Identifier.schema("part"),
-  })
-  .pipe(
-    Schema.brand("PartID"),
-    withStatics((s) => ({
-      ascending: (id?: string) => s.make(Identifier.ascending("part", id)),
-      zod: zod(s),
-    })),
-  )
+export const PartID = Schema.String.check(Schema.isStartsWith("prt")).pipe(
+  Schema.brand("PartID"),
+  withStatics((s) => ({
+    ascending: (id?: string) => s.make(Identifier.ascending("part", id)),
+    zod: zod(s),
+  })),
+)
 
 export type PartID = Schema.Schema.Type<typeof PartID>

--- a/packages/opencode/src/sync/schema.ts
+++ b/packages/opencode/src/sync/schema.ts
@@ -1,10 +1,10 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
+import { zod } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
-export const EventID = Schema.String.annotate({ [ZodOverride]: Identifier.schema("event") }).pipe(
+export const EventID = Schema.String.check(Schema.isStartsWith("evt")).pipe(
   Schema.brand("EventID"),
   withStatics((s) => ({
     ascending: (id?: string) => s.make(Identifier.ascending("event", id)),

--- a/packages/opencode/src/tool/schema.ts
+++ b/packages/opencode/src/tool/schema.ts
@@ -1,10 +1,10 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
+import { zod } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
-const toolIdSchema = Schema.String.annotate({ [ZodOverride]: Identifier.schema("tool") }).pipe(Schema.brand("ToolID"))
+const toolIdSchema = Schema.String.check(Schema.isStartsWith("tool")).pipe(Schema.brand("ToolID"))
 
 export type ToolID = typeof toolIdSchema.Type
 


### PR DESCRIPTION
## Summary
- Remove redundant `ZodOverride` annotations from prefixed ID schemas now that Effect schemas carry the same prefix checks.
- Move the remaining `ToolID` / `EventID` prefix constraints to Effect schemas too.
- Remove the now-unused `Identifier.schema(...)` helper and unused identifier prefix entries.
- Keep ID constructors and `.zod` statics backed by Effect schema-derived Zod output.

## Testing
- `bun test --timeout 5000 test/server/httpapi-query-schema-drift.test.ts test/cli/github-action.test.ts test/project/migrate-global.test.ts test/session/message-v2.test.ts`
- `bun typecheck`
- `bunx prettier --check packages/opencode/src/id/id.ts packages/opencode/src/tool/schema.ts packages/opencode/src/sync/schema.ts packages/opencode/src/control-plane/schema.ts packages/opencode/src/permission/schema.ts packages/opencode/src/pty/schema.ts packages/opencode/src/question/schema.ts packages/opencode/src/session/schema.ts`
- `bunx oxlint packages/opencode/src/id/id.ts packages/opencode/src/tool/schema.ts packages/opencode/src/sync/schema.ts packages/opencode/src/control-plane/schema.ts packages/opencode/src/permission/schema.ts packages/opencode/src/pty/schema.ts packages/opencode/src/question/schema.ts packages/opencode/src/session/schema.ts`
- pre-push `bun turbo typecheck`

<!-- stack:links:start -->
### Stack

- [x] #26623
- [x] #26632
- [ ] **#26633** ← current
<!-- stack:links:end -->