### PR TITLE
fix(opencode): auto-exit plan mode when user asks to implement

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -16,7 +16,6 @@ import { ProviderTransform } from "@/provider/transform"
 import { SystemPrompt } from "./system"
 import { Instruction } from "./instruction"
 import { Plugin } from "../plugin"
-import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
 import { ToolRegistry } from "@/tool/registry"
@@ -387,31 +386,6 @@ export const layer = Layer.effect(
     }) {
       const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
       if (!userMessage) return input.messages
-
-      if (!flags.experimentalPlanMode) {
-        if (input.agent.name === "plan") {
-          userMessage.parts.push({
-            id: PartID.ascending(),
-            messageID: userMessage.info.id,
-            sessionID: userMessage.info.sessionID,
-            type: "text",
-            text: PROMPT_PLAN,
-            synthetic: true,
-          })
-        }
-        const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-        if (wasPlan && input.agent.name === "build") {
-          userMessage.parts.push({
-            id: PartID.ascending(),
-            messageID: userMessage.info.id,
-            sessionID: userMessage.info.sessionID,
-            type: "text",
-            text: BUILD_SWITCH,
-            synthetic: true,
-          })
-        }
-        return input.messages
-      }
 
       const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
       if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -250,7 +250,7 @@ export const layer: Layer.Layer<
             tool.skill,
             tool.patch,
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
-            ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),
+            ...(flags.client === "cli" || flags.client === "desktop" ? [tool.plan] : []),
           ],
           task: tool.task,
           read: tool.read,


### PR DESCRIPTION
### Issue for this PR

Closes #15231
Closes #17428

### Type of change

- [x] Bug fix

### What does this PR do?

When plan mode is active without `OPENCODE_EXPERIMENTAL_PLAN_MODE`, the agent gets stuck in read-only mode after the user asks to implement the plan. It never sees `plan_exit` as a way out because `plan.txt` doesn't mention it and the tool isn't registered without the experimental flag.

Prior art: branch `opencode/clever-falcon` (commit `afec40e8d`) removed the same branching but was never merged.

**Changes:**

1. **`prompt.ts`**: Remove the `if (!flags.experimentalPlanMode)` branching. The rich 5-phase prompt is now the only path — it already has explicit `plan_exit` instructions in Phase 5 and handles the plan\\->build transition via `BUILD_SWITCH`.

2. **`registry.ts`**: Register `plan_exit` for `desktop` client alongside `cli`. The macOS app sets `OPENCODE_CLIENT=desktop` and was previously excluded.

An alternative approach would be to keep both paths and just add `plan_exit` awareness to `plan.txt` / register the tool without the experimental gate. Happy to pivot if preferred.

### How did you verify your code works?

- Removed the non-experimental branching — the rich path already handles both plan\\->build transition and plan agent prompts. No new code added, only deletion.
- Verified `flags` (from `RuntimeFlags.Service`) is still used by `experimentalEventSystem` elsewhere in the file.
- `PROMPT_PLAN` import removed since `plan.txt` is no longer referenced.
- Tests pass: confirmed existing snapshots and plan bypass tests still reference the rich prompt path.
- Use plan mode and then prompting to approve it and implement it (the switch happens automatically)

### Screenshots / recordings


Example of the UX bug:

<img width="766" height="268" alt="image" src="https://github.com/user-attachments/assets/af5ad986-d9b6-4cec-ae04-49fbc2735dc7" />

then when trying to approve it:

> Plan mode is still active — I'm currently in read-only mode and cannot create files or make edits yet.
If you'd like me to implement this, please confirm by saying "exit plan mode" or "implement it" to switch to execution mode.

then I do exactly what it ask me to do, but still is not able to change, so it requires manual mode switch

> The "implement it" command should have exited plan mode, but the system is still enforcing read-only. Could you please explicitly say: "exit plan mode" — that will release the restriction and let me create the file.

<img width="765" height="271" alt="image" src="https://github.com/user-attachments/assets/0b3bfbb3-09ac-45dd-9507-6769c8221fd2" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR