### PR TITLE
test(httpapi): simplify event stream regression coverage

### DIFF
--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -51,6 +51,20 @@ async function readEvent(reader: ReadableStreamDefaultReader<Uint8Array>) {
   return Schema.decodeUnknownSync(EventData)(JSON.parse(new TextDecoder().decode(result.value).replace(/^data: /, "")))
 }
 
+async function readStatusWithin(reader: ReadableStreamDefaultReader<Uint8Array>, delay: number) {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      reader.read().then((result) => (result.done ? "closed" : "event")),
+      new Promise<"open">((resolve) => {
+        timeout = setTimeout(() => resolve("open"), delay)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
 afterEach(async () => {
   await disposeAllInstances()
   await resetDatabase()
@@ -69,14 +83,6 @@ describe("event HttpApi", () => {
     expect(await readFirstEvent(response)).toMatchObject({ type: "server.connected", properties: {} })
   })
 
-  test("serves the initial server connected event", async () => {
-    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
-    const headers = { "x-opencode-directory": tmp.path }
-    const response = await app().request(EventPaths.event, { headers })
-
-    expect(await readFirstEvent(response)).toMatchObject({ type: "server.connected", properties: {} })
-  })
-
   test("keeps the event stream open after the initial event", async () => {
     await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
     const response = await app().request(EventPaths.event, { headers: { "x-opencode-directory": tmp.path } })
@@ -85,12 +91,7 @@ describe("event HttpApi", () => {
     const reader = response.body.getReader()
     try {
       expect(await readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
-      const next = await Promise.race([
-        reader.read().then((result) => (result.done ? "closed" : "event")),
-        new Promise<"open">((resolve) => setTimeout(() => resolve("open"), 250)),
-      ])
-
-      expect(next).toBe("open")
+      expect(await readStatusWithin(reader, 250)).toBe("open")
     } finally {
       await reader.cancel()
     }


### PR DESCRIPTION
## Summary
- Remove the redundant initial `/event` connected-event test now that the stream/header test covers it.
- Add a small timeout-cleanup helper for the open-stream assertion so the test does not leave unmanaged timers behind.

## Testing
- `bun test --timeout 5000 test/server/httpapi-event.test.ts`
- `bun typecheck` from `packages/opencode`
- `bun oxlint packages/opencode/test/server/httpapi-event.test.ts`
- `bun prettier --check packages/opencode/test/server/httpapi-event.test.ts`