### PR TITLE
fix(llm): drop removed dispatch option from recorded cache tests

### DIFF
--- a/packages/llm/test/provider/anthropic-messages-cache.recorded.test.ts
+++ b/packages/llm/test/provider/anthropic-messages-cache.recorded.test.ts
@@ -31,10 +31,9 @@ const recorded = recordedTests({
   provider: "anthropic",
   protocol: "anthropic-messages",
   requires: ["ANTHROPIC_API_KEY"],
-  // Two identical requests in one cassette — match by recording order so the
-  // second call replays the cached-hit interaction.
+  // Two identical requests in one cassette — replay walks the cassette in
+  // recording order so the second call replays the cached-hit interaction.
   options: {
-    dispatch: "sequential",
     redactor: Redactor.defaults({ requestHeaders: { allow: ["content-type", "anthropic-version"] } }),
   },
 })

--- a/packages/llm/test/provider/bedrock-converse-cache.recorded.test.ts
+++ b/packages/llm/test/provider/bedrock-converse-cache.recorded.test.ts
@@ -38,9 +38,8 @@ const recorded = recordedTests({
   provider: "amazon-bedrock",
   protocol: "bedrock-converse",
   requires: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
-  // Two identical requests in one cassette — match by recording order so the
-  // second call replays the cached-hit interaction.
-  options: { dispatch: "sequential" },
+  // Two identical requests in one cassette — replay walks the cassette in
+  // recording order so the second call replays the cached-hit interaction.
 })
 
 describe("Bedrock Converse cache recorded", () => {

--- a/packages/llm/test/provider/gemini-cache.recorded.test.ts
+++ b/packages/llm/test/provider/gemini-cache.recorded.test.ts
@@ -29,9 +29,8 @@ const recorded = recordedTests({
   provider: "google",
   protocol: "gemini",
   requires: ["GOOGLE_GENERATIVE_AI_API_KEY"],
-  // Two identical requests in one cassette — match by recording order so the
-  // second call replays the cached-hit interaction.
-  options: { dispatch: "sequential" },
+  // Two identical requests in one cassette — replay walks the cassette in
+  // recording order so the second call replays the cached-hit interaction.
 })
 
 describe("Gemini cache recorded", () => {

--- a/packages/llm/test/provider/openai-responses-cache.recorded.test.ts
+++ b/packages/llm/test/provider/openai-responses-cache.recorded.test.ts
@@ -29,9 +29,9 @@ const recorded = recordedTests({
   provider: "openai",
   protocol: "openai-responses",
   requires: ["OPENAI_API_KEY"],
-  // Two identical requests in one cassette — match by recording order so the
-  // second call replays the cached-hit interaction, not the cold-miss one.
-  options: { dispatch: "sequential" },
+  // Two identical requests in one cassette — replay walks the cassette in
+  // recording order so the second call replays the cached-hit interaction,
+  // not the cold-miss one.
 })
 
 describe("OpenAI Responses cache recorded", () => {


### PR DESCRIPTION
## Summary
- #26792 removed the `dispatch` field from `RecordReplayOptions` in `@opencode-ai/http-recorder` (sequential matching is now the only behavior).
- Four LLM cache-recorded test files still passed `dispatch: \"sequential\"` to `recordedTests`, which fails typecheck on every PR built against current dev.
- Drop the redundant field. Replay behavior is unchanged — the cassette is still walked in recording order, exactly as the http-recorder change made the default and only mode.

## Verification
- \`bun typecheck\` in \`packages/llm\` passes locally.
- \`bun turbo typecheck\` at the repo root passes.

## Notes
- Comments on each test still describe the recording-order semantics so the intent stays visible at the call site.