### PR TITLE
agent: use Effect schema for generated agent object

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -1,5 +1,4 @@
 import { Config } from "@/config/config"
-import z from "zod"
 import { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
 import { generateObject, streamObject, type ModelMessage } from "ai"
@@ -48,6 +47,12 @@ export const Info = Schema.Struct({
   steps: Schema.optional(Schema.Finite),
 }).annotate({ identifier: "Agent" })
 export type Info = DeepMutable<Schema.Schema.Type<typeof Info>>
+
+const GeneratedAgent = Schema.Struct({
+  identifier: Schema.String,
+  whenToUse: Schema.String,
+  systemPrompt: Schema.String,
+})
 
 export interface Interface {
   readonly get: (agent: string) => Effect.Effect<Info>
@@ -405,11 +410,10 @@ export const layer = Layer.effect(
             },
           ],
           model: language,
-          schema: z.object({
-            identifier: z.string(),
-            whenToUse: z.string(),
-            systemPrompt: z.string(),
-          }),
+          schema: Object.assign(
+            Schema.toStandardSchemaV1(GeneratedAgent),
+            Schema.toStandardJSONSchemaV1(GeneratedAgent),
+          ),
         } satisfies Parameters<typeof generateObject>[0]
 
         if (isOpenaiOauth) {


### PR DESCRIPTION
## Summary
- Replace the remaining Zod object-generation schema in `Agent.generate` with an Effect Schema struct.
- Pass AI SDK a schema object containing both Standard Schema validation and Standard JSON Schema metadata.
- Preserve the generated object shape and leave provider/message behavior unchanged.

## Verification
- `bunx prettier --write packages/opencode/src/agent/agent.ts`
- `bun run lint -- packages/opencode/src/agent/agent.ts`
- `bun run test test/agent/agent.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`