### PR TITLE
fix: allow worktree creation without request body

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
@@ -5,7 +5,7 @@ import { Session } from "@/session/session"
 import { Worktree } from "@/worktree"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
 import { Schema } from "effect"
-import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
 import {
@@ -167,7 +167,7 @@ export const ExperimentalApi = HttpApi.make("experimental")
         ),
         HttpApiEndpoint.post("worktreeCreate", ExperimentalPaths.worktree, {
           query: WorkspaceRoutingQuery,
-          payload: Schema.optional(Worktree.CreateInput),
+          payload: [HttpApiSchema.NoContent, Worktree.CreateInput],
           success: described(Worktree.Info, "Worktree created"),
           error: WorktreeApiError,
         }).annotateMerge(

--- a/packages/opencode/test/server/httpapi-experimental.test.ts
+++ b/packages/opencode/test/server/httpapi-experimental.test.ts
@@ -209,6 +209,19 @@ describe("experimental HttpApi", () => {
     }),
   )
 
+  it.instance("accepts worktree create requests without a body", () =>
+    Effect.gen(function* () {
+      const tmp = yield* TestInstance
+      const response = yield* request(ExperimentalPaths.worktree, tmp.directory, { method: "POST" })
+
+      expect(response.status).toBe(400)
+      expect(yield* json(response)).toEqual({
+        name: "WorktreeNotGitError",
+        data: { message: "Worktrees are only supported for git projects" },
+      })
+    }),
+  )
+
   it.instance(
     "serves Console org switch through the default server app",
     () =>


### PR DESCRIPTION
### Issue for this PR

Closes #27450

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows `POST /experimental/worktree` to omit the request body. The web client creates a default worktree with only the `directory` query parameter, so the HttpApi endpoint should accept no-content requests just like `session.create` already does.

This changes the worktree create payload schema to `NoContent | Worktree.CreateInput` and adds a regression test for a bodyless create request.

### How did you verify your code works?

- `git diff --check`
- LSP diagnostics on changed files
- Tried `/home/xtalpi/nan.zhang/.bun/bin/bun typecheck`, but the local install is missing `@typescript/native-preview-linux-x64`
- Tried `/home/xtalpi/nan.zhang/.bun/bin/bun test test/server/httpapi-experimental.test.ts --timeout 30000`, but the local install cannot resolve `@opencode-ai/core` from the test preload

### Screenshots / recordings

N/A - no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR