### PR TITLE
refactor: migrate installation tests to testEffect

### DIFF
--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect } from "bun:test"
 import { Effect, Layer, Stream } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { Installation } from "../../src/installation"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
+import { testEffect } from "../lib/effect"
 
 const encoder = new TextEncoder()
 
@@ -51,86 +52,84 @@ function testLayer(
 
 describe("installation", () => {
   describe("latest", () => {
-    test("reads release version from GitHub releases", async () => {
-      const layer = testLayer(() => jsonResponse({ tag_name: "v1.2.3" }))
+    testEffect(testLayer(() => jsonResponse({ tag_name: "v1.2.3" }))).effect(
+      "reads release version from GitHub releases",
+      () =>
+        Effect.gen(function* () {
+          const result = yield* Installation.Service.use((svc) => svc.latest("unknown"))
+          expect(result).toBe("1.2.3")
+        }),
+    )
 
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("unknown")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("1.2.3")
-    })
+    testEffect(testLayer(() => jsonResponse({ tag_name: "v4.0.0-beta.1" }))).effect(
+      "strips v prefix from GitHub release tag",
+      () =>
+        Effect.gen(function* () {
+          const result = yield* Installation.Service.use((svc) => svc.latest("curl"))
+          expect(result).toBe("4.0.0-beta.1")
+        }),
+    )
 
-    test("strips v prefix from GitHub release tag", async () => {
-      const layer = testLayer(() => jsonResponse({ tag_name: "v4.0.0-beta.1" }))
-
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("curl")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("4.0.0-beta.1")
-    })
-
-    test("reads npm versions via registry", async () => {
-      const calls: string[] = []
-      const layer = testLayer((request) => {
-        calls.push(request.url)
+    const npmCalls: string[] = []
+    testEffect(
+      testLayer((request) => {
+        npmCalls.push(request.url)
         return jsonResponse({ version: "1.5.0" })
-      })
+      }),
+    ).effect("reads npm versions via registry", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.Service.use((svc) => svc.latest("npm"))
+        expect(result).toBe("1.5.0")
+        expect(npmCalls).toContain(`https://registry.npmjs.org/opencode-ai/${InstallationChannel}`)
+      }),
+    )
 
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("npm")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("1.5.0")
-      expect(calls).toContain(`https://registry.npmjs.org/opencode-ai/${InstallationChannel}`)
-    })
-
-    test("reads bun versions via registry", async () => {
-      const calls: string[] = []
-      const layer = testLayer((request) => {
-        calls.push(request.url)
+    const bunCalls: string[] = []
+    testEffect(
+      testLayer((request) => {
+        bunCalls.push(request.url)
         return jsonResponse({ version: "1.6.0" })
-      })
+      }),
+    ).effect("reads bun versions via registry", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.Service.use((svc) => svc.latest("bun"))
+        expect(result).toBe("1.6.0")
+        expect(bunCalls).toContain(`https://registry.npmjs.org/opencode-ai/${InstallationChannel}`)
+      }),
+    )
 
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("bun")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("1.6.0")
-      expect(calls).toContain(`https://registry.npmjs.org/opencode-ai/${InstallationChannel}`)
-    })
-
-    test("reads pnpm versions via registry", async () => {
-      const calls: string[] = []
-      const layer = testLayer((request) => {
-        calls.push(request.url)
+    const pnpmCalls: string[] = []
+    testEffect(
+      testLayer((request) => {
+        pnpmCalls.push(request.url)
         return jsonResponse({ version: "1.7.0" })
-      })
+      }),
+    ).effect("reads pnpm versions via registry", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.Service.use((svc) => svc.latest("pnpm"))
+        expect(result).toBe("1.7.0")
+        expect(pnpmCalls).toContain(`https://registry.npmjs.org/opencode-ai/${InstallationChannel}`)
+      }),
+    )
 
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("pnpm")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("1.7.0")
-      expect(calls).toContain(`https://registry.npmjs.org/opencode-ai/${InstallationChannel}`)
-    })
+    testEffect(testLayer(() => jsonResponse({ version: "2.3.4" }))).effect("reads scoop manifest versions", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.Service.use((svc) => svc.latest("scoop"))
+        expect(result).toBe("2.3.4")
+      }),
+    )
 
-    test("reads scoop manifest versions", async () => {
-      const layer = testLayer(() => jsonResponse({ version: "2.3.4" }))
+    testEffect(testLayer(() => jsonResponse({ d: { results: [{ Version: "3.4.5" }] } }))).effect(
+      "reads chocolatey feed versions",
+      () =>
+        Effect.gen(function* () {
+          const result = yield* Installation.Service.use((svc) => svc.latest("choco"))
+          expect(result).toBe("3.4.5")
+        }),
+    )
 
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("scoop")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("2.3.4")
-    })
-
-    test("reads chocolatey feed versions", async () => {
-      const layer = testLayer(() => jsonResponse({ d: { results: [{ Version: "3.4.5" }] } }))
-
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("choco")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("3.4.5")
-    })
-
-    test("reads brew formulae API versions", async () => {
-      const layer = testLayer(
+    testEffect(
+      testLayer(
         () => jsonResponse({ versions: { stable: "2.0.0" } }),
         (cmd, args) => {
           // getBrewFormula: return core formula (no tap)
@@ -138,31 +137,31 @@ describe("installation", () => {
           if (cmd === "brew" && args.includes("--formula") && args.includes("opencode")) return "opencode"
           return ""
         },
-      )
+      ),
+    ).effect("reads brew formulae API versions", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.Service.use((svc) => svc.latest("brew"))
+        expect(result).toBe("2.0.0")
+      }),
+    )
 
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("brew")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("2.0.0")
+    const brewInfoJson = JSON.stringify({
+      formulae: [{ versions: { stable: "2.1.0" } }],
     })
-
-    test("reads brew tap info JSON via CLI", async () => {
-      const brewInfoJson = JSON.stringify({
-        formulae: [{ versions: { stable: "2.1.0" } }],
-      })
-      const layer = testLayer(
+    testEffect(
+      testLayer(
         () => jsonResponse({}), // HTTP not used for tap formula
         (cmd, args) => {
           if (cmd === "brew" && args.includes("anomalyco/tap/opencode") && args.includes("--formula")) return "opencode"
           if (cmd === "brew" && args.includes("--json=v2")) return brewInfoJson
           return ""
         },
-      )
-
-      const result = await Effect.runPromise(
-        Installation.Service.use((svc) => svc.latest("brew")).pipe(Effect.provide(layer)),
-      )
-      expect(result).toBe("2.1.0")
-    })
+      ),
+    ).effect("reads brew tap info JSON via CLI", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.Service.use((svc) => svc.latest("brew"))
+        expect(result).toBe("2.1.0")
+      }),
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Migrate installation latest-version tests from async `bun:test` bodies to `testEffect(...).effect`.
- Keep existing mocked HTTP client and child process spawner layers while yielding `Installation.Service` inside Effect bodies.

## Tests
- `bun run test test/installation/installation.test.ts`
- `bun typecheck`