### PR TITLE
fix(server): stop exposing named defects

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
@@ -20,9 +20,6 @@ export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect)
       const error = defect.defect
       log.error("failed", { error, cause: Cause.pretty(cause) })
 
-      if (error instanceof NamedError) {
-        return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 }))
-      }
       return Effect.succeed(
         HttpServerResponse.jsonUnsafe(
           new NamedError.Unknown({

--- a/packages/opencode/test/server/httpapi-error-middleware.test.ts
+++ b/packages/opencode/test/server/httpapi-error-middleware.test.ts
@@ -1,4 +1,5 @@
 import { NodeHttpServer, NodeServices } from "@effect/platform-node"
+import { NamedError } from "@opencode-ai/core/util/error"
 import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
@@ -26,6 +27,26 @@ describe("HttpApi error middleware", () => {
         data: { message: "Unexpected server error. Check server logs for details." },
       })
       expect(JSON.stringify(body)).not.toContain("secret stack marker")
+    }),
+  )
+
+  it.live("returns a safe body for named defects", () =>
+    Effect.gen(function* () {
+      yield* HttpRouter.add(
+        "GET",
+        "/named",
+        Effect.die(new NamedError.Unknown({ message: "secret named marker" })),
+      ).pipe(Layer.provide(errorLayer), HttpRouter.serve, Layer.build)
+
+      const response = yield* HttpClientRequest.get("/named").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(500)
+      expect(body).toEqual({
+        name: "UnknownError",
+        data: { message: "Unexpected server error. Check server logs for details." },
+      })
+      expect(JSON.stringify(body)).not.toContain("secret named marker")
     }),
   )
 


### PR DESCRIPTION
## summary
- return the generic safe 500 body for `NamedError` defects instead of exposing their serialized payload
- add middleware coverage that proves named defects do not leak internal messages

## testing
- `bun test test/server/httpapi-error-middleware.test.ts --timeout 30000`
- `bun typecheck`