### PR TITLE
test: migrate agent color config tests

### DIFF
--- a/packages/opencode/test/config/agent-color.test.ts
+++ b/packages/opencode/test/config/agent-color.test.ts
@@ -1,58 +1,50 @@
 import { test, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import path from "path"
-import { provideInstance, tmpdirScoped } from "../fixture/fixture"
 import { Config } from "@/config/config"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { Color } from "@/util/color"
-import { AppRuntime } from "../../src/effect/app-runtime"
 import { testEffect } from "../lib/effect"
 
-const it = testEffect(Layer.mergeAll(AgentSvc.defaultLayer, CrossSpawnSpawner.defaultLayer))
+const it = testEffect(Layer.mergeAll(Config.defaultLayer, AgentSvc.defaultLayer, CrossSpawnSpawner.defaultLayer))
 
-const writeConfig = (dir: string, agent: Config.Info["agent"]) =>
-  Effect.promise(() =>
-    Bun.write(
-      path.join(dir, "opencode.json"),
-      JSON.stringify({
-        $schema: "https://opencode.ai/config.json",
-        agent,
-      }),
-    ),
-  )
-
-it.live("agent color parsed from project config", () =>
-  Effect.gen(function* () {
-    const dir = yield* tmpdirScoped()
-    yield* writeConfig(dir, {
-      build: { color: "#FFA500" },
-      plan: { color: "primary" },
-    })
-
-    yield* Effect.gen(function* () {
-      const cfg = yield* Effect.promise(() => AppRuntime.runPromise(Config.Service.use((svc) => svc.get())))
+it.instance(
+  "agent color parsed from project config",
+  () =>
+    Effect.gen(function* () {
+      const cfg = yield* Config.Service.use((svc) => svc.get())
       expect(cfg.agent?.["build"]?.color).toBe("#FFA500")
       expect(cfg.agent?.["plan"]?.color).toBe("primary")
-    }).pipe(provideInstance(dir))
-  }),
+    }),
+  {
+    git: true,
+    config: {
+      agent: {
+        build: { color: "#FFA500" },
+        plan: { color: "primary" },
+      },
+    },
+  },
 )
 
-it.live("Agent.get includes color from config", () =>
-  Effect.gen(function* () {
-    const dir = yield* tmpdirScoped()
-    yield* writeConfig(dir, {
-      plan: { color: "#A855F7" },
-      build: { color: "accent" },
-    })
-
-    yield* Effect.gen(function* () {
+it.instance(
+  "Agent.get includes color from config",
+  () =>
+    Effect.gen(function* () {
       const plan = yield* AgentSvc.Service.use((svc) => svc.get("plan"))
       expect(plan?.color).toBe("#A855F7")
       const build = yield* AgentSvc.Service.use((svc) => svc.get("build"))
       expect(build?.color).toBe("accent")
-    }).pipe(provideInstance(dir))
-  }),
+    }),
+  {
+    git: true,
+    config: {
+      agent: {
+        plan: { color: "#A855F7" },
+        build: { color: "accent" },
+      },
+    },
+  },
 )
 
 test("Color.hexToAnsiBold converts valid hex to ANSI", () => {


### PR DESCRIPTION
## Summary
- Migrate agent color config tests to `it.instance` with fixture-provided config.
- Remove AppRuntime/manual tmpdir config setup from the target test file.

## Tests
- `bun run test test/config/agent-color.test.ts`
- `bun typecheck`