### PR TITLE
fix: load photon wasm in compiled builds

### DIFF
--- a/packages/opencode/src/image/image.ts
+++ b/packages/opencode/src/image/image.ts
@@ -67,7 +67,8 @@ export const layer = Layer.effect(
           ;(globalThis as typeof globalThis & { __OPENCODE_PHOTON_WASM_PATH?: string }).__OPENCODE_PHOTON_WASM_PATH =
             photonWasm
           return await import("@silvia-odwyer/photon-node")
-        } catch {
+        } catch (err) {
+          log.error("failed to load photon", { error: err })
           return null
         }
       }),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -407,6 +407,9 @@ export const layer: Layer.Layer<
                 ? image.normalize(attachment).pipe(Effect.exit)
                 : Effect.succeed(Exit.succeed<MessageV2.FilePart>(attachment)),
             )
+            for (const result of normalized) {
+              if (Exit.isFailure(result)) slog.error("image normalize failed", { error: Cause.squash(result.cause) })
+            }
             const omitted = normalized.filter(Exit.isFailure).length
             const attachments = normalized.filter(Exit.isSuccess).map((item) => item.value)
             const output = {

--- a/patches/@silvia-odwyer%2Fphoton-node@0.3.4.patch
+++ b/patches/@silvia-odwyer%2Fphoton-node@0.3.4.patch
@@ -2,6 +2,14 @@ diff --git a/photon_rs.js b/photon_rs.js
 index 8f4144d..b83e9a9 100644
 --- a/photon_rs.js
 +++ b/photon_rs.js
+@@ -1,6 +1,6 @@
+ 
+ let imports = {};
+-imports['__wbindgen_placeholder__'] = module.exports;
++imports['__wbindgen_placeholder__'] = exports;
+ let wasm;
+ const { TextEncoder, TextDecoder } = require(`util`);
+ 
 @@ -4509,7 +4509,8 @@ module.exports.__wbindgen_init_externref_table = function() {
      ;
  };


### PR DESCRIPTION
### Issue for this PR

Closes #27109

### Type of change

- [x] Bug fix

### What does this PR do?

First, image auto-resize errors were being silently swallowed — the user only saw a generic "could not be resized below the inline image size limit" message with no diagnostic info. This PR adds error logging in `processor.ts` so failures are visible in the session log.

After improving the logging, I found errors like `photon = yield* loadPhoton is null` and `TK is not defined`. These only occur in the compiled Bun binary — dev mode works fine. This pointed to a photon WASM import issue.

Through analysis and testing, I identified that changing `module.exports` to `exports` in the photon CJS glue code (`photon_rs.js`) fixes this. The **AGENT** said the likely cause is a bug in Bun's ESM bundler when handling `module.exports` self-references in CJS modules — it rewrites `module.exports` into an internal temporary that ends up undefined at runtime. Using `exports` (a direct variable reference) avoids this code path. I'm not a Bun or WASM expert and can't confirm this is the true root cause, but I can confirm it works on my machine.

**Caveats:** I'm unsure if this affects the Node.js build or desktop app. I can only verify it's an effective fix on my ArchLinux x86_64 environment with the Bun-compiled CLI binary.

**Note:** You need to delete `node_modules/@silvia-odwyer/photon-node` and re-run `bun install` to apply the patch changes.

### How did you verify your code works?

- `bun install --force` applies the patch cleanly; verified the patched `photon_rs.js` contains `exports` instead of `module.exports`
- Confirmed the `globalThis.__OPENCODE_PHOTON_WASM_PATH` wasm path injection (already in `image.ts` on `dev`) works alongside this fix

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
