### PR TITLE
fix(tui): accept keymap alias, guard leader none, graceful unknown keys

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -21,7 +21,7 @@ export const TuiOptions = z.object({
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
 })
 
-export const TuiInfo = z
+const TuiInfoShape = z
   .object({
     $schema: z.string().optional(),
     theme: z.string().optional(),
@@ -30,6 +30,14 @@ export const TuiInfo = z
     plugin_enabled: z.record(z.string(), z.boolean()).optional(),
   })
   .extend(TuiOptions.shape)
-  .strict()
+
+export const TuiInfo = TuiInfoShape.strict()
+
+/**
+ * Permissive variant that strips unrecognised keys instead of failing.
+ * Used as a fallback when `TuiInfo` (strict) rejects the file so that
+ * valid settings are still applied.
+ */
+export const TuiInfoPermissive = TuiInfoShape.strip()
 
 export const TuiJsonSchemaInfo = TuiInfo

--- a/packages/opencode/src/cli/cmd/tui/config/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui.ts
@@ -7,7 +7,7 @@ import { Context, Effect, Fiber, Layer } from "effect"
 import { ConfigParse } from "@/config/parse"
 import * as ConfigPaths from "@/config/paths"
 import { migrateTuiConfig } from "./tui-migrate"
-import { KeymapLeaderTimeoutDefault, TuiInfo, TuiJsonSchemaInfo } from "./tui-schema"
+import { KeymapLeaderTimeoutDefault, TuiInfo, TuiInfoPermissive, TuiJsonSchemaInfo } from "./tui-schema"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { isRecord } from "@/util/record"
 import { Global } from "@opencode-ai/core/global"
@@ -53,20 +53,30 @@ function pluginScope(file: string, ctx: { directory: string }): ConfigPlugin.Sco
   return "global"
 }
 
+function aliasKeymap(obj: Record<string, unknown>) {
+  // Accept `keymap` as an alias for `keybinds` — the published JSON schema
+  // at opencode.ai/tui.json marks `keybinds` deprecated in favour of `keymap`.
+  if ("keymap" in obj && !("keybinds" in obj)) {
+    obj.keybinds = obj.keymap
+    delete obj.keymap
+  }
+  return obj
+}
+
 function normalize(raw: Record<string, unknown>) {
   const data = { ...raw }
-  if (!("tui" in data)) return data
+  if (!("tui" in data)) return aliasKeymap(data)
   if (!isRecord(data.tui)) {
     delete data.tui
-    return data
+    return aliasKeymap(data)
   }
 
   const tui = data.tui
   delete data.tui
-  return {
+  return aliasKeymap({
     ...tui,
     ...data,
-  }
+  })
 }
 
 const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: string }) {
@@ -91,8 +101,18 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
       if (!isRecord(data)) return {} as Info
       // Flatten a nested "tui" key so users who wrote `{ "tui": { ... } }` inside tui.json
       // (mirroring the old opencode.json shape) still get their settings applied.
-      const validated = ConfigParse.schema(Info, normalize(data), configFilepath)
-      return yield* resolvePlugins(validated, configFilepath)
+      const normalized = normalize(data)
+      try {
+        const validated = ConfigParse.schema(Info, normalized, configFilepath)
+        return yield* resolvePlugins(validated, configFilepath)
+      } catch {
+        // Strict parse failed (likely unrecognised keys). Fall back to a
+        // permissive parse that strips unknown keys so valid settings are
+        // still applied instead of silently dropping the entire config.
+        log.warn("tui config has unrecognised keys, ignoring them", { path: configFilepath })
+        const permissive = ConfigParse.schema(TuiInfoPermissive, normalized, configFilepath)
+        return yield* resolvePlugins(permissive as Info, configFilepath)
+      }
     }).pipe(
       // catchCause (not tapErrorCause + orElseSucceed) because ConfigParse.jsonc/.schema
       // can sync-throw — those become defects, which orElseSucceed wouldn't catch.
@@ -187,6 +207,12 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     ]).join(",")
   }
   const parsedKeybinds = TuiKeybind.Keybinds.parse(keybinds)
+  // Guard against leader set to "none" or false — the keymap engine
+  // requires exactly one real trigger binding for the leader key.
+  if (parsedKeybinds.leader === "none" || parsedKeybinds.leader === false) {
+    log.warn('leader key cannot be disabled, falling back to default', { got: parsedKeybinds.leader, fallback: TuiKeybind.LeaderDefault })
+    parsedKeybinds.leader = TuiKeybind.LeaderDefault
+  }
   const result: Resolved = {
     ...acc.result,
     keybinds: createBindingLookup(TuiKeybind.toBindingConfig(parsedKeybinds), {


### PR DESCRIPTION
## Summary

Fixes three tui config issues reported in #26628.

## Related Issue

Closes #26628

## Changes

### 1. Accept `keymap` as alias for `keybinds`

The published JSON schema at `opencode.ai/tui.json` marks `keybinds` deprecated in favour of `keymap`, but the code only accepted `keybinds`. Configs following the schema's recommendation were silently rejected.

Added an `aliasKeymap()` step in the `normalize()` function that renames `keymap` → `keybinds` before schema validation.

### 2. Guard `leader: "none"` crash

Setting `leader: "none"` (or `false`) is accepted by the keybind schema but crashes at runtime because `createBindingLookup` requires exactly one real trigger binding for the leader key.

Added a guard in `loadState()` that detects disabled leader values and falls back to the default (`ctrl+x`) with a warning log.

### 3. Graceful handling of unknown keys

When `TuiInfo.strict()` validation fails (e.g. unrecognised keys from a newer config), the entire config file was silently dropped — the `catchCause` handler returned `{} as Info`.

Now uses a two-pass approach: try strict validation first, and if it fails, fall back to a permissive `.strip()` parse that ignores unknown keys while preserving valid settings. A warning is logged about unrecognised keys.

## Testing

- All 31 existing tui config tests pass
- All 99 tui CLI tests pass
- TypeScript compilation passes with no errors

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.