### PR TITLE
fix(app): ignore CRLF and symlink type changes on Windows

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -421,6 +421,7 @@ export const layer = Layer.effect(
         "-c",
         "core.quotepath=false",
         "diff",
+        "--ignore-cr-at-eol",
         "--numstat",
         "HEAD",
       ])
@@ -470,6 +471,7 @@ export const layer = Layer.effect(
         "-c",
         "core.quotepath=false",
         "diff",
+        "--ignore-cr-at-eol",
         "--name-only",
         "--diff-filter=D",
         "HEAD",

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -11,8 +11,6 @@ const cfg = [
   "-c",
   "core.longpaths=true",
   "-c",
-  "core.symlinks=true",
-  "-c",
   "core.quotepath=false",
 ] as const
 
@@ -244,7 +242,7 @@ export const layer = Layer.effect(
 
     const diff = Effect.fn("Git.diff")(function* (cwd: string, ref: string) {
       const list = nuls(
-        yield* text(["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", ref, "--", "."], { cwd }),
+          yield* text(["diff", "--ignore-cr-at-eol", "--no-ext-diff", "--no-renames", "--name-status", "-z", ref, "--", "."], { cwd }),
       )
       return list.flatMap((code, idx) => {
         if (idx % 2 !== 0) return []
@@ -256,7 +254,7 @@ export const layer = Layer.effect(
 
     const stats = Effect.fn("Git.stats")(function* (cwd: string, ref: string) {
       return nuls(
-        yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
+          yield* text(["diff", "--ignore-cr-at-eol", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
       ).flatMap((item) => {
         const a = item.indexOf("\t")
         const b = item.indexOf("\t", a + 1)
@@ -279,7 +277,7 @@ export const layer = Layer.effect(
 
     const patch = Effect.fn("Git.patch")(function* (cwd: string, ref: string, file: string, options?: PatchOptions) {
       const result = yield* run(
-        ["diff", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", file],
+        ["diff", "--ignore-cr-at-eol", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", file],
         { cwd, maxOutputBytes: options?.maxOutputBytes },
       )
       return { text: result.truncated ? "" : result.text(), truncated: result.truncated } satisfies Patch
@@ -287,7 +285,7 @@ export const layer = Layer.effect(
 
     const patchAll = Effect.fn("Git.patchAll")(function* (cwd: string, ref: string, options?: PatchOptions) {
       const result = yield* run(
-        ["diff", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", "."],
+        ["diff", "--ignore-cr-at-eol", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", "."],
         { cwd, maxOutputBytes: options?.maxOutputBytes },
       )
       return { text: result.text(), truncated: result.truncated } satisfies Patch
@@ -301,6 +299,7 @@ export const layer = Layer.effect(
       const result = yield* run(
         [
           "diff",
+          "--ignore-cr-at-eol",
           "--no-index",
           "--patch",
           "--no-ext-diff",
@@ -316,7 +315,7 @@ export const layer = Layer.effect(
     })
 
     const statUntracked = Effect.fn("Git.statUntracked")(function* (cwd: string, file: string) {
-      const result = yield* run(["diff", "--no-index", "--numstat", "--", "/dev/null", file], {
+      const result = yield* run(["diff", "--ignore-cr-at-eol", "--no-index", "--numstat", "--", "/dev/null", file], {
         cwd,
         maxOutputBytes: 4096,
       })


### PR DESCRIPTION
### Issue for this PR

Closes #27276

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, the Review window and Changes tab show many files as "Modified" even though they have no actual content changes. Two root causes in the hardcoded git config (`packages/opencode/src/git/index.ts`):

1. **`core.autocrlf=false` conflict** — Windows defaults to `core.autocrlf=true`, which converts LF→CRLF on checkout. The VCS layer overrides this to `false`, so `git diff` compares CRLF working trees against LF repository blobs literally, marking every text file as modified.
2. **`core.symlinks=true` on a non-symlink filesystem** — There are 62 symlink files in the repository. Windows does not natively support symlinks, so they are checked out as regular files. Forcing `core.symlinks=true` makes `git diff` detect these as type changes (T) and report them as modified.

**Fixes:**

- **`git/index.ts`**: Remove `-c core.symlinks=true` from the config array so git uses the platform default (`true` on macOS/Linux, `false` on Windows). Add `--ignore-cr-at-eol` to all 6 `git diff` commands so git ignores carriage-return at end-of-line during comparison.
- **`file/index.ts`**: Add `--ignore-cr-at-eol` to the two `git diff` commands used by the file tree Changes tab (`diff --numstat HEAD` and `diff --name-only --diff-filter=D HEAD`), which run independently of the git layer's config.

### How did you verify your code works?

- **CRLF fix**: Before the fix, all text files appeared modified. After adding `--ignore-cr-at-eol`, only genuinely changed files show. Confirmed by comparing `git diff --name-status HEAD` output with and without the flag — the file count dropped from hundreds to single digits on a Windows machine with `core.autocrlf=true`.
- **Symlink fix**: Before the fix, `git -c core.symlinks=true diff --name-status HEAD` listed all 62 symlink files as type changes (T). After removing the override, only actually modified files (like the replaced `icon.png`) appear.
- **Binary files**: Replaced `sdks/vscode/images/icon.png` and confirmed the change shows correctly — binary file modifications are not affected by either fix.
- **Cross-platform**: `core.symlinks` defaults to `true` on macOS/Linux, so removing the override has zero effect there. `--ignore-cr-at-eol` is a no-op on platforms without CRLF working trees.

### Screenshots / recordings

N/A — this is a git layer logic fix, not a UI change.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR