### PR TITLE
test(util): migrate log cleanup test to Effect

### DIFF
--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -1,44 +1,49 @@
-import { afterEach, expect, test } from "bun:test"
+import { expect } from "bun:test"
+import { Effect } from "effect"
 import fs from "fs/promises"
 import path from "path"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Global } from "@opencode-ai/core/global"
 import * as Log from "@opencode-ai/core/util/log"
-import { tmpdir } from "../fixture/fixture"
+import { tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
-const log = Global.Path.log
+const it = testEffect(CrossSpawnSpawner.defaultLayer)
 
-afterEach(() => {
-  Global.Path.log = log
-})
+function files(dir: string) {
+  return Effect.gen(function* () {
+    let last = ""
+    let same = 0
 
-async function files(dir: string) {
-  let last = ""
-  let same = 0
+    for (let i = 0; i < 50; i++) {
+      const list = yield* Effect.promise(() => fs.readdir(dir).then((files) => files.sort()))
+      const next = JSON.stringify(list)
+      same = next === last ? same + 1 : 0
+      if (same >= 2 && list.length === 11) return list
+      last = next
+      yield* Effect.sleep("10 millis")
+    }
 
-  for (let i = 0; i < 50; i++) {
-    const list = (await fs.readdir(dir)).sort()
-    const next = JSON.stringify(list)
-    same = next === last ? same + 1 : 0
-    if (same >= 2 && list.length === 11) return list
-    last = next
-    await Bun.sleep(10)
-  }
-
-  return (await fs.readdir(dir)).sort()
+    return yield* Effect.promise(() => fs.readdir(dir).then((files) => files.sort()))
+  })
 }
 
-test("init cleanup keeps the newest timestamped logs", async () => {
-  await using tmp = await tmpdir()
-  Global.Path.log = tmp.path
+it.live("init cleanup keeps the newest timestamped logs", () =>
+  Effect.gen(function* () {
+    const log = Global.Path.log
+    yield* Effect.addFinalizer(() => Effect.sync(() => (Global.Path.log = log)))
+    const dir = yield* tmpdirScoped()
+    Global.Path.log = dir
 
-  const list = Array.from({ length: 12 }, (_, i) => `2000-01-${String(i + 1).padStart(2, "0")}T000000.log`)
+    const list = Array.from({ length: 12 }, (_, i) => `2000-01-${String(i + 1).padStart(2, "0")}T000000.log`)
 
-  await Promise.all(list.map((file) => fs.writeFile(path.join(tmp.path, file), file)))
+    yield* Effect.all(list.map((file) => Effect.promise(() => fs.writeFile(path.join(dir, file), file))))
 
-  await Log.init({ print: false, dev: false })
+    yield* Effect.promise(() => Log.init({ print: false, dev: false }))
 
-  const next = await files(tmp.path)
+    const next = yield* files(dir)
 
-  expect(next).not.toContain(list[0]!)
-  expect(next).toContain(list.at(-1)!)
-})
+    expect(next).not.toContain(list[0]!)
+    expect(next).toContain(list.at(-1)!)
+  }),
+)


### PR DESCRIPTION
## Summary
- migrate the log cleanup test to the shared Effect runner
- scope temp directory and Global.Path.log restoration with Effect finalizers
- replace Bun.sleep polling with Effect.sleep

## Verification
- bun run test test/util/log.test.ts
- bun typecheck