### PR TITLE
fix(provider): stabilize LM Studio Qwen requests

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1511,6 +1511,11 @@ const layer: Layer.Layer<
               opts.body = JSON.stringify(body)
             }
           }
+          if (model.api.npm === "@ai-sdk/openai-compatible" && opts.body && opts.method === "POST") {
+            const body = JSON.parse(opts.body as string)
+            const transformed = ProviderTransform.openaiCompatibleBody(model, body)
+            if (transformed !== body) opts.body = JSON.stringify(transformed)
+          }
 
           const res = await fetchFn(input, {
             ...opts,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -18,9 +18,49 @@ function mimeToModality(mime: string): Modality | undefined {
 }
 
 export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
+const LOCAL_PROVIDER_OPTION_KEYS = new Set(["stripReasoningContent", "toolResultsAsUser"])
 
 export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
+}
+
+function isLmStudioOpenAICompatible(model: Provider.Model) {
+  if (model.api.npm !== "@ai-sdk/openai-compatible") return false
+
+  const providerID = model.providerID.toLowerCase()
+  const apiURL = model.api.url.toLowerCase()
+  return (
+    providerID.includes("lmstudio") ||
+    providerID.includes("lm-studio") ||
+    apiURL.includes("127.0.0.1:1234") ||
+    apiURL.includes("localhost:1234")
+  )
+}
+
+function stripReasoningContent(model: Provider.Model, options: Record<string, unknown>) {
+  if (options.stripReasoningContent === true) return true
+  if (options.stripReasoningContent === false) return false
+  return isLmStudioOpenAICompatible(model)
+}
+
+function withoutReasoningContent(msgs: ModelMessage[]): ModelMessage[] {
+  return msgs.map((msg) => {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) return msg
+    if (!msg.content.some((part) => part.type === "reasoning")) return msg
+    return {
+      ...msg,
+      content: msg.content.filter((part) => part.type !== "reasoning"),
+    }
+  })
+}
+
+function toolResultsAsUser(model: Provider.Model, options: Record<string, unknown>) {
+  if (options.toolResultsAsUser === true) return true
+  if (options.toolResultsAsUser === false || options.stripReasoningContent === false) return false
+  if (!isLmStudioOpenAICompatible(model)) return false
+
+  const id = `${model.id} ${model.api.id}`.toLowerCase()
+  return id.includes("qwen") || id.includes("qwq")
 }
 
 // Maps npm package to the key the AI SDK expects for providerOptions
@@ -302,7 +342,13 @@ function normalizeMessages(
     })
   }
 
+  const shouldStripReasoningContent = stripReasoningContent(model, _options)
+  if (shouldStripReasoningContent) {
+    msgs = withoutReasoningContent(msgs)
+  }
+
   if (
+    !shouldStripReasoningContent &&
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
     model.api.npm !== "@openrouter/ai-sdk-provider"
@@ -1228,6 +1274,10 @@ const SLUG_OVERRIDES: Record<string, string> = {
 }
 
 export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
+  const requestOptions = Object.fromEntries(
+    Object.entries(options).filter(([key]) => !LOCAL_PROVIDER_OPTION_KEYS.has(key)),
+  )
+
   if (model.api.npm === "@ai-sdk/gateway") {
     // Gateway providerOptions are split across two namespaces:
     // - `gateway`: gateway-native routing/caching controls (order, only, byok, etc.)
@@ -1237,8 +1287,8 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
     const i = model.api.id.indexOf("/")
     const rawSlug = i > 0 ? model.api.id.slice(0, i) : undefined
     const slug = rawSlug ? (SLUG_OVERRIDES[rawSlug] ?? rawSlug) : undefined
-    const gateway = options.gateway
-    const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "gateway"))
+    const gateway = requestOptions.gateway
+    const rest = Object.fromEntries(Object.entries(requestOptions).filter(([k]) => k !== "gateway"))
     const has = Object.keys(rest).length > 0
 
     const result: Record<string, any> = {}
@@ -1272,9 +1322,52 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
   // "azure" first. Pass both so model options work on either code path.
   if (model.api.npm === "@ai-sdk/azure") {
-    return { openai: options, azure: options }
+    return { openai: requestOptions, azure: requestOptions }
   }
