### PR TITLE
Drop compaction create facade

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -4,7 +4,6 @@ import * as Session from "./session"
 import { SessionID, MessageID, PartID } from "./schema"
 import { Provider } from "@/provider/provider"
 import { MessageV2 } from "./message-v2"
-import z from "zod"
 import { Token } from "@/util/token"
 import * as Log from "@opencode-ai/core/util/log"
 import { SessionProcessor } from "./processor"
@@ -19,7 +18,6 @@ import { InstanceState } from "@/effect/instance-state"
 import { isOverflow as overflow, usable } from "./overflow"
 import { makeRuntime } from "@/effect/run-service"
 import { serviceUse } from "@/effect/service-use"
-import { fn } from "@/util/fn"
 import { EventV2 } from "@/v2/event"
 import { SessionEvent } from "@/v2/session-event"
 
@@ -640,16 +638,5 @@ export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"];
 export async function prune(input: { sessionID: SessionID }) {
   return runPromise((svc) => svc.prune(input))
 }
-
-export const create = fn(
-  z.object({
-    sessionID: SessionID.zod,
-    agent: z.string(),
-    model: z.object({ providerID: ProviderID.zod, modelID: ModelID.zod }),
-    auto: z.boolean(),
-    overflow: z.boolean().optional(),
-  }),
-  (input) => runPromise((svc) => svc.create(input)),
-)
 
 export * as SessionCompaction from "./compaction"


### PR DESCRIPTION
## Summary
- Remove the exported promise/Zod wrapper for `SessionCompaction.create`.
- Keep the Effect service method and `SessionCompaction.use.create` as the supported call path.

## Testing
- `bun test --timeout 5000 test/session/compaction.test.ts -t "summarizes only the head|anchors repeated compactions|keeps recent pre-compaction|ignores previous summaries"`
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check packages/opencode/src/session/compaction.ts`
- `bunx oxlint packages/opencode/src/session/compaction.ts` (existing warnings only, no errors)

<!-- stack:links:start -->
### Stack

1. #26732
2. #26733
3. #26734
4. #26736
5. #26737
6. #26738
7. **#26739** 👈 current
8. #26740
9. #26742
<!-- stack:links:end -->