### PR TITLE
Migrate UI cancel error to tagged error

### DIFF
--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -78,8 +78,8 @@ export function FormatError(input: unknown) {
     ].join("\n")
   }
 
-  // UICancelledError: void (no data)
-  if (NamedError.hasName(input, "UICancelledError")) {
+  // UICancelledError: user cancelled an interactive CLI prompt
+  if (isTaggedError(input, "UICancelledError") || NamedError.hasName(input, "UICancelledError")) {
     return ""
   }
 }

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -1,5 +1,4 @@
 import { EOL } from "os"
-import { NamedError } from "@opencode-ai/core/util/error"
 import { Schema } from "effect"
 import { logo as glyphs } from "./logo"
 
@@ -10,7 +9,7 @@ const wordmark = [
   `▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀`,
 ]
 
-export const CancelledError = NamedError.create("UICancelledError", Schema.optional(Schema.Void))
+export class CancelledError extends Schema.TaggedErrorClass<CancelledError>()("UICancelledError", {}) {}
 
 export const Style = {
   TEXT_HIGHLIGHT: "\x1b[96m",

--- a/packages/opencode/test/cli/error.test.ts
+++ b/packages/opencode/test/cli/error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { AccountTransportError } from "../../src/account/schema"
 import { FormatError } from "../../src/cli/error"
+import { UI } from "../../src/cli/ui"
 
 describe("cli.error", () => {
   test("formats account transport errors clearly", () => {
@@ -14,5 +15,9 @@ describe("cli.error", () => {
     expect(formatted).toContain("Could not reach POST https://console.opencode.ai/auth/device/code.")
     expect(formatted).toContain("This failed before the server returned an HTTP response.")
     expect(formatted).toContain("Check your network, proxy, or VPN configuration and try again.")
+  })
+
+  test("formats cancelled UI errors as empty output", () => {
+    expect(FormatError(new UI.CancelledError())).toBe("")
   })
 })

--- a/packages/opencode/test/util/error.test.ts
+++ b/packages/opencode/test/util/error.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { Schema } from "effect"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { errorData, errorFormat, errorMessage } from "../../src/util/error"
-import { UI } from "../../src/cli/ui"
 import { MessageError } from "../../src/session/message-error"
 
 describe("util.error", () => {
@@ -60,9 +58,7 @@ describe("util.error", () => {
     expect(error.toObject()).toEqual({ name: "ProviderAuthError", data: { providerID: "anthropic", message: "boom" } })
   })
 
-  test("void named errors accept JSON without data", () => {
-    const serialized = JSON.parse(JSON.stringify(new UI.CancelledError(undefined).toObject()))
-
-    expect(Schema.decodeUnknownOption(UI.CancelledError.Schema)(serialized)._tag).toBe("Some")
+  test("named errors without fields serialize data", () => {
+    expect(new MessageError.OutputLengthError({}).toObject()).toEqual({ name: "MessageOutputLengthError", data: {} })
   })
 })


### PR DESCRIPTION
## Summary
- Converts the CLI `UICancelledError` from `NamedError.create(...)` to `Schema.TaggedErrorClass`.
- Keeps `FormatError` compatible with both tagged and legacy named cancel errors.
- Updates focused error tests for the tagged cancel path and preserves named-error serialization coverage with a session message error.

## Verification
- `bun typecheck` in `packages/opencode`
- `bun run test -- test/util/error.test.ts test/cli/error.test.ts`
- `bunx prettier --check packages/opencode/src/cli/ui.ts packages/opencode/src/cli/error.ts packages/opencode/test/util/error.test.ts packages/opencode/test/cli/error.test.ts`
- `bunx oxlint ...` on changed files (warnings only, existing patterns)
- `git diff --check`
- pre-push `bun turbo typecheck`