### PR TITLE
chore: delete unused util/network module

### DIFF
--- a/packages/opencode/src/util/network.ts
+++ b/packages/opencode/src/util/network.ts
@@ -1,9 +1,0 @@
-export function online() {
-  const nav = globalThis.navigator
-  if (!nav || typeof nav.onLine !== "boolean") return true
-  return nav.onLine
-}
-
-export function proxied() {
-  return !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
-}


### PR DESCRIPTION
## Summary

`src/util/network.ts` exports `online()` and `proxied()`. No file in `packages/` imports either function or the module path.

Originally added with the proxy install fix (#12161) and touched by the TUI plugins refactor (#19347), but the callers have since moved on.

## Test plan

- [x] grep confirms zero importers of the module path
- [x] grep confirms zero callers of `online()` or `proxied()` named exports
- [ ] CI green