### PR TITLE
docs: remove stale vouch list path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,7 @@ For net-new functionality, start with a design conversation. Open an issue descr
 
 ## Trust & Vouch System
 
-This project uses [vouch](https://github.com/mitchellh/vouch) to manage contributor trust. The vouch list is maintained in [`.github/VOUCHED.td`](.github/VOUCHED.td).
+This project uses [vouch](https://github.com/mitchellh/vouch) to manage contributor trust. The vouch list is maintained by project automation.
 
 ### How it works
 
@@ -273,7 +273,7 @@ Collaborators with write access can manage the vouch list by commenting on any i
 - `denounce @username <reason>` — denounce with a reason
 - `unvouch` / `unvouch @username` — remove someone from the list
 
-Changes are committed automatically to `.github/VOUCHED.td`.
+Changes are applied automatically by the vouch automation.
 
 ### Denouncement policy
 


### PR DESCRIPTION
### Issue for this PR

Closes #26089

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates `CONTRIBUTING.md` so the Trust & Vouch section no longer points maintainers and contributors to `.github/VOUCHED.td`, which is not present in the repository.

The PR keeps the vouch guidance itself intact because a contributor noted the system still appears to be in use; it only removes the stale file-path claim and says the list is maintained by project automation.

### How did you verify your code works?

- `git diff --check` passed
- Verified there is no `.github/VOUCHED.td` or other vouch-list file under `.github`
- Verified the remaining vouch references are limited to the contributing guidance

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR