### PR TITLE
fix(server): hide unknown 500 details

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
@@ -48,7 +48,7 @@ export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect)
       return Effect.succeed(
         HttpServerResponse.jsonUnsafe(
           new NamedError.Unknown({
-            message: error instanceof Error && error.stack ? error.stack : String(error),
+            message: "Unexpected server error. Check server logs for details.",
           }).toObject(),
           { status: 500 },
         ),

--- a/packages/opencode/test/server/httpapi-error-middleware.test.ts
+++ b/packages/opencode/test/server/httpapi-error-middleware.test.ts
@@ -1,0 +1,30 @@
+import { NodeHttpServer, NodeServices } from "@effect/platform-node"
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
+import { errorLayer } from "../../src/server/routes/instance/httpapi/middleware/error"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.mergeAll(NodeHttpServer.layerTest, NodeServices.layer))
+
+describe("HttpApi error middleware", () => {
+  it.live("returns a safe body for unknown 500 defects", () =>
+    Effect.gen(function* () {
+      yield* HttpRouter.add("GET", "/boom", Effect.die(new Error("secret stack marker"))).pipe(
+        Layer.provide(errorLayer),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.get("/boom").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(500)
+      expect(body).toEqual({
+        name: "UnknownError",
+        data: { message: "Unexpected server error. Check server logs for details." },
+      })
+      expect(JSON.stringify(body)).not.toContain("secret stack marker")
+    }),
+  )
+})


### PR DESCRIPTION
## summary
- return a safe UnknownError body for unknown HTTP 500 defects instead of exposing stack details
- add a focused Effect HTTP middleware regression test for the fallback response

## testing
- bun test test/server/httpapi-error-middleware.test.ts
- bun typecheck