### PR TITLE
test(server): stabilize SDK project skill prompt test

### DIFF
--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -743,7 +743,7 @@ describe("HttpApi SDK", () => {
   )
 
   httpapi(
-    "includes project skills in REST API async prompt context",
+    "includes project skills in REST API prompt context",
     withFakeLlmProject("default", { setup: writeProjectSkill }, ({ sdk, llm }) =>
       Effect.gen(function* () {
         yield* llm.text("skill context ok", { usage: { input: 11, output: 7 } })
@@ -755,18 +755,17 @@ describe("HttpApi SDK", () => {
         )
         const sessionID = String(record(session.data).id)
         const prompt = yield* capture(() =>
-          sdk.session.promptAsync({
+          sdk.session.prompt({
             sessionID,
             agent: "build",
             model: { providerID: "test", modelID: "test-model" },
             parts: [{ type: "text", text: "hello skill context" }],
           }),
         )
-        yield* llm.wait(1)
         const inputs = yield* llm.inputs
 
         expect(session.status).toBe(200)
-        expect(prompt.status).toBe(204)
+        expect(prompt.status).toBe(200)
         expect(JSON.stringify(inputs[0])).toContain("project-rest-skill")
       }),
     ),


### PR DESCRIPTION
## Summary
- make the SDK project-skill prompt test use the synchronous REST prompt path
- avoid waiting on detached promptAsync background processing in full-suite CI
- promptAsync context inheritance remains covered by the dedicated promptAsync context test

## Test
- bun run test test/server/httpapi-sdk.test.ts
- bun typecheck