### PR TITLE
test(tool): use Effect sleep in edit concurrency test

### DIFF
--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -500,7 +500,7 @@ describe("tool.edit", () => {
               asks++
               if (asks !== 1) return
               yield* Deferred.succeed(firstAsk, undefined)
-              yield* Effect.promise(() => Bun.sleep(50))
+              yield* Effect.sleep("50 millis")
             }),
         }
 


### PR DESCRIPTION
## Summary
- replace the raw Bun.sleep promise in the edit concurrency test with Effect.sleep
- keep the existing coordination behavior inside the Effect test body

## Verification
- bun run test test/tool/edit.test.ts
- bun typecheck