### PR TITLE
fix: Allow disabling tool streaming in provider options

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1049,7 +1049,8 @@ export function options(input: {
 
   if (
     input.model.api.npm === "@ai-sdk/google-vertex/anthropic" ||
-    (!input.model.api.id.includes("claude") && input.model.api.npm === "@ai-sdk/anthropic")
+    (!input.model.api.id.includes("claude") && input.model.api.npm === "@ai-sdk/anthropic") ||
+    input.providerOptions?.["toolStreaming"] === false
   ) {
     result["toolStreaming"] = false
   }


### PR DESCRIPTION
### Issue for this PR

Closes #26853

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On some non-Anthropic endpoints (in my case DataBricks Frontier Model API), tool streaming is not always supported resulting in `tools.0.custom.eager_input_streaming: Extra inputs are not permitted` error. It's pretty similar to issue https://github.com/anomalyco/opencode/issues/24562 but for another provider.

In this issue we're invited to include `"toolStreaming": false` option like that:

```json
"provider": {
    "google-vertex-anthropic": {
      "options": {
        "toolStreaming": false,
      },
    },
  },
```
However in my case it wasn't working, so 'I'm proposing a fix for this.

I'm using the following configuration:

```json
"provider": {
    "databricks": {
      "npm": "@ai-sdk/anthropic",
      "name": "Databricks",
      "options": {
        "baseURL": "https://****.azuredatabricks.net/serving-endpoints/anthropic/v1",
        "authToken": "***",
        "headers": {
          "x-databricks-use-coding-agent-mode": "true"
        },
        "toolStreaming": false
      },
      "models": {
        "databricks-claude-sonnet-4-6": {
          "name": "Claude Sonnet (Databricks)"
        },  
        "databricks-claude-opus-4-7": {
          "name": "Claude Opus (Databricks)"
        },
        "databricks-claude-haiku-4-5": {
          "name": "Claude Haiku (Databricks)"
        }
   }
```
*NB: Sonnet and Opus work correctly so they seem to support tools streaming. A per model configuration would be a better fix but I didn't want to make things too complicated and diverge from the workaround previously mentioned.*

### How did you verify your code works?

Run opencode locally with my configuration with ` "toolStreaming": false` 👉 it fails without current fix and succeeds with current fix applied.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR