### PR TITLE
feat(plugin): add sidebar panel API for plugin-contributed UI panels

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -11,6 +11,7 @@ import { GlobalApi } from "./groups/global"
 import { InstanceApi } from "./groups/instance"
 import { McpApi } from "./groups/mcp"
 import { PermissionApi } from "./groups/permission"
+import { PluginApi } from "./groups/plugin"
 import { ProjectApi } from "./groups/project"
 import { ProviderApi } from "./groups/provider"
 import { PtyApi, PtyConnectApi } from "./groups/pty"
@@ -39,6 +40,7 @@ export const InstanceHttpApi = HttpApi.make("opencode-instance")
   .addHttpApi(FileApi)
   .addHttpApi(InstanceApi)
   .addHttpApi(McpApi)
+  .addHttpApi(PluginApi)
   .addHttpApi(ProjectApi)
   .addHttpApi(PtyApi)
   .addHttpApi(QuestionApi)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/plugin.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/plugin.ts
@@ -1,0 +1,55 @@
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { Authorization } from "../middleware/authorization"
+import { InstanceContextMiddleware } from "../middleware/instance-context"
+import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
+
+const root = "/plugin"
+
+const SidebarPanelItemSchema = Schema.Struct({
+  label: Schema.String,
+  value: Schema.optional(Schema.String),
+  status: Schema.optional(Schema.Literal("success", "warning", "error", "info")),
+}).annotate({ identifier: "SidebarPanelItem" })
+
+const SidebarPanelSchema = Schema.Struct({
+  id: Schema.String,
+  title: Schema.String,
+  items: Schema.Array(SidebarPanelItemSchema),
+}).annotate({ identifier: "SidebarPanel" })
+
+const PluginSidebarResponse = Schema.Struct({
+  panels: Schema.Array(SidebarPanelSchema),
+}).annotate({ identifier: "PluginSidebarResponse" })
+
+export const PluginPaths = {
+  sidebar: `${root}/sidebar`,
+} as const
+
+export const PluginApi = HttpApi.make("plugin")
+  .add(
+    HttpApiGroup.make("plugin")
+      .add(
+        HttpApiEndpoint.get("sidebar", PluginPaths.sidebar, {
+          query: WorkspaceRoutingQuery,
+          success: PluginSidebarResponse,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "plugin.sidebar",
+            summary: "Get plugin sidebar panels",
+            description: "Returns aggregated sidebar panels from all registered plugins.",
+          }),
+        ),
+      )
+      .annotateMerge(OpenApi.annotations({ title: "plugin", description: "Plugin sidebar API." }))
+      .middleware(InstanceContextMiddleware)
+      .middleware(WorkspaceRoutingMiddleware)
+      .middleware(Authorization),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode plugin HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for plugin-contributed UI.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/plugin.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/plugin.ts
@@ -1,0 +1,46 @@
+import { Plugin } from "@/plugin"
+import { Effect } from "effect"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { InstanceHttpApi } from "../api"
+import type { SidebarPanel, SidebarPanelItem, SidebarPanelStatus } from "@opencode-ai/plugin"
+
+export const pluginHandlers = HttpApiBuilder.group(InstanceHttpApi, "plugin", (handlers) =>
+  Effect.gen(function* () {
+    const plugin = yield* Plugin.Service
+
+    return handlers.handle("sidebar", () =>
+      Effect.gen(function* () {
+        const hooks = yield* plugin.list()
+
+        const panels: Array<{
+          id: string
+          title: string
+          items: Array<{ label: string; value?: string; status?: SidebarPanelStatus }>
+        }> = []
+
+        for (const hook of hooks) {
+          if (!hook.sidebar) continue
+          const resolved = typeof hook.sidebar === "function" ? await hook.sidebar() : hook.sidebar
+          for (const panel of resolved) {
+            const items =
+              typeof panel.items === "function"
+                ? await panel.items()
+                : panel.items
+
+            panels.push({
+              id: panel.id,
+              title: panel.title,
+              items: items.map((item: any) => ({
+                label: item.label,
+                value: item.value,
+                status: item.status,
+              })),
+            })
+          }
+        }
+
+        return { panels }
+      }),
+    )
+  }),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -67,6 +67,7 @@ import { globalHandlers } from "./handlers/global"
 import { instanceHandlers } from "./handlers/instance"
 import { mcpHandlers } from "./handlers/mcp"
 import { permissionHandlers } from "./handlers/permission"
+import { pluginHandlers } from "./handlers/plugin"
 import { projectHandlers } from "./handlers/project"
 import { providerHandlers } from "./handlers/provider"
 import { ptyConnectRoute, ptyHandlers } from "./handlers/pty"
@@ -133,6 +134,7 @@ const instanceApiRoutes = HttpApiBuilder.layer(InstanceHttpApi).pipe(
     fileHandlers,
     instanceHandlers,
     mcpHandlers,
+    pluginHandlers,
     projectHandlers,
     ptyHandlers,
     questionHandlers,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -219,6 +219,20 @@ export type ProviderHook = {
 /** @deprecated Use AuthOAuthResult instead. */
 export type AuthOuathResult = AuthOAuthResult
 
+export type SidebarPanelStatus = "success" | "warning" | "error" | "info"
+
+export interface SidebarPanelItem {
+  label: string
+  value?: string
+  status?: SidebarPanelStatus
+}
+
+export interface SidebarPanel {
+  id: string
+  title: string
+  items: SidebarPanelItem[] | (() => SidebarPanelItem[])
+}
+
 export interface Hooks {
   event?: (input: { event: Event }) => Promise<void>
   config?: (input: Config) => Promise<void>
@@ -330,4 +344,9 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  /**
+   * Register sidebar panels. The sidebar polls every 5 seconds for updates.
+   * Each panel shows a title with labeled status items.
+   */
+  sidebar?: SidebarPanel[] | (() => SidebarPanel[])
 }


### PR DESCRIPTION
### Issue for this PR

### Type of change

- [x] Bug fix
- [√] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

为插件系统添加侧边栏面板 API，允许插件注册包含 label/value/status 的数据面板。后续还需要实现 TUI 和桌面端的渲染层


### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [√] I have tested my changes locally
- [√] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
