### PR TITLE
fix(run): restore non-interactive exit behavior

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -24,6 +24,7 @@ import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
+import { FormatError, FormatUnknownError } from "../error"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
 
 const runtimeTask = import("./run/runtime")
@@ -80,6 +81,10 @@ function block(info: Inline, output?: string) {
   if (!output?.trim()) return
   UI.println(output)
   UI.empty()
+}
+
+function formatRunError(error: unknown) {
+  return FormatError(error) ?? FormatUnknownError(error)
 }
 
 async function tool(part: ToolPart) {
@@ -737,7 +742,7 @@ export const RunCommand = effectCmd({
           })
 
           if (args.command) {
-            await client.session.command({
+            const result = await client.session.command({
               sessionID,
               agent,
               model: args.model,
@@ -745,17 +750,25 @@ export const RunCommand = effectCmd({
               arguments: message,
               variant: args.variant,
             })
+            if (result.error) {
+              if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+              process.exitCode = 1
+            }
             return
           }
 
           const model = pick(args.model)
-          await client.session.prompt({
+          const result = await client.session.prompt({
             sessionID,
             agent,
             model,
             variant: args.variant,
             parts: [...files, { type: "text", text: message }],
           })
+          if (result.error) {
+            if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+            process.exitCode = 1
+          }
           return
         }
 

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -731,7 +731,10 @@ export const RunCommand = effectCmd({
 
         if (!args.interactive) {
           const events = await client.event.subscribe()
-          const completed = loop(client, events)
+          loop(client, events).catch((e) => {
+            console.error(e)
+            process.exit(1)
+          })
 
           if (args.command) {
             await client.session.command({
@@ -742,8 +745,6 @@ export const RunCommand = effectCmd({
               arguments: message,
               variant: args.variant,
             })
-            const error = await completed
-            if (error) process.exitCode = 1
             return
           }
 
@@ -755,8 +756,6 @@ export const RunCommand = effectCmd({
             variant: args.variant,
             parts: [...files, { type: "text", text: message }],
           })
-          const error = await completed
-          if (error) process.exitCode = 1
           return
         }
 


### PR DESCRIPTION
## Summary
- Avoid waiting indefinitely for a `session.status` idle event before non-interactive `opencode run` exits.
- Print shaped SDK errors returned from prompt/command requests, such as invalid model errors.

## Testing
- `bun run dev run \"hello\" --model opencode/claude-haiku-4-5`
- Temporary SDK repro confirmed fake-model prompt publishes `session.error` and idle while returning a shaped SDK error.