### PR TITLE
Drop small session Zod statics

### DIFF
--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -4,8 +4,6 @@ import { Snapshot } from "../snapshot"
 import { Storage } from "@/storage/storage"
 import { SyncEvent } from "../sync"
 import * as Log from "@opencode-ai/core/util/log"
-import { zod } from "@opencode-ai/core/effect-zod"
-import { withStatics } from "@opencode-ai/core/schema"
 import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionID, MessageID, PartID } from "./schema"
@@ -18,7 +16,7 @@ export const RevertInput = Schema.Struct({
   sessionID: SessionID,
   messageID: MessageID,
   partID: Schema.optional(PartID),
-}).pipe(withStatics((s) => ({ zod: zod(s) })))
+})
 export type RevertInput = Schema.Schema.Type<typeof RevertInput>
 
 export interface Interface {

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -2,10 +2,8 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
 import { SessionID } from "./schema"
-import { zod } from "@opencode-ai/core/effect-zod"
-import { NonNegativeInt, withStatics } from "@opencode-ai/core/schema"
+import { NonNegativeInt } from "@opencode-ai/core/schema"
 import { Effect, Layer, Context, Schema } from "effect"
-import z from "zod"
 
 export const Info = Schema.Union([
   Schema.Struct({
@@ -30,9 +28,7 @@ export const Info = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("busy"),
   }),
-])
-  .annotate({ identifier: "SessionStatus" })
-  .pipe(withStatics((s) => ({ zod: zod(s) })))
+]).annotate({ identifier: "SessionStatus" })
 export type Info = Schema.Schema.Type<typeof Info>
 
 export const Event = {

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -1,10 +1,7 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { SessionID } from "./schema"
-import { zod } from "@opencode-ai/core/effect-zod"
-import { withStatics } from "@opencode-ai/core/schema"
 import { Effect, Layer, Context, Schema } from "effect"
-import z from "zod"
 import { Database } from "@/storage/db"
 import { eq } from "drizzle-orm"
 import { asc } from "drizzle-orm"
@@ -16,9 +13,7 @@ export const Info = Schema.Struct({
     description: "Current status of the task: pending, in_progress, completed, cancelled",
   }),
   priority: Schema.String.annotate({ description: "Priority level of the task: high, medium, low" }),
-})
-  .annotate({ identifier: "Todo" })
-  .pipe(withStatics((s) => ({ zod: zod(s) })))
+}).annotate({ identifier: "Todo" })
 export type Info = Schema.Schema.Type<typeof Info>
 
 export const Event = {

--- a/packages/opencode/test/session/schema-decoding.test.ts
+++ b/packages/opencode/test/session/schema-decoding.test.ts
@@ -221,14 +221,11 @@ describe("SessionRevert.RevertInput", () => {
   test("messageID is required, partID is optional", () => {
     const withPart = { sessionID, messageID, partID }
     expect(decode(withPart)).toEqual(withPart)
-    expect(SessionRevert.RevertInput.zod.parse(withPart)).toEqual(withPart)
 
     const noPart = { sessionID, messageID }
     expect(decode(noPart)).toEqual(noPart)
-    expect(SessionRevert.RevertInput.zod.parse(noPart)).toEqual(noPart)
 
     expect(() => decode({ sessionID })).toThrow()
-    expect(() => SessionRevert.RevertInput.zod.parse({ sessionID })).toThrow()
   })
 })
 
@@ -247,7 +244,6 @@ describe("SessionStatus.Info", () => {
   test("idle / busy discriminators", () => {
     expect(decode({ type: "idle" })).toEqual({ type: "idle" })
     expect(decode({ type: "busy" })).toEqual({ type: "busy" })
-    expect(SessionStatus.Info.zod.parse({ type: "idle" })).toEqual({ type: "idle" })
   })
 
   test("retry carries attempt/message/action/next", () => {
@@ -266,12 +262,10 @@ describe("SessionStatus.Info", () => {
       next: 500,
     }
     expect(decode(input)).toEqual(input)
-    expect(SessionStatus.Info.zod.parse(input)).toEqual(input)
   })
 
   test("rejects unknown type", () => {
     expect(() => decode({ type: "bogus" })).toThrow()
-    expect(() => SessionStatus.Info.zod.parse({ type: "bogus" })).toThrow()
   })
 })
 
@@ -281,7 +275,6 @@ describe("Todo.Info", () => {
   test("three-field round-trip", () => {
     const input = { content: "do a thing", status: "pending", priority: "high" }
     expect(decode(input)).toEqual(input)
-    expect(Todo.Info.zod.parse(input)).toEqual(input)
   })
 })
 


### PR DESCRIPTION
## Summary
- Remove unused `.zod` compatibility statics from `SessionRevert.RevertInput`, `SessionStatus.Info`, and `Todo.Info`.
- Keep schema decoding coverage through Effect Schema only.

## Testing
- `bun typecheck` from `packages/opencode`
- `bun test --timeout 5000 test/session/schema-decoding.test.ts`
- `bunx prettier --check <changed files>`
- `bunx oxlint <changed files>` (existing warnings only, no errors)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#26921** 👈 current
2. #26923
3. #26926
<!-- stack:links:end -->