### PR TITLE
fix(permission): worktree-relative paths fall back to directory in non-git projects

### DIFF
--- a/packages/opencode/src/project/instance-context.ts
+++ b/packages/opencode/src/project/instance-context.ts
@@ -22,3 +22,11 @@ export function containsPath(filepath: string, ctx: InstanceContext): boolean {
   if (ctx.worktree === "/") return false
   return AppFileSystem.contains(ctx.worktree, filepath)
 }
+
+/**
+ * The project root for worktree-relative paths. Returns `directory` when
+ * `worktree` is "/", which `Project.fromDirectory` uses for non-git projects.
+ */
+export function workspaceRoot(ctx: Pick<InstanceContext, "directory" | "worktree">): string {
+  return ctx.worktree === "/" ? ctx.directory : ctx.worktree
+}

--- a/packages/opencode/src/reference/reference.ts
+++ b/packages/opencode/src/reference/reference.ts
@@ -5,6 +5,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
 import { Config } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
+import { workspaceRoot } from "@/project/instance-context"
 import { Git } from "@/git"
 import { parseRepositoryReference, repositoryCachePath, type Reference as RepositoryReference } from "@/util/repository"
 import { RepositoryCache } from "./repository-cache"
@@ -50,9 +51,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Re
 
 export function referencePath(input: { directory: string; worktree: string; value: string }) {
   if (input.value.startsWith("~/")) return path.join(Global.Path.home, input.value.slice(2))
-  return path.isAbsolute(input.value)
-    ? input.value
-    : path.resolve(input.worktree === "/" ? input.directory : input.worktree, input.value)
+  return path.isAbsolute(input.value) ? input.value : path.resolve(workspaceRoot(input), input.value)
 }
 
 function resolveGit(

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -4,6 +4,7 @@ import * as Tool from "./tool"
 import { Bus } from "../bus"
 import { FileWatcher } from "../file/watcher"
 import { InstanceState } from "@/effect/instance-state"
+import { workspaceRoot } from "@/project/instance-context"
 import { Patch } from "../patch"
 import { createTwoFilesPatch, diffLines } from "diff"
 import { assertExternalDirectoryEffect } from "./external-directory"
@@ -189,7 +190,7 @@ export const ApplyPatchTool = Tool.define(
       // Build per-file metadata for UI rendering (used for both permission and result)
       const files = fileChanges.map((change) => ({
         filePath: change.filePath,
-        relativePath: path.relative(instance.worktree, change.movePath ?? change.filePath).replaceAll("\\", "/"),
+        relativePath: path.relative(workspaceRoot(instance), change.movePath ?? change.filePath).replaceAll("\\", "/"),
         type: change.type,
         patch: change.diff,
         additions: change.additions,
@@ -198,7 +199,7 @@ export const ApplyPatchTool = Tool.define(
       }))
 
       // Check permissions if needed
-      const relativePaths = fileChanges.map((c) => path.relative(instance.worktree, c.filePath).replaceAll("\\", "/"))
+      const relativePaths = fileChanges.map((c) => path.relative(workspaceRoot(instance), c.filePath).replaceAll("\\", "/"))
       yield* ctx.ask({
         permission: "edit",
         patterns: relativePaths,
@@ -269,13 +270,13 @@ export const ApplyPatchTool = Tool.define(
       // Generate output summary
       const summaryLines = fileChanges.map((change) => {
         if (change.type === "add") {
-          return `A ${path.relative(instance.worktree, change.filePath).replaceAll("\\", "/")}`
+          return `A ${path.relative(workspaceRoot(instance), change.filePath).replaceAll("\\", "/")}`
         }
         if (change.type === "delete") {
-          return `D ${path.relative(instance.worktree, change.filePath).replaceAll("\\", "/")}`
+          return `D ${path.relative(workspaceRoot(instance), change.filePath).replaceAll("\\", "/")}`
         }
         const target = change.movePath ?? change.filePath
-        return `M ${path.relative(instance.worktree, target).replaceAll("\\", "/")}`
+        return `M ${path.relative(workspaceRoot(instance), target).replaceAll("\\", "/")}`
       })
       let output = `Success. Updated the following files:\n${summaryLines.join("\n")}`
 
@@ -284,7 +285,7 @@ export const ApplyPatchTool = Tool.define(
         const target = change.movePath ?? change.filePath
         const block = LSP.Diagnostic.report(target, diagnostics[AppFileSystem.normalizePath(target)] ?? [])
         if (!block) continue
-        const rel = path.relative(instance.worktree, target).replaceAll("\\", "/")
+        const rel = path.relative(workspaceRoot(instance), target).replaceAll("\\", "/")
         output += `\n\nLSP errors detected in ${rel}, please fix:\n${block}`
       }
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -14,6 +14,7 @@ import { FileWatcher } from "../file/watcher"
 import { Bus } from "../bus"
 import { Format } from "../format"
 import { InstanceState } from "@/effect/instance-state"
+import { workspaceRoot } from "@/project/instance-context"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -97,7 +98,7 @@ export const EditTool = Tool.define(
                 diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
                 yield* ctx.ask({
                   permission: "edit",
-                  patterns: [path.relative(instance.worktree, filePath)],
+                  patterns: [path.relative(workspaceRoot(instance), filePath)],
                   always: ["*"],
                   metadata: {
                     filepath: filePath,
@@ -140,7 +141,7 @@ export const EditTool = Tool.define(
               )
               yield* ctx.ask({
                 permission: "edit",
-                patterns: [path.relative(instance.worktree, filePath)],
+                patterns: [path.relative(workspaceRoot(instance), filePath)],
                 always: ["*"],
                 metadata: {
                   filepath: filePath,
@@ -202,7 +203,7 @@ export const EditTool = Tool.define(
               diff,
               filediff,
             },
-            title: `${path.relative(instance.worktree, filePath)}`,
+            title: `${path.relative(workspaceRoot(instance), filePath)}`,
             output,
           }
         }),

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { LSP } from "@/lsp/lsp"
 import DESCRIPTION from "./lsp.txt"
 import { InstanceState } from "@/effect/instance-state"
+import { workspaceRoot } from "@/project/instance-context"
 import { pathToFileURL } from "url"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -62,7 +63,7 @@ export const LspTool = Tool.define(
 
           const uri = pathToFileURL(file).href
           const position = { file, line: args.line - 1, character: args.character - 1 }
-          const relPath = path.relative(instance.worktree, file)
+          const relPath = path.relative(workspaceRoot(instance), file)
           const detail =
             args.operation === "workspaceSymbol"
               ? ""

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -8,6 +8,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { LSP } from "@/lsp/lsp"
 import DESCRIPTION from "./read.txt"
 import { InstanceState } from "@/effect/instance-state"
+import { workspaceRoot } from "@/project/instance-context"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
 import { isPdfAttachment, sniffAttachmentMime } from "@/util/media"
@@ -165,7 +166,7 @@ export const ReadTool = Tool.define(
         filepath = AppFileSystem.normalizePath(filepath)
       }
       yield* reference.ensure(filepath)
-      const title = path.relative(instance.worktree, filepath)
+      const title = path.relative(workspaceRoot(instance), filepath)
 
       const stat = yield* fs.stat(filepath).pipe(
         Effect.catchIf(
@@ -181,7 +182,7 @@ export const ReadTool = Tool.define(
 
       yield* ctx.ask({
         permission: "read",
-        patterns: [path.relative(instance.worktree, filepath)],
+        patterns: [path.relative(workspaceRoot(instance), filepath)],
         always: ["*"],
         metadata: {},
       })

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -11,6 +11,7 @@ import { FileWatcher } from "../file/watcher"
 import { Format } from "../format"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { InstanceState } from "@/effect/instance-state"
+import { workspaceRoot } from "@/project/instance-context"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import * as Bom from "@/util/bom"
@@ -53,7 +54,7 @@ export const WriteTool = Tool.define(
           const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, contentNew))
           yield* ctx.ask({
             permission: "edit",
-            patterns: [path.relative(instance.worktree, filepath)],
+            patterns: [path.relative(workspaceRoot(instance), filepath)],
             always: ["*"],
             metadata: {
               filepath,
@@ -90,7 +91,7 @@ export const WriteTool = Tool.define(
           }
 
           return {
-            title: path.relative(instance.worktree, filepath),
+            title: path.relative(workspaceRoot(instance), filepath),
             metadata: {
               diagnostics,
               filepath,

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -196,6 +196,26 @@ describe("tool.apply_patch freeform", () => {
     })
   })
 
+  test("uses project-relative paths in non-git projects", async () => {
+    await using fixture = await tmpdir()
+    const { ctx, calls } = makeCtx()
+
+    await WithInstance.provide({
+      directory: fixture.path,
+      fn: async () => {
+        const target = path.join(fixture.path, "modify.txt")
+        await fs.writeFile(target, "line1\n", "utf-8")
+
+        const patchText = "*** Begin Patch\n*** Update File: modify.txt\n@@\n-line1\n+changed\n*** End Patch"
+
+        const result = await execute({ patchText }, ctx)
+
+        expect(result.output).toMatch(/M modify\.txt/)
+        expect(calls[0]?.metadata.files[0]?.relativePath).toBe("modify.txt")
+      },
+    })
+  })
+
   test("does not invent a first-line diff for BOM files", async () => {
     await using fixture = await tmpdir()
     const { ctx, calls } = makeCtx()

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -184,6 +184,23 @@ describe("tool.edit", () => {
         },
       })
     })
+
+    test("uses project-relative title in non-git projects", async () => {
+      await using tmp = await tmpdir()
+      const filepath = path.join(tmp.path, "new.txt")
+
+      await WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const edit = await resolve()
+          const result = await Effect.runPromise(
+            edit.execute({ filePath: filepath, oldString: "", newString: "content" }, ctx),
+          )
+
+          expect(result.title).toBe("new.txt")
+        },
+      })
+    })
   })
 
   describe("editing existing files", () => {

--- a/packages/opencode/test/tool/lsp.test.ts
+++ b/packages/opencode/test/tool/lsp.test.ts
@@ -183,5 +183,18 @@ describe("tool.lsp", () => {
         { git: true },
       ),
     )
+
+    it.live("uses project-relative title in non-git projects", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const file = path.join(dir, "test.ts")
+          yield* put(file)
+
+          const result = yield* run({ operation: "goToDefinition", filePath: file, line: 3, character: 7 })
+
+          expect(result.title).toBe("goToDefinition test.ts:3:7")
+        }),
+      ),
+    )
   })
 })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -220,6 +220,19 @@ describe("tool.read external_directory permission", () => {
     }),
   )
 
+  it.live("uses project-relative path for read permission in non-git projects", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "src", "secret.ts"), "shh")
+
+      const { items, next } = asks()
+      yield* exec(dir, { filePath: path.join(dir, "src", "secret.ts") }, next)
+      const read = items.find((item) => item.permission === "read")
+      expect(read).toBeDefined()
+      expect(read!.patterns).toEqual([path.join("src", "secret.ts")])
+    }),
+  )
+
   it.live("asks for directory-scoped external_directory permission when reading external directory", () =>
     Effect.gen(function* () {
       const outer = yield* tmpdirScoped()

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -92,6 +92,16 @@ describe("tool.write", () => {
         expect(content).toBe("relative content")
       }),
     )
+
+    it.live("uses project-relative title in non-git projects", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "newfile.txt")
+          const result = yield* run({ filePath: filepath, content: "content" })
+          expect(result.title).toBe("newfile.txt")
+        }),
+      ),
+    )
   })
 
   describe("existing file overwrite", () => {

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -129,8 +129,8 @@ Keep the list focused on trusted paths, and layer extra allow or deny rules as n
 
 OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 
-- `read` — reading a file (matches the file path)
-- `edit` — all file modifications (covers `edit`, `write`, `patch`)
+- `read` — reading a file (matches the project-relative file path)
+- `edit` — all file modifications (covers `edit`, `write`, `patch`; matches the project-relative file path)
 - `glob` — file globbing (matches the glob pattern)
 - `grep` — content search (matches the regex pattern)
 - `bash` — running shell commands (matches parsed commands like `git status --porcelain`)


### PR DESCRIPTION
### Issue for this PR

Closes #24694

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`Project.fromDirectory` sets `worktree: "/"` as a sentinel for non-git projects (`packages/opencode/src/project/project.ts:210`). Tools then do `path.relative(instance.worktree, file)` to build worktree-relative permission patterns / titles / summary lines. In a non-git project that produces `"home/u/proj/src/foo.ts"` (the absolute path with the leading `/` stripped) instead of `"src/foo.ts"`, so a config rule like `"src/*"` silently never matches and titles read as the absolute path.

This PR adds `workspaceRoot(ctx)` next to `containsPath` in `src/project/instance-context.ts`. It returns `ctx.directory` when `ctx.worktree === "/"`, otherwise `ctx.worktree` — i.e. the same sentinel `containsPath` already inverts. All call sites that compute worktree-relative strings switch to `path.relative(workspaceRoot(instance), …)`:

- `tool/read.ts` (permission pattern + title)
- `tool/edit.ts` (two permission asks + title)
- `tool/write.ts` (permission ask + title)
- `tool/apply_patch.ts` (permission ask + per-file `relativePath` + summary lines + LSP diagnostic header)
- `tool/lsp.ts` (title display)
- `reference/reference.ts` `referencePath` (same inline ternary; helper signature widened to `Pick<InstanceContext, "directory" | "worktree">` so this caller's plain `{directory, worktree, value}` shape can use it)

### Relationship to #18761

#18761 proposes the same fix and the author has been keeping it actively merged with dev (latest ~5 days ago). It's currently conflicting after #26583 landed; #26583 covers the absolute→relative shift for `read.ts` in git projects, but the non-git fallback for the four file tools and the title/summary/relativePath call sites still needs to land.

This PR re-does the same idea on a clean baseline with a few differences:

- Helper goes in `src/project/instance-context.ts` next to `containsPath` (both invert the same `worktree === "/"` sentinel) instead of `src/tool/relative.ts`.
- Named `workspaceRoot` to avoid shadowing `path.relative` at every call site.
- Tests mirror the closest existing test in each file rather than mixing legacy `Instance.provide` with newer `provideTmpdirInstance` / `it.live`.
- Adds a permissions docs note.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — clean.
- `bun test test/tool/{read,edit,write,apply_patch,lsp}.test.ts` — 117/117 pass (one new non-git test per tool).
- `bun test test/permission test/tool` — 369/369 pass.
- Each new test mirrors the closest existing test in its file: `read` asserts on the captured permission pattern (the file's existing idiom for permission tests), `edit` / `write` / `lsp` assert on `result.title`, `apply_patch` asserts on `result.output` and `metadata.files[0].relativePath` (the same shape "applies add/update/delete in one patch" already uses). All sites compute their relative path through the new helper, so an assertion on any one of them exercises the fix.
- Manually tested with a built `--single` binary in a non-git tmpdir; `read` and `edit` rules under `src/*` now deny as configured (silently passed through before).

### Behavior change for users

For non-git projects:

- Permission rules anchored to the project root (e.g. `"read": { "src/*": "deny" }`) now actually match — they were silently passing through to the wildcard before.
- User-visible titles, summary lines, and LSP diagnostic headers show project-relative paths (e.g. `src/foo.ts`) instead of `home/u/proj/src/foo.ts`.

For git projects: no change — `worktree` was already a meaningful root.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR