### PR TITLE
test(server): migrate pty websocket input test

### DIFF
--- a/packages/opencode/test/server/httpapi-pty-websocket.test.ts
+++ b/packages/opencode/test/server/httpapi-pty-websocket.test.ts
@@ -1,16 +1,19 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { handlePtyInput } from "../../src/pty/input"
+import { it } from "../lib/effect"
 
 describe("pty HttpApi websocket input", () => {
-  test("does not forward invalid binary frames to the PTY handler", async () => {
-    const messages: Array<string | ArrayBuffer> = []
-    const handler = { onMessage: (message: string | ArrayBuffer) => messages.push(message) }
+  it.effect("does not forward invalid binary frames to the PTY handler", () =>
+    Effect.gen(function* () {
+      const messages: Array<string | ArrayBuffer> = []
+      const handler = { onMessage: (message: string | ArrayBuffer) => messages.push(message) }
 
-    await Effect.runPromise(handlePtyInput(handler, "ready"))
-    await Effect.runPromise(handlePtyInput(handler, new Uint8Array([0xff, 0xfe, 0xfd])))
-    await Effect.runPromise(handlePtyInput(handler, new TextEncoder().encode("hello")))
+      yield* handlePtyInput(handler, "ready")
+      yield* handlePtyInput(handler, new Uint8Array([0xff, 0xfe, 0xfd]))
+      yield* handlePtyInput(handler, new TextEncoder().encode("hello"))
 
-    expect(messages).toEqual(["ready", "hello"])
-  })
+      expect(messages).toEqual(["ready", "hello"])
+    }),
+  )
 })


### PR DESCRIPTION
## Summary
- migrate the PTY websocket input test to the shared Effect test runner
- remove direct Effect.runPromise usage from the test body

## Verification
- bun run test test/server/httpapi-pty-websocket.test.ts
- bun typecheck