### PR TITLE
fix: correct typo in dev README (whenver -> whenever)

### DIFF
--- a/packages/opencode/src/control-plane/dev/README.md
+++ b/packages/opencode/src/control-plane/dev/README.md
@@ -16,4 +16,4 @@ How this works:
 
 - The workspace server needs to know the workspace id and port to run. It waits for this information to be written to a file and starts the server when the data is written.
 - The debug plugin writes this information in the `create` call to the workspace. So create a `debug` workspace will always kick off a new external server.
-- The server script watches for file changes, so whenver you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.
+- The server script watches for file changes, so whenever you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.


### PR DESCRIPTION
Fixes #27485

## Summary
Fixed a typo in the dev README file where "whenver" was misspelled. Changed it to "whenever".

## Changes
- Updated `packages/opencode/src/control-plane/dev/README.md` line 19

## Testing
- Verified the typo exists in the original file
- Confirmed the correction is accurate

