### PR TITLE
fix: prevent TUI from ignoring config model on startup

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -188,6 +188,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
         }
 
+        if (!modelStore.ready) return undefined
+
         const provider = sync.data.provider[0]
         if (!provider) return undefined
         const defaultModel = sync.data.provider_default[provider.id]


### PR DESCRIPTION
### Issue for this PR

Closes #27299
See also #15225

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI's `fallbackModel` memo in `local.tsx` resolves on the first render cycle before two async data sources are ready: `sync.data.config.model` (from the server sync bootstrap) and `modelStore.recent` (from `model.json` on disk). When neither is available yet, the memo falls through to `provider_default`, which picks a model via the `sort()` priority array — typically `gemini-3-pro-preview` rather than the user's configured model.

The fix adds `if (!modelStore.ready) return undefined` before the `provider_default` fallback. This makes the memo return `undefined` until the local state file has loaded, at which point SolidJS reactivity re-runs the memo and the config model or recent model is correctly selected. The server-side `defaultModel()` is unaffected because it reads `cfg.model` synchronously via Effect.

### How did you verify your code works?

- `bun typecheck` passes (exit 0, zero errors)
- `bun test` in `packages/opencode` shows identical pass/fail counts before and after the change (40 pass / 2 pre-existing fail in the TUI test suite; the 2 failures are unrelated ENOENT errors from missing native deps)
- Confirmed the same 2 TUI test failures exist on unmodified `dev` by stashing the change and re-running

### Screenshots / recordings

_N/A — no UI changes, only timing of model resolution._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR