### PR TITLE
fix: treat unrecognized slash commands as regular text input

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1492,6 +1492,28 @@ export class Agent implements ACPAgent {
           { throwOnError: true },
         )
         break
+      default:
+        // Unrecognized slash command - treat as regular text input
+        const response = await this.sdk.session.prompt({
+          sessionID,
+          model: {
+            providerID: model.providerID,
+            modelID: model.modelID,
+          },
+          variant: this.sessionManager.getVariant(sessionID),
+          parts,
+          agent,
+          directory,
+        })
+        const msg = response.data?.info
+
+        await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)
+
+        return {
+          stopReason: "end_turn" as const,
+          usage: msg ? buildUsage(msg) : undefined,
+          _meta: {},
+        }
     }
 
     await sendUsageUpdate(this.connection, this.sdk, sessionID, directory)


### PR DESCRIPTION
### Issue for this PR

Closes #27528

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a user types text starting with "/" that doesn't match any registered command or built-in command (like `/compact`), the system silently drops the input and returns `end_turn` without processing it.

This affects users who:
- Type natural language like "/fix this bug" or "/help me with..."
- Paste code containing `/*...*/` comments at the start
- Use "/" in any context that doesn't match a command

The fix adds a `default` case to the switch statement in `packages/opencode/src/acp/agent.ts` (lines 1483-1495) that processes unrecognized slash commands as regular text input, ensuring the user's message is handled properly instead of being silently ignored.

### How did you verify your code works?

- Verified the fix handles unrecognized slash commands by processing them as regular text
- Existing slash commands (like `/compact`) continue to work as expected
- No breaking changes to the command handling flow

### Screenshots / recordings

_N/A - This is a backend logic fix_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR