### PR TITLE
feat(provider): add NVIDIA endpoints origin header

### DIFF
--- a/packages/core/src/plugin/provider/nvidia.ts
+++ b/packages/core/src/plugin/provider/nvidia.ts
@@ -10,6 +10,7 @@ export const NvidiaPlugin = PluginV2.define({
         if (evt.provider.id !== ProviderV2.ID.make("nvidia")) return
         evt.provider.options.headers["HTTP-Referer"] = "https://opencode.ai/"
         evt.provider.options.headers["X-Title"] = "opencode"
+        evt.provider.options.headers["X-BILLING-INVOKE-ORIGIN"] ??= "OpenCode"
       }),
     }
   }),

--- a/packages/core/test/plugin/provider-nvidia.test.ts
+++ b/packages/core/test/plugin/provider-nvidia.test.ts
@@ -15,7 +15,7 @@ describe("NvidiaPlugin", () => {
     ),
   )
 
-  it.effect("applies legacy referer headers only to nvidia", () =>
+  it.effect("applies NVIDIA tracking headers only to nvidia", () =>
     Effect.gen(function* () {
       const plugin = yield* PluginV2.Service
       yield* plugin.add(NvidiaPlugin)
@@ -34,8 +34,60 @@ describe("NvidiaPlugin", () => {
         Existing: "value",
         "HTTP-Referer": "https://opencode.ai/",
         "X-Title": "opencode",
+        "X-BILLING-INVOKE-ORIGIN": "OpenCode",
       })
       expect(ignored.provider.options.headers).toEqual({})
+    }),
+  )
+
+  it.effect("adds billing origin for custom NVIDIA endpoints", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      yield* plugin.add(NvidiaPlugin)
+      const result = yield* plugin.trigger(
+        "provider.update",
+        {},
+        {
+          provider: provider("nvidia", {
+            endpoint: { type: "aisdk", package: "test-provider", url: "http://localhost:8000/v1" },
+            options: { headers: {}, body: {}, aisdk: { provider: {}, request: {} } },
+          }),
+          cancel: false,
+        },
+      )
+
+      expect(result.provider.options.headers).toEqual({
+        "HTTP-Referer": "https://opencode.ai/",
+        "X-Title": "opencode",
+        "X-BILLING-INVOKE-ORIGIN": "OpenCode",
+      })
+    }),
+  )
+
+  it.effect("preserves an explicit NVIDIA billing origin header", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      yield* plugin.add(NvidiaPlugin)
+      const result = yield* plugin.trigger(
+        "provider.update",
+        {},
+        {
+          provider: provider("nvidia", {
+            options: {
+              headers: { "X-BILLING-INVOKE-ORIGIN": "CustomOrigin" },
+              body: {},
+              aisdk: { provider: { baseURL: "https://integrate.api.nvidia.com/v1" }, request: {} },
+            },
+          }),
+          cancel: false,
+        },
+      )
+
+      expect(result.provider.options.headers).toEqual({
+        "HTTP-Referer": "https://opencode.ai/",
+        "X-Title": "opencode",
+        "X-BILLING-INVOKE-ORIGIN": "CustomOrigin",
+      })
     }),
   )
 })

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -427,13 +427,14 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
-    nvidia: () =>
+    nvidia: (provider) =>
       Effect.succeed({
-        autoload: false,
+        autoload: provider.source === "config",
         options: {
           headers: {
             "HTTP-Referer": "https://opencode.ai/",
             "X-Title": "opencode",
+            "X-BILLING-INVOKE-ORIGIN": "OpenCode",
           },
         },
       }),

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1810,6 +1810,100 @@ test("provider options are deeply merged", async () => {
   })
 })
 
+test("hosted nvidia provider adds billing origin header", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            nvidia: {
+              options: {
+                apiKey: "test-api-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.make("nvidia")].options.headers).toEqual({
+        "HTTP-Referer": "https://opencode.ai/",
+        "X-Title": "opencode",
+        "X-BILLING-INVOKE-ORIGIN": "OpenCode",
+      })
+    },
+  })
+})
+
+test("custom nvidia baseURL adds billing origin header", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            nvidia: {
+              options: {
+                apiKey: "test-api-key",
+                baseURL: "http://localhost:8000/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.make("nvidia")].options.headers).toEqual({
+        "HTTP-Referer": "https://opencode.ai/",
+        "X-Title": "opencode",
+        "X-BILLING-INVOKE-ORIGIN": "OpenCode",
+      })
+    },
+  })
+})
+
+test("explicit nvidia billing origin header is preserved", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            nvidia: {
+              options: {
+                apiKey: "test-api-key",
+                baseURL: "http://localhost:8000/v1",
+                headers: {
+                  "X-BILLING-INVOKE-ORIGIN": "CustomOrigin",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      expect(providers[ProviderID.make("nvidia")].options.headers["X-BILLING-INVOKE-ORIGIN"]).toBe("CustomOrigin")
+    },
+  })
+})
+
 test("custom model inherits npm package from models.dev provider config", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `X-BILLING-INVOKE-ORIGIN: OpenCode` to NVIDIA provider requests so NVIDIA can identify requests originating from opencode. The header is added through the same provider-level header path used for existing NVIDIA/OpenRouter attribution headers.

The default billing-origin header is applied for hosted NVIDIA and custom/local NVIDIA NIM `baseURL` configurations so app-origin attribution is consistent across NVIDIA provider requests. Explicitly configured `X-BILLING-INVOKE-ORIGIN` values are preserved.

### How did you verify your code works?

- Ran `git diff --check`
- Ran `bun typecheck` from `packages/core`
- Ran `bun typecheck` from `packages/opencode`
- Ran `bun test test/v2/plugin/provider-nvidia.test.ts` from `packages/core` (4 pass)
- Ran `bun test test/provider/provider.test.ts --test-name-pattern nvidia` from `packages/opencode` (3 pass, 78 filtered)
- Pre-push hook ran `bun turbo typecheck` successfully (14 tasks)
- Earlier full `bun test` from `packages/core`: 333 pass, 1 unrelated failure in `cross-spawn-spawner.test.ts` caused by macOS temp path canonicalization (`/var/...` expected, `/private/var/...` received)
- Earlier full `bun test` from `packages/opencode`: 2298 pass, 282 fail, 49 errors; failures were outside the NVIDIA provider path and dominated by `FSEvents`, port binding, and timeout issues

### Screenshots / recordings

N/A. This is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR