### PR TITLE
test: migrate session action route to effect runner

### DIFF
--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -1,28 +1,14 @@
-import { afterEach, describe, expect, mock, test } from "bun:test"
+import { afterEach, describe, expect, mock } from "bun:test"
 import { Effect } from "effect"
-import { Instance } from "../../src/project/instance"
-import { WithInstance } from "../../src/project/with-instance"
 import { Server } from "../../src/server/server"
 import { Session as SessionNs } from "@/session/session"
-import type { SessionID } from "../../src/session/schema"
 import * as Log from "@opencode-ai/core/util/log"
-import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
 void Log.init({ print: false })
 
-function run<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
-  return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
-}
-
-const svc = {
-  ...SessionNs,
-  create(input?: SessionNs.CreateInput) {
-    return run(SessionNs.Service.use((svc) => svc.create(input)))
-  },
-  remove(id: SessionID) {
-    return run(SessionNs.Service.use((svc) => svc.remove(id)))
-  },
-}
+const it = testEffect(SessionNs.defaultLayer)
 
 afterEach(async () => {
   mock.restore()
@@ -30,21 +16,26 @@ afterEach(async () => {
 })
 
 describe("session action routes", () => {
-  test("abort route returns success", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await WithInstance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await svc.create({})
-        const app = Server.Default().app
+  it.instance("abort route returns success", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const session = yield* Effect.acquireRelease(
+        SessionNs.Service.use((svc) => svc.create({})),
+        (created) => SessionNs.Service.use((svc) => svc.remove(created.id)).pipe(Effect.ignore),
+      )
 
-        const res = await app.request(`/session/${session.id}/abort`, { method: "POST" })
+      const res = yield* Effect.promise(() =>
+        Promise.resolve(
+          Server.Default().app.request(`/session/${session.id}/abort`, {
+            method: "POST",
+            headers: { "x-opencode-directory": test.directory },
+          }),
+        ),
+      )
 
-        expect(res.status).toBe(200)
-        expect(await res.json()).toBe(true)
-
-        await svc.remove(session.id)
-      },
-    })
-  })
+      expect(res.status).toBe(200)
+      expect(yield* Effect.promise(() => res.json())).toBe(true)
+    }),
+    { git: true },
+  )
 })


### PR DESCRIPTION
## Summary
- Migrate `session-actions.test.ts` from Promise/WithInstance helpers to `testEffect` with `it.instance`.
- Keep session setup and cleanup inside the Effect test body with scoped acquisition.

## Tests
- `bun run test test/server/session-actions.test.ts`
- `bun typecheck`