### PR TITLE
feat(cli): Add `--no-pager` option to session list

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -82,6 +82,11 @@ export const SessionListCommand = effectCmd({
         type: "string",
         choices: ["table", "json"],
         default: "table",
+      })
+      .option("pager", {
+        describe: "use pager for table output to terminal",
+        type: "boolean",
+        default: true,
       }),
   handler: Effect.fn("Cli.session.list")(function* (args) {
     const sessions = yield* Session.Service.use((svc) => svc.list({ roots: true, limit: args.maxCount }))
@@ -90,7 +95,7 @@ export const SessionListCommand = effectCmd({
 
     const output = args.format === "json" ? formatSessionJSON(sessions) : formatSessionTable(sessions)
 
-    const shouldPaginate = process.stdout.isTTY && !args.maxCount && args.format === "table"
+    const shouldPaginate = args.pager !== false && process.stdout.isTTY && !args.maxCount && args.format === "table"
 
     if (shouldPaginate) {
       yield* Effect.promise(async () => {


### PR DESCRIPTION

### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Even when running in a terminal and using table output mode, it's not always desirable to launch a pager. The user might prefer to use their terminal's paging capabilities.

### How did you verify your code works?

Manually.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR