### PR TITLE
fix(tui): guard prompt submit against concurrent invocation

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -989,7 +989,24 @@ export function Prompt(props: PromptProps) {
     }
   })
 
+  let submitting = false
   async function submit() {
+    // Prevent overlapping invocations (e.g. a double-pressed Enter, or the
+    // input's native onSubmit racing another dispatch). Without this guard,
+    // a second call slips past the empty-input check before the first call
+    // clears `store.prompt.input`, then awaits its own `session.create` and
+    // ultimately reads the now-empty store — sending a phantom empty prompt
+    // to a freshly created session.
+    if (submitting) return false
+    submitting = true
+    try {
+      return await submitInner()
+    } finally {
+      submitting = false
+    }
+  }
+
+  async function submitInner() {
     setWarpNotice(undefined)
 
     // IME: double-defer may fire before onContentChange flushes the last

--- a/packages/opencode/test/cli/tui/prompt-submit-race.test.ts
+++ b/packages/opencode/test/cli/tui/prompt-submit-race.test.ts
@@ -1,31 +1,23 @@
 import { describe, expect, test } from "bun:test"
 
-// Structural reproducer for the prompt submit race observed in
+// Regression test for the prompt submit race in
 // packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx (`submit`).
 //
-// The bug: two concurrent `submit()` calls (e.g. a double-pressed Enter, or
-// the input's native onSubmit racing another dispatch) each pass the
-// `if (!store.prompt.input) return false` guard, each `await
-// sdk.client.session.create(...)`, and each only capture
-// `inputText = store.prompt.input` AFTER that await.
-//
-// The first invocation finishes, sends the prompt, then clears the store.
-// The second invocation, now past its await, reads the cleared store and
-// sends an empty prompt to a second freshly-created session. The user is
-// then navigated to whichever session id was assigned last, leaving an
-// orphaned session containing their actual text and a phantom session with
+// Before the fix, two concurrent `submit()` calls (e.g. a double-pressed
+// Enter, or the input's native onSubmit racing another dispatch) each
+// passed the `if (!store.prompt.input) return false` guard, each
+// `await sdk.client.session.create(...)`, and each only captured
+// `inputText = store.prompt.input` AFTER that await. The first invocation
+// finished, sent the prompt, and cleared the store; the second invocation,
+// now past its await, read the cleared store and sent an empty prompt to a
+// second freshly-created session - leaving an orphaned session with the
+// user's actual text and a phantom session visible to the user containing
 // only an assistant reply.
 //
-// `submitMirror` below has the exact shape of the production `submit()`:
-//
-//   1. bail if input is empty
-//   2. await session.create()
-//   3. read inputText from the store
-//   4. await sendPrompt(sessionID, inputText)
-//   5. clear the store
-//
-// Running two concurrent invocations against it must not lose the user's
-// text. Today it does — this test FAILS until the race is fixed.
+// `submitMirror` below has the exact shape of the production `submit()`
+// after the fix: an in-flight `submitting` guard wraps the original body.
+// Two concurrent invocations must result in exactly one submission carrying
+// the user's text, with no empty-text submission.
 
 type Store = { input: string }
 
@@ -57,26 +49,50 @@ function createHarness(opts: { sessionCreateDelayMs: number }): Harness {
   }
 }
 
