### PR TITLE
fix: await execFilePromise in resolveWindowsAppPath

### DIFF
--- a/packages/desktop/src/main/apps.ts
+++ b/packages/desktop/src/main/apps.ts
@@ -58,7 +58,8 @@ async function checkMacosApp(appName: string) {
 async function resolveWindowsAppPath(appName: string): Promise<string | null> {
   let output: string
   try {
-    output = execFilePromise("where", [appName]).toString()
+    const result = await execFilePromise("where", [appName])
+    output = result.stdout
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
Fixes the Windows-specific bug where editor and terminal launches fail with "spawn [object Promise] ENOENT" errors.

## Problem
The `resolveWindowsAppPath` function was calling `.toString()` on a Promise object instead of awaiting it. This caused the function to return the literal string `"[object Promise]"` instead of the actual filesystem path, breaking all external app launches on Windows.

## Solution
Properly await the `execFilePromise` call and extract the `stdout` property from the result object.

## Testing
On Windows:
- Open a file in an external editor (VS Code, Cursor, Zed, etc.)
- Open a terminal
- Verify both operations work without "spawn [object Promise] ENOENT" errors

Fixes #27432, #26287, #26928, #26814, #26657