### PR TITLE
feat: add configurable max retry limit for SessionRetry

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -283,6 +283,18 @@ export const Info = Schema.Struct({
       }),
     }),
   ),
+  session: Schema.optional(
+    Schema.Struct({
+      retry: Schema.optional(
+        Schema.Struct({
+          maxAttempts: Schema.optional(NonNegativeInt).annotate({
+            description:
+              "Maximum number of retry attempts for transient errors (5xx, rate limits). Set to 0 to disable retries. Default: 5",
+          }),
+        }),
+      ),
+    }),
+  ),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -749,6 +749,7 @@ export const layer: Layer.Layer<
                     next: info.next,
                   })
                 },
+                maxAttempts: (yield* config.get()).session?.retry?.maxAttempts,
               }),
             ),
             Effect.catch(halt),

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -25,6 +25,7 @@ export const RETRY_INITIAL_DELAY = 2000
 export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
+export const RETRY_MAX_ATTEMPTS = 5 // default max retry attempts
 
 function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
@@ -175,8 +176,10 @@ export function policy(opts: {
   provider: string
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
+  maxAttempts?: number
 }) {
-  return Schedule.fromStepWithMetadata(
+  const maxAttempts = opts.maxAttempts ?? RETRY_MAX_ATTEMPTS
+  const retryPolicy = Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
@@ -194,6 +197,7 @@ export function policy(opts: {
       })
     }),
   )
+  return Schedule.intersect(retryPolicy, Schedule.recurs(maxAttempts))
 }
 
 export * as SessionRetry from "./retry"


### PR DESCRIPTION
## Summary

This PR adds a configurable maximum retry limit for the `SessionRetry` mechanism, addressing the issue where persistent 5xx errors cause infinite retry loops with exponential backoff.

## Changes

- Add `RETRY_MAX_ATTEMPTS` constant (default: 5) to `retry.ts`
- Add `maxAttempts` parameter to `SessionRetry.policy()`
- Use `Schedule.intersect` with `Schedule.recurs` to enforce the limit
- Add `session.retry.maxAttempts` to config schema in `config.ts`
- Pass config value from `processor.ts` to retry policy

## Configuration

Users can now configure the max retry attempts in `opencode.json`:

```json
{
  "session": {
    "retry": {
      "maxAttempts": 5
    }
  }
}
```

- Default: 5 attempts
- Set to 0 to disable retries entirely
- Applies globally to all agents

## Motivation

Previously, when a provider returned persistent 5xx errors (e.g., DeepSeek-V4-Pro returning 500), OpenCode would retry indefinitely with exponential backoff:
- Attempt 1: 2s delay
- Attempt 13: ~2h 11min delay
- ...continues indefinitely

This made it impossible for fallback mechanisms (like oh-my-openagent) to take over, as OpenCode kept retrying the same model forever.

## Testing

- Existing tests in `retry.test.ts` should continue to pass
- The `Schedule.intersect` approach ensures both the backoff delay AND max attempts are respected
- When max attempts is reached, the error is propagated (not retried)

## Related Issues

Closes #26675