### PR TITLE
docs(ecosystem): add theSaver plugin to ecosystem page

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
+| [theSaver](https://github.com/DrunkkToys/theSaver-oc)                                            | Cost-aware delegation enforcer with three-tier model routing, prompt-cache tracking, ROI reporting, and a trinity CLI for brain/medium/cheap slot switching |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |


### PR DESCRIPTION
### Issue for this PR

Closes #27255

### Type of change

- [x] Documentation

### What does this PR do?

Adds theSaver, a cost-aware delegation enforcer plugin, to the Plugins table in the ecosystem page.

### How did you verify your code works?

Changes are limited to adding one row in an MDX table. Verified the entry follows the existing format and is placed in alphabetical order.

### Screenshots / recordings

N/A — documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR