### PR TITLE
Source diff message query pattern

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -62,7 +62,6 @@ const QueryParameterSchemas: Record<string, OpenApiSchema> = {
   "GET /experimental/session limit": { type: "number" },
   "GET /session start": { type: "number" },
   "GET /session limit": { type: "number" },
-  "GET /session/{sessionID}/diff messageID": { type: "string", pattern: "^msg.*" },
   "GET /session/{sessionID}/message limit": { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
   "GET /api/session limit": { type: "number" },
   "GET /api/session start": { type: "number" },

--- a/packages/opencode/test/server/httpapi-query-schema-drift.test.ts
+++ b/packages/opencode/test/server/httpapi-query-schema-drift.test.ts
@@ -75,6 +75,10 @@ const numericSdkQueryParams = [
   { method: "get", path: "/api/session/:sessionID/message", name: "limit", schema: { type: "number" } },
 ] satisfies Array<{ method: Method; path: string; name: string; schema: OpenApiSchema }>
 
+const queryParamPatterns = [
+  { method: "get", path: SessionPaths.diff, name: "messageID", pattern: "^msg" },
+] satisfies Array<{ method: Method; path: string; name: string; pattern: string }>
+
 const pathParamPatterns = [
   { method: "get", path: SessionPaths.get, name: "sessionID", pattern: "^ses" },
   { method: "get", path: SessionPaths.message, name: "messageID", pattern: "^msg" },
@@ -165,6 +169,19 @@ describe("httpapi query schema drift", () => {
 
       for (const input of ["1", "yes", "True", "", true, false]) {
         expect(() => decode(input)).toThrow()
+      }
+    }),
+  )
+
+  it.effect(
+    "OpenAPI query parameter patterns come from runtime schemas",
+    Effect.sync(() => {
+      const spec = OpenApi.fromApi(PublicApi)
+      for (const expected of queryParamPatterns) {
+        expect(
+          queryParameter(spec.paths[openApiPath(expected.path)]?.[expected.method], expected.name)?.schema,
+          `${expected.method.toUpperCase()} ${expected.path} ${expected.name}`,
+        ).toEqual({ type: "string", pattern: expected.pattern })
       }
     }),
   )


### PR DESCRIPTION
## Summary
- Remove the `GET /session/{sessionID}/diff messageID` query schema override from `public.ts`.
- Cover that the query parameter pattern now comes from the runtime `MessageID` schema.

## Testing
- `bun test --timeout 5000 test/server/httpapi-query-schema-drift.test.ts`
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check packages/opencode/src/server/routes/instance/httpapi/public.ts packages/opencode/test/server/httpapi-query-schema-drift.test.ts`
- `bunx oxlint packages/opencode/src/server/routes/instance/httpapi/public.ts packages/opencode/test/server/httpapi-query-schema-drift.test.ts`
- `./packages/sdk/js/script/build.ts` generated only unrelated declaration-order churn; not committed.

<!-- stack:links:start -->
### Stack

- [x] #26623
- [x] #26632
- [x] #26633
- [ ] **#26638** ← current
<!-- stack:links:end -->