### PR TITLE
Migrate compaction plugin test

### DIFF
--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1202,48 +1202,37 @@ describe("session.compaction.process", () => {
     { git: true },
   )
 
-  test("allows plugins to disable synthetic continue prompt", async () => {
-    await using tmp = await tmpdir()
-    await WithInstance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await svc.create({})
-        const msg = await user(session.id, "hello")
-        const rt = runtime("continue", autocontinue(false), wide())
-        try {
-          const msgs = await svc.messages({ sessionID: session.id })
-          const result = await rt.runPromise(
-            SessionCompaction.Service.use((svc) =>
-              svc.process({
-                parentID: msg.id,
-                messages: msgs,
-                sessionID: session.id,
-                auto: true,
-              }),
-            ),
-          )
+  itProcess.instance(
+    "allows plugins to disable synthetic continue prompt",
+    Effect.gen(function* () {
+      const ssn = yield* SessionNs.Service
+      const session = yield* ssn.create({})
+      const msg = yield* createUserMessage(session.id, "hello")
+      const msgs = yield* ssn.messages({ sessionID: session.id })
 
-          const all = await svc.messages({ sessionID: session.id })
-          const last = all.at(-1)
+      const result = yield* SessionCompaction.use.process({
+        parentID: msg.id,
+        messages: msgs,
+        sessionID: session.id,
+        auto: true,
+      })
 
-          expect(result).toBe("continue")
-          expect(last?.info.role).toBe("assistant")
-          expect(
-            all.some(
-              (msg) =>
-                msg.info.role === "user" &&
-                msg.parts.some(
-                  (part) =>
-                    part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
-                ),
+      const all = yield* ssn.messages({ sessionID: session.id })
+      const last = all.at(-1)
+
+      expect(result).toBe("continue")
+      expect(last?.info.role).toBe("assistant")
+      expect(
+        all.some(
+          (msg) =>
+            msg.info.role === "user" &&
+            msg.parts.some(
+              (part) => part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
             ),
-          ).toBe(false)
-        } finally {
-          await rt.dispose()
-        }
-      },
-    })
-  })
+        ),
+      ).toBe(false)
+    }).pipe(Effect.provide(compactionProcessLayer({ plugin: autocontinue(false) }))),
+  )
 
   it.instance(
     "replays the prior user turn on overflow when earlier context exists",


### PR DESCRIPTION
## Summary
- Convert the plugin-controlled auto-continue compaction test to `it.instance` and yielded services.
- Use the per-test compaction layer helper for plugin overrides.

## Testing
- `bun test --timeout 5000 test/session/compaction.test.ts -t "allows plugins to disable synthetic continue prompt"`
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check packages/opencode/test/session/compaction.test.ts`
- `bunx oxlint packages/opencode/test/session/compaction.test.ts` (existing warnings only, no errors)

<!-- stack:links:start -->
### Stack

1. #26732
2. #26733
3. #26734
4. **#26736** 👈 current
5. #26737
6. #26738
7. #26739
8. #26740
9. #26742
<!-- stack:links:end -->