### PR TITLE
feat: stream tool call inputs in real time

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync-v2.tsx
@@ -187,6 +187,10 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
           })
           break
         case "session.next.tool.input.ended":
+          update(event.properties.sessionID, (draft) => {
+            const match = latestTool(activeAssistant(draft), event.properties.callID)
+            if (match?.state.status === "pending") match.state.input = event.properties.text
+          })
           break
         case "session.next.tool.called":
           update(event.properties.sessionID, (draft) => {

--- a/packages/opencode/src/server/routes/instance/httpapi/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/event.ts
@@ -1,6 +1,10 @@
 import { Bus } from "@/bus"
+import { GlobalBus, type GlobalEvent as GlobalBusEvent } from "@/bus/global"
+import * as InstanceState from "@/effect/instance-state"
+import type { WorkspaceID } from "@/control-plane/schema"
+import type { InstanceContext } from "@/project/instance"
 import * as Log from "@opencode-ai/core/util/log"
-import { Effect, Schema } from "effect"
+import { Effect, Queue, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
@@ -39,8 +43,21 @@ function eventData(data: unknown): Sse.Event {
   }
 }
 
-function eventResponse(bus: Bus.Interface) {
-  const events = bus.subscribeAll().pipe(Stream.takeUntil((event) => event.type === Bus.InstanceDisposed.type))
+function eventResponse(context: { instance: InstanceContext; workspace: WorkspaceID | undefined }) {
+  const events = Stream.callback<GlobalBusEvent>((queue) => {
+    const handler = (event: GlobalBusEvent) => {
+      if (event.directory !== context.instance.directory) return
+      if (event.workspace !== context.workspace) return
+      Queue.offerUnsafe(queue, event)
+    }
+    return Effect.acquireRelease(
+      Effect.sync(() => GlobalBus.on("event", handler)),
+      () => Effect.sync(() => GlobalBus.off("event", handler)),
+    )
+  }).pipe(
+    Stream.map((event) => event.payload),
+    Stream.takeUntil((event) => event.type === Bus.InstanceDisposed.type),
+  )
   const heartbeat = Stream.tick("10 seconds").pipe(
     Stream.drop(1),
     Stream.map(() => ({ id: Bus.createID(), type: "server.heartbeat", properties: {} })),
@@ -68,11 +85,13 @@ function eventResponse(bus: Bus.Interface) {
 
 export const eventHandlers = HttpApiBuilder.group(EventApi, "event", (handlers) =>
   Effect.gen(function* () {
-    const bus = yield* Bus.Service
     return handlers.handleRaw(
       "subscribe",
       Effect.fn("EventHttpApi.subscribe")(function* () {
-        return eventResponse(bus)
+        return eventResponse({
+          instance: yield* InstanceState.context,
+          workspace: yield* InstanceState.workspaceID,
+        })
       }),
     )
   }),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -65,6 +65,7 @@ type ToolCall = {
   messageID: MessageV2.ToolPart["messageID"]
   sessionID: MessageV2.ToolPart["sessionID"]
   done: Deferred.Deferred<void>
+  raw: string
 }
 
 interface ProcessorContext extends Input {
@@ -299,20 +300,44 @@ export const layer: Layer.Layer<
               partID: part.id,
               messageID: part.messageID,
               sessionID: part.sessionID,
+              raw: ctx.toolcalls[value.id]?.raw ?? "",
             }
             return
 
-          case "tool-input-delta":
+          case "tool-input-delta": {
+            if (!value.delta) return
+            const call = ctx.toolcalls[value.id]
+            if (!call) return
+            call.raw += value.delta
+            EventV2.run(SessionEvent.Tool.Input.Delta.Sync, {
+              sessionID: ctx.sessionID,
+              callID: value.id,
+              delta: value.delta,
+              timestamp: DateTime.makeUnsafe(Date.now()),
+            })
             return
+          }
 
           case "tool-input-end": {
+            const raw = ctx.toolcalls[value.id]?.raw ?? ""
             // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
             EventV2.run(SessionEvent.Tool.Input.Ended.Sync, {
               sessionID: ctx.sessionID,
               callID: value.id,
-              text: "",
+              text: raw,
               timestamp: DateTime.makeUnsafe(Date.now()),
             })
+            yield* updateToolCall(value.id, (match) =>
+              match.state.status === "pending"
+                ? {
+                    ...match,
+                    state: {
+                      ...match.state,
+                      raw,
+                    },
+                  }
+                : match,
+            )
             return
           }
 
@@ -337,7 +362,6 @@ export const layer: Layer.Layer<
               ...match,
               tool: value.toolName,
               state: {
-                ...match.state,
                 status: "running",
                 input: value.input,
                 time: { start: Date.now() },

--- a/packages/opencode/src/v2/event.ts
+++ b/packages/opencode/src/v2/event.ts
@@ -1,7 +1,6 @@
 import { Identifier } from "@/id/id"
 import { SyncEvent } from "@/sync"
 import { withStatics } from "@opencode-ai/core/schema"
-import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Schema from "effect/Schema"
 
 export const ID = Schema.String.pipe(
@@ -46,7 +45,6 @@ export function run<Def extends SyncEvent.Definition>(
   data: SyncEvent.Event<Def>["data"],
   options?: { publish?: boolean },
 ) {
-  if (!Flag.OPENCODE_EXPERIMENTAL_EVENT_SYSTEM) return
   SyncEvent.run(def, data, options)
 }
 

--- a/packages/opencode/src/v2/session-message-updater.ts
+++ b/packages/opencode/src/v2/session-message-updater.ts
@@ -269,7 +269,16 @@ export function update<Result>(adapter: Adapter<Result>, event: SessionEvent.Eve
         )
       }
     },
-    "session.next.tool.input.ended": () => {},
+    "session.next.tool.input.ended": (event) => {
+      if (currentAssistant) {
+        adapter.updateAssistant(
+          produce(currentAssistant, (draft) => {
+            const match = latestTool(draft, event.data.callID)
+            if (match && match.state.status === "pending") match.state.input = event.data.text
+          }),
+        )
+      }
+    },
     "session.next.tool.called": (event) => {
       if (currentAssistant) {
         adapter.updateAssistant(

--- a/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
+++ b/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
@@ -174,7 +174,11 @@ describe("doStream", () => {
 
     // Check tool calls
     const toolParts = parts.filter(
-      (p) => p.type === "tool-input-start" || p.type === "tool-call" || p.type === "tool-input-end",
+      (p) =>
+        p.type === "tool-input-start" ||
+        p.type === "tool-input-delta" ||
+        p.type === "tool-call" ||
+        p.type === "tool-input-end",
     )
 
     expect(toolParts).toContainEqual({
@@ -196,6 +200,15 @@ describe("doStream", () => {
       id: "call_def456",
       toolName: "read_file",
     })
+    expect(
+      toolParts.some(
+        (part) =>
+          part.type === "tool-input-delta" &&
+          part.id === "call_abc123" &&
+          typeof part.delta === "string" &&
+          part.delta.length > 0,
+      ),
+    ).toBe(true)
 
     // Check finish
     const finish = parts.find((p) => p.type === "finish")
@@ -367,7 +380,11 @@ describe("doStream", () => {
 
     // Check tool call
     const toolParts = parts.filter(
-      (p) => p.type === "tool-input-start" || p.type === "tool-call" || p.type === "tool-input-end",
+      (p) =>
+        p.type === "tool-input-start" ||
+        p.type === "tool-input-delta" ||
+        p.type === "tool-call" ||
+        p.type === "tool-input-end",
     )
 
     expect(toolParts).toContainEqual({
@@ -383,6 +400,15 @@ describe("doStream", () => {
         toolName: "list_project_files",
       }),
     )
+    expect(
+      toolParts.some(
+        (part) =>
+          part.type === "tool-input-delta" &&
+          part.id === "call_MHxqRDd5WVo3NU8wUXRaMmc0MFE" &&
+          typeof part.delta === "string" &&
+          part.delta.length > 0,
+      ),
+    ).toBe(true)
 
     // Check finish
     const finish = parts.find((p) => p.type === "finish")

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -263,6 +263,46 @@ function createChatStream(text: string) {
   })
 }
 
+function createToolChatStream(toolName: string, input: Record<string, unknown>) {
+  const args = JSON.stringify(input)
+  return createEventStream(
+    [
+      {
+        id: "chatcmpl-tool",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { role: "assistant" } }],
+      },
+      {
+        id: "chatcmpl-tool",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function",
+                  function: {
+                    name: toolName,
+                    arguments: args,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-tool",
+        object: "chat.completion.chunk",
+        choices: [{ delta: {}, finish_reason: "tool_calls" }],
+      },
+    ],
+    true,
+  )
+}
+
 async function loadFixture(providerID: string, modelID: string) {
   const fixturePath = path.join(import.meta.dir, "../tool/fixtures/models-api.json")
   const data = await Filesystem.readJson<Record<string, ModelsDev.Provider>>(fixturePath)
@@ -300,6 +340,108 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
 }
 
 describe("session.llm.stream", () => {
+  test("emits tool input streaming events for openai-compatible tool calls", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "vivgrid"
+    const modelID = "gemini-3.1-pro-preview"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    waitRequest(
+      "/chat/completions",
+      new Response(createToolChatStream("bash", { command: "pwd" }), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            provider: {
+              [providerID]: {
+                ...fixture.provider,
+                models: { [model.id]: model },
+                options: {
+                  apiKey: "test-key",
+                  baseURL: server.url.origin,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const events = await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-tool-stream")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("msg_user-tool-stream"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        return await llm.runPromise((svc) =>
+          svc
+            .stream({
+              user,
+              sessionID,
+              model: resolved,
+              agent,
+              system: ["You are a helpful assistant."],
+              messages: [{ role: "user", content: "Run bash" }],
+              tools: {
+                bash: tool({
+                  description: "Stub bash tool",
+                  inputSchema: z.object({ command: z.string() }),
+                  execute: async () => ({ output: "pwd" }),
+                }),
+              },
+            })
+            .pipe(
+              Stream.runCollect,
+              Effect.map((chunks) => [...chunks]),
+            ),
+        )
+      },
+    })
+
+    expect(events.some((event) => event.type === "tool-input-start" && event.id === "call_1")).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.type === "tool-input-delta" && event.id === "call_1" && event.delta === '{"command":"pwd"}',
+      ),
+    ).toBe(true)
+    expect(events.some((event) => event.type === "tool-input-end" && event.id === "call_1")).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.type === "tool-call" &&
+          event.toolCallId === "call_1" &&
+          JSON.stringify(event.input) === '{"command":"pwd"}',
+      ),
+    ).toBe(true)
+  })
+
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,7 +1,9 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { expect } from "bun:test"
+import { tool } from "ai"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
+import z from "zod"
 import type { Agent } from "../../src/agent/agent"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
@@ -407,6 +409,141 @@ it.live("session.processor effect tests capture reasoning from http mock", () =>
         expect(yield* llm.calls).toBe(1)
         expect(reasoning?.text).toBe("think")
         expect(text?.text).toBe("done")
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests execute tool calls with parsed structured input", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.tool("bash", { command: "pwd" })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "tool stream")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "tool stream" }],
+          tools: {
+            bash: tool({
+              description: "Stub bash tool",
+              inputSchema: z.object({
+                command: z.string(),
+              }),
+              execute: async ({ command }) => ({
+                title: "Bash",
+                metadata: { command },
+                output: command,
+              }),
+            }),
+          },
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const call = parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+
+        expect(value).toBe("continue")
+        expect(call?.state.status).toBe("completed")
+        if (call?.state.status === "completed") {
+          expect(call.state.input).toEqual({ command: "pwd" })
+          expect(call.state.output).toBe("pwd")
+          expect(call.state.metadata.command).toBe("pwd")
+        }
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests do not carry raw input into running tool state", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const release = defer<void>()
+
+        yield* llm.tool("bash", { command: "pwd" })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "tool raw")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const run = yield* handle
+          .process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+            } satisfies MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "tool raw" }],
+            tools: {
+              bash: tool({
+                description: "Stub bash tool",
+                inputSchema: z.object({
+                  command: z.string(),
+                }),
+                execute: async () => {
+                  await release.promise
+                  return {
+                    title: "Bash",
+                    metadata: {},
+                    output: "pwd",
+                  }
+                },
+              }),
+            },
+          })
+          .pipe(Effect.forkChild)
+
+        const call = yield* Effect.promise(async () => {
+          const end = Date.now() + 1_000
+          while (Date.now() < end) {
+            const call = MessageV2.parts(msg.id).find((part): part is MessageV2.ToolPart => part.type === "tool")
+            if (call?.state.status === "running") return call
+            await Bun.sleep(10)
+          }
+          throw new Error("Tool call did not enter running state")
+        })
+
+        expect("raw" in call.state).toBe(false)
+        expect(call.state.input).toEqual({ command: "pwd" })
+
+        release.resolve()
+        expect(yield* Fiber.join(run)).toBe("continue")
       }),
     { git: true, config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/v2/session-message-updater.test.ts
+++ b/packages/opencode/test/v2/session-message-updater.test.ts
@@ -158,6 +158,95 @@ test("tool completion stores completed timestamp", () => {
   expect(state.messages[0].content[0].provider).toEqual({ executed: true, metadata: { status: "done" } })
 })
 
+test("tool input delta and ended populate pending input before tool called", () => {
+  const state: SessionMessageUpdater.MemoryState = { messages: [] }
+  const sessionID = SessionID.make("session")
+  const callID = "call"
+
+  SessionMessageUpdater.update(SessionMessageUpdater.memory(state), {
+    id: EventV2.ID.create(),
+    type: "session.next.step.started",
+    data: {
+      sessionID,
+      timestamp: DateTime.makeUnsafe(1),
+      agent: "build",
+      model: {
+        id: Modelv2.ID.make("model"),
+        providerID: Modelv2.ProviderID.make("provider"),
+        variant: Modelv2.VariantID.make("default"),
+      },
+    },
+  } satisfies SessionEvent.Event)
+
+  SessionMessageUpdater.update(SessionMessageUpdater.memory(state), {
+    id: EventV2.ID.create(),
+    type: "session.next.tool.input.started",
+    data: {
+      sessionID,
+      timestamp: DateTime.makeUnsafe(2),
+      callID,
+      name: "bash",
+    },
+  } satisfies SessionEvent.Event)
+
+  SessionMessageUpdater.update(SessionMessageUpdater.memory(state), {
+    id: EventV2.ID.create(),
+    type: "session.next.tool.input.delta",
+    data: {
+      sessionID,
+      timestamp: DateTime.makeUnsafe(3),
+      callID,
+      delta: '{"command":"pw',
+    },
+  } satisfies SessionEvent.Event)
+
+  SessionMessageUpdater.update(SessionMessageUpdater.memory(state), {
+    id: EventV2.ID.create(),
+    type: "session.next.tool.input.ended",
+    data: {
+      sessionID,
+      timestamp: DateTime.makeUnsafe(4),
+      callID,
+      text: '{"command":"pwd"}',
+    },
+  } satisfies SessionEvent.Event)
+
+  expect(state.messages[0]?.type).toBe("assistant")
+  if (state.messages[0]?.type !== "assistant") return
+  expect(state.messages[0].content[0]).toMatchObject({
+    type: "tool",
+    id: callID,
+    state: {
+      status: "pending",
+      input: '{"command":"pwd"}',
+    },
+  })
+
+  SessionMessageUpdater.update(SessionMessageUpdater.memory(state), {
+    id: EventV2.ID.create(),
+    type: "session.next.tool.called",
+    data: {
+      sessionID,
+      timestamp: DateTime.makeUnsafe(5),
+      callID,
+      tool: "bash",
+      input: { command: "pwd" },
+      provider: { executed: false },
+    },
+  } satisfies SessionEvent.Event)
+
+  expect(state.messages[0]?.type).toBe("assistant")
+  if (state.messages[0]?.type !== "assistant") return
+  expect(state.messages[0].content[0]).toMatchObject({
+    type: "tool",
+    id: callID,
+    state: {
+      status: "running",
+      input: { command: "pwd" },
+    },
+  })
+})
+
 test("compaction events reduce to compaction message", () => {
   const state: SessionMessageUpdater.MemoryState = { messages: [] }
   const sessionID = SessionID.make("session")


### PR DESCRIPTION
### Issue for this PR

Closes #9737

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

opencode already had v2 event definitions for streaming tool call inputs
(`session.next.tool.input.started/delta/ended`) but none of the plumbing was connected,
so clients received no streaming input events at all. This PR wires everything up so
frontends can show tool arguments appearing incrementally while the LLM is still
generating them — similar to how Cursor displays tool call inputs as they stream in.

Four concrete problems were fixed:

1. `SessionProcessor` silently dropped `tool-input-delta` events — the handler was a
   bare `return` with no logic.
2. `session.next.tool.input.ended` was a no-op in both `SessionMessageUpdater` and the
   TUI's `sync-v2`, so even the final accumulated text was never written back to the
   pending tool part.
3. `EventV2.run` was gated behind `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM`, so no v2 events
   were dispatched in normal operation regardless of the above.
4. The `/event` SSE route subscribed to the request-scoped `Bus.Service`. Its lifetime
   ended when the HTTP handler returned the streaming response, causing the client event
   stream to close immediately — so even if events had been published, clients would
   never have received them.

Changes per file:

- **`processor.ts`**: accumulate delta text per tool call, publish
  `session.next.tool.input.delta` on each chunk, write the full string to `state.raw`
  on `tool-input-end` and publish `session.next.tool.input.ended`. Also fixed a schema
  bug: the pending→running transition was spreading `...match.state`, which leaked the
  `raw` field (only valid on `ToolStatePending`) into `ToolStateRunning`.
- **`v2/event.ts`**: removed the experimental flag guard — v2 events are now always on.
- **`session-message-updater.ts`** + **`sync-v2.tsx`**: implemented the
  `session.next.tool.input.ended` handler to write the accumulated text into the pending
  tool part's input field.
- **`httpapi/event.ts`**: replaced the request-scoped `Bus.Service` subscription with a
  `GlobalBus` listener filtered by `directory`/`workspace`, so the SSE stream stays
  alive for the full duration of the client connection.

### How did you verify your code works?

- Added unit tests for delta accumulation and the `session-message-updater` reducer
  (`test/session/llm.test.ts`, `test/v2/session-message-updater.test.ts`).
- Added a live integration test in `test/session/processor-effect.test.ts` that asserts
  `ToolStateRunning` does not contain a `raw` field after the pending→running transition.
- Ran an end-to-end demo against a local opencode server and confirmed
  `session.next.tool.input.delta` events arrive over SSE while the LLM is generating,
  followed by `session.next.tool.input.ended` and `session.next.tool.called`.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
