### PR TITLE
Generate config schema from Effect Schema

### DIFF
--- a/packages/opencode/script/schema.ts
+++ b/packages/opencode/script/schema.ts
@@ -1,64 +1,11 @@
 #!/usr/bin/env bun
 
-import { z } from "zod"
 import { Config } from "@/config/config"
-import { zodObject } from "@opencode-ai/core/effect-zod"
-import { TuiJsonSchema } from "../src/cli/cmd/tui/config/tui-json-schema"
 import { Schema } from "effect"
+import { TuiJsonSchema } from "../src/cli/cmd/tui/config/tui-json-schema"
 
 type JsonSchema = Record<string, unknown>
-
-function generate(schema: z.ZodType) {
-  const result = z.toJSONSchema(schema, {
-    io: "input", // Generate input shape (treats optional().default() as not required)
-    /**
-     * We'll use the `default` values of the field as the only value in `examples`.
-     * This will ensure no docs are needed to be read, as the configuration is
-     * self-documenting.
-     *
-     * See https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.9.5
-     */
-    override(ctx) {
-      const schema = ctx.jsonSchema
-
-      // Preserve strictness: set additionalProperties: false for objects
-      if (
-        schema &&
-        typeof schema === "object" &&
-        schema.type === "object" &&
-        schema.additionalProperties === undefined
-      ) {
-        schema.additionalProperties = false
-      }
-
-      // Add examples and default descriptions for string fields with defaults
-      if (schema && typeof schema === "object" && "type" in schema && schema.type === "string" && schema?.default) {
-        if (!schema.examples) {
-          schema.examples = [schema.default]
-        }
-
-        schema.description = [schema.description || "", `default: \`${formatDefault(schema.default)}\``]
-          .filter(Boolean)
-          .join("\n\n")
-          .trim()
-      }
-    },
-  }) as Record<string, unknown> & {
-    allowComments?: boolean
-    allowTrailingCommas?: boolean
-  }
-
-  // used for json lsps since config supports jsonc
-  result.allowComments = true
-  result.allowTrailingCommas = true
-
-  return result
-}
-
-function formatDefault(value: unknown) {
-  if (typeof value !== "object" || value === null) return String(value)
-  return JSON.stringify(value)
-}
+const MODEL_REF = "https://models.dev/model-schema.json#/$defs/Model"
 
 function generateEffect(schema: Schema.Top) {
   const document = Schema.toJsonSchemaDocument(schema)
@@ -68,9 +15,11 @@ function generateEffect(schema: Schema.Top) {
     $defs: document.definitions,
   })
   if (!isRecord(normalized)) throw new Error("schema generator produced a non-object schema")
