### PR TITLE
fix(tui): restore DialogPrompt enter submit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -1,8 +1,9 @@
 import { TextareaRenderable, TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
-import { Show, createEffect, onMount, type JSX } from "solid-js"
+import { Show, createEffect, createSignal, onMount, type JSX } from "solid-js"
 import { Spinner } from "../component/spinner"
+import { useBindings } from "../keymap"
 
 export type DialogPromptProps = {
   title: string
@@ -18,7 +19,27 @@ export type DialogPromptProps = {
 export function DialogPrompt(props: DialogPromptProps) {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const [textareaTarget, setTextareaTarget] = createSignal<TextareaRenderable>()
   let textarea: TextareaRenderable
+
+  function confirm() {
+    if (props.busy) return
+    props.onConfirm?.(textarea.plainText)
+  }
+
+  useBindings(() => ({
+    target: textareaTarget,
+    enabled: textareaTarget() !== undefined && !props.busy,
+    priority: 10,
+    bindings: [
+      {
+        key: "return",
+        desc: "Submit dialog prompt",
+        group: "Dialog",
+        cmd: confirm,
+      },
+    ],
+  }))
 
   onMount(() => {
     dialog.setSize("medium")
@@ -59,13 +80,11 @@ export function DialogPrompt(props: DialogPromptProps) {
       <box gap={1}>
         {props.description}
         <textarea
-          onSubmit={() => {
-            if (props.busy) return
-            props.onConfirm?.(textarea.plainText)
-          }}
+          onSubmit={() => confirm()}
           height={3}
           ref={(val: TextareaRenderable) => {
             textarea = val
+            setTextareaTarget(val)
           }}
           initialValue={props.value}
           placeholder={props.placeholder ?? "Enter text"}

--- a/packages/opencode/test/cli/tui/dialog-prompt.test.tsx
+++ b/packages/opencode/test/cli/tui/dialog-prompt.test.tsx
@@ -1,0 +1,112 @@
+/** @jsxImportSource @opentui/solid */
+import { TextareaRenderable } from "@opentui/core"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { onCleanup } from "solid-js"
+import { tmpdir } from "../../fixture/fixture"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+
+function config() {
+  return createTuiResolvedConfig({
+    keybinds: {
+      input_submit: "super+return",
+      input_newline: "return,shift+return,alt+return,ctrl+j",
+    },
+    leader_timeout: 1000,
+  })
+}
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+async function mountPrompt(root: string, onConfirm: (value: string) => void) {
+  const { Global } = await import("@opencode-ai/core/global")
+  const previous = {
+    config: Global.Path.config,
+    state: Global.Path.state,
+  }
+  Global.Path.config = path.join(root, "config")
+  Global.Path.state = path.join(root, "state")
+  await mkdir(Global.Path.config, { recursive: true })
+  await mkdir(Global.Path.state, { recursive: true })
+  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+
+  const [
+    { DialogProvider },
+    { DialogPrompt },
+    { KVProvider },
+    { ThemeProvider },
+    { TuiConfigProvider },
+    { ToastProvider },
+    { OpencodeKeymapProvider, registerOpencodeKeymap },
+  ] = await Promise.all([
+    import("../../../src/cli/cmd/tui/ui/dialog"),
+    import("../../../src/cli/cmd/tui/ui/dialog-prompt"),
+    import("../../../src/cli/cmd/tui/context/kv"),
+    import("../../../src/cli/cmd/tui/context/theme"),
+    import("../../../src/cli/cmd/tui/context/tui-config"),
+    import("../../../src/cli/cmd/tui/ui/toast"),
+    import("../../../src/cli/cmd/tui/keymap"),
+  ])
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const resolvedConfig = config()
+    const off = registerOpencodeKeymap(keymap, renderer, resolvedConfig)
+    onCleanup(off)
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <TuiConfigProvider config={resolvedConfig}>
+          <KVProvider>
+            <ThemeProvider mode="dark">
+              <ToastProvider>
+                <DialogProvider>
+                  <DialogPrompt title="Rename Session" value="draft" onConfirm={onConfirm} />
+                </DialogProvider>
+              </ToastProvider>
+            </ThemeProvider>
+          </KVProvider>
+        </TuiConfigProvider>
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { kittyKeyboard: true })
+  return {
+    app,
+    async cleanup() {
+      app.renderer.destroy()
+      Global.Path.config = previous.config
+      Global.Path.state = previous.state
+    },
+  }
+}
+
+test("dialog prompt bare enter submits when global input newline is return", async () => {
+  await using tmp = await tmpdir()
+  const confirmed: string[] = []
+  const prompt = await mountPrompt(tmp.path, (value) => confirmed.push(value))
+
+  try {
+    await wait(() => prompt.app.renderer.currentFocusedEditor instanceof TextareaRenderable)
+    const textarea = prompt.app.renderer.currentFocusedEditor
+    if (!(textarea instanceof TextareaRenderable)) throw new Error("expected focused dialog textarea")
+
+    prompt.app.mockInput.pressEnter()
+
+    expect(confirmed).toEqual(["draft"])
+    expect(textarea.plainText).toBe("draft")
+  } finally {
+    await prompt.cleanup()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #26817

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores bare Enter submit behavior for `DialogPrompt` while keeping the OpenTUI keymap architecture.

When a user configures `return` as `input_newline`, the global managed textarea binding also applies to dialog textareas. This PR adds a dialog-local focused textarea binding so form-style dialogs, such as session rename, still confirm on bare Enter.

It keeps `onSubmit` wired to the same confirm path, so configured submit bindings still work.

Human driven and reviewed, with agentic assistance from openai/gpt-5.5/xhigh.

### How did you verify your code works?

- `bun test --timeout 30000 test/cli/tui/dialog-prompt.test.tsx`
- `bun typecheck`
- Rebuilt a local OpenCode fork with this patch and confirmed dialog Enter submit works with `return` configured as `input_newline`

### Screenshots / recordings

N/A. This is a TUI input behavior fix with no visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR