### PR TITLE
test(plugin): use noop dependency boundaries

### DIFF
--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -1,26 +1,43 @@
-import { afterAll, describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { describe, expect } from "bun:test"
+import { Effect, Layer, Option } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import path from "path"
 import { pathToFileURL } from "url"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config"
+import { Env } from "../../src/env"
+import { Plugin } from "../../src/plugin/index"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { NpmTest } from "../fake/npm"
 
-const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
-process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
-
-const { Plugin } = await import("../../src/plugin/index")
-const it = testEffect(Layer.mergeAll(Plugin.defaultLayer, CrossSpawnSpawner.defaultLayer))
-const systemHook = "experimental.chat.system.transform"
-
-afterAll(() => {
-  if (disableDefault === undefined) {
-    delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
-    return
-  }
-  process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disableDefault
+const emptyAccount = Layer.mock(Account.Service)({
+  active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
 })
+const emptyAuth = Layer.mock(Auth.Service)({
+  all: () => Effect.succeed({}),
+})
+const configLayer = Config.layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(Env.defaultLayer),
+  Layer.provide(emptyAuth),
+  Layer.provide(emptyAccount),
+  Layer.provide(NpmTest.noop),
+)
+const it = testEffect(
+  Layer.mergeAll(
+    Plugin.layer.pipe(Layer.provide(Bus.layer), Layer.provide(configLayer)),
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
+const systemHook = "experimental.chat.system.transform"
 
 function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
   return provideTmpdirInstance((dir) =>

--- a/packages/opencode/test/plugin/workspace-adapter.test.ts
+++ b/packages/opencode/test/plugin/workspace-adapter.test.ts
@@ -1,25 +1,46 @@
 import { afterAll, afterEach, describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Option } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import path from "path"
 import { pathToFileURL } from "url"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config"
+import { Env } from "../../src/env"
+import { Workspace } from "../../src/control-plane/workspace"
+import { Plugin } from "../../src/plugin/index"
+import { InstanceBootstrap } from "../../src/project/bootstrap-service"
+import { Instance } from "../../src/project/instance"
+import { InstanceStore } from "../../src/project/instance-store"
 import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { NpmTest } from "../fake/npm"
 
-const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
-process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
-
-const { Flag } = await import("@opencode-ai/core/flag/flag")
-const { Plugin } = await import("../../src/plugin/index")
-const { Workspace } = await import("../../src/control-plane/workspace")
-const { InstanceBootstrap } = await import("../../src/project/bootstrap")
-const { Instance } = await import("../../src/project/instance")
-const { InstanceStore } = await import("../../src/project/instance-store")
-const workspaceLayer = Workspace.defaultLayer.pipe(
-  Layer.provide(InstanceStore.defaultLayer),
-  Layer.provide(InstanceBootstrap.defaultLayer),
+const emptyAccount = Layer.mock(Account.Service)({
+  active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
+})
+const emptyAuth = Layer.mock(Auth.Service)({
+  all: () => Effect.succeed({}),
+})
+const configLayer = Config.layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(Env.defaultLayer),
+  Layer.provide(emptyAuth),
+  Layer.provide(emptyAccount),
+  Layer.provide(NpmTest.noop),
 )
-const it = testEffect(Layer.mergeAll(Plugin.defaultLayer, workspaceLayer, CrossSpawnSpawner.defaultLayer))
+const pluginLayer = Plugin.layer.pipe(Layer.provide(Bus.layer), Layer.provide(configLayer))
+const noopBootstrapLayer = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+const workspaceLayer = Workspace.defaultLayer.pipe(
+  Layer.provide(InstanceStore.defaultLayer.pipe(Layer.provide(noopBootstrapLayer))),
+)
+const it = testEffect(Layer.mergeAll(pluginLayer, workspaceLayer, CrossSpawnSpawner.defaultLayer))
 
 const experimental = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
 
@@ -30,12 +51,6 @@ afterEach(async () => {
 })
 
 afterAll(() => {
-  if (disableDefault === undefined) {
-    delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
-  } else {
-    process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disableDefault
-  }
-
   Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = experimental
 })
 


### PR DESCRIPTION
## Summary
- Replaces closed `Plugin.defaultLayer` in focused plugin tests with `Plugin.layer` plus a test config layer backed by `NpmTest.noop`.
- Keeps auth/account boundaries empty so plugin tests do not pay for unrelated account state.
- Replaces `InstanceBootstrap.defaultLayer` in the workspace adapter test with a noop bootstrap service, since the test only exercises plugin adapter registration and workspace creation.
- Removes redundant per-file `OPENCODE_DISABLE_DEFAULT_PLUGINS` mutation and returns these tests to static imports; `test/preload.ts` already owns test env setup.

## Why
These tests were already Effectified but still pulled in broad default layers. In CI, local file plugin tests could wait on config dependency installation or real bootstrap services unrelated to the assertions.

## Verification
- `bun run test -- test/plugin/workspace-adapter.test.ts test/plugin/trigger.test.ts`
- Repeated focused plugin tests 5 times in a row
- `bunx prettier --check packages/opencode/test/plugin/workspace-adapter.test.ts packages/opencode/test/plugin/trigger.test.ts`
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`