-  return { [key]: options }
+  return { [key]: requestOptions }
+}
+
+export function openaiCompatibleBody(
+  model: Provider.Model,
+  body: unknown,
+  options: Record<string, unknown> = model.options ?? {},
+) {
+  const shouldStripReasoningContent = stripReasoningContent(model, options)
+  const shouldConvertToolResults = toolResultsAsUser(model, options)
+  if (!shouldStripReasoningContent && !shouldConvertToolResults) return body
+  if (!body || typeof body !== "object") return body
+
+  const request = body as Record<string, unknown>
+  if (!Array.isArray(request.messages)) return body
+
+  let changed = false
+  const messages = request.messages.map((message) => {
+    if (!message || typeof message !== "object") return message
+
+    const item = message as Record<string, unknown>
+    const stripped =
+      shouldStripReasoningContent && item.role === "assistant" && "reasoning_content" in item
+        ? iife(() => {
+            changed = true
+            const { reasoning_content: _reasoningContent, ...rest } = item
+            return rest
+          })
+        : item
+
+    if (!shouldConvertToolResults || stripped.role !== "tool") return stripped
+
+    changed = true
+    return {
+      role: "user",
+      content: `Tool response:\n<tool_response>\n${stripped.content ?? ""}\n</tool_response>`,
+    }
+  })
+
+  if (!changed) return body
+  return {
+    ...request,
+    messages,
+  }
 }
 
 export function maxOutputTokens(model: Provider.Model): number {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -506,6 +506,27 @@ describe("ProviderTransform.providerOptions", () => {
       groq: { reasoningFormat: "parsed" },
     })
   })
+
+  test("does not send local stripReasoningContent option to providers", () => {
+    const model = createModel({
+      providerID: "lmstudio",
+      api: {
+        id: "qwen3.6-35b-a3b-mlx",
+        url: "http://127.0.0.1:1234/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    expect(
+      ProviderTransform.providerOptions(model, {
+        stripReasoningContent: true,
+        toolResultsAsUser: true,
+        reasoningEffort: "medium",
+      }),
+    ).toEqual({
+      lmstudio: { reasoningEffort: "medium" },
+    })
+  })
 })
 
 describe("ProviderTransform.schema - gemini array items", () => {
@@ -1120,6 +1141,195 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
       { type: "text", text: "Answer" },
     ])
     expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+  })
