### PR TITLE
fix(skill): skip duplicate skill warning when same file is loaded twice

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -97,6 +97,7 @@ const add = Effect.fnUntraced(function* (state: State, match: string, bus: Bus.I
   if (!parsed.success) return
 
   if (state.skills[parsed.data.name]) {
+    if (state.skills[parsed.data.name].location === match) return
     log.warn("duplicate skill name", {
       name: parsed.data.name,
       existing: state.skills[parsed.data.name].location,


### PR DESCRIPTION
### Issue for this PR

Closes #26709

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When OpenCode discovers skills from multiple scan paths (e.g. global `~/.agents/skills/` and project-level `.agents/skills/`), the same physical skill file is found multiple times. The `add()` function logs a warning with `existing` and `duplicate` pointing to the **same path**, then overwrites the same map entry pointlessly.

The fix adds an early return when the newly discovered skill file path matches the already-loaded one. This silences the false-positive warning. If two genuinely different files share the same skill name, the warning is still shown as intended.

### How did you verify your code works?

All 11 tests in `packages/opencode/test/skill/skill.test.ts` pass (8 pass normally, 3 need `--timeout 30000` due to filesystem-heavy setup). The fix is a single-line addition at `packages/opencode/src/skill/index.ts:100`:

```typescript
if (state.skills[parsed.data.name].location === match) return
```

### Screenshots / recordings

Not applicable (non-UI change).

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR