### PR TITLE
refactor(llm): normalize Usage as inclusive total + non-overlapping breakdown

### DIFF
--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -364,6 +364,14 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
   return "unknown"
 }
 
+// Anthropic already reports input/cache-read/cache-write as separate
+// non-overlapping categories per the Messages API docs, so the additive
+// `LLM.Usage` contract is satisfied by direct pass-through. Extended
+// thinking tokens are *not* broken out by Anthropic — they're billed as
+// part of `output_tokens`, so `outputTokens` here may include reasoning
+// the same way OpenAI's `output_tokens` does pre-normalization. This is
+// a documented limitation of the Anthropic API surface, not a contract
+// violation.
 const mapUsage = (usage: AnthropicUsage | undefined): Usage | undefined => {
   if (!usage) return undefined
   return new Usage({

--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -384,7 +384,7 @@ const mapUsage = (usage: AnthropicUsage | undefined): Usage | undefined => {
     cacheReadInputTokens: cacheRead,
     cacheWriteInputTokens: cacheWrite,
     totalTokens: ProviderShared.totalTokens(inputTokens, usage.output_tokens, undefined),
-    native: usage,
+    providerMetadata: { anthropic: usage },
   })
 }
 
@@ -408,7 +408,12 @@ const mergeUsage = (left: Usage | undefined, right: Usage | undefined) => {
     cacheReadInputTokens,
     cacheWriteInputTokens,
     totalTokens: ProviderShared.totalTokens(inputTokens, outputTokens, undefined),
-    native: { ...left.native, ...right.native },
+    providerMetadata: {
+      anthropic: {
+        ...(left.providerMetadata?.["anthropic"] ?? {}),
+        ...(right.providerMetadata?.["anthropic"] ?? {}),
+      },
+    },
   })
 }
 

--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -364,40 +364,49 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
   return "unknown"
 }
 
-// Anthropic already reports input/cache-read/cache-write as separate
-// non-overlapping categories per the Messages API docs, so the additive
-// `LLM.Usage` contract is satisfied by direct pass-through. Extended
+// Anthropic reports the non-overlapping breakdown natively — its
+// `input_tokens` is the *non-cached* count per the Messages API docs, with
+// cache reads and writes as separate fields. We sum them to derive the
+// inclusive `inputTokens` the rest of the contract expects. Extended
 // thinking tokens are *not* broken out by Anthropic — they're billed as
-// part of `output_tokens`, so `outputTokens` here may include reasoning
-// the same way OpenAI's `output_tokens` does pre-normalization. This is
-// a documented limitation of the Anthropic API surface, not a contract
-// violation.
+// part of `output_tokens`, so `reasoningTokens` stays `undefined` and
+// `outputTokens` carries the combined total.
 const mapUsage = (usage: AnthropicUsage | undefined): Usage | undefined => {
   if (!usage) return undefined
+  const nonCached = usage.input_tokens
+  const cacheRead = usage.cache_read_input_tokens ?? undefined
+  const cacheWrite = usage.cache_creation_input_tokens ?? undefined
+  const inputTokens = ProviderShared.sumTokens(nonCached, cacheRead, cacheWrite)
   return new Usage({
-    inputTokens: usage.input_tokens,
+    inputTokens,
     outputTokens: usage.output_tokens,
-    cacheReadInputTokens: usage.cache_read_input_tokens ?? undefined,
-    cacheWriteInputTokens: usage.cache_creation_input_tokens ?? undefined,
-    totalTokens: ProviderShared.totalTokens(usage.input_tokens, usage.output_tokens, undefined),
+    nonCachedInputTokens: nonCached,
+    cacheReadInputTokens: cacheRead,
+    cacheWriteInputTokens: cacheWrite,
+    totalTokens: ProviderShared.totalTokens(inputTokens, usage.output_tokens, undefined),
     native: usage,
   })
 }
 
 // Anthropic emits usage on `message_start` and again on `message_delta` — the
 // final delta carries the authoritative totals. Right-biased merge: each
