### PR TITLE
Define project update input with Effect Schema

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,4 +1,3 @@
-import z from "zod"
 import { and } from "drizzle-orm"
 import { Database } from "@/storage/db"
 import { eq } from "drizzle-orm"
@@ -89,13 +88,13 @@ export function fromRow(row: Row): Info {
   }
 }
 
-export const UpdateInput = z.object({
-  projectID: ProjectID.zod,
-  name: z.string().optional(),
-  icon: zod(ProjectIcon).optional(),
-  commands: zod(ProjectCommands).optional(),
+export const UpdateInput = Schema.Struct({
+  projectID: ProjectID,
+  name: Schema.optional(Schema.String),
+  icon: Schema.optional(ProjectIcon),
+  commands: Schema.optional(ProjectCommands),
 })
-export type UpdateInput = z.infer<typeof UpdateInput>
+export type UpdateInput = Types.DeepMutable<Schema.Schema.Type<typeof UpdateInput>>
 
 export const UpdatePayload = Schema.Struct({
   name: Schema.optional(Schema.String),


### PR DESCRIPTION
## Summary
- Replace the Zod-defined `Project.UpdateInput` with an Effect Schema definition.
- Remove the direct Zod import from `project.ts` and stop relying on `ProjectID.zod` for update input typing.

## Testing
- `bun typecheck` from `packages/opencode`
- `bun test --timeout 5000 test/project/project.test.ts -t "should update"`
- `bunx prettier --check packages/opencode/src/project/project.ts`
- `bunx oxlint packages/opencode/src/project/project.ts`