### PR TITLE
fix(tui): move app.agents from blocking to non-blocking bootstrap

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -393,7 +393,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       const blockingRequests: { name: string; promise: Promise<unknown> }[] = [
         { name: "config.providers", promise: providersPromise },
         { name: "provider.list", promise: providerListPromise },
-        { name: "app.agents", promise: agentsPromise },
         { name: "config.get", promise: configPromise },
         { name: "project.sync", promise: projectPromise },
         ...(args.continue ? [{ name: "session.list", promise: sessionListPromise }] : []),
@@ -411,7 +410,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           const providersResponse = providersPromise.then((x) => x.data!)
           const providerListResponse = providerListPromise.then((x) => x.data!)
           const consoleStateResponse = consoleStatePromise
-          const agentsResponse = agentsPromise.then((x) => x.data ?? [])
           const configResponse = configPromise.then((x) => x.data!)
           const sessionListResponse = args.continue ? sessionListPromise : undefined
 
@@ -419,23 +417,20 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             providersResponse,
             providerListResponse,
             consoleStateResponse,
-            agentsResponse,
             configResponse,
             ...(sessionListResponse ? [sessionListResponse] : []),
           ]).then((responses) => {
             const providers = responses[0]
             const providerList = responses[1]
             const consoleState = responses[2]
-            const agents = responses[3]
-            const config = responses[4]
-            const sessions = responses[5]
+            const config = responses[3]
+            const sessions = responses[4]
 
             batch(() => {
               setStore("provider", reconcile(providers.providers))
               setStore("provider_default", reconcile(providers.default))
               setStore("provider_next", reconcile(providerList))
               setStore("console_state", reconcile(consoleState))
-              setStore("agent", reconcile(agents))
               setStore("config", reconcile(config))
               if (sessions !== undefined) setStore("session", reconcile(sessions))
             })
@@ -445,6 +440,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
+            agentsPromise
+              .then((x) => setStore("agent", reconcile(x.data ?? [])))
+              .catch(() => {}),
             ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),


### PR DESCRIPTION
## Summary

- Move `agentsPromise` from `blockingRequests` to non-blocking `Promise.all` in `SyncProvider.bootstrap()`
- Adjust response array indices (agents removed from blocking section)

## Problem

The TUI shows a blank page indefinitely when the `app.agents` HTTP request hangs. This happens because:

1. `SyncProvider.bootstrap()` puts ALL initial HTTP requests into a `blockingRequests` array
2. The `ready` getter returns `store.status !== "loading"`, which blocks the **entire** component tree from rendering until all blocking requests complete
3. `app.agents` triggers `Agent.Service` initialization via lazy `InstanceState`/`ScopedCache`
4. If `Agent.Service` init encounters filesystem errors (e.g. `ENAMETOOLONG` on deeply nested `node_modules/.pnpm` paths in the project directory), the error is not properly propagated, causing the request to hang forever
5. Result: TUI never renders — user sees a blank screen

## Fix

Move `agentsPromise` from `blockingRequests` to the non-blocking section (alongside `command.list`, `lsp.status`, `mcp.status`, etc.). The TUI now renders as soon as essential data (providers, config, project) is available, while agents load asynchronously in the background with `.catch(() => {})`.

The agents data is still populated into the store when the request eventually resolves — the UI just doesn't block on it.

## Testing

- Verified TUI renders successfully in ~1.5s with the fix applied
- Agent list populates correctly after initial render
- No regression in normal startup flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)