### PR TITLE
fix(tui): make websearch provider label reactive

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1984,11 +1984,11 @@ function WebFetch(props: ToolProps<typeof WebFetchTool>) {
 }
 
 function WebSearch(props: ToolProps<typeof WebSearchTool>) {
-  const metadata = props.metadata as { numResults?: number; provider?: unknown }
+  const metadata = () => props.metadata as { numResults?: number; provider?: unknown }
   return (
     <InlineTool icon="◈" pending="Searching web..." complete={props.input.query} part={props.part}>
-      {webSearchProviderLabel(metadata.provider)} "{props.input.query}"{" "}
-      <Show when={metadata.numResults}>({metadata.numResults} results)</Show>
+      {webSearchProviderLabel(metadata().provider)} "{props.input.query}"{" "}
+      <Show when={metadata().numResults}>({metadata().numResults} results)</Show>
     </InlineTool>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #26942

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI's `WebSearch` component captured `props.metadata` into a `const`. The component first renders while the part is in `pending` state — at that point the `toolprops.metadata` getter returns `{}` — so the snapshot has no `provider`. Solid only invokes the component once, so later metadata updates from `ctx.metadata({ metadata: { provider } })` never reach the JSX, and `webSearchProviderLabel(undefined)` falls back to `"Web Search"` regardless of which provider actually ran.

Switching `const metadata = props.metadata` to `const metadata = () => props.metadata` (and calling `metadata()` at each read) makes every access flow through Solid's reactive tracking, so the label updates when the part transitions to `running`/`completed`. The sibling renderer at `feature-plugins/system/session-v2.tsx` already does this with `createMemo` and works correctly.

### How did you verify your code works?

- `bun test test/tool/websearch.test.ts` — 10 pass
- `bun typecheck` in `packages/opencode` — clean
- `bun lint` — 0 errors
- Ran the dev TUI on a free Zen model with `OPENCODE_WEBSEARCH_PROVIDER=parallel`, ran a web search, confirmed the label renders as `◈ Parallel Web Search "..."` instead of `◈ Web Search "..."`. The persisted `state.metadata.provider` in `opencode.db` was already correct before the fix — only the render was stale.

### Screenshots / recordings

Before: `◈ Web Search "latest news today"`
<img width="678" height="209" alt="image" src="https://github.com/user-attachments/assets/779f8970-0255-4ffa-a6cc-9ce49a5d8f01" />


After: `◈ Parallel Web Search "latest news today 2026"`
<img width="902" height="202" alt="image" src="https://github.com/user-attachments/assets/7f6b5287-b21c-4dff-ac30-9a930be2ebe5" />

(attaching shortly)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR