### PR TITLE
Remove Zod from app global SDK

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,6 @@
         "solid-list": "catalog:",
         "tailwindcss": "catalog:",
         "virtua": "catalog:",
-        "zod": "catalog:",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.11",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,6 @@
     "solid-js": "catalog:",
     "solid-list": "catalog:",
     "tailwindcss": "catalog:",
-    "virtua": "catalog:",
-    "zod": "catalog:"
+    "virtua": "catalog:"
   }
 }

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -3,15 +3,13 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { batch, onCleanup, onMount } from "solid-js"
-import z from "zod"
 import { createSdkForServer } from "@/utils/server"
 import { useLanguage } from "./language"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
 
-const abortError = z.object({
-  name: z.literal("AbortError"),
-})
+const isAbortError = (error: unknown) =>
+  error !== null && typeof error === "object" && "name" in error && error.name === "AbortError"
 
 export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleContext({
   name: "GlobalSDK",
@@ -103,7 +101,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
 
     let streamErrorLogged = false
     const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
-    const aborted = (error: unknown) => abortError.safeParse(error).success
+    const aborted = isAbortError
 
     let attempt: AbortController | undefined
     let run: Promise<void> | undefined


### PR DESCRIPTION
## Summary
- Replaces the `global-sdk` AbortError Zod schema with a direct predicate.
- Removes the last Zod import from `packages/app/src`.
- Drops the app package's direct `zod` dependency and updates `bun.lock`.

## Verification
- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/desktop`
- `bun run test -- src/context/global-sync src/utils/server-health.test.ts` in `packages/app`
- `bunx prettier --check packages/app/src/context/global-sdk.tsx packages/app/package.json`
- `bunx oxlint packages/app/src/context/global-sdk.tsx` (warnings only, existing patterns)
- `git diff --check`
- `rg 'from \"zod\"|from '\''zod'\''|zod/v4|zod/v3' packages/app/src --glob '*.ts*'` returns no matches
- pre-push `bun turbo typecheck`