### PR TITLE
fix(ui): better handle patch file support when rendering patch/edit tools

### DIFF
--- a/packages/ui/src/components/apply-patch-file.ts
+++ b/packages/ui/src/components/apply-patch-file.ts
@@ -35,7 +35,7 @@ function status(type: Kind): "added" | "deleted" | "modified" {
   return "modified"
 }
 
-export function patchFile(raw: unknown): ApplyPatchFile | undefined {
+export function patchFile(raw: unknown, partial = false): ApplyPatchFile | undefined {
   if (!raw || typeof raw !== "object") return
 
   const value = raw as Raw
@@ -60,19 +60,22 @@ export function patchFile(raw: unknown): ApplyPatchFile | undefined {
     additions,
     deletions,
     movePath,
-    view: normalize({
-      file: relativePath,
-      patch,
-      before,
-      after,
-      additions,
-      deletions,
-      status: status(type),
-    }),
+    view: normalize(
+      {
+        file: relativePath,
+        patch,
+        before,
+        after,
+        additions,
+        deletions,
+        status: status(type),
+      },
+      partial,
+    ),
   }
 }
 
-export function patchFiles(raw: unknown) {
+export function patchFiles(raw: unknown, partial = false) {
   if (!Array.isArray(raw)) return []
-  return raw.map(patchFile).filter((file): file is ApplyPatchFile => !!file)
+  return raw.map((v) => patchFile(v, partial)).filter((file): file is ApplyPatchFile => !!file)
 }

--- a/packages/ui/src/components/apply-patch-file.ts
+++ b/packages/ui/src/components/apply-patch-file.ts
@@ -35,7 +35,7 @@ function status(type: Kind): "added" | "deleted" | "modified" {
   return "modified"
 }
 
-export function patchFile(raw: unknown, partial = false): ApplyPatchFile | undefined {
+export function patchFile(raw: unknown): ApplyPatchFile | undefined {
   if (!raw || typeof raw !== "object") return
 
   const value = raw as Raw
@@ -60,22 +60,19 @@ export function patchFile(raw: unknown, partial = false): ApplyPatchFile | undef
     additions,
     deletions,
     movePath,
-    view: normalize(
-      {
-        file: relativePath,
-        patch,
-        before,
-        after,
-        additions,
-        deletions,
-        status: status(type),
-      },
-      partial,
-    ),
+    view: normalize({
+      file: relativePath,
+      patch,
+      before,
+      after,
+      additions,
+      deletions,
+      status: status(type),
+    }),
   }
 }
 
-export function patchFiles(raw: unknown, partial = false) {
+export function patchFiles(raw: unknown) {
   if (!Array.isArray(raw)) return []
-  return raw.map((v) => patchFile(v, partial)).filter((file): file is ApplyPatchFile => !!file)
+  return raw.map(patchFile).filter((file): file is ApplyPatchFile => !!file)
 }

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -2115,7 +2115,7 @@ ToolRegistry.register({
                                   component={fileComponent}
                                   mode="diff"
                                   fileDiff={file.view.fileDiff}
-                                  hunkSeparators="simple"
+                                  hunkSeparators={file.view.fileDiff.isPartial ? "simple" : "line-info-basic"}
                                 />
                               </div>
                             </Show>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -2005,7 +2005,7 @@ ToolRegistry.register({
   render(props) {
     const i18n = useI18n()
     const fileComponent = useFileComponent()
-    const files = createMemo(() => patchFiles(props.metadata.files))
+    const files = createMemo(() => patchFiles(props.metadata.files, true))
     const pending = createMemo(() => props.status === "pending" || props.status === "running")
     const single = createMemo(() => {
       const list = files()
@@ -2111,7 +2111,12 @@ ToolRegistry.register({
                           <Accordion.Content>
                             <Show when={visible()}>
                               <div data-component="apply-patch-file-diff">
-                                <Dynamic component={fileComponent} mode="diff" fileDiff={file.view.fileDiff} />
+                                <Dynamic
+                                  component={fileComponent}
+                                  mode="diff"
+                                  fileDiff={file.view.fileDiff}
+                                  hunkSeparators="simple"
+                                />
                               </div>
                             </Show>
                           </Accordion.Content>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -264,6 +264,7 @@ function getDirectory(path: string | undefined) {
 }
 
 import type { IconProps } from "./icon"
+import { normalize } from "./session-diff"
 
 export type ToolInfo = {
   icon: IconProps["name"]
@@ -1878,6 +1879,29 @@ ToolRegistry.register({
     const path = createMemo(() => props.metadata?.filediff?.file || props.input.filePath || "")
     const filename = () => getFilename(props.input.filePath ?? "")
     const pending = () => props.status === "pending" || props.status === "running"
+
+    const fileCompProps = createMemo(() => {
+      if (props.metadata?.filediff) {
+        const diff = normalize({
+          ...props.metadata?.filediff,
+          status: "modified",
+        })
+        const fileDiff = diff.fileDiff
+        if (fileDiff) return { fileDiff, hunkSeparators: fileDiff.isPartial ? "simple" : "line-info-basic" }
+      }
+
+      return {
+        before: {
+          name: props.metadata?.filediff?.file || props.input.filePath,
+          contents: props.metadata?.filediff?.before || props.input.oldString || "",
+        },
+        after: {
+          name: props.metadata?.filediff?.file || props.input.filePath,
+          contents: props.metadata?.filediff?.after || props.input.newString || "",
+        },
+      }
+    })
+
     return (
       <div data-component="edit-tool">
         <BasicTool
@@ -1919,18 +1943,7 @@ ToolRegistry.register({
               }
             >
               <div data-component="edit-content">
-                <Dynamic
-                  component={fileComponent}
-                  mode="diff"
-                  before={{
-                    name: props.metadata?.filediff?.file || props.input.filePath,
-                    contents: props.metadata?.filediff?.before || props.input.oldString || "",
-                  }}
-                  after={{
-                    name: props.metadata?.filediff?.file || props.input.filePath,
-                    contents: props.metadata?.filediff?.after || props.input.newString || "",
-                  }}
-                />
+                <Dynamic component={fileComponent} mode="diff" {...fileCompProps()} />
               </div>
             </ToolFileAccordion>
           </Show>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -2005,7 +2005,7 @@ ToolRegistry.register({
   render(props) {
     const i18n = useI18n()
     const fileComponent = useFileComponent()
-    const files = createMemo(() => patchFiles(props.metadata.files, true))
+    const files = createMemo(() => patchFiles(props.metadata.files))
     const pending = createMemo(() => props.status === "pending" || props.status === "running")
     const single = createMemo(() => {
       const list = files()

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1881,14 +1881,16 @@ ToolRegistry.register({
     const pending = () => props.status === "pending" || props.status === "running"
 
     const fileCompProps = createMemo(() => {
-      if (props.metadata?.filediff) {
-        const diff = normalize({
-          ...props.metadata?.filediff,
-          status: "modified",
-        })
-        const fileDiff = diff.fileDiff
-        if (fileDiff) return { fileDiff, hunkSeparators: fileDiff.isPartial ? "simple" : "line-info-basic" }
-      }
+      try {
+        if (props.metadata?.filediff) {
+          const diff = normalize({
+            ...props.metadata?.filediff,
+            status: "modified",
+          })
+          const fileDiff = diff.fileDiff
+          if (fileDiff) return { fileDiff, hunkSeparators: fileDiff.isPartial ? "simple" : "line-info-basic" }
+        }
+      } catch {}
 
       return {
         before: {

--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -1,4 +1,4 @@
-import { parseDiffFromFile, type FileDiffMetadata } from "@pierre/diffs"
+import { parseDiffFromFile, parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs"
 import { formatPatch, parsePatch, structuredPatch } from "diff"
 import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
 
@@ -89,24 +89,29 @@ function patch(diff: ReviewDiff) {
   }
 }
 
-function file(file: string, patch: string, before: string, after: string) {
+function file(file: string, patch: string, before: string, after: string, partial = false) {
   const hit = cache.get(patch)
   if (hit) return hit
 
-  const value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
+  let value: FileDiffMetadata
+  value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
+  if (partial) value = parsePatchFiles(patch)[0].files[0]!
+
   cache.set(patch, value)
   return value
 }
 
-export function normalize(diff: ReviewDiff): ViewDiff {
+export function normalize(diff: ReviewDiff, partial = false): ViewDiff {
   const next = patch(diff)
+  const fileDiff = file(diff.file, next.patch, next.before, next.after, partial)
+  // debugger
   return {
     file: diff.file,
     patch: next.patch,
     additions: diff.additions,
     deletions: diff.deletions,
     status: diff.status,
-    fileDiff: file(diff.file, next.patch, next.before, next.after),
+    fileDiff,
   }
 }
 

--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -97,10 +97,9 @@ function file(file: string, patch: string, before: string, after: string, partia
   const hit = cache.get(patch)
   if (hit) return hit
 
-  let value: FileDiffMetadata
-  if (partial) {
-    value = parsePatchFiles(patch)[0].files[0]!
-  } else value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
+  let value: FileDiffMetadata | undefined
+  if (partial) value = parsePatchFiles(patch)[0]?.files[0]
+  if (value === undefined) value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
 
   cache.set(patch, value)
   return value

--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -34,6 +34,8 @@ function patch(diff: ReviewDiff) {
       const afterLines: Array<{ text: string; newline: boolean }> = []
       let previous: "-" | "+" | " " | undefined
 
+      const patchIsPartial = patch.hunks.every((h) => h.oldStart > 1)
+
       for (const hunk of patch.hunks) {
         for (const line of hunk.lines) {
           if (line.startsWith("\\")) {
@@ -67,9 +69,10 @@ function patch(diff: ReviewDiff) {
         before: beforeLines.map((line) => line.text + (line.newline ? "\n" : "")).join(""),
         after: afterLines.map((line) => line.text + (line.newline ? "\n" : "")).join(""),
         patch: diff.patch,
+        patchIsPartial,
       }
     } catch {
-      return { before: "", after: "", patch: diff.patch }
+      return { before: "", after: "", patch: diff.patch, patchIsPartial: false }
     }
   }
   return {
@@ -86,6 +89,7 @@ function patch(diff: ReviewDiff) {
         { context: Number.MAX_SAFE_INTEGER },
       ),
     ),
+    patchIsPartial: false,
   }
 }
 
@@ -94,17 +98,17 @@ function file(file: string, patch: string, before: string, after: string, partia
   if (hit) return hit
 
   let value: FileDiffMetadata
-  value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
-  if (partial) value = parsePatchFiles(patch)[0].files[0]!
+  if (partial) {
+    value = parsePatchFiles(patch)[0].files[0]!
+  } else value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
 
   cache.set(patch, value)
   return value
 }
 
-export function normalize(diff: ReviewDiff, partial = false): ViewDiff {
+export function normalize(diff: ReviewDiff): ViewDiff {
   const next = patch(diff)
-  const fileDiff = file(diff.file, next.patch, next.before, next.after, partial)
-  // debugger
+  const fileDiff = file(diff.file, next.patch, next.before, next.after, next.patchIsPartial)
   return {
     file: diff.file,
     patch: next.patch,


### PR DESCRIPTION
Fixes patch tool diffs rendering always starting from line number 1. The partial patch that gets provided from the server was previously being interpreted as being a full-file diff, ignoring the line range of the diff

- [x] Still need to fix for edit tool with deepseek

|before|after|
|-|-|
| <img width="797" height="756" alt="image" src="https://github.com/user-attachments/assets/c38eb59e-7f1c-4c1d-9357-b224c51cee9b" /> | <img width="815" height="833" alt="image" src="https://github.com/user-attachments/assets/2be60729-7546-4de3-aa02-5090758bef63" /> |