### PR TITLE
fix(session): handle missing finishReason and null usage from custom provider plugins

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -627,6 +627,14 @@ export const layer: Layer.Layer<
             return
 
           case "finish":
+            // When using custom provider plugins via wrapLanguageModel, the finish-step
+            // event may not carry finishReason (e.g. when the middleware's stream transform
+            // strips it). The "finish" event always has finishReason, so use it as a
+            // fallback to ensure the prompt loop can detect completion and exit.
+            if (!ctx.assistantMessage.finish && value.finishReason) {
+              ctx.assistantMessage.finish = value.finishReason
+              yield* session.updateMessage(ctx.assistantMessage)
+            }
             return
 
           default:

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -355,6 +355,12 @@ export const getUsage = (input: { model: Provider.Model; usage: LanguageModelUsa
     if (!Number.isFinite(value)) return 0
     return Math.max(0, value)
   }
+  if (!input.usage) {
+    return {
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    }
+  }
   const inputTokens = safe(input.usage.inputTokens ?? 0)
   const outputTokens = safe(input.usage.outputTokens ?? 0)
   const reasoningTokens = safe(input.usage.outputTokenDetails?.reasoningTokens ?? input.usage.reasoningTokens ?? 0)


### PR DESCRIPTION
## Summary

Fixes two issues that break custom provider plugins (e.g. `opencode-codex-provider`) when used with `wrapLanguageModel`:

1. **Infinite loop**: `assistantMessage.finish` stays `undefined` → prompt loop never exits → model responds repeatedly
2. **Usage crash**: `getUsage` crashes when `usage` is `undefined`/`null`

## Root Cause

### Infinite loop (#22855, #26220, #10573)

When a custom provider plugin is loaded via `wrapLanguageModel`, the middleware's stream transform can restructure the `finish-step` event, stripping `finishReason` and `usage` fields. The processor's `case "finish-step"` handler (line 499) reads `value.finishReason` and `value.usage` from this event, but they may be `undefined`.

Meanwhile, the `"finish"` event in `fullStream` **always** carries `finishReason`, but the processor previously ignored it entirely (`case "finish": return`).

The prompt loop exit condition (`prompt.ts:1464`) checks `lastAssistant?.finish` — if it's never set, the loop runs forever.

**Fix**: In `case "finish"`, set `assistantMessage.finish` from `value.finishReason` as a fallback when `finish-step` didn't provide it.

### Usage crash (#22855)

Custom providers may return `undefined` usage in stream events. `getUsage()` in `session.ts` immediately accesses `input.usage.inputTokens` etc., causing `TypeError: undefined is not an object (evaluating '$.inputTokens.total')`.

**Fix**: Early return with zero-value defaults when `input.usage` is falsy.

## Changes

- **`processor.ts`**: `case "finish"` now extracts `finishReason` as fallback for `assistantMessage.finish`
- **`session.ts`**: `getUsage()` guards against `undefined`/`null` usage with early return

## Testing

Verified with `opencode-codex-provider` plugin (Codex CLI OAuth provider):
- Before: `inputTokens.total` TypeError on every response + infinite response loop
- After: Single clean response, no errors, prompt loop exits correctly

## Related Issues

- Fixes #22855 (`inputTokens.total` crash with custom providers)
- Related to #26220 (infinite loop after tool calls)
- Related to #10573 (custom OpenAI-compatible provider looping)