### PR TITLE
test(server): migrate global bus helper to Effect

### DIFF
--- a/packages/opencode/test/server/global-bus.ts
+++ b/packages/opencode/test/server/global-bus.ts
@@ -29,6 +29,3 @@ export function waitGlobalBusEvent(input: {
     ),
   )
 }
-
-export const waitGlobalBusEventPromise = (input: Parameters<typeof waitGlobalBusEvent>[0]) =>
-  Effect.runPromise(waitGlobalBusEvent(input))

--- a/packages/opencode/test/server/httpapi-config.test.ts
+++ b/packages/opencode/test/server/httpapi-config.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect } from "bun:test"
 import path from "path"
 import { Server } from "../../src/server/server"
 import * as Log from "@opencode-ai/core/util/log"
+import { Effect, Fiber } from "effect"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, tmpdir } from "../fixture/fixture"
-import { waitGlobalBusEventPromise } from "./global-bus"
+import { it } from "../lib/effect"
+import { waitGlobalBusEvent } from "./global-bus"
 
 void Log.init({ print: false })
 
@@ -12,12 +14,18 @@ function app() {
   return Server.Default().app
 }
 
-async function waitDisposed(directory: string) {
-  await waitGlobalBusEventPromise({
+function waitDisposed(directory: string) {
+  return waitGlobalBusEvent({
     message: "timed out waiting for instance disposal",
     predicate: (event) => event.payload.type === "server.instance.disposed" && event.directory === directory,
   })
 }
+
+const tmpdirEffect = (options: Parameters<typeof tmpdir>[0]) =>
+  Effect.acquireRelease(
+    Effect.promise(() => tmpdir(options)),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  )
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -25,34 +33,71 @@ afterEach(async () => {
 })
 
 describe("config HttpApi", () => {
-  test("serves config update through the default server app", async () => {
-    await using tmp = await tmpdir({ config: { formatter: false, lsp: false } })
-    const disposed = waitDisposed(tmp.path)
+  it.live(
+    "serves config update through the default server app",
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirEffect({ config: { formatter: false, lsp: false } })
+      const disposed = yield* waitDisposed(tmp.path).pipe(Effect.forkScoped)
 
-    const response = await app().request("/config", {
-      method: "PATCH",
-      headers: {
-        "content-type": "application/json",
-        "x-opencode-directory": tmp.path,
-      },
-      body: JSON.stringify({ username: "patched-user", formatter: false, lsp: false }),
-    })
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app().request("/config", {
+            method: "PATCH",
+            headers: {
+              "content-type": "application/json",
+              "x-opencode-directory": tmp.path,
+            },
+            body: JSON.stringify({ username: "patched-user", formatter: false, lsp: false }),
+          }),
+        ),
+      )
 
-    expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({ username: "patched-user", formatter: false, lsp: false })
-    await disposed
-    expect(await Bun.file(path.join(tmp.path, "config.json")).json()).toMatchObject({
-      username: "patched-user",
-      formatter: false,
-      lsp: false,
-    })
-  })
-
-  test("serves config with active provider model status", async () => {
-    await using tmp = await tmpdir({
-      config: {
+      expect(response.status).toBe(200)
+      expect(yield* Effect.promise(() => response.json())).toMatchObject({
+        username: "patched-user",
         formatter: false,
         lsp: false,
+      })
+      yield* Fiber.join(disposed)
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "config.json")).json())).toMatchObject({
+        username: "patched-user",
+        formatter: false,
+        lsp: false,
+      })
+    }),
+  )
+
+  it.live(
+    "serves config with active provider model status",
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirEffect({
+        config: {
+          formatter: false,
+          lsp: false,
+          provider: {
+            omniroute: {
+              models: {
+                "gpt-4o": {
+                  status: "active",
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app().request("/config", {
+            headers: {
+              "x-opencode-directory": tmp.path,
+            },
+          }),
+        ),
+      )
+
+      expect(response.status).toBe(200)
+      expect(yield* Effect.promise(() => response.json())).toMatchObject({
         provider: {
           omniroute: {
             models: {
@@ -62,26 +107,7 @@ describe("config HttpApi", () => {
             },
           },
         },
-      },
-    })
-
-    const response = await app().request("/config", {
-      headers: {
-        "x-opencode-directory": tmp.path,
-      },
-    })
-
-    expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({
-      provider: {
-        omniroute: {
-          models: {
-            "gpt-4o": {
-              status: "active",
-            },
-          },
-        },
-      },
-    })
-  })
+      })
+    }),
+  )
 })


### PR DESCRIPTION
## Summary
- Remove the Promise wrapper around the global bus test helper so callers use the Effect directly.
- Convert the remaining config HTTP API caller to the Effect test runner with scoped temp directory cleanup.

## Tests
- bun typecheck
- bun run test test/server/httpapi-config.test.ts test/server/httpapi-instance-context.test.ts