### PR TITLE
Remove Zod from core log

### DIFF
--- a/packages/core/src/util/log.ts
+++ b/packages/core/src/util/log.ts
@@ -7,12 +7,10 @@ import * as Global from "../global"
 import { Schema } from "effect"
 import { Glob } from "./glob"
 
-export const Level = Schema.Union([
-  Schema.Literal("DEBUG"),
-  Schema.Literal("INFO"),
-  Schema.Literal("WARN"),
-  Schema.Literal("ERROR"),
-]).annotate({ identifier: "LogLevel", description: "Log level" })
+export const Level = Schema.Literals(["DEBUG", "INFO", "WARN", "ERROR"]).annotate({
+  identifier: "LogLevel",
+  description: "Log level",
+})
 export type Level = Schema.Schema.Type<typeof Level>
 
 const levelPriority: Record<Level, number> = {

--- a/packages/core/src/util/log.ts
+++ b/packages/core/src/util/log.ts
@@ -4,11 +4,16 @@ import path from "path"
 import fs from "fs/promises"
 import { createWriteStream } from "fs"
 import * as Global from "../global"
-import z from "zod"
+import { Schema } from "effect"
 import { Glob } from "./glob"
 
-export const Level = z.enum(["DEBUG", "INFO", "WARN", "ERROR"]).meta({ ref: "LogLevel", description: "Log level" })
-export type Level = z.infer<typeof Level>
+export const Level = Schema.Union([
+  Schema.Literal("DEBUG"),
+  Schema.Literal("INFO"),
+  Schema.Literal("WARN"),
+  Schema.Literal("ERROR"),
+]).annotate({ identifier: "LogLevel", description: "Log level" })
+export type Level = Schema.Schema.Type<typeof Level>
 
 const levelPriority: Record<Level, number> = {
   DEBUG: 0,


### PR DESCRIPTION
## Summary
- Converts `Log.Level` from a Zod enum to an Effect Schema union.
- Preserves the exported `Level` symbol and `Level` TypeScript type.
- Removes the direct Zod import from `packages/core/src/util/log.ts`.

## Verification
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/opencode`
- `bun run test -- test/util/log.test.ts`
- `bunx prettier --check packages/core/src/util/log.ts`
- `bunx oxlint packages/core/src/util/log.ts`
- `git diff --check`
- pre-push `bun turbo typecheck`