### PR TITLE
fix(provider): detect max-token request overflow errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -9,6 +9,7 @@ const OVERFLOW_PATTERNS = [
   /prompt is too long/i, // Anthropic
   /input is too long for requested model/i, // Amazon Bedrock
   /exceeds the context window/i, // OpenAI (Completions + Responses API message text)
+  /(?:tokens? in (?:request|input|prompt|context)|(?:request|input|prompt|context) tokens?|input token count).*?(?:more than|greater than|exceeds?|exceeded).*?(?:max(?:imum)?(?: number of)? tokens?(?: allowed)?|token limit)/i, // Conservative request-token overflow variants
   /input token count.*exceeds the maximum/i, // Google (Gemini)
   /maximum prompt length is \d+/i, // xAI (Grok)
   /reduce the length of the messages/i, // Groq
@@ -27,6 +28,10 @@ const OVERFLOW_PATTERNS = [
   /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
 ]
 
+function normalizeOverflowText(message: string) {
+  return message.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim()
+}
+
 function isOpenAiErrorRetryable(e: APICallError) {
   const status = e.statusCode
   if (!status) return e.isRetryable
@@ -37,7 +42,8 @@ function isOpenAiErrorRetryable(e: APICallError) {
 // Providers not reliably handled in this function:
 // - z.ai: can accept overflow silently (needs token-count/context-window checks)
 function isOverflow(message: string) {
-  if (OVERFLOW_PATTERNS.some((p) => p.test(message))) return true
+  const normalized = normalizeOverflowText(message)
+  if (OVERFLOW_PATTERNS.some((p) => p.test(message) || p.test(normalized))) return true
 
   // Providers/status patterns handled outside of regex list:
   // - Cerebras: often returns "400 (no body)" / "413 (no body)"
@@ -181,7 +187,12 @@ export type ParsedAPICallError =
 export function parseAPICallError(input: { providerID: ProviderID; error: APICallError }): ParsedAPICallError {
   const m = message(input.providerID, input.error)
   const body = json(input.error.responseBody)
-  if (isOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
+  if (
+    isOverflow(m) ||
+    (input.error.responseBody ? isOverflow(input.error.responseBody) : false) ||
+    input.error.statusCode === 413 ||
+    body?.error?.code === "context_length_exceeded"
+  ) {
     return {
       type: "context_overflow",
       message: m,

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1462,6 +1462,31 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("detects request max-token overflow API call errors", () => {
+    const cases = [
+      "tokens in request more than max tokens allowed",
+      "Input token count exceeded maximum number of tokens allowed",
+    ]
+
+    cases.forEach((message) => {
+      const result = MessageV2.fromError(
+        new APICallError({
+          message,
+          url: "https://example.com",
+          requestBodyValues: {},
+          statusCode: 400,
+          responseHeaders: { "content-type": "application/json" },
+          isRetryable: false,
+        }),
+        { providerID },
+      )
+
+      expect(MessageV2.ContextOverflowError.isInstance(result)).toBe(true)
+      if (!MessageV2.ContextOverflowError.isInstance(result)) throw new Error("expected ContextOverflowError")
+      expect(result.data.message).toBe(message)
+    })
+  })
+
   test("detects context overflow from context_length_exceeded code in response body", () => {
     const error = new APICallError({
       message: "Request failed",
@@ -1496,6 +1521,27 @@ describe("session.message-v2.fromError", () => {
     )
     expect(MessageV2.ContextOverflowError.isInstance(result)).toBe(false)
     expect(MessageV2.APIError.isInstance(result)).toBe(true)
+  })
+
+  test("does not classify max_tokens setting errors as context overflow", () => {
+    const message = "max_tokens must be less than or equal to 4096"
+    const result = MessageV2.fromError(
+      new APICallError({
+        message,
+        url: "https://example.com",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody: JSON.stringify({ error: { message } }),
+        isRetryable: false,
+      }),
+      { providerID },
+    )
+
+    expect(MessageV2.ContextOverflowError.isInstance(result)).toBe(false)
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    if (!MessageV2.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.message).toContain(message)
   })
 
   test("serializes unknown inputs", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -172,6 +172,23 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
   })
 
+  test("does not retry request max-token overflow API call errors", () => {
+    const error = MessageV2.fromError(
+      new APICallError({
+        message: "tokens in request more than max tokens allowed",
+        url: "https://example.com",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseHeaders: { "content-type": "application/json" },
+        isRetryable: false,
+      }),
+      { providerID },
+    )
+
+    expect(MessageV2.ContextOverflowError.isInstance(error)).toBe(true)
+    expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
+  })
+
   test("retries 500 errors even when isRetryable is false", () => {
     const error = Schema.decodeUnknownSync(MessageV2.APIError.Schema)(
       new MessageV2.APIError({


### PR DESCRIPTION
Fixes #27519

Adds detection of context overflow / max-token request errors in the provider layer. When the model returns a 400 error indicating the context window is exceeded (e.g., "maximum context length exceeded" or similar token limit errors), this change:

- Parses the error message from the provider response to identify max-token overflow conditions
- Maps these errors to a structured error type for consistent handling upstream
- Adds comprehensive test coverage for the error detection logic

This prevents cryptic provider errors from bubbling up unhandled and allows the caller to respond appropriately (e.g., by reducing context or switching models).