### PR TITLE
fix(ui): add clipboard fallback for non-HTTPS environments

### DIFF
--- a/packages/core/src/util/clipboard.ts
+++ b/packages/core/src/util/clipboard.ts
@@ -1,0 +1,36 @@
+/**
+ * Copy text to clipboard with fallback for non-HTTPS environments.
+ * Uses document.execCommand('copy') as fallback when navigator.clipboard is unavailable.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!text) return false
+
+  // Try navigator.clipboard.writeText first (modern API)
+  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(text)
+      return true
+    } catch {
+      // Fall through to execCommand fallback
+    }
+  }
+
+  // Fallback to document.execCommand('copy') for older browsers / non-HTTPS
+  const body = typeof document === "undefined" ? undefined : document.body
+  if (body) {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.setAttribute("readonly", "")
+    textarea.style.position = "fixed"
+    textarea.style.opacity = "0"
+    textarea.style.pointerEvents = "none"
+    body.appendChild(textarea)
+    textarea.select()
+    const copied = document.execCommand("copy")
+    body.removeChild(textarea)
+    return copied
+  }
+
+  return false
+}

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -3,6 +3,7 @@ import { useI18n } from "../context/i18n"
 import DOMPurify from "dompurify"
 import morphdom from "morphdom"
 import { checksum } from "@opencode-ai/core/util/encode"
+import { copyToClipboard } from "@opencode-ai/core/util/clipboard"
 import { ComponentProps, createEffect, createResource, createSignal, onCleanup, splitProps } from "solid-js"
 import { isServer } from "solid-js/web"
 import { stream } from "./markdown-stream"
@@ -201,9 +202,7 @@ function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
     const code = button.closest('[data-component="markdown-code"]')?.querySelector("code")
     const content = code?.textContent ?? ""
     if (!content) return
-    const clipboard = navigator?.clipboard
-    if (!clipboard) return
-    await clipboard.writeText(content)
+    await copyToClipboard(content)
     const labels = getLabels()
     setCopyState(button, labels, true)
     const existing = timeouts.get(button)

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -46,6 +46,7 @@ import { DiffChanges } from "./diff-changes"
 import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
 import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/core/util/path"
+import { copyToClipboard } from "@opencode-ai/core/util/clipboard"
 import { checksum } from "@opencode-ai/core/util/encode"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
@@ -1057,7 +1058,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   const handleCopy = async () => {
     const content = text()
     if (!content) return
-    await navigator.clipboard.writeText(content)
+    await copyToClipboard(content)
     setState("copied", true)
     setTimeout(() => setState("copied", false), 2000)
   }
@@ -1480,7 +1481,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const handleCopy = async () => {
     const content = text()
     if (!content) return
-    await navigator.clipboard.writeText(content)
+    await copyToClipboard(content)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
@@ -1820,7 +1821,7 @@ ToolRegistry.register({
     const handleCopy = async () => {
       const content = text()
       if (!content) return
-      await navigator.clipboard.writeText(content)
+      await copyToClipboard(content)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     }

--- a/packages/ui/src/components/text-field.tsx
+++ b/packages/ui/src/components/text-field.tsx
@@ -2,6 +2,7 @@ import { TextField as Kobalte } from "@kobalte/core/text-field"
 import { createSignal, Show, splitProps } from "solid-js"
 import type { ComponentProps } from "solid-js"
 import { useI18n } from "../context/i18n"
+import { copyToClipboard } from "@opencode-ai/core/util/clipboard"
 import { IconButton } from "./icon-button"
 import { Tooltip } from "./tooltip"
 
@@ -69,7 +70,7 @@ export function TextField(props: TextFieldProps) {
 
   async function handleCopy() {
     const value = local.value ?? local.defaultValue ?? ""
-    await navigator.clipboard.writeText(value)
+    await copyToClipboard(value)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }

--- a/packages/ui/src/components/tool-error-card.tsx
+++ b/packages/ui/src/components/tool-error-card.tsx
@@ -6,6 +6,7 @@ import { Icon } from "./icon"
 import { IconButton } from "./icon-button"
 import { Tooltip } from "./tooltip"
 import { useI18n } from "../context/i18n"
+import { copyToClipboard } from "@opencode-ai/core/util/clipboard"
 
 export interface ToolErrorCardProps extends Omit<ComponentProps<typeof Card>, "children" | "variant"> {
   tool: string
@@ -70,7 +71,7 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
   const copy = async () => {
     const text = cleaned()
     if (!text) return
-    await navigator.clipboard.writeText(text)
+    await copyToClipboard(text)
     setState("copied", true)
     setTimeout(() => setState("copied", false), 2000)
   }

--- a/packages/web/src/components/share/clipboard.ts
+++ b/packages/web/src/components/share/clipboard.ts
@@ -1,0 +1,36 @@
+/**
+ * Copy text to clipboard with fallback for non-HTTPS environments.
+ * Uses document.execCommand('copy') as fallback when navigator.clipboard is unavailable.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!text) return false
+
+  // Try navigator.clipboard.writeText first (modern API)
+  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(text)
+      return true
+    } catch {
+      // Fall through to execCommand fallback
+    }
+  }
+
+  // Fallback to document.execCommand('copy') for older browsers / non-HTTPS
+  const body = typeof document === "undefined" ? undefined : document.body
+  if (body) {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.setAttribute("readonly", "")
+    textarea.style.position = "fixed"
+    textarea.style.opacity = "0"
+    textarea.style.pointerEvents = "none"
+    body.appendChild(textarea)
+    textarea.select()
+    const copied = document.execCommand("copy")
+    body.removeChild(textarea)
+    return copied
+  }
+
+  return false
+}

--- a/packages/web/src/components/share/common.tsx
+++ b/packages/web/src/components/share/common.tsx
@@ -2,6 +2,7 @@ import { createContext, createSignal, splitProps, useContext } from "solid-js"
 import type { JSX } from "solid-js/jsx-runtime"
 import { makeResizeObserver } from "@solid-primitives/resize-observer"
 import { IconCheckCircle, IconHashtag } from "../icons"
+import { copyToClipboard } from "./clipboard"
 
 export type ShareMessages = { locale: string } & Record<string, string>
 
@@ -53,16 +54,14 @@ export function AnchorIcon(props: AnchorProps) {
     <div {...rest} data-element-anchor title={messages.link_to_message} data-status={copied() ? "copied" : ""}>
       <a
         href={`#${local.id}`}
-        onClick={(e) => {
+        onClick={async (e) => {
           e.preventDefault()
 
           const anchor = e.currentTarget
           const hash = anchor.getAttribute("href") || ""
           const { origin, pathname, search } = window.location
 
-          navigator.clipboard
-            .writeText(`${origin}${pathname}${search}${hash}`)
-            .catch((err) => console.error("Copy failed", err))
+          await copyToClipboard(`${origin}${pathname}${search}${hash}`)
 
           setCopied(true)
           setTimeout(() => setCopied(false), 3000)

--- a/packages/web/src/components/share/copy-button.tsx
+++ b/packages/web/src/components/share/copy-button.tsx
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js"
 import { IconClipboard, IconCheckCircle } from "../icons"
 import { useShareMessages } from "./common"
+import { copyToClipboard } from "./clipboard"
 import styles from "./copy-button.module.css"
 
 interface CopyButtonProps {
@@ -11,9 +12,9 @@ export function CopyButton(props: CopyButtonProps) {
   const [copied, setCopied] = createSignal(false)
   const messages = useShareMessages()
 
-  function handleCopyClick() {
+  async function handleCopyClick() {
     if (props.text) {
-      navigator.clipboard.writeText(props.text).catch((err) => console.error("Copy failed", err))
+      await copyToClipboard(props.text)
 
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)

--- a/packages/web/src/components/share/part.tsx
+++ b/packages/web/src/components/share/part.tsx
@@ -26,6 +26,7 @@ import { ContentText } from "./content-text"
 import { ContentBash } from "./content-bash"
 import { ContentError } from "./content-error"
 import { formatCount, formatDuration, formatNumber, normalizeLocale, useShareMessages } from "../share/common"
+import { copyToClipboard } from "./clipboard"
 import { ContentMarkdown } from "./content-markdown"
 import type { MessageV2 } from "opencode/session/message-v2"
 import type { Diagnostic } from "vscode-languageserver-types"
@@ -59,14 +60,12 @@ export function Part(props: PartProps) {
         <div data-slot="anchor" title={messages.link_to_message}>
           <a
             href={`#${id()}`}
-            onClick={(e) => {
+            onClick={async (e) => {
               e.preventDefault()
               const anchor = e.currentTarget
               const hash = anchor.getAttribute("href") || ""
               const { origin, pathname, search } = window.location
-              navigator.clipboard
-                .writeText(`${origin}${pathname}${search}${hash}`)
-                .catch((err) => console.error("Copy failed", err))
+              await copyToClipboard(`${origin}${pathname}${search}${hash}`)
 
               setCopied(true)
               setTimeout(() => setCopied(false), 3000)


### PR DESCRIPTION
## Problem

Clipboard API (`navigator.clipboard.writeText`) is only available in secure contexts (HTTPS or localhost). In HTTP environments, copy buttons failed silently with no fallback mechanism.

## Solution

Added fallback using `document.execCommand('copy')` when Clipboard API is unavailable.

## Changes

- **New**: `packages/core/src/util/clipboard.ts` - Clipboard utility with fallback
- **New**: `packages/web/src/components/share/clipboard.ts` - Web-specific clipboard utility
- **Modified**: Updated all copy button components to use the fallback:
  - `packages/ui/src/components/message-part.tsx`
  - `packages/ui/src/components/markdown.tsx`
  - `packages/ui/src/components/text-field.tsx`
  - `packages/ui/src/components/tool-error-card.tsx`
  - `packages/web/src/components/share/common.tsx`
  - `packages/web/src/components/share/copy-button.tsx`
  - `packages/web/src/components/share/part.tsx`

## Testing

✅ Tested in HTTP environment - copy buttons work correctly with fallback

## Implementation Details

The clipboard utility:
1. First tries the modern Clipboard API (`navigator.clipboard.writeText`)
2. If unavailable or fails, falls back to `document.execCommand('copy')`
3. Creates a temporary textarea element for the fallback method
4. Returns boolean indicating success/failure

This ensures copy functionality works across:
- HTTPS environments (modern Clipboard API)
- HTTP environments (fallback)
- Older browsers (fallback)