### PR TITLE
fix: skip duplicate skill warning for same file

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -107,6 +107,7 @@ const add = Effect.fnUntraced(function* (state: State, match: string, bus: Bus.I
   if (!parsed.success) return
 
   if (state.skills[parsed.data.name]) {
+    if (state.skills[parsed.data.name].location === match) return
     log.warn("duplicate skill name", {
       name: parsed.data.name,
       existing: state.skills[parsed.data.name].location,

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -325,6 +325,41 @@ This skill is loaded from the global home directory.
     }),
   )
 
+  it.live("deduplicates the same .agents skill discovered as global and project skill", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir({ git: true })),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+
+      yield* withHome(
+        tmp.path,
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(tmp.path, ".agents", "skills", "shared-skill", "SKILL.md"),
+              `---
+name: shared-skill
+description: A skill discovered through global and project scan paths.
+---
+
+# Shared Skill
+`,
+            ),
+          )
+
+          yield* Effect.gen(function* () {
+            const skill = yield* Skill.Service
+            const list = yield* skill.all()
+            expect(list.length).toBe(1)
+            expect(list[0].name).toBe("shared-skill")
+            expect((yield* skill.dirs()).length).toBe(1)
+          }).pipe(provideInstance(tmp.path))
+        }),
+      )
+    }),
+  )
+
   it.live("discovers skills from both .claude/skills/ and .agents/skills/", () =>
     provideTmpdirInstance(
       (dir) =>


### PR DESCRIPTION
Fixes #26709

## Summary
- skip re-loading a skill when the same file path is discovered again
- keep duplicate-name warnings for different files
- add a regression test for .agents skills discovered through both global and project scan paths

## Test
- npx --yes bun@1.3.13 test test/skill/skill.test.ts --timeout 30000
- npx --yes bun@1.3.13 typecheck