### PR TITLE
fix(session): dedup file and agent parts in slash command merge

### DIFF
--- a/packages/opencode/src/session/prompt-merge.ts
+++ b/packages/opencode/src/session/prompt-merge.ts
@@ -1,0 +1,46 @@
+import type { PromptInput } from "./prompt"
+
+type Part = PromptInput["parts"][number]
+
+function fileKey(url: string): string {
+  try {
+    const u = new URL(url)
+    if (u.protocol === "file:") return `file://${u.host}${u.pathname}`
+    return url
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Merge a slash-command template's resolved parts with client-supplied input
+ * parts. Drops later FileParts whose normalized URL has already appeared and
+ * later AgentParts whose name has already appeared, so the persisted user
+ * message doesn't carry the same file or agent twice. Template-side parts win
+ * on collision because the template body produced the reference first.
+ *
+ * file: URLs are normalized to `file://<host><pathname>`, dropping
+ * searchParams, hash, and credentials. This dedups TUI autocomplete's
+ * `?start=N&end=M` line-range refs against bare template `@file` refs to the
+ * same path.
+ */
+export function mergeCommandParts(
+  templateParts: readonly Part[],
+  inputParts: readonly Part[] | undefined = [],
+): Part[] {
+  const seenFiles = new Set<string>()
+  const seenAgents = new Set<string>()
+  const out: Part[] = []
+  for (const part of [...templateParts, ...inputParts]) {
+    if (part.type === "file") {
+      const key = fileKey(part.url)
+      if (seenFiles.has(key)) continue
+      seenFiles.add(key)
+    } else if (part.type === "agent") {
+      if (seenAgents.has(part.name)) continue
+      seenAgents.add(part.name)
+    }
+    out.push(part)
+  }
+  return out
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -38,6 +38,7 @@ import { Tool } from "@/tool"
 import { Permission } from "@/permission"
 import { SessionStatus } from "./status"
 import { LLM } from "./llm"
+import { mergeCommandParts } from "./prompt-merge"
 import { Shell } from "@/shell/shell"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 import { Truncate } from "@/tool"
@@ -1628,7 +1629,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
             },
           ]
-        : [...templateParts, ...(input.parts ?? [])]
+        : mergeCommandParts(templateParts, input.parts)
 
       const userAgent = isSubtask ? (input.agent ?? (yield* agents.defaultAgent())) : agentName
       const userModel = isSubtask

--- a/packages/opencode/test/session/prompt-merge.test.ts
+++ b/packages/opencode/test/session/prompt-merge.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test"
+import { mergeCommandParts } from "../../src/session/prompt-merge"
+
+const file = (url: string, overrides: { filename?: string; mime?: string } = {}) => ({
+  type: "file" as const,
+  url,
+  mime: overrides.mime ?? "text/plain",
+  filename: overrides.filename ?? "file.md",
+})
+
+const agent = (name: string) => ({ type: "agent" as const, name })
+const text = (t: string) => ({ type: "text" as const, text: t })
+
+describe("mergeCommandParts", () => {
+  test("returns concat unchanged when there is no overlap", () => {
+    const result = mergeCommandParts(
+      [text("template body"), file("file:///repo/AGENTS.md", { filename: "AGENTS.md" })],
+      [file("file:///repo/USER.md", { filename: "USER.md" })],
+    )
+    expect(result).toHaveLength(3)
+    expect(result.map((p) => p.type)).toEqual(["text", "file", "file"])
+  })
+
+  test("drops FilePart from inputParts when its URL already appeared in templateParts", () => {
+    const result = mergeCommandParts(
+      [file("file:///repo/AGENTS.md", { filename: "AGENTS.md" })],
+      [file("file:///repo/AGENTS.md", { filename: "AGENTS.md" })],
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe("file")
+  })
+
+  test("template-side wins on collision (first occurrence preserved)", () => {
+    const fromTemplate = file("file:///repo/AGENTS.md", { filename: "@AGENTS.md" })
+    const fromInput = file("file:///repo/AGENTS.md", { filename: "client-name.md" })
+    const result = mergeCommandParts([fromTemplate], [fromInput])
+    expect(result).toEqual([fromTemplate])
+  })
+
+  test("normalizes file: URLs by ignoring searchParams so ?start/?end-annotated client refs dedup", () => {
+    // TUI autocomplete appends ?start=N&end=M for line ranges; the template
+    // does not. Without normalization these two strings differ literally but
+    // refer to the same file.
+    const result = mergeCommandParts(
+      [file("file:///repo/AGENTS.md")],
+      [file("file:///repo/AGENTS.md?start=10&end=20")],
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ url: "file:///repo/AGENTS.md" })
+  })
+
+  test("does not normalize non-file: URLs (data:, http:, etc. compare verbatim)", () => {
+    const a = file("data:text/plain;base64,YQ==")
+    const b = file("data:text/plain;base64,Yg==")
+    const result = mergeCommandParts([a], [b])
+    expect(result).toHaveLength(2)
+  })
+
+  test("dedups AgentPart by name", () => {
+    const result = mergeCommandParts([agent("review")], [agent("review")])
+    expect(result).toEqual([agent("review")])
+  })
+
+  test("agent and file dedup are independent", () => {
+    const result = mergeCommandParts(
+      [agent("review"), file("file:///repo/AGENTS.md")],
+      [agent("review"), file("file:///repo/AGENTS.md"), agent("debug"), file("file:///repo/OTHER.md")],
+    )
+    expect(result.map((p) => (p.type === "agent" ? `a:${p.name}` : p.type === "file" ? `f:${p.url}` : `t`))).toEqual([
+      "a:review",
+      "f:file:///repo/AGENTS.md",
+      "a:debug",
+      "f:file:///repo/OTHER.md",
+    ])
+  })
+
+  test("does NOT dedup TextParts (multiple texts are legitimate)", () => {
+    const result = mergeCommandParts([text("hello")], [text("hello")])
+    expect(result).toHaveLength(2)
+  })
+
+  test("handles undefined inputParts", () => {
+    const result = mergeCommandParts([text("hi")], undefined)
+    expect(result).toEqual([text("hi")])
+  })
+
+  test("handles malformed URLs by falling back to literal string comparison", () => {
+    const a = file("not a url")
+    const b = file("not a url")
+    const result = mergeCommandParts([a], [b])
+    expect(result).toHaveLength(1)
+  })
+
+  test("dedups within templateParts alone", () => {
+    const result = mergeCommandParts(
+      [file("file:///repo/AGENTS.md"), file("file:///repo/AGENTS.md")],
+      [],
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  test("dedups within inputParts alone", () => {
+    const result = mergeCommandParts(
+      [],
+      [file("file:///repo/AGENTS.md"), file("file:///repo/AGENTS.md?start=1&end=5")],
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ url: "file:///repo/AGENTS.md" })
+  })
+
+  test("two client-side parts referencing the same file at different ranges silently dedup (template-first-wins applies intra-array too)", () => {
+    // Pins down current behavior: ranges are merged away on collision. If a
+    // future change wants to preserve distinct ranges as separate parts, it
+    // will need to update this test deliberately.
+    const result = mergeCommandParts(
+      [],
+      [file("file:///repo/AGENTS.md?start=1&end=10"), file("file:///repo/AGENTS.md?start=50&end=60")],
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ url: "file:///repo/AGENTS.md?start=1&end=10" })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14508

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`session.command` builds the parts array for the user message by concatenating the resolved template parts with `input.parts` from the client (`packages/opencode/src/session/prompt.ts:1631`):

```ts
const parts = isSubtask
  ? [/* ... */]
  : [...templateParts, ...(input.parts ?? [])]
```

I've realized that there's no overlap check. If the template body references `@AGENTS.md` and the client also passes a FilePart for `AGENTS.md`, the persisted user message ends up with two FileParts for the same file. `createUserMessage` then runs the `Read` tool once per part, so the conversation gets the synthetic "Called the Read tool ..." preamble twice and the full file body twice in context. This is the same bug for AgentParts via the agent-resolution branch at `packages/opencode/src/session/prompt.ts:141`.

The most reachable path to this today is the TUI restore work in #24477: forking or reverting a slash-command message re-sends the persisted file parts back through `session.command`, which concats them with the freshly-resolved template parts. But the bug is in the concat, so this PR is server-side and stands alone.

Fix: a small pure helper `mergeCommandParts(template, input)` in a new file `packages/opencode/src/session/prompt-merge.ts`:

- Dedups FilePart by a normalized `file://<host><pathname>` key. URL searchParams, hash, and credentials are dropped from the key. TUI autocomplete appends `?start=N&end=M` for line-range refs (`autocomplete.tsx:259-262`) while templates emit bare URLs from `pathToFileURL()`, so nammon real collision.
- Dedups AgentPart by `name`.
- Leaves TextPart alone.
- Template-first wins on collision, order preserved.

Behavior choice: on collision the template-side part wins, so a client's `?start/?end` range loses to a full-file template ref. Doubling the file body in context is a bigger correctness problem than losing a range, but happy to invert if you'd prefer.

The subtask branch at `prompt.ts:1620-1630` is untouched. `prompt()`, `shell()`, and `loop()` don't go through this concat.

### How did you verify your code works?

- New unit tests in `packages/opencode/test/session/prompt-merge.test.ts`: 13 cases covering simple dedup, URL searchParam normalization, host preservation, malformed-URL fallback, AgentPart dedup, TextPartnon-dedup, intra-array dedup in template-only and input-only, and the range-collision behavior. All pass.
- `bun test test/session/` from `packages/opencode`: 295/295 pass.
- `bun run typecheck`: clean.

### Screenshots / recordings

N/A, server-side change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR