### PR TITLE
test(server): migrate session select to effect runner

### DIFF
--- a/packages/opencode/test/server/session-select.test.ts
+++ b/packages/opencode/test/server/session-select.test.ts
@@ -1,101 +1,87 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { describe, expect } from "bun:test"
 import { Effect } from "effect"
-import { Session as SessionNs } from "@/session/session"
-import type { SessionID } from "../../src/session/schema"
+import { Session } from "@/session/session"
 import * as Log from "@opencode-ai/core/util/log"
-import { Instance } from "../../src/project/instance"
-import { WithInstance } from "../../src/project/with-instance"
 import { Server } from "../../src/server/server"
-import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
 void Log.init({ print: false })
 
-function run<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
-  return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
-}
-
-const svc = {
-  ...SessionNs,
-  create(input?: SessionNs.CreateInput) {
-    return run(SessionNs.Service.use((svc) => svc.create(input)))
-  },
-  remove(id: SessionID) {
-    return run(SessionNs.Service.use((svc) => svc.remove(id)))
-  },
-}
-
-afterEach(async () => {
-  await disposeAllInstances()
-})
+const it = testEffect(Session.defaultLayer)
 
 describe("tui.selectSession endpoint", () => {
-  test("should return 200 when called with valid session", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await WithInstance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        // #given
-        const session = await svc.create({})
+  it.instance("should return 200 when called with valid session", () =>
+    Effect.gen(function* () {
+      const tmp = yield* TestInstance
+      const session = yield* Session.Service.use((svc) => svc.create({}))
 
-        // #when
-        const app = Server.Default().app
-        const response = await app.request("/tui/select-session", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sessionID: session.id }),
-        })
+      const app = Server.Default().app
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app.request("/tui/select-session", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-opencode-directory": tmp.directory,
+            },
+            body: JSON.stringify({ sessionID: session.id }),
+          }),
+        ),
+      )
 
-        // #then
-        expect(response.status).toBe(200)
-        const body = await response.json()
-        expect(body).toBe(true)
+      expect(response.status).toBe(200)
+      const body = yield* Effect.promise(() => response.json())
+      expect(body).toBe(true)
+    }),
+    { git: true },
+  )
 
-        await svc.remove(session.id)
-      },
-    })
-  })
+  it.instance("should return 404 when session does not exist", () =>
+    Effect.gen(function* () {
+      const tmp = yield* TestInstance
+      const nonExistentSessionID = "ses_nonexistent123"
 
-  test("should return 404 when session does not exist", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await WithInstance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        // #given
-        const nonExistentSessionID = "ses_nonexistent123"
+      const app = Server.Default().app
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app.request("/tui/select-session", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-opencode-directory": tmp.directory,
+            },
+            body: JSON.stringify({ sessionID: nonExistentSessionID }),
+          }),
+        ),
+      )
 
-        // #when
-        const app = Server.Default().app
-        const response = await app.request("/tui/select-session", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sessionID: nonExistentSessionID }),
-        })
+      expect(response.status).toBe(404)
+    }),
+    { git: true },
+  )
 
-        // #then
-        expect(response.status).toBe(404)
-      },
-    })
-  })
+  it.instance("should return 400 when session ID format is invalid", () =>
+    Effect.gen(function* () {
+      const tmp = yield* TestInstance
+      const invalidSessionID = "invalid_session_id"
 
-  test("should return 400 when session ID format is invalid", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await WithInstance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        // #given
-        const invalidSessionID = "invalid_session_id"
+      const app = Server.Default().app
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app.request("/tui/select-session", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-opencode-directory": tmp.directory,
+            },
+            body: JSON.stringify({ sessionID: invalidSessionID }),
+          }),
+        ),
+      )
 
-        // #when
-        const app = Server.Default().app
-        const response = await app.request("/tui/select-session", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sessionID: invalidSessionID }),
-        })
-
-        // #then
-        expect(response.status).toBe(400)
-      },
-    })
-  })
+      expect(response.status).toBe(400)
+    }),
+    { git: true },
+  )
 })


### PR DESCRIPTION
## Summary
- Migrates `session-select.test.ts` to the Effect-native test runner with `it.instance`.
- Removes ad hoc `Effect.runPromise`, `WithInstance.provide`, and manual session cleanup from the test body.

## Tests
- `bun run test test/server/session-select.test.ts`
- `bun typecheck`

## Notes
- `bun install` initially failed while building `tree-sitter-powershell`, but it linked enough dependencies for the requested verification commands to pass.