### PR TITLE
fix(tui): add super paste binding

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/config/keybind.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/keybind.ts
@@ -125,7 +125,13 @@ const Definitions = {
   workspace_set: keybind("none", "Set workspace"),
 
   input_clear: keybind("ctrl+c", "Clear input field"),
-  input_paste: keybind({ key: "ctrl+v", preventDefault: false }, "Paste from clipboard"),
+  input_paste: keybind(
+    [
+      { key: "ctrl+v", preventDefault: false },
+      { key: "super+v", preventDefault: false },
+    ],
+    "Paste from clipboard",
+  ),
   input_submit: keybind("return", "Submit input"),
   input_newline: keybind("shift+return,ctrl+return,alt+return,ctrl+j", "Insert newline in input"),
   input_move_left: keybind("left,ctrl+b", "Move cursor left in input"),

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -446,6 +446,16 @@ test("resolves keybind lookup from canonical keybinds", async () => {
   ])
 })
 
+test("defaults paste to ctrl+v and cmd+v", async () => {
+  await using tmp = await tmpdir()
+  const config = await getTuiConfig(tmp.path)
+
+  expect(config.keybinds.get("prompt.paste")).toEqual([
+    { key: "ctrl+v", cmd: "prompt.paste", preventDefault: false, desc: "Paste from clipboard" },
+    { key: "super+v", cmd: "prompt.paste", preventDefault: false, desc: "Paste from clipboard" },
+  ])
+})
+
 test("keybinds accept OpenTUI binding specs", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #26695

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `super+v` as a default TUI paste binding alongside `ctrl+v`. Both shortcuts resolve to the existing `prompt.paste` command, which already reads the native clipboard and attaches images when image data is available.

The binding keeps `preventDefault: false` so terminal-native text paste is not broken.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test test/config/tui.test.ts`
- `cd packages/opencode && bun test test/cli/tui/thread.test.ts test/cli/tui/transcript.test.ts`
- Pre-push hook: `bun turbo typecheck`

The added regression test resolves the real TUI keybind lookup and verifies both `ctrl+v` and `super+v` map to `prompt.paste` with `preventDefault: false`.

### Screenshots / recordings

N/A - keyboard shortcut/default keybind change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR