### PR TITLE
test(agent): isolate plugin agent regression

### DIFF
--- a/packages/opencode/test/agent/plugin-agent-regression.test.ts
+++ b/packages/opencode/test/agent/plugin-agent-regression.test.ts
@@ -1,9 +1,18 @@
 import { expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Npm } from "@opencode-ai/core/npm"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Effect, Layer, Option } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
+import { Account } from "../../src/account/account"
 import { Agent } from "../../src/agent/agent"
+import { Auth } from "../../src/auth"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config"
+import { Env } from "../../src/env"
 import { Plugin } from "../../src/plugin"
+import { Skill } from "../../src/skill"
+import { ProviderTest } from "../fake/provider"
 import { testEffect } from "../lib/effect"
 import { PLUGIN_AGENT } from "../fixture/agent-plugin.constants"
 
@@ -12,7 +21,41 @@ import { PLUGIN_AGENT } from "../fixture/agent-plugin.constants"
 // to verify plugin → config hook → Agent.list.
 const pluginUrl = pathToFileURL(path.join(import.meta.dir, "..", "fixture", "agent-plugin.ts")).href
 
-const it = testEffect(Layer.mergeAll(Agent.defaultLayer, Plugin.defaultLayer))
+const emptyAccount = Layer.mock(Account.Service)({
+  active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
+})
+
+const emptyAuth = Layer.mock(Auth.Service)({
+  all: () => Effect.succeed({}),
+})
+
+const emptySkill = Layer.mock(Skill.Service)({
+  dirs: () => Effect.succeed([]),
+})
+
+const noopNpm = Layer.mock(Npm.Service)({
+  install: () => Effect.void,
+})
+
+const provider = ProviderTest.fake()
+const configLayer = Config.layer.pipe(
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(Env.defaultLayer),
+  Layer.provide(emptyAuth),
+  Layer.provide(emptyAccount),
+  Layer.provide(noopNpm),
+)
+const pluginLayer = Plugin.layer.pipe(Layer.provide(Bus.layer), Layer.provide(configLayer))
+const agentLayer = Agent.layer.pipe(
+  Layer.provide(configLayer),
+  Layer.provide(emptyAuth),
+  Layer.provide(emptySkill),
+  Layer.provide(provider.layer),
+  Layer.provide(pluginLayer),
+)
+
+const it = testEffect(Layer.mergeAll(agentLayer, pluginLayer))
 
 it.instance(
   "plugin-registered agents appear in Agent.list",

--- a/packages/opencode/test/agent/plugin-agent-regression.test.ts
+++ b/packages/opencode/test/agent/plugin-agent-regression.test.ts
@@ -1,18 +1,18 @@
 import { expect } from "bun:test"
-import { Npm } from "@opencode-ai/core/npm"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
-import { Effect, Layer, Option } from "effect"
+import { Effect, Layer } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
-import { Account } from "../../src/account/account"
 import { Agent } from "../../src/agent/agent"
-import { Auth } from "../../src/auth"
 import { Bus } from "../../src/bus"
 import { Config } from "../../src/config/config"
 import { Env } from "../../src/env"
 import { Plugin } from "../../src/plugin"
-import { Skill } from "../../src/skill"
+import { AccountTest } from "../fake/account"
+import { AuthTest } from "../fake/auth"
+import { NpmTest } from "../fake/npm"
 import { ProviderTest } from "../fake/provider"
+import { SkillTest } from "../fake/skill"
 import { testEffect } from "../lib/effect"
 import { PLUGIN_AGENT } from "../fixture/agent-plugin.constants"
 
@@ -21,36 +21,19 @@ import { PLUGIN_AGENT } from "../fixture/agent-plugin.constants"
 // to verify plugin → config hook → Agent.list.
 const pluginUrl = pathToFileURL(path.join(import.meta.dir, "..", "fixture", "agent-plugin.ts")).href
 
-const emptyAccount = Layer.mock(Account.Service)({
-  active: () => Effect.succeed(Option.none()),
-  activeOrg: () => Effect.succeed(Option.none()),
-})
-
-const emptyAuth = Layer.mock(Auth.Service)({
-  all: () => Effect.succeed({}),
-})
-
-const emptySkill = Layer.mock(Skill.Service)({
-  dirs: () => Effect.succeed([]),
-})
-
-const noopNpm = Layer.mock(Npm.Service)({
-  install: () => Effect.void,
-})
-
 const provider = ProviderTest.fake()
 const configLayer = Config.layer.pipe(
   Layer.provide(AppFileSystem.defaultLayer),
   Layer.provide(Env.defaultLayer),
-  Layer.provide(emptyAuth),
-  Layer.provide(emptyAccount),
-  Layer.provide(noopNpm),
+  Layer.provide(AuthTest.empty),
+  Layer.provide(AccountTest.empty),
+  Layer.provide(NpmTest.noop),
 )
 const pluginLayer = Plugin.layer.pipe(Layer.provide(Bus.layer), Layer.provide(configLayer))
 const agentLayer = Agent.layer.pipe(
   Layer.provide(configLayer),
-  Layer.provide(emptyAuth),
-  Layer.provide(emptySkill),
+  Layer.provide(AuthTest.empty),
+  Layer.provide(SkillTest.empty),
   Layer.provide(provider.layer),
   Layer.provide(pluginLayer),
 )

--- a/packages/opencode/test/fake/account.ts
+++ b/packages/opencode/test/fake/account.ts
@@ -1,0 +1,9 @@
+import { Effect, Layer, Option } from "effect"
+import { Account } from "../../src/account/account"
+
+export const empty = Layer.mock(Account.Service)({
+  active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
+})
+
+export * as AccountTest from "./account"

--- a/packages/opencode/test/fake/auth.ts
+++ b/packages/opencode/test/fake/auth.ts
@@ -1,0 +1,8 @@
+import { Effect, Layer } from "effect"
+import { Auth } from "../../src/auth"
+
+export const empty = Layer.mock(Auth.Service)({
+  all: () => Effect.succeed({}),
+})
+
+export * as AuthTest from "./auth"

--- a/packages/opencode/test/fake/npm.ts
+++ b/packages/opencode/test/fake/npm.ts
@@ -1,0 +1,8 @@
+import { Npm } from "@opencode-ai/core/npm"
+import { Effect, Layer } from "effect"
+
+export const noop = Layer.mock(Npm.Service)({
+  install: () => Effect.void,
+})
+
+export * as NpmTest from "./npm"

--- a/packages/opencode/test/fake/skill.ts
+++ b/packages/opencode/test/fake/skill.ts
@@ -1,0 +1,8 @@
+import { Effect, Layer } from "effect"
+import { Skill } from "../../src/skill"
+
+export const empty = Layer.mock(Skill.Service)({
+  dirs: () => Effect.succeed([]),
+})
+
+export * as SkillTest from "./skill"


### PR DESCRIPTION
## Summary
- Wire the plugin-agent regression test with explicit Effect layers instead of broad default layers
- Replace the real npm dependency-prep path with a fake Npm service so the test stays deterministic
- Keep the plugin config hook to Agent.list regression path covered

## Test Plan
- bun run test test/agent/plugin-agent-regression.test.ts
- bun typecheck