### PR TITLE
fix: filter archived sessions from per-project list

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -263,6 +263,7 @@ export type ListInput = {
   start?: number
   search?: string
   limit?: number
+  archived?: boolean
 }
 
 const CreatedEventSchema = Schema.Struct({
@@ -846,6 +847,9 @@ function* listByProject(
   }
   if (input.search) {
     conditions.push(like(SessionTable.title, `%${input.search}%`))
+  }
+  if (!input.archived) {
+    conditions.push(isNull(SessionTable.time_archived))
   }
 
   const limit = input.limit ?? 100


### PR DESCRIPTION
## Summary

- `listByProject()` was returning all sessions including archived ones, while `listGlobal()` already filtered them out via `isNull(time_archived)`
- Added `archived` option to `ListInput` type and `isNull(SessionTable.time_archived)` filter to `listByProject()` to match `listGlobal()` behavior

## Why

When sessions are archived (e.g. via API `PATCH /:sessionID`), they still appear in per-project session listings (`Session.list()` / `GET /session`). This causes archived sessions from automated workflows to pollute the session history displayed to users.

The global listing (`GET /experimental/session`) already excludes archived sessions by default, but the per-project listing did not.

## Testing

- Verified no new type errors in session.ts
- Manually tested: archived sessions no longer appear in per-project session list output
