### PR TITLE
test(project): migrate project tests to Effect runner

### DIFF
--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -4,26 +4,41 @@ import { Project } from "@/project/project"
 import * as Log from "@opencode-ai/core/util/log"
 import { $ } from "bun"
 import path from "path"
-import { tmpdir } from "../fixture/fixture"
+import { tmpdirScoped } from "../fixture/fixture"
 import { GlobalBus } from "../../src/bus/global"
 import { ProjectID } from "../../src/project/schema"
-import { Effect, Layer, Stream } from "effect"
+import { Cause, Effect, Exit, Layer, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { testEffect } from "../lib/effect"
 
 void Log.init({ print: false })
 
 const encoder = new TextEncoder()
 
-function run<A>(fn: (svc: Project.Interface) => Effect.Effect<A>, layer = Project.defaultLayer) {
-  return Effect.runPromise(
-    Effect.gen(function* () {
-      const svc = yield* Project.Service
-      return yield* fn(svc)
-    }).pipe(Effect.provide(layer)),
-  )
+const layer = Layer.mergeAll(Project.defaultLayer, CrossSpawnSpawner.defaultLayer)
+const it = testEffect(layer)
+
+function run<A>(fn: (svc: Project.Interface) => Effect.Effect<A>) {
+  return Effect.gen(function* () {
+    const svc = yield* Project.Service
+    return yield* fn(svc)
+  })
+}
+
+function gitTmpdir() {
+  return Effect.gen(function* () {
+    const tmp = yield* tmpdirScoped()
+    yield* Effect.promise(() => $`git init`.cwd(tmp).quiet())
+    yield* Effect.promise(() => $`git config core.fsmonitor false`.cwd(tmp).quiet())
+    yield* Effect.promise(() => $`git config commit.gpgsign false`.cwd(tmp).quiet())
+    yield* Effect.promise(() => $`git config user.email "test@opencode.test"`.cwd(tmp).quiet())
+    yield* Effect.promise(() => $`git config user.name "Test"`.cwd(tmp).quiet())
+    yield* Effect.promise(() => $`git commit --allow-empty -m ${`root commit ${tmp}`}`.cwd(tmp).quiet())
+    return tmp
+  })
 }
 
 /**
@@ -70,400 +85,430 @@ function projectLayerWithFailure(failArg: string) {
   )
 }
 
+const failureIt = (failArg: string) => testEffect(Layer.mergeAll(projectLayerWithFailure(failArg), CrossSpawnSpawner.defaultLayer))
+
 describe("Project.fromDirectory", () => {
-  test("should handle git repository with no commits", async () => {
-    await using tmp = await tmpdir()
-    await $`git init`.cwd(tmp.path).quiet()
+  it.live("should handle git repository with no commits", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* Effect.promise(() => $`git init`.cwd(tmp).quiet())
 
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    expect(project).toBeDefined()
-    expect(project.id).toBe(ProjectID.global)
-    expect(project.vcs).toBe("git")
-    expect(project.worktree).toBe(tmp.path)
+      expect(project).toBeDefined()
+      expect(project.id).toBe(ProjectID.global)
+      expect(project.vcs).toBe("git")
+      expect(project.worktree).toBe(tmp)
 
-    const opencodeFile = path.join(tmp.path, ".git", "opencode")
-    expect(await Bun.file(opencodeFile).exists()).toBe(false)
-  })
+      const opencodeFile = path.join(tmp, ".git", "opencode")
+      expect(yield* Effect.promise(() => Bun.file(opencodeFile).exists())).toBe(false)
+    }),
+  )
 
-  test("should handle git repository with commits", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("should handle git repository with commits", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    expect(project).toBeDefined()
-    expect(project.id).not.toBe(ProjectID.global)
-    expect(project.vcs).toBe("git")
-    expect(project.worktree).toBe(tmp.path)
+      expect(project).toBeDefined()
+      expect(project.id).not.toBe(ProjectID.global)
+      expect(project.vcs).toBe("git")
+      expect(project.worktree).toBe(tmp)
 
-    const opencodeFile = path.join(tmp.path, ".git", "opencode")
-    expect(await Bun.file(opencodeFile).exists()).toBe(true)
-  })
+      const opencodeFile = path.join(tmp, ".git", "opencode")
+      expect(yield* Effect.promise(() => Bun.file(opencodeFile).exists())).toBe(true)
+    }),
+  )
 
-  test("returns global for non-git directory", async () => {
-    await using tmp = await tmpdir()
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
-    expect(project.id).toBe(ProjectID.global)
-  })
+  it.live("returns global for non-git directory", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
+      expect(project.id).toBe(ProjectID.global)
+    }),
+  )
 
-  test("derives stable project ID from root commit", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project: a } = await run((svc) => svc.fromDirectory(tmp.path))
-    const { project: b } = await run((svc) => svc.fromDirectory(tmp.path))
-    expect(b.id).toBe(a.id)
-  })
+  it.live("derives stable project ID from root commit", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project: a } = yield* run((svc) => svc.fromDirectory(tmp))
+      const { project: b } = yield* run((svc) => svc.fromDirectory(tmp))
+      expect(b.id).toBe(a.id)
+    }),
+  )
 })
 
 describe("Project.fromDirectory git failure paths", () => {
-  test("keeps vcs when rev-list exits non-zero (no commits)", async () => {
-    await using tmp = await tmpdir()
-    await $`git init`.cwd(tmp.path).quiet()
+  it.live("keeps vcs when rev-list exits non-zero (no commits)", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* Effect.promise(() => $`git init`.cwd(tmp).quiet())
 
-    // rev-list fails because HEAD doesn't exist yet — this is the natural scenario
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
-    expect(project.vcs).toBe("git")
-    expect(project.id).toBe(ProjectID.global)
-    expect(project.worktree).toBe(tmp.path)
-  })
+      // rev-list fails because HEAD doesn't exist yet: this is the natural scenario.
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
+      expect(project.vcs).toBe("git")
+      expect(project.id).toBe(ProjectID.global)
+      expect(project.worktree).toBe(tmp)
+    }),
+  )
 
-  test("handles show-toplevel failure gracefully", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const layer = projectLayerWithFailure("--show-toplevel")
+  failureIt("--show-toplevel").live("handles show-toplevel failure gracefully", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const { project, sandbox } = await run((svc) => svc.fromDirectory(tmp.path), layer)
-    expect(project.worktree).toBe(tmp.path)
-    expect(sandbox).toBe(tmp.path)
-  })
+      const { project, sandbox } = yield* run((svc) => svc.fromDirectory(tmp))
+      expect(project.worktree).toBe(tmp)
+      expect(sandbox).toBe(tmp)
+    }),
+  )
 
-  test("handles git-common-dir failure gracefully", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const layer = projectLayerWithFailure("--git-common-dir")
+  failureIt("--git-common-dir").live("handles git-common-dir failure gracefully", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const { project, sandbox } = await run((svc) => svc.fromDirectory(tmp.path), layer)
-    expect(project.worktree).toBe(tmp.path)
-    expect(sandbox).toBe(tmp.path)
-  })
+      const { project, sandbox } = yield* run((svc) => svc.fromDirectory(tmp))
+      expect(project.worktree).toBe(tmp)
+      expect(sandbox).toBe(tmp)
+    }),
+  )
 })
 
 describe("Project.fromDirectory with worktrees", () => {
-  test("should set worktree to root when called from root", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("should set worktree to root when called from root", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const { project, sandbox } = await run((svc) => svc.fromDirectory(tmp.path))
+      const { project, sandbox } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    expect(project.worktree).toBe(tmp.path)
-    expect(sandbox).toBe(tmp.path)
-    expect(project.sandboxes).not.toContain(tmp.path)
-  })
+      expect(project.worktree).toBe(tmp)
+      expect(sandbox).toBe(tmp)
+      expect(project.sandboxes).not.toContain(tmp)
+    }),
+  )
 
-  test("should set worktree to root when called from a worktree", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("should set worktree to root when called from a worktree", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const worktreePath = path.join(tmp.path, "..", path.basename(tmp.path) + "-worktree")
-    try {
-      await $`git worktree add ${worktreePath} -b test-branch-${Date.now()}`.cwd(tmp.path).quiet()
+      const worktreePath = path.join(tmp, "..", path.basename(tmp) + "-worktree")
+      yield* Effect.addFinalizer(() => Effect.promise(() => $`git worktree remove ${worktreePath}`.cwd(tmp).quiet().catch(() => {})))
+      yield* Effect.promise(() => $`git worktree add ${worktreePath} -b test-branch-${Date.now()}`.cwd(tmp).quiet())
 
-      const { project, sandbox } = await run((svc) => svc.fromDirectory(worktreePath))
+      const { project, sandbox } = yield* run((svc) => svc.fromDirectory(worktreePath))
 
-      expect(project.worktree).toBe(tmp.path)
+      expect(project.worktree).toBe(tmp)
       expect(sandbox).toBe(worktreePath)
       expect(project.sandboxes).toContain(worktreePath)
-      expect(project.sandboxes).not.toContain(tmp.path)
-    } finally {
-      await $`git worktree remove ${worktreePath}`
-        .cwd(tmp.path)
-        .quiet()
-        .catch(() => {})
-    }
-  })
+      expect(project.sandboxes).not.toContain(tmp)
+    }),
+  )
 
-  test("worktree should share project ID with main repo", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("worktree should share project ID with main repo", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const { project: main } = await run((svc) => svc.fromDirectory(tmp.path))
+      const { project: main } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const worktreePath = path.join(tmp.path, "..", path.basename(tmp.path) + "-wt-shared")
-    try {
-      await $`git worktree add ${worktreePath} -b shared-${Date.now()}`.cwd(tmp.path).quiet()
+      const worktreePath = path.join(tmp, "..", path.basename(tmp) + "-wt-shared")
+      yield* Effect.addFinalizer(() => Effect.promise(() => $`git worktree remove ${worktreePath}`.cwd(tmp).quiet().catch(() => {})))
+      yield* Effect.promise(() => $`git worktree add ${worktreePath} -b shared-${Date.now()}`.cwd(tmp).quiet())
 
-      const { project: wt } = await run((svc) => svc.fromDirectory(worktreePath))
+      const { project: wt } = yield* run((svc) => svc.fromDirectory(worktreePath))
 
       expect(wt.id).toBe(main.id)
 
       // Cache should live in the common .git dir, not the worktree's .git file
-      const cache = path.join(tmp.path, ".git", "opencode")
-      const exists = await Bun.file(cache).exists()
+      const cache = path.join(tmp, ".git", "opencode")
+      const exists = yield* Effect.promise(() => Bun.file(cache).exists())
       expect(exists).toBe(true)
-    } finally {
-      await $`git worktree remove ${worktreePath}`
-        .cwd(tmp.path)
-        .quiet()
-        .catch(() => {})
-    }
-  })
+    }),
+  )
 
-  test("separate clones of the same repo should share project ID", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("separate clones of the same repo should share project ID", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
     // Create a bare remote, push, then clone into a second directory
-    const bare = tmp.path + "-bare"
-    const clone = tmp.path + "-clone"
-    try {
-      await $`git clone --bare ${tmp.path} ${bare}`.quiet()
-      await $`git clone ${bare} ${clone}`.quiet()
+      const bare = tmp + "-bare"
+      const clone = tmp + "-clone"
+      yield* Effect.addFinalizer(() => Effect.promise(() => $`rm -rf ${bare} ${clone}`.quiet().nothrow()).pipe(Effect.ignore))
+      yield* Effect.promise(() => $`git clone --bare ${tmp} ${bare}`.quiet())
+      yield* Effect.promise(() => $`git clone ${bare} ${clone}`.quiet())
 
-      const { project: a } = await run((svc) => svc.fromDirectory(tmp.path))
-      const { project: b } = await run((svc) => svc.fromDirectory(clone))
+      const { project: a } = yield* run((svc) => svc.fromDirectory(tmp))
+      const { project: b } = yield* run((svc) => svc.fromDirectory(clone))
 
       expect(b.id).toBe(a.id)
-    } finally {
-      await $`rm -rf ${bare} ${clone}`.quiet().nothrow()
-    }
-  })
+    }),
+  )
 
-  test("should accumulate multiple worktrees in sandboxes", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("should accumulate multiple worktrees in sandboxes", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const worktree1 = path.join(tmp.path, "..", path.basename(tmp.path) + "-wt1")
-    const worktree2 = path.join(tmp.path, "..", path.basename(tmp.path) + "-wt2")
-    try {
-      await $`git worktree add ${worktree1} -b branch-${Date.now()}`.cwd(tmp.path).quiet()
-      await $`git worktree add ${worktree2} -b branch-${Date.now() + 1}`.cwd(tmp.path).quiet()
+      const worktree1 = path.join(tmp, "..", path.basename(tmp) + "-wt1")
+      const worktree2 = path.join(tmp, "..", path.basename(tmp) + "-wt2")
+      yield* Effect.addFinalizer(() =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => $`git worktree remove ${worktree1}`.cwd(tmp).quiet().catch(() => {}))
+          yield* Effect.promise(() => $`git worktree remove ${worktree2}`.cwd(tmp).quiet().catch(() => {}))
+        }),
+      )
+      yield* Effect.promise(() => $`git worktree add ${worktree1} -b branch-${Date.now()}`.cwd(tmp).quiet())
+      yield* Effect.promise(() => $`git worktree add ${worktree2} -b branch-${Date.now() + 1}`.cwd(tmp).quiet())
 
-      await run((svc) => svc.fromDirectory(worktree1))
-      const { project } = await run((svc) => svc.fromDirectory(worktree2))
+      yield* run((svc) => svc.fromDirectory(worktree1))
+      const { project } = yield* run((svc) => svc.fromDirectory(worktree2))
 
-      expect(project.worktree).toBe(tmp.path)
+      expect(project.worktree).toBe(tmp)
       expect(project.sandboxes).toContain(worktree1)
       expect(project.sandboxes).toContain(worktree2)
-      expect(project.sandboxes).not.toContain(tmp.path)
-    } finally {
-      await $`git worktree remove ${worktree1}`
-        .cwd(tmp.path)
-        .quiet()
-        .catch(() => {})
-      await $`git worktree remove ${worktree2}`
-        .cwd(tmp.path)
-        .quiet()
-        .catch(() => {})
-    }
-  })
+      expect(project.sandboxes).not.toContain(tmp)
+    }),
+  )
 })
 
 describe("Project.discover", () => {
-  test("should discover favicon.png in root", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should discover favicon.png in root", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
-    await Bun.write(path.join(tmp.path, "favicon.png"), pngData)
+      const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      yield* Effect.promise(() => Bun.write(path.join(tmp, "favicon.png"), pngData))
 
-    await run((svc) => svc.discover(project))
+      yield* run((svc) => svc.discover(project))
 
-    const updated = Project.get(project.id)
-    expect(updated).toBeDefined()
-    expect(updated!.icon).toBeDefined()
-    expect(updated!.icon?.url).toStartWith("data:")
-    expect(updated!.icon?.url).toContain("base64")
-    expect(updated!.icon?.color).toBeUndefined()
-  })
+      const updated = Project.get(project.id)
+      expect(updated).toBeDefined()
+      expect(updated!.icon).toBeDefined()
+      expect(updated!.icon?.url).toStartWith("data:")
+      expect(updated!.icon?.url).toContain("base64")
+      expect(updated!.icon?.color).toBeUndefined()
+    }),
+  )
 
-  test("should not discover non-image files", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should not discover non-image files", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    await Bun.write(path.join(tmp.path, "favicon.txt"), "not an image")
+      yield* Effect.promise(() => Bun.write(path.join(tmp, "favicon.txt"), "not an image"))
 
-    await run((svc) => svc.discover(project))
+      yield* run((svc) => svc.discover(project))
 
-    const updated = Project.get(project.id)
-    expect(updated).toBeDefined()
-    expect(updated!.icon).toBeUndefined()
-  })
+      const updated = Project.get(project.id)
+      expect(updated).toBeDefined()
+      expect(updated!.icon).toBeUndefined()
+    }),
+  )
 
-  test("should not discover favicon when override is set", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should not discover favicon when override is set", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    await run((svc) =>
-      svc.update({
-        projectID: project.id,
-        icon: { override: "data:image/png;base64,override" },
-      }),
-    )
+      yield* run((svc) =>
+        svc.update({
+          projectID: project.id,
+          icon: { override: "data:image/png;base64,override" },
+        }),
+      )
 
-    const updatedProject = await run((svc) => svc.get(project.id))
-    if (!updatedProject) throw new Error("Project not found")
+      const updatedProject = yield* run((svc) => svc.get(project.id))
+      if (!updatedProject) throw new Error("Project not found")
 
-    const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
-    await Bun.write(path.join(tmp.path, "favicon.png"), pngData)
+      const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      yield* Effect.promise(() => Bun.write(path.join(tmp, "favicon.png"), pngData))
 
-    await run((svc) => svc.discover(updatedProject))
+      yield* run((svc) => svc.discover(updatedProject))
 
-    const updated = Project.get(project.id)
-    expect(updated).toBeDefined()
-    expect(updated!.icon?.override).toBe("data:image/png;base64,override")
-    expect(updated!.icon?.url).toBeUndefined()
-  })
+      const updated = Project.get(project.id)
+      expect(updated).toBeDefined()
+      expect(updated!.icon?.override).toBe("data:image/png;base64,override")
+      expect(updated!.icon?.url).toBeUndefined()
+    }),
+  )
 })
 
 describe("Project.update", () => {
-  test("should update name", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should update name", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const updated = await run((svc) =>
-      svc.update({
-        projectID: project.id,
-        name: "New Project Name",
-      }),
-    )
+      const updated = yield* run((svc) =>
+        svc.update({
+          projectID: project.id,
+          name: "New Project Name",
+        }),
+      )
 
-    expect(updated.name).toBe("New Project Name")
+      expect(updated.name).toBe("New Project Name")
 
-    const fromDb = Project.get(project.id)
-    expect(fromDb?.name).toBe("New Project Name")
-  })
+      const fromDb = Project.get(project.id)
+      expect(fromDb?.name).toBe("New Project Name")
+    }),
+  )
 
-  test("should update icon url", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should update icon url", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const updated = await run((svc) =>
-      svc.update({
-        projectID: project.id,
-        icon: { url: "https://example.com/icon.png" },
-      }),
-    )
+      const updated = yield* run((svc) =>
+        svc.update({
+          projectID: project.id,
+          icon: { url: "https://example.com/icon.png" },
+        }),
+      )
 
-    expect(updated.icon?.url).toBe("https://example.com/icon.png")
+      expect(updated.icon?.url).toBe("https://example.com/icon.png")
 
-    const fromDb = Project.get(project.id)
-    expect(fromDb?.icon?.url).toBe("https://example.com/icon.png")
-  })
+      const fromDb = Project.get(project.id)
+      expect(fromDb?.icon?.url).toBe("https://example.com/icon.png")
+    }),
+  )
 
-  test("should update icon color", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should update icon color", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const updated = await run((svc) =>
-      svc.update({
-        projectID: project.id,
-        icon: { color: "#ff0000" },
-      }),
-    )
+      const updated = yield* run((svc) =>
+        svc.update({
+          projectID: project.id,
+          icon: { color: "#ff0000" },
+        }),
+      )
 
-    expect(updated.icon?.color).toBe("#ff0000")
+      expect(updated.icon?.color).toBe("#ff0000")
 
-    const fromDb = Project.get(project.id)
-    expect(fromDb?.icon?.color).toBe("#ff0000")
-  })
+      const fromDb = Project.get(project.id)
+      expect(fromDb?.icon?.color).toBe("#ff0000")
+    }),
+  )
 
-  test("should update icon override", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should update icon override", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const updated = await run((svc) =>
-      svc.update({
-        projectID: project.id,
-        icon: { override: "data:image/png;base64,abc123" },
-      }),
-    )
+      const updated = yield* run((svc) =>
+        svc.update({
+          projectID: project.id,
+          icon: { override: "data:image/png;base64,abc123" },
+        }),
+      )
 
-    expect(updated.icon?.override).toBe("data:image/png;base64,abc123")
+      expect(updated.icon?.override).toBe("data:image/png;base64,abc123")
 
-    const fromDb = Project.get(project.id)
-    expect(fromDb?.icon?.override).toBe("data:image/png;base64,abc123")
-  })
+      const fromDb = Project.get(project.id)
+      expect(fromDb?.icon?.override).toBe("data:image/png;base64,abc123")
+    }),
+  )
 
-  test("should update commands", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should update commands", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const updated = await run((svc) =>
-      svc.update({
-        projectID: project.id,
-        commands: { start: "npm run dev" },
-      }),
-    )
+      const updated = yield* run((svc) =>
+        svc.update({
+          projectID: project.id,
+          commands: { start: "npm run dev" },
+        }),
+      )
 
-    expect(updated.commands?.start).toBe("npm run dev")
+      expect(updated.commands?.start).toBe("npm run dev")
 
-    const fromDb = Project.get(project.id)
-    expect(fromDb?.commands?.start).toBe("npm run dev")
-  })
+      const fromDb = Project.get(project.id)
+      expect(fromDb?.commands?.start).toBe("npm run dev")
+    }),
+  )
 
-  test("should throw error when project not found", async () => {
-    await expect(
-      run((svc) =>
+  it.live("should throw error when project not found", () =>
+    Effect.gen(function* () {
+      const exit = yield* run((svc) =>
         svc.update({
           projectID: ProjectID.make("nonexistent-project-id"),
           name: "Should Fail",
         }),
-      ),
-    ).rejects.toThrow("Project not found: nonexistent-project-id")
-  })
+      ).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const error = Cause.squash(exit.cause)
+        expect(error instanceof Error ? error.message : String(error)).toContain("Project not found: nonexistent-project-id")
+      }
+    }),
+  )
 
-  test("should emit GlobalBus event on update", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should emit GlobalBus event on update", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    let eventPayload: any = null
-    const on = (data: any) => {
-      eventPayload = data
-    }
-    GlobalBus.on("event", on)
+      let eventPayload: any = null
+      const on = (data: any) => {
+        eventPayload = data
+      }
+      GlobalBus.on("event", on)
+      yield* Effect.addFinalizer(() => Effect.sync(() => GlobalBus.off("event", on)))
 
-    try {
-      await run((svc) => svc.update({ projectID: project.id, name: "Updated Name" }))
+      yield* run((svc) => svc.update({ projectID: project.id, name: "Updated Name" }))
 
       expect(eventPayload).not.toBeNull()
       expect(eventPayload.payload.type).toBe("project.updated")
       expect(eventPayload.payload.properties.name).toBe("Updated Name")
-    } finally {
-      GlobalBus.off("event", on)
-    }
-  })
+    }),
+  )
 
-  test("should update multiple fields at once", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("should update multiple fields at once", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const updated = await run((svc) =>
-      svc.update({
-        projectID: project.id,
-        name: "Multi Update",
-        icon: { url: "https://example.com/favicon.ico", override: "data:image/png;base64,abc123", color: "#00ff00" },
-        commands: { start: "make start" },
-      }),
-    )
+      const updated = yield* run((svc) =>
+        svc.update({
+          projectID: project.id,
+          name: "Multi Update",
+          icon: { url: "https://example.com/favicon.ico", override: "data:image/png;base64,abc123", color: "#00ff00" },
+          commands: { start: "make start" },
+        }),
+      )
 
-    expect(updated.name).toBe("Multi Update")
-    expect(updated.icon?.url).toBe("https://example.com/favicon.ico")
-    expect(updated.icon?.override).toBe("data:image/png;base64,abc123")
-    expect(updated.icon?.color).toBe("#00ff00")
-    expect(updated.commands?.start).toBe("make start")
-  })
+      expect(updated.name).toBe("Multi Update")
+      expect(updated.icon?.url).toBe("https://example.com/favicon.ico")
+      expect(updated.icon?.override).toBe("data:image/png;base64,abc123")
+      expect(updated.icon?.color).toBe("#00ff00")
+      expect(updated.commands?.start).toBe("make start")
+    }),
+  )
 })
 
 describe("Project.list and Project.get", () => {
-  test("list returns all projects", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("list returns all projects", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const all = Project.list()
-    expect(all.length).toBeGreaterThan(0)
-    expect(all.find((p) => p.id === project.id)).toBeDefined()
-  })
+      const all = Project.list()
+      expect(all.length).toBeGreaterThan(0)
+      expect(all.find((p) => p.id === project.id)).toBeDefined()
+    }),
+  )
 
-  test("get returns project by id", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("get returns project by id", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    const found = Project.get(project.id)
-    expect(found).toBeDefined()
-    expect(found!.id).toBe(project.id)
-  })
+      const found = Project.get(project.id)
+      expect(found).toBeDefined()
+      expect(found!.id).toBe(project.id)
+    }),
+  )
 
   test("get returns undefined for unknown id", () => {
     const found = Project.get(ProjectID.make("nonexistent"))
@@ -472,65 +517,72 @@ describe("Project.list and Project.get", () => {
 })
 
 describe("Project.setInitialized", () => {
-  test("sets time_initialized on project", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
+  it.live("sets time_initialized on project", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
 
-    expect(project.time.initialized).toBeUndefined()
+      expect(project.time.initialized).toBeUndefined()
 
-    Project.setInitialized(project.id)
+      Project.setInitialized(project.id)
 
-    const updated = Project.get(project.id)
-    expect(updated?.time.initialized).toBeDefined()
-  })
+      const updated = Project.get(project.id)
+      expect(updated?.time.initialized).toBeDefined()
+    }),
+  )
 })
 
 describe("Project.addSandbox and Project.removeSandbox", () => {
-  test("addSandbox adds directory and removeSandbox removes it", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
-    const sandboxDir = path.join(tmp.path, "sandbox-test")
+  it.live("addSandbox adds directory and removeSandbox removes it", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
+      const sandboxDir = path.join(tmp, "sandbox-test")
 
-    await run((svc) => svc.addSandbox(project.id, sandboxDir))
+      yield* run((svc) => svc.addSandbox(project.id, sandboxDir))
 
-    let found = Project.get(project.id)
-    expect(found?.sandboxes).toContain(sandboxDir)
+      let found = Project.get(project.id)
+      expect(found?.sandboxes).toContain(sandboxDir)
 
-    await run((svc) => svc.removeSandbox(project.id, sandboxDir))
+      yield* run((svc) => svc.removeSandbox(project.id, sandboxDir))
 
-    found = Project.get(project.id)
-    expect(found?.sandboxes).not.toContain(sandboxDir)
-  })
+      found = Project.get(project.id)
+      expect(found?.sandboxes).not.toContain(sandboxDir)
+    }),
+  )
 
-  test("addSandbox emits GlobalBus event", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
-    const sandboxDir = path.join(tmp.path, "sandbox-event")
+  it.live("addSandbox emits GlobalBus event", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
+      const sandboxDir = path.join(tmp, "sandbox-event")
 
-    const events: any[] = []
-    const on = (evt: any) => events.push(evt)
-    GlobalBus.on("event", on)
+      const events: any[] = []
+      const on = (evt: any) => events.push(evt)
+      GlobalBus.on("event", on)
+      yield* Effect.addFinalizer(() => Effect.sync(() => GlobalBus.off("event", on)))
 
-    await run((svc) => svc.addSandbox(project.id, sandboxDir))
+      yield* run((svc) => svc.addSandbox(project.id, sandboxDir))
 
-    GlobalBus.off("event", on)
-    expect(events.some((e) => e.payload.type === Project.Event.Updated.type)).toBe(true)
-  })
+      expect(events.some((e) => e.payload.type === Project.Event.Updated.type)).toBe(true)
+    }),
+  )
 })
 
 describe("Project.fromDirectory with bare repos", () => {
-  test("worktree from bare repo should cache in bare repo, not parent", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("worktree from bare repo should cache in bare repo, not parent", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const parentDir = path.dirname(tmp.path)
-    const barePath = path.join(parentDir, `bare-${Date.now()}.git`)
-    const worktreePath = path.join(parentDir, `worktree-${Date.now()}`)
+      const parentDir = path.dirname(tmp)
+      const barePath = path.join(parentDir, `bare-${Date.now()}.git`)
+      const worktreePath = path.join(parentDir, `worktree-${Date.now()}`)
+      yield* Effect.addFinalizer(() => Effect.promise(() => $`rm -rf ${barePath} ${worktreePath}`.quiet().nothrow()).pipe(Effect.ignore))
 
-    try {
-      await $`git clone --bare ${tmp.path} ${barePath}`.quiet()
-      await $`git worktree add ${worktreePath} HEAD`.cwd(barePath).quiet()
+      yield* Effect.promise(() => $`git clone --bare ${tmp} ${barePath}`.quiet())
+      yield* Effect.promise(() => $`git worktree add ${worktreePath} HEAD`.cwd(barePath).quiet())
 
-      const { project } = await run((svc) => svc.fromDirectory(worktreePath))
+      const { project } = yield* run((svc) => svc.fromDirectory(worktreePath))
 
       expect(project.id).not.toBe(ProjectID.global)
       expect(project.worktree).toBe(barePath)
@@ -538,31 +590,34 @@ describe("Project.fromDirectory with bare repos", () => {
       const correctCache = path.join(barePath, "opencode")
       const wrongCache = path.join(parentDir, ".git", "opencode")
 
-      expect(await Bun.file(correctCache).exists()).toBe(true)
-      expect(await Bun.file(wrongCache).exists()).toBe(false)
-    } finally {
-      await $`rm -rf ${barePath} ${worktreePath}`.quiet().nothrow()
-    }
-  })
+      expect(yield* Effect.promise(() => Bun.file(correctCache).exists())).toBe(true)
+      expect(yield* Effect.promise(() => Bun.file(wrongCache).exists())).toBe(false)
+    }),
+  )
 
-  test("different bare repos under same parent should not share project ID", async () => {
-    await using tmp1 = await tmpdir({ git: true })
-    await using tmp2 = await tmpdir({ git: true })
+  it.live("different bare repos under same parent should not share project ID", () =>
+    Effect.gen(function* () {
+      const tmp1 = yield* gitTmpdir()
+      const tmp2 = yield* gitTmpdir()
 
-    const parentDir = path.dirname(tmp1.path)
-    const bareA = path.join(parentDir, `bare-a-${Date.now()}.git`)
-    const bareB = path.join(parentDir, `bare-b-${Date.now()}.git`)
-    const worktreeA = path.join(parentDir, `wt-a-${Date.now()}`)
-    const worktreeB = path.join(parentDir, `wt-b-${Date.now()}`)
+      const parentDir = path.dirname(tmp1)
+      const bareA = path.join(parentDir, `bare-a-${Date.now()}.git`)
+      const bareB = path.join(parentDir, `bare-b-${Date.now()}.git`)
+      const worktreeA = path.join(parentDir, `wt-a-${Date.now()}`)
+      const worktreeB = path.join(parentDir, `wt-b-${Date.now()}`)
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => $`rm -rf ${bareA} ${bareB} ${worktreeA} ${worktreeB}`.quiet().nothrow()).pipe(
+          Effect.ignore,
+        ),
+      )
 
-    try {
-      await $`git clone --bare ${tmp1.path} ${bareA}`.quiet()
-      await $`git clone --bare ${tmp2.path} ${bareB}`.quiet()
-      await $`git worktree add ${worktreeA} HEAD`.cwd(bareA).quiet()
-      await $`git worktree add ${worktreeB} HEAD`.cwd(bareB).quiet()
+      yield* Effect.promise(() => $`git clone --bare ${tmp1} ${bareA}`.quiet())
+      yield* Effect.promise(() => $`git clone --bare ${tmp2} ${bareB}`.quiet())
+      yield* Effect.promise(() => $`git worktree add ${worktreeA} HEAD`.cwd(bareA).quiet())
+      yield* Effect.promise(() => $`git worktree add ${worktreeB} HEAD`.cwd(bareB).quiet())
 
-      const { project: projA } = await run((svc) => svc.fromDirectory(worktreeA))
-      const { project: projB } = await run((svc) => svc.fromDirectory(worktreeB))
+      const { project: projA } = yield* run((svc) => svc.fromDirectory(worktreeA))
+      const { project: projB } = yield* run((svc) => svc.fromDirectory(worktreeB))
 
       expect(projA.id).not.toBe(projB.id)
 
@@ -570,34 +625,31 @@ describe("Project.fromDirectory with bare repos", () => {
       const cacheB = path.join(bareB, "opencode")
       const wrongCache = path.join(parentDir, ".git", "opencode")
 
-      expect(await Bun.file(cacheA).exists()).toBe(true)
-      expect(await Bun.file(cacheB).exists()).toBe(true)
-      expect(await Bun.file(wrongCache).exists()).toBe(false)
-    } finally {
-      await $`rm -rf ${bareA} ${bareB} ${worktreeA} ${worktreeB}`.quiet().nothrow()
-    }
-  })
+      expect(yield* Effect.promise(() => Bun.file(cacheA).exists())).toBe(true)
+      expect(yield* Effect.promise(() => Bun.file(cacheB).exists())).toBe(true)
+      expect(yield* Effect.promise(() => Bun.file(wrongCache).exists())).toBe(false)
+    }),
+  )
 
-  test("bare repo without .git suffix is still detected via core.bare", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("bare repo without .git suffix is still detected via core.bare", () =>
+    Effect.gen(function* () {
+      const tmp = yield* gitTmpdir()
 
-    const parentDir = path.dirname(tmp.path)
-    const barePath = path.join(parentDir, `bare-no-suffix-${Date.now()}`)
-    const worktreePath = path.join(parentDir, `worktree-${Date.now()}`)
+      const parentDir = path.dirname(tmp)
+      const barePath = path.join(parentDir, `bare-no-suffix-${Date.now()}`)
+      const worktreePath = path.join(parentDir, `worktree-${Date.now()}`)
+      yield* Effect.addFinalizer(() => Effect.promise(() => $`rm -rf ${barePath} ${worktreePath}`.quiet().nothrow()).pipe(Effect.ignore))
 
-    try {
-      await $`git clone --bare ${tmp.path} ${barePath}`.quiet()
-      await $`git worktree add ${worktreePath} HEAD`.cwd(barePath).quiet()
+      yield* Effect.promise(() => $`git clone --bare ${tmp} ${barePath}`.quiet())
+      yield* Effect.promise(() => $`git worktree add ${worktreePath} HEAD`.cwd(barePath).quiet())
 
-      const { project } = await run((svc) => svc.fromDirectory(worktreePath))
+      const { project } = yield* run((svc) => svc.fromDirectory(worktreePath))
 
       expect(project.id).not.toBe(ProjectID.global)
       expect(project.worktree).toBe(barePath)
 
       const correctCache = path.join(barePath, "opencode")
-      expect(await Bun.file(correctCache).exists()).toBe(true)
-    } finally {
-      await $`rm -rf ${barePath} ${worktreePath}`.quiet().nothrow()
-    }
-  })
+      expect(yield* Effect.promise(() => Bun.file(correctCache).exists())).toBe(true)
+    }),
+  )
 })


### PR DESCRIPTION
## Summary
- Migrates project tests from Promise-based Effect execution to the shared `testEffect` runner.
- Uses scoped Effect temp directories and finalizers while preserving unique git root commits for project ID assertions.

## Tests
- `bun run test test/project/project.test.ts`
- `bun typecheck`