### PR TITLE
fix(session): preserve usage update timestamps

### DIFF
--- a/packages/opencode/src/data-migration.ts
+++ b/packages/opencode/src/data-migration.ts
@@ -94,6 +94,7 @@ export const layer = Layer.effect(
                         tokens_reasoning: value.tokens.reasoning,
                         tokens_cache_read: value.tokens.cache.read,
                         tokens_cache_write: value.tokens.cache.write,
+                        time_updated: sql`${SessionTable.time_updated}`,
                       })
                       .where(eq(SessionTable.id, sessionID))
                       .run()
@@ -115,6 +116,29 @@ export const layer = Layer.effect(
             cursor = next
             yield* Effect.sleep("10 millis")
           }
+        }),
+      },
+      {
+        name: "restore_session_updated_after_usage_migration",
+        run: Effect.sync(() => {
+          Database.use((db) => {
+            const usageMigration = db
+              .select({ time_completed: DataMigrationTable.time_completed })
+              .from(DataMigrationTable)
+              .where(eq(DataMigrationTable.name, "session_usage_from_messages"))
+              .get()
+            if (!usageMigration) return
+
+            db.run(sql`
+              update ${SessionTable}
+              set time_updated = coalesce(
+                (select max(${MessageTable.time_updated}) from ${MessageTable} where ${MessageTable.session_id} = ${SessionTable.id}),
+                ${SessionTable.time_created}
+              )
+              where ${SessionTable.time_updated} between ${usageMigration.time_completed - 60_000} and ${usageMigration.time_completed}
+                and ${SessionTable.time_created} < ${usageMigration.time_completed - 60_000}
+            `)
+          })
         }),
       },
     ]

--- a/packages/opencode/src/data-migration.ts
+++ b/packages/opencode/src/data-migration.ts
@@ -118,29 +118,6 @@ export const layer = Layer.effect(
           }
         }),
       },
-      {
-        name: "restore_session_updated_after_usage_migration",
-        run: Effect.sync(() => {
-          Database.use((db) => {
-            const usageMigration = db
-              .select({ time_completed: DataMigrationTable.time_completed })
-              .from(DataMigrationTable)
-              .where(eq(DataMigrationTable.name, "session_usage_from_messages"))
-              .get()
-            if (!usageMigration) return
-
-            db.run(sql`
-              update ${SessionTable}
-              set time_updated = coalesce(
-                (select max(${MessageTable.time_updated}) from ${MessageTable} where ${MessageTable.session_id} = ${SessionTable.id}),
-                ${SessionTable.time_created}
-              )
-              where ${SessionTable.time_updated} between ${usageMigration.time_completed - 60_000} and ${usageMigration.time_completed}
-                and ${SessionTable.time_created} < ${usageMigration.time_completed - 60_000}
-            `)
-          })
-        }),
-      },
     ]
 
     yield* Effect.gen(function* () {

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -38,6 +38,7 @@ function applyUsage(db: TxOrDb, sessionID: Session.Info["id"], value: Usage, sig
       tokens_reasoning: sql`${SessionTable.tokens_reasoning} + ${value.tokens.reasoning * sign}`,
       tokens_cache_read: sql`${SessionTable.tokens_cache_read} + ${value.tokens.cache.read * sign}`,
       tokens_cache_write: sql`${SessionTable.tokens_cache_write} + ${value.tokens.cache.write * sign}`,
+      time_updated: sql`${SessionTable.time_updated}`,
     })
     .where(eq(SessionTable.id, sessionID))
     .run()
@@ -110,7 +111,7 @@ export default [
     const info = data.info
     const row = db
       .update(SessionTable)
-      .set(toPartialRow(info as Session.Patch))
+      .set({ time_updated: sql`${SessionTable.time_updated}`, ...toPartialRow(info as Session.Patch) })
       .where(eq(SessionTable.id, data.sessionID))
       .returning()
       .get()


### PR DESCRIPTION
## summary
- preserve session `time_updated` when the usage totals backfill updates existing sessions
- preserve session `time_updated` for usage-total projector updates
- avoid letting Drizzle `$onUpdate` make usage-only writes reorder old sessions

## testing
- `bun typecheck` from `packages/opencode`

## note
- no repair migration is included since the usage migration has not gone out in a tagged release yet