### PR TITLE
fix: avoid invalid reasoning variants for free models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -637,6 +637,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("deepseek-r1") ||
     id.includes("deepseek-v3") ||
     id.includes("minimax") ||
+    id.includes("mimo") ||
+    id.includes("nemotron") ||
     id.includes("glm") ||
     id.includes("kimi") ||
     id.includes("k2p") ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2917,6 +2917,42 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@ai-sdk/openai-compatible", () => {
+    test("returns empty object for Nemotron reasoning-output models", () => {
+      const model = createMockModel({
+        id: "opencode/nemotron-3-super-free",
+        providerID: "opencode",
+        api: {
+          id: "nemotron-3-super-free",
+          url: "https://opencode.ai/zen/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        capabilities: {
+          reasoning: true,
+          interleaved: { field: "reasoning_content" },
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({})
+    })
+
+    test("returns empty object for MiMo reasoning-output models", () => {
+      const model = createMockModel({
+        id: "opencode/mimo-v2-flash-free",
+        providerID: "opencode",
+        api: {
+          id: "mimo-v2-flash-free",
+          url: "https://opencode.ai/zen/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        capabilities: {
+          reasoning: true,
+          interleaved: { field: "reasoning_content" },
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({})
+    })
+
     test("returns WIDELY_SUPPORTED_EFFORTS with reasoningEffort", () => {
       const model = createMockModel({
         id: "custom-provider/custom-model",
@@ -3030,6 +3066,26 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
       expect(result.low).toEqual({
         reasoningEffort: "low",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
+    })
+
+    test("opencode gpt-5-nano keeps OpenAI SDK reasoning variants", () => {
+      const model = createMockModel({
+        id: "gpt-5-nano",
+        providerID: "opencode",
+        api: {
+          id: "gpt-5-nano",
+          url: "https://opencode.ai/zen/v1",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2025-08-07",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
+      expect(result.high).toEqual({
+        reasoningEffort: "high",
         reasoningSummary: "auto",
         include: ["reasoning.encrypted_content"],
       })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -396,6 +396,94 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("does not send reasoning effort for Nemotron when a stale variant is selected", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "opencode"
+    const modelID = "nemotron-3-super-free"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-nemotron")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 0.4,
+          topP: 0.8,
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-nemotron"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id, variant: "high" },
+        } satisfies MessageV2.User
+
+        expect(resolved.variants).toEqual({})
+
+        await drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = await request
+        const body = capture.body
+
+        expect(capture.url.pathname.endsWith("/chat/completions")).toBe(true)
+        expect(body.model).toBe(resolved.api.id)
+        expect(body.temperature).toBe(0.4)
+        expect(body.top_p).toBe(0.8)
+        expect(body.reasoningEffort).toBeUndefined()
+        expect(body.reasoning_effort).toBeUndefined()
+        expect(body.reasoning).toBeUndefined()
+      },
+    })
+  })
+
   test("service stream cancellation cancels provider response body promptly", async () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")


### PR DESCRIPTION
### Issue for this PR

Fixes #26107

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Nemotron and MiMo free models can return reasoning content, but they do not support OpenAI-style user-selectable reasoning effort controls. OpenCode was generating `low`, `medium`, and `high` variants for them from `reasoning: true`, so selecting a variant like `High` could send unsupported reasoning fields and trigger provider failures.

This PR skips generated reasoning-effort variants for Nemotron and MiMo, keeps valid OpenAI SDK reasoning variants for GPT-5 Nano, and adds regression coverage for both variant generation and the actual request body sent for `nemotron-3-super-free`.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts`
- `bun test test/provider/provider.test.ts`
- `bun test test/session/llm.test.ts`
- `PATH=/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun typecheck`
- `git diff --check`

The session LLM test was run outside the sandbox because its local mock server needs to bind a local port.

### Screenshots / recordings

No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
