### PR TITLE
refactor(provider): type init errors

### DIFF
--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -72,8 +72,9 @@ export function FormatError(input: unknown) {
   }
 
   // ProviderInitError: { providerID: string }
-  if (NamedError.hasName(input, "ProviderInitError")) {
-    return `Failed to initialize provider "${(input as ErrorLike).data?.providerID}". Check credentials and configuration.`
+  const providerInit = configData(input, "ProviderInitError")
+  if (providerInit) {
+    return `Failed to initialize provider "${stringField(providerInit, "providerID")}". Check credentials and configuration.`
   }
 
   // ConfigJsonError: { path: string, message?: string }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -13,7 +13,6 @@ import { Auth } from "../auth"
 import { Env } from "../env"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Flag } from "@opencode-ai/core/flag/flag"
-import { NamedError } from "@opencode-ai/core/util/error"
 import { iife } from "@/util/iife"
 import { Global } from "@opencode-ai/core/global"
 import path from "path"
@@ -975,7 +974,16 @@ export class ModelNotFoundError extends Schema.TaggedErrorClass<ModelNotFoundErr
   }
 }
 
-export type Error = ModelNotFoundError
+export class InitError extends Schema.TaggedErrorClass<InitError>()("ProviderInitError", {
+  providerID: ProviderID,
+  cause: Schema.optional(Schema.Defect),
+}) {
+  static isInstance(input: unknown): input is InitError {
+    return input instanceof InitError
+  }
+}
+
+export type Error = ModelNotFoundError | InitError
 
 export interface Interface {
   readonly list: () => Effect.Effect<Record<ProviderID, Info>>
@@ -1634,7 +1642,7 @@ const layer = Layer.effect(
         s.sdk.set(key, loaded)
         return loaded as SDK
       } catch (e) {
-        throw new InitError({ providerID: model.providerID }, { cause: e })
+        throw new InitError({ providerID: model.providerID, cause: e })
       }
     }
 
@@ -1826,9 +1834,5 @@ export function parseModel(model: string) {
     modelID: ModelID.make(rest.join("/")),
   }
 }
-
-export const InitError = NamedError.create("ProviderInitError", {
-  providerID: ProviderID,
-})
 
 export * as Provider from "./provider"

--- a/packages/opencode/test/cli/error.test.ts
+++ b/packages/opencode/test/cli/error.test.ts
@@ -81,6 +81,14 @@ describe("cli.error", () => {
     expect(FormatError({ _tag: "ProviderModelNotFoundError", ...data })).toBe(expected)
   })
 
+  test("formats legacy and tagged provider init errors the same way", () => {
+    const data = { providerID: "anthropic" }
+    const expected = 'Failed to initialize provider "anthropic". Check credentials and configuration.'
+
+    expect(FormatError({ name: "ProviderInitError", data })).toBe(expected)
+    expect(FormatError({ _tag: "ProviderInitError", ...data })).toBe(expected)
+  })
+
   test("formats cancelled UI errors as empty output", () => {
     expect(FormatError(new UI.CancelledError())).toBe("")
   })


### PR DESCRIPTION
## summary
- convert `Provider.InitError` from legacy `NamedError.create` to `Schema.TaggedErrorClass`
- keep CLI formatting compatible for both legacy `{ name, data }` and tagged error shapes

## testing
- `bun test test/cli/error.test.ts --timeout 30000`
- `bun test test/provider/provider.test.ts --timeout 30000`
- `bun typecheck`