### PR TITLE
fix(tui): refresh session messages after reconnect

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -124,14 +124,29 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       }
     }
 
-    function listSessions() {
-      return sdk.client.session
-        .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
-        .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
+    async function listSessions() {
+      return ((await sdk.client.session.list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })).data ?? []).toSorted(
+        (a, b) => a.id.localeCompare(b.id),
+      )
+    }
+
+    function refreshSyncedSessionsAfterReconnect() {
+      const sessionIDs = new Set([...Object.keys(store.message), ...fullSyncedSessions])
+      if (sessionIDs.size === 0) return
+      void Promise.all([...sessionIDs].map((sessionID) => syncSession(sessionID, { force: true }))).catch((e) => {
+        Log.Default.error("tui reconnect session refresh failed", {
+          error: e instanceof Error ? e.message : String(e),
+          name: e instanceof Error ? e.name : undefined,
+          stack: e instanceof Error ? e.stack : undefined,
+        })
+      })
     }
 
     event.subscribe((event, { workspace }) => {
       switch (event.type) {
+        case "server.connected":
+          refreshSyncedSessionsAfterReconnect()
+          break
         case "server.instance.disposed":
           void bootstrap()
           break
@@ -518,33 +533,37 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (last.role === "user") return "working"
           return last.time.completed ? "idle" : "working"
         },
-        async sync(sessionID: string) {
-          if (fullSyncedSessions.has(sessionID)) return
-          const [session, messages, todo, diff] = await Promise.all([
-            sdk.client.session.get({ sessionID }, { throwOnError: true }),
-            sdk.client.session.messages({ sessionID, limit: 100 }),
-            sdk.client.session.todo({ sessionID }),
-            sdk.client.session.diff({ sessionID }),
-          ])
-          setStore(
-            produce((draft) => {
-              const match = Binary.search(draft.session, sessionID, (s) => s.id)
-              if (match.found) draft.session[match.index] = session.data!
-              if (!match.found) draft.session.splice(match.index, 0, session.data!)
-              draft.todo[sessionID] = todo.data ?? []
-              const infos: (typeof draft.message)[string] = []
-              for (const message of messages.data ?? []) {
-                infos.push(message.info)
-                draft.part[message.info.id] = message.parts
-              }
-              draft.message[sessionID] = infos
-              draft.session_diff[sessionID] = diff.data ?? []
-            }),
-          )
-          fullSyncedSessions.add(sessionID)
+        sync(sessionID: string) {
+          return syncSession(sessionID)
         },
       },
       bootstrap,
+    }
+
+    async function syncSession(sessionID: string, input: { force?: boolean } = {}) {
+      if (!input.force && fullSyncedSessions.has(sessionID)) return
+      const [session, messages, todo, diff] = await Promise.all([
+        sdk.client.session.get({ sessionID }, { throwOnError: true }),
+        sdk.client.session.messages({ sessionID, limit: 100 }),
+        sdk.client.session.todo({ sessionID }),
+        sdk.client.session.diff({ sessionID }),
+      ])
+      setStore(
+        produce((draft) => {
+          const match = Binary.search(draft.session, sessionID, (s) => s.id)
+          if (match.found) draft.session[match.index] = session.data!
+          if (!match.found) draft.session.splice(match.index, 0, session.data!)
+          draft.todo[sessionID] = todo.data ?? []
+          const infos: (typeof draft.message)[string] = []
+          for (const message of messages.data ?? []) {
+            infos.push(message.info)
+            draft.part[message.info.id] = message.parts
+          }
+          draft.message[sessionID] = infos
+          draft.session_diff[sessionID] = diff.data ?? []
+        }),
+      )
+      fullSyncedSessions.add(sessionID)
     }
     return result
   },

--- a/packages/opencode/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/opencode/test/cli/cmd/tui/sync.test.tsx
@@ -2,7 +2,7 @@
 import { describe, expect, test } from "bun:test"
 import { Global } from "@opencode-ai/core/global"
 import { tmpdir } from "../../../fixture/fixture"
-import { mount, wait } from "./sync-fixture"
+import { directory, json, mount, wait } from "./sync-fixture"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 
 function branchEvent(branch: string, workspace?: string): GlobalEvent {
@@ -15,6 +15,21 @@ function branchEvent(branch: string, workspace?: string): GlobalEvent {
       type: "vcs.branch.updated",
       properties: { branch },
     },
+  }
+}
+
+function sessionMessage(id: string, role: "user" | "assistant", time: number) {
+  return {
+    info: {
+      id,
+      sessionID: "ses_test",
+      role,
+      time: {
+        created: time,
+        completed: time,
+      },
+    },
+    parts: [],
   }
 }
 
@@ -62,6 +77,56 @@ describe("tui sync", () => {
       await wait(() => sync.data.vcs?.branch === "feature")
 
       expect(sync.data.vcs?.branch).toBe("feature")
+    } finally {
+      app.renderer.destroy()
+      Global.Path.state = previous
+    }
+  })
+
+  test("reconnect refresh loads messages missed by live events", async () => {
+    const previous = Global.Path.state
+    await using tmp = await tmpdir()
+    Global.Path.state = tmp.path
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const messages = [sessionMessage("msg_1", "user", 1)]
+    const testSession = {
+      id: "ses_test",
+      projectID: "proj_test",
+      title: "Test session",
+      time: {
+        created: 1,
+        updated: 1,
+      },
+    }
+    const { app, emit, sync } = await mount((url) => {
+      switch (url.pathname) {
+        case "/session/ses_test":
+          return json(testSession)
+        case "/session/ses_test/diff":
+        case "/session/ses_test/todo":
+          return json([])
+        case "/session/ses_test/message":
+          return json(messages)
+      }
+    })
+
+    try {
+      await sync.session.sync("ses_test")
+      expect(sync.data.message.ses_test.map((message) => message.id)).toEqual(["msg_1"])
+
+      messages.push(sessionMessage("msg_2", "assistant", 2))
+      emit({
+        directory,
+        project: "proj_test",
+        payload: {
+          id: "evt_test_connected",
+          type: "server.connected",
+          properties: {},
+        },
+      })
+
+      await wait(() => sync.data.message.ses_test?.some((message) => message.id === "msg_2") ?? false)
+      expect(sync.data.message.ses_test.map((message) => message.id)).toEqual(["msg_1", "msg_2"])
     } finally {
       app.renderer.destroy()
       Global.Path.state = previous


### PR DESCRIPTION
### Issue for this PR

Closes #27380

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the TUI reconnects to the global event stream, it now force-refreshes already-known sessions through the existing REST sync path. This backfills messages that were persisted while live events were missed instead of leaving `fullSyncedSessions` cached stale until a reload.

### How did you verify your code works?

- `bun test test/cli/cmd/tui/sync.test.tsx` from `packages/opencode`: 3 pass, 0 fail, 10 expect()
- `bun typecheck` from `packages/opencode`: passed
- LSP diagnostics on changed files: no diagnostics
- `git diff --check` on changed files: passed
- Oracle pre-publish review: PASS

### Screenshots / recordings

N/A. No visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR