### PR TITLE
test(worktree): use timeoutOrElse for ready wait

### DIFF
--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -29,11 +29,10 @@ const waitReady = Effect.fn("WorktreeTest.waitReady")(function* () {
   yield* Effect.addFinalizer(() => Effect.sync(() => GlobalBus.off("event", on)))
 
   return Deferred.await(ready).pipe(
-    Effect.race(
-      Effect.sleep("10 seconds").pipe(
-        Effect.flatMap(() => Effect.fail(new Error("timed out waiting for worktree.ready"))),
-      ),
-    ),
+    Effect.timeoutOrElse({
+      duration: "10 seconds",
+      orElse: () => Effect.fail(new Error("timed out waiting for worktree.ready")),
+    }),
   )
 })
 


### PR DESCRIPTION
## Summary
- replace the manual race/sleep timeout around worktree.ready with Effect.timeoutOrElse

## Test
- bun run test test/project/worktree.test.ts
- bun typecheck