### PR TITLE
fix(mcp): support OAuth for servers without RFC 8414 discovery

### DIFF
--- a/packages/opencode/src/config/mcp.ts
+++ b/packages/opencode/src/config/mcp.ts
@@ -32,6 +32,14 @@ export const OAuth = Schema.Struct({
   redirectUri: Schema.optional(Schema.String).annotate({
     description: "OAuth redirect URI (default: http://127.0.0.1:19876/mcp/oauth/callback).",
   }),
+  authorizationEndpoint: Schema.optional(Schema.String).annotate({
+    description:
+      "OAuth authorization endpoint URL. Required for servers that do not support RFC 8414 metadata discovery (e.g. Google Workspace MCP servers).",
+  }),
+  tokenEndpoint: Schema.optional(Schema.String).annotate({
+    description:
+      "OAuth token endpoint URL. Required for servers that do not support RFC 8414 metadata discovery (e.g. Google Workspace MCP servers).",
+  }),
 })
   .annotate({ identifier: "McpOAuthConfig" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -3,7 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
-import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { UnauthorizedError, auth as sdkAuth } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,
   ToolSchema,
@@ -794,6 +794,8 @@ export const layer = Layer.effect(
           clientSecret: oauthConfig?.clientSecret,
           scope: oauthConfig?.scope,
           redirectUri: oauthConfig?.redirectUri,
+          authorizationEndpoint: oauthConfig?.authorizationEndpoint,
+          tokenEndpoint: oauthConfig?.tokenEndpoint,
         },
         {
           onRedirect: async (url) => {
@@ -820,6 +822,42 @@ export const layer = Layer.effect(
             return Effect.succeed({ authorizationUrl: capturedUrl.toString(), oauthState } satisfies AuthResult)
           }
           return Effect.die(error)
+        }),
+        Effect.flatMap((result) => {
+          if (result.authorizationUrl || !oauthConfig?.authorizationEndpoint || !oauthConfig?.tokenEndpoint) {
+            return Effect.succeed(result)
+          }
+
+          const existingTokens = Effect.promise(() => authProvider.tokens())
+          return existingTokens.pipe(
+            Effect.flatMap((tokens) => {
+              if (tokens) return Effect.succeed(result)
+
+              log.info("server connected without auth challenge but oauth config has explicit endpoints, triggering OAuth", { mcpName })
+
+              if ("client" in result && result.client) {
+                Effect.runPromise(Effect.tryPromise(() => result.client!.close()).pipe(Effect.ignore))
+              }
+
+              return Effect.tryPromise({
+                try: () =>
+                  sdkAuth(authProvider, {
+                    serverUrl: url.toString(),
+                    scope: oauthConfig.scope,
+                  }),
+                catch: (error) => error,
+              }).pipe(
+                Effect.map(() => {
+                  if (capturedUrl) {
+                    pendingOAuthTransports.set(mcpName, transport)
+                    return { authorizationUrl: capturedUrl.toString(), oauthState } satisfies AuthResult
+                  }
+                  return { authorizationUrl: "", oauthState } satisfies AuthResult
+                }),
+                Effect.catch(() => Effect.succeed({ authorizationUrl: "", oauthState } satisfies AuthResult)),
+              )
+            }),
+          )
         }),
       )
     })

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -1,4 +1,4 @@
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
+import type { OAuthClientProvider, OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
 import type {
   OAuthClientMetadata,
   OAuthTokens,
@@ -19,6 +19,8 @@ export interface McpOAuthConfig {
   clientSecret?: string
   scope?: string
   redirectUri?: string
+  authorizationEndpoint?: string
+  tokenEndpoint?: string
 }
 
 export interface McpOAuthCallbacks {
@@ -26,6 +28,8 @@ export interface McpOAuthCallbacks {
 }
 
 export class McpOAuthProvider implements OAuthClientProvider {
+  private cachedDiscoveryState?: OAuthDiscoveryState
+
   constructor(
     private mcpName: string,
     private serverUrl: string,
@@ -189,6 +193,31 @@ export class McpOAuthProvider implements OAuthClientProvider {
         await Effect.runPromise(this.auth.set(this.mcpName, entry))
         break
     }
+  }
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    if (this.cachedDiscoveryState) return this.cachedDiscoveryState
+
+    // When the server does not support RFC 8414 metadata discovery (e.g.
+    // Google Workspace MCP servers), the SDK's automatic discovery will fail.
+    // If the config provides explicit authorization/token endpoints, build a
+    // synthetic discovery state so the SDK skips its failing discovery and
+    // uses the configured endpoints directly.
+    if (!this.config.authorizationEndpoint || !this.config.tokenEndpoint) return undefined
+
+    return {
+      authorizationServerUrl: new URL(this.config.authorizationEndpoint).origin,
+      authorizationServerMetadata: {
+        issuer: new URL(this.config.authorizationEndpoint).origin,
+        authorization_endpoint: this.config.authorizationEndpoint,
+        token_endpoint: this.config.tokenEndpoint,
+        response_types_supported: ["code"],
+      },
+    }
+  }
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    this.cachedDiscoveryState = state
   }
 }
 

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -101,6 +101,7 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
 // Mock UnauthorizedError in the auth module so instanceof checks work
 void mock.module("@modelcontextprotocol/sdk/client/auth.js", () => ({
   UnauthorizedError: MockUnauthorizedError,
+  auth: async () => "AUTHORIZED" as const,
 }))
 
 beforeEach(() => {
@@ -277,6 +278,71 @@ test("authenticate() stores a connected client when auth completes without redir
           }),
         ).pipe(Effect.provide(MCP.defaultLayer)),
       )
