### PR TITLE
fix(tui): insert selected skill into prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -587,12 +587,9 @@ export function Prompt(props: PromptProps) {
           dialog.replace(() => (
             <DialogSkill
               onSelect={(skill) => {
-                input.setText(`/${skill} `)
-                setStore("prompt", {
-                  input: `/${skill} `,
-                  parts: [],
-                })
-                input.gotoBufferEnd()
+                input.insertText(`/${skill}`)
+                setStore("prompt", "input", input.plainText)
+                syncExtmarksWithPromptParts()
               }}
             />
           ))


### PR DESCRIPTION
### Issue for this PR

Closes #18755

I've read in `CONTRIBUTING.md` that UI features should go through design review, but this issue drives me nuts and the fix is quite small. If you end up rejecting this for whatever reason, please fix it for me 😭

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Selecting a skill from the TUI skill picker replaces the entire prompt with `/<skill> `.

This changes the picker to insert `/<skill>` at the current cursor instead, without clearing existing prompt text.

### How did you verify your code works?

Manually verified. Also ran `bun run --cwd packages/opencode typecheck` and `bun run --cwd packages/opencode test test/cli/cmd/tui` just in case.

### Screenshots / recordings

https://github.com/user-attachments/assets/e3010aa1-a862-40e0-8222-5fb8cf73612d

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR