### PR TITLE
feat: add manager agent session flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@tsconfig/bun": "catalog:",
         "@types/mime-types": "3.0.1",
         "@typescript/native-preview": "catalog:",
+        "electron": "42.0.1",
         "glob": "13.0.5",
         "husky": "9.1.7",
         "oxlint": "1.60.0",
@@ -1089,7 +1090,7 @@
 
     "@electron/fuses": ["@electron/fuses@1.8.0", "", { "dependencies": { "chalk": "^4.1.1", "fs-extra": "^9.0.1", "minimist": "^1.2.5" }, "bin": { "electron-fuses": "dist/bin.js" } }, "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw=="],
 
-    "@electron/get": ["@electron/get@2.0.3", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ=="],
+    "@electron/get": ["@electron/get@5.0.0", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^3.0.0", "graceful-fs": "^4.2.11", "progress": "^2.0.3", "semver": "^7.6.3", "sumchecker": "^3.0.1" }, "optionalDependencies": { "undici": "^7.24.4" } }, "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA=="],
 
     "@electron/notarize": ["@electron/notarize@2.5.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.1", "promise-retry": "^2.0.1" } }, "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A=="],
 
@@ -2197,7 +2198,7 @@
 
     "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }, "sha512-7JjjA49VGNOsMRI8QRUhVudZmv0CnJ18SliSgK1ojszs/c3ijftgVkzvXdkSLN4miDTzbkXewf65D6ZBo6W+GQ=="],
