### PR TITLE
Drop unused ID Zod statics

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/validate-session.ts
+++ b/packages/opencode/src/cli/cmd/tui/validate-session.ts
@@ -1,5 +1,8 @@
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { SessionID } from "@/session/schema"
+import { Schema } from "effect"
+
+const decodeSessionID = Schema.decodeUnknownSync(SessionID)
 
 export async function validateSession(input: {
   url: string
@@ -10,9 +13,11 @@ export async function validateSession(input: {
 }) {
   if (!input.sessionID) return
 
-  const result = SessionID.zod.safeParse(input.sessionID)
-  if (!result.success) {
-    throw new Error(`Invalid session ID: ${result.error.issues.at(0)?.message ?? "unknown error"}`)
+  let sessionID: SessionID
+  try {
+    sessionID = decodeSessionID(input.sessionID)
+  } catch (error) {
+    throw new Error(`Invalid session ID: ${error instanceof Error ? error.message : "unknown error"}`, { cause: error })
   }
 
   await createOpencodeClient({
@@ -20,5 +25,5 @@ export async function validateSession(input: {
     directory: input.directory,
     fetch: input.fetch,
     headers: input.headers,
-  }).session.get({ sessionID: result.data }, { throwOnError: true })
+  }).session.get({ sessionID }, { throwOnError: true })
 }

--- a/packages/opencode/src/control-plane/schema.ts
+++ b/packages/opencode/src/control-plane/schema.ts
@@ -1,7 +1,6 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
 const workspaceIdSchema = Schema.String.check(Schema.isStartsWith("wrk")).pipe(Schema.brand("WorkspaceID"))
@@ -11,6 +10,5 @@ export type WorkspaceID = typeof workspaceIdSchema.Type
 export const WorkspaceID = workspaceIdSchema.pipe(
   withStatics((schema: typeof workspaceIdSchema) => ({
     ascending: (id?: string) => schema.make(Identifier.ascending("workspace", id)),
-    zod: zod(schema),
   })),
 )

--- a/packages/opencode/src/session/schema.ts
+++ b/packages/opencode/src/session/schema.ts
@@ -1,14 +1,12 @@
 import { Schema } from "effect"
 
 import { Identifier } from "@/id/id"
-import { zod } from "@opencode-ai/core/effect-zod"
 import { withStatics } from "@opencode-ai/core/schema"
 
 export const SessionID = Schema.String.check(Schema.isStartsWith("ses")).pipe(
   Schema.brand("SessionID"),
   withStatics((s) => ({
     descending: (id?: string) => s.make(Identifier.descending("session", id)),
-    zod: zod(s),
   })),
 )
 
@@ -18,7 +16,6 @@ export const MessageID = Schema.String.check(Schema.isStartsWith("msg")).pipe(
   Schema.brand("MessageID"),
   withStatics((s) => ({
     ascending: (id?: string) => s.make(Identifier.ascending("message", id)),
-    zod: zod(s),
   })),
 )
 
@@ -28,7 +25,6 @@ export const PartID = Schema.String.check(Schema.isStartsWith("prt")).pipe(
   Schema.brand("PartID"),
   withStatics((s) => ({
     ascending: (id?: string) => s.make(Identifier.ascending("part", id)),
-    zod: zod(s),
   })),
 )
 

--- a/packages/opencode/test/session/schema-decoding.test.ts
+++ b/packages/opencode/test/session/schema-decoding.test.ts
@@ -15,20 +15,20 @@ import { WorkspaceID } from "../../src/control-plane/schema"
 // schema we assert:
 //   1. The Effect decoder (`Schema.decodeUnknownSync`) accepts valid input.
 //   2. The derived Zod (`X.zod.parse`) accepts the same input and returns the
-//      same shape.
-//   3. Clearly-invalid input is rejected by both paths.
+//      same shape for schemas that still expose Zod statics.
+//   3. Clearly-invalid input is rejected by both paths where both exist.
 //
 // The point is to lock down the Schema <-> Zod bridge so a future edit to
 // any input schema can't silently drop or widen a field on one side.
 
 // Representative valid IDs — the branded schemas require the right prefix
 // (see src/id/id.ts).
-const sessionID = SessionID.zod.parse("ses_01J5Y5H0AH4Q4NXJ6P4C3P5V2K")
-const sessionIDChild = SessionID.zod.parse("ses_01J5Y5H0AH4Q4NXJ6P4C3P5V2L")
-const messageID = MessageID.zod.parse("msg_01J5Y5H0AH4Q4NXJ6P4C3P5V2M")
-const partID = PartID.zod.parse("prt_01J5Y5H0AH4Q4NXJ6P4C3P5V2N")
+const sessionID = Schema.decodeUnknownSync(SessionID)("ses_01J5Y5H0AH4Q4NXJ6P4C3P5V2K")
+const sessionIDChild = Schema.decodeUnknownSync(SessionID)("ses_01J5Y5H0AH4Q4NXJ6P4C3P5V2L")
+const messageID = Schema.decodeUnknownSync(MessageID)("msg_01J5Y5H0AH4Q4NXJ6P4C3P5V2M")
+const partID = Schema.decodeUnknownSync(PartID)("prt_01J5Y5H0AH4Q4NXJ6P4C3P5V2N")
 const projectID = ProjectID.zod.parse("proj-alpha")
-const workspaceID = WorkspaceID.zod.parse("wrk-primary")
+const workspaceID = Schema.decodeUnknownSync(WorkspaceID)("wrk-primary")
 
 function decodeUnknown<S extends Schema.Top>(schema: S) {
   const decode = Schema.decodeUnknownSync(schema as any)


### PR DESCRIPTION
## Summary
- Remove unused `.zod` statics from simple session/workspace ID schemas.
- Convert TUI session ID validation to Effect Schema decoding.
- Update schema decoding tests to use Effect decoders for IDs without Zod statics.

## Testing
- `bun test --timeout 5000 test/session/schema-decoding.test.ts test/session/compaction.test.ts -t "summarizes only the head|anchors repeated compactions|keeps recent pre-compaction|ignores previous summaries|accepts minimal session"`
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check packages/opencode/src/cli/cmd/tui/validate-session.ts packages/opencode/src/session/schema.ts packages/opencode/src/control-plane/schema.ts packages/opencode/test/session/schema-decoding.test.ts packages/opencode/test/session/compaction.test.ts`
- `bunx oxlint packages/opencode/src/cli/cmd/tui/validate-session.ts packages/opencode/src/control-plane/schema.ts packages/opencode/src/session/schema.ts packages/opencode/test/session/schema-decoding.test.ts`

<!-- stack:links:start -->
### Stack

1. #26732
2. #26733
3. #26734
4. #26736
5. #26737
6. #26738
7. #26739
8. **#26740** 👈 current
9. #26742
<!-- stack:links:end -->