### PR TITLE
fix: add optional chaining to session_status access

### DIFF
--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -209,7 +209,7 @@ export function createChildStoreManager(input: {
             sessionTotal: 0,
             session_status: {},
             session_working(id: string) {
-              return this.session_status[id].type !== "idle"
+              return this.session_status[id]?.type !== "idle"
             },
             session_diff: {},
             todo: {},


### PR DESCRIPTION
Prevents potential runtime error when `session_status[id]` is undefined by using optional chaining (`?.`).