### PR TITLE
refactor(http-recorder): use Schema.TaggedErrorClass for cassette errors

### DIFF
--- a/packages/http-recorder/src/cassette.ts
+++ b/packages/http-recorder/src/cassette.ts
@@ -1,4 +1,4 @@
-import { Context, Data, Effect, FileSystem, Layer } from "effect"
+import { Context, Effect, FileSystem, Layer, Schema } from "effect"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import { secretFindings, type SecretFinding } from "./redaction"
@@ -6,9 +6,10 @@ import { decodeCassette, encodeCassette, type Cassette, type CassetteMetadata, t
 
 const DEFAULT_RECORDINGS_DIR = path.resolve(process.cwd(), "test", "fixtures", "recordings")
 
-export class CassetteNotFoundError extends Data.TaggedError("CassetteNotFoundError")<{
-  readonly cassetteName: string
-}> {
+export class CassetteNotFoundError extends Schema.TaggedErrorClass<CassetteNotFoundError>()(
+  "CassetteNotFoundError",
+  { cassetteName: Schema.String },
+) {
   override get message() {
     return `Cassette "${this.cassetteName}" not found`
   }

--- a/packages/http-recorder/src/recorder.ts
+++ b/packages/http-recorder/src/recorder.ts
@@ -1,13 +1,13 @@
-import { Data, Effect, Ref, Scope } from "effect"
+import { Effect, Ref, Schema, Scope } from "effect"
 import type * as CassetteService from "./cassette"
 import type { CassetteNotFoundError } from "./cassette"
-import type { SecretFinding } from "./redaction"
+import { SecretFindingSchema } from "./redaction"
 import type { CassetteMetadata, Interaction } from "./schema"
 
-export class UnsafeCassetteError extends Data.TaggedError("UnsafeCassetteError")<{
-  readonly cassetteName: string
-  readonly findings: ReadonlyArray<SecretFinding>
-}> {
+export class UnsafeCassetteError extends Schema.TaggedErrorClass<UnsafeCassetteError>()("UnsafeCassetteError", {
+  cassetteName: Schema.String,
+  findings: Schema.Array(SecretFindingSchema),
+}) {
   override get message() {
     return `Refusing to write cassette "${this.cassetteName}" because it contains possible secrets: ${this.findings
       .map((finding) => `${finding.path} (${finding.reason})`)

--- a/packages/http-recorder/src/redaction.ts
+++ b/packages/http-recorder/src/redaction.ts
@@ -95,10 +95,13 @@ export const redactHeaders = (
   )
 }
 
-export type SecretFinding = {
-  readonly path: string
-  readonly reason: string
-}
+import { Schema } from "effect"
+
+export const SecretFindingSchema = Schema.Struct({
+  path: Schema.String,
+  reason: Schema.String,
+})
+export type SecretFinding = Schema.Schema.Type<typeof SecretFindingSchema>
 
 export const secretFindings = (value: unknown): ReadonlyArray<SecretFinding> =>
   stringEntries(value).flatMap((entry) => [


### PR DESCRIPTION
## Summary

Follow-up to #26725. Switches `CassetteNotFoundError` and `UnsafeCassetteError` from `Data.TaggedError` to `Schema.TaggedErrorClass` to match the codebase convention (`LLMError`, `FileSystemError`, `AuthError`, `CliError`, `InstallFailedError`, etc. all use `Schema.TaggedErrorClass`).

Adds `SecretFindingSchema` so `UnsafeCassetteError.findings` is backed by a real Schema rather than an opaque type — gives the error encode/decode + structural equality that `Data.TaggedError` doesn't provide.

## Test plan
- [x] \`bun run test\` in \`packages/http-recorder\` — 17/17 pass
- [x] \`bun turbo typecheck\` — 14/14 pass