### PR TITLE
test(session): fix shell-cancel race when trap hasn't installed yet

### DIFF
--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1512,11 +1512,26 @@ unix(
     withSh(() =>
       Effect.gen(function* () {
         const { prompt, chat } = yield* boot()
+        const { directory: dir } = yield* TestInstance
+        const afs = yield* AppFileSystem.Service
+        const ready = path.join(dir, ".trap-ready")
 
         const sh = yield* prompt
-          .shell({ sessionID: chat.id, agent: "build", command: "trap '' TERM; sleep 30" })
+          .shell({
+            sessionID: chat.id,
+            agent: "build",
+            // Touch marker AFTER trap installs so the test waits for the actual
+            // ignore-TERM state before cancelling; otherwise SIGTERM can arrive
+            // before `trap` runs and the escalation path is never exercised.
+            command: `trap '' TERM; touch "${ready}"; sleep 30`,
+          })
           .pipe(Effect.forkChild)
-        yield* Effect.sleep(50)
+
+        yield* Effect.gen(function* () {
+          while (!(yield* afs.existsSafe(ready))) {
+            yield* Effect.sleep(Duration.millis(10))
+          }
+        }).pipe(Effect.timeout(Duration.seconds(5)))
 
         yield* prompt.cancel(chat.id)
 


### PR DESCRIPTION
## Summary

The \`cancel persists aborted shell result when shell ignores TERM\` test at \`test/session/prompt.test.ts:1509\` flakes on Linux CI because of a timing race:

1. Test forks a shell running \`trap '' TERM; sleep 30\`.
2. Test waits 50ms.
3. Test calls \`prompt.cancel(chat.id)\` which fires \`SIGTERM\`.

On a slow runner, the SIGTERM can arrive before bash has parsed and installed the \`trap\` line, so the kill-escalation path the test is named after never gets exercised — and the resulting failure mode varies run-to-run.

## Fix

Touch a marker file *after* trap installs, and poll for its existence before cancelling. The marker is a hard happens-before that the 50ms sleep was only approximating:

\`\`\`
trap '' TERM; touch \"\${ready}\"; sleep 30
\`\`\`

POSIX guarantees the three commands run sequentially within bash, so once the marker exists the trap is installed.

## Why polling beats a longer sleep

A bigger \`Effect.sleep\` would still be theoretically racy under CI load and would always burn its full duration. The poll typically resolves in 10–30ms (first or second tick) and is provably race-free.

## Test plan

- [x] Single run passes locally
- [x] 5 consecutive local runs pass
- [ ] Linux CI green on this PR