### PR TITLE
test(format): remove formatter check sleeps

### DIFF
--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -186,14 +186,14 @@ describe("Format", () => {
               Formatter.gofmt.enabled = async () => {
                 active++
                 max = Math.max(max, active)
-                await Bun.sleep(20)
+                await Promise.resolve()
                 active--
                 return ["sh", "-c", "true"]
               }
               Formatter.mix.enabled = async () => {
                 active++
                 max = Math.max(max, active)
-                await Bun.sleep(20)
+                await Promise.resolve()
                 active--
                 return ["sh", "-c", "true"]
               }


### PR DESCRIPTION
## Summary
- replace timer sleeps in formatter parallel-check coverage with microtask yields
- keep the test deterministic while avoiding raw `Bun.sleep`

## Test plan
- `bun run test test/format/format.test.ts`
- `bun run typecheck` from `packages/opencode`