### PR TITLE
fix(session): prevent double auto-compaction from filterCompacted reorder

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1067,6 +1067,33 @@ export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: Ses
   return filterCompacted(stream(sessionID))
 })
 
+// filterCompacted reorders messages for model consumption
+// ([compaction-user, summary, ...retained tail..., continue-user]), so array
+// position is not chronological. Derive each binding by max id (MessageID
+// is monotonic via MessageID.ascending) so a pre-compaction overflowing tail
+// assistant doesn't get mistaken for the most recent turn. tasks are
+// compaction/subtask parts attached to user messages newer than the latest
+// finished assistant — i.e. unprocessed work.
+export function latest(msgs: WithParts[]) {
+  let user: User | undefined
+  let assistant: Assistant | undefined
+  let finished: Assistant | undefined
+  for (const msg of msgs) {
+    const info = msg.info
+    if (info.role === "user" && (!user || info.id > user.id)) user = info
+    if (info.role === "assistant" && (!assistant || info.id > assistant.id)) assistant = info
+    if (info.role === "assistant" && info.finish && (!finished || info.id > finished.id)) finished = info
+  }
+  const tasks = msgs.flatMap((m) =>
+    finished && m.info.id <= finished.id
+      ? []
+      : m.parts.filter(
+          (p): p is CompactionPart | SubtaskPart => p.type === "compaction" || p.type === "subtask",
+        ),
+  )
+  return { user, assistant, finished, tasks }
+}
+
 export function fromError(
   e: unknown,
   ctx: { providerID: ProviderID; aborted?: boolean },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1653,29 +1653,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
 
-          // filterCompacted returns messages in model-consumption order
-          // ([compaction-user, summary, ...tail..., continue-user]), not
-          // chronological. Pick by max id (MessageID.ascending is monotonic)
-          // so a pre-compaction overflowing tail assistant doesn't get
-          // mistaken for the most recent turn and re-trigger auto-compaction.
-          let lastUser: MessageV2.User | undefined
-          let lastAssistant: MessageV2.Assistant | undefined
-          let lastFinished: MessageV2.Assistant | undefined
-          for (const msg of msgs) {
-            const info = msg.info
-            if (info.role === "user" && (!lastUser || info.id > lastUser.id)) lastUser = info
-            if (info.role === "assistant" && (!lastAssistant || info.id > lastAssistant.id)) lastAssistant = info
-            if (info.role === "assistant" && info.finish && (!lastFinished || info.id > lastFinished.id))
-              lastFinished = info
-          }
-          const tasks = msgs.flatMap((m) =>
-            lastFinished && m.info.id <= lastFinished.id
-              ? []
-              : m.parts.filter(
-                  (p): p is MessageV2.CompactionPart | MessageV2.SubtaskPart =>
-                    p.type === "compaction" || p.type === "subtask",
-                ),
-          )
+          const { user: lastUser, assistant: lastAssistant, finished: lastFinished, tasks } = MessageV2.latest(msgs)
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1653,27 +1653,29 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
 
+          // filterCompacted returns messages in model-consumption order
+          // ([compaction-user, summary, ...tail..., continue-user]), not
+          // chronological. Pick by max id (MessageID.ascending is monotonic)
+          // so a pre-compaction overflowing tail assistant doesn't get
+          // mistaken for the most recent turn and re-trigger auto-compaction.
           let lastUser: MessageV2.User | undefined
           let lastAssistant: MessageV2.Assistant | undefined
           let lastFinished: MessageV2.Assistant | undefined
-          let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
-          // filterCompacted returns messages in model-consumption order
-          // ([compaction-user, summary, ...tail..., continue-user]) so a plain
-          // backward array walk would pick a pre-compaction overflowing
-          // assistant from the retained tail as lastFinished and re-trigger
-          // auto-compaction. Walk in chronological id order instead.
-          const chronological = msgs
-            .slice()
-            .sort((a, b) => (a.info.id < b.info.id ? -1 : a.info.id > b.info.id ? 1 : 0))
-          for (let i = chronological.length - 1; i >= 0; i--) {
-            const msg = chronological[i]
-            if (!lastUser && msg.info.role === "user") lastUser = msg.info
-            if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info
-            if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
-            if (lastUser && lastFinished) break
-            const task = msg.parts.filter((part) => part.type === "compaction" || part.type === "subtask")
-            if (task && !lastFinished) tasks.push(...task)
+          for (const msg of msgs) {
+            const info = msg.info
+            if (info.role === "user" && (!lastUser || info.id > lastUser.id)) lastUser = info
+            if (info.role === "assistant" && (!lastAssistant || info.id > lastAssistant.id)) lastAssistant = info
+            if (info.role === "assistant" && info.finish && (!lastFinished || info.id > lastFinished.id))
+              lastFinished = info
           }
+          const tasks = msgs.flatMap((m) =>
+            lastFinished && m.info.id <= lastFinished.id
+              ? []
+              : m.parts.filter(
+                  (p): p is MessageV2.CompactionPart | MessageV2.SubtaskPart =>
+                    p.type === "compaction" || p.type === "subtask",
+                ),
+          )
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1657,8 +1657,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           let lastAssistant: MessageV2.Assistant | undefined
           let lastFinished: MessageV2.Assistant | undefined
           let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
-          for (let i = msgs.length - 1; i >= 0; i--) {
-            const msg = msgs[i]
+          // filterCompacted returns messages in model-consumption order
+          // ([compaction-user, summary, ...tail..., continue-user]) so a plain
+          // backward array walk would pick a pre-compaction overflowing
+          // assistant from the retained tail as lastFinished and re-trigger
+          // auto-compaction. Walk in chronological id order instead.
+          const chronological = msgs
+            .slice()
+            .sort((a, b) => (a.info.id < b.info.id ? -1 : a.info.id > b.info.id ? 1 : 0))
+          for (let i = chronological.length - 1; i >= 0; i--) {
+            const msg = chronological[i]
             if (!lastUser && msg.info.role === "user") lastUser = msg.info
             if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info
             if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1630,11 +1630,16 @@ describe("session.message-v2.filterCompacted", () => {
     expect(ids).toContain(OVERFLOW_ASSISTANT)
 
     // Replicate the backward walk in SessionPrompt.runLoop
-    // (packages/opencode/src/session/prompt.ts ~1660).
+    // (packages/opencode/src/session/prompt.ts ~1660). The runLoop sorts msgs
+    // chronologically by id before walking so the model-consumption reorder
+    // performed by filterCompacted does not poison lastFinished.
+    const chronological = filtered
+      .slice()
+      .sort((a, b) => (a.info.id < b.info.id ? -1 : a.info.id > b.info.id ? 1 : 0))
     let lastUser: MessageV2.User | undefined
     let lastFinished: MessageV2.Assistant | undefined
-    for (let i = filtered.length - 1; i >= 0; i--) {
-      const msg = filtered[i]
+    for (let i = chronological.length - 1; i >= 0; i--) {
+      const msg = chronological[i]
       if (!lastUser && msg.info.role === "user") lastUser = msg.info
       if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
       if (lastUser && lastFinished) break

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1548,93 +1548,109 @@ describe("session.message-v2.fromError", () => {
   })
 })
 
-describe("session.message-v2.filterCompacted", () => {
-  // Regression for double auto-compaction: after a successful auto-compaction,
-  // the next runLoop iteration walks `msgs` backward to find `lastFinished` and
-  // gates the overflow check on `lastFinished.summary !== true`. The reorder
-  // added in PR #27145 puts the array in the order
-  //   [compaction-user, summary-assistant, ...tail..., continue-user]
-  // so the backward walk hits a finished tail assistant before the summary,
-  // bypasses the `summary !== true` guard, and triggers a second compaction.
-  test("backward walk surfaces summary assistant, not pre-compaction overflow", () => {
-    const TAIL_USER = MessageID.make("msg_001")
-    const OVERFLOW_ASSISTANT = MessageID.make("msg_002")
-    const COMPACTION_USER = MessageID.make("msg_003")
-    const SUMMARY_ASSISTANT = MessageID.make("msg_004")
-    const CONTINUE_USER = MessageID.make("msg_005")
+describe("session.message-v2.latest", () => {
+  const TAIL_USER = MessageID.make("msg_001")
+  const OVERFLOW_ASSISTANT = MessageID.make("msg_002")
+  const COMPACTION_USER = MessageID.make("msg_003")
+  const SUMMARY_ASSISTANT = MessageID.make("msg_004")
+  const CONTINUE_USER = MessageID.make("msg_005")
+  const NEW_COMPACTION_USER = MessageID.make("msg_006")
 
-    const tailUser: MessageV2.WithParts = {
-      info: userInfo(TAIL_USER),
+  const tailUser: MessageV2.WithParts = {
+    info: userInfo(TAIL_USER),
+    parts: [{ ...basePart(TAIL_USER, "p1"), type: "text", text: "original prompt" }] as MessageV2.Part[],
+  }
+
+  const overflowAssistant: MessageV2.WithParts = {
+    info: {
+      ...assistantInfo(OVERFLOW_ASSISTANT, TAIL_USER),
+      finish: "tool-calls",
+      tokens: { input: 280_000, output: 200, reasoning: 0, cache: { read: 0, write: 0 }, total: 280_200 },
+    } as MessageV2.Assistant,
+    parts: [],
+  }
+
+  const compactionUser: MessageV2.WithParts = {
+    info: userInfo(COMPACTION_USER),
+    parts: [
+      {
+        ...basePart(COMPACTION_USER, "p1"),
+        type: "compaction",
+        auto: true,
+        tail_start_id: TAIL_USER,
+      },
+    ] as MessageV2.Part[],
+  }
+
+  const summaryAssistant: MessageV2.WithParts = {
+    info: {
+      ...assistantInfo(SUMMARY_ASSISTANT, COMPACTION_USER),
+      summary: true,
+      finish: "stop",
+      tokens: { input: 150_000, output: 1_500, reasoning: 0, cache: { read: 0, write: 0 }, total: 151_500 },
+    } as MessageV2.Assistant,
+    parts: [],
+  }
+
+  const continueUser: MessageV2.WithParts = {
+    info: userInfo(CONTINUE_USER),
+    parts: [
+      {
+        ...basePart(CONTINUE_USER, "p1"),
+        type: "text",
+        text: "Continue if you have next steps...",
+        synthetic: true,
+        metadata: { compaction_continue: true },
+      },
+    ] as MessageV2.Part[],
+  }
+
+  // Regression for double auto-compaction. The reorder in filterCompacted
+  // (#27145) returns [compaction-user, summary, ...tail..., continue-user],
+  // so picking lastFinished by array position landed on the pre-compaction
+  // overflow assistant and bypassed the `summary !== true` overflow guard
+  // in SessionPrompt.runLoop, firing a second compaction.create immediately.
+  test("finished is the chronologically-latest finished assistant, not the array-latest", () => {
+    const filtered = MessageV2.filterCompacted([
+      continueUser,
+      summaryAssistant,
+      compactionUser,
+      overflowAssistant,
+      tailUser,
+    ])
+
+    const state = MessageV2.latest(filtered)
+
+    expect(state.finished?.id).toBe(SUMMARY_ASSISTANT)
+    expect(state.finished?.summary).toBe(true)
+    expect(state.user?.id).toBe(CONTINUE_USER)
+    expect(state.tasks).toEqual([])
+  })
+
+  test("a fresh compaction-user newer than the latest summary surfaces in tasks", () => {
+    const newCompactionUser: MessageV2.WithParts = {
+      info: userInfo(NEW_COMPACTION_USER),
       parts: [
         {
-          ...basePart(TAIL_USER, "p1"),
-          type: "text",
-          text: "original prompt",
-        },
-      ] as MessageV2.Part[],
-    }
-
-    const overflowAssistant: MessageV2.WithParts = {
-      info: {
-        ...assistantInfo(OVERFLOW_ASSISTANT, TAIL_USER),
-        finish: "tool-calls",
-        tokens: { input: 280_000, output: 200, reasoning: 0, cache: { read: 0, write: 0 }, total: 280_200 },
-      } as MessageV2.Assistant,
-      parts: [],
-    }
-
-    const compactionUser: MessageV2.WithParts = {
-      info: userInfo(COMPACTION_USER),
-      parts: [
-        {
-          ...basePart(COMPACTION_USER, "p1"),
+          ...basePart(NEW_COMPACTION_USER, "p1"),
           type: "compaction",
           auto: true,
-          tail_start_id: TAIL_USER,
         },
       ] as MessageV2.Part[],
     }
 
-    const summaryAssistant: MessageV2.WithParts = {
-      info: {
-        ...assistantInfo(SUMMARY_ASSISTANT, COMPACTION_USER),
-        summary: true,
-        finish: "stop",
-        tokens: { input: 150_000, output: 1_500, reasoning: 0, cache: { read: 0, write: 0 }, total: 151_500 },
-      } as MessageV2.Assistant,
-      parts: [],
-    }
+    const state = MessageV2.latest([
+      tailUser,
+      overflowAssistant,
+      compactionUser,
+      summaryAssistant,
+      continueUser,
+      newCompactionUser,
+    ])
 
-    const continueUser: MessageV2.WithParts = {
-      info: userInfo(CONTINUE_USER),
-      parts: [
-        {
-          ...basePart(CONTINUE_USER, "p1"),
-          type: "text",
-          text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
-          synthetic: true,
-          metadata: { compaction_continue: true },
-        },
-      ] as MessageV2.Part[],
-    }
-
-    // MessageV2.stream yields newest-first, which is what filterCompacted expects.
-    const reverseChronological = [continueUser, summaryAssistant, compactionUser, overflowAssistant, tailUser]
-    const filtered = MessageV2.filterCompacted(reverseChronological)
-
-    // Mirror SessionPrompt.runLoop: pick lastFinished as the chronologically
-    // latest finished assistant by id (MessageID is monotonic). Picking by
-    // array position would land on the pre-compaction overflow assistant
-    // because filterCompacted reorders for model consumption.
-    const lastFinished = filtered.reduce<MessageV2.Assistant | undefined>((acc, m) => {
-      if (m.info.role !== "assistant" || !m.info.finish) return acc
-      return !acc || m.info.id > acc.id ? m.info : acc
-    }, undefined)
-
-    // If lastFinished ever resolves to the pre-compaction overflow assistant
-    // (msg_002), the runLoop overflow guard at prompt.ts (`summary !== true &&
-    // isOverflow(tokens)`) fails open and fires a second compaction.
-    expect(lastFinished?.id).toBe(SUMMARY_ASSISTANT)
-    expect(lastFinished?.summary).toBe(true)
+    expect(state.finished?.id).toBe(SUMMARY_ASSISTANT)
+    expect(state.user?.id).toBe(NEW_COMPACTION_USER)
+    expect(state.tasks).toHaveLength(1)
+    expect(state.tasks[0]).toMatchObject({ type: "compaction", auto: true })
   })
 })

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1622,36 +1622,18 @@ describe("session.message-v2.filterCompacted", () => {
     const reverseChronological = [continueUser, summaryAssistant, compactionUser, overflowAssistant, tailUser]
     const filtered = MessageV2.filterCompacted(reverseChronological)
 
-    // Sanity check: both the summary and the overflow assistant survive the filter
-    // (tail is retained via tail_start_id), so the bug is purely about which one
-    // the backward walk picks up first.
-    const ids = filtered.map((m) => m.info.id)
-    expect(ids).toContain(SUMMARY_ASSISTANT)
-    expect(ids).toContain(OVERFLOW_ASSISTANT)
+    // Mirror SessionPrompt.runLoop: pick lastFinished as the chronologically
+    // latest finished assistant by id (MessageID is monotonic). Picking by
+    // array position would land on the pre-compaction overflow assistant
+    // because filterCompacted reorders for model consumption.
+    const lastFinished = filtered.reduce<MessageV2.Assistant | undefined>((acc, m) => {
+      if (m.info.role !== "assistant" || !m.info.finish) return acc
+      return !acc || m.info.id > acc.id ? m.info : acc
+    }, undefined)
 
-    // Replicate the backward walk in SessionPrompt.runLoop
-    // (packages/opencode/src/session/prompt.ts ~1660). The runLoop sorts msgs
-    // chronologically by id before walking so the model-consumption reorder
-    // performed by filterCompacted does not poison lastFinished.
-    const chronological = filtered
-      .slice()
-      .sort((a, b) => (a.info.id < b.info.id ? -1 : a.info.id > b.info.id ? 1 : 0))
-    let lastUser: MessageV2.User | undefined
-    let lastFinished: MessageV2.Assistant | undefined
-    for (let i = chronological.length - 1; i >= 0; i--) {
-      const msg = chronological[i]
-      if (!lastUser && msg.info.role === "user") lastUser = msg.info
-      if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
-      if (lastUser && lastFinished) break
-    }
-
-    expect(lastUser?.id).toBe(CONTINUE_USER)
-    // The runLoop guard at prompt.ts:1722 reads:
-    //   lastFinished.summary !== true && isOverflow(lastFinished.tokens)
-    // For that guard to behave correctly post-compaction, `lastFinished` MUST be
-    // the summary assistant. If the backward walk picks the pre-compaction
-    // overflow assistant instead, the guard fails open and a second
-    // compaction.create fires immediately.
+    // If lastFinished ever resolves to the pre-compaction overflow assistant
+    // (msg_002), the runLoop overflow guard at prompt.ts (`summary !== true &&
+    // isOverflow(tokens)`) fails open and fires a second compaction.
     expect(lastFinished?.id).toBe(SUMMARY_ASSISTANT)
     expect(lastFinished?.summary).toBe(true)
   })

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1547,3 +1547,107 @@ describe("session.message-v2.fromError", () => {
     expect(result.name).toBe("MessageAbortedError")
   })
 })
+
+describe("session.message-v2.filterCompacted", () => {
+  // Regression for double auto-compaction: after a successful auto-compaction,
+  // the next runLoop iteration walks `msgs` backward to find `lastFinished` and
+  // gates the overflow check on `lastFinished.summary !== true`. The reorder
+  // added in PR #27145 puts the array in the order
+  //   [compaction-user, summary-assistant, ...tail..., continue-user]
+  // so the backward walk hits a finished tail assistant before the summary,
+  // bypasses the `summary !== true` guard, and triggers a second compaction.
+  test("backward walk surfaces summary assistant, not pre-compaction overflow", () => {
+    const TAIL_USER = MessageID.make("msg_001")
+    const OVERFLOW_ASSISTANT = MessageID.make("msg_002")
+    const COMPACTION_USER = MessageID.make("msg_003")
+    const SUMMARY_ASSISTANT = MessageID.make("msg_004")
+    const CONTINUE_USER = MessageID.make("msg_005")
+
+    const tailUser: MessageV2.WithParts = {
+      info: userInfo(TAIL_USER),
+      parts: [
+        {
+          ...basePart(TAIL_USER, "p1"),
+          type: "text",
+          text: "original prompt",
+        },
+      ] as MessageV2.Part[],
+    }
+
+    const overflowAssistant: MessageV2.WithParts = {
+      info: {
+        ...assistantInfo(OVERFLOW_ASSISTANT, TAIL_USER),
+        finish: "tool-calls",
+        tokens: { input: 280_000, output: 200, reasoning: 0, cache: { read: 0, write: 0 }, total: 280_200 },
+      } as MessageV2.Assistant,
+      parts: [],
+    }
+
+    const compactionUser: MessageV2.WithParts = {
+      info: userInfo(COMPACTION_USER),
+      parts: [
+        {
+          ...basePart(COMPACTION_USER, "p1"),
+          type: "compaction",
+          auto: true,
+          tail_start_id: TAIL_USER,
+        },
+      ] as MessageV2.Part[],
+    }
+
+    const summaryAssistant: MessageV2.WithParts = {
+      info: {
+        ...assistantInfo(SUMMARY_ASSISTANT, COMPACTION_USER),
+        summary: true,
+        finish: "stop",
+        tokens: { input: 150_000, output: 1_500, reasoning: 0, cache: { read: 0, write: 0 }, total: 151_500 },
+      } as MessageV2.Assistant,
+      parts: [],
+    }
+
+    const continueUser: MessageV2.WithParts = {
+      info: userInfo(CONTINUE_USER),
+      parts: [
+        {
+          ...basePart(CONTINUE_USER, "p1"),
+          type: "text",
+          text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
+          synthetic: true,
+          metadata: { compaction_continue: true },
+        },
+      ] as MessageV2.Part[],
+    }
+
+    // MessageV2.stream yields newest-first, which is what filterCompacted expects.
+    const reverseChronological = [continueUser, summaryAssistant, compactionUser, overflowAssistant, tailUser]
+    const filtered = MessageV2.filterCompacted(reverseChronological)
+
+    // Sanity check: both the summary and the overflow assistant survive the filter
+    // (tail is retained via tail_start_id), so the bug is purely about which one
+    // the backward walk picks up first.
+    const ids = filtered.map((m) => m.info.id)
+    expect(ids).toContain(SUMMARY_ASSISTANT)
+    expect(ids).toContain(OVERFLOW_ASSISTANT)
+
+    // Replicate the backward walk in SessionPrompt.runLoop
+    // (packages/opencode/src/session/prompt.ts ~1660).
+    let lastUser: MessageV2.User | undefined
+    let lastFinished: MessageV2.Assistant | undefined
+    for (let i = filtered.length - 1; i >= 0; i--) {
+      const msg = filtered[i]
+      if (!lastUser && msg.info.role === "user") lastUser = msg.info
+      if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info
+      if (lastUser && lastFinished) break
+    }
+
+    expect(lastUser?.id).toBe(CONTINUE_USER)
+    // The runLoop guard at prompt.ts:1722 reads:
+    //   lastFinished.summary !== true && isOverflow(lastFinished.tokens)
+    // For that guard to behave correctly post-compaction, `lastFinished` MUST be
+    // the summary assistant. If the backward walk picks the pre-compaction
+    // overflow assistant instead, the guard fails open and a second
+    // compaction.create fires immediately.
+    expect(lastFinished?.id).toBe(SUMMARY_ASSISTANT)
+    expect(lastFinished?.summary).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

After #27145, `MessageV2.filterCompacted` returns messages reordered for model consumption:

```
[compaction-user, summary-assistant, ...retained tail..., continue-user]
```

`SessionPrompt.runLoop` walks `msgs` backward from the array end to pick `lastUser`, `lastAssistant`, `lastFinished`, and `tasks` (`packages/opencode/src/session/prompt.ts:1660-1668`). The walk treats array order as chronological. With the reorder it isn't — the backward walk hits a finished assistant inside the retained tail (a pre-compaction overflow turn) before it reaches the summary at the front. `lastFinished` then has `summary === undefined` and `tokens.total ≈ 280K`, the overflow guard at `prompt.ts:1722` (`lastFinished.summary !== true && isOverflow(...)`) fails open on the stale tokens, and `compaction.create` fires a second time as soon as the first summary completes.

Observed in `opencode.db` as pairs of `auto: true` compaction parts ~1s–3m apart in multiple sessions post-2026-05-12, e.g. `ses_1dcaf652cffeB0ZVK2zWAkxRSD` at 08:01:35 → 08:02:41 today, where the second compaction summary started and then aborted.

## Fix

Sort `msgs` by `id` (monotonic) inside the walk and iterate the chronological view. `msgs` itself stays in model-consumption order so `toModelMessagesEffect` and `handleSubtask` keep receiving the layout #27145 intended.

Smallest change that fixes the bug at the source. Alternatives considered:

- **Move the reorder out of `filterCompacted` into model-message construction.** Architecturally cleaner, but `msgs` is consumed by both `toModelMessagesEffect` (`prompt.ts:1827`) and `handleSubtask` → `taskTool.execute` (`prompt.ts:1705`), so the reorder would have to be threaded through both paths. Bigger blast radius than a regression fix should carry; that cleanup is its own change.
- **Reshape the reorder so backward walk happens to work.** Loses the point of #27145, which deliberately puts `[summary, tail]` immediately before the continue prompt so the model attends to recent grounding.
- **Patch only the overflow guard.** `lastFinished` and `lastAssistant` also feed the loop-exit check (`prompt.ts:1682-1690`) and the user-text wrap (`prompt.ts:1803-1819`). Both happen to coincidentally tolerate the wrong value today; better to fix the source.

## Commits

1. `test(compaction): reproduce double auto-compaction trigger` — failing regression test using the post-compaction message shape.
2. `fix(session): walk msgs chronologically when picking lastFinished` — sort by id before the walk; updates the test to mirror the fixed walk so it stays a faithful regression contract.

## Test plan

- [x] `bun run test test/session/message-v2.test.ts -t filterCompacted` fails on the test-only commit, passes after the fix
- [x] `bun run test test/session/message-v2.test.ts test/session/compaction.test.ts test/session/prompt.test.ts` — 138 pass, 0 fail
- [x] `bun run typecheck` clean