### PR TITLE
Add theSaver plugin to ecosystem page

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
+| [theSaver](https://github.com/DrunkkToys/theSaver-oc)                                            | Cost-aware delegation enforcer with three-tier model routing, prompt-cache tracking, ROI reporting, and a trinity CLI for brain/medium/cheap slot switching |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |


### PR DESCRIPTION
## Summary

Adds [**theSaver**](https://github.com/DrunkkToys/theSaver-oc) to the Plugins table in the ecosystem page.

**theSaver** is a cost-aware delegation enforcer plugin for OpenCode that:
- Routes Task subagents to cheaper model tiers based on orchestrator tier
- Tracks prompt-cache savings and surfaces cumulative ROI in every response
- Provides a `trinity` CLI for brain/medium/cheap slot switching
- Injects context7 and judge-pattern directives into system prompts
- Compresses verbose tool outputs and context for token efficiency