+
+  test("LM Studio strips reasoning_content by default for stable prefix caching", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "This thinking should not be replayed" },
+            {
+              type: "tool-call",
+              toolCallId: "toolu_123",
+              toolName: "read",
+              input: { filePath: "/tmp/example.txt" },
+            },
+          ],
+        },
+      ] as any[],
+      {
+        id: ModelID.make("qwen3.6-35b-a3b-mlx"),
+        providerID: ProviderID.make("lmstudio"),
+        api: {
+          id: "qwen3.6-35b-a3b-mlx",
+          url: "http://127.0.0.1:1234/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        name: "Qwen 3.6 35B MLX",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: false,
+          toolcall: true,
+          input: { text: true, audio: false, image: false, video: false, pdf: false },
+          output: { text: true, audio: false, image: false, video: false, pdf: false },
+          interleaved: { field: "reasoning_content" },
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: { read: 0, write: 0 },
+        },
+        limit: {
+          context: 262144,
+          output: 8192,
+        },
+        status: "active",
+        options: {},
+        headers: {},
+        release_date: "2026-01-01",
+      },
+      {},
+    )
+
+    expect(result[0].content).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "toolu_123",
+        toolName: "read",
+        input: { filePath: "/tmp/example.txt" },
+      },
+    ])
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+  })
+
+  test("LM Studio reasoning_content strip can be disabled", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "Keep this thinking" },
+            { type: "text", text: "Answer" },
+          ],
+        },
+      ] as any[],
+      {
+        id: ModelID.make("qwen3.6-35b-a3b-mlx"),
+        providerID: ProviderID.make("lmstudio"),
+        api: {
+          id: "qwen3.6-35b-a3b-mlx",
+          url: "http://127.0.0.1:1234/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        name: "Qwen 3.6 35B MLX",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: false,
+          toolcall: true,
+          input: { text: true, audio: false, image: false, video: false, pdf: false },
+          output: { text: true, audio: false, image: false, video: false, pdf: false },
+          interleaved: { field: "reasoning_content" },
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: { read: 0, write: 0 },
+        },
+        limit: {
+          context: 262144,
+          output: 8192,
+        },
+        status: "active",
+        options: {},
+        headers: {},
+        release_date: "2026-01-01",
+      },
+      { stripReasoningContent: false },
+    )
+
+    expect(result[0].content).toEqual([{ type: "text", text: "Answer" }])
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Keep this thinking")
+  })
+
+  test("LM Studio Qwen normalizes raw OpenAI-compatible body for stable prefix caching", () => {
+    const result = ProviderTransform.openaiCompatibleBody(
+      {
+        id: ModelID.make("qwen3.6-35b-a3b-mlx"),
+        providerID: ProviderID.make("lmstudio"),
+        api: {
+          id: "qwen3.6-35b-a3b-mlx",
+          url: "http://127.0.0.1:1234/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        name: "Qwen 3.6 35B MLX",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: false,
+          toolcall: true,
+          input: { text: true, audio: false, image: false, video: false, pdf: false },
+          output: { text: true, audio: false, image: false, video: false, pdf: false },
+          interleaved: { field: "reasoning_content" },
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: { read: 0, write: 0 },
+        },
+        limit: {
+          context: 262144,
+          output: 8192,
+        },
+        status: "active",
+        options: {},
+        headers: {},
+        release_date: "2026-01-01",
+      },
+      {
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            reasoning_content: "Hidden thinking",
+            tool_calls: [
+              {
+                id: "toolu_123",
+                type: "function",
+                function: { name: "read", arguments: "{}" },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "toolu_123",
+            content: "<path>/tmp/example.txt</path>\n<content>Hello</content>",
+          },
+        ],
+      },
+    )
+
+    expect((result as any).messages).toEqual([
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "toolu_123",
+            type: "function",
+            function: { name: "read", arguments: "{}" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content:
+          "Tool response:\n<tool_response>\n<path>/tmp/example.txt</path>\n<content>Hello</content>\n</tool_response>",
+      },
+    ])
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #26750

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

> Note: re-saving description after a `pull_request_target` race that briefly mis-flagged the type-of-change checkbox.

LM Studio's prefix cache only hits when the tokenized prompt prefix is byte-stable across turns. When OpenCode replays a Qwen / QwQ-family model's conversation history through LM Studio's OpenAI-compatible endpoint, two things make that prefix unstable:

1. Historical assistant `reasoning` content gets re-rendered differently by the Qwen chat template once a new user message is appended, so the same historical assistant turn tokenizes differently the second time it is in the prompt.
2. Standalone `role: "tool"` messages get rendered inconsistently by Qwen-style templates, while `<tool_response>...</tool_response>` blocks embedded in the surrounding turn render stably.

This PR makes the model-visible history stable for that specific provider/model shape, without changing behavior for non-Qwen OpenAI-compatible backends or for Anthropic/OpenAI proper:

- **Drop replayed assistant reasoning content for LM Studio Qwen-shaped requests.** Reasoning is kept for the live turn (where the model emits it) but stripped from history before it is replayed, so the prefix that ends up in the cache does not contain content that re-renders unpredictably.
- **Inline tool messages as `<tool_response>` blocks.** In the outgoing OpenAI-compatible JSON body, raw `role: "tool"` messages are converted into `<tool_response>...</tool_response>` text wrapped onto the previous turn for Qwen/QwQ-like LM Studio models. Non-Qwen targets keep the normal OpenAI-compatible tool-message shape.
- **Don't leak local compatibility options into the SDK call.** The flags that drive this normalization are kept out of `providerOptions` so the underlying provider/SDK only sees standard fields.

There are tests covering both the default normalization behavior and the opt-out (i.e. that a non-Qwen LM Studio model is not affected). The change is gated by provider+model detection; it does not run for Anthropic, OpenAI, or arbitrary OpenAI-compatible endpoints.

This is intentionally separate from the plan-mode reminder persistence fix in the sibling PR. That one is a general OpenCode history-stability bug; this PR is provider/model compatibility behavior for LM Studio Qwen-style chat templates.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode`
- `bun test test/provider/transform.test.ts` — covers the default tool-message-to-`<tool_response>` rewrite for LM Studio Qwen-shaped requests, the reasoning-strip on replayed assistant turns, and the opt-out path for non-Qwen models so they keep the standard OpenAI-compatible shape.
- Manually exercised against LM Studio running a Qwen-family model: confirmed that on turn 2+ the prompt prefix matches the prefix that was sent on turn 1, so LM Studio's prefix-cache hit ratio stops collapsing on multi-turn sessions.

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
