### PR TITLE
Opencode-cli missing in Debian package

### DIFF
--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -39,6 +39,10 @@ const getBase = (): Configuration => ({
       to: "native/",
       filter: ["index.js", "index.d.ts", "build/Release/mac_window.node", "swift-build/**"],
     },
+    {
+      from: `resources/opencode-cli${process.platform === "win32" ? ".exe" : ""}`,
+      to: `opencode-cli${process.platform === "win32" ? ".exe" : ""}`,
+    },
   ],
   mac: {
     category: "public.app-category.developer-tools",
@@ -75,6 +79,10 @@ const getBase = (): Configuration => ({
     icon: `resources/icons`,
     category: "Development",
     target: ["AppImage", "deb", "rpm"],
+  },
+  deb: {
+    afterInstall: "scripts/deb-after-install.sh",
+    afterRemove: "scripts/deb-after-remove.sh",
   },
 })
 

--- a/packages/desktop/scripts/deb-after-install.sh
+++ b/packages/desktop/scripts/deb-after-install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+LINK="/usr/bin/opencode-cli"
+
+for dir in '/opt/OpenCode' '/opt/OpenCode Beta' '/opt/OpenCode Dev'; do
+  target="${dir}/resources/opencode-cli"
+  if [ -x "${target}" ]; then
+    ln -sf "${target}" "${LINK}"
+    exit 0
+  fi
+done

--- a/packages/desktop/scripts/deb-after-remove.sh
+++ b/packages/desktop/scripts/deb-after-remove.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+LINK="/usr/bin/opencode-cli"
+
+if [ -L "${LINK}" ] && [ ! -e "${LINK}" ]; then
+  rm -f "${LINK}"
+fi

--- a/packages/desktop/scripts/download-cli.ts
+++ b/packages/desktop/scripts/download-cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+import { $ } from "bun"
+import path from "node:path"
+
+import { copyBinaryToSidecarFolder, getCurrentSidecar, windowsify } from "./utils"
+
+const artifact = process.env.OPENCODE_CLI_ARTIFACT
+const runId = process.env.GITHUB_RUN_ID
+
+if (!artifact || !runId) {
+  console.log(`Skipping CLI download (OPENCODE_CLI_ARTIFACT=${artifact ?? ""}, GITHUB_RUN_ID=${runId ?? ""})`)
+  process.exit(0)
+}
+
+const sidecar = getCurrentSidecar()
+const downloadDir = path.resolve(import.meta.dir, "../.cli-artifact")
+
+await $`rm -rf ${downloadDir}`
+await $`mkdir -p ${downloadDir}`
+await $`gh run download ${runId} --name ${artifact} --dir ${downloadDir}`
+
+const source = windowsify(path.join(downloadDir, sidecar.ocBinary, "bin", "opencode"))
+await copyBinaryToSidecarFolder(source)

--- a/packages/desktop/scripts/prepare.ts
+++ b/packages/desktop/scripts/prepare.ts
@@ -2,6 +2,7 @@
 import { Script } from "@opencode-ai/script"
 
 await import("./prebuild")
+await import("./download-cli")
 
 const pkg = await Bun.file("./package.json").json()
 pkg.version = Script.version

--- a/packages/desktop/scripts/utils.test.ts
+++ b/packages/desktop/scripts/utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+
+import type { Configuration } from "electron-builder"
+
+import { getCurrentSidecar, SIDECAR_BINARIES, windowsify } from "./utils"
+
+describe("sidecar utils", () => {
+  test("SIDECAR_BINARIES has an entry for every supported electron-builder target", () => {
+    const targets = SIDECAR_BINARIES.map((b) => b.rustTarget).sort()
+    expect(targets).toEqual([
+      "aarch64-apple-darwin",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-linux-gnu",
+    ])
+  })
+
+  test("getCurrentSidecar resolves the Linux x64 baseline binary", () => {
+    expect(getCurrentSidecar("x86_64-unknown-linux-gnu").ocBinary).toBe("opencode-linux-x64-baseline")
+  })
+
+  test("getCurrentSidecar throws for an unknown target", () => {
+    expect(() => getCurrentSidecar("riscv64-unknown-linux-gnu")).toThrow(/Sidecar configuration not available/)
+  })
+
+  test("windowsify only appends .exe on win32", () => {
+    expect(windowsify("resources/opencode-cli")).toBe(
+      process.platform === "win32" ? "resources/opencode-cli.exe" : "resources/opencode-cli",
+    )
+    expect(windowsify("resources/opencode-cli.exe")).toBe("resources/opencode-cli.exe")
+  })
+})
+
+describe("electron-builder config", () => {
+  test("packages opencode-cli as an extra resource so it ends up in the deb", async () => {
+    const previous = process.env.OPENCODE_CHANNEL
+    process.env.OPENCODE_CHANNEL = "prod"
+    try {
+      const mod: { default: Configuration } = await import(`./../electron-builder.config.ts?t=${Date.now()}`)
+      const config = mod.default
+
+      const binary = `opencode-cli${process.platform === "win32" ? ".exe" : ""}`
+      const resources = config.extraResources
+      expect(Array.isArray(resources)).toBe(true)
+      const entry =
+        Array.isArray(resources) &&
+        resources
+          .filter((r): r is { from: string; to: string } => typeof r === "object" && r !== null && "to" in r)
+          .find((r) => r.to === binary)
+      expect(entry).toBeTruthy()
+      expect(entry && entry.from).toBe(`resources/${binary}`)
+
+      expect(config.deb?.afterInstall).toBe("scripts/deb-after-install.sh")
+      expect(config.deb?.afterRemove).toBe("scripts/deb-after-remove.sh")
+    } finally {
+      if (previous === undefined) delete process.env.OPENCODE_CHANNEL
+      else process.env.OPENCODE_CHANNEL = previous
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #27064

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Tauri → Electron migration removed the step that actually fetches the CLI artifact but kept `copyBinaryToSidecarFolder` and the `OPENCODE_CLI_ARTIFACT` / `GITHUB_RUN_ID` env vars in place, so the `opencode-cli` binary and its `/usr/bin/opencode-cli` symlink stopped shipping in the deb from 1.14.34 onward.

This PR adds `scripts/download-cli.ts` (called from `prepare.ts`) which pulls the CLI artifact via `gh run download` and stages it at `resources/opencode-cli`. `electron-builder.config.ts` then bundles it via `extraResources` and installs/removes the `/usr/bin/opencode-cli` symlink through `deb.afterInstall` / `deb.afterRemove` hooks.

### How did you verify your code works?

Added `scripts/utils.test.ts` covering the download helper. Built the deb locally, confirmed `opencode-cli` is inside it, and confirmed `/usr/bin/opencode-cli` is created on install and removed on uninstall.

### Screenshots / recordings

N/A — build/packaging change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR