### PR TITLE
fix(session): persist plan mode reminders

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -237,28 +237,26 @@ export const layer = Layer.effect(
     }) {
       const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
       if (!userMessage) return input.messages
+      const ensureSyntheticPart = Effect.fn("SessionPrompt.ensureSyntheticPart")(function* (text: string) {
+        if (userMessage.parts.some((part) => part.type === "text" && part.synthetic && part.text === text)) return
+        const part = yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: userMessage.info.id,
+          sessionID: userMessage.info.sessionID,
+          type: "text",
+          text,
+          synthetic: true,
+        })
+        userMessage.parts.push(part)
+      })
 
       if (!Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE) {
         if (input.agent.name === "plan") {
-          userMessage.parts.push({
-            id: PartID.ascending(),
-            messageID: userMessage.info.id,
-            sessionID: userMessage.info.sessionID,
-            type: "text",
-            text: PROMPT_PLAN,
-            synthetic: true,
-          })
+          yield* ensureSyntheticPart(PROMPT_PLAN)
         }
         const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
         if (wasPlan && input.agent.name === "build") {
-          userMessage.parts.push({
-            id: PartID.ascending(),
-            messageID: userMessage.info.id,
-            sessionID: userMessage.info.sessionID,
-            type: "text",
-            text: BUILD_SWITCH,
-            synthetic: true,
-          })
+          yield* ensureSyntheticPart(BUILD_SWITCH)
         }
         return input.messages
       }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -495,6 +495,50 @@ it.live("static loop consumes queued replies across turns", () =>
   ),
 )
 
+it.live("plan mode reminders remain stable when the message becomes history", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Plan prompt cache",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "plan",
+        noReply: true,
+        parts: [{ type: "text", text: "first plan question" }],
+      })
+
+      yield* llm.text("first plan answer")
+      yield* prompt.loop({ sessionID: session.id })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "plan",
+        noReply: true,
+        parts: [{ type: "text", text: "second plan question" }],
+      })
+
+      yield* llm.text("second plan answer")
+      yield* prompt.loop({ sessionID: session.id })
+
+      const hits = yield* llm.hits
+      const messages = hits[1].body.messages as { role: string; content: unknown }[]
+      expect(messages[1].role).toBe("user")
+      expect(messages[1].content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "text", text: expect.stringContaining("first plan question") }),
+          expect.objectContaining({ type: "text", text: expect.stringContaining("Plan Mode - System Reminder") }),
+        ]),
+      )
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop continues when finish is tool-calls", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {


### PR DESCRIPTION
### Issue for this PR

Closes #26749

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode appends a synthetic plan-mode reminder to the user message before sending the prompt, but the synthetic part is not stored in message history. On the next turn, the same historical user message is replayed without the reminder, so the model-visible serialization of that turn changes between request 1 and request 2.

This PR persists the non-experimental plan / build synthetic reminder into the user message itself when it is added, so the message that lives in history is identical to what the model saw on the original turn. As a result, the prompt prefix on every later turn matches the prefix that was seen first, which is what prefix caches in OpenAI-compatible backends (LM Studio, llama.cpp, vLLM, LiteLLM proxies) require to actually hit.

It also guards against duplicate reminder parts when a prompt is retried or reprocessed, by checking whether the same reminder text is already present on the user message before appending another one.

This is intentionally narrow:

- It does not change the user-visible message text shown in the UI (the synthetic reminder is appended as a separate `text` part on the same user message, just like before, only persisted instead of dropped after the request).
- It does not touch the experimental inline reminder injection in `prompt.ts`.
- It is a different concern from #24121 / #24343, which strip plan reminders that leak into Build mode after a switch. That fix removes stale reminders; this fix makes the current-turn reminder stable. They can both be true at once and they don't conflict — this PR only persists the reminder for the turn where the user is in Plan mode, and #24343 is what cleans it up on a later Build turn.

The change works because OpenCode's history is the source of truth replayed to the model on every turn, so persisting the synthetic part once means the next turn replays the exact same tokens for that historical user message instead of re-deriving them from a runtime branch.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode`
- `bun test test/session/prompt.test.ts --timeout 30000 --grep "plan mode reminders remain stable"` — new live-session test that drives a plan turn, advances the session so that the user message becomes history, then asserts the plan reminder text is still present on that historical user message.

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
