### PR TITLE
fix: honor --model flag when resuming a session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -397,7 +397,7 @@ export function Prompt(props: PromptProps) {
       if (msg.agent && isPrimaryAgent) {
         // Keep command line --agent if specified.
         if (!args.agent) local.agent.set(msg.agent)
-        if (msg.model) {
+        if (msg.model && !args.model) {
           local.model.set(msg.model)
           local.model.variant.set(msg.model.variant)
         }


### PR DESCRIPTION
### Issue for this PR

Closes #26901

### Type of change

- [x]  Bug fix

### What does this PR do?

When resuming a session with `-s <sessionID>` and specifying a different model with `-m <model>`, the `-m` flag was silently ignored because the TUI prompt component synced the model from the session'\''s last user message, overwriting the CLI-provided model.

The prompt component already guarded the agent sync with `!args.agent` (line 399), but the model sync at line 400 lacked the equivalent guard. This PR adds `&& !args.model` so the CLI `-m` flag takes precedence.

### How did you verify your code works?

Verified by tracing the full flow from `app.tsx` onMount (where `args.model` is stored) through the `createEffect` in `prompt/index.tsx` that was overwriting it. The change mirrors the existing `!args.agent` guard pattern on the very next line.

Typechecked the opencode package — no new errors introduced.

### Checklist

- [x]  I have tested my changes locally
- [x]  I have not included unrelated changes in this PR