### PR TITLE
fix: annotate Effect log metadata

### DIFF
--- a/packages/opencode/src/data-migration.ts
+++ b/packages/opencode/src/data-migration.ts
@@ -145,7 +145,7 @@ export const layer = Layer.effect(
         )
       }
     }).pipe(
-      Effect.tapCause((cause) => Effect.logError("failed to run data migrations", { cause })),
+      Effect.tapCause((cause) => Effect.logError("failed to run data migrations").pipe(Effect.annotateLogs("cause", cause))),
       Effect.ignore,
       Effect.forkScoped,
     )

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -37,7 +37,7 @@ export const layer = Layer.effect(
 
     const run = Effect.gen(function* () {
       const ctx = yield* InstanceState.context
-      yield* Effect.logInfo("bootstrapping", { directory: ctx.directory })
+      yield* Effect.logInfo("bootstrapping").pipe(Effect.annotateLogs("directory", ctx.directory))
       // everything depends on config so eager load it for nice traces
       yield* config.get()
       // Plugin can mutate config so it has to be initialized before anything else.

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -156,7 +156,9 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
           Effect.gen(function* () {
             const exit = yield* Deferred.await(item[1].deferred).pipe(Effect.exit)
             if (Exit.isFailure(exit)) {
-              yield* Effect.logWarning("instance dispose failed", { key: item[0], cause: exit.cause })
+              yield* Effect.logWarning("instance dispose failed").pipe(
+                Effect.annotateLogs({ key: item[0], cause: exit.cause }),
+              )
               yield* removeEntry(item[0], item[1])
               return
             }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -177,7 +177,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | HttpClie
           yield* invalidate
         }),
       ).pipe(
-        Effect.tapCause((cause) => Effect.logError("Failed to fetch models.dev", { cause })),
+        Effect.tapCause((cause) => Effect.logError("Failed to fetch models.dev").pipe(Effect.annotateLogs("cause", cause))),
         Effect.ignore,
       )
     })

--- a/packages/opencode/src/reference/reference.ts
+++ b/packages/opencode/src/reference/reference.ts
@@ -169,7 +169,9 @@ export const layer = Layer.effect(
               ).pipe(
                 Effect.asVoid,
                 Effect.catchCause((cause) =>
-                  Effect.logWarning("failed to materialize reference repository", { name: reference.name, cause }),
+                  Effect.logWarning("failed to materialize reference repository").pipe(
+                    Effect.annotateLogs({ name: reference.name, cause }),
+                  ),
                 ),
               ),
             )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -299,7 +299,9 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       yield* promptSvc.prompt({ ...ctx.payload, sessionID: ctx.params.sessionID }).pipe(
         Effect.catchCause((cause) =>
           Effect.gen(function* () {
-            yield* Effect.logError("prompt_async failed", { sessionID: ctx.params.sessionID, cause })
+            yield* Effect.logError("prompt_async failed").pipe(
+              Effect.annotateLogs({ sessionID: ctx.params.sessionID, cause }),
+            )
             yield* bus.publish(Session.Event.Error, {
               sessionID: ctx.params.sessionID,
               error: new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(),


### PR DESCRIPTION
## Summary
- Convert Effect log metadata from extra message arguments to log annotations.
- Prevent object metadata from rendering as `[object Object]` in log output.

## Testing
- Verified annotated Effect log output with a focused `bun -e` reproduction.