### PR TITLE
Make core fn Zod import type-only

### DIFF
--- a/packages/core/src/util/fn.ts
+++ b/packages/core/src/util/fn.ts
@@ -1,4 +1,4 @@
-import { z } from "zod"
+import type { z } from "zod"
 
 export function fn<T extends z.ZodType, Result>(schema: T, cb: (input: z.infer<T>) => Result) {
   const result = (input: z.infer<T>) => {


### PR DESCRIPTION
## Summary
- Changes `packages/core/src/util/fn.ts` to import Zod only as a type.
- Preserves the existing Zod-based helper contract and enterprise inference.
- Removes the runtime Zod dependency edge from this helper without expanding the cleanup beyond a safe small step.

## Verification
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/enterprise`
- `bunx prettier --check packages/core/src/util/fn.ts`
- `bunx oxlint packages/core/src/util/fn.ts`
- `git diff --check`
- pre-push `bun turbo typecheck`