### PR TITLE
fix: support image input in OpenAI Chat user messages

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -10,11 +10,12 @@ import {
   Usage,
   type FinishReason,
   type LLMRequest,
+  type MediaPart,
   type TextPart,
   type ToolCallPart,
   type ToolDefinition,
 } from "../schema"
-import { isRecord, JsonObject, optionalArray, optionalNull, ProviderShared } from "./shared"
+import { isRecord, JsonObject, mediaBytes, optionalArray, optionalNull, ProviderShared } from "./shared"
 import { OpenAIOptions } from "./utils/openai-options"
 import { ToolStream } from "./utils/tool-stream"
 
@@ -50,9 +51,21 @@ const OpenAIChatAssistantToolCall = Schema.Struct({
 })
 type OpenAIChatAssistantToolCall = Schema.Schema.Type<typeof OpenAIChatAssistantToolCall>
 
+const OpenAIChatTextContentBlock = Schema.Struct({
+  type: Schema.Literal("text"),
+  text: Schema.String,
+})
+const OpenAIChatImageUrlContentBlock = Schema.Struct({
+  type: Schema.Literal("image_url"),
+  image_url: Schema.Struct({
+    url: Schema.String,
+  }),
+})
+const OpenAIChatContentBlock = Schema.Union([OpenAIChatTextContentBlock, OpenAIChatImageUrlContentBlock])
+
 const OpenAIChatMessage = Schema.Union([
   Schema.Struct({ role: Schema.Literal("system"), content: Schema.String }),
-  Schema.Struct({ role: Schema.Literal("user"), content: Schema.String }),
+  Schema.Struct({ role: Schema.Literal("user"), content: Schema.Union([Schema.String, Schema.Array(OpenAIChatContentBlock)]) }),
   Schema.Struct({
     role: Schema.Literal("assistant"),
     content: Schema.NullOr(Schema.String),
@@ -186,14 +199,29 @@ const lowerToolCall = (part: ToolCallPart): OpenAIChatAssistantToolCall => ({
 const openAICompatibleReasoningContent = (native: unknown) =>
   isRecord(native) && typeof native.reasoning_content === "string" ? native.reasoning_content : undefined
 
+const lowerUserPart = (part: TextPart | MediaPart) =>
+  part.type === "text"
+    ? { type: "text" as const, text: part.text }
+    : {
+        type: "image_url" as const,
+        image_url: {
+          url: `data:${part.mediaType};base64,${mediaBytes(part)}`,
+        },
+      }
+
 const lowerUserMessage = Effect.fn("OpenAIChat.lowerUserMessage")(function* (message: OpenAIChatRequestMessage) {
-  const content: TextPart[] = []
+  const textParts: TextPart[] = []
+  const hasMedia = message.content.some((p) => p.type === "media")
   for (const part of message.content) {
-    if (!ProviderShared.supportsContent(part, ["text"]))
-      return yield* ProviderShared.unsupportedContent("OpenAI Chat", "user", ["text"])
-    content.push(part)
+    if (!ProviderShared.supportsContent(part, ["text", "media"]))
+      return yield* ProviderShared.unsupportedContent("OpenAI Chat", "user", ["text", "media"])
+    if (part.type === "text") textParts.push(part)
   }
-  return { role: "user" as const, content: ProviderShared.joinText(content) }
+  if (hasMedia) {
+    const contentBlocks = message.content.map((part) => lowerUserPart(part as TextPart | MediaPart))
+    return { role: "user" as const, content: contentBlocks }
+  }
+  return { role: "user" as const, content: ProviderShared.joinText(textParts) }
 })
 
 const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(function* (

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -179,17 +179,75 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
-  it.effect("rejects unsupported user media content", () =>
+  it.effect("prepares user message with media as image_url content block", () =>
     Effect.gen(function* () {
-      const error = yield* LLMClient.prepare(
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
         LLM.request({
           id: "req_media",
           model,
           messages: [LLM.user({ type: "media", mediaType: "image/png", data: "AAECAw==" })],
         }),
-      ).pipe(Effect.flip)
+      )
 
-      expect(error.message).toContain("OpenAI Chat user messages only support text content for now")
+      expect(prepared.body.messages).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: {
+                url: "data:image/png;base64,AAECAw==",
+              },
+            },
+          ],
+        },
+      ])
+    }),
+  )
+
+  it.effect("prepares user message with mixed text and media", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          id: "req_mixed",
+          model,
+          messages: [
+            LLM.user([
+              { type: "text", text: "What is in this image?" },
+              { type: "media", mediaType: "image/png", data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHAFQIAxflheFOeAAAAABJRU5ErkJggg==" },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.messages).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "image_url",
+              image_url: {
+                url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHAFQIAxflheFOeAAAAABJRU5ErkJggg==",
+              },
+            },
+          ],
+        },
+      ])
+    }),
+  )
+
+  it.effect("prepares user message with only text (no content blocks)", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          id: "req_text",
+          model,
+          messages: [LLM.user("Hello world")],
+        }),
+      )
+
+      expect(prepared.body.messages).toEqual([{ role: "user", content: "Hello world" }])
     }),
   )
 


### PR DESCRIPTION
Convert MediaPart to OpenAI image_url content block format in user messages.
Adds schema for text and image_url content blocks. Updates lowerUserMessage
to handle mixed text+media content. Adds tests for media handling.

Fixes: Custom OpenAI-compatible providers image file attachments not reaching
vision-capable models.
