### PR TITLE
feat(desktop): respect autoupdate config from opencode.json

### DIFF
--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -1,4 +1,7 @@
 import { app, dialog } from "electron"
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
 import pkg from "electron-updater"
 import { UPDATER_ENABLED } from "./constants"
 import { initLogging } from "./logging"
@@ -8,8 +11,70 @@ const { autoUpdater } = pkg
 
 let downloadedUpdateVersion: string | undefined
 
+/**
+ * Read the "autoupdate" setting from the global opencode config file.
+ * The desktop app does not share the CLI's Effect-based config service,
+ * so we read the file directly using the same path resolution logic.
+ *
+ * Checks (in order of priority):
+ * 1. OPENCODE_DISABLE_AUTOUPDATE env var
+ * 2. Managed/system config dir (enterprise, not user-overridable)
+ * 3. User global config (~/.config/opencode/opencode.json[c])
+ */
+function isAutoupdateDisabled(): boolean {
+  // Environment variable takes highest runtime priority
+  if (process.env.OPENCODE_DISABLE_AUTOUPDATE === "true") {
+    logger.log("autoupdate disabled by OPENCODE_DISABLE_AUTOUPDATE env var")
+    return true
+  }
+
+  // Resolve config: check managed dir first (enterprise/MDM), then user global
+  const configDirs: string[] = []
+
+  // Managed config dir (highest config priority, same logic as CLI's ConfigManaged.managedConfigDir)
+  const managedDir = (() => {
+    switch (process.platform) {
+      case "darwin":
+        return "/Library/Application Support/opencode"
+      case "win32":
+        return join(process.env.ProgramData || "C:\\ProgramData", "opencode")
+      default:
+        return "/etc/opencode"
+    }
+  })()
+  configDirs.push(managedDir)
+
+  // User global config dir (XDG convention, same as CLI's Global.Path.config)
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+  configDirs.push(join(xdgConfigHome, "opencode"))
+
+  for (const dir of configDirs) {
+    for (const filename of ["opencode.jsonc", "opencode.json"]) {
+      const filepath = join(dir, filename)
+      if (!existsSync(filepath)) continue
+      try {
+        const text = readFileSync(filepath, "utf-8")
+        // Strip JSONC comments (single-line // and multi-line /* */) before parsing
+        const stripped = text
+          .replace(/\/\/.*$/gm, "")
+          .replace(/\/\*[\s\S]*?\*\//g, "")
+        const config = JSON.parse(stripped)
+        if (config.autoupdate === false) {
+          logger.log("autoupdate disabled by config", { path: filepath })
+          return true
+        }
+      } catch {
+        // Ignore parse errors — fall through to next file
+      }
+    }
+  }
+
+  return false
+}
+
 export function setupAutoUpdater() {
   if (!UPDATER_ENABLED) return
+  if (isAutoupdateDisabled()) return
   autoUpdater.logger = logger
   autoUpdater.channel = "latest"
   autoUpdater.allowPrerelease = false
@@ -26,6 +91,7 @@ export function setupAutoUpdater() {
 
 export async function checkUpdate() {
   if (!UPDATER_ENABLED) return { updateAvailable: false }
+  if (isAutoupdateDisabled()) return { updateAvailable: false }
   if (downloadedUpdateVersion) {
     logger.log("returning cached downloaded update", {
       version: downloadedUpdateVersion,
@@ -81,6 +147,10 @@ export async function installUpdate(killSidecar: () => Promise<void>) {
 
 export async function checkForUpdates(alertOnFail: boolean, killSidecar: () => Promise<void>) {
   if (!UPDATER_ENABLED) return
+  if (isAutoupdateDisabled()) {
+    logger.log("checkForUpdates skipped", { reason: "autoupdate disabled by config" })
+    return
+  }
   logger.log("checkForUpdates invoked", { alertOnFail })
   const result = await checkUpdate()
   if (!result.updateAvailable) {


### PR DESCRIPTION
### Issue for this PR

Related to #1793, #3412, #6984, #20027, #21083

### Type of change

- [x] New feature

### What does this PR do?

The desktop GUI updater only checks the build-time `UPDATER_ENABLED` constant (`app.isPackaged && CHANNEL !== "dev"`), ignoring the user's `autoupdate` config from `opencode.json`. Setting `"autoupdate": false` works for CLI/TUI but has no effect on the desktop app.

Added `isAutoupdateDisabled()` to `packages/desktop/src/main/updater.ts` that reads the `autoupdate` setting at runtime from:

1. `OPENCODE_DISABLE_AUTOUPDATE=true` env var
2. Managed/system config dir (enterprise/MDM)
3. User global config (`~/.config/opencode/opencode.json[c]`)

When `autoupdate === false`, `setupAutoUpdater()`, `checkUpdate()`, and `checkForUpdates()` all skip. The desktop app can't use the CLI's Effect-based config service, so this reads config files directly with `fs.readFileSync` using the same path resolution as `ConfigManaged.managedConfigDir()` and `Global.Path.config`. Supports `.jsonc` with comment stripping.

### How did you verify your code works?

- Reviewed the CLI's `upgrade.ts` and `config.ts` source to confirm config schema and path resolution logic matches
- Traced all three update entry points (`setupAutoUpdater`, `checkUpdate`, `checkForUpdates`) to confirm they are guarded
- Verified path resolution matches `ConfigManaged.managedConfigDir()` for all three platforms (macOS/Windows/Linux)
- Cannot build and run the desktop app locally without the full monorepo setup — requesting maintainer verification of the Electron build

### Screenshots / recordings

N/A — no UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR