### PR TITLE
fix: serialize mcp-auth.json mutations with EffectFlock to prevent concurrent refresh token race

### DIFF
--- a/packages/opencode/src/mcp/auth.ts
+++ b/packages/opencode/src/mcp/auth.ts
@@ -3,6 +3,7 @@ import z from "zod"
 import { Global } from "@opencode-ai/core/global"
 import { Effect, Layer, Context } from "effect"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 
 export const Tokens = z.object({
   accessToken: z.string(),
@@ -30,6 +31,7 @@ export const Entry = z.object({
 export type Entry = z.infer<typeof Entry>
 
 const filepath = path.join(Global.Path.data, "mcp-auth.json")
+const lockKey = `mcp-auth:${filepath}`
 
 export interface Interface {
   readonly all: () => Effect.Effect<Record<string, Entry>>
@@ -38,7 +40,9 @@ export interface Interface {
   readonly set: (mcpName: string, entry: Entry, serverUrl?: string) => Effect.Effect<void>
   readonly remove: (mcpName: string) => Effect.Effect<void>
   readonly updateTokens: (mcpName: string, tokens: Tokens, serverUrl?: string) => Effect.Effect<void>
+  readonly clearTokens: (mcpName: string) => Effect.Effect<void>
   readonly updateClientInfo: (mcpName: string, clientInfo: ClientInfo, serverUrl?: string) => Effect.Effect<void>
+  readonly clearClientInfo: (mcpName: string) => Effect.Effect<void>
   readonly updateCodeVerifier: (mcpName: string, codeVerifier: string) => Effect.Effect<void>
   readonly clearCodeVerifier: (mcpName: string) => Effect.Effect<void>
   readonly updateOAuthState: (mcpName: string, oauthState: string) => Effect.Effect<void>
@@ -53,6 +57,7 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
+    const flock = yield* EffectFlock.Service
 
     const all = Effect.fn("McpAuth.all")(function* () {
       return yield* fs.readJson(filepath).pipe(
@@ -74,36 +79,64 @@ export const layer = Layer.effect(
       return entry
     })
 
+    // withFileLock wraps a mutation in the cross-process file lock and treats
+    // LockError as a defect so callers keep Effect<void, never, never> signatures.
+    const withFileLock = <A, E, R>(body: Effect.Effect<A, E, R>) =>
+      flock.withLock(body, lockKey).pipe(Effect.orDie)
+
+    // All mutations go through withFileLock, which holds the file lock across
+    // the read-modify-write so concurrent processes and fibers serialize.
     const set = Effect.fn("McpAuth.set")(function* (mcpName: string, entry: Entry, serverUrl?: string) {
-      const data = yield* all()
-      if (serverUrl) entry.serverUrl = serverUrl
-      yield* fs.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600).pipe(Effect.orDie)
+      yield* withFileLock(
+        Effect.gen(function* () {
+          const data = yield* all()
+          if (serverUrl) entry.serverUrl = serverUrl
+          yield* fs.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600).pipe(Effect.orDie)
+        }),
+      )
     })
 
     const remove = Effect.fn("McpAuth.remove")(function* (mcpName: string) {
-      const data = yield* all()
-      delete data[mcpName]
-      yield* fs.writeJson(filepath, data, 0o600).pipe(Effect.orDie)
+      yield* withFileLock(
+        Effect.gen(function* () {
+          const data = yield* all()
+          delete data[mcpName]
+          yield* fs.writeJson(filepath, data, 0o600).pipe(Effect.orDie)
+        }),
+      )
     })
 
     const updateField = <K extends keyof Entry>(field: K, spanName: string) =>
       Effect.fn(`McpAuth.${spanName}`)(function* (mcpName: string, value: NonNullable<Entry[K]>, serverUrl?: string) {
-        const entry = (yield* get(mcpName)) ?? {}
-        entry[field] = value
-        yield* set(mcpName, entry, serverUrl)
+        yield* withFileLock(
+          Effect.gen(function* () {
+            const data = yield* all()
+            const entry = data[mcpName] ?? {}
+            entry[field] = value
+            if (serverUrl) entry.serverUrl = serverUrl
+            yield* fs.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600).pipe(Effect.orDie)
+          }),
+        )
       })
 
     const clearField = <K extends keyof Entry>(field: K, spanName: string) =>
       Effect.fn(`McpAuth.${spanName}`)(function* (mcpName: string) {
-        const entry = yield* get(mcpName)
-        if (entry) {
-          delete entry[field]
-          yield* set(mcpName, entry)
-        }
+        yield* withFileLock(
+          Effect.gen(function* () {
+            const data = yield* all()
+            const entry = data[mcpName]
+            if (entry) {
+              delete entry[field]
+              yield* fs.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600).pipe(Effect.orDie)
+            }
+          }),
+        )
       })
 
     const updateTokens = updateField("tokens", "updateTokens")
+    const clearTokens = clearField("tokens", "clearTokens")
     const updateClientInfo = updateField("clientInfo", "updateClientInfo")
+    const clearClientInfo = clearField("clientInfo", "clearClientInfo")
     const updateCodeVerifier = updateField("codeVerifier", "updateCodeVerifier")
     const updateOAuthState = updateField("oauthState", "updateOAuthState")
     const clearCodeVerifier = clearField("codeVerifier", "clearCodeVerifier")
@@ -128,7 +161,9 @@ export const layer = Layer.effect(
       set,
       remove,
       updateTokens,
+      clearTokens,
       updateClientInfo,
+      clearClientInfo,
       updateCodeVerifier,
       clearCodeVerifier,
       updateOAuthState,
@@ -139,6 +174,9 @@ export const layer = Layer.effect(
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(AppFileSystem.defaultLayer))
+export const defaultLayer = layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+)
 
 export * as McpAuth from "./auth"

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -18,6 +18,7 @@ import { Installation } from "../installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { withTimeout } from "@/util/timeout"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { McpOAuthProvider } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
@@ -911,6 +912,7 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Bus.layer),
   Layer.provide(Config.defaultLayer),
   Layer.provide(CrossSpawnSpawner.defaultLayer),
+  Layer.provide(EffectFlock.defaultLayer),
   Layer.provide(AppFileSystem.defaultLayer),
 )
 

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -26,6 +26,11 @@ export interface McpOAuthCallbacks {
 }
 
 export class McpOAuthProvider implements OAuthClientProvider {
+  // Deduplicates concurrent in-process token refresh attempts. All callers
+  // that race to refresh share this single promise; when it settles the
+  // promise is cleared so the next expiry triggers a fresh refresh.
+  private _refreshPromise: Promise<void> | undefined
+
   constructor(
     private mcpName: string,
     private serverUrl: string,
@@ -116,7 +121,14 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await Effect.runPromise(
+    // If a refresh is already in progress (same process, concurrent callers),
+    // wait for it rather than firing a second write that could race.
+    if (this._refreshPromise) {
+      await this._refreshPromise
+      return
+    }
+
+    const save = Effect.runPromise(
       this.auth.updateTokens(
         this.mcpName,
         {
@@ -128,6 +140,12 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.serverUrl,
       ),
     )
+
+    this._refreshPromise = save.finally(() => {
+      this._refreshPromise = undefined
+    })
+
+    await this._refreshPromise
     log.info("saved oauth tokens", { mcpName: this.mcpName })
   }
 
@@ -171,22 +189,19 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
     log.info("invalidating credentials", { mcpName: this.mcpName, type })
-    const entry = await Effect.runPromise(this.auth.get(this.mcpName))
-    if (!entry) {
-      return
-    }
 
+    // Use the service's own atomic operations rather than a manual
+    // read-modify-write, which would race with concurrent saveTokens /
+    // saveClientInformation calls.
     switch (type) {
       case "all":
         await Effect.runPromise(this.auth.remove(this.mcpName))
         break
       case "client":
-        delete entry.clientInfo
-        await Effect.runPromise(this.auth.set(this.mcpName, entry))
+        await Effect.runPromise(this.auth.clearClientInfo(this.mcpName))
         break
       case "tokens":
-        delete entry.tokens
-        await Effect.runPromise(this.auth.set(this.mcpName, entry))
+        await Effect.runPromise(this.auth.clearTokens(this.mcpName))
         break
     }
   }


### PR DESCRIPTION

Multiple opencode tabs sharing the same OAuth MCP server would each independently fire a token refresh on 401, consuming the same single-use refresh token. Tabs that lost the race received invalid_grant, which caused the SDK to delete stored tokens and force a full re-auth.

- Wrap all McpAuth read-modify-write operations in EffectFlock so concurrent processes and fibers serialize on mcp-auth.json (cross-process fix)
- Add _refreshPromise deduplication to McpOAuthProvider.saveTokens so concurrent in-process callers share a single in-flight write (in-process fix)
- Replace invalidateCredentials manual read-modify-write with atomic clearTokens/clearClientInfo service operations to avoid clobbering a freshly written token
- Add RCA document describing root cause and recommended fixes

Closes anomalyco/opencode#21702

### Issue for this PR

Closes #

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
