### PR TITLE
Fix run JSON output draining

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -719,6 +719,7 @@ export const RunCommand = effectCmd({
               }
             }
           }
+          return error
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)
         const client = args.attach ? attachSDK(cwd) : sdk
@@ -730,10 +731,7 @@ export const RunCommand = effectCmd({
 
         if (!args.interactive) {
           const events = await client.event.subscribe()
-          loop(client, events).catch((e) => {
-            console.error(e)
-            process.exit(1)
-          })
+          const completed = loop(client, events)
 
           if (args.command) {
             await client.session.command({
@@ -744,6 +742,8 @@ export const RunCommand = effectCmd({
               arguments: message,
               variant: args.variant,
             })
+            const error = await completed
+            if (error) process.exitCode = 1
             return
           }
 
@@ -755,6 +755,8 @@ export const RunCommand = effectCmd({
             variant: args.variant,
             parts: [...files, { type: "text", text: message }],
           })
+          const error = await completed
+          if (error) process.exitCode = 1
           return
         }
 


### PR DESCRIPTION
## Summary
- wait for the non-interactive `opencode run` event subscription to drain before returning
- preserve existing JSON event formatting while ensuring final text and step-finish events are emitted
- propagate captured session errors via process exit code after the stream ends

## Test Plan
- `bun typecheck`
- `bun run dev -- --pure run --dir /var/folders/dd/5fz89drs5p9_r0fk7rwqqnbr0000gn/T/opencode/native-runtime-smoke --model openai/gpt-4o-mini --format json --title dev-json-drain-smoke "Reply with exactly: dev-json-drain-ok"`
- `git diff --check`