### PR TITLE
fix(tui): copy selection on Cmd+C when copy-on-select is disabled

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/selection.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/selection.ts
@@ -17,6 +17,8 @@ type Renderer = {
 
 type SelectionKeyEvent = {
   ctrl?: boolean
+  meta?: boolean
+  super?: boolean
   name: string
   preventDefault: () => void
   stopPropagation: () => void
@@ -38,7 +40,7 @@ export function handleSelectionKey(renderer: Renderer, toast: Toast, event: Sele
   const selection = renderer.getSelection()
   if (!selection) return
 
-  if (event.ctrl && event.name === "c") {
+  if ((event.ctrl || event.meta || event.super) && event.name === "c") {
     if (!copy(renderer, toast)) {
       renderer.clearSelection()
       return


### PR DESCRIPTION
### Issue for this PR

Closes #27058

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `handleSelectionKey` (`packages/opencode/src/cli/cmd/tui/util/selection.ts`), the copy shortcut only matched `event.ctrl`. opencode enables the Kitty Keyboard Protocol (`useKittyKeyboard: {}` in `app.tsx`), so macOS Cmd+C reaches the app as `event.super` — but no branch matched, and the function fell through to `renderer.clearSelection()`, wiping the highlight without copying.

Fix: accept `meta` and `super` in addition to `ctrl`. The `SelectionKeyEvent` type is widened to mirror the actual `KeyEvent` shape from `@opentui/core/lib/KeyHandler`.

Follow-up to #4996, which introduced the flag.

### How did you verify your code works?

- Traced the key path: `parseKittyKeyboard` sets `key.super = true` when Cmd is held (modifier bit 8 in `fromKittyMods`). The widened condition matches it.
- Monorepo typecheck passes (pre-push hook ran `bun turbo typecheck` — 14/14 successful).
- Manual TUI test on **Ghostty / macOS** with `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT=1`: drag-select → Cmd+C copies to clipboard and shows the "Copied to clipboard" toast. Ctrl+C still works (no regression). Without the env var, the existing copy-on-select behavior is unchanged.
- Note: terminals that don't forward Cmd+C (Terminal.app, Warp, etc.) are unaffected by this change — that's a terminal-side limitation outside this PR's scope.

### Screenshots / recordings

N/A — not a visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR