### PR TITLE
fix(server): remove storage not found defect fallback

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
@@ -1,6 +1,5 @@
 import { Provider } from "@/provider/provider"
 import { Session } from "@/session/session"
-import { NotFoundError } from "@/storage/storage"
 import { iife } from "@/util/iife"
 import { NamedError } from "@opencode-ai/core/util/error"
 import * as Log from "@opencode-ai/core/util/log"
@@ -23,10 +22,6 @@ export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect)
 
       const error = defect.defect
       log.error("failed", { error, cause: Cause.pretty(cause) })
-
-      if (error instanceof NotFoundError) {
-        return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 404 }))
-      }
 
       if (error instanceof NamedError) {
         return Effect.succeed(

--- a/packages/opencode/test/server/httpapi-error-middleware.test.ts
+++ b/packages/opencode/test/server/httpapi-error-middleware.test.ts
@@ -3,6 +3,7 @@ import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { errorLayer } from "../../src/server/routes/instance/httpapi/middleware/error"
+import { NotFoundError } from "../../src/storage/storage"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(NodeHttpServer.layerTest, NodeServices.layer))
@@ -25,6 +26,25 @@ describe("HttpApi error middleware", () => {
         data: { message: "Unexpected server error. Check server logs for details." },
       })
       expect(JSON.stringify(body)).not.toContain("secret stack marker")
+    }),
+  )
+
+  it.live("does not map storage not-found defects to 404", () =>
+    Effect.gen(function* () {
+      yield* HttpRouter.add(
+        "GET",
+        "/missing",
+        Effect.die(new NotFoundError({ message: "Resource not found: secret" })),
+      ).pipe(Layer.provide(errorLayer), HttpRouter.serve, Layer.build)
+
+      const response = yield* HttpClientRequest.get("/missing").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(500)
+      expect(body).toEqual({
+        name: "UnknownError",
+        data: { message: "Unexpected server error. Check server logs for details." },
+      })
     }),
   )
 })


### PR DESCRIPTION
## summary
- remove the HTTP middleware branch that converted defected storage `NotFoundError` values into 404 responses
- keep declared route-level not-found handling intact for session APIs
- add middleware coverage that storage not-found defects now fall through to the safe 500 fallback

## testing
- `bun test test/server/httpapi-error-middleware.test.ts`
- `bun test test/server/httpapi-session.test.ts`
- `bun typecheck`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #27280
2. **#27287** 👈 current
<!-- stack:links:end -->