### PR TITLE
fix(app): project switch keybinds override browser tab shortcuts

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -70,6 +70,7 @@ import {
   effectiveWorkspaceOrder,
   errorMessage,
   latestRootSession,
+  projectIndexKeybind,
   sortedRootSessions,
 } from "./layout/helpers"
 import {
@@ -1056,7 +1057,7 @@ export default function Layout(props: ParentProps) {
           id: `project.${number}`,
           category: language.t("command.category.project"),
           title: `Open Project {number}`,
-          keybind: `mod+${number}`,
+          keybind: projectIndexKeybind(index),
           disabled: layout.projects.list().length <= index,
           hidden: true,
           onSelect: () => navigateToProjectIndex(index),

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -14,7 +14,9 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  projectIndexKeybind,
 } from "./helpers"
+import { matchKeybind, parseKeybind } from "@/context/command"
 import { pathKey } from "@/utils/path-key"
 
 const session = (input: Partial<Session> & Pick<Session, "id" | "directory">) =>
@@ -221,5 +223,23 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+
+  test("project quick-switch keybind does not capture browser tab shortcuts (issue #27568)", () => {
+    for (let i = 0; i < 9; i++) {
+      const number = `${i + 1}`
+      const keybinds = parseKeybind(projectIndexKeybind(i))
+      const kb = keybinds[0]
+      // Browser tab shortcuts (Cmd+1..9 on Mac, Ctrl+1..9 elsewhere) must not be captured.
+      expect(matchKeybind(keybinds, new KeyboardEvent("keydown", { key: number, metaKey: true }))).toBe(false)
+      expect(matchKeybind(keybinds, new KeyboardEvent("keydown", { key: number, ctrlKey: true }))).toBe(false)
+      // The intended chord (mod+alt+N) still matches on the active platform.
+      expect(
+        matchKeybind(
+          keybinds,
+          new KeyboardEvent("keydown", { key: number, ctrlKey: kb.ctrl, metaKey: kb.meta, altKey: true }),
+        ),
+      ).toBe(true)
+    }
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -55,6 +55,9 @@ export const childSessionOnPath = (sessions: Session[] | undefined, rootID: stri
 export const displayName = (project: { name?: string; worktree: string }) =>
   project.name || getFilename(project.worktree)
 
+// mod+alt+N (not mod+N) so Cmd/Ctrl+1..9 stay free for the browser's tab switching shortcut.
+export const projectIndexKeybind = (index: number) => `mod+alt+${index + 1}`
+
 export const errorMessage = (err: unknown, fallback: string) => {
   if (err && typeof err === "object" && "data" in err) {
     const data = (err as { data?: { message?: string } }).data


### PR DESCRIPTION
### Issue for this PR

Closes #27568

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The hidden project quick-switch commands in `packages/app/src/pages/layout.tsx` registered `mod+${number}` (Cmd+1..9 / Ctrl+1..9) which the command dispatcher then `preventDefault`s, swallowing the browser's tab-switch shortcut in `opencode web`. Extracted `projectIndexKeybind` into `layout/helpers.ts` returning `mod+alt+${index + 1}` to match the existing `mod+alt+arrowup/down` project-nav convention, and routed the inline registration through it.

### How did you verify your code works?

Updated unit tests in `packages/app/src/pages/layout/helpers.test.ts` cover the new `projectIndexKeybind` helper.

### Checklist

- [x] self-reviewed my code
- [x] added tests that prove my fix is effective or that my feature works
- [ ] updated the documentation accordingly

Closes #27568