+    },
+  })
+})
+
+test("discoveryState() returns metadata from config when explicit endpoints are provided", async () => {
+  const { McpOAuthProvider } = await import("../../src/mcp/oauth-provider")
+  const { McpAuth } = await import("../../src/mcp/auth")
+
+  await using tmp = await tmpdir()
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const auth = await Effect.runPromise(
+        Effect.gen(function* () {
+          return yield* McpAuth.Service
+        }).pipe(Effect.provide(McpAuth.defaultLayer)),
+      )
+      const provider = new McpOAuthProvider(
+        "test-discovery",
+        "https://example.com/mcp",
+        {
+          clientId: "test-client",
+          authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenEndpoint: "https://oauth2.googleapis.com/token",
+        },
+        { onRedirect: async () => {} },
+        auth,
+      )
+
+      const state = await provider.discoveryState()
+      expect(state).toBeDefined()
+      expect(state!.authorizationServerUrl).toBe("https://accounts.google.com")
+      expect(state!.authorizationServerMetadata?.authorization_endpoint).toBe(
+        "https://accounts.google.com/o/oauth2/v2/auth",
+      )
+      expect(state!.authorizationServerMetadata?.token_endpoint).toBe("https://oauth2.googleapis.com/token")
+    },
+  })
+})
+
+test("discoveryState() returns undefined when no explicit endpoints configured", async () => {
+  const { McpOAuthProvider } = await import("../../src/mcp/oauth-provider")
+  const { McpAuth } = await import("../../src/mcp/auth")
+
+  await using tmp = await tmpdir()
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const auth = await Effect.runPromise(
+        Effect.gen(function* () {
+          return yield* McpAuth.Service
+        }).pipe(Effect.provide(McpAuth.defaultLayer)),
+      )
+      const provider = new McpOAuthProvider(
+        "test-no-discovery",
+        "https://example.com/mcp",
+        { clientId: "test-client" },
+        { onRedirect: async () => {} },
+        auth,
+      )
+
+      const state = await provider.discoveryState()
+      expect(state).toBeUndefined()
     },
   })
 })


### PR DESCRIPTION
## Summary

Fixes #26195

MCP servers like Google's endpoints don't implement RFC 8414 (`.well-known/oauth-authorization-server`) discovery. The MCP SDK already supports a `discoveryState()` hook on `OAuthClientProvider` to supply pre-cached authorization metadata, but OpenCode never implemented it.

This PR:
- Adds `authorizationEndpoint` and `tokenEndpoint` fields to MCP server config
- Implements `discoveryState()` / `saveDiscoveryState()` on `McpOAuthProvider` to provide pre-cached OAuth metadata when configured
- Adds an `auth()` fallback in `startAuth()` for servers that have explicit OAuth endpoints but no existing tokens (so the OAuth flow triggers correctly)

## Example config

```json
{
  "mcp": {
    "google-calendar": {
      "type": "remote",
      "url": "https://calendar.googleapis.com/mcp",
      "authorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
      "tokenEndpoint": "https://oauth2.googleapis.com/token"
    }
  }
}
```

Then `opencode mcp auth google-calendar` triggers the standard OAuth browser flow.

## Testing

- Added tests for `discoveryState()` in `oauth-auto-connect.test.ts` (6 tests, all passing)
- TypeScript build passes (`npx tsc --noEmit`)
- Manually verified end-to-end with Google People, Gmail, Calendar, and Drive MCP servers