### PR TITLE
fix(tui): flush message.part.delta events immediately to reduce Claude streaming latency

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -59,8 +59,21 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
 
     const handleEvent = (event: GlobalEvent) => {
       queue.push(event)
-      const elapsed = Date.now() - last
 
+      // Streaming text deltas must render immediately — bypassing the 16 ms
+      // batching window — so that bursty upstream SSE delivery (e.g. Copilot's
+      // /v1/messages shim for Claude) is not held back an extra frame. Other
+      // events (session status, tool results, etc.) still benefit from batching.
+      if (event.payload?.type === "message.part.delta") {
+        if (timer) {
+          clearTimeout(timer)
+          timer = undefined
+        }
+        flush()
+        return
+      }
+
+      const elapsed = Date.now() - last
       if (timer) return
       // If we just flushed recently (within 16ms), batch this with future events
       // Otherwise, process immediately to avoid latency


### PR DESCRIPTION
### Issue for this PR

Closes #25472

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`handleEvent` in `sdk.tsx` batches all incoming SSE events into a 16ms window before flushing to the SolidJS render cycle. For `message.part.delta` (streaming text), this adds an extra frame of latency on top of whatever the upstream delivers.

Claude via `github-copilot` goes through Copilot's `/v1/messages` Anthropic shim, which already delivers SSE in bursts with gaps up to ~750ms. The 16ms hold makes each burst render even later than it arrives.

The fix: when the incoming event is `message.part.delta`, cancel any pending timer and flush immediately. All other event types (session status, tool results, permission prompts) still go through the existing 16ms batching path unchanged.

### How did you verify your code works?

Reviewed the event flow from `startSSE` → `handleEvent` → `flush` → `emitter.emit`. The `message.part.delta` type is what the server emits for each streaming text chunk (confirmed in `stream.transport.ts:123` and `session-data.ts:731`). The change is a targeted early-return before the timer logic, so the batching path for all other events is not touched.

I haven't been able to run a full local build to test end-to-end — flagging that so maintainers can weigh the PR accordingly.

### Screenshots / recordings

_Not applicable — this is a logic change with no visual difference other than text arriving sooner._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR