### PR TITLE
refactor(storage): remove not found wire serializer

### DIFF
--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -20,13 +20,6 @@ export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("Not
   static isInstance(input: unknown): input is NotFoundError {
     return input instanceof NotFoundError
   }
-
-  toObject() {
-    return {
-      name: "NotFoundError" as const,
-      data: { message: this.message },
-    }
-  }
 }
 
 export type Error = AppFileSystem.Error | NotFoundError


### PR DESCRIPTION
## Summary
- Remove legacy `{ name, data }` serialization from `Storage.NotFoundError`.
- Keep storage not-found as a domain tagged error; HTTP not-found wire shape remains handled by `ApiNotFoundError` at route boundaries.

## Verification
- `bun test --timeout 30000 test/storage/storage.test.ts`
- `bun test --timeout 30000 test/server/httpapi-schema-error-body.test.ts`
- `bun typecheck`
- `bunx prettier --check src/storage/storage.ts`
- `bunx oxlint packages/opencode/src/storage/storage.ts` (0 errors; existing warnings only)
- `git diff --check`