### PR TITLE
test: migrate auth override plugin test

### DIFF
--- a/packages/opencode/test/plugin/auth-override.test.ts
+++ b/packages/opencode/test/plugin/auth-override.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
-import fs from "fs/promises"
 import { pathToFileURL } from "url"
 import { Effect, Layer } from "effect"
-import { provideTestInstance, tmpdir } from "../fixture/fixture"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { provideInstance, TestInstance, tmpdirScoped } from "../fixture/fixture"
 import { ProviderAuth } from "@/provider/auth"
 import { ProviderID } from "../../src/provider/schema"
 import { Plugin } from "@/plugin"
 import { Auth } from "@/auth"
 import { Bus } from "@/bus"
 import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+
+const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, AppFileSystem.defaultLayer))
 
 function layer(directory: string, plugins: string[]) {
   return ProviderAuth.layer.pipe(
@@ -37,13 +41,15 @@ function layer(directory: string, plugins: string[]) {
 }
 
 describe("plugin.auth-override", () => {
-  test("user plugin overrides built-in github-copilot auth", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const pluginDir = path.join(dir, ".opencode", "plugin")
-        await fs.mkdir(pluginDir, { recursive: true })
+  it.instance(
+    "user plugin overrides built-in github-copilot auth",
+    () =>
+      Effect.gen(function* () {
+        const tmp = yield* TestInstance
+        const fs = yield* AppFileSystem.Service
+        const pluginDir = path.join(tmp.directory, ".opencode", "plugin")
 
-        await Bun.write(
+        yield* fs.writeWithDirs(
           path.join(pluginDir, "custom-copilot-auth.ts"),
           [
             "export default {",
@@ -61,37 +67,26 @@ describe("plugin.auth-override", () => {
             "",
           ].join("\n"),
         )
-      },
-    })
 
-    await using plain = await tmpdir()
+        const plain = yield* tmpdirScoped({ git: true })
+        const plugin = pathToFileURL(path.join(pluginDir, "custom-copilot-auth.ts")).href
+        const methods = yield* ProviderAuth.Service.use((svc) => svc.methods()).pipe(
+          Effect.provide(layer(tmp.directory, [plugin])),
+        )
+        const plainMethods = yield* ProviderAuth.Service.use((svc) => svc.methods()).pipe(
+          Effect.provide(layer(plain, [])),
+          provideInstance(plain),
+        )
 
-    const plugin = pathToFileURL(path.join(tmp.path, ".opencode", "plugin", "custom-copilot-auth.ts")).href
-    const [methods, plainMethods] = await Promise.all([
-      provideTestInstance({
-        directory: tmp.path,
-        fn: async () => {
-          return Effect.runPromise(
-            ProviderAuth.Service.use((svc) => svc.methods()).pipe(Effect.provide(layer(tmp.path, [plugin]))),
-          )
-        },
+        const copilot = methods[ProviderID.make("github-copilot")]
+        expect(copilot).toBeDefined()
+        expect(copilot.length).toBe(1)
+        expect(copilot[0].label).toBe("Test Override Auth")
+        expect(plainMethods[ProviderID.make("github-copilot")][0].label).not.toBe("Test Override Auth")
       }),
-      provideTestInstance({
-        directory: plain.path,
-        fn: async () => {
-          return Effect.runPromise(
-            ProviderAuth.Service.use((svc) => svc.methods()).pipe(Effect.provide(layer(plain.path, []))),
-          )
-        },
-      }),
-    ])
-
-    const copilot = methods[ProviderID.make("github-copilot")]
-    expect(copilot).toBeDefined()
-    expect(copilot.length).toBe(1)
-    expect(copilot[0].label).toBe("Test Override Auth")
-    expect(plainMethods[ProviderID.make("github-copilot")][0].label).not.toBe("Test Override Auth")
-  }, 30000)
+    { git: true },
+    30000,
+  )
 })
 
 const file = path.join(import.meta.dir, "../../src/plugin/index.ts")


### PR DESCRIPTION
## Summary
- Migrates the plugin auth override test to the Effect-native test runner.
- Uses scoped temp instances and existing instance provisioning instead of Promise-style Effect.runPromise/provideTestInstance.

## Tests
- bun run test test/plugin/auth-override.test.ts
- bun typecheck