+    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
@@ -3041,7 +3042,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@41.2.1", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-teeRThiYGTPKf/2yOW7zZA1bhb91KEQ4yLBPOg7GxpmnkLFLugKgQaAKOrCgdzwsXh/5mFIfmkm+4+wACJKwaA=="],
+    "electron": ["electron@42.0.1", "", { "dependencies": { "@electron/get": "^5.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg=="],
 
     "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
 
@@ -3089,7 +3090,7 @@
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+    "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
     "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
@@ -5433,10 +5434,6 @@
 
     "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
     "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
@@ -5588,6 +5585,8 @@
     "@openauthjs/openauth/jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
 
     "@opencode-ai/desktop/@actions/artifact": ["@actions/artifact@4.0.0", "", { "dependencies": { "@actions/core": "^1.10.0", "@actions/github": "^6.0.1", "@actions/http-client": "^2.1.0", "@azure/core-http": "^3.0.5", "@azure/storage-blob": "^12.15.0", "@octokit/core": "^5.2.1", "@octokit/plugin-request-log": "^1.0.4", "@octokit/plugin-retry": "^3.0.9", "@octokit/request": "^8.4.1", "@octokit/request-error": "^5.1.1", "@protobuf-ts/plugin": "^2.2.3-alpha.1", "archiver": "^7.0.1", "jwt-decode": "^3.1.2", "unzip-stream": "^0.3.1" } }, "sha512-HCc2jMJRAfviGFAh0FsOR/jNfWhirxl7W6z8zDtttt0GltwxBLdEIjLiweOPFl9WbyJRW1VWnPUSAixJqcWUMQ=="],
+
+    "@opencode-ai/desktop/electron": ["electron@41.2.1", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-teeRThiYGTPKf/2yOW7zZA1bhb91KEQ4yLBPOg7GxpmnkLFLugKgQaAKOrCgdzwsXh/5mFIfmkm+4+wACJKwaA=="],
 
     "@opencode-ai/desktop/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
@@ -5867,8 +5866,6 @@
 
     "conf/dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
-    "conf/env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
-
     "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "crc/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
@@ -5894,8 +5891,6 @@
     "editorconfig/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "electron/@types/node": ["@types/node@22.13.9", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw=="],
 
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -6004,6 +5999,8 @@
     "mssql/tedious": ["tedious@18.6.2", "", { "dependencies": { "@azure/core-auth": "^1.7.2", "@azure/identity": "^4.2.1", "@azure/keyvault-keys": "^4.4.0", "@js-joda/core": "^5.6.1", "@types/node": ">=18", "bl": "^6.0.11", "iconv-lite": "^0.6.3", "js-md4": "^0.3.2", "native-duplexpair": "^1.0.0", "sprintf-js": "^1.1.3" } }, "sha512-g7jC56o3MzLkE3lHkaFe2ZdOVFBahq5bsB60/M4NYUbocw/MCrS89IOEQUFr+ba6pb8ZHczZ/VqCyYeYq0xBAg=="],
 
     "nitro/h3": ["h3@2.0.1-rc.5", "", { "dependencies": { "rou3": "^0.7.9", "srvx": "^0.9.1" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"] }, "sha512-qkohAzCab0nLzXNm78tBjZDvtKMTmtygS8BJLT3VPczAQofdqlFXDPkXdLMJN4r05+xqneG8snZJ0HgkERCZTg=="],
+
+    "node-gyp/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "node-gyp-build-optional-packages/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -6453,9 +6450,9 @@
 
     "@electron/fuses/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
-    "@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
     "@electron/notarize/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+
+    "@electron/rebuild/node-gyp/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "@electron/rebuild/node-gyp/make-fetch-happen": ["make-fetch-happen@14.0.3", "", { "dependencies": { "@npmcli/agent": "^3.0.0", "cacache": "^19.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ=="],
 
@@ -6663,6 +6660,10 @@
 
     "@opencode-ai/desktop/@actions/artifact/@actions/http-client": ["@actions/http-client@2.2.3", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^5.25.4" } }, "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA=="],
 
+    "@opencode-ai/desktop/electron/@electron/get": ["@electron/get@2.0.3", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ=="],
+
+    "@opencode-ai/desktop/electron/@types/node": ["@types/node@22.13.9", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw=="],
+
     "@opencode-ai/llm/@smithy/eventstream-codec/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
 
     "@opencode-ai/web/@shikijs/transformers/@shikijs/core": ["@shikijs/core@3.20.0", "", { "dependencies": { "@shikijs/types": "3.20.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-f2ED7HYV4JEk827mtMDwe/yQ25pRiXZmtHjWF8uzZKuKiEsJR7Ce1nuQ+HhV9FzDcbIo4ObBCD9GPTzNuy9S1g=="],
@@ -6791,6 +6792,8 @@
 
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "app-builder-lib/@electron/get/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
     "app-builder-lib/@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -6844,8 +6847,6 @@
     "electron-builder/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "electron-winstaller/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "electron/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "esbuild-plugin-copy/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -7195,6 +7196,14 @@
 
     "@opencode-ai/desktop/@actions/artifact/@actions/http-client/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
+    "@opencode-ai/desktop/electron/@electron/get/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "@opencode-ai/desktop/electron/@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@opencode-ai/desktop/electron/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@opencode-ai/desktop/electron/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
     "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
     "@sentry/bundler-plugin-core/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -7358,6 +7367,8 @@
     "@electron/rebuild/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@jsx-email/cli/tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "@opencode-ai/desktop/electron/@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@tsconfig/bun": "catalog:",
     "@types/mime-types": "3.0.1",
     "@typescript/native-preview": "catalog:",
+    "electron": "42.0.1",
     "glob": "13.0.5",
     "husky": "9.1.7",
     "oxlint": "1.60.0",

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -9,7 +9,7 @@ import { Font } from "@opencode-ai/ui/font"
 import { Splash } from "@opencode-ai/ui/logo"
 import { ThemeProvider } from "@opencode-ai/ui/theme/context"
 import { MetaProvider } from "@solidjs/meta"
-import { type BaseRouterProps, Navigate, Route, Router } from "@solidjs/router"
+import { type BaseRouterProps, Navigate, Route, Router, useLocation } from "@solidjs/router"
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
 import { Effect } from "effect"
 import {
@@ -48,6 +48,7 @@ import { ErrorPage } from "./pages/error"
 import { useCheckServerHealth } from "./utils/server-health"
 
 const HomeRoute = lazy(() => import("@/pages/home"))
+const ManagerRoutePage = lazy(() => import("@/pages/manager"))
 const loadSession = () => import("@/pages/session")
 const Session = lazy(loadSession)
 const Loading = () => <div class="size-full" />
@@ -63,6 +64,12 @@ const SessionRoute = () => (
 )
 
 const SessionIndexRoute = () => <Navigate href="session" />
+
+const ManagerRoute = () => (
+  <ModelsProvider>
+    <ManagerRoutePage />
+  </ModelsProvider>
+)
 
 function UiI18nBridge(props: ParentProps) {
   const language = useLanguage()
@@ -128,13 +135,17 @@ function SessionProviders(props: ParentProps) {
 }
 
 function RouterRoot(props: ParentProps<{ appChildren?: JSX.Element }>) {
+  const location = useLocation()
+  const minimal = createMemo(() => location.pathname === "/manager")
   return (
-    <AppShellProviders>
-      {/*<Suspense fallback={<Loading />}>*/}
-      {props.appChildren}
-      {props.children}
-      {/*</Suspense>*/}
-    </AppShellProviders>
+    <Show when={!minimal()} fallback={<>{props.children}</>}>
+      <AppShellProviders>
+        {/*<Suspense fallback={<Loading />}>*/}
+        {props.appChildren}
+        {props.children}
+        {/*</Suspense>*/}
+      </AppShellProviders>
+    </Show>
   )
 }
 
@@ -315,6 +326,8 @@ export function AppInterface(props: {
                   root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
                 >
                   <Route path="/" component={HomeRoute} />
+                  <Route path="/classic" component={HomeRoute} />
+                  <Route path="/manager" component={ManagerRoute} />
                   <Route path="/:dir" component={DirectoryLayout}>
                     <Route path="/" component={SessionIndexRoute} />
                     <Route path="/session/:id?" component={SessionRoute} />

--- a/packages/app/src/pages/manager.tsx
+++ b/packages/app/src/pages/manager.tsx
@@ -1,0 +1,217 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2/client"
+import { Button } from "@opencode-ai/ui/button"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { createEffect, createResource, createSignal, For, onCleanup, Show } from "solid-js"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useModels } from "@/context/models"
+import { Identifier } from "@/utils/id"
+
+const managerSessionID = "ses_manager_agent"
+const managerTitle = "管理agent"
+const proxyStorageKey = "opencode.manager.proxy"
+
+type WithParts = {
+  info: Message
+  parts: Part[]
+}
+
+function partText(part: Part) {
+  if (part.type === "text") return part.text
+  return ""
+}
+
+function messageText(message: WithParts) {
+  return message.parts.map(partText).filter(Boolean).join("\n").trim()
+}
+
+function loadProxy() {
+  try {
+    return localStorage.getItem(proxyStorageKey) ?? ""
+  } catch {
+    return ""
+  }
+}
+
+function saveProxy(value: string) {
+  try {
+    localStorage.setItem(proxyStorageKey, value)
+  } catch {
+    return
+  }
+}
+
+export default function ManagerPage() {
+  const sdk = useGlobalSDK()
+  const models = useModels()
+  const [proxy, setProxy] = createSignal(loadProxy())
+  const [draft, setDraft] = createSignal("")
+  const [selected, setSelected] = createSignal("")
+  const [error, setError] = createSignal("")
+  const [sending, setSending] = createSignal(false)
+
+  const modelOptions = () =>
+    models
+      .list()
+      .filter((model) => models.visible({ providerID: model.provider.id, modelID: model.id }))
+      .map((model) => ({
+        key: `${model.provider.id}/${model.id}`,
+        providerID: model.provider.id,
+        modelID: model.id,
+        label: `${model.provider.name} / ${model.name}`,
+      }))
+
+  createEffect(() => {
+    if (selected()) return
+    const first = modelOptions()[0]
+    if (first) setSelected(first.key)
+  })
+
+  const selectedModel = () => modelOptions().find((model) => model.key === selected())
+
+  const ensureSession = async () => {
+    await sdk.client.session.get({ sessionID: managerSessionID }).catch(async () => {
+      await sdk.client.session.create({ id: managerSessionID, title: managerTitle, agent: "build" })
+    })
+    return true
+  }
+
+  const [ready] = createResource(ensureSession)
+  const [messages, messagesAction] = createResource(
+    () => ready(),
+    async () => {
+      const result = await sdk.client.session.messages({ sessionID: managerSessionID })
+      return result.data ?? []
+    },
+    { initialValue: [] as WithParts[] },
+  )
+
+  const interval = setInterval(() => {
+    if (ready()) void messagesAction.refetch()
+  }, 1500)
+  onCleanup(() => clearInterval(interval))
+
+  const submit = async () => {
+    const text = draft().trim()
+    const model = selectedModel()
+    if (!text || !model || sending()) return
+    setSending(true)
+    setError("")
+    setDraft("")
+    try {
+      await sdk.client.session.promptAsync({
+        sessionID: managerSessionID,
+        agent: "build",
+        messageID: Identifier.ascending("message"),
+        model: {
+          providerID: model.providerID,
+          modelID: model.modelID,
+        },
+        parts: [
+          {
+            id: Identifier.ascending("part"),
+            type: "text",
+            text,
+          },
+        ],
+      })
+      await messagesAction.refetch()
+    } catch (err) {
+      setDraft(text)
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <main class="min-h-dvh bg-background-base text-text-base flex flex-col">
+      <header class="border-b border-border-weak-base px-4 py-3 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div class="flex flex-col gap-1">
+          <h1 class="text-18-medium text-text-strong">{managerTitle}</h1>
+          <p class="text-12-regular text-text-weak">固定会话：{managerSessionID}</p>
+        </div>
+        <div class="grid gap-2 md:grid-cols-[260px_340px] md:items-end">
+          <label class="flex flex-col gap-1 text-12-medium text-text-base">
+            代理地址
+            <TextField
+              value={proxy()}
+              onChange={setProxy}
+              onBlur={() => saveProxy(proxy())}
+              placeholder="http://127.0.0.1:7890"
+            />
+          </label>
+          <label class="flex flex-col gap-1 text-12-medium text-text-base">
+            模型
+            <select
+              class="h-9 rounded-md bg-surface-base border border-border-weak-base px-2 text-13-regular text-text-strong"
+              value={selected()}
+              onChange={(event) => setSelected(event.currentTarget.value)}
+            >
+              <For each={modelOptions()}>
+                {(model) => <option value={model.key}>{model.label}</option>}
+              </For>
+            </select>
+          </label>
+        </div>
+      </header>
+      <Show when={proxy()}>
+        <div class="px-4 py-2 bg-surface-base border-b border-border-weak-base text-12-regular text-text-weak">
+          代理地址已保存到本地设置。当前 sidecar 仍通过环境变量读取代理，重启生效入口待接入。
+        </div>
+      </Show>
+      <section class="flex-1 overflow-y-auto px-4 py-4">
+        <Show
+          when={!messages.loading}
+          fallback={<div class="text-14-regular text-text-weak">正在加载管理会话...</div>}
+        >
+          <div class="mx-auto max-w-3xl flex flex-col gap-3">
+            <Show when={messages().length > 0} fallback={<div class="text-14-regular text-text-weak">开始和管理 agent 对话。</div>}>
+              <For each={messages()}>
+                {(message) => {
+                  const text = messageText(message)
+                  return (
+                    <Show when={text}>
+                      <div
+                        class={`rounded-xl px-4 py-3 whitespace-pre-wrap text-14-regular leading-6 ${
+                          message.info.role === "user"
+                            ? "bg-surface-raised-base ml-8 text-text-strong"
+                            : "bg-surface-base mr-8 text-text-base"
+                        }`}
+                      >
+                        {text}
+                      </div>
+                    </Show>
+                  )
+                }}
+              </For>
+            </Show>
+          </div>
+        </Show>
+      </section>
+      <footer class="border-t border-border-weak-base p-4">
+        <div class="mx-auto max-w-3xl flex flex-col gap-2">
+          <Show when={error()}>
+            <div class="text-12-regular text-danger-base">{error()}</div>
+          </Show>
+          <div class="flex gap-2">
+            <TextField
+              value={draft()}
+              onChange={setDraft}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter" || event.shiftKey) return
+                event.preventDefault()
+                void submit()
+              }}
+              placeholder="输入要管理的事项..."
+              disabled={!ready() || sending()}
+              class="flex-1"
+            />
+            <Button onClick={() => void submit()} disabled={!draft().trim() || !selectedModel() || sending()}>
+              {sending() ? "发送中" : "发送"}
+            </Button>
+          </div>
+        </div>
+      </footer>
+    </main>
+  )
+}

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsgo -b",
     "predev": "bun ./scripts/predev.ts",
     "dev": "electron-vite dev",
+    "manager:dev": "bun ./scripts/manager-dev.ts",
     "prebuild": "bun ./scripts/prebuild.ts",
     "build": "electron-vite build",
     "preview": "electron-vite preview",

--- a/packages/desktop/scripts/manager-dev.ts
+++ b/packages/desktop/scripts/manager-dev.ts
@@ -1,0 +1,184 @@
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+
+const managerSessionID = "ses_manager_agent"
+const managerTitle = "管理agent"
+const port = Number(process.env.OPENCODE_MANAGER_DEV_PORT ?? 17686)
+
+const sidecarPath = join(process.env.APPDATA ?? join(process.env.USERPROFILE ?? "", "AppData", "Roaming"), "ai.opencode.desktop.dev", "sidecar.json")
+
+if (!existsSync(sidecarPath)) {
+  console.error(`sidecar connection file not found: ${sidecarPath}`)
+  console.error("Start dev:desktop once after this change, then run this command again.")
+  process.exit(1)
+}
+
+const sidecar = await Bun.file(sidecarPath).json() as { url: string; username?: string; password?: string }
+const auth = sidecar.password ? `Basic ${btoa(`${sidecar.username ?? "opencode"}:${sidecar.password}`)}` : undefined
+
+const html = String.raw`<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>管理agent</title>
+    <style>
+      * { box-sizing: border-box; }
+      body { margin: 0; font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #d8dee9; background: #101318; }
+      header { display: flex; gap: 12px; align-items: end; justify-content: space-between; padding: 14px 18px; border-bottom: 1px solid #2a2f3a; background: #151922; }
+      h1 { margin: 0; font-size: 18px; }
+      .muted { color: #8f98a8; font-size: 12px; }
+      label { display: grid; gap: 4px; color: #b8c0cc; font-size: 12px; }
+      select, input, button { border: 1px solid #343b49; border-radius: 8px; background: #10141c; color: #e8edf5; padding: 8px 10px; }
+      button { cursor: pointer; background: #2f6feb; border-color: #2f6feb; }
+      button:disabled { cursor: not-allowed; opacity: .55; }
+      main { height: calc(100vh - 142px); overflow: auto; padding: 18px; }
+      .list { max-width: 860px; margin: 0 auto; display: grid; gap: 12px; }
+      .msg { padding: 12px 14px; border-radius: 14px; white-space: pre-wrap; border: 1px solid #2a2f3a; background: #151922; }
+      .user { margin-left: 48px; background: #1d2636; }
+      .assistant { margin-right: 48px; }
+      footer { display: flex; gap: 10px; padding: 14px 18px; border-top: 1px solid #2a2f3a; background: #151922; }
+      #draft { flex: 1; }
+      #error { color: #ff7b72; padding: 0 18px 10px; min-height: 20px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        <h1>管理agent</h1>
+        <div class="muted">固定会话：ses_manager_agent · sidecar: <span id="sidecar"></span></div>
+      </div>
+      <label>模型<select id="model"></select></label>
+    </header>
+    <main><div id="messages" class="list"><div class="muted">正在加载...</div></div></main>
+    <div id="error"></div>
+    <footer>
+      <input id="draft" placeholder="输入要管理的事项..." />
+      <button id="send">发送</button>
+    </footer>
+    <script>
+      const managerSessionID = "ses_manager_agent"
+      const managerTitle = "管理agent"
+      const sidecar = document.getElementById("sidecar")
+      const messages = document.getElementById("messages")
+      const model = document.getElementById("model")
+      const draft = document.getElementById("draft")
+      const send = document.getElementById("send")
+      const error = document.getElementById("error")
+      sidecar.textContent = location.origin
+
+      const id = (prefix) => prefix + "_" + Date.now().toString(36) + Math.random().toString(36).slice(2).padEnd(18, "0")
+      const api = async (path, options = {}) => {
+        const res = await fetch("/api" + path, { ...options, headers: { "content-type": "application/json", ...(options.headers || {}) } })
+        if (!res.ok) throw new Error(await res.text() || res.statusText)
+        if (res.status === 204) return undefined
+        return res.json()
+      }
+      const data = (value) => value && "data" in value ? value.data : value
+      const partText = (part) => part.type === "text" ? part.text : ""
+      const messageText = (message) => (message.parts || []).map(partText).filter(Boolean).join("\n").trim()
+
+      async function ensureSession() {
+        try {
+          await api("/session/" + managerSessionID)
+        } catch {
+          await api("/session", { method: "POST", body: JSON.stringify({ id: managerSessionID, title: managerTitle, agent: "build" }) })
+        }
+      }
+
+      async function loadModels() {
+        const providers = data(await api("/provider")) || { all: [], connected: [] }
+        const connected = new Set(providers.connected || [])
+        const options = (providers.all || []).flatMap((provider) => {
+          if (!connected.has(provider.id)) return []
+          return Object.values(provider.models || {}).map((m) => ({ provider, model: m }))
+        })
+        model.innerHTML = options.map((item) => '<option value="' + item.provider.id + '/' + item.model.id + '">' + item.provider.name + ' / ' + item.model.name + '</option>').join("")
+      }
+
+      async function loadMessages() {
+        const list = data(await api("/session/" + managerSessionID + "/message")) || []
+        messages.innerHTML = list.length ? "" : '<div class="muted">开始和管理 agent 对话。</div>'
+        for (const message of list) {
+          const text = messageText(message)
+          if (!text) continue
+          const div = document.createElement("div")
+          div.className = "msg " + (message.info?.role === "user" ? "user" : "assistant")
+          div.textContent = text
+          messages.appendChild(div)
+        }
+      }
+
+      async function submit() {
+        const text = draft.value.trim()
+        const selected = model.value.split("/")
+        if (!text || selected.length !== 2) return
+        send.disabled = true
+        error.textContent = ""
+        draft.value = ""
+        try {
+          await api("/session/" + managerSessionID + "/prompt_async", {
+            method: "POST",
+            body: JSON.stringify({
+              agent: "build",
+              messageID: id("msg"),
+              model: { providerID: selected[0], modelID: selected[1] },
+              parts: [{ id: id("prt"), type: "text", text }],
+            }),
+          })
+          await loadMessages()
+        } catch (err) {
+          draft.value = text
+          error.textContent = err instanceof Error ? err.message : String(err)
+        } finally {
+          send.disabled = false
+        }
+      }
+
+      send.addEventListener("click", submit)
+      draft.addEventListener("keydown", (event) => { if (event.key === "Enter") submit() })
+      ;(async () => {
+        try {
+          await ensureSession()
+          await loadModels()
+          await loadMessages()
+          setInterval(() => loadMessages().catch(() => {}), 1500)
+        } catch (err) {
+          error.textContent = err instanceof Error ? err.message : String(err)
+        }
+      })()
+    </script>
+  </body>
+</html>`
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  async fetch(request) {
+    const url = new URL(request.url)
+    if (url.pathname === "/") return new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } })
+    if (!url.pathname.startsWith("/api/")) return new Response("not found", { status: 404 })
+
+    const target = new URL(url.pathname.slice(4) + url.search, sidecar.url)
+    const response = await fetch(target, {
+      method: request.method,
+      headers: {
+        ...(auth ? { authorization: auth } : {}),
+        "content-type": request.headers.get("content-type") ?? "application/json",
+      },
+      body: request.method === "GET" || request.method === "HEAD" ? undefined : await request.text(),
+    })
+    const headers = new Headers(response.headers)
+    headers.delete("content-encoding")
+    headers.delete("content-length")
+    return new Response(response.body, { status: response.status, statusText: response.statusText, headers })
+  },
+})
+
+console.log(`manager dev frontend: http://127.0.0.1:${server.port}`)
+console.log(`proxying sidecar: ${sidecar.url}`)
+
+const opener = process.platform === "win32" ? ["cmd", "/c", "start", "", `http://127.0.0.1:${server.port}`] : process.platform === "darwin" ? ["open", `http://127.0.0.1:${server.port}`] : ["xdg-open", `http://127.0.0.1:${server.port}`]
+Bun.spawn(opener, { stdout: "ignore", stderr: "ignore" })
+
+await new Promise(() => {})

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto"
 import { EventEmitter } from "node:events"
-import { existsSync, mkdirSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import * as http from "node:http"
 import { createServer } from "node:net"
 import { homedir, tmpdir } from "node:os"
@@ -281,6 +281,13 @@ const main = Effect.gen(function* () {
   const hostname = "127.0.0.1"
   const url = `http://${hostname}:${port}`
   const password = randomUUID()
+  if (!app.isPackaged) {
+    mkdirSync(app.getPath("userData"), { recursive: true })
+    writeFileSync(
+      join(app.getPath("userData"), "sidecar.json"),
+      JSON.stringify({ url, username: "opencode", password }, undefined, 2),
+    )
+  }
 
   const loadingTask = yield* Effect.gen(function* () {
     logger.log("sidecar connection started", { url })

--- a/packages/opencode/src/session/assemble-template.ts
+++ b/packages/opencode/src/session/assemble-template.ts
@@ -1,0 +1,516 @@
+import fs from "fs/promises"
+import path from "path"
+
+export const filename = "assemble.ts"
+export const schemaFilename = "assemble-schema.md"
+
+export const content = `// Runs before opencode converts messages to provider-specific model messages.
+// Edit this file to customize this session's context; changes apply on the next request.
+//
+// Call contract:
+// - input.sessionID: current session id, always starts with "ses".
+// - input.sessionDir: per-session data directory that contains this assemble.ts file.
+// - input.workspaceRoot: project workspace root.
+// - input.directory: current working directory for this request.
+// - input.step: current model step number; step === 1 is the first step for a user turn.
+// - input.session, input.agent, and input.model describe the current session, agent, and model.
+// - input.messages is MessageV2.WithParts[] after compaction filtering and reminder insertion.
+//
+// MessageV2.WithParts[] format:
+// - return an array; every item must be { info, parts }.
+// - info is MessageV2.Info, discriminated by info.role.
+// - parts is MessageV2.Part[], a list of typed content/tool/file/reasoning parts for that message.
+//
+// User message info shape:
+// - info.id: MessageID string, starts with "msg".
+// - info.sessionID: SessionID string, normally input.sessionID, starts with "ses".
+// - info.role: "user".
+// - info.time: { created: non-negative number }.
+// - info.agent: string.
+// - info.model: { providerID: string, modelID: string, variant?: string }.
+// - optional: format, summary, system, tools.
+//
+// Assistant message info shape:
+// - info.id: MessageID string, starts with "msg".
+// - info.sessionID: SessionID string, normally input.sessionID, starts with "ses".
+// - info.role: "assistant".
+// - info.time: { created: non-negative number, completed?: non-negative number }.
+// - required: parentID, modelID, providerID, mode, agent, path, cost, tokens.
+// - optional: error, summary, structured, variant, finish.
+//
+// Part shape:
+// - every part has id, sessionID, messageID, and type.
+// - part.id must be a PartID string starting with "prt".
+// - part.sessionID must be a SessionID string, normally input.sessionID.
+// - part.messageID must reference the containing message info.id.
+// - valid part.type values include text, tool, file, reasoning, step-start, step-finish,
+//   snapshot, patch, agent, subtask, retry, and compaction.
+// - text parts are { type: "text", text: string, synthetic?: boolean, ignored?: boolean,
+//   time?: { start: number, end?: number }, metadata?: object } plus the common ids.
+// - tool parts are { type: "tool", callID: string, tool: string, state: ToolState,
+//   metadata?: object } plus the common ids.
+// - file parts are { type: "file", mime: string, url: string, filename?: string,
+//   source?: object } plus the common ids.
+//
+// Return contract:
+// - return MessageV2.WithParts[] only.
+// - do not return provider messages like [{ role: "user", content: "..." }].
+// - do not return strings, plain parts, or objects without { info, parts }.
+// - new synthetic context should still be wrapped as a valid user or assistant message.
+// - invalid returns are ignored by opencode; the original input.messages is used instead.
+// - see assemble-schema.md in this session directory for the full schema reference.
+//
+export default async function assemble(input) {
+  const all = Array.isArray(input.messages) ? input.messages : []
+  return all
+}
+`
+
+export const schema = `# assemble.ts Schema Reference
+
+This file documents the input and return shape for the session-local assemble hook.
+The hook runs before opencode converts internal messages into provider-specific model messages.
+
+## Hook Signature
+
+\`\`\`ts
+export default async function assemble(input) {
+  return input.messages
+}
+\`\`\`
+
+\`assemble(input)\` may be sync or async. It must return \`MessageV2.WithParts[]\`.
+
+## Input
+
+\`\`\`ts
+type AssembleInput = {
+  sessionID: string
+  sessionDir: string
+  workspaceRoot: string
+  directory: string
+  step: number
+  messages: MessageV2.WithParts[]
+  session: SessionInfo
+  agent: { name: string }
+  model: { id: string; providerID: string }
+}
+\`\`\`
+
+- \`sessionID\` is the current session id and starts with \`ses\`.
+- \`sessionDir\` is the per-session data directory containing \`assemble.ts\` and this document.
+- \`workspaceRoot\` is the project workspace root.
+- \`directory\` is the current request directory.
+- \`step\` is the current model step; \`step === 1\` is the first step for a user turn.
+- \`messages\` is already filtered for compaction and includes opencode reminders inserted before assemble.
+
+## Return Value
+
+Return only this shape:
+
+\`\`\`ts
+type WithParts = {
+  info: UserInfo | AssistantInfo
+  parts: Part[]
+}
+\`\`\`
+
+The returned value must be an array:
+
+\`\`\`ts
+MessageV2.WithParts[]
+\`\`\`
+
+Do not return provider messages:
+
+\`\`\`ts
+// Invalid
+return [{ role: "user", content: "hello" }]
+\`\`\`
+
+Do not return strings, raw parts, or objects missing \`{ info, parts }\`.
+If the return value is invalid, opencode ignores it, uses the original \`input.messages\`, and adds a temporary reminder telling the agent that \`assemble.ts\` is invalid.
+
+## IDs
+
+IDs are strings with required prefixes:
+
+\`\`\`ts
+type SessionID = string // starts with "ses"
+type MessageID = string // starts with "msg"
+type PartID = string    // starts with "prt"
+\`\`\`
+
+When creating a synthetic message:
+
+- \`info.id\` must start with \`msg\`.
+- every \`part.id\` must start with \`prt\`.
+- every \`part.messageID\` must equal the containing \`info.id\`.
+- every \`info.sessionID\` and \`part.sessionID\` should normally equal \`input.sessionID\`.
+
+## Message Info
+
+\`info\` is a discriminated union. Use \`info.role\` to know which shape is valid.
+
+### UserInfo
+
+\`\`\`ts
+type UserInfo = {
+  id: MessageID
+  sessionID: SessionID
+  role: "user"
+  time: {
+    created: number
+  }
+  agent: string
+  model: {
+    providerID: string
+    modelID: string
+    variant?: string
+  }
+  format?:
+    | { type: "text" }
+    | { type: "json_schema"; schema: object; retryCount?: number }
+  summary?: {
+    title?: string
+    body?: string
+    diffs: unknown[]
+  }
+  system?: string
+  tools?: Record<string, boolean>
+}
+\`\`\`
+
+### AssistantInfo
+
+\`\`\`ts
+type AssistantInfo = {
+  id: MessageID
+  sessionID: SessionID
+  role: "assistant"
+  time: {
+    created: number
+    completed?: number
+  }
+  parentID: MessageID
+  modelID: string
+  providerID: string
+  mode: string
+  agent: string
+  path: {
+    cwd: string
+    root: string
+  }
+  cost: number
+  tokens: {
+    total?: number
+    input: number
+    output: number
+    reasoning: number
+    cache: {
+      read: number
+      write: number
+    }
+  }
+  error?: unknown
+  summary?: boolean
+  structured?: unknown
+  variant?: string
+  finish?: string
+}
+\`\`\`
+
+## Parts
+
+Every part has common IDs:
+
+\`\`\`ts
+type PartBase = {
+  id: PartID
+  sessionID: SessionID
+  messageID: MessageID
+}
+\`\`\`
+
+\`Part\` is one of the following \`type\` values:
+
+- \`text\`
+- \`subtask\`
+- \`reasoning\`
+- \`file\`
+- \`tool\`
+- \`step-start\`
+- \`step-finish\`
+- \`snapshot\`
+- \`patch\`
+- \`agent\`
+- \`retry\`
+- \`compaction\`
+
+### TextPart
+
+\`\`\`ts
+type TextPart = PartBase & {
+  type: "text"
+  text: string
+  synthetic?: boolean
+  ignored?: boolean
+  time?: {
+    start: number
+    end?: number
+  }
+  metadata?: Record<string, unknown>
+}
+\`\`\`
+
+Use \`synthetic: true\` for temporary context that was not directly typed by the user.
+
+### ReasoningPart
+
+\`\`\`ts
+type ReasoningPart = PartBase & {
+  type: "reasoning"
+  text: string
+  metadata?: Record<string, unknown>
+  time: {
+    start: number
+    end?: number
+  }
+}
+\`\`\`
+
+### FilePart
+
+\`\`\`ts
+type FilePart = PartBase & {
+  type: "file"
+  mime: string
+  filename?: string
+  url: string
+  source?: FileSource | SymbolSource | ResourceSource
+}
+\`\`\`
+
+\`\`\`ts
+type FileSource = {
+  type: "file"
+  path: string
+  text: { value: string; start: number; end: number }
+}
+
+type SymbolSource = {
+  type: "symbol"
+  path: string
+  range: unknown
+  name: string
+  kind: number
+  text: { value: string; start: number; end: number }
+}
+
+type ResourceSource = {
+  type: "resource"
+  clientName: string
+  uri: string
+  text: { value: string; start: number; end: number }
+}
+\`\`\`
+
+### ToolPart
+
+\`\`\`ts
+type ToolPart = PartBase & {
+  type: "tool"
+  callID: string
+  tool: string
+  state: ToolState
+  metadata?: Record<string, unknown>
+}
+\`\`\`
+
+\`\`\`ts
+type ToolState =
+  | { status: "pending"; input: Record<string, unknown>; raw: string }
+  | {
+      status: "running"
+      input: Record<string, unknown>
+      title?: string
+      metadata?: Record<string, unknown>
+      time: { start: number }
+    }
+  | {
+      status: "completed"
+      input: Record<string, unknown>
+      output: string
+      title: string
+      metadata: Record<string, unknown>
+      time: { start: number; end: number; compacted?: number }
+      attachments?: FilePart[]
+    }
+  | {
+      status: "error"
+      input: Record<string, unknown>
+      error: string
+      metadata?: Record<string, unknown>
+      time: { start: number; end: number }
+    }
+\`\`\`
+
+### StepStartPart
+
+\`\`\`ts
+type StepStartPart = PartBase & {
+  type: "step-start"
+  snapshot?: string
+}
+\`\`\`
+
+### StepFinishPart
+
+\`\`\`ts
+type StepFinishPart = PartBase & {
+  type: "step-finish"
+  reason: string
+  snapshot?: string
+  cost: number
+  tokens: {
+    total?: number
+    input: number
+    output: number
+    reasoning: number
+    cache: {
+      read: number
+      write: number
+    }
+  }
+}
+\`\`\`
+
+### SnapshotPart
+
+\`\`\`ts
+type SnapshotPart = PartBase & {
+  type: "snapshot"
+  snapshot: string
+}
+\`\`\`
+
+### PatchPart
+
+\`\`\`ts
+type PatchPart = PartBase & {
+  type: "patch"
+  hash: string
+  files: string[]
+}
+\`\`\`
+
+### AgentPart
+
+\`\`\`ts
+type AgentPart = PartBase & {
+  type: "agent"
+  name: string
+  source?: {
+    value: string
+    start: number
+    end: number
+  }
+}
+\`\`\`
+
+### SubtaskPart
+
+\`\`\`ts
+type SubtaskPart = PartBase & {
+  type: "subtask"
+  prompt: string
+  description: string
+  agent: string
+  model?: {
+    providerID: string
+    modelID: string
+  }
+  command?: string
+}
+\`\`\`
+
+### RetryPart
+
+\`\`\`ts
+type RetryPart = PartBase & {
+  type: "retry"
+  attempt: number
+  error: unknown
+  time: {
+    created: number
+  }
+}
+\`\`\`
+
+### CompactionPart
+
+\`\`\`ts
+type CompactionPart = PartBase & {
+  type: "compaction"
+  auto: boolean
+  overflow?: boolean
+  tail_start_id?: MessageID
+}
+\`\`\`
+
+## Minimal Synthetic Text Example
+
+\`\`\`ts
+export default async function assemble(input) {
+  const latest = [...input.messages].reverse().find((msg) => msg.info.role === "user")
+  const created = Date.now()
+  const id = "msg_assemble_" + created
+
+  return [
+    ...input.messages,
+    {
+      info: {
+        id,
+        sessionID: input.sessionID,
+        role: "user",
+        time: { created },
+        agent: latest?.info.role === "user" ? latest.info.agent : input.agent.name,
+        model:
+          latest?.info.role === "user"
+            ? latest.info.model
+            : { providerID: input.model.providerID, modelID: input.model.id },
+      },
+      parts: [
+        {
+          id: "prt_assemble_" + created,
+          sessionID: input.sessionID,
+          messageID: id,
+          type: "text",
+          synthetic: true,
+          text: "Temporary context for this request.",
+        },
+      ],
+    },
+  ]
+}
+\`\`\`
+
+## Safe Defaults
+
+- To keep normal behavior, return \`input.messages\` unchanged.
+- To add temporary text context, create a synthetic user message with a text part.
+- Prefer preserving existing messages instead of rebuilding assistant/tool history unless necessary.
+- If you filter messages, keep related assistant tool parts together so the model sees coherent history.
+`
+
+export async function ensure(dir: string) {
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, filename), content, { flag: "wx" }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+  })
+  await fs.writeFile(path.join(dir, schemaFilename), schema, { flag: "wx" }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+  })
+}
+
+export * as SessionAssembleTemplate from "./assemble-template"

--- a/packages/opencode/src/session/assemble.test.ts
+++ b/packages/opencode/src/session/assemble.test.ts
@@ -1,0 +1,156 @@
+import { mkdtemp } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Global } from "@opencode-ai/core/global"
+import { InstanceRef } from "@/effect/instance-ref"
+import { SessionAssemble } from "./assemble"
+import type { Agent } from "@/agent/agent"
+import type { Provider } from "@/provider/provider"
+import { ProjectID } from "@/project/schema"
+import { ModelID, ProviderID } from "@/provider/schema"
+import type { Session } from "./session"
+import { MessageID, PartID, SessionID } from "./schema"
+import type { MessageV2 } from "./message-v2"
+
+const sid = SessionID.descending("ses_assemble_test")
+const providerID = ProviderID.make("provider")
+const modelID = ModelID.make("model")
+
+const session = {
+  id: sid,
+  slug: "assemble-test",
+  projectID: ProjectID.make("prj_assemble_test"),
+  workspaceID: "wrk_assemble_test",
+  directory: tmpdir(),
+  title: "Assemble Test",
+  version: "test",
+  time: {
+    created: 1,
+    updated: 1,
+  },
+} as Session.Info
+
+const agent = {
+  name: "build",
+  mode: "primary",
+  permission: [],
+  options: {},
+} as Agent.Info
+
+const model = {
+  id: modelID,
+  providerID,
+} as Provider.Model
+
+const messages = [
+  {
+    info: {
+      id: MessageID.ascending("msg_user"),
+      sessionID: session.id,
+      role: "user",
+      time: { created: 1 },
+      agent: agent.name,
+      model: { providerID, modelID },
+    },
+    parts: [
+      {
+        id: PartID.ascending("prt_user"),
+        sessionID: session.id,
+        messageID: MessageID.ascending("msg_user"),
+        type: "text",
+        text: "hello",
+      },
+    ],
+  },
+] satisfies MessageV2.WithParts[]
+
+async function run(script: string) {
+  const root = await mkdtemp(path.join(tmpdir(), "opencode-assemble-run-"))
+  const dir = path.join(Global.Path.data, "session", session.id)
+  await Bun.$`rm -rf ${dir}`.quiet()
+  await Bun.$`mkdir -p ${dir}`.quiet()
+  await Bun.write(path.join(dir, "assemble.ts"), script)
+  return await Effect.runPromise(
+    SessionAssemble.run({ session, agent, model, step: 1, messages }).pipe(
+      Effect.provideService(InstanceRef, {
+        directory: root,
+        worktree: root,
+        project: {
+          id: session.projectID,
+          worktree: root,
+          time: { created: 1, updated: 1 },
+          sandboxes: [],
+        },
+      }),
+    ),
+  )
+}
+
+test("assemble run returns script messages when output has internal message shape", async () => {
+  const result = await run(`export default async function assemble(input) {
+  return input.messages.concat({
+    info: {
+      id: "msg_extra",
+      sessionID: input.sessionID,
+      role: "user",
+      time: { created: 2 },
+      agent: input.agent.name,
+      model: { providerID: input.model.providerID, modelID: input.model.id },
+    },
+    parts: [{
+      id: "prt_extra",
+      sessionID: input.sessionID,
+      messageID: "msg_extra",
+      type: "text",
+      synthetic: true,
+      text: "extra context",
+    }],
+  })
+}`)
+
+  expect(result).toHaveLength(2)
+  expect(result.at(-1)?.parts[0]).toMatchObject({ text: "extra context", synthetic: true })
+})
+
+function text(part: MessageV2.Part) {
+  if (part.type === "text") return part.text
+  return ""
+}
+
+test("assemble run falls back and adds reminder when script throws", async () => {
+  const result = await run(`export default async function assemble() {
+  throw new Error("broken")
+}`)
+
+  expect(result).toHaveLength(2)
+  expect(result[0]).toEqual(messages[0])
+  expect(result.at(-1)?.parts[0]).toMatchObject({
+    type: "text",
+    synthetic: true,
+  })
+  expect(text(result.at(-1)!.parts[0])).toContain("execution error")
+})
+
+test("assemble run falls back and adds reminder when script returns provider messages", async () => {
+  const result = await run(`export default async function assemble() {
+  return [{ role: "user", content: "provider shape is invalid here" }]
+}`)
+
+  expect(result).toHaveLength(2)
+  expect(result[0]).toEqual(messages[0])
+  expect(text(result.at(-1)!.parts[0])).toContain("invalid return value")
+})
+
+test("assemble run recovers after invalid script is replaced", async () => {
+  const first = await run(`export default async function assemble() {
+  return "bad"
+}`)
+  const second = await run(`export default async function assemble(input) {
+  return input.messages
+}`)
+
+  expect(text(first.at(-1)!.parts[0])).toContain("invalid return value")
+  expect(second).toEqual(messages)
+})

--- a/packages/opencode/src/session/assemble.ts
+++ b/packages/opencode/src/session/assemble.ts
@@ -1,0 +1,137 @@
+import path from "path"
+import * as Log from "@opencode-ai/core/util/log"
+import { Effect } from "effect"
+import { InstanceState } from "@/effect/instance-state"
+import { Agent } from "@/agent/agent"
+import { Provider } from "@/provider/provider"
+import { MessageV2 } from "./message-v2"
+import { Session } from "./session"
+import { MessageID, PartID } from "./schema"
+import { SessionAssembleTemplate } from "./assemble-template"
+import { loadScriptDefault } from "./script"
+
+const log = Log.create({ service: "session.assemble" })
+
+export interface Input {
+  sessionID: string
+  sessionDir: string
+  workspaceRoot: string
+  directory: string
+  step: number
+  messages: MessageV2.WithParts[]
+  session: Session.Info
+  agent: {
+    name: string
+  }
+  model: {
+    id: string
+    providerID: string
+  }
+}
+
+function valid(input: unknown): input is MessageV2.WithParts[] {
+  return (
+    Array.isArray(input) &&
+    input.every((msg) => {
+      if (!msg || typeof msg !== "object") return false
+      const value = msg as { info?: { role?: unknown }; parts?: unknown }
+      return (value.info?.role === "user" || value.info?.role === "assistant") && Array.isArray(value.parts)
+    })
+  )
+}
+
+function fallback(input: {
+  session: Session.Info
+  agent: Agent.Info
+  model: Provider.Model
+  messages: MessageV2.WithParts[]
+  reason: string
+}) {
+  const messageID = MessageID.ascending()
+  return [
+    ...input.messages,
+    {
+      info: {
+        id: messageID,
+        sessionID: input.session.id,
+        role: "user",
+        time: {
+          created: Date.now(),
+        },
+        agent: input.agent.name,
+        model: {
+          providerID: input.model.providerID,
+          modelID: input.model.id,
+        },
+      },
+      parts: [
+        {
+          id: PartID.ascending(),
+          sessionID: input.session.id,
+          messageID,
+          type: "text",
+          synthetic: true,
+          text: `<system-reminder>
+The session's custom assemble.ts context template failed (${input.reason}). The original messages are being used for this request.
+
+Tell the user that their custom assemble.ts is invalid and should be fixed in the session directory. This reminder is temporary and will disappear once assemble.ts loads, runs, and returns MessageV2.WithParts[] successfully.
+</system-reminder>`,
+        },
+      ],
+    },
+  ] satisfies MessageV2.WithParts[]
+}
+
+export const run = Effect.fn("SessionAssemble.run")(function* (input: {
+  session: Session.Info
+  agent: Agent.Info
+  model: Provider.Model
+  step: number
+  messages: MessageV2.WithParts[]
+}) {
+  const ctx = yield* InstanceState.context
+  const dir = Session.folder(input.session.id)
+  yield* Effect.promise(() => SessionAssembleTemplate.ensure(dir)).pipe(
+    Effect.catchCause((cause) => {
+      log.error("failed to ensure assemble script", { sessionID: input.session.id, cause })
+      return Effect.void
+    }),
+  )
+  const execute = yield* Effect.promise(() => loadScriptDefault(path.join(dir, "assemble.ts"))).pipe(
+    Effect.catchCause((cause) => {
+      log.error("failed to load assemble script", { sessionID: input.session.id, cause })
+      return Effect.succeed(undefined)
+    }),
+  )
+  if (!execute) return fallback({ ...input, reason: "load error" })
+  const result = yield* Effect.promise(() =>
+    Promise.resolve(
+      execute({
+        sessionID: input.session.id,
+        sessionDir: dir,
+        workspaceRoot: ctx.worktree,
+        directory: ctx.directory,
+        step: input.step,
+        messages: input.messages,
+        session: input.session,
+        agent: {
+          name: input.agent.name,
+        },
+        model: {
+          id: input.model.id,
+          providerID: input.model.providerID,
+        },
+      } satisfies Input),
+    ),
+  ).pipe(
+    Effect.catchCause((cause) => {
+      log.error("failed to execute assemble script", { sessionID: input.session.id, cause })
+      return Effect.succeed(fallback({ ...input, reason: "execution error" }))
+    }),
+  )
+  if (valid(result)) return result
+  log.warn("assemble script returned invalid messages", { sessionID: input.session.id })
+  return fallback({ ...input, reason: "invalid return value" })
+})
+
+export * as SessionAssemble from "./assemble"

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -24,10 +24,28 @@ import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { EffectBridge } from "@/effect/bridge"
 import * as Option from "effect/Option"
 import * as OtelTracer from "@effect/opentelemetry/Tracer"
+import { Session } from "./session"
+import path from "path"
+import fs from "fs/promises"
 
 const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 type Result = Awaited<ReturnType<typeof streamText>>
+const SYSTEM_FILES = {
+  provider: "provider.txt",
+  environment: "environment.txt",
+  instructions: "instructions.txt",
+  skills: "skills.txt",
+  "structured-output": "structured-output.txt",
+  user: "user.txt",
+  prepend: "prepend.txt",
+  append: "append.txt",
+} as const
+
+export type SystemSection = {
+  id: "environment" | "instructions" | "skills" | "structured-output"
+  content: string
+}
 
 // Avoid re-instantiating remeda's deep merge types in this hot LLM path; the runtime behavior is still mergeDeep.
 const mergeOptions = (target: Record<string, any>, source: Record<string, any> | undefined): Record<string, any> =>
@@ -40,7 +58,10 @@ export type StreamInput = {
   model: Provider.Model
   agent: Agent.Info
   permission?: Permission.Ruleset
-  system: string[]
+  // Incoming session system format: prompt.ts sends named sections so this
+  // layer can still tell environment, instructions, skills, and structured
+  // output apart before rendering them for plugins and providers.
+  system: SystemSection[]
   messages: ModelMessage[]
   small?: boolean
   tools: Record<string, Tool>
@@ -100,19 +121,41 @@ const live: Layer.Layer<
       // TODO: move this to a proper hook
       const isOpenaiOauth = item.id === "openai" && info?.type === "oauth"
 
-      const system: string[] = []
-      system.push(
-        [
-          // use agent prompt otherwise provider prompt
-          ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
-          // any custom prompt passed into this call
-          ...input.system,
-          // any custom prompt from last user message
-          ...(input.user.system ? [input.user.system] : []),
-        ]
-          .filter((x) => x)
-          .join("\n"),
-      )
+      const dir = path.join(Session.folder(SessionID.make(input.sessionID)), "system")
+      const read = (file: string) =>
+        Effect.tryPromise(() => fs.readFile(path.join(dir, file), "utf8")).pipe(
+          Effect.catch(() => Effect.succeed(undefined as string | undefined)),
+        )
+      const replacements = yield* Effect.all({
+        provider: read(SYSTEM_FILES.provider),
+        environment: read(SYSTEM_FILES.environment),
+        instructions: read(SYSTEM_FILES.instructions),
+        skills: read(SYSTEM_FILES.skills),
+        structured: read(SYSTEM_FILES["structured-output"]),
+        user: read(SYSTEM_FILES.user),
+        prepend: read(SYSTEM_FILES.prepend),
+        append: read(SYSTEM_FILES.append),
+      })
+      const replace = (item: SystemSection) =>
+        item.id === "structured-output"
+          ? (replacements.structured ?? item.content)
+          : (replacements[item.id] ?? item.content)
+
+      // Session-local system overrides are read from session/<id>/system/*.txt.
+      // Incoming format is named sections plus explicit provider/user slots;
+      // files with matching names replace only that slot, while prepend/append
+      // add extra system messages around the rendered sections.
+      // Outgoing plugin/provider format is string[]: [provider, ...sections,
+      // user?], with optional prepend/append entries. The transform hook sees
+      // this rendered array before providers receive it.
+      const system = [
+        replacements.prepend,
+        replacements.provider ??
+          (input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)).filter((x) => x).join("\n"),
+        ...input.system.map(replace),
+        ...(replacements.user ? [replacements.user] : input.user.system ? [input.user.system] : []),
+        replacements.append,
+      ].filter((x): x is string => !!x)
 
       const header = system[0]
       yield* plugin.trigger(
@@ -226,6 +269,7 @@ const live: Layer.Layer<
         })
       }
       const sortedTools = Object.fromEntries(Object.entries(tools).toSorted(([a], [b]) => a.localeCompare(b)))
+      const activeTools = Object.keys(sortedTools).filter((x) => x !== "invalid")
 
       // Wire up toolExecutor for DWS workflow models so that tool calls
       // from the workflow service are executed via opencode's tool system
@@ -334,8 +378,8 @@ const live: Layer.Layer<
         ? (yield* InstanceState.context).project.id
         : undefined
 
-      return streamText({
-        onError(error) {
+      const payload: Parameters<typeof streamText>[0] = {
+        onError(error: unknown) {
           l.error("stream error", {
             error,
           })
@@ -365,7 +409,7 @@ const live: Layer.Layer<
         topP: params.topP,
         topK: params.topK,
         providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-        activeTools: Object.keys(sortedTools).filter((x) => x !== "invalid"),
+        activeTools,
         tools: sortedTools,
         toolChoice: input.toolChoice,
         maxOutputTokens: params.maxOutputTokens,
@@ -413,8 +457,79 @@ const live: Layer.Layer<
             sessionId: input.sessionID,
           },
         },
+      }
+
+      // Outgoing request log format: each LLM call writes a JSON file under
+      // <session>/llm-request containing the final provider input plus a
+      // serializable tool summary. This mirrors the streamText payload closely
+      // enough to inspect system/messages/tools without storing executable
+      // functions or mutating the actual request sent to the provider.
+      yield* writeRequestLog(SessionID.make(input.sessionID), input.user.id, {
+        time: new Date().toISOString(),
+        sessionID: input.sessionID,
+        requestID: input.user.id,
+        agent: input.agent.name,
+        model: {
+          providerID: input.model.providerID,
+          modelID: input.model.id,
+        },
+        params: {
+          temperature: params.temperature,
+          topP: params.topP,
+          topK: params.topK,
+          maxOutputTokens: params.maxOutputTokens,
+          maxRetries: input.retries ?? 0,
+          toolChoice: input.toolChoice,
+        },
+        activeTools,
+        toolNames: Object.keys(sortedTools),
+        headerKeys: Object.keys(payload.headers ?? {}),
+        providerOptionKeys: Object.keys(payload.providerOptions ?? {}),
+        assembly: {
+          system,
+          messages,
+          tools: serializeTools(sortedTools),
+        },
       })
+
+      return streamText(payload)
     })
+
+    const writeRequestLog = Effect.fn("LLM.writeRequestLog")(function* (
+      sessionID: SessionID,
+      requestID: string,
+      payload: unknown,
+    ) {
+      const dir = path.join(Session.folder(sessionID), "llm-request")
+      yield* Effect.promise(() => fs.mkdir(dir, { recursive: true }))
+      yield* Effect.promise(() =>
+        fs.writeFile(path.join(dir, `${Date.now()}-${sanitize(requestID)}.json`), JSON.stringify(payload, null, 2)),
+      )
+      const list = (yield* Effect.promise(() => fs.readdir(dir))).filter((item) => item.endsWith(".json")).sort()
+      if (list.length <= 100) return
+      yield* Effect.promise(() =>
+        Promise.all(list.slice(0, list.length - 100).map((item) => fs.rm(path.join(dir, item), { force: true }))),
+      )
+    })
+
+    function sanitize(input: string) {
+      return input.replace(/[\\/:*?"<>|]/g, "_")
+    }
+
+    function serializeTools(input: Record<string, Tool>) {
+      return Object.fromEntries(
+        Object.entries(input).map(([id, item]) => {
+          const info = item as Record<string, unknown>
+          return [
+            id,
+            {
+              description: info.description,
+              inputSchema: info.inputSchema,
+            },
+          ]
+        }),
+      )
+    }
 
     const stream: Interface["stream"] = (input) =>
       Stream.scoped(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,6 +1,8 @@
 import path from "path"
 import os from "os"
+import fs from "fs/promises"
 import * as EffectZod from "@opencode-ai/core/effect-zod"
+import { ZodOverride } from "@opencode-ai/core/effect-zod"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import * as Log from "@opencode-ai/core/util/log"
@@ -10,6 +12,7 @@ import { Agent } from "../agent/agent"
 import { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
 import { type Tool as AITool, tool, jsonSchema, type ToolExecutionOptions, asSchema } from "ai"
+import { type ToolDefinition as PluginToolDefinition } from "@opencode-ai/plugin"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import { SessionCompaction } from "./compaction"
 import { Bus } from "../bus"
@@ -47,6 +50,7 @@ import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Latch, Layer, Option, Scope, Context, Schema, Types } from "effect"
 import { zod } from "@opencode-ai/core/effect-zod"
+import z from "zod"
 import { withStatics } from "@opencode-ai/core/schema"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
 import { InstanceState } from "@/effect/instance-state"
@@ -61,6 +65,7 @@ import * as DateTime from "effect/DateTime"
 import { eq } from "@/storage/db"
 import * as Database from "@/storage/db"
 import { SessionTable } from "./session.sql"
+import { SessionAssemble } from "./assemble"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -125,6 +130,99 @@ export const layer = Layer.effect(
         resolvePromptParts: (template: string) => resolvePromptParts(template),
         prompt: (input: PromptInput) => prompt(input),
       } satisfies TaskPromptOps
+    })
+
+    const sessionToolGuide = `# Session Tools
+
+This folder lets this session add extra tools without changing global config.
+
+Create .ts or .js files in this folder. Each file may export a default tool, or named tools. Tools use the same plugin tool shape as config tools.
+
+Example weather.ts:
+
+\`\`\`ts
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Return a demo weather report for a city.",
+  args: {
+    city: tool.schema.string().describe("City name"),
+  },
+  async execute(args) {
+    return \"Weather for \" + args.city + \": sunny and 25C\"
+  },
+})
+\`\`\`
+
+File names become tool ids. For example, weather.ts default export becomes weather. A named export named forecast in weather.ts becomes weather_forecast.
+
+Session tools are loaded only for this session. They do not replace built-in, MCP, or structured output tools; conflicting ids are skipped.
+`
+
+    function fromSessionTool(id: string, def: PluginToolDefinition): Tool.Def {
+      // Session-local tools are received as plugin-style modules from
+      // <session>/tool/*.ts or *.js. Convert that shape into the internal
+      // Tool.Def shape consumed by resolveTools so the existing LLM tool-call
+      // execution, plugin hooks, result storage, and next-turn context replay
+      // all continue to use the normal pipeline.
+      const zodParams = z.object(def.args)
+      const parameters = Schema.declare<unknown>((u): u is unknown => zodParams.safeParse(u).success).annotate({
+        [ZodOverride]: zodParams,
+      })
+      return {
+        id,
+        parameters,
+        description: def.description,
+        execute: (args, toolCtx) =>
+          Effect.gen(function* () {
+            const ctx = yield* InstanceState.context
+            const result = yield* Effect.promise(() =>
+              def.execute(args as Record<string, unknown>, {
+                sessionID: toolCtx.sessionID,
+                messageID: toolCtx.messageID,
+                agent: toolCtx.agent,
+                directory: ctx.directory,
+                worktree: ctx.worktree,
+                abort: toolCtx.abort,
+                metadata: (val) => toolCtx.metadata(val),
+                ask: (req) => toolCtx.ask(req),
+              }),
+            )
+            return typeof result === "string"
+              ? { title: "", output: result, metadata: {} }
+              : { title: "", output: result.output, metadata: result.metadata ?? {} }
+          }),
+      }
+    }
+
+    const sessionTools = Effect.fn("SessionPrompt.sessionTools")(function* (sessionID: SessionID) {
+      const dir = path.join(Session.folder(sessionID), "tool")
+      yield* fsys.ensureDir(dir).pipe(Effect.catch(Effect.die))
+      const readme = path.join(dir, "README.md")
+      if (!(yield* fsys.existsSafe(readme))) yield* Effect.promise(() => fs.writeFile(readme, sessionToolGuide))
+
+      // Incoming format: a session tool is a .ts or .js module exporting
+      // plugin-style tool definitions. Outgoing format: Tool.Def[], ready to
+      // merge with registry tools before conversion into AI SDK tool objects.
+      // This loader only adds session-local tools; built-in/global tool loading
+      // stays unchanged in ToolRegistry.
+      const files = yield* Effect.promise(() =>
+        fs
+          .readdir(dir)
+          .then((items) => items.filter((item) => /\.(ts|js)$/.test(item)).map((item) => path.join(dir, item))),
+      )
+      if (files.length) yield* config.waitForDependencies()
+      return yield* Effect.forEach(
+        files,
+        Effect.fnUntraced(function* (file) {
+          const namespace = path.basename(file, path.extname(file))
+          const mod = yield* Effect.promise(() => import(pathToFileURL(file).href))
+          return Object.entries<PluginToolDefinition>(mod).map((entry) =>
+            fromSessionTool(entry[0] === "default" ? namespace : `${namespace}_${entry[0]}`, entry[1]),
+          )
+        }),
+        { concurrency: "unbounded" },
+      ).pipe(Effect.map((items) => items.flat()))
     })
 
     const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
@@ -448,6 +546,50 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 if (options.abortSignal?.aborted) {
                   yield* input.processor.completeToolCall(options.toolCallId, output)
                 }
+                return output
+              }),
+            )
+          },
+        })
+      }
+
+      const used = new Set(Object.keys(tools))
+      for (const item of yield* sessionTools(input.session.id)) {
+        if (used.has(item.id)) continue
+        used.add(item.id)
+        const schema = ProviderTransform.schema(input.model, EffectZod.toJsonSchema(item.parameters))
+        // Session tools leave the session/tool module format as plugin-style
+        // definitions, then become normal AI SDK tools here. The outgoing
+        // object is the same format as built-in tools: description,
+        // JSON-schema input, and an execute handler returning Tool.ExecuteResult.
+        tools[item.id] = tool({
+          description: item.description,
+          inputSchema: jsonSchema(schema),
+          execute(args, options) {
+            return run.promise(
+              Effect.gen(function* () {
+                const ctx = context(args, options)
+                yield* plugin.trigger(
+                  "tool.execute.before",
+                  { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
+                  { args },
+                )
+                const result = yield* item.execute(args, ctx)
+                const output = {
+                  ...result,
+                  attachments: result.attachments?.map((attachment) => ({
+                    ...attachment,
+                    id: PartID.ascending(),
+                    sessionID: ctx.sessionID,
+                    messageID: input.processor.message.id,
+                  })),
+                }
+                yield* plugin.trigger(
+                  "tool.execute.after",
+                  { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
+                  output,
+                )
+                if (options.abortSignal?.aborted) yield* input.processor.completeToolCall(options.toolCallId, output)
                 return output
               }),
             )
@@ -1563,6 +1705,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }
             }
 
+            msgs = yield* SessionAssemble.run({
+              session,
+              agent,
+              model,
+              step,
+              messages: msgs,
+            })
+
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
             const [skills, env, instructions, modelMsgs] = yield* Effect.all([
@@ -1571,9 +1721,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
-            const system = [...env, ...instructions, ...(skills ? [skills] : [])]
+            // Outgoing LLM system format: keep sections named until llm.ts so
+            // later transforms can target environment, instructions, skills,
+            // or structured output without guessing by array position.
+            const system: LLM.SystemSection[] = [
+              ...env.map((content) => ({ id: "environment" as const, content })),
+              ...instructions.map((content) => ({ id: "instructions" as const, content })),
+              ...(skills ? [{ id: "skills" as const, content: skills }] : []),
+            ]
             const format = lastUser.format ?? { type: "text" as const }
-            if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
+            if (format.type === "json_schema") {
+              system.push({ id: "structured-output", content: STRUCTURED_OUTPUT_SYSTEM_PROMPT })
+            }
             const result = yield* handle.process({
               user: lastUser,
               agent,

--- a/packages/opencode/src/session/script.test.ts
+++ b/packages/opencode/src/session/script.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { expect, test } from "bun:test"
+import { loadScriptDefault } from "./script"
+import { SessionAssembleTemplate } from "./assemble-template"
+
+test("loadScriptDefault caches unchanged source and reloads changed source", async () => {
+  const file = path.join(await mkdtemp(path.join(tmpdir(), "opencode-script-")), "assemble.ts")
+
+  await Bun.write(
+    file,
+    `export default async function assemble(input) {
+  return input.messages
+}
+`,
+  )
+
+  const first = await loadScriptDefault(file)
+  const same = await loadScriptDefault(file)
+
+  expect(first).toBeFunction()
+  expect(same).toBe(first)
+  expect(await first?.({ messages: ["a"] })).toEqual(["a"])
+
+  await Bun.write(
+    file,
+    `export default async function assemble(input) {
+  return input.messages.concat("b")
+}
+`,
+  )
+
+  const second = await loadScriptDefault(file)
+
+  expect(second).toBeFunction()
+  expect(second).not.toBe(first)
+  expect(await second?.({ messages: ["a"] })).toEqual(["a", "b"])
+})
+
+test("assemble template ensure creates script and schema without overwriting existing files", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "opencode-assemble-template-"))
+
+  await SessionAssembleTemplate.ensure(dir)
+
+  expect(await Bun.file(path.join(dir, "assemble.ts")).text()).toContain("MessageV2.WithParts[] format")
+  expect(await Bun.file(path.join(dir, "assemble-schema.md")).text()).toContain("# assemble.ts Schema Reference")
+
+  await Bun.write(path.join(dir, "assemble.ts"), "custom script")
+  await Bun.write(path.join(dir, "assemble-schema.md"), "custom schema")
+  await SessionAssembleTemplate.ensure(dir)
+
+  expect(await Bun.file(path.join(dir, "assemble.ts")).text()).toBe("custom script")
+  expect(await Bun.file(path.join(dir, "assemble-schema.md")).text()).toBe("custom schema")
+})
+
+test("default assemble template discovers json context and updates countdown", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "opencode-assemble-discovery-"))
+  await SessionAssembleTemplate.ensure(dir)
+  await Bun.write(
+    path.join(dir, "context.json"),
+    JSON.stringify(
+      { assemble: true, content: "remember schema contract", position: "suffix", timestamp: 30, countdown: 2 },
+      null,
+      2,
+    ),
+  )
+
+  const execute = await loadScriptDefault(path.join(dir, "assemble.ts"))
+  const result = await execute?.({
+    sessionID: "ses_test",
+    sessionDir: dir,
+    workspaceRoot: dir,
+    directory: dir,
+    step: 1,
+    session: {},
+    agent: { name: "build" },
+    model: { id: "model", providerID: "provider" },
+    messages: [
+      {
+        info: {
+          id: "msg_user",
+          sessionID: "ses_test",
+          role: "user",
+          time: { created: 20 },
+          agent: "build",
+          model: { providerID: "provider", modelID: "model" },
+        },
+        parts: [
+          {
+            id: "prt_user",
+            sessionID: "ses_test",
+            messageID: "msg_user",
+            type: "text",
+            text: "hello",
+          },
+        ],
+      },
+    ],
+  })
+
+  expect(result).toHaveLength(2)
+  expect(result?.at(-1)?.info.id).toStartWith("msg_assemble_")
+  expect(result?.at(-1)?.parts[0]).toMatchObject({
+    id: expect.stringMatching(/^prt_assemble_/),
+    sessionID: "ses_test",
+    type: "text",
+    synthetic: true,
+    text: "remember schema contract",
+  })
+  expect(await Bun.file(path.join(dir, "context.json")).json()).toMatchObject({ countdown: 1 })
+})

--- a/packages/opencode/src/session/script.ts
+++ b/packages/opencode/src/session/script.ts
@@ -1,0 +1,32 @@
+import { readFile } from "node:fs/promises"
+import { ModuleKind, ScriptTarget, transpileModule } from "typescript"
+
+const cache = new Map<string, { source: string; execute: (input: unknown) => unknown }>()
+
+function compile(source: string) {
+  const js = transpileModule(source, {
+    compilerOptions: {
+      module: ModuleKind.ESNext,
+      target: ScriptTarget.ESNext,
+    },
+  }).outputText
+  if (/^\s*import\s/m.test(js)) throw new Error("Script imports are not supported in session script mode")
+  const code = js.replace(/\bexport\s+default\s+/m, "return ")
+  if (code === js) return
+  return new Function(code)()
+}
+
+export async function loadScriptDefault(filepath: string) {
+  const source = await readFile(filepath, "utf8").catch(() => "")
+  if (!source.trim()) return
+  const existing = cache.get(filepath)
+  if (existing && existing.source === source) return existing.execute
+  const value = compile(source)
+  if (typeof value !== "function") return
+  const execute = (input: unknown) => value(input)
+  cache.set(filepath, {
+    source,
+    execute,
+  })
+  return execute
+}

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -1,4 +1,5 @@
 import { Slug } from "@opencode-ai/core/util/slug"
+import fs from "fs/promises"
 import path from "path"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
@@ -39,11 +40,64 @@ import { Global } from "@opencode-ai/core/global"
 import { Effect, Layer, Option, Context, Schema, Types } from "effect"
 import { zod } from "@opencode-ai/core/effect-zod"
 import { NonNegativeInt, optionalOmitUndefined, withStatics } from "@opencode-ai/core/schema"
+import { SessionAssembleTemplate } from "./assemble-template"
 
 const log = Log.create({ service: "session" })
 
 const parentTitlePrefix = "New session - "
 const childTitlePrefix = "Child session - "
+const systemPromptGuide = `# Session System Prompt
+
+This folder lets this session replace selected system prompt sections without changing global config.
+
+Create any of these .txt files to override that section for this session only:
+
+- provider.txt: replace the provider or agent base prompt.
+- environment.txt: replace the runtime environment section.
+- instructions.txt: replace project and config instructions.
+- skills.txt: replace the available skills section.
+- structured-output.txt: replace the structured output helper prompt when JSON schema output is requested.
+- user.txt: replace the optional per-request user system prompt.
+- prepend.txt: add text before all rendered system sections.
+- append.txt: add text after all rendered system sections.
+
+Files that do not exist are ignored. No .txt files are created by default.
+
+Example instructions.txt:
+
+\`\`\`text
+You are OpenCode working in this repository.
+Prefer concise answers, preserve existing code style, and explain risky changes before applying them.
+When editing, keep changes focused on the current request.
+\`\`\`
+`
+
+const toolGuide = `# Session Tools
+
+This folder lets this session add extra tools without changing global config.
+
+Create .ts or .js files in this folder. Each file may export a default tool, or named tools. Tools use the same plugin tool shape as config tools.
+
+Example weather.ts:
+
+\`\`\`ts
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Return a demo weather report for a city.",
+  args: {
+    city: tool.schema.string().describe("City name"),
+  },
+  async execute(args) {
+    return "Weather for " + args.city + ": sunny and 25C"
+  },
+})
+\`\`\`
+
+File names become tool ids. For example, weather.ts default export becomes weather. A named export named forecast in weather.ts becomes weather_forecast.
+
+Session tools are loaded only for this session. They do not replace built-in, MCP, or structured output tools; conflicting ids are skipped.
+`
 
 function createDefaultTitle(isChild = false) {
   return (isChild ? childTitlePrefix : parentTitlePrefix) + new Date().toISOString()
@@ -141,6 +195,43 @@ function sessionPath(worktree: string, cwd: string) {
   return path.relative(path.resolve(worktree), cwd).replaceAll("\\", "/")
 }
 
+export function folder(sessionID: SessionID) {
+  return path.join(Global.Path.data, "session", sessionID)
+}
+
+function init(info: Info) {
+  return Effect.promise(async () => {
+    const dir = folder(info.id)
+    await fs.mkdir(dir, { recursive: true })
+    await fs.mkdir(path.join(dir, "system"), { recursive: true })
+    await fs.mkdir(path.join(dir, "tool"), { recursive: true })
+    await fs.writeFile(path.join(dir, "system", "README.md"), systemPromptGuide, { flag: "wx" }).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+    })
+    await fs.writeFile(path.join(dir, "tool", "README.md"), toolGuide, { flag: "wx" }).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+    })
+    await SessionAssembleTemplate.ensure(dir)
+    await fs.writeFile(
+      path.join(dir, "metadata.json"),
+      JSON.stringify(
+        {
+          id: info.id,
+          project_id: info.projectID,
+          workspace_id: info.workspaceID,
+          parent_id: info.parentID,
+          directory: info.directory,
+          path: info.path,
+          title: info.title,
+          time: info.time,
+        },
+        undefined,
+        2,
+      ),
+    )
+  })
+}
+
 const Summary = Schema.Struct({
   additions: Schema.Finite,
   deletions: Schema.Finite,
@@ -217,6 +308,7 @@ export type GlobalInfo = Types.DeepMutable<Schema.Schema.Type<typeof GlobalInfo>
 
 export const CreateInput = Schema.optional(
   Schema.Struct({
+    id: Schema.optional(SessionID),
     parentID: Schema.optional(SessionID),
     title: Schema.optional(Schema.String),
     agent: Schema.optional(Schema.String),
@@ -519,6 +611,8 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
       }
       log.info("created", result)
 
+      yield* init(result)
+
       yield* sync.run(Event.Created, { sessionID: result.id, info: result })
 
       if (!Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
@@ -619,6 +713,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
     })
 
     const create = Effect.fn("Session.create")(function* (input?: {
+      id?: SessionID
       parentID?: SessionID
       title?: string
       agent?: string
@@ -629,6 +724,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service | 
       const ctx = yield* InstanceState.context
       const workspace = yield* InstanceState.workspaceID
       return yield* createNext({
+        id: input?.id,
         parentID: input?.parentID,
         directory: ctx.directory,
         path: sessionPath(ctx.worktree, ctx.directory),

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -367,7 +367,7 @@ describe("session.llm.stream", () => {
           sessionID,
           model: resolved,
           agent,
-          system: ["You are a helpful assistant."],
+          system: [{ id: "instructions", content: "You are a helpful assistant." }],
           messages: [{ role: "user", content: "Hello" }],
           tools: {},
         })
@@ -455,7 +455,7 @@ describe("session.llm.stream", () => {
                 sessionID,
                 model: resolved,
                 agent,
-                system: ["You are a helpful assistant."],
+                system: [{ id: "instructions", content: "You are a helpful assistant." }],
                 messages: [{ role: "user", content: "Hello" }],
                 tools: {},
               })
@@ -544,7 +544,7 @@ describe("session.llm.stream", () => {
           model: resolved,
           agent,
           permission: [{ permission: "question", pattern: "*", action: "allow" }],
-          system: ["You are a helpful assistant."],
+          system: [{ id: "instructions", content: "You are a helpful assistant." }],
           messages: [{ role: "user", content: "Hello" }],
           tools: {
             question: tool({
@@ -657,7 +657,7 @@ describe("session.llm.stream", () => {
           sessionID,
           model: resolved,
           agent,
-          system: ["You are a helpful assistant."],
+          system: [{ id: "instructions", content: "You are a helpful assistant." }],
           messages: [{ role: "user", content: "Hello" }],
           tools: {},
         })
@@ -772,7 +772,7 @@ describe("session.llm.stream", () => {
           sessionID,
           model: resolved,
           agent,
-          system: ["You are a helpful assistant."],
+          system: [{ id: "instructions", content: "You are a helpful assistant." }],
           messages: [
             {
               role: "user",
@@ -893,7 +893,7 @@ describe("session.llm.stream", () => {
           sessionID,
           model: resolved,
           agent,
-          system: ["You are a helpful assistant."],
+          system: [{ id: "instructions", content: "You are a helpful assistant." }],
           messages: [{ role: "user", content: "Hello" }],
           tools: {},
         })
@@ -1252,7 +1252,7 @@ describe("session.llm.stream", () => {
           sessionID,
           model: resolved,
           agent,
-          system: ["You are a helpful assistant."],
+          system: [{ id: "instructions", content: "You are a helpful assistant." }],
           messages: [{ role: "user", content: "Hello" }],
           tools: {},
         })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -3,6 +3,7 @@ import { FetchHttpClient } from "effect/unstable/http"
 import { expect } from "bun:test"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
+import fs from "fs/promises"
 import { fileURLToPath } from "url"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Agent as AgentSvc } from "../../src/agent/agent"
@@ -557,6 +558,63 @@ it.live("glob tool keeps instance context during prompt runs", () =>
         expect(tool.state.output).not.toContain("No context found for instance")
         expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
       }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loads and executes a session-local tool", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Session tool",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      expect(
+        yield* Effect.promise(() => Bun.file(path.join(Session.folder(session.id), "tool", "README.md")).exists()),
+      ).toBe(true)
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(Session.folder(session.id), "tool", "local.ts"),
+          `export default {
+  description: "Return a local session value.",
+  args: {},
+  async execute(args) {
+    return "local:ok"
+  },
+}
+`,
+        ),
+      )
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "call local" }],
+      })
+      yield* llm.tool("local", {})
+      yield* llm.text("done")
+
+      const result = yield* prompt.loop({ sessionID: session.id })
+      const logs = yield* Effect.promise(() => fs.readdir(path.join(Session.folder(session.id), "llm-request")))
+      expect(logs.some((item) => item.endsWith(".json"))).toBe(true)
+      const log = yield* Effect.promise(() =>
+        Bun.file(
+          path.join(Session.folder(session.id), "llm-request", logs.find((item) => item.endsWith(".json"))!),
+        ).json(),
+      )
+      expect(log.toolNames).toContain("local")
+      expect(log.assembly.tools.local.description).toBe("Return a local session value.")
+      const tool = (yield* MessageV2.filterCompactedEffect(session.id))
+        .flatMap((msg) => msg.parts)
+        .find(
+          (part): part is CompletedToolPart =>
+            part.type === "tool" && part.tool === "local" && part.state.status === "completed",
+        )
+      expect(tool?.state.output).toBe("local:ok")
+      expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+    }),
     { git: true, config: providerCfg },
   ),
 )

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2998,6 +2998,7 @@ export class Session2 extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
+      id?: string
       parentID?: string
       title?: string
       agent?: string
@@ -3018,6 +3019,7 @@ export class Session2 extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "body", key: "id" },
             { in: "body", key: "parentID" },
             { in: "body", key: "title" },
             { in: "body", key: "agent" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5134,6 +5134,7 @@ export type SessionListResponse = SessionListResponses[keyof SessionListResponse
 
 export type SessionCreateData = {
   body?: {
+    id?: string
     parentID?: string
     title?: string
     agent?: string

--- a/specs/custom-session-flow.md
+++ b/specs/custom-session-flow.md
@@ -1,0 +1,380 @@
+# Custom Session Flow Changes
+
+## Purpose
+
+Track custom changes for the forked opencode worktree. The goal is to keep the
+upstream SQLite session flow while adding session-level extension points for
+context assembly, session tools, skills, and per-session state.
+
+## Workflow
+
+- Development worktree: `D:\llm\opencode-custom`
+- Development branch: `custom/opencode-local`
+- Upstream branch: `upstream/dev`
+- Fork remote: `origin=https://github.com/ts18006786422-cmyk/opencode.git`
+- Official remote: `upstream=https://github.com/anomalyco/opencode.git`
+- Local changes are not pushed automatically. Commit and push only when the user
+  explicitly asks for it.
+
+## Requirements
+
+- Create a global session directory for every newly created session.
+- Use the session ID as the directory name so session-level resources can be
+  managed directly by ID.
+- Keep SQLite as the source of truth for the message stream.
+- Delegate final context composition to the session ID directory through its
+  `assemble.ts` file.
+- Store session-level assembly files, declared tools, skills, and state outside
+  the database so they remain editable and discoverable.
+- Track every custom change in this document before or while implementing it.
+
+## Global Session Directory
+
+Root path:
+
+```text
+{Global.Path.data}/session/{sessionID}/
+```
+
+Initial contents:
+
+```text
+assemble.ts
+metadata.json
+```
+
+Planned contents:
+
+```text
+assemble.ts
+context/
+tool/
+skill/
+state/
+```
+
+## Session Assemble Design
+
+Core principle:
+
+```text
+The runtime supplies context inputs and a safe execution point. The session ID
+directory decides how those inputs are composed into the final model context.
+```
+
+Current upstream flow in `opencode-custom`:
+
+```text
+MessageV2.filterCompactedEffect(sessionID)
+  -> insertReminders(...)
+  -> plugin experimental.chat.messages.transform
+  -> MessageV2.toModelMessagesEffect(msgs, model)
+  -> provider request
+```
+
+Target flow:
+
+```text
+MessageV2.filterCompactedEffect(sessionID)
+  -> insertReminders(...)
+  -> SessionAssemble.run(...)
+  -> plugin experimental.chat.messages.transform
+  -> MessageV2.toModelMessagesEffect(msgs, model)
+  -> provider request
+```
+
+`SessionAssemble.run` behavior:
+
+- Resolve `{Global.Path.data}/session/{sessionID}/assemble.ts`.
+- Every newly created session receives a default `assemble.ts` template.
+- Load the default export through the source-based session script loader and
+  call it with the assemble input.
+- The loader reads script source each time, reuses the compiled function when
+  the source is unchanged, and recompiles when the user edits the file.
+- Validate the returned messages before passing them to the rest of the flow.
+- Fall back to the input messages only when loading, execution, or validation
+  fails.
+- Keep provider conversion in the runtime; do not require `assemble.ts` to emit
+  provider-specific `ModelMessage[]`.
+
+Initial assemble input contract:
+
+```ts
+export type AssembleInput = {
+  sessionID: string
+  sessionDir: string
+  workspaceRoot: string
+  directory: string
+  step: number
+  messages: MessageV2.WithParts[]
+  session: Session.Info
+  agent: {
+    name: string
+  }
+  model: {
+    id: string
+    providerID: string
+  }
+}
+```
+
+Field notes:
+
+- `messages` are the current SQLite-backed session messages after compaction
+  filtering and reminder insertion.
+- `sessionDir` is the global session ID directory for local discovery.
+- `workspaceRoot` is the project worktree root.
+- `directory` is the active working directory for the request.
+- `step` identifies the current request/tool loop step.
+- `session`, `agent`, and `model` are metadata only. The assemble script should
+  not depend on internal services.
+
+Initial assemble output contract:
+
+```ts
+export type AssembleOutput = MessageV2.WithParts[]
+```
+
+Validation rules:
+
+- The output must be an array.
+- Each item must contain `info` and `parts`.
+- `info.role` must be `user` or `assistant`.
+- `parts` must be an array.
+- Invalid output falls back to `input.messages`.
+
+Default session template:
+
+```ts
+// Runs before opencode converts messages to provider-specific model messages.
+// Input:
+// - input.messages is MessageV2.WithParts[] after compaction filtering and reminder insertion.
+// - each item is { info, parts }; info.role is "user" or "assistant" and determines info fields.
+// - parts contains typed message parts such as text, tool, file, reasoning, step-start, and step-finish.
+// Return MessageV2.WithParts[]; do not return provider messages like { role, content }[].
+// Edit this file to customize this session's context; changes apply on the next request.
+export default async function assemble(input) {
+  return input.messages
+}
+```
+
+Non-goals for the first implementation:
+
+- Do not port the old LanceDB bootstrap logic.
+- Do not add `context_mode` config.
+- Do not make the runtime understand module names like `necessary`, `team`,
+  `history`, or `skill`.
+- Do not let `assemble.ts` bypass provider conversion or tool permissions.
+
+## Change Log
+
+### 2026-05-10: Create Session ID Directory
+
+Purpose:
+
+- Establish a stable filesystem location for each session.
+- Prepare for session-level context assembly and session tool discovery.
+
+Files changed:
+
+- `packages/opencode/src/session/session.ts`
+
+Input:
+
+- `Session.create` or `Session.fork` creates a new `Session.Info` object.
+- `Global.Path.data` provides the global opencode data root.
+
+Output:
+
+- Creates `{Global.Path.data}/session/{sessionID}/`.
+- Writes `{Global.Path.data}/session/{sessionID}/metadata.json`.
+
+Metadata fields:
+
+- `id`
+- `project_id`
+- `workspace_id`
+- `parent_id`
+- `directory`
+- `path`
+- `title`
+- `time`
+
+Notes:
+
+- Session deletion does not remove the directory yet. This avoids deleting user
+  authored session files by accident.
+- The directory is initialized before the session creation event is published.
+
+### 2026-05-10: Add Session Assemble Runtime
+
+Purpose:
+
+- Delegate context composition to each session directory.
+- Keep provider conversion and tool permission handling in the runtime.
+- Support edit-and-run behavior for `{Global.Path.data}/session/{sessionID}/assemble.ts`.
+
+Files changed:
+
+- `packages/opencode/src/session/session.ts`
+- `packages/opencode/src/session/assemble-template.ts`
+- `packages/opencode/src/session/script.ts`
+- `packages/opencode/src/session/assemble.ts`
+- `packages/opencode/src/session/prompt.ts`
+- `specs/custom-session-flow.md`
+
+Input:
+
+- `Session.create` or `Session.fork` creates `{Global.Path.data}/session/{sessionID}/assemble.ts` and `assemble-schema.md` when missing.
+- `SessionAssemble.run` receives the current compacted/reminder-adjusted `MessageV2.WithParts[]`, session metadata, agent name, model ID, provider ID, step, workspace root, and active directory.
+
+Output:
+
+- `assemble.ts` returns `MessageV2.WithParts[]`.
+- The runtime passes the assembled messages through the existing plugin transform and `MessageV2.toModelMessagesEffect`.
+
+Loader behavior:
+
+- Uses `Bun.Transpiler` instead of dynamic `import()` to avoid ESM module cache issues.
+- Caches by filepath and source content.
+- Recompiles automatically on the next request after the source changes.
+- Supports `export default function` / `export default async function`; script imports are intentionally unsupported.
+
+Minimal test added:
+
+- `packages/opencode/src/session/script.test.ts` verifies that unchanged script source reuses the cached function and changed source reloads on the next call.
+- Minimal loader test passes when run outside the package bunfig preload path: `bun test "D:\llm\opencode-custom\packages\opencode\src\session\script.test.ts" --timeout 30000` from `D:\llm`.
+- Package-local test execution in this shell is currently blocked before the test body runs: `bun test src/session/script.test.ts --timeout 30000` fails while resolving the package bunfig preload `@opentui/solid/preload`.
+- `bun typecheck` is also blocked in this shell while resolving the catalog tsconfig path `@tsconfig/bun/tsconfig.json`.
+
+### 2026-05-11: Document Default Assemble Contract In Template
+
+Purpose:
+
+- Make every newly created session self-document the assemble hook contract.
+- Clarify that `assemble.ts` receives and returns internal `MessageV2.WithParts[]`, not provider messages.
+
+Files changed:
+
+- `packages/opencode/src/session/session.ts`
+- `packages/opencode/src/session/assemble-template.ts`
+- `specs/custom-session-flow.md`
+
+Notes:
+
+- The template is owned by `session/assemble-template.ts`; `session.ts` only calls `SessionAssembleTemplate.ensure(dir)` during directory initialization.
+- The default template includes modular-style JSON discovery under the session directory. Files with `{ "assemble": true, "content": "..." }` become synthetic text messages; optional `position`, `timestamp`/`time`, and `countdown` fields control placement and lifetime.
+- `session/assemble.ts` also calls `SessionAssembleTemplate.ensure(dir)` before loading the hook, so deleting a session's `assemble.ts` or `assemble-schema.md` restores the default files on the next request.
+- `assemble-schema.md` documents the complete `MessageV2.WithParts[]` return schema, including user/assistant `info`, all supported part types, ID prefixes, and a minimal synthetic text example.
+- If the hook fails to load, throws, or returns an invalid shape, the runner appends a temporary synthetic system reminder to the fallback messages so the agent tells the user to fix `assemble.ts`; the reminder is not persisted and disappears once the hook succeeds.
+- Keep the template independent from the assemble runtime so the loader, runner, and session bootstrap can evolve separately.
+
+### 2026-05-11: Remove Bun Runtime Calls From Desktop Sidecar Session Path
+
+Purpose:
+
+- Avoid `ReferenceError: Bun is not defined` when the packaged desktop sidecar runs under Electron/Node instead of Bun.
+- Keep the send-session path free of direct `Bun.*` calls before `streamText(...)` executes.
+
+Files changed:
+
+- `packages/opencode/src/session/session.ts`
+- `packages/opencode/src/session/assemble-template.ts`
+- `packages/opencode/src/session/llm.ts`
+- `packages/opencode/src/session/prompt.ts`
+- `specs/custom-session-flow.md`
+
+Notes:
+
+- Replaced session bootstrap file writes and existence checks with `node:fs/promises`.
+- Replaced session system prompt override reads and LLM request log writes with `node:fs/promises`; request logging no longer blocks on `Bun.write` in Node sidecar builds.
+- Replaced session tool discovery `Bun.Glob` with `fs.readdir` for top-level `.ts`/`.js` files, matching the documented session tool directory behavior.
+- Simplified the default `assemble.ts` template to return `input.messages`; this prevents newly generated session templates from embedding `Bun.file`, `Bun.Glob`, or `Bun.write` into code executed by the Node sidecar.
+- Runtime `Bun.*` references under `packages/opencode/src/session` are now limited to tests.
+
+### 2026-05-11: Allow Explicit Session ID On Create
+
+Purpose:
+
+- Support stable manager-agent sessions whose filesystem directory is known before first launch.
+- Let clients call `POST /session` with an explicit `id` and `title`, then reuse the same `{Global.Path.data}/session/{sessionID}/` for JSON context and tools.
+
+Files changed:
+
+- `packages/opencode/src/session/session.ts`
+- `specs/custom-session-flow.md`
+
+Notes:
+
+- `Session.CreateInput` now accepts optional `id: SessionID`.
+- `Session.create` passes `input.id` through to the existing `createNext` path.
+- Default session creation remains unchanged when `id` is omitted.
+- This is create-only behavior; callers that want ensure semantics should still `GET /session/{id}` first and create only on not found.
+
+### 2026-05-11: Add Minimal Manager Agent Frontend Entry
+
+Purpose:
+
+- Make the default desktop renderer a minimal chat surface bound to a stable manager-agent session.
+- Keep the sidecar/backend as the single capability layer while allowing alternate frontend shapes.
+
+Files changed:
+
+- `packages/app/src/app.tsx`
+- `packages/app/src/pages/manager.tsx`
+- `packages/sdk/js/src/v2/*`
+- `specs/custom-session-flow.md`
+
+Notes:
+
+- The root route `/` now renders the minimal manager page without the classic desktop layout.
+- The classic desktop home remains available at `/classic`; existing project/session routes remain under `/:dir/session/:id?`.
+- The manager page ensures fixed session `ses_manager_agent` with title `管理agent`, creating it through `POST /session` when missing.
+- The page lists visible connected models and sends prompts to the fixed session with the selected provider/model.
+- Proxy input is currently local-only documentation/UI state. The sidecar already reads `HTTP_PROXY`/`HTTPS_PROXY` from environment at startup, but there is no desktop UI/API yet to persist proxy settings into sidecar launch env or restart sidecar automatically.
+- Follow-up work: add a desktop-side proxy settings entry that writes proxy env values, preserves loopback `NO_PROXY`, and restarts sidecar or prompts for app restart.
+
+### 2026-05-12: Restore Classic Desktop as Default Entry
+
+Purpose:
+
+- Make the desktop root route show the classic home layout again.
+- Keep the minimal manager-agent frontend available as an alternate entry.
+
+Files changed:
+
+- `packages/app/src/app.tsx`
+- `specs/custom-session-flow.md`
+
+Notes:
+
+- The root route `/` now renders the classic desktop home inside the normal app shell.
+- The minimal manager page moved to `/manager`, where it still bypasses the classic app shell.
+- The existing `/classic` alias remains available for compatibility.
+- `packages/app` typecheck is currently blocked in this Windows checkout because `packages/app/src/custom-elements.d.ts` and `packages/enterprise/src/custom-elements.d.ts` are Git symlinks checked out as ordinary files containing `../../ui/src/custom-elements.d.ts`; leave this unresolved while `dev:desktop` is running because deleting/recreating the watched files can interrupt the live desktop process.
+
+### 2026-05-12: Add Standalone Manager Dev Frontend
+
+Purpose:
+
+- Allow opening the minimal manager frontend in a separate browser page while keeping the classic desktop window and its session intact.
+- Reuse the existing sidecar connection through a dev-only local proxy instead of starting another backend.
+
+Files changed:
+
+- `packages/desktop/src/main/index.ts`
+- `packages/desktop/scripts/manager-dev.ts`
+- `packages/desktop/package.json`
+- `specs/custom-session-flow.md`
+
+Notes:
+
+- In development, desktop writes `{userData}/sidecar.json` with the current sidecar URL and Basic Auth credentials after choosing the sidecar port/password.
+- `bun --cwd packages/desktop manager:dev` reads that file, starts a local-only browser frontend on `127.0.0.1:17686`, and proxies `/api/*` to the existing sidecar with Basic Auth attached.
+- The classic desktop window remains unchanged; this is only a debugging/inspection frontend.
+
+## Open Design Items
+
+- Define session tool declaration format and permission scope.
+- Define how session skills differ from project/global skills.
+- Define cleanup, archive, and export behavior for session directories.


### PR DESCRIPTION
## Summary
- Adds a manager page and desktop dev entrypoint for running manager-agent sessions.
- Introduces custom session assemble/script support with template-backed prompt assembly.
- Extends session prompt/LLM handling and regenerates SDK types for the new flow.

## Testing
- Not run locally; PR created from existing remote branch.