### PR TITLE
feat(desktop): reintroduce AppStream MetaInfo for Linux desktop builds

### DIFF
--- a/packages/desktop/.gitignore
+++ b/packages/desktop/.gitignore
@@ -26,3 +26,4 @@ out/
 
 resources/opencode-cli*
 resources/icons
+resources/*.metainfo.xml

--- a/packages/desktop/scripts/copy-metainfo.ts
+++ b/packages/desktop/scripts/copy-metainfo.ts
@@ -1,0 +1,47 @@
+import { resolveChannel } from "./utils"
+
+const arg = process.argv[2]
+const channel = arg === "dev" || arg === "beta" || arg === "prod" ? arg : resolveChannel()
+
+const appId = channel === "prod" ? "ai.opencode.desktop" : `ai.opencode.desktop.${channel}`
+const productName = channel === "prod" ? "OpenCode" : `OpenCode ${channel.charAt(0).toUpperCase() + channel.slice(1)}`
+const summary = `Open source AI coding agent${channel !== "prod" ? ` (${channel})` : ""}`
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>${appId}</id>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <name>${productName}</name>
+  <summary>${summary}</summary>
+
+  <developer id="ly.anoma">
+    <name>Anomaly Innovations Inc.</name>
+  </developer>
+
+  <description>
+    <p>
+      OpenCode is an open source agent that helps you write and run code with any AI model.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">${appId}.desktop</launchable>
+
+  <content_rating type="oars-1.1" />
+
+  <url type="bugtracker">https://github.com/anomalyco/opencode/issues</url>
+  <url type="homepage">https://opencode.ai</url>
+  <url type="vcs-browser">https://github.com/anomalyco/opencode</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/anomalyco/opencode/b75d4d1c5ec449585d515c756fc81f080a157a9a/packages/web/src/assets/lander/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+</component>
+`
+
+await Bun.write(`resources/${appId}.metainfo.xml`, xml)
+console.log(`Generated metainfo for ${channel} at resources/${appId}.metainfo.xml`)

--- a/packages/desktop/scripts/prebuild.ts
+++ b/packages/desktop/scripts/prebuild.ts
@@ -5,5 +5,6 @@ import { resolveChannel } from "./utils"
 
 const channel = resolveChannel()
 await $`bun ./scripts/copy-icons.ts ${channel}`
+await $`bun ./scripts/copy-metainfo.ts ${channel}`
 
 await $`cd ../opencode && bun script/build-node.ts`


### PR DESCRIPTION
Restores the AppStream MetaInfo file that was dropped during the Tauri-to-Electron migration in #25822.

The metainfo file is essential for Flatpak packaging and provides metadata about the application to Linux software centers (GNOME Software, KDE Discover, etc.).

- Creates channel-specific metainfo XML files (prod/beta/dev) with correct app IDs
- Adds `copy-metainfo.ts` script, called during prebuild, that places the right file in the build resources directory
- electron-builder auto-detects and embeds the metainfo in AppImage/deb/rpm packages

Closes #27083