-  normalized.allowComments = true
-  normalized.allowTrailingCommas = true
-  return normalized
+  const restored = restoreModelRefs(normalized)
+  if (!isRecord(restored)) throw new Error("schema generator produced a non-object schema")
+  restored.allowComments = true
+  restored.allowTrailingCommas = true
+  return restored
 }
 
 function normalize(value: unknown): unknown {
@@ -84,7 +33,7 @@ function normalize(value: unknown): unknown {
     if (anyOf.length !== schema.anyOf.length) {
       const { anyOf: _, ...rest } = schema
       if (anyOf.length === 1 && isRecord(anyOf[0])) return normalize({ ...anyOf[0], ...rest })
-      return { ...rest, anyOf }
+      return order({ ...rest, anyOf })
     }
   }
 
@@ -94,10 +43,56 @@ function normalize(value: unknown): unknown {
   }
 
   if (schema.type === "integer" && schema.maximum === undefined) {
-    return { ...schema, maximum: Number.MAX_SAFE_INTEGER }
+    return order({ ...schema, maximum: Number.MAX_SAFE_INTEGER })
   }
 
-  return schema
+  return order(schema)
+}
+
+function restoreModelRefs(value: unknown, key?: string): unknown {
+  if (Array.isArray(value)) return value.map((item) => restoreModelRefs(item))
+  if (!isRecord(value)) return value
+
+  const schema = Object.fromEntries(Object.entries(value).map(([name, item]) => [name, restoreModelRefs(item, name)]))
+  if ((key === "model" || key === "small_model") && schema.type === "string") {
+    return order({ ...schema, $ref: MODEL_REF })
+  }
+  return order(schema)
+}
+
+function order(schema: JsonSchema) {
+  const result: JsonSchema = {}
+  for (const key of [
+    "$schema",
+    "$ref",
+    "type",
+    "const",
+    "enum",
+    "anyOf",
+    "properties",
+    "required",
+    "propertyNames",
+    "additionalProperties",
+    "items",
+    "prefixItems",
+    "$defs",
+    "minimum",
+    "exclusiveMinimum",
+    "maximum",
+    "exclusiveMaximum",
+    "pattern",
+    "description",
+    "default",
+    "examples",
+    "allowComments",
+    "allowTrailingCommas",
+  ]) {
+    if (key in schema) result[key] = schema[key]
+  }
+  for (const [key, value] of Object.entries(schema)) {
+    if (!(key in result)) result[key] = value
+  }
+  return result
 }
 
 function isRecord(value: unknown): value is JsonSchema {
@@ -108,7 +103,7 @@ const configFile = process.argv[2]
 const tuiFile = process.argv[3]
 
 console.log(configFile)
-await Bun.write(configFile, JSON.stringify(generate(zodObject(Config.Info).strict().meta({ ref: "Config" })), null, 2))
+await Bun.write(configFile, JSON.stringify(generateEffect(Config.Info), null, 2))
 
 if (tuiFile) {
   console.log(tuiFile)

--- a/packages/opencode/script/schema.ts
+++ b/packages/opencode/script/schema.ts
@@ -33,7 +33,7 @@ function normalize(value: unknown): unknown {
     if (anyOf.length !== schema.anyOf.length) {
       const { anyOf: _, ...rest } = schema
       if (anyOf.length === 1 && isRecord(anyOf[0])) return normalize({ ...anyOf[0], ...rest })
-      return order({ ...rest, anyOf })
+      return { ...rest, anyOf }
     }
   }
 
@@ -43,10 +43,10 @@ function normalize(value: unknown): unknown {
   }
 
   if (schema.type === "integer" && schema.maximum === undefined) {
-    return order({ ...schema, maximum: Number.MAX_SAFE_INTEGER })
+    return { ...schema, maximum: Number.MAX_SAFE_INTEGER }
   }
 
-  return order(schema)
+  return schema
 }
 
 function restoreModelRefs(value: unknown, key?: string): unknown {
@@ -55,44 +55,9 @@ function restoreModelRefs(value: unknown, key?: string): unknown {
 
   const schema = Object.fromEntries(Object.entries(value).map(([name, item]) => [name, restoreModelRefs(item, name)]))
   if ((key === "model" || key === "small_model") && schema.type === "string") {
-    return order({ ...schema, $ref: MODEL_REF })
+    return { ...schema, $ref: MODEL_REF }
   }
-  return order(schema)
-}
-
-function order(schema: JsonSchema) {
-  const result: JsonSchema = {}
-  for (const key of [
-    "$schema",
-    "$ref",
-    "type",
-    "const",
-    "enum",
-    "anyOf",
-    "properties",
-    "required",
-    "propertyNames",
-    "additionalProperties",
-    "items",
-    "prefixItems",
-    "$defs",
-    "minimum",
-    "exclusiveMinimum",
-    "maximum",
-    "exclusiveMaximum",
-    "pattern",
-    "description",
-    "default",
-    "examples",
-    "allowComments",
-    "allowTrailingCommas",
-  ]) {
-    if (key in schema) result[key] = schema[key]
-  }
-  for (const [key, value] of Object.entries(schema)) {
-    if (!(key in result)) result[key] = value
-  }
-  return result
+  return schema
 }
 
 function isRecord(value: unknown): value is JsonSchema {


### PR DESCRIPTION
## Summary
- Generate the public `config.json` schema directly from `Config.Info` with `Schema.toJsonSchemaDocument`
- Normalize Effect's optional-field JSON Schema output so editor validation does not allow `null` values that runtime config parsing rejects
- Restore the external `models.dev` `$ref` for model fields, preserving editor model validation/autocomplete

## Compatibility
- Runtime config parsing is unchanged; this only changes the build-time public JSON Schema generator
- Generated `tui.json` is byte-for-byte unchanged
- Generated `config.json` now uses standard `$defs`/`$ref` instead of inlining repeated schemas, but preserves JSONC flags and model refs
- Verified generated `config.json` has no `anyOf` branches allowing `null`

## Verification
- `bun run script/schema.ts /tmp/config.json /tmp/tui.json`
- `diff -u <before-tui.json> <after-tui.json>` produced no diff
- Generated config schema invariants: no nullable optional branches, restored `models.dev` refs, `allowComments`, `allowTrailingCommas`
- `bun typecheck`
- `bunx prettier --check script/schema.ts`
- `bunx oxlint packages/opencode/script/schema.ts`