### PR TITLE
fix(desktop): await execFilePromise and read stdout properly

### DIFF
--- a/packages/desktop/src/main/apps.ts
+++ b/packages/desktop/src/main/apps.ts
@@ -58,7 +58,7 @@ async function checkMacosApp(appName: string) {
 async function resolveWindowsAppPath(appName: string): Promise<string | null> {
   let output: string
   try {
-    output = execFilePromise("where", [appName]).toString()
+    output = await execFilePromise("where", [appName]).then((r) => r.stdout.toString())
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

Fixes a bug in `resolveWindowsAppPath` where `execFilePromise` was not being awaited correctly. The function returns a Promise that resolves to an object with a `stdout` property, but the code was treating it as if it returned a string directly.

### Changes
- Added `await` to properly wait for the promise to resolve
- Changed from `.toString()` on the promise to `.then((r) => r.stdout.toString())` to correctly access the stdout output

This fixes the Windows app path resolution functionality.