-// field prefers `right` when defined, falls back to `left`. `totalTokens` is
-// recomputed from the merged input/output to stay consistent.
+// field prefers `right` when defined, falls back to `left`. `inputTokens` is
+// recomputed from the merged breakdown so the inclusive total stays
+// consistent with `nonCached + cacheRead + cacheWrite`.
 const mergeUsage = (left: Usage | undefined, right: Usage | undefined) => {
   if (!left) return right
   if (!right) return left
-  const inputTokens = right.inputTokens ?? left.inputTokens
+  const nonCachedInputTokens = right.nonCachedInputTokens ?? left.nonCachedInputTokens
+  const cacheReadInputTokens = right.cacheReadInputTokens ?? left.cacheReadInputTokens
+  const cacheWriteInputTokens = right.cacheWriteInputTokens ?? left.cacheWriteInputTokens
+  const inputTokens = ProviderShared.sumTokens(nonCachedInputTokens, cacheReadInputTokens, cacheWriteInputTokens)
   const outputTokens = right.outputTokens ?? left.outputTokens
   return new Usage({
     inputTokens,
     outputTokens,
-    cacheReadInputTokens: right.cacheReadInputTokens ?? left.cacheReadInputTokens,
-    cacheWriteInputTokens: right.cacheWriteInputTokens ?? left.cacheWriteInputTokens,
+    nonCachedInputTokens,
+    cacheReadInputTokens,
+    cacheWriteInputTokens,
     totalTokens: ProviderShared.totalTokens(inputTokens, outputTokens, undefined),
     native: { ...left.native, ...right.native },
   })

--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -363,12 +363,21 @@ const mapFinishReason = (reason: string): FinishReason => {
   return "unknown"
 }
 
+// AWS Bedrock Converse reports `inputTokens` as the total prompt with
+// cached and cache-write tokens included (per the Bedrock prompt-caching
+// docs). Pull each subtotal out at the boundary so the additive
+// `LLM.Usage` contract holds. Bedrock does not separately report
+// reasoning tokens for any current model.
 const mapUsage = (usage: BedrockUsageSchema | undefined): Usage | undefined => {
   if (!usage) return undefined
+  const inputTokens = ProviderShared.subtractTokens(
+    ProviderShared.subtractTokens(usage.inputTokens, usage.cacheReadInputTokens),
+    usage.cacheWriteInputTokens,
+  )
   return new Usage({
-    inputTokens: usage.inputTokens,
+    inputTokens,
     outputTokens: usage.outputTokens,
-    totalTokens: ProviderShared.totalTokens(usage.inputTokens, usage.outputTokens, usage.totalTokens),
+    totalTokens: ProviderShared.totalTokens(inputTokens, usage.outputTokens, usage.totalTokens),
     cacheReadInputTokens: usage.cacheReadInputTokens,
     cacheWriteInputTokens: usage.cacheWriteInputTokens,
     native: usage,

--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -370,10 +370,8 @@ const mapFinishReason = (reason: string): FinishReason => {
 // reasoning tokens for any current model.
 const mapUsage = (usage: BedrockUsageSchema | undefined): Usage | undefined => {
   if (!usage) return undefined
-  const inputTokens = ProviderShared.subtractTokens(
-    ProviderShared.subtractTokens(usage.inputTokens, usage.cacheReadInputTokens),
-    usage.cacheWriteInputTokens,
-  )
+  const cacheTotal = (usage.cacheReadInputTokens ?? 0) + (usage.cacheWriteInputTokens ?? 0)
+  const inputTokens = ProviderShared.subtractTokens(usage.inputTokens, cacheTotal)
   return new Usage({
     inputTokens,
     outputTokens: usage.outputTokens,

--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -378,7 +378,7 @@ const mapUsage = (usage: BedrockUsageSchema | undefined): Usage | undefined => {
     cacheReadInputTokens: usage.cacheReadInputTokens,
     cacheWriteInputTokens: usage.cacheWriteInputTokens,
     totalTokens: ProviderShared.totalTokens(usage.inputTokens, usage.outputTokens, usage.totalTokens),
-    native: usage,
+    providerMetadata: { bedrock: usage },
   })
 }
 

--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -363,21 +363,21 @@ const mapFinishReason = (reason: string): FinishReason => {
   return "unknown"
 }
 
-// AWS Bedrock Converse reports `inputTokens` as the total prompt with
-// cached and cache-write tokens included (per the Bedrock prompt-caching
-// docs). Pull each subtotal out at the boundary so the additive
-// `LLM.Usage` contract holds. Bedrock does not separately report
-// reasoning tokens for any current model.
+// AWS Bedrock Converse reports `inputTokens` (inclusive total) with
+// `cacheReadInputTokens` and `cacheWriteInputTokens` as subsets. Pass
+// the total through and derive the non-cached breakdown. Bedrock does
+// not break reasoning out of `outputTokens` for any current model.
 const mapUsage = (usage: BedrockUsageSchema | undefined): Usage | undefined => {
   if (!usage) return undefined
   const cacheTotal = (usage.cacheReadInputTokens ?? 0) + (usage.cacheWriteInputTokens ?? 0)
-  const inputTokens = ProviderShared.subtractTokens(usage.inputTokens, cacheTotal)
+  const nonCached = ProviderShared.subtractTokens(usage.inputTokens, cacheTotal)
   return new Usage({
-    inputTokens,
+    inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,
-    totalTokens: ProviderShared.totalTokens(inputTokens, usage.outputTokens, usage.totalTokens),
+    nonCachedInputTokens: nonCached,
     cacheReadInputTokens: usage.cacheReadInputTokens,
     cacheWriteInputTokens: usage.cacheWriteInputTokens,
+    totalTokens: ProviderShared.totalTokens(usage.inputTokens, usage.outputTokens, usage.totalTokens),
     native: usage,
   })
 }

--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -304,7 +304,7 @@ const mapUsage = (usage: GeminiUsage | undefined) => {
     cacheReadInputTokens: cached,
     reasoningTokens: usage.thoughtsTokenCount,
     totalTokens: ProviderShared.totalTokens(usage.promptTokenCount, outputTokens, usage.totalTokenCount),
-    native: usage,
+    providerMetadata: { google: usage },
   })
 }
 

--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -281,21 +281,29 @@ const fromRequest = Effect.fn("Gemini.fromRequest")(function* (request: LLMReque
 // =============================================================================
 // Stream Parsing
 // =============================================================================
-// Gemini reports `promptTokenCount` as the total prompt with cached
-// content included, but `candidatesTokenCount` already excludes
-// `thoughtsTokenCount` (visible vs reasoning are separate). Pull the
-// cached portion out at the boundary so the additive `LLM.Usage` contract
-// holds across providers.
+// Gemini reports `promptTokenCount` (inclusive total) with a
+// `cachedContentTokenCount` subset. `candidatesTokenCount` is *exclusive*
+// of `thoughtsTokenCount` — visible-only, not a total — so we sum the two
+// to produce the inclusive `outputTokens` the rest of the contract expects.
 const mapUsage = (usage: GeminiUsage | undefined) => {
   if (!usage) return undefined
   const cached = usage.cachedContentTokenCount
-  const inputTokens = ProviderShared.subtractTokens(usage.promptTokenCount, cached)
+  const nonCached = ProviderShared.subtractTokens(usage.promptTokenCount, cached)
+  // `candidatesTokenCount` is visible-only; sum with thoughts to produce the
+  // inclusive `outputTokens` the contract expects. Only compute the total
+  // when the visible component is reported — otherwise we'd fabricate an
+  // inclusive number from a partial breakdown.
+  const outputTokens =
+    usage.candidatesTokenCount !== undefined
+      ? usage.candidatesTokenCount + (usage.thoughtsTokenCount ?? 0)
+      : undefined
   return new Usage({
-    inputTokens,
-    outputTokens: usage.candidatesTokenCount,
-    reasoningTokens: usage.thoughtsTokenCount,
+    inputTokens: usage.promptTokenCount,
+    outputTokens,
+    nonCachedInputTokens: nonCached,
     cacheReadInputTokens: cached,
-    totalTokens: ProviderShared.totalTokens(inputTokens, usage.candidatesTokenCount, usage.totalTokenCount),
+    reasoningTokens: usage.thoughtsTokenCount,
+    totalTokens: ProviderShared.totalTokens(usage.promptTokenCount, outputTokens, usage.totalTokenCount),
     native: usage,
   })
 }

--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -281,14 +281,21 @@ const fromRequest = Effect.fn("Gemini.fromRequest")(function* (request: LLMReque
 // =============================================================================
 // Stream Parsing
 // =============================================================================
+// Gemini reports `promptTokenCount` as the total prompt with cached
+// content included, but `candidatesTokenCount` already excludes
+// `thoughtsTokenCount` (visible vs reasoning are separate). Pull the
+// cached portion out at the boundary so the additive `LLM.Usage` contract
+// holds across providers.
 const mapUsage = (usage: GeminiUsage | undefined) => {
   if (!usage) return undefined
+  const cached = usage.cachedContentTokenCount
+  const inputTokens = ProviderShared.subtractTokens(usage.promptTokenCount, cached)
   return new Usage({
-    inputTokens: usage.promptTokenCount,
+    inputTokens,
     outputTokens: usage.candidatesTokenCount,
     reasoningTokens: usage.thoughtsTokenCount,
-    cacheReadInputTokens: usage.cachedContentTokenCount,
-    totalTokens: ProviderShared.totalTokens(usage.promptTokenCount, usage.candidatesTokenCount, usage.totalTokenCount),
+    cacheReadInputTokens: cached,
+    totalTokens: ProviderShared.totalTokens(inputTokens, usage.candidatesTokenCount, usage.totalTokenCount),
     native: usage,
   })
 }

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -290,14 +290,23 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
   return "unknown"
 }
 
+// OpenAI Chat reports `prompt_tokens` as the total prompt (cached tokens
+// included) and `completion_tokens` as the total output (reasoning tokens
+// included). The additive `LLM.Usage` contract pulls each subtotal out at
+// the boundary so consumers never subtract — eliminating the underflow
+// class addressed by opencode#26620.
 const mapUsage = (usage: OpenAIChatEvent["usage"]): Usage | undefined => {
   if (!usage) return undefined
+  const cached = usage.prompt_tokens_details?.cached_tokens
+  const reasoning = usage.completion_tokens_details?.reasoning_tokens
+  const inputTokens = ProviderShared.subtractTokens(usage.prompt_tokens, cached)
+  const outputTokens = ProviderShared.subtractTokens(usage.completion_tokens, reasoning)
   return new Usage({
-    inputTokens: usage.prompt_tokens,
-    outputTokens: usage.completion_tokens,
-    reasoningTokens: usage.completion_tokens_details?.reasoning_tokens,
-    cacheReadInputTokens: usage.prompt_tokens_details?.cached_tokens,
-    totalTokens: ProviderShared.totalTokens(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens),
+    inputTokens,
+    outputTokens,
+    reasoningTokens: reasoning,
+    cacheReadInputTokens: cached,
+    totalTokens: ProviderShared.totalTokens(inputTokens, outputTokens, usage.total_tokens),
     native: usage,
   })
 }

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -290,22 +290,23 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
   return "unknown"
 }
 
-// OpenAI Chat reports `prompt_tokens` as the total prompt (cached tokens
-// included) and `completion_tokens` as the total output (reasoning tokens
-// included). Pull each subtotal out at the boundary so the additive
-// `LLM.Usage` contract holds and consumers never subtract.
+// OpenAI Chat reports `prompt_tokens` (inclusive total) with a
+// `cached_tokens` subset, and `completion_tokens` (inclusive total) with
+// a `reasoning_tokens` subset. We pass the inclusive totals through and
+// derive the non-cached breakdown so the `LLM.Usage` contract is
+// satisfied on both sides.
 const mapUsage = (usage: OpenAIChatEvent["usage"]): Usage | undefined => {
   if (!usage) return undefined
   const cached = usage.prompt_tokens_details?.cached_tokens
   const reasoning = usage.completion_tokens_details?.reasoning_tokens
-  const inputTokens = ProviderShared.subtractTokens(usage.prompt_tokens, cached)
-  const outputTokens = ProviderShared.subtractTokens(usage.completion_tokens, reasoning)
+  const nonCached = ProviderShared.subtractTokens(usage.prompt_tokens, cached)
   return new Usage({
-    inputTokens,
-    outputTokens,
-    reasoningTokens: reasoning,
+    inputTokens: usage.prompt_tokens,
+    outputTokens: usage.completion_tokens,
+    nonCachedInputTokens: nonCached,
     cacheReadInputTokens: cached,
-    totalTokens: ProviderShared.totalTokens(inputTokens, outputTokens, usage.total_tokens),
+    reasoningTokens: reasoning,
+    totalTokens: ProviderShared.totalTokens(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens),
     native: usage,
   })
 }

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -307,7 +307,7 @@ const mapUsage = (usage: OpenAIChatEvent["usage"]): Usage | undefined => {
     cacheReadInputTokens: cached,
     reasoningTokens: reasoning,
     totalTokens: ProviderShared.totalTokens(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens),
-    native: usage,
+    providerMetadata: { openai: usage },
   })
 }
 

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -292,9 +292,8 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
 
 // OpenAI Chat reports `prompt_tokens` as the total prompt (cached tokens
 // included) and `completion_tokens` as the total output (reasoning tokens
-// included). The additive `LLM.Usage` contract pulls each subtotal out at
-// the boundary so consumers never subtract — eliminating the underflow
-// class addressed by opencode#26620.
+// included). Pull each subtotal out at the boundary so the additive
+// `LLM.Usage` contract holds and consumers never subtract.
 const mapUsage = (usage: OpenAIChatEvent["usage"]): Usage | undefined => {
   if (!usage) return undefined
   const cached = usage.prompt_tokens_details?.cached_tokens

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -276,22 +276,22 @@ const fromRequest = Effect.fn("OpenAIResponses.fromRequest")(function* (request:
 // =============================================================================
 // Stream Parsing
 // =============================================================================
-// OpenAI Responses reports `input_tokens` as the total prompt (cached
-// included) and `output_tokens` as the total output (reasoning included).
-// The additive `LLM.Usage` contract pulls each subtotal out at the boundary
-// so consumers never subtract.
+// OpenAI Responses reports `input_tokens` (inclusive total) with a
+// `cached_tokens` subset, and `output_tokens` (inclusive total) with a
+// `reasoning_tokens` subset. Pass the totals through and derive the
+// non-cached breakdown.
 const mapUsage = (usage: OpenAIResponsesUsage | null | undefined) => {
   if (!usage) return undefined
   const cached = usage.input_tokens_details?.cached_tokens
   const reasoning = usage.output_tokens_details?.reasoning_tokens
-  const inputTokens = ProviderShared.subtractTokens(usage.input_tokens, cached)
-  const outputTokens = ProviderShared.subtractTokens(usage.output_tokens, reasoning)
+  const nonCached = ProviderShared.subtractTokens(usage.input_tokens, cached)
   return new Usage({
-    inputTokens,
-    outputTokens,
-    reasoningTokens: reasoning,
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    nonCachedInputTokens: nonCached,
     cacheReadInputTokens: cached,
-    totalTokens: ProviderShared.totalTokens(inputTokens, outputTokens, usage.total_tokens),
+    reasoningTokens: reasoning,
+    totalTokens: ProviderShared.totalTokens(usage.input_tokens, usage.output_tokens, usage.total_tokens),
     native: usage,
   })
 }

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -292,7 +292,7 @@ const mapUsage = (usage: OpenAIResponsesUsage | null | undefined) => {
     cacheReadInputTokens: cached,
     reasoningTokens: reasoning,
     totalTokens: ProviderShared.totalTokens(usage.input_tokens, usage.output_tokens, usage.total_tokens),
-    native: usage,
+    providerMetadata: { openai: usage },
   })
 }
 

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -276,14 +276,22 @@ const fromRequest = Effect.fn("OpenAIResponses.fromRequest")(function* (request:
 // =============================================================================
 // Stream Parsing
 // =============================================================================
+// OpenAI Responses reports `input_tokens` as the total prompt (cached
+// included) and `output_tokens` as the total output (reasoning included).
+// The additive `LLM.Usage` contract pulls each subtotal out at the boundary
+// so consumers never subtract.
 const mapUsage = (usage: OpenAIResponsesUsage | null | undefined) => {
   if (!usage) return undefined
+  const cached = usage.input_tokens_details?.cached_tokens
+  const reasoning = usage.output_tokens_details?.reasoning_tokens
+  const inputTokens = ProviderShared.subtractTokens(usage.input_tokens, cached)
+  const outputTokens = ProviderShared.subtractTokens(usage.output_tokens, reasoning)
   return new Usage({
-    inputTokens: usage.input_tokens,
-    outputTokens: usage.output_tokens,
-    reasoningTokens: usage.output_tokens_details?.reasoning_tokens,
-    cacheReadInputTokens: usage.input_tokens_details?.cached_tokens,
-    totalTokens: ProviderShared.totalTokens(usage.input_tokens, usage.output_tokens, usage.total_tokens),
+    inputTokens,
+    outputTokens,
+    reasoningTokens: reasoning,
+    cacheReadInputTokens: cached,
+    totalTokens: ProviderShared.totalTokens(inputTokens, outputTokens, usage.total_tokens),
     native: usage,
   })
 }

--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -42,6 +42,13 @@ export interface ToolAccumulator {
  * supplied total; otherwise falls back to `inputTokens + outputTokens` only
  * when at least one is defined. Returns `undefined` when neither input nor
  * output is known so routes don't publish a misleading `0`.
+ *
+ * Under the additive `LLM.Usage` contract, `inputTokens` and `outputTokens`
+ * are the non-cached input and visible output only. The provider-supplied
+ * `total` is the source of truth when present; the computed fallback
+ * under-counts cache and reasoning by design and exists mainly so
+ * Anthropic-style providers (which don't surface a total) still get a
+ * sensible aggregate on the input + output axes.
  */
 export const totalTokens = (
   inputTokens: number | undefined,
@@ -51,6 +58,28 @@ export const totalTokens = (
   if (total !== undefined) return total
   if (inputTokens === undefined && outputTokens === undefined) return undefined
   return (inputTokens ?? 0) + (outputTokens ?? 0)
+}
+
+/**
+ * Subtract `subtrahend` from `total`, clamping to zero if the provider
+ * reports a non-sensical breakdown (e.g. `cached_tokens > prompt_tokens`).
+ * Used by protocol mappers to enforce the additive `LLM.Usage` contract:
+ * each provider's "inclusive" subtotals (cached, reasoning) are pulled out
+ * of the parent count at the boundary so downstream consumers never have to
+ * subtract — eliminating the underflow class of bug where a clamped
+ * difference would silently store the wrong value.
+ *
+ * If `total` is `undefined`, returns `undefined` (we don't fabricate
+ * counts). If `subtrahend` is `undefined`, returns `total` unchanged. The
+ * provider-native breakdown stays available on `Usage.native` for debugging.
+ */
+export const subtractTokens = (
+  total: number | undefined,
+  subtrahend: number | undefined,
+): number | undefined => {
+  if (total === undefined) return undefined
+  if (subtrahend === undefined) return total
+  return Math.max(0, total - subtrahend)
 }
 
 export const eventError = (route: string, message: string, raw?: string) =>

--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -63,11 +63,9 @@ export const totalTokens = (
 /**
  * Subtract `subtrahend` from `total`, clamping to zero if the provider
  * reports a non-sensical breakdown (e.g. `cached_tokens > prompt_tokens`).
- * Used by protocol mappers to enforce the additive `LLM.Usage` contract:
- * each provider's "inclusive" subtotals (cached, reasoning) are pulled out
- * of the parent count at the boundary so downstream consumers never have to
- * subtract — eliminating the underflow class of bug where a clamped
- * difference would silently store the wrong value.
+ * Used by protocol mappers when deriving a non-overlapping breakdown field
+ * from a provider's inclusive total — `nonCachedInputTokens` from
+ * `inputTokens - cacheReadInputTokens - cacheWriteInputTokens`.
  *
  * If `total` is `undefined`, returns `undefined` (we don't fabricate
  * counts). If `subtrahend` is `undefined`, returns `total` unchanged. The
@@ -80,6 +78,18 @@ export const subtractTokens = (
   if (total === undefined) return undefined
   if (subtrahend === undefined) return total
   return Math.max(0, total - subtrahend)
+}
+
+/**
+ * Sum a list of optional token counts, returning `undefined` only when
+ * every value is `undefined` (so we don't fabricate a `0`). Used by
+ * protocol mappers to derive the inclusive `inputTokens` total from a
+ * provider that natively reports a non-overlapping breakdown
+ * (e.g. Anthropic, whose `input_tokens` is already non-cached only).
+ */
+export const sumTokens = (...values: ReadonlyArray<number | undefined>): number | undefined => {
+  if (values.every((value) => value === undefined)) return undefined
+  return values.reduce<number>((acc, value) => acc + (value ?? 0), 0)
 }
 
 export const eventError = (route: string, message: string, raw?: string) =>

--- a/packages/llm/src/schema/events.ts
+++ b/packages/llm/src/schema/events.ts
@@ -45,15 +45,6 @@ export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   native: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
 }) {}
 
-export namespace Usage {
-  /** Sum of every input-side category. Monotonic under the additive contract. */
-  export const totalInput = (usage: Usage) =>
-    (usage.inputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0) + (usage.cacheWriteInputTokens ?? 0)
-
-  /** Sum of every output-side category. Monotonic under the additive contract. */
-  export const totalOutput = (usage: Usage) => (usage.outputTokens ?? 0) + (usage.reasoningTokens ?? 0)
-}
-
 export const RequestStart = Schema.Struct({
   type: Schema.tag("request-start"),
   id: ResponseID,

--- a/packages/llm/src/schema/events.ts
+++ b/packages/llm/src/schema/events.ts
@@ -42,7 +42,10 @@ import { ToolResultValue } from "./messages"
  *   `reasoningTokens` is `undefined` and `outputTokens` carries the
  *   combined total — a documented limitation of the Anthropic API.
  *
- * `native` always carries the provider's raw usage payload for debugging.
+ * `providerMetadata` always carries the provider's raw usage payload —
+ * keyed by provider name (`{ openai: ... }`, `{ anthropic: ... }`, etc.)
+ * — for fields we don't normalize and for billing-level audit trails.
+ * Matches the same escape-hatch field on `LLMEvent`.
  */
 export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   inputTokens: Schema.optional(Schema.Number),
@@ -52,7 +55,7 @@ export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   cacheWriteInputTokens: Schema.optional(Schema.Number),
   reasoningTokens: Schema.optional(Schema.Number),
   totalTokens: Schema.optional(Schema.Number),
-  native: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  providerMetadata: Schema.optional(ProviderMetadata),
 }) {
   /**
    * Visible output tokens — `outputTokens` minus `reasoningTokens`, clamped

--- a/packages/llm/src/schema/events.ts
+++ b/packages/llm/src/schema/events.ts
@@ -3,6 +3,38 @@ import { ContentBlockID, FinishReason, ProtocolID, ProviderMetadata, ResponseID,
 import { ModelRef } from "./options"
 import { ToolResultValue } from "./messages"
 
+/**
+ * Token usage reported by an LLM provider, normalized to a fully-additive
+ * contract so consumers never have to subtract.
+ *
+ * **Field semantics** (each non-negative; missing means "not reported"):
+ *
+ * - `inputTokens` — non-cached input tokens (the "fresh" prompt portion).
+ * - `cacheReadInputTokens` — input tokens served from cache.
+ * - `cacheWriteInputTokens` — input tokens written to cache.
+ * - `outputTokens` — visible output tokens (text + tool calls).
+ * - `reasoningTokens` — hidden reasoning / thinking tokens.
+ * - `totalTokens` — provider-supplied total, or sum of input + output as a
+ *   fallback (see `ProviderShared.totalTokens`).
+ * - `native` — the provider's raw usage payload, preserved for debugging.
+ *
+ * **Invariant**: every aggregate of interest is a *sum*, never a difference.
+ * Total billable input = `inputTokens + cacheReadInputTokens +
+ * cacheWriteInputTokens`. Total billable output = `outputTokens +
+ * reasoningTokens`. Adding two non-negatives cannot underflow, so consumers
+ * cannot reproduce the underflow-then-clamp bug class where a stored
+ * negative gets rejected by a strict schema later.
+ *
+ * Each protocol mapper enforces this contract at the provider boundary.
+ * Providers that report cache or reasoning as subsets of input/output
+ * (OpenAI Chat/Responses, Gemini, Bedrock) have those subsets pulled out
+ * once via `ProviderShared.subtractTokens`, with `Math.max(0, …)` clamping
+ * for defense against provider bugs. Providers that already report
+ * separately (Anthropic) pass through. Where a provider doesn't surface a
+ * category at all (e.g. Anthropic does not break out extended-thinking
+ * tokens), the corresponding field is `undefined` and the parent count
+ * carries the combined total — a documented limitation of that API.
+ */
 export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   inputTokens: Schema.optional(Schema.Number),
   outputTokens: Schema.optional(Schema.Number),
@@ -12,6 +44,24 @@ export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   totalTokens: Schema.optional(Schema.Number),
   native: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
 }) {}
+
+export namespace Usage {
+  type InputFields = Pick<Usage, "inputTokens" | "cacheReadInputTokens" | "cacheWriteInputTokens">
+  type OutputFields = Pick<Usage, "outputTokens" | "reasoningTokens">
+
+  /**
+   * Sum of every input-side category: non-cached input + cache reads +
+   * cache writes. Monotonic; cannot underflow under the additive contract.
+   */
+  export const totalInput = (usage: InputFields) =>
+    (usage.inputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0) + (usage.cacheWriteInputTokens ?? 0)
+
+  /**
+   * Sum of every output-side category: visible output + reasoning.
+   * Monotonic; cannot underflow under the additive contract.
+   */
+  export const totalOutput = (usage: OutputFields) => (usage.outputTokens ?? 0) + (usage.reasoningTokens ?? 0)
+}
 
 export const RequestStart = Schema.Struct({
   type: Schema.tag("request-start"),

--- a/packages/llm/src/schema/events.ts
+++ b/packages/llm/src/schema/events.ts
@@ -46,21 +46,12 @@ export class Usage extends Schema.Class<Usage>("LLM.Usage")({
 }) {}
 
 export namespace Usage {
-  type InputFields = Pick<Usage, "inputTokens" | "cacheReadInputTokens" | "cacheWriteInputTokens">
-  type OutputFields = Pick<Usage, "outputTokens" | "reasoningTokens">
-
-  /**
-   * Sum of every input-side category: non-cached input + cache reads +
-   * cache writes. Monotonic; cannot underflow under the additive contract.
-   */
-  export const totalInput = (usage: InputFields) =>
+  /** Sum of every input-side category. Monotonic under the additive contract. */
+  export const totalInput = (usage: Usage) =>
     (usage.inputTokens ?? 0) + (usage.cacheReadInputTokens ?? 0) + (usage.cacheWriteInputTokens ?? 0)
 
-  /**
-   * Sum of every output-side category: visible output + reasoning.
-   * Monotonic; cannot underflow under the additive contract.
-   */
-  export const totalOutput = (usage: OutputFields) => (usage.outputTokens ?? 0) + (usage.reasoningTokens ?? 0)
+  /** Sum of every output-side category. Monotonic under the additive contract. */
+  export const totalOutput = (usage: Usage) => (usage.outputTokens ?? 0) + (usage.reasoningTokens ?? 0)
 }
 
 export const RequestStart = Schema.Struct({

--- a/packages/llm/src/schema/events.ts
+++ b/packages/llm/src/schema/events.ts
@@ -43,7 +43,17 @@ export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   cacheWriteInputTokens: Schema.optional(Schema.Number),
   totalTokens: Schema.optional(Schema.Number),
   native: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
-}) {}
+}) {
+  /** Sum of every input-side category. Monotonic under the additive contract. */
+  get totalInputTokens() {
+    return (this.inputTokens ?? 0) + (this.cacheReadInputTokens ?? 0) + (this.cacheWriteInputTokens ?? 0)
+  }
+
+  /** Sum of every output-side category. Monotonic under the additive contract. */
+  get totalOutputTokens() {
+    return (this.outputTokens ?? 0) + (this.reasoningTokens ?? 0)
+  }
+}
 
 export const RequestStart = Schema.Struct({
   type: Schema.tag("request-start"),

--- a/packages/llm/src/schema/events.ts
+++ b/packages/llm/src/schema/events.ts
@@ -4,54 +4,64 @@ import { ModelRef } from "./options"
 import { ToolResultValue } from "./messages"
 
 /**
- * Token usage reported by an LLM provider, normalized to a fully-additive
- * contract so consumers never have to subtract.
+ * Token usage reported by an LLM provider.
  *
- * **Field semantics** (each non-negative; missing means "not reported"):
+ * **Inclusive totals** (match AI SDK / OpenAI / LangChain convention — a
+ * reader from any of those ecosystems sees the number they expect):
  *
- * - `inputTokens` — non-cached input tokens (the "fresh" prompt portion).
+ * - `inputTokens` — total prompt tokens, *including* cached reads/writes.
+ * - `outputTokens` — total output tokens, *including* reasoning.
+ * - `totalTokens` — provider-supplied total, or `inputTokens + outputTokens`.
+ *
+ * **Non-overlapping breakdown** (every field is independently meaningful;
+ * consumers never have to subtract):
+ *
+ * - `nonCachedInputTokens` — the "fresh" portion of the prompt.
  * - `cacheReadInputTokens` — input tokens served from cache.
  * - `cacheWriteInputTokens` — input tokens written to cache.
- * - `outputTokens` — visible output tokens (text + tool calls).
- * - `reasoningTokens` — hidden reasoning / thinking tokens.
- * - `totalTokens` — provider-supplied total, or sum of input + output as a
- *   fallback (see `ProviderShared.totalTokens`).
- * - `native` — the provider's raw usage payload, preserved for debugging.
+ * - `reasoningTokens` — subset of `outputTokens` spent on hidden reasoning.
  *
- * **Invariant**: every aggregate of interest is a *sum*, never a difference.
- * Total billable input = `inputTokens + cacheReadInputTokens +
- * cacheWriteInputTokens`. Total billable output = `outputTokens +
- * reasoningTokens`. Adding two non-negatives cannot underflow, so consumers
- * cannot reproduce the underflow-then-clamp bug class where a stored
- * negative gets rejected by a strict schema later.
+ * **Invariant**: `nonCachedInputTokens + cacheReadInputTokens +
+ * cacheWriteInputTokens = inputTokens`, and `reasoningTokens ≤ outputTokens`.
+ * Each protocol mapper computes whichever side it doesn't get natively,
+ * with `Math.max(0, …)` clamping for defense against provider bugs. Because
+ * every breakdown field is stored independently, downstream consumers can
+ * read whatever they need (cost-by-category, context-pressure, AI-SDK-style
+ * inclusive total) without ever subtracting — eliminating the underflow
+ * class of bug where a clamped difference would silently store the wrong
+ * value.
  *
- * Each protocol mapper enforces this contract at the provider boundary.
- * Providers that report cache or reasoning as subsets of input/output
- * (OpenAI Chat/Responses, Gemini, Bedrock) have those subsets pulled out
- * once via `ProviderShared.subtractTokens`, with `Math.max(0, …)` clamping
- * for defense against provider bugs. Providers that already report
- * separately (Anthropic) pass through. Where a provider doesn't surface a
- * category at all (e.g. Anthropic does not break out extended-thinking
- * tokens), the corresponding field is `undefined` and the parent count
- * carries the combined total — a documented limitation of that API.
+ * **Semantics by provider**:
+ *
+ * - OpenAI Chat / Responses / Gemini / Bedrock: provider reports inclusive
+ *   `inputTokens` and an inclusive `outputTokens`; mapper subtracts to
+ *   derive the breakdown.
+ * - Anthropic: provider reports the breakdown natively (`input_tokens` is
+ *   non-cached only); mapper sums to derive the inclusive `inputTokens`.
+ *   Anthropic does *not* break extended-thinking out of `output_tokens`, so
+ *   `reasoningTokens` is `undefined` and `outputTokens` carries the
+ *   combined total — a documented limitation of the Anthropic API.
+ *
+ * `native` always carries the provider's raw usage payload for debugging.
  */
 export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   inputTokens: Schema.optional(Schema.Number),
   outputTokens: Schema.optional(Schema.Number),
-  reasoningTokens: Schema.optional(Schema.Number),
+  nonCachedInputTokens: Schema.optional(Schema.Number),
   cacheReadInputTokens: Schema.optional(Schema.Number),
   cacheWriteInputTokens: Schema.optional(Schema.Number),
+  reasoningTokens: Schema.optional(Schema.Number),
   totalTokens: Schema.optional(Schema.Number),
   native: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
 }) {
-  /** Sum of every input-side category. Monotonic under the additive contract. */
-  get totalInputTokens() {
-    return (this.inputTokens ?? 0) + (this.cacheReadInputTokens ?? 0) + (this.cacheWriteInputTokens ?? 0)
-  }
-
-  /** Sum of every output-side category. Monotonic under the additive contract. */
-  get totalOutputTokens() {
-    return (this.outputTokens ?? 0) + (this.reasoningTokens ?? 0)
+  /**
+   * Visible output tokens — `outputTokens` minus `reasoningTokens`, clamped
+   * to zero. The one place subtraction happens in this contract; the clamp
+   * means a provider reporting `reasoningTokens > outputTokens` produces a
+   * harmless zero rather than a negative that crashes downstream schemas.
+   */
+  get visibleOutputTokens() {
+    return Math.max(0, (this.outputTokens ?? 0) - (this.reasoningTokens ?? 0))
   }
 }
 

--- a/packages/llm/test/provider/anthropic-messages.test.ts
+++ b/packages/llm/test/provider/anthropic-messages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
-import { CacheHint, LLM, LLMError } from "../../src"
+import { CacheHint, LLM, LLMError, Usage } from "../../src"
 import { LLMClient } from "../../src/route"
 import * as AnthropicMessages from "../../src/protocols/anthropic-messages"
 import { it } from "../lib/effect"
@@ -152,7 +152,7 @@ describe("Anthropic Messages route", () => {
         {
           type: "request-finish",
           reason: "tool-calls",
-          usage: { inputTokens: 5, outputTokens: 1, totalTokens: 6, native: { input_tokens: 5, output_tokens: 1 } },
+          usage: new Usage({ inputTokens: 5, outputTokens: 1, totalTokens: 6, native: { input_tokens: 5, output_tokens: 1 } }),
         },
       ])
     }),

--- a/packages/llm/test/provider/anthropic-messages.test.ts
+++ b/packages/llm/test/provider/anthropic-messages.test.ts
@@ -110,10 +110,11 @@ describe("Anthropic Messages route", () => {
       expect(response.text).toBe("Hello!")
       expect(response.reasoning).toBe("thinking")
       expect(response.usage).toMatchObject({
-        inputTokens: 5,
+        inputTokens: 6,
         outputTokens: 2,
+        nonCachedInputTokens: 5,
         cacheReadInputTokens: 1,
-        totalTokens: 7,
+        totalTokens: 8,
       })
       expect(response.events.find((event) => event.type === "reasoning-end")).toMatchObject({
         providerMetadata: { anthropic: { signature: "sig_1" } },
@@ -152,7 +153,13 @@ describe("Anthropic Messages route", () => {
         {
           type: "request-finish",
           reason: "tool-calls",
-          usage: new Usage({ inputTokens: 5, outputTokens: 1, totalTokens: 6, native: { input_tokens: 5, output_tokens: 1 } }),
+          usage: new Usage({
+            inputTokens: 5,
+            outputTokens: 1,
+            nonCachedInputTokens: 5,
+            totalTokens: 6,
+            native: { input_tokens: 5, output_tokens: 1 },
+          }),
         },
       ])
     }),

--- a/packages/llm/test/provider/anthropic-messages.test.ts
+++ b/packages/llm/test/provider/anthropic-messages.test.ts
@@ -158,7 +158,7 @@ describe("Anthropic Messages route", () => {
             outputTokens: 1,
             nonCachedInputTokens: 5,
             totalTokens: 6,
-            native: { input_tokens: 5, output_tokens: 1 },
+            providerMetadata: { anthropic: { input_tokens: 5, output_tokens: 1 } },
           }),
         },
       ])

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -218,12 +218,14 @@ describe("Gemini route", () => {
             cacheReadInputTokens: 1,
             reasoningTokens: 1,
             totalTokens: 7,
-            native: {
-              promptTokenCount: 5,
-              candidatesTokenCount: 2,
-              totalTokenCount: 7,
-              thoughtsTokenCount: 1,
-              cachedContentTokenCount: 1,
+            providerMetadata: {
+              google: {
+                promptTokenCount: 5,
+                candidatesTokenCount: 2,
+                totalTokenCount: 7,
+                thoughtsTokenCount: 1,
+                cachedContentTokenCount: 1,
+              },
             },
           }),
         },
@@ -264,7 +266,7 @@ describe("Gemini route", () => {
             outputTokens: 1,
             nonCachedInputTokens: 5,
             totalTokens: 6,
-            native: { promptTokenCount: 5, candidatesTokenCount: 1 },
+            providerMetadata: { google: { promptTokenCount: 5, candidatesTokenCount: 1 } },
           }),
         },
       ])

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
-import { LLM, LLMError } from "../../src"
+import { LLM, LLMError, Usage } from "../../src"
 import { LLMClient } from "../../src/route"
 import * as Gemini from "../../src/protocols/gemini"
 import { it } from "../lib/effect"
@@ -210,7 +210,7 @@ describe("Gemini route", () => {
         {
           type: "request-finish",
           reason: "stop",
-          usage: {
+          usage: new Usage({
             inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 1,
@@ -223,7 +223,7 @@ describe("Gemini route", () => {
               thoughtsTokenCount: 1,
               cachedContentTokenCount: 1,
             },
-          },
+          }),
         },
       ])
     }),
@@ -257,12 +257,12 @@ describe("Gemini route", () => {
         {
           type: "request-finish",
           reason: "tool-calls",
-          usage: {
+          usage: new Usage({
             inputTokens: 5,
             outputTokens: 1,
             totalTokens: 6,
             native: { promptTokenCount: 5, candidatesTokenCount: 1 },
-          },
+          }),
         },
       ])
     }),

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -197,9 +197,6 @@ describe("Gemini route", () => {
       expect(response.text).toBe("Hello!")
       expect(response.reasoning).toBe("thinking")
       expect(response.usage).toMatchObject({
-        // Additive contract: promptTokenCount=5 includes 1 cached, so
-        // inputTokens=4 + cacheReadInputTokens=1. Gemini already splits
-        // candidates from thoughts, so outputTokens=2 + reasoningTokens=1.
         inputTokens: 4,
         outputTokens: 2,
         reasoningTokens: 1,

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -197,10 +197,11 @@ describe("Gemini route", () => {
       expect(response.text).toBe("Hello!")
       expect(response.reasoning).toBe("thinking")
       expect(response.usage).toMatchObject({
-        inputTokens: 4,
-        outputTokens: 2,
-        reasoningTokens: 1,
+        inputTokens: 5,
+        outputTokens: 3,
+        nonCachedInputTokens: 4,
         cacheReadInputTokens: 1,
+        reasoningTokens: 1,
         totalTokens: 7,
       })
       expect(response.events).toEqual([
@@ -211,10 +212,11 @@ describe("Gemini route", () => {
           type: "request-finish",
           reason: "stop",
           usage: new Usage({
-            inputTokens: 4,
-            outputTokens: 2,
-            reasoningTokens: 1,
+            inputTokens: 5,
+            outputTokens: 3,
+            nonCachedInputTokens: 4,
             cacheReadInputTokens: 1,
+            reasoningTokens: 1,
             totalTokens: 7,
             native: {
               promptTokenCount: 5,
@@ -260,6 +262,7 @@ describe("Gemini route", () => {
           usage: new Usage({
             inputTokens: 5,
             outputTokens: 1,
+            nonCachedInputTokens: 5,
             totalTokens: 6,
             native: { promptTokenCount: 5, candidatesTokenCount: 1 },
           }),

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -197,7 +197,10 @@ describe("Gemini route", () => {
       expect(response.text).toBe("Hello!")
       expect(response.reasoning).toBe("thinking")
       expect(response.usage).toMatchObject({
-        inputTokens: 5,
+        // Additive contract: promptTokenCount=5 includes 1 cached, so
+        // inputTokens=4 + cacheReadInputTokens=1. Gemini already splits
+        // candidates from thoughts, so outputTokens=2 + reasoningTokens=1.
+        inputTokens: 4,
         outputTokens: 2,
         reasoningTokens: 1,
         cacheReadInputTokens: 1,
@@ -211,7 +214,7 @@ describe("Gemini route", () => {
           type: "request-finish",
           reason: "stop",
           usage: {
-            inputTokens: 5,
+            inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 1,
             cacheReadInputTokens: 1,

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -231,9 +231,6 @@ describe("OpenAI Chat route", () => {
           type: "request-finish",
           reason: "stop",
           usage: {
-            // Additive contract: prompt_tokens=5 includes 1 cached, so
-            // inputTokens=4 (non-cached) + cacheReadInputTokens=1.
-            // completion_tokens=2 includes 0 reasoning, so outputTokens=2.
             inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 0,

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "bun:test"
 import { Effect, Schema, Stream } from "effect"
 import { HttpClientRequest } from "effect/unstable/http"
-import { LLM, LLMError } from "../../src"
+import { LLM, LLMError, Usage } from "../../src"
 import * as Azure from "../../src/providers/azure"
 import * as OpenAI from "../../src/providers/openai"
 import * as OpenAIChat from "../../src/protocols/openai-chat"
@@ -230,7 +230,7 @@ describe("OpenAI Chat route", () => {
         {
           type: "request-finish",
           reason: "stop",
-          usage: {
+          usage: new Usage({
             inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 0,
@@ -243,7 +243,7 @@ describe("OpenAI Chat route", () => {
               prompt_tokens_details: { cached_tokens: 1 },
               completion_tokens_details: { reasoning_tokens: 0 },
             },
-          },
+          }),
         },
       ])
     }),

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -237,12 +237,14 @@ describe("OpenAI Chat route", () => {
             cacheReadInputTokens: 1,
             reasoningTokens: 0,
             totalTokens: 7,
-            native: {
-              prompt_tokens: 5,
-              completion_tokens: 2,
-              total_tokens: 7,
-              prompt_tokens_details: { cached_tokens: 1 },
-              completion_tokens_details: { reasoning_tokens: 0 },
+            providerMetadata: {
+              openai: {
+                prompt_tokens: 5,
+                completion_tokens: 2,
+                total_tokens: 7,
+                prompt_tokens_details: { cached_tokens: 1 },
+                completion_tokens_details: { reasoning_tokens: 0 },
+              },
             },
           }),
         },

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -231,10 +231,11 @@ describe("OpenAI Chat route", () => {
           type: "request-finish",
           reason: "stop",
           usage: new Usage({
-            inputTokens: 4,
+            inputTokens: 5,
             outputTokens: 2,
-            reasoningTokens: 0,
+            nonCachedInputTokens: 4,
             cacheReadInputTokens: 1,
+            reasoningTokens: 0,
             totalTokens: 7,
             native: {
               prompt_tokens: 5,

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -231,7 +231,10 @@ describe("OpenAI Chat route", () => {
           type: "request-finish",
           reason: "stop",
           usage: {
-            inputTokens: 5,
+            // Additive contract: prompt_tokens=5 includes 1 cached, so
+            // inputTokens=4 (non-cached) + cacheReadInputTokens=1.
+            // completion_tokens=2 includes 0 reasoning, so outputTokens=2.
+            inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 0,
             cacheReadInputTokens: 1,

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -343,7 +343,10 @@ describe("OpenAI Responses route", () => {
           reason: "stop",
           providerMetadata: { openai: { responseId: "resp_1", serviceTier: "default" } },
           usage: {
-            inputTokens: 5,
+            // Additive contract: input_tokens=5 includes 1 cached, so
+            // inputTokens=4 + cacheReadInputTokens=1.
+            // output_tokens=2 includes 0 reasoning, so outputTokens=2.
+            inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 0,
             cacheReadInputTokens: 1,

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -349,12 +349,14 @@ describe("OpenAI Responses route", () => {
             cacheReadInputTokens: 1,
             reasoningTokens: 0,
             totalTokens: 7,
-            native: {
-              input_tokens: 5,
-              output_tokens: 2,
-              total_tokens: 7,
-              input_tokens_details: { cached_tokens: 1 },
-              output_tokens_details: { reasoning_tokens: 0 },
+            providerMetadata: {
+              openai: {
+                input_tokens: 5,
+                output_tokens: 2,
+                total_tokens: 7,
+                input_tokens_details: { cached_tokens: 1 },
+                output_tokens_details: { reasoning_tokens: 0 },
+              },
             },
           }),
         },
@@ -417,7 +419,7 @@ describe("OpenAI Responses route", () => {
             outputTokens: 1,
             nonCachedInputTokens: 5,
             totalTokens: 6,
-            native: { input_tokens: 5, output_tokens: 1 },
+            providerMetadata: { openai: { input_tokens: 5, output_tokens: 1 } },
           }),
         },
       ])

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -343,9 +343,6 @@ describe("OpenAI Responses route", () => {
           reason: "stop",
           providerMetadata: { openai: { responseId: "resp_1", serviceTier: "default" } },
           usage: {
-            // Additive contract: input_tokens=5 includes 1 cached, so
-            // inputTokens=4 + cacheReadInputTokens=1.
-            // output_tokens=2 includes 0 reasoning, so outputTokens=2.
             inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 0,

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -343,10 +343,11 @@ describe("OpenAI Responses route", () => {
           reason: "stop",
           providerMetadata: { openai: { responseId: "resp_1", serviceTier: "default" } },
           usage: new Usage({
-            inputTokens: 4,
+            inputTokens: 5,
             outputTokens: 2,
-            reasoningTokens: 0,
+            nonCachedInputTokens: 4,
             cacheReadInputTokens: 1,
+            reasoningTokens: 0,
             totalTokens: 7,
             native: {
               input_tokens: 5,
@@ -411,7 +412,13 @@ describe("OpenAI Responses route", () => {
         {
           type: "request-finish",
           reason: "tool-calls",
-          usage: new Usage({ inputTokens: 5, outputTokens: 1, totalTokens: 6, native: { input_tokens: 5, output_tokens: 1 } }),
+          usage: new Usage({
+            inputTokens: 5,
+            outputTokens: 1,
+            nonCachedInputTokens: 5,
+            totalTokens: 6,
+            native: { input_tokens: 5, output_tokens: 1 },
+          }),
         },
       ])
     }),

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "bun:test"
 import { ConfigProvider, Effect, Layer, Stream } from "effect"
 import { Headers, HttpClientRequest } from "effect/unstable/http"
-import { LLM, LLMError } from "../../src"
+import { LLM, LLMError, Usage } from "../../src"
 import { Auth, LLMClient, RequestExecutor, WebSocketExecutor } from "../../src/route"
 import * as Azure from "../../src/providers/azure"
 import * as OpenAI from "../../src/providers/openai"
@@ -342,7 +342,7 @@ describe("OpenAI Responses route", () => {
           type: "request-finish",
           reason: "stop",
           providerMetadata: { openai: { responseId: "resp_1", serviceTier: "default" } },
-          usage: {
+          usage: new Usage({
             inputTokens: 4,
             outputTokens: 2,
             reasoningTokens: 0,
@@ -355,7 +355,7 @@ describe("OpenAI Responses route", () => {
               input_tokens_details: { cached_tokens: 1 },
               output_tokens_details: { reasoning_tokens: 0 },
             },
-          },
+          }),
         },
       ])
     }),
@@ -411,7 +411,7 @@ describe("OpenAI Responses route", () => {
         {
           type: "request-finish",
           reason: "tool-calls",
-          usage: { inputTokens: 5, outputTokens: 1, totalTokens: 6, native: { input_tokens: 5, output_tokens: 1 } },
+          usage: new Usage({ inputTokens: 5, outputTokens: 1, totalTokens: 6, native: { input_tokens: 5, output_tokens: 1 } }),
         },
       ])
     }),

--- a/packages/llm/test/schema.test.ts
+++ b/packages/llm/test/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Schema } from "effect"
-import { ContentPart, LLMEvent, LLMRequest, ModelID, ModelLimits, ModelRef, ProviderID, Usage } from "../src/schema"
+import { ContentPart, LLMEvent, LLMRequest, ModelID, ModelLimits, ModelRef, ProviderID } from "../src/schema"
 import { ProviderShared } from "../src/protocols/shared"
 
 const model = new ModelRef({
@@ -53,24 +53,12 @@ describe("llm schema", () => {
 describe("LLM.Usage additive contract", () => {
   test("subtractTokens clamps non-sensical breakdowns to zero", () => {
     // Defense against a provider reporting cached_tokens > prompt_tokens or
-    // reasoning_tokens > completion_tokens. The clamp prevents the negative
-    // values that triggered opencode#26620 from ever entering the pipeline.
+    // reasoning_tokens > completion_tokens — the negative would otherwise
+    // round-trip through the pipeline and crash strict downstream schemas.
     expect(ProviderShared.subtractTokens(5, 3)).toBe(2)
     expect(ProviderShared.subtractTokens(5, 10)).toBe(0)
     expect(ProviderShared.subtractTokens(5, undefined)).toBe(5)
     expect(ProviderShared.subtractTokens(undefined, 3)).toBeUndefined()
     expect(ProviderShared.subtractTokens(undefined, undefined)).toBeUndefined()
-  })
-
-  test("totalInput sums every input-side category", () => {
-    expect(Usage.totalInput(new Usage({ inputTokens: 10, cacheReadInputTokens: 3, cacheWriteInputTokens: 2 }))).toBe(15)
-    expect(Usage.totalInput(new Usage({ inputTokens: 10 }))).toBe(10)
-    expect(Usage.totalInput(new Usage({}))).toBe(0)
-  })
-
-  test("totalOutput sums every output-side category", () => {
-    expect(Usage.totalOutput(new Usage({ outputTokens: 7, reasoningTokens: 4 }))).toBe(11)
-    expect(Usage.totalOutput(new Usage({ outputTokens: 7 }))).toBe(7)
-    expect(Usage.totalOutput(new Usage({}))).toBe(0)
   })
 })

--- a/packages/llm/test/schema.test.ts
+++ b/packages/llm/test/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Schema } from "effect"
-import { ContentPart, LLMEvent, LLMRequest, ModelID, ModelLimits, ModelRef, ProviderID } from "../src/schema"
+import { ContentPart, LLMEvent, LLMRequest, ModelID, ModelLimits, ModelRef, ProviderID, Usage } from "../src/schema"
 import { ProviderShared } from "../src/protocols/shared"
 
 const model = new ModelRef({
@@ -60,5 +60,17 @@ describe("LLM.Usage additive contract", () => {
     expect(ProviderShared.subtractTokens(5, undefined)).toBe(5)
     expect(ProviderShared.subtractTokens(undefined, 3)).toBeUndefined()
     expect(ProviderShared.subtractTokens(undefined, undefined)).toBeUndefined()
+  })
+
+  test("totalInputTokens sums every input-side category", () => {
+    expect(new Usage({ inputTokens: 10, cacheReadInputTokens: 3, cacheWriteInputTokens: 2 }).totalInputTokens).toBe(15)
+    expect(new Usage({ inputTokens: 10 }).totalInputTokens).toBe(10)
+    expect(new Usage({}).totalInputTokens).toBe(0)
+  })
+
+  test("totalOutputTokens sums every output-side category", () => {
+    expect(new Usage({ outputTokens: 7, reasoningTokens: 4 }).totalOutputTokens).toBe(11)
+    expect(new Usage({ outputTokens: 7 }).totalOutputTokens).toBe(7)
+    expect(new Usage({}).totalOutputTokens).toBe(0)
   })
 })

--- a/packages/llm/test/schema.test.ts
+++ b/packages/llm/test/schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Schema } from "effect"
-import { ContentPart, LLMEvent, LLMRequest, ModelID, ModelLimits, ModelRef, ProviderID } from "../src/schema"
+import { ContentPart, LLMEvent, LLMRequest, ModelID, ModelLimits, ModelRef, ProviderID, Usage } from "../src/schema"
+import { ProviderShared } from "../src/protocols/shared"
 
 const model = new ModelRef({
   id: ModelID.make("fake-model"),
@@ -46,5 +47,30 @@ describe("llm schema", () => {
   test("content part tagged union exposes guards", () => {
     expect(ContentPart.guards.text({ type: "text", text: "hi" })).toBe(true)
     expect(ContentPart.guards.media({ type: "text", text: "hi" })).toBe(false)
+  })
+})
+
+describe("LLM.Usage additive contract", () => {
+  test("subtractTokens clamps non-sensical breakdowns to zero", () => {
+    // Defense against a provider reporting cached_tokens > prompt_tokens or
+    // reasoning_tokens > completion_tokens. The clamp prevents the negative
+    // values that triggered opencode#26620 from ever entering the pipeline.
+    expect(ProviderShared.subtractTokens(5, 3)).toBe(2)
+    expect(ProviderShared.subtractTokens(5, 10)).toBe(0)
+    expect(ProviderShared.subtractTokens(5, undefined)).toBe(5)
+    expect(ProviderShared.subtractTokens(undefined, 3)).toBeUndefined()
+    expect(ProviderShared.subtractTokens(undefined, undefined)).toBeUndefined()
+  })
+
+  test("totalInput sums every input-side category", () => {
+    expect(Usage.totalInput(new Usage({ inputTokens: 10, cacheReadInputTokens: 3, cacheWriteInputTokens: 2 }))).toBe(15)
+    expect(Usage.totalInput(new Usage({ inputTokens: 10 }))).toBe(10)
+    expect(Usage.totalInput(new Usage({}))).toBe(0)
+  })
+
+  test("totalOutput sums every output-side category", () => {
+    expect(Usage.totalOutput(new Usage({ outputTokens: 7, reasoningTokens: 4 }))).toBe(11)
+    expect(Usage.totalOutput(new Usage({ outputTokens: 7 }))).toBe(7)
+    expect(Usage.totalOutput(new Usage({}))).toBe(0)
   })
 })

--- a/packages/llm/test/schema.test.ts
+++ b/packages/llm/test/schema.test.ts
@@ -50,7 +50,7 @@ describe("llm schema", () => {
   })
 })
 
-describe("LLM.Usage additive contract", () => {
+describe("LLM.Usage", () => {
   test("subtractTokens clamps non-sensical breakdowns to zero", () => {
     // Defense against a provider reporting cached_tokens > prompt_tokens or
     // reasoning_tokens > completion_tokens — the negative would otherwise
@@ -62,15 +62,17 @@ describe("LLM.Usage additive contract", () => {
     expect(ProviderShared.subtractTokens(undefined, undefined)).toBeUndefined()
   })
 
-  test("totalInputTokens sums every input-side category", () => {
-    expect(new Usage({ inputTokens: 10, cacheReadInputTokens: 3, cacheWriteInputTokens: 2 }).totalInputTokens).toBe(15)
-    expect(new Usage({ inputTokens: 10 }).totalInputTokens).toBe(10)
-    expect(new Usage({}).totalInputTokens).toBe(0)
+  test("sumTokens returns undefined only when every input is undefined", () => {
+    expect(ProviderShared.sumTokens(1, 2, 3)).toBe(6)
+    expect(ProviderShared.sumTokens(1, undefined, 3)).toBe(4)
+    expect(ProviderShared.sumTokens(undefined, undefined, undefined)).toBeUndefined()
+    expect(ProviderShared.sumTokens()).toBeUndefined()
   })
 
-  test("totalOutputTokens sums every output-side category", () => {
-    expect(new Usage({ outputTokens: 7, reasoningTokens: 4 }).totalOutputTokens).toBe(11)
-    expect(new Usage({ outputTokens: 7 }).totalOutputTokens).toBe(7)
-    expect(new Usage({}).totalOutputTokens).toBe(0)
+  test("visibleOutputTokens clamps reasoning > output to zero", () => {
+    expect(new Usage({ outputTokens: 10, reasoningTokens: 4 }).visibleOutputTokens).toBe(6)
+    expect(new Usage({ outputTokens: 10 }).visibleOutputTokens).toBe(10)
+    expect(new Usage({ outputTokens: 4, reasoningTokens: 10 }).visibleOutputTokens).toBe(0)
+    expect(new Usage({}).visibleOutputTokens).toBe(0)
   })
 })


### PR DESCRIPTION
## TL;DR

Reshapes `LLM.Usage` in `packages/llm` so consumers can read token counts without ever subtracting.

- **Inclusive totals** (`inputTokens`, `outputTokens`, `totalTokens`) match the AI SDK / OpenAI / LangChain convention — a reader from any of those ecosystems sees the number they expect.
- **Non-overlapping breakdown** (`nonCachedInputTokens`, `cacheReadInputTokens`, `cacheWriteInputTokens`, `reasoningTokens`) is populated alongside, so cost / category metrics never require a subtraction.
- `providerMetadata` holds the provider's raw usage payload, keyed by provider name — matches the same escape hatch on `LLMEvent`.

Each protocol mapper enforces the contract at the provider boundary, so the underflow bug class behind opencode#26620 (and a cluster of equivalent open bugs across the ecosystem) is impossible above this layer.

## The shape

```ts
class Usage {
  // Inclusive totals — match AI SDK / OpenAI / LangChain convention.
  inputTokens?:  number   // = nonCachedInputTokens + cacheReadInputTokens + cacheWriteInputTokens
  outputTokens?: number   // includes reasoningTokens
  totalTokens?:  number   // provider-supplied, or inputTokens + outputTokens

  // Non-overlapping breakdown — every field independently meaningful.
  nonCachedInputTokens?:  number
  cacheReadInputTokens?:  number
  cacheWriteInputTokens?: number
  reasoningTokens?:       number  // subset of outputTokens

  // Provider's raw usage payload, keyed by provider name. Matches
  // LLMEvent.providerMetadata. Use for fields we don't normalize and for
  // billing-level audit trails.
  providerMetadata?: { openai: {...} } | { anthropic: {...} } | { google: {...} } | { bedrock: {...} }

  // The one place subtraction happens, clamped to zero.
  get visibleOutputTokens(): number  // = max(0, outputTokens - reasoningTokens)
}
```

**Invariants** (enforced at the mapper boundary):
- `nonCachedInputTokens + cacheReadInputTokens + cacheWriteInputTokens = inputTokens`
- `reasoningTokens ≤ outputTokens`

## Why this shape

This PR started as a fix for the bug class behind #26620: `Session.getUsage` did `outputTokens - reasoningTokens`, the AI SDK reported them inconsistently across providers, the subtraction underflowed below zero, the negative got stored, and a strict `NonNegativeInt` schema rejected it on read → 400 → desktop crash on startup. PR #26620 clamped negatives to zero, which fixed the crash but left the underlying inconsistency in place.

The naming question split the design into two passes:

1. **First cut**: make `Usage` purely additive — `inputTokens` and `outputTokens` represent non-cached / visible portions only. Structurally kills the underflow class, but **diverges on naming**: AI SDK, OpenAI, LangChain, and OTel all use `inputTokens` to mean the inclusive total. A reader from any of those ecosystems would land on our `usage.inputTokens` and get a smaller number than expected. Worst-case API surface: same names, opposite semantics.
2. **Final shape**: keep the inclusive totals (match the ecosystem) AND populate a non-overlapping breakdown alongside (kill the bug class). Both views available; nobody subtracts.

This is also the direction the **AI SDK v3 spec proposal** (vercel/ai#9921) is taking — explicit non-overlapping breakdown alongside the inclusive total — to address a cluster of active ecosystem bugs that all stem from the same source:

- pydantic-ai#4364 — Anthropic cache tokens double-counted in Langfuse/OTel
- langfuse#12306 — cache tokens double-counted via OTel
- langfuse#11979 — input tokens become `0` when `cache_read > input_tokens` (literally our underflow bug, in another library)
- vercel/ai#8349 — inaccurate usage counts with Anthropic
- vercel/ai#4335 — Anthropic cache control not returning cached token usage
- langchain-ai/langchain#32818 — usage metadata inaccurate for prompt cache
- langchain-ai/langchainjs#10249 — cache tokens double-counted in streaming

Every one of these is the inclusive-only convention requiring subtraction at consumer sites where implementations disagree about whether subtotals overlap. Storing the breakdown explicitly removes the foot-gun.

## Mapper normalization

Each protocol mapper produces both views at the boundary, using two helpers in `ProviderShared`:

- `subtractTokens(total, subtrahend)` — clamps to zero to defend against provider bugs (e.g. `cached_tokens > prompt_tokens`).
- `sumTokens(...values)` — returns `undefined` only when every value is `undefined`, so we don't fabricate a `0`.

By provider:

| Provider | Native shape | Mapper does |
|---|---|---|
| **OpenAI Chat / Responses** | `prompt_tokens`/`input_tokens` inclusive, `cached_tokens` subset; `completion_tokens`/`output_tokens` inclusive, `reasoning_tokens` subset | Pass totals through, derive `nonCachedInputTokens = subtractTokens(prompt_tokens, cached_tokens)` |
| **Bedrock** | `inputTokens` inclusive, `cacheReadInputTokens`/`cacheWriteInputTokens` subsets; no reasoning split | Pass total through, derive `nonCachedInputTokens` via summed cache total |
| **Gemini** | `promptTokenCount` inclusive (cached is a subset); `candidatesTokenCount` is *exclusive* of `thoughtsTokenCount` | Pass input total through; *sum* candidates + thoughts to produce inclusive `outputTokens`, but only when the visible component is reported |
| **Anthropic** | `input_tokens` is non-cached only; `cache_read_input_tokens` and `cache_creation_input_tokens` are separate; `output_tokens` includes thinking | Sum breakdown to derive inclusive `inputTokens`; pass `output_tokens` through; leave `reasoningTokens` undefined (Anthropic doesn't break it out) |

Anthropic's streaming `mergeUsage` was also updated to recompute the inclusive `inputTokens` from the merged breakdown so the invariant stays consistent across `message_start` + `message_delta` updates.

## `providerMetadata` (renamed from `native`)

The raw provider payload is preserved under `providerMetadata`, keyed by provider name (e.g. `{ openai: { prompt_tokens, completion_tokens, ... } }`). This matches the existing escape-hatch field on `LLMEvent` and the AI SDK / pydantic-ai / LangChain conventions for the same idea. Use it for fields we don't normalize and for billing-level audit trails.

## Tests

- Per-provider fixtures updated for the new field shape — e.g. an OpenAI Chat fixture with `prompt_tokens: 5, cached_tokens: 1` now expects `inputTokens: 5, nonCachedInputTokens: 4, cacheReadInputTokens: 1`.
- Inline test usage literals wrapped with `new Usage({...})` so the `visibleOutputTokens` getter doesn't break structural type matching.
- New regression tests in `schema.test.ts` for `subtractTokens` clamp, `sumTokens` undefined behavior, and `visibleOutputTokens` clamp.

## Verification

```bash
cd packages/llm
bun run typecheck     # clean
bun run test          # 167 pass, 27 skip (recorded scenarios w/o keys), 0 fail
```

## Follow-ups (out of scope here)

- [ ] When v2 begins consuming `LLM.Usage` in session storage, replace `Session.getUsage`'s subtractions with direct field reads — they become redundant.
- [ ] Once a backfill scrubs legacy bad values left over from #26620, tighten the stored `Schema.Finite` token fields in `MessageV2` / `Step.Finished` back to `NonNegativeInt`.