### PR TITLE
refactor(desktop): remove configureEnv callback from spawnLocalServer

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -291,25 +291,19 @@ const main = Effect.gen(function* () {
       if (mainWindow) sendSqliteMigrationProgress(mainWindow, progress)
     })
 
+    ensureLoopbackNoProxy()
+    useEnvProxy()
+
     logger.log("spawning sidecar", { url })
     const { listener, health } = yield* Effect.promise(() =>
-      spawnLocalServer(
-        hostname,
-        port,
-        password,
-        () => {
-          ensureLoopbackNoProxy()
-          useEnvProxy()
-        },
-        {
-          needsMigration,
-          userDataPath: app.getPath("userData"),
-          onSqliteProgress: (progress) => initEmitter.emit("sqlite", progress),
-          onStdout: (message) => logger.log("sidecar stdout", { message }),
-          onStderr: (message) => logger.warn("sidecar stderr", { message }),
-          onExit: (code) => logger.warn("sidecar exited", { code }),
-        },
-      ),
+      spawnLocalServer(hostname, port, password, {
+        needsMigration,
+        userDataPath: app.getPath("userData"),
+        onSqliteProgress: (progress) => initEmitter.emit("sqlite", progress),
+        onStdout: (message) => logger.log("sidecar stdout", { message }),
+        onStderr: (message) => logger.warn("sidecar stderr", { message }),
+        onExit: (code) => logger.warn("sidecar exited", { code }),
+      }),
     )
     server = listener
     yield* Deferred.succeed(serverReady, {

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -70,10 +70,8 @@ export async function spawnLocalServer(
   hostname: string,
   port: number,
   password: string,
-  configureEnv: () => void,
   options: SpawnLocalServerOptions,
 ) {
-  configureEnv?.()
   const sidecar = join(dirname(fileURLToPath(import.meta.url)), "sidecar.js")
   const child = utilityProcess.fork(sidecar, [], {
     cwd: process.cwd(),


### PR DESCRIPTION
Removes the `configureEnv` callback parameter from `spawnLocalServer` and instead calls `ensureLoopbackNoProxy()` and `useEnvProxy()` directly before spawning the server. This simplifies the function signature and makes the side effect more explicit at the call site.