### PR TITLE
docs(effect): refresh TODO with shipped P0 and RF work

### DIFF
--- a/packages/opencode/specs/effect/todo.md
+++ b/packages/opencode/specs/effect/todo.md
@@ -94,19 +94,16 @@ shapes and sometimes collapse rich errors into opaque strings.
 
 ### Problems
 
-- Some expected service failures still use `NamedError.create(...)`.
-- Some expected service failures still become `Effect.die(...)`, which
-  makes them defects instead of typed, recoverable failures.
-- CLI and HTTP boundaries can render structured errors as generic
-  `Error: SomeName` output.
-- HTTP error middleware still guesses status codes from error names like
-  `Worktree*` or `ProviderAuthValidationFailed`.
+- Some expected service failures still use `NamedError.create(...)` or
+  collapse to `Effect.die(...)`. The storage/worktree/provider-auth
+  conversions are done; an inventory sweep is needed for the rest.
+- HTTP error middleware still guesses status codes from error names —
+  some entries (e.g. storage `NotFound`, provider auth) can now be
+  removed, but the middleware overall has not shrunk.
 - Route handlers and route groups do not consistently declare the public
   error body they intend to expose.
 - Repeated route error translations do not yet have a clear home: some
   should stay inline, some deserve tiny shared mapper helpers.
-- Unknown 500s should log full detail server-side while returning a safe
-  public body.
 
 ### Target Shape
 
@@ -126,19 +123,33 @@ shapes and sometimes collapse rich errors into opaque strings.
 - Generic HTTP middleware should shrink; it should not accumulate more
   name-based domain knowledge.
 
+### Recently completed
+
+- [x] `RENDER-1` CLI tagged config error rendering (#27256, tests #27257).
+- [x] `ERR-1` [`storage/storage.ts`](../../src/storage/storage.ts) typed
+      `NotFoundError` (#27265) and removal of the server defect fallback
+      (#27287).
+- [x] `ERR-2` [`worktree/index.ts`](../../src/worktree/index.ts) typed
+      errors (#27296).
+- [x] `ERR-3` [`provider/auth.ts`](../../src/provider/auth.ts) typed
+      validation/oauth errors (#27301).
+- [x] `HTTP-1` Unknown-500 details no longer leaked (#27251); follow-up
+      to stop exposing named defects (#27471).
+- [x] Session message reads typed and made effectful (#27269, #27275,
+      #27280, #27291).
+- [x] Session HTTP error contracts tightened (#27308); busy-session
+      mapping centralized (#27375, #27473).
+- [x] Provider init (#27484) and LSP init (#27494) errors typed.
+
 ### First PR Candidates
 
-- [ ] `RENDER-1` Fix CLI top-level rendering for typed config errors.
-- [ ] `ERR-1` Convert [`storage/storage.ts`](../../src/storage/storage.ts)
-      not-found errors.
-- [ ] `ERR-2` Convert [`worktree/index.ts`](../../src/worktree/index.ts)
-      errors and remove matching HTTP name checks where possible.
-- [ ] `ERR-3` Convert [`provider/auth.ts`](../../src/provider/auth.ts)
-      validation errors.
-- [ ] `HTTP-1` Remove the unknown-500 stack leak from
-      [`middleware/error.ts`](../../src/server/routes/instance/httpapi/middleware/error.ts).
 - [ ] `HTTP-2` Audit one route group for explicit error contracts and
       decide which mappings stay inline vs. shared helper.
+- [ ] `ERR-4` Sweep remaining `NamedError.create(...)` and
+      `Effect.die(...)` callsites for expected failures — re-run `git
+      grep` to build a current inventory.
+- [ ] `RENDER-2` Audit CLI and TUI surfaces for any remaining opaque
+      `Error: Name` rendering of typed errors.
 
 ## P1: Tests
 
@@ -163,26 +174,24 @@ Recently completed:
 - [x] Built-in websearch provider selection uses the same runtime flags as
       tool visibility.
 - [x] Removed global default-plugin disabling from test preload.
+- [x] `RF-1` Scout reads routed through runtime flags (#27318).
+- [x] `RF-2` Plan-mode prompt read routed through runtime flags (#27320).
+- [x] `RF-3` Event-system reads routed through runtime flags (#27323).
+- [x] `RF-4` Workspaces reads routed through runtime flags for session
+      (#27335), sync (#27336), and control-plane (#27337).
+- [x] LLM client (#27368) and installation client (#27369) routed
+      through runtime flags.
+- [x] TUI plugin runtime flags simplified (#27506).
+- [x] Background-subagents flag moved to RuntimeFlags, then removed
+      (`refactor(task): use runtime flag for background subagents`,
+      `refactor(flags): remove background subagents flag`).
 
-Recommended next PRs:
+Remaining cleanup:
 
-```text
-RF-1 scout consumers ─┐
-                      ├─ can run in parallel
-RF-2 plan-mode prompt ┘
-   └─ RF-3 event-system cluster, stacked only if RF-2 still touches prompt.ts
-
-RF-4 workspaces cluster: later, after mutable Flag tests are cleaned up
-```
-
-- [ ] `RF-1` Move scout reads in [`agent.ts`](../../src/agent/agent.ts)
-      and [`reference.ts`](../../src/reference/reference.ts).
-- [ ] `RF-2` Move plan-mode prompt read in
-      [`session/prompt.ts`](../../src/session/prompt.ts).
-- [ ] `RF-3` Move event-system reads in session prompt/processor/
-      compaction and TUI debug plugin.
-- [ ] `RF-4` Move workspaces reads in session/sync/control-plane after
-      tests stop relying on mutable `Flag` timing.
+- [ ] Sweep lingering `Flag.*` reads — many CLI/TUI/config/observability
+      callsites still import [`flag.ts`](../../../core/src/flag/flag.ts).
+      Decide per-callsite whether to route through RuntimeFlags, accept
+      as legitimate env/config boundary, or migrate to typed `Config`.
 - [ ] Delete [`test/fixture/flag.ts`](../../test/fixture/flag.ts) once
       tests no longer mutate `Flag`.
 - [ ] Delete [`flag.ts`](../../../core/src/flag/flag.ts) once no packages


### PR DESCRIPTION
## Summary

- Marks P0 first-PR candidates done (RENDER-1, ERR-1/2/3, HTTP-1) and lists the additional P0 work that shipped this week (session typed message reads, HTTP error contracts, busy-session mapping, provider/LSP init errors).
- Marks RF-1 through RF-4 done plus the LLM/installation client, TUI plugin, and background-subagents flag migrations; reframes remaining RuntimeFlags work as a sweep of lingering `Flag.*` callsites.
- Trims the P0 problems list to reflect what's actually open and adds follow-up candidates (HTTP-2 route-group audit, ERR-4 inventory sweep, RENDER-2 CLI/TUI rendering audit).

## Test plan

- [ ] N/A — docs-only change. Confirmed the listed PR numbers correspond to merged commits on `dev` (see commit log) and that the typed-error files (`storage/storage.ts`, `worktree/index.ts`, `provider/auth.ts`) now use `Schema.TaggedErrorClass`.