### PR TITLE
Fix MCP object array tool schemas

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -150,17 +150,38 @@ function listTools(key: string, client: MCPClient, timeout: number) {
   )
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function normalizeMcpInputSchema(schema: JSONSchema7): JSONSchema7 {
+  const normalize = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(normalize)
+    if (!isRecord(value)) return value
+
+    const result = Object.fromEntries(Object.entries(value).map(([key, item]) => [key, normalize(item)]))
+
+    if (result.type === "object" && result.additionalProperties === true && result.properties === undefined) {
+      result.properties = {}
+    }
+
+    return result
+  }
+
+  return normalize(schema) as JSONSchema7
+}
+
 // Convert MCP tool definition to AI SDK Tool type
 function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Tool {
   const inputSchema = mcpTool.inputSchema
 
   // Spread first, then override type to ensure it's always "object"
-  const schema: JSONSchema7 = {
+  const schema = normalizeMcpInputSchema({
     ...(inputSchema as JSONSchema7),
     type: "object",
     properties: (inputSchema.properties ?? {}) as JSONSchema7["properties"],
     additionalProperties: false,
-  }
+  })
 
   return dynamicTool({
     description: mcpTool.description ?? "",

--- a/packages/opencode/test/mcp/schema.test.ts
+++ b/packages/opencode/test/mcp/schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeMcpInputSchema } from "../../src/mcp"
+
+describe("MCP tool schemas", () => {
+  test("preserves open-ended object arrays", () => {
+    const schema = normalizeMcpInputSchema({
+      type: "object",
+      properties: {
+        body: {
+          type: "object",
+          properties: {
+            numberlist: { type: "array", items: { type: "number" } },
+            objectdata: {
+              type: "array",
+              items: { type: "object", additionalProperties: true },
+            },
+            objectlist: {
+              type: "array",
+              items: { type: "object", additionalProperties: true },
+            },
+            text: { type: "string" },
+          },
+          required: ["objectdata", "objectlist", "text", "numberlist"],
+        },
+      },
+      required: ["body"],
+    })
+
+    expect(schema).toMatchObject({
+      properties: {
+        body: {
+          properties: {
+            objectdata: {
+              items: {
+                type: "object",
+                additionalProperties: true,
+                properties: {},
+              },
+            },
+            objectlist: {
+              items: {
+                type: "object",
+                additionalProperties: true,
+                properties: {},
+              },
+            },
+          },
+          required: ["objectdata", "objectlist", "text", "numberlist"],
+        },
+      },
+    })
+  })
+
+  test("preserves nested map fields in object arrays", () => {
+    const schema = normalizeMcpInputSchema({
+      type: "object",
+      properties: {
+        records: {
+          type: ["null", "array"],
+          items: {
+            type: "object",
+            properties: {
+              record_id: { type: "string" },
+              value: { type: "object", additionalProperties: true },
+            },
+            required: ["record_id", "value"],
+            additionalProperties: false,
+          },
+        },
+      },
+    })
+
+    expect(schema).toMatchObject({
+      properties: {
+        records: {
+          items: {
+            properties: {
+              value: {
+                type: "object",
+                additionalProperties: true,
+                properties: {},
+              },
+            },
+            required: ["record_id", "value"],
+          },
+        },
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Normalize MCP input schemas so open-ended object/map fields include explicit empty `properties`.
- Preserve array-of-object and nested map fields when MCP tools are converted into AI SDK tools.
- Add regression coverage for MCP schemas with object arrays and nested map fields.

## Test
- `bun test test/mcp/schema.test.ts`
- `bun run typecheck`
- pre-push hook ran `bun turbo typecheck` with Bun 1.3.13