-async function submitMirror(h: Harness) {
-  if (!h.store.input) return false
-  const sessionID = await h.createSession()
-  const inputText = h.store.input
-  await h.sendPrompt(sessionID, inputText)
-  h.store.input = ""
-  return true
+function createSubmit() {
+  let submitting = false
+  return async function submit(h: Harness) {
+    if (submitting) return false
+    submitting = true
+    try {
+      if (!h.store.input) return false
+      const sessionID = await h.createSession()
+      const inputText = h.store.input
+      await h.sendPrompt(sessionID, inputText)
+      h.store.input = ""
+      return true
+    } finally {
+      submitting = false
+    }
+  }
 }
 
 describe("Prompt.submit race", () => {
   test("concurrent submits must not lose the user's text", async () => {
+    const submit = createSubmit()
     const h = createHarness({ sessionCreateDelayMs: 5 })
     h.store.input = "Hello there."
 
     // Two invocations back-to-back, mimicking a double-Enter.
-    await Promise.all([submitMirror(h), submitMirror(h)])
+    await Promise.all([submit(h), submit(h)])
 
     // Every submission that did make it through must carry the actual user
     // text, and no submission may have an empty text payload.
     expect(h.submissions.every((s) => s.text === "Hello there.")).toBe(true)
     expect(h.submissions.some((s) => s.text === "")).toBe(false)
+  })
+
+  test("a sequential second submit after clear is a no-op, not a phantom session", async () => {
+    const submit = createSubmit()
+    const h = createHarness({ sessionCreateDelayMs: 1 })
+    h.store.input = "Hello there."
+
+    await submit(h)
+    // After the first submission completes, the store is cleared; a second
+    // Enter on an empty input must not create a phantom session.
+    await submit(h)
+
+    expect(h.submissions).toHaveLength(1)
+    expect(h.submissions[0].text).toBe("Hello there.")
   })
 })

--- a/packages/opencode/test/cli/tui/prompt-submit-race.test.ts
+++ b/packages/opencode/test/cli/tui/prompt-submit-race.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+
+// Structural reproducer for the prompt submit race observed in
+// packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx (`submit`).
+//
+// The bug: two concurrent `submit()` calls (e.g. a double-pressed Enter, or
+// the input's native onSubmit racing another dispatch) each pass the
+// `if (!store.prompt.input) return false` guard, each `await
+// sdk.client.session.create(...)`, and each only capture
+// `inputText = store.prompt.input` AFTER that await.
+//
+// The first invocation finishes, sends the prompt, then clears the store.
+// The second invocation, now past its await, reads the cleared store and
+// sends an empty prompt to a second freshly-created session. The user is
+// then navigated to whichever session id was assigned last, leaving an
+// orphaned session containing their actual text and a phantom session with
+// only an assistant reply.
+//
+// `submitMirror` below has the exact shape of the production `submit()`:
+//
+//   1. bail if input is empty
+//   2. await session.create()
+//   3. read inputText from the store
+//   4. await sendPrompt(sessionID, inputText)
+//   5. clear the store
+//
+// Running two concurrent invocations against it must not lose the user's
+// text. Today it does — this test FAILS until the race is fixed.
+
+type Store = { input: string }
+
+type SubmitResult = { sessionID: string; text: string }
+
+type Harness = {
+  store: Store
+  submissions: SubmitResult[]
+  createSession(): Promise<string>
+  sendPrompt(sessionID: string, text: string): Promise<void>
+}
+
+function createHarness(opts: { sessionCreateDelayMs: number }): Harness {
+  let sessionCounter = 0
+  const submissions: SubmitResult[] = []
+
+  return {
+    store: { input: "" },
+    submissions,
+    async createSession() {
+      sessionCounter += 1
+      const id = `ses_${sessionCounter}`
+      await Bun.sleep(opts.sessionCreateDelayMs)
+      return id
+    },
+    async sendPrompt(sessionID, text) {
+      submissions.push({ sessionID, text })
+    },
+  }
+}
+
+async function submitMirror(h: Harness) {
+  if (!h.store.input) return false
+  const sessionID = await h.createSession()
+  const inputText = h.store.input
+  await h.sendPrompt(sessionID, inputText)
+  h.store.input = ""
+  return true
+}
+
+describe("Prompt.submit race", () => {
+  test("concurrent submits must not lose the user's text", async () => {
+    const h = createHarness({ sessionCreateDelayMs: 5 })
+    h.store.input = "Hello there."
+
+    // Two invocations back-to-back, mimicking a double-Enter.
+    await Promise.all([submitMirror(h), submitMirror(h)])
+
+    // Every submission that did make it through must carry the actual user
+    // text, and no submission may have an empty text payload.
+    expect(h.submissions.every((s) => s.text === "Hello there.")).toBe(true)
+    expect(h.submissions.some((s) => s.text === "")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Two `submit()` calls in `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` can overlap (most commonly a double-pressed Enter). Both pass the `if (!store.prompt.input) return false` guard, both `await sdk.client.session.create(...)`, and both only read `inputText = store.prompt.input` *after* that await. The first call finishes, sends its prompt, then clears the store; the second call, now past its await, reads `""` and sends an empty prompt to a second freshly-created session.

The user observes:
- An orphaned session (visible only by browsing) containing their actual text and a real assistant reply.
- A phantom session — the one they navigate to — with an empty user message, an assistant reply (the model responds to nothing), and a hallucinated title (the title generator inferred from its own system prompt because the user content was empty).

Reproduced in a real session in the OpenCode DB: two `session` rows created 3ms apart, one with `text: "Hello there."` and one with `text: ""`, sharing the same directory.

## Fix

Wrap `submit()` in an in-flight `submitting` flag. The original body is preserved verbatim as `submitInner()`; only the guard is new.

```ts
let submitting = false
async function submit() {
  if (submitting) return false
  submitting = true
  try {
    return await submitInner()
  } finally {
    submitting = false
  }
}
```

## Tests

`packages/opencode/test/cli/tui/prompt-submit-race.test.ts` is a structural mirror of `submit()`. The first commit adds it pointed at the **buggy** shape (no guard) and fails. The second commit adds the production fix and updates the mirror to match, after which both tests pass.

Caveat: this is a structural regression test, not an integration test against the real `Prompt` component. Mounting `Prompt` for a true E2E test would require building harnesses for ~14 contexts (sync, sdk, project, editor, dialog, toast, command-palette, keymap, tui-config, route, args, local, prompt-history, prompt-stash) plus a fake SDK client. Happy to do that as a follow-up if reviewers want it.

## Test plan

- [x] `bun run test test/cli/tui/prompt-submit-race.test.ts` from `packages/opencode` (2 pass)
- [x] `bun run typecheck` from `packages/opencode` (clean)
- [ ] Manual: in the TUI, type a message, double-press Enter quickly, verify exactly one session is created and contains the typed text