### PR TITLE
fix(opencode): allow partial command overrides in JSON config

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -95,6 +95,7 @@ export const layer = Layer.effect(
       }
 
       for (const [name, command] of Object.entries(cfg.command ?? {})) {
+        if (!command.template) continue
         commands[name] = {
           name,
           agent: command.agent,
@@ -102,7 +103,7 @@ export const layer = Layer.effect(
           description: command.description,
           source: "command",
           get template() {
-            return command.template
+            return command.template!
           },
           subtask: command.subtask,
           hints: hints(command.template),

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -13,7 +13,7 @@ import { ConfigModelID } from "./model-id"
 const log = Log.create({ service: "config" })
 
 export const Info = Schema.Struct({
-  template: Schema.String,
+  template: Schema.optional(Schema.String),
   description: Schema.optional(Schema.String),
   agent: Schema.optional(Schema.String),
   model: Schema.optional(ConfigModelID),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -727,6 +727,30 @@ test("handles command configuration", async () => {
   })
 })
 
+test("accepts partial command override without template", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        command: {
+          commit: {
+            model: "anthropic/claude-4-6-sonnet",
+          },
+        },
+      })
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await load()
+      expect(config.command?.["commit"]).toEqual({
+        model: "anthropic/claude-4-6-sonnet",
+      })
+    },
+  })
+})
+
 test("migrates autoshare to share field", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Fixes #27035

### Type of change

- [x] Bug fix

### What does this PR do?

`ConfigCommand.Info` requires `template` as a mandatory field, but the docs show that JSON config can override just the `model` for a built-in command. Since `template` is derived from markdown content for built-in commands, users shouldn't need to copy-paste it.

Made `template` optional in the `Info` schema. Markdown-loaded commands always set `template` from `md.content.trim()`, so they're unaffected. The `command/index.ts` loop now skips entries without a `template` — partial overrides get their template filled in when markdown commands are merged at `config.ts:619`.

> **Note:** This PR is scoped to fixing the schema validation only. The actual override values (e.g. `model`) are currently overwritten by the markdown merge at `config.ts:619` due to merge order (`mergeDeep(jsonConfig, markdownCommands)` — markdown wins on overlapping keys). That should be addressed as a separate issue.

### How did you verify your code works?

- `bun test test/config/config.test.ts` — 84 tests pass, including a new test that configures a command override with only `model` (no `template`)
- `bun turbo typecheck` — 14/14 packages clean
- Pre-push CI hook confirmed typecheck passes

### Screenshots / recordings

N/A — config validation fix, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR