### PR TITLE
chore: cleanup opencode brand residue in 6 workflow files (#44)

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -41,7 +41,7 @@ jobs:
             } >> $GITHUB_OUTPUT
           fi
 
-      - name: Run opencode
+      - name: Run octopus
         if: steps.commits.outputs.has_commits == 'true'
         uses: sst/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
         env:

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
-      - name: Install opencode
+      - name: Install octopus
         run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Check duplicates and compliance
@@ -131,7 +131,7 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
-      - name: Install opencode
+      - name: Install octopus
         run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Recheck compliance

--- a/.github/workflows/octopus.yml
+++ b/.github/workflows/octopus.yml
@@ -1,4 +1,4 @@
-name: opencode
+name: octopus
 
 on:
   issue_comment:
@@ -7,10 +7,12 @@ on:
     types: [created]
 
 jobs:
-  opencode:
+  octopus:
     if: |
       contains(github.event.comment.body, ' /oc') ||
       startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /octopus') ||
+      startsWith(github.event.comment.body, '/octopus') ||
       contains(github.event.comment.body, ' /opencode') ||
       startsWith(github.event.comment.body, '/opencode')
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -25,7 +27,7 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
-      - name: Run opencode
+      - name: Run octopus
         uses: anomalyco/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -35,7 +35,7 @@ jobs:
         if: steps.team-check.outputs.is_team != 'true'
         run: bun install
 
-      - name: Install opencode
+      - name: Install octopus
         if: steps.team-check.outputs.is_team != 'true'
         run: curl -fsSL https://opencode.ai/install | bash
 

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -100,7 +100,7 @@ jobs:
             - \`refactor:\` or \`refactor(scope):\` code refactoring
             - \`test:\` or \`test(scope):\` adding or updating tests
 
-            Where \`scope\` is the package name (e.g., \`app\`, \`desktop\`, \`opencode\`).
+            Where \`scope\` is the package name (e.g., \`app\`, \`desktop\`, \`octopus\`).
 
             See [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md#pr-titles) for details.`);
               return;

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
-      - name: Install opencode
+      - name: Install octopus
         run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Get PR details


### PR DESCRIPTION
## Summary

Cleans up remaining `opencode` brand references in 6 CI/CD workflow files
as part of Issue #44 (gap remediation Wave 1, XS fast-track).

### Changes

| File | Change |
|------|--------|
| `opencode.yml` → `octopus.yml` | Renamed file; updated workflow name, job name, step name |
| `octopus.yml` | Added `/octopus` trigger alias alongside existing `/opencode` (backward compat) |
| `docs-update.yml` | Step name `Run opencode` → `Run octopus` |
| `duplicate-issues.yml` | Step name `Install opencode` → `Install octopus` (×2) |
| `review.yml` | Step name `Install opencode` → `Install octopus` |
| `pr-management.yml` | Step name `Install opencode` → `Install octopus` |
| `pr-standards.yml` | Scope example `opencode` → `octopus` in conventional commit docs |

### Preserved (per constraints)
- All model IDs (`opencode/claude-*`, `opencode/gpt-*`)
- Bot username `opencode-agent[bot]` (not renamed)
- `/opencode` trigger alias (backward compatibility)
- External URLs (`https://opencode.ai/install`)
- GitHub Action paths (`uses: anomalyco/opencode/github@...`, `uses: sst/opencode/github@...`)
- Secret names (`OPENCODE_API_KEY`, `OPENCODE_PERMISSION`)

### Verification
- ✅ All 6 YAML files pass `yaml.safe_load` validation
- ✅ No residual `opencode` step names
- ✅ All model IDs retained
- ✅ `/opencode` trigger still functional
- ✅ Blocked files (nix-eval, docs-locale-sync) untouched

Closes #44