### PR TITLE
test: migrate app runtime logger effect tests

### DIFF
--- a/packages/opencode/test/effect/app-runtime-logger.test.ts
+++ b/packages/opencode/test/effect/app-runtime-logger.test.ts
@@ -1,12 +1,13 @@
 import { expect } from "bun:test"
-import { Context, Effect, Layer, Logger } from "effect"
+import { Context, Deferred, Effect, Fiber, Layer, Logger } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import { AppRuntime } from "../../src/effect/app-runtime"
+import { AppLayer } from "../../src/effect/app-runtime"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
-import { makeRuntime } from "../../src/effect/run-service"
-import { provideInstance, tmpdirScoped } from "../fixture/fixture"
+import * as Observability from "@opencode-ai/core/effect/observability"
+import { attach } from "../../src/effect/run-service"
+import { TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(CrossSpawnSpawner.defaultLayer)
@@ -35,17 +36,8 @@ it.live("makeRuntime installs EffectLogger through Observability.layer", () =>
       }),
     )
 
-    const current = yield* Effect.promise(() => makeRuntime(Dummy, layer).runPromise((svc) => svc.current()))
-
-    expect(current.effectLogger).toBe(true)
-    expect(current.defaultLogger).toBe(false)
-  }),
-)
-
-it.live("AppRuntime also installs EffectLogger through Observability.layer", () =>
-  Effect.gen(function* () {
-    const current = yield* Effect.promise(() =>
-      AppRuntime.runPromise(Effect.map(Effect.service(Logger.CurrentLoggers), check)),
+    const current = yield* Dummy.use((svc) => svc.current()).pipe(
+      Effect.provide(Layer.provideMerge(layer, Observability.layer)),
     )
 
     expect(current.effectLogger).toBe(true)
@@ -53,46 +45,61 @@ it.live("AppRuntime also installs EffectLogger through Observability.layer", () 
   }),
 )
 
-it.live("AppRuntime attaches InstanceRef from ALS", () =>
+it.live("AppLayer also installs EffectLogger through Observability.layer", () =>
   Effect.gen(function* () {
-    const dir = yield* tmpdirScoped({ git: true })
-    const current = yield* Effect.promise(() =>
-      AppRuntime.runPromise(
-        Effect.gen(function* () {
-          return (yield* InstanceRef)?.directory
-        }),
-      ),
-    ).pipe(provideInstance(dir))
+    const current = yield* Effect.map(Effect.service(Logger.CurrentLoggers), check).pipe(Effect.provide(AppLayer))
 
-    expect(current).toBe(dir)
+    expect(current.effectLogger).toBe(true)
+    expect(current.defaultLogger).toBe(false)
   }),
 )
 
-it.live("EffectBridge preserves logger and instance context across async boundaries", () =>
-  Effect.gen(function* () {
-    const dir = yield* tmpdirScoped({ git: true })
-    const result = yield* Effect.promise(() =>
-      AppRuntime.runPromise(
+it.instance(
+  "attach preserves InstanceRef from the current fiber context",
+  () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const current = yield* attach(
         Effect.gen(function* () {
-          const bridge = yield* EffectBridge.make()
-          return yield* Effect.promise(() =>
-            Promise.resolve().then(() =>
-              bridge.promise(
-                Effect.gen(function* () {
-                  return {
-                    directory: (yield* InstanceRef)?.directory,
-                    ...check(yield* Effect.service(Logger.CurrentLoggers)),
-                  }
-                }),
-              ),
-            ),
-          )
+          return (yield* InstanceRef)?.directory
         }),
-      ),
-    ).pipe(provideInstance(dir))
+      )
 
-    expect(result.directory).toBe(dir)
-    expect(result.effectLogger).toBe(true)
-    expect(result.defaultLogger).toBe(false)
-  }),
+      expect(current).toBe(test.directory)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "EffectBridge preserves logger and instance context across async boundaries",
+  () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const bridge = yield* EffectBridge.make()
+      const started = yield* Deferred.make<void>()
+
+      const fiber = yield* Effect.gen(function* () {
+        yield* Deferred.succeed(started, undefined)
+        return yield* Effect.promise(() =>
+          Promise.resolve().then(() =>
+            bridge.promise(
+              Effect.gen(function* () {
+                return {
+                  directory: (yield* InstanceRef)?.directory,
+                  ...check(yield* Effect.service(Logger.CurrentLoggers)),
+                }
+              }),
+            ),
+          ),
+        )
+      }).pipe(Effect.forkScoped)
+
+      yield* Deferred.await(started)
+      const result = yield* Fiber.join(fiber)
+
+      expect(result.directory).toBe(test.directory)
+      expect(result.effectLogger).toBe(true)
+      expect(result.defaultLogger).toBe(false)
+    }).pipe(Effect.provide(Observability.layer)),
+  { git: true },
 )


### PR DESCRIPTION
## Summary
- Migrates `app-runtime-logger.test.ts` away from Promise runtime helpers to Effect-native test runner patterns.
- Uses explicit scoped layers and `it.instance` for instance-context assertions.

## Tests
- `bun run test test/effect/app-runtime-logger.test.ts`
- `bun typecheck`