### PR TITLE
fix(tui): handle CJK mention autocomplete offsets

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-trigger.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-trigger.ts
@@ -1,0 +1,11 @@
+export function mentionTriggerIndex(text: string) {
+  const idx = text.lastIndexOf("@")
+  if (idx === -1) return
+
+  const before = text.slice(0, idx)
+  const between = text.slice(idx)
+  if (between.match(/\s/)) return
+  if (before && !before.match(/\s$/)) return
+
+  return Bun.stringWidth(before)
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -20,6 +20,7 @@ import { useFrecency } from "./frecency"
 import { useBindings } from "../../keymap"
 import { Reference } from "@/reference/reference"
 import type { Config } from "@/config/config"
+import { mentionTriggerIndex } from "./autocomplete-trigger"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -786,14 +787,9 @@ export function Autocomplete(props: {
           return
         }
 
-        // Check for "@" trigger - find the nearest "@" before cursor with no whitespace between
-        const text = value.slice(0, offset)
-        const idx = text.lastIndexOf("@")
-        if (idx === -1) return
-
-        const between = text.slice(idx)
-        const before = idx === 0 ? undefined : value[idx - 1]
-        if ((before === undefined || /\s/.test(before)) && !between.match(/\s/)) {
+        // cursorOffset is in terminal cells, so use Textarea ranges instead of JS string indexes.
+        const idx = mentionTriggerIndex(props.input().getTextRange(0, offset))
+        if (idx !== undefined) {
           show("@")
           setStore("index", idx)
         }

--- a/packages/opencode/test/cli/cmd/tui/prompt-autocomplete.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-autocomplete.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { mentionTriggerIndex } from "../../../../src/cli/cmd/tui/component/prompt/autocomplete-trigger"
+
+describe("mentionTriggerIndex", () => {
+  test("returns offset for mention triggers at the start or after ascii text", () => {
+    expect(mentionTriggerIndex("@")).toBe(0)
+    expect(mentionTriggerIndex("test @")).toBe(5)
+  })
+
+  test("returns display-width offset for CJK text before @", () => {
+    expect(mentionTriggerIndex("中文 @")).toBe(5)
+    expect(mentionTriggerIndex("こんにちは @")).toBe(11)
+    expect(mentionTriggerIndex("한국어 @")).toBe(7)
+    expect(mentionTriggerIndex("🙂 @")).toBe(3)
+  })
+
+  test("does not trigger inside ascii words or after whitespace in the query", () => {
+    expect(mentionTriggerIndex("中文@")).toBeUndefined()
+    expect(mentionTriggerIndex("こんにちは@")).toBeUndefined()
+    expect(mentionTriggerIndex("한국어@")).toBeUndefined()
+    expect(mentionTriggerIndex("🙂@")).toBeUndefined()
+    expect(mentionTriggerIndex("hello@")).toBeUndefined()
+    expect(mentionTriggerIndex("foo@bar.com")).toBeUndefined()
+    expect(mentionTriggerIndex("中文 @src file")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #26816
Closes #26889
Closes #20852

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes TUI `@` mention autocomplete after CJK/wide characters.

`cursorOffset` is measured in terminal cells, but the previous trigger detection used JS string indexes. With input like `中文 @file`, this made the stored `@` position too small, so the file query was read from the wrong offset.

This uses `getTextRange()` plus `Bun.stringWidth()` so the stored trigger index stays in terminal-cell coordinates. The existing trigger rule is preserved: `@` only opens autocomplete at the start of input or after whitespace.

### How did you verify your code works?
- `bun test /Users/abel/Documents/Code/opencode-dev/packages/opencode/test/cli/cmd/tui/prompt-autocomplete.test.ts`
- `cd packages/opencode && bun typecheck`
- Manually verified `中文 @...` can trigger file autocomplete in the TUI.

### Screenshots / recordings


https://github.com/user-attachments/assets/bd05c90f-2d2c-4b59-82b4-2f3214b92da4



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

