### PR TITLE
perf(app): unmount closed review panel

### DIFF
--- a/packages/app/src/pages/session/review-tab.tsx
+++ b/packages/app/src/pages/session/review-tab.tsx
@@ -32,7 +32,7 @@ export interface SessionReviewTabProps {
   focusedComment?: { file: string; id: string } | null
   onFocusedCommentChange?: (focus: { file: string; id: string } | null) => void
   focusedFile?: string
-  onScrollRef?: (el: HTMLDivElement) => void
+  onScrollRef?: (el: HTMLDivElement | undefined) => void
   commentMentions?: {
     items: (query: string) => string[] | Promise<string[]>
   }
@@ -126,6 +126,7 @@ export function SessionReviewTab(props: SessionReviewTabProps) {
 
   onCleanup(() => {
     if (restoreFrame !== undefined) cancelAnimationFrame(restoreFrame)
+    props.onScrollRef?.(undefined)
   })
 
   return (

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -221,7 +221,8 @@ export function SessionSidePanel(props: {
         }}
         style={{ width: panelWidth() }}
       >
-        <div class="size-full flex border-l border-border-weaker-base">
+        <Show when={open()}>
+          <div class="size-full flex border-l border-border-weaker-base">
           <div
             aria-hidden={!reviewOpen()}
             inert={!reviewOpen()}
@@ -313,7 +314,7 @@ export function SessionSidePanel(props: {
 
                   <Show when={reviewTab() && props.canReview()}>
                     <Tabs.Content value="review" class="flex flex-col h-full overflow-hidden contain-strict">
-                      <Show when={activeTab() === "review"}>{props.reviewPanel()}</Show>
+                      <Show when={reviewOpen() && activeTab() === "review"}>{props.reviewPanel()}</Show>
                     </Tabs.Content>
                   </Show>
 
@@ -453,7 +454,8 @@ export function SessionSidePanel(props: {
               </Show>
             </div>
           </Show>
-        </div>
+          </div>
+        </Show>
       </aside>
     </Show>
   )


### PR DESCRIPTION
## Summary
- Do not mount review/file-tree side panel content while the desktop side panel is closed.
- Only mount the review tab body when the review panel is actually open.
- Clear the stored review scroll ref when the review tab unmounts.

## Perf comparison
Chrome trace, same repro: review visibly closed, New Session -> GitHub CLI session.

| Metric | Baseline | PR | Change |
|---|---:|---:|---:|
| Hidden review DOM while closed | present | gone | fixed |
| session-review mounted while closed | yes | no | fixed |
| Total DOM elements | 1836 | 1625 | -211 / -11.5% |
| Forced reflow total | 356ms | 198ms | -158ms / -44% |
| ScrollView.updateThumb reflow | 16ms | 6ms | -62% |
| updateScrollState reflow | 19ms | 3ms | -84% |
| Pierre diff forced reflow | 559ms | 396ms | -163ms / -29% |
| Largest style recalcs | 150/170/154ms | 159/163/42ms | third large recalc mostly gone |
| CLS trace metric | 0.00 | 0.00 | unchanged |

Notes: this does not claim to fix timeline virtualization flicker; it only removes closed review panel work from the baseline.

## Validation
- bun typecheck from packages/app
- push hook: bun turbo typecheck
- Runtime DOM check on this worktree: review closed => sessionReviewCount 0, reviewScrollCount 0, empty #review-panel text; review opened => both counts 1; closed again => both counts 0.