### PR TITLE
feat(command): add noReply flag to skip LLM dispatch for display-only commands

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -35,6 +35,8 @@ export const Info = Schema.Struct({
   // Some command templates are lazy promises from MCP prompt resolution.
   template: Schema.Unknown,
   subtask: Schema.optional(Schema.Boolean),
+  // noReply: skip LLM dispatch after command output (display-only commands)
+  noReply: Schema.optional(Schema.Boolean),
   hints: Schema.Array(Schema.String),
 }).annotate({ identifier: "Command" })
 
@@ -105,6 +107,7 @@ export const layer = Layer.effect(
             return command.template
           },
           subtask: command.subtask,
+          noReply: command.noReply,
           hints: hints(command.template),
         }
       }

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -18,6 +18,8 @@ export const Info = Schema.Struct({
   agent: Schema.optional(Schema.String),
   model: Schema.optional(ConfigModelID),
   subtask: Schema.optional(Schema.Boolean),
+  // noReply: skip LLM dispatch after command output (display-only commands)
+  noReply: Schema.optional(Schema.Boolean),
 })
 
 export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2005,6 +2005,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         agent: userAgent,
         parts,
         variant: input.variant,
+        noReply: cmd.noReply ?? false,
       })
       yield* bus.publish(Command.Event.Executed, {
         name: input.command,


### PR DESCRIPTION
### Issue for this PR

Related: #26022 (existing tracked issue for the same mechanism — that one targets `chat.message`, this PR targets `command.execute.before`; same underlying `PromptInput.noReply` short-circuit).

The companion issue I filed for this PR (#27520) was auto-closed by the compliance bot at 13:07 today for a title-prefix template mismatch (needed `[FEATURE]:`); see the bot's comment there for the cross-reference to #26022.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `noReply` flag to the command schema. When set, the command dispatch path forwards `noReply: true` to `prompt()`, which already short-circuits at the existing `if (input.noReply === true) return message` guard.

Why this matters: a plugin I maintain ships display-only slash commands (panels, confirmations) where the model has nothing useful to say after the command output. Today the command dispatch always invokes the LLM for the next assistant turn, wasting a round-trip. The plugin side can't suppress this — `command.execute.before` only returns `{ parts }`, `chat.message` only returns `{ message, parts }`, and `session.abort` from a hook races the runner becoming busy.

The patch is opt-in and additive. Existing commands without `noReply` keep their current behavior.

### How did you verify your code works?

- `bun run typecheck` clean (14/14 tasks)
- `bun test test/session/prompt.test.ts` — 53 pass / 0 fail on the cherry-picked branch
- End-to-end via my fork's TUI: a 20-second baseline window (no input) and a 20-second window after invoking a `noReply: true` command both show zero `service=llm stream` lines. On an unpatched build, the post-command window contains the dispatch.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
