### PR TITLE
fix(file): detect extension-less binary files via content sniffing to avoid preview hang

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -9,6 +9,7 @@ import { formatPatch, structuredPatch } from "diff"
 import fuzzysort from "fuzzysort"
 import ignore from "ignore"
 import path from "path"
+import fs from "fs/promises"
 import { Global } from "@opencode-ai/core/global"
 import { containsPath } from "../project/instance-context"
 import * as Log from "@opencode-ai/core/util/log"
@@ -298,6 +299,18 @@ function shouldEncode(mimeType: string) {
   return ["image", "audio", "video", "font", "model", "multipart"].includes(top)
 }
 
+const SNIFF_BYTES = 8192
+
+// Sniff a small prefix of bytes to detect binary content. Used as a fallback
+// for files whose extension/MIME does not classify them (e.g. extensionless
+// compiled executables), which would otherwise be read as a UTF-8 string and
+// fed to `git diff` — slow or hung for large binaries.
+function isBinaryBySniff(bytes: Uint8Array) {
+  if (bytes.length === 0) return false
+  if (bytes.includes(0)) return true
+  return bytes.filter((b) => b < 9 || (b > 13 && b < 32)).length / bytes.length > 0.3
+}
+
 const hidden = (item: string) => {
   const normalized = item.replaceAll("\\", "/").replace(/\/+$/, "")
   return normalized.split("/").some((part) => part.startsWith(".") && part.length > 1)
@@ -545,6 +558,24 @@ export const layer = Layer.effect(
           mimeType,
           encoding: "base64" as const,
         }
+      }
+
+      if (!knownText) {
+        const sniff = yield* Effect.scoped(
+          Effect.acquireRelease(
+            Effect.promise(() => fs.open(full, "r")),
+            (fh) => Effect.promise(() => fh.close()),
+          ).pipe(
+            Effect.flatMap((fh) =>
+              Effect.promise(async () => {
+                const buf = new Uint8Array(SNIFF_BYTES)
+                const result = await fh.read(buf, 0, SNIFF_BYTES, 0)
+                return buf.subarray(0, result.bytesRead)
+              }),
+            ),
+          ),
+        ).pipe(Effect.catch(() => Effect.succeed(new Uint8Array())))
+        if (isBinaryBySniff(sniff)) return { type: "binary" as const, content: "", mimeType }
       }
 
       const content = yield* appFs.readFileString(full).pipe(


### PR DESCRIPTION
### Issue for this PR
Closes #26642

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
`File.read()` already handles known binary extensions correctly — `isBinaryByExtension` returns `{ type: "binary" }` and `FileMedia` renders the placeholder card. Extension-less binaries are not handled, so this PR adds a fallback that opens the file, partially reads the first 8 KB, and classifies it as binary when it contains any NUL byte (early return) or when non-printable bytes exceed 30%. No frontend changes.

### How did you verify your code works?
Clicked the same binary that previously caused the issue (104 MB). The preview pane now resolves to the binary card, just like binaries with known extensions.

### Screenshots / recordings
<img width="1508" height="1028" alt="CleanShot 2026-05-10 at 11 40 26" src="https://github.com/user-attachments/assets/c51c4943-306a-4a50-9dd0-051089905d28" />

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
