### PR TITLE
feat(plugin): expose user message to experimental.chat.system.transform hook

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -117,7 +117,7 @@ const live: Layer.Layer<
       const header = system[0]
       yield* plugin.trigger(
         "experimental.chat.system.transform",
-        { sessionID: input.sessionID, model: input.model },
+        { sessionID: input.sessionID, model: input.model, user: input.user },
         { system },
       )
       // rejoin to maintain 2-part structure for caching if header unchanged

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -288,7 +288,7 @@ export interface Hooks {
     },
   ) => Promise<void>
   "experimental.chat.system.transform"?: (
-    input: { sessionID?: string; model: Model },
+    input: { sessionID?: string; model: Model; user?: UserMessage },
     output: {
       system: string[]
     },


### PR DESCRIPTION
### Issue for this PR

Closes #27401

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`experimental.chat.system.transform` receives `sessionID` and `model` but not the user message. `StreamInput.user` is already at the call site in `llm.ts` — it just wasn't being passed through. Two lines: add `user: input.user` to the trigger call, add `user?: UserMessage` to the hook input type in `packages/plugin`.

### How did you verify your code works?

Tested locally with a plugin that reads `input.user.system` — the field is available and typed correctly. Backward compatible — existing plugins receive `user: undefined` at the agent.ts call site which doesn't pass user context.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR