### PR TITLE
fix(plan): use build agent's configured model on plan_exit switch

### DIFF
--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -4,6 +4,7 @@ import * as Tool from "./tool"
 import { Question } from "../question"
 import { Session } from "@/session/session"
 import { MessageV2 } from "../session/message-v2"
+import { Agent } from "@/agent/agent"
 import { Provider } from "@/provider/provider"
 import { InstanceState } from "@/effect/instance-state"
 import { type SessionID, MessageID, PartID } from "../session/schema"
@@ -21,6 +22,7 @@ export const Parameters = Schema.Struct({})
 export const PlanExitTool = Tool.define(
   "plan_exit",
   Effect.gen(function* () {
+    const agents = yield* Agent.Service
     const session = yield* Session.Service
     const question = yield* Question.Service
     const provider = yield* Provider.Service
@@ -51,7 +53,8 @@ export const PlanExitTool = Tool.define(
 
           if (answers[0]?.[0] === "No") yield* new Question.RejectedError()
 
-          const model = getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel())
+          const buildAgent = yield* agents.get("build")
+          const model = buildAgent.model ?? getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel())
 
           const msg: MessageV2.User = {
             id: MessageID.ascending(),


### PR DESCRIPTION
## Summary

When switching from plan to build agent via `plan_exit`, the tool was using `getLastModel()` which returned the plan agent's model (from the last user message). This caused the build agent to keep using the plan agent's model instead of its own configured model from `agent/build.md` frontmatter.

## Fix

`plan_exit` now consults the build agent's configured model first via `agents.get("build")`, falling back to `getLastModel()` and `provider.defaultModel()` as before.

## Model resolution chain (new)

1. Build agent's model from config/frontmatter (e.g., `crofai/deepseek-v4-flash`)
2. Last user message model (previous behavior)
3. Provider default model (previous fallback)

## File changed

- `packages/opencode/src/tool/plan.ts`