### PR TITLE
fix(httpapi): drop redundant InstanceRef/WorkspaceRef in session prompt handler

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -1,5 +1,3 @@
-import * as InstanceState from "@/effect/instance-state"
-import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
 import { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { Command } from "@/command"
@@ -275,18 +273,12 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID }
       payload: typeof PromptPayload.Type
     }) {
-      const instance = yield* InstanceState.context
-      const workspace = yield* InstanceState.workspaceID
       const message = yield* promptSvc
         .prompt({
           ...ctx.payload,
           sessionID: ctx.params.sessionID,
         })
-        .pipe(
-          Effect.provideService(InstanceRef, instance),
-          Effect.provideService(WorkspaceRef, workspace),
-          Effect.mapError(() => new HttpApiError.BadRequest({})),
-        )
+        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
       return HttpServerResponse.stream(Stream.make(JSON.stringify(message)).pipe(Stream.encodeText), {
         contentType: "application/json",
       })


### PR DESCRIPTION
## Summary

The `prompt` handler in `httpapi/handlers/session.ts` was manually re-providing `InstanceRef` and `WorkspaceRef` to the prompt effect:

```ts
const instance = yield* InstanceState.context
const workspace = yield* InstanceState.workspaceID
const message = yield* promptSvc
  .prompt({ ...ctx.payload, sessionID: ctx.params.sessionID })
  .pipe(
    Effect.provideService(InstanceRef, instance),
    Effect.provideService(WorkspaceRef, workspace),
    Effect.mapError(() => new HttpApiError.BadRequest({})),
  )
```

These provisions are redundant — `instanceContextLayer` middleware (`middleware/instance-context.ts`) already provides both services to every handler:

- `InstanceStore.provide({ directory })` attaches `InstanceRef` (instance-store.ts:177)
- The middleware then layers `Effect.provideService(WorkspaceRef, route.workspaceID)` on top (instance-context.ts:31)

Sibling handlers (`promptAsync`, `loop`, `cancel`, `shell`) call `promptSvc.prompt(...)` without re-providing and work fine. The `prompt` method's signature also has no `R` requirements, so providing these has no type-level effect either.

This was the only redundant `Effect.provideService(InstanceRef|WorkspaceRef, ...)` call site outside of the middleware/runtime/CLI bootstrap layer.

## Test plan

- [x] `bun run typecheck` passes
- [ ] CI green