### PR TITLE
fix: workspace creation on desktop app

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1945,7 +1945,12 @@ export default function Layout(props: ParentProps) {
   const createWorkspace = async (project: LocalProject) => {
     clearSidebarHoverState()
     const created = await globalSDK.client.worktree
-      .create({ directory: project.worktree })
+      .create({
+        directory: project.worktree,
+        worktreeCreateInput: {
+          name: "",
+        },
+      })
       .then((x) => x.data)
       .catch((err) => {
         showToast({
@@ -2256,6 +2261,7 @@ export default function Layout(props: ParentProps) {
                         icon="plus-small"
                         class="w-full"
                         onClick={() => {
+                          console.log(project)
                           void createWorkspace(project)
                         }}
                       >

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2261,7 +2261,6 @@ export default function Layout(props: ParentProps) {
                         icon="plus-small"
                         class="w-full"
                         onClick={() => {
-                          console.log(project)
                           void createWorkspace(project)
                         }}
                       >


### PR DESCRIPTION
### Issue for this PR

Closes #27563

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes workspace creation.
The backend sent no body, which Effect treated like undefiend rather than null.
Set the object sent in the body to cause otherwise the `hey-api` sdk parsed it back to undefiend

```ts
worktreeCreateInput: {
  name: "",
},
```

### How did you verify your code works?

Creates worksapce

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
