### PR TITLE
Drop EventV2 run facade

### DIFF
--- a/packages/opencode/src/v2/event.ts
+++ b/packages/opencode/src/v2/event.ts
@@ -1,7 +1,6 @@
 import { Identifier } from "@/id/id"
 import { SyncEvent } from "@/sync"
 import { withStatics } from "@opencode-ai/core/schema"
-import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Schema from "effect/Schema"
 
 export const ID = Schema.String.pipe(
@@ -39,16 +38,6 @@ export function define<const Type extends string, Fields extends Schema.Struct.F
     version: input.version,
     aggregate: input.aggregate,
   })
-}
-
-export function run<Def extends SyncEvent.Definition>(
-  def: Def,
-  data: SyncEvent.Event<Def>["data"],
-  // Temporary escape hatch while the full v2 event system remains experimental.
-  options?: { publish?: boolean; bypassExperimentalEventSystem?: boolean },
-) {
-  if (!options?.bypassExperimentalEventSystem && !Flag.OPENCODE_EXPERIMENTAL_EVENT_SYSTEM) return
-  SyncEvent.run(def, data, options)
 }
 
 export * as EventV2 from "./event"


### PR DESCRIPTION
## Summary
- Delete the synchronous `EventV2.run` facade after migrating call sites to `SyncEvent.Service.run`.
- Keep `EventV2.define` as the v2 event schema and SyncEvent-definition builder.

## Testing
- `bun typecheck` from `packages/opencode`
- `bun test --timeout 5000 test/session/compaction.test.ts -t "creates a compaction user message and part"`
- `bun test --timeout 5000 test/session/processor-effect.test.ts -t "publish retry status updates|capture llm input cleanly"`
- `bun test --timeout 5000 test/session/prompt.test.ts -t "switch|shell|prompt"`
- `bunx prettier --check ...` for changed files
- `bunx oxlint ...` for changed files (existing warnings only, no errors)
- pre-push `bun turbo typecheck`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #26782
2. **#26783** 👈 current
<!-- stack:links:end -->