### PR TITLE
fix: filter archived sessions from per-project session list

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -263,6 +263,7 @@ export type ListInput = {
   start?: number
   search?: string
   limit?: number
+  archived?: boolean
 }
 
 const CreatedEventSchema = Schema.Struct({
@@ -846,6 +847,9 @@ function* listByProject(
   }
   if (input.search) {
     conditions.push(like(SessionTable.title, `%${input.search}%`))
+  }
+  if (!input.archived) {
+    conditions.push(isNull(SessionTable.time_archived))
   }
 
   const limit = input.limit ?? 100


### PR DESCRIPTION
### Issue for this PR

Closes #27030

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The per-project session listing (`Session.list()` / `GET /session`) returns all sessions including archived ones, while the global listing (`Session.listGlobal()` / `GET /experimental/session`) already filters out archived sessions via `isNull(time_archived)`.

This causes archived sessions from automated workflows (cron tasks, CI runs) to pollute the session history displayed to users.

**Fix:** Added `isNull(SessionTable.time_archived)` filter condition to `listByProject()` function to match `listGlobal()` behavior. Also added `archived?: boolean` option to `ListInput` type so callers can optionally include archived sessions.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode` - no new type errors
- Manually tested: archived sessions no longer appear in per-project session list output

### Screenshots / recordings

N/A (backend change, no UI impact)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR