### PR TITLE
Simplify single-backend HttpApi exerciser

### DIFF
--- a/packages/opencode/test/server/httpapi-exercise/backend.ts
+++ b/packages/opencode/test/server/httpapi-exercise/backend.ts
@@ -2,7 +2,7 @@ import { ConfigProvider, Effect, Layer } from "effect"
 import { HttpRouter } from "effect/unstable/http"
 import { parse } from "./assertions"
 import { runtime, type Runtime } from "./runtime"
-import type { ActiveScenario, Backend, BackendApp, CallResult, CaptureMode, SeededContext } from "./types"
+import type { ActiveScenario, BackendApp, CallResult, CaptureMode, SeededContext } from "./types"
 
 type CallOptions = {
   auth?: {
@@ -11,27 +11,18 @@ type CallOptions = {
   }
 }
 
-export function call(
-  backend: Backend,
-  scenario: ActiveScenario,
-  ctx: SeededContext<unknown>,
-  options: CallOptions = {},
-) {
+export function call(scenario: ActiveScenario, ctx: SeededContext<unknown>, options: CallOptions = {}) {
   return Effect.promise(async () =>
-    capture(await app(await runtime(), backend, options).request(toRequest(scenario, ctx)), scenario.capture),
+    capture(await app(await runtime(), options).request(toRequest(scenario, ctx)), scenario.capture),
   )
 }
 
-export function callAuthProbe(
-  backend: Backend,
-  scenario: ActiveScenario,
-  credentials: "missing" | "valid" = "missing",
-) {
+export function callAuthProbe(scenario: ActiveScenario, credentials: "missing" | "valid" = "missing") {
   return Effect.promise(async () => {
     const controller = new AbortController()
     return Promise.race([
       Promise.resolve(
-        app(await runtime(), backend, { auth: { password: "secret" } }).request(
+        app(await runtime(), { auth: { password: "secret" } }).request(
           toAuthProbeRequest(scenario, credentials, controller.signal),
         ),
       ).then((response) => capture(response, scenario.capture)),
@@ -51,10 +42,10 @@ export function callAuthProbe(
 
 const appCache: Partial<Record<string, BackendApp>> = {}
 
-function app(modules: Runtime, backend: Backend, options: CallOptions) {
+function app(modules: Runtime, options: CallOptions) {
   const username = options.auth?.username
   const password = options.auth?.password
-  const cacheKey = `${backend}:${username ?? ""}:${password ?? ""}`
+  const cacheKey = `${username ?? ""}:${password ?? ""}`
   if (appCache[cacheKey]) return appCache[cacheKey]
 
   const handler = HttpRouter.toWebHandler(

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -30,28 +30,28 @@ function runActive(options: Options, scenario: ActiveScenario) {
 
   return withContext(options, scenario, "shared", (ctx) =>
     Effect.gen(function* () {
-      yield* trace(options, scenario, "effect request start")
-      const effect = yield* call("effect", scenario, ctx)
-      yield* trace(options, scenario, `effect response ${effect.status}`)
-      yield* trace(options, scenario, "effect expect start")
-      yield* scenario.expect(ctx, ctx.state, effect)
-      yield* trace(options, scenario, "effect expect done")
+      yield* trace(options, scenario, "request start")
+      const result = yield* call(scenario, ctx)
+      yield* trace(options, scenario, `response ${result.status}`)
+      yield* trace(options, scenario, "expect start")
+      yield* scenario.expect(ctx, ctx.state, result)
+      yield* trace(options, scenario, "expect done")
     }),
   )
 }
 
 function runAuth(scenario: ActiveScenario) {
   return Effect.gen(function* () {
-    const effect = yield* callAuthProbe("effect", scenario, "missing")
+    const result = yield* callAuthProbe(scenario, "missing")
     if (scenario.auth === "protected") {
-      if (effect.status !== 401) throw new Error(`effect auth expected 401, got ${effect.status}`)
-      const effectAuthed = yield* callAuthProbe("effect", scenario, "valid")
-      if (effectAuthed.status === 401) throw new Error("effect auth rejected valid credentials")
+      if (result.status !== 401) throw new Error(`auth expected 401, got ${result.status}`)
+      const authed = yield* callAuthProbe(scenario, "valid")
+      if (authed.status === 401) throw new Error("auth rejected valid credentials")
       return
     }
 
-    if (effect.status === 401) throw new Error("effect auth expected public access, got 401")
-    if (effect.timedOut) throw new Error("effect auth expected public access, probe timed out")
+    if (result.status === 401) throw new Error("auth expected public access, got 401")
+    if (result.timedOut) throw new Error("auth expected public access, probe timed out")
   })
 }
 

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -11,7 +11,6 @@ export const Methods = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const
 export type Method = (typeof Methods)[number]
 export type OpenApiMethod = (typeof OpenApiMethods)[number]
 export type Mode = "effect" | "coverage" | "auth"
-export type Backend = "effect"
 export type Comparison = "none" | "status" | "json"
 export type CaptureMode = "full" | "stream"
 export type AuthPolicy = "protected" | "public" | "public-bypass" | "ticket-bypass"


### PR DESCRIPTION
## Summary
- Remove the single-value `Backend` parameter from the HttpApi exercise harness.
- Rename trace/auth diagnostics from `effect ...` to backend-neutral request/response wording.
- Keep coverage/auth/effect modes and route scenarios unchanged.

## Testing
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check packages/opencode/test/server/httpapi-exercise/backend.ts packages/opencode/test/server/httpapi-exercise/runner.ts packages/opencode/test/server/httpapi-exercise/types.ts`
- `bunx oxlint packages/opencode/test/server/httpapi-exercise/backend.ts packages/opencode/test/server/httpapi-exercise/runner.ts packages/opencode/test/server/httpapi-exercise/types.ts`
- `bun run script/httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip` printed `summary pass=145 fail=0 skip=0 missing=0 extra=0`; the process then remained alive until the shell timeout, matching the existing script resource-lifetime behavior.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #26903
2. **#26906** 👈 current
3. #26908
<!-- stack:links:end -->