### PR TITLE
fix(httpapi): provide instance context to event stream subscription

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/event.ts
@@ -1,4 +1,8 @@
 import { Bus } from "@/bus"
+import type { WorkspaceID } from "@/control-plane/schema"
+import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
+import { InstanceState } from "@/effect/instance-state"
+import type { InstanceContext } from "@/project/instance"
 import * as Log from "@opencode-ai/core/util/log"
 import { Effect, Schema } from "effect"
 import * as Stream from "effect/Stream"
@@ -39,8 +43,12 @@ function eventData(data: unknown): Sse.Event {
   }
 }
 
-function eventResponse(bus: Bus.Interface) {
-  const events = bus.subscribeAll().pipe(Stream.takeUntil((event) => event.type === Bus.InstanceDisposed.type))
+function eventResponse(bus: Bus.Interface, refs: { instance: InstanceContext; workspace?: WorkspaceID }) {
+  const events = bus.subscribeAll().pipe(
+    Stream.provideService(InstanceRef, refs.instance),
+    Stream.provideService(WorkspaceRef, refs.workspace),
+    Stream.takeUntil((event) => event.type === Bus.InstanceDisposed.type),
+  )
   const heartbeat = Stream.tick("10 seconds").pipe(
     Stream.drop(1),
     Stream.map(() => ({ id: Bus.createID(), type: "server.heartbeat", properties: {} })),
@@ -72,7 +80,10 @@ export const eventHandlers = HttpApiBuilder.group(EventApi, "event", (handlers) 
     return handlers.handleRaw(
       "subscribe",
       Effect.fn("EventHttpApi.subscribe")(function* () {
-        return eventResponse(bus)
+        return eventResponse(bus, {
+          instance: yield* InstanceState.context,
+          workspace: yield* InstanceState.workspaceID,
+        })
       }),
     )
   }),

--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -31,6 +31,18 @@ async function readFirstEvent(response: Response) {
   }
 }
 
+async function readEvent(reader: ReadableStreamDefaultReader<Uint8Array>) {
+  const result = await Promise.race([
+    reader.read(),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timed out waiting for event")), 5_000)),
+  ])
+  return JSON.parse(new TextDecoder().decode(result.value).replace(/^data: /, "")) as {
+    id?: string
+    type: string
+    properties: Record<string, unknown>
+  }
+}
+
 afterEach(async () => {
   await disposeAllInstances()
   await resetDatabase()
@@ -55,5 +67,21 @@ describe("event HttpApi", () => {
     const response = await app().request(EventPaths.event, { headers })
 
     expect(await readFirstEvent(response)).toMatchObject({ type: "server.connected", properties: {} })
+  })
+
+  test("keeps the event stream open after the initial event", async () => {
+    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+    const response = await app().request(EventPaths.event, { headers: { "x-opencode-directory": tmp.path } })
+    if (!response.body) throw new Error("missing response body")
+
+    const reader = response.body.getReader()
+    expect(await readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+    const next = await Promise.race([
+      reader.read().then((result) => (result.done ? "closed" : "event")),
+      new Promise<"open">((resolve) => setTimeout(() => resolve("open"), 250)),
+    ])
+    await reader.cancel()
+
+    expect(next).toBe("open")
   })
 })


### PR DESCRIPTION
## Summary

Fixes #27391. Also closes #26697, #27023, and #26635. The `/event` SSE stream closed immediately after `server.connected`, so message deltas, permission asks, heartbeats, etc. never reached clients on v1.14.43+.

## Root cause

`bus.subscribeAll()` is `Stream.unwrap(Effect.gen(function* () { const s = yield* InstanceState.get(state); return Stream.fromPubSub(s.wildcard) }))`. The inner `InstanceState.get` reads `(yield* InstanceRef) ?? Instance.current` to pick the per-instance PubSub.

In real HTTP that lookup runs inside the body-stream consumer fiber, which doesn't carry the request handler's ALS or `InstanceRef`. The lookup throws `NotFound`, the subscription is never acquired, and the stream halts after the initial `server.connected` element finishes flushing.

`/global/event` doesn't hit this because `GlobalBus` is a plain Node `EventEmitter` — process-singleton, no per-instance lookup required, registered synchronously inside a `Stream.callback` acquire effect.

## Fix

Capture `InstanceState.context` and `InstanceState.workspaceID` at handler time and provide them to the bus subscription via `Stream.provideService(InstanceRef, ...)` / `Stream.provideService(WorkspaceRef, ...)`. The Stream-native subscription path now works because the consumer fiber sees the needed services in its Effect environment.

## Test

Added a regression test in `packages/opencode/test/server/httpapi-event.test.ts` that drives `/event` via `Server.Default().app.request(...)`, reads the initial `server.connected`, then races a second `reader.read()` against a 250ms watchdog. Without this fix the second read resolves with `done: true` immediately; with it the watchdog wins and the stream remains open.

## Affected surfaces

Only consumers of `/event` are affected by the bug:

- `opencode run --attach` legacy transport (`cli/cmd/run.ts:738`) — covers #27023
- The Slack bot (`packages/slack/src/index.ts:24`)
- External SDK users calling `client.event.subscribe()` — covers #26697, #26635, #27391

Desktop/web/Tauri/ACP/control-plane/remote-TUI all use `/global/event`, which uses a different (correct) subscription pattern and was unaffected.

Note: #26635 also reports an unrelated `session.idle`-on-connect issue and an `opencode version` CLI bug that this PR does not address.

## Credit

Patch by @jlongster (see https://gist.github.com/jlongster/155911f154572f5a8485af040934ae9d).