### PR TITLE
fix: detect extensionless binary files

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -288,6 +288,18 @@ const isBinaryByExtension = (file: string) => binary.has(ext(file))
 const isImage = (mimeType: string) => mimeType.startsWith("image/")
 const getImageMimeType = (file: string) => mime[ext(file)] || "image/" + ext(file)
 
+function isBinaryContent(bytes: Uint8Array) {
+  if (bytes.length === 0) return false
+
+  let nonPrintable = 0
+  for (const byte of bytes) {
+    if (byte === 0) return true
+    if (byte < 9 || (byte > 13 && byte < 32)) nonPrintable++
+  }
+
+  return nonPrintable / bytes.length > 0.3
+}
+
 function shouldEncode(mimeType: string) {
   const type = mimeType.toLowerCase()
   log.debug("shouldEncode", { type })
@@ -536,6 +548,15 @@ export const layer = Layer.effect(
       const encode = knownText ? false : shouldEncode(mimeType)
 
       if (encode && !isImage(mimeType)) return { type: "binary" as const, content: "", mimeType }
+      if (!knownText) {
+        const sample = yield* Effect.tryPromise({
+          try: () => Bun.file(full).slice(0, 4096).arrayBuffer(),
+          catch: (error) => error,
+        }).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        if (sample && isBinaryContent(new Uint8Array(sample))) {
+          return { type: "binary" as const, content: "", mimeType }
+        }
+      }
 
       if (encode) {
         const bytes = yield* appFs.readFile(full).pipe(Effect.catch(() => Effect.succeed(new Uint8Array())))

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -130,6 +130,21 @@ describe("file/index Filesystem patterns", () => {
         },
       })
     })
+
+    test("returns binary for extensionless binary files", async () => {
+      await using tmp = await tmpdir()
+      const filepath = path.join(tmp.path, "extensionless-binary")
+      await fs.writeFile(filepath, Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01, 0x02, 0x03]), "binary")
+
+      await WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const result = await read("extensionless-binary")
+          expect(result.type).toBe("binary")
+          expect(result.content).toBe("")
+        },
+      })
+    })
   })
 
   describe("read() - Filesystem.mimeType()", () => {


### PR DESCRIPTION
Fixes #26642

## Summary
- sample unknown file types before reading them as UTF-8 text
- return the existing binary file response for extensionless binary content
- add coverage for an extensionless binary file

## Test
- npx --yes bun@1.3.13 test test/file/index.test.ts --timeout 30000
- npx --yes bun@1.3.13 typecheck