### PR TITLE
fix(provider): sanitize Gemini schema refs

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1319,17 +1319,47 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
       ].some((key) => key in node)
     }
 
-    const sanitizeGemini = (obj: any): any => {
+    const rootDefinitions = [schema].flatMap((node) => {
+      if (!isPlainObject(node)) return []
+      return [node.$defs, node.definitions].filter(isPlainObject)
+    })
+
+    const resolveLocalReference = (ref: string): unknown => {
+      const name = ref.match(/^#\/\$defs\/(.+)$/)?.[1] ?? ref.match(/^#\/definitions\/(.+)$/)?.[1]
+      if (!name) return undefined
+      for (const definitions of rootDefinitions) {
+        const target = definitions[name]
+        if (target !== undefined) return target
+      }
+      return undefined
+    }
+
+    const sanitizeGemini = (obj: any, seenRefs = new Set<string>()): any => {
       if (obj === null || typeof obj !== "object") {
         return obj
       }
 
       if (Array.isArray(obj)) {
-        return obj.map(sanitizeGemini)
+        return obj.map((item) => sanitizeGemini(item, seenRefs))
+      }
+
+      if (typeof obj.$ref === "string") {
+        const target = resolveLocalReference(obj.$ref)
+        if (isPlainObject(target) && !seenRefs.has(obj.$ref)) {
+          const { $ref: _ref, ...siblings } = obj
+          const merged = { ...target, ...siblings }
+          return sanitizeGemini(merged, new Set(seenRefs).add(obj.$ref))
+        }
+
+        const result: any = { $ref: obj.$ref }
+        if (typeof obj.description === "string") result.description = obj.description
+        if ("default" in obj) result.default = sanitizeGemini(obj.default, seenRefs)
+        return result
       }
 
       const result: any = {}
       for (const [key, value] of Object.entries(obj)) {
+        if (key === "$schema" || key === "$defs" || key === "definitions") continue
         if (key === "enum" && Array.isArray(value)) {
           // Convert all enum values to strings
           result[key] = value.map((v) => String(v))
@@ -1338,7 +1368,7 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
             result.type = "string"
           }
         } else if (typeof value === "object" && value !== null) {
-          result[key] = sanitizeGemini(value)
+          result[key] = sanitizeGemini(value, seenRefs)
         } else {
           result[key] = value
         }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -924,6 +924,108 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
   })
 })
 
+describe("ProviderTransform.schema - gemini $ref schemas", () => {
+  const geminiModel = {
+    providerID: "google",
+    api: {
+      id: "gemini-3-pro",
+    },
+  } as any
+
+  test("inlines local refs that contain Gemini-unsupported sibling fields", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        questions: {
+          type: "array",
+          items: {
+            $ref: "#/$defs/QuestionPrompt",
+            description: "Question prompts to ask the user",
+            type: "object",
+            required: ["question", "missing"],
+            properties: {
+              question: { type: "string" },
+            },
+          },
+        },
+      },
+      $defs: {
+        QuestionPrompt: {
+          type: "object",
+          properties: {
+            question: { type: "string" },
+            header: { type: "string" },
+          },
+          required: ["question", "header"],
+        },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+    const item = result.properties.questions.items
+
+    expect(result.$defs).toBeUndefined()
+    expect(item.$ref).toBeUndefined()
+    expect(item.type).toBe("object")
+    expect(item.properties.question.type).toBe("string")
+    expect(item.required).toEqual(["question"])
+  })
+
+  test("keeps only Gemini-allowed siblings when a local ref cannot be resolved", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        prompt: {
+          $ref: "#/$defs/MissingPrompt",
+          description: "Prompt to ask",
+          type: "object",
+          properties: { question: { type: "string" } },
+          default: { question: "Continue?" },
+        },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+    const prompt = result.properties.prompt
+
+    expect(prompt).toEqual({
+      $ref: "#/$defs/MissingPrompt",
+      description: "Prompt to ask",
+      default: { question: "Continue?" },
+    })
+  })
+
+  test("does not affect refs for non-gemini providers", () => {
+    const openaiModel = {
+      providerID: "openai",
+      api: {
+        id: "gpt-4",
+      },
+    } as any
+
+    const schema = {
+      type: "object",
+      properties: {
+        prompt: {
+          $ref: "#/$defs/Prompt",
+          description: "Prompt to ask",
+          type: "object",
+          properties: { question: { type: "string" } },
+        },
+      },
+      $defs: {
+        Prompt: { type: "object", properties: { question: { type: "string" } } },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(openaiModel, schema) as any
+
+    expect(result.properties.prompt.$ref).toBe("#/$defs/Prompt")
+    expect(result.properties.prompt.properties).toBeDefined()
+    expect(result.$defs).toBeDefined()
+  })
+})
+
 describe("ProviderTransform.schema - moonshot $ref siblings", () => {
   const moonshotModel = {
     providerID: "moonshotai",


### PR DESCRIPTION
### Issue for this PR

Closes #12295

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes Gemini tool-schema compatibility in OpenCode. Gemini rejects schemas when a `$ref` node is sent together with unsupported sibling fields, which was causing Gemini-backed subagent/tool sessions to fail with empty results or `INVALID_ARGUMENT` errors.

The patch teaches the Gemini schema path to inline local references before sending the schema and then strip unsupported wrapper fields such as `$schema`, `$defs`, and `definitions`. The same Gemini sanitization path is also reused for structured output so both tool schemas and structured output stay aligned.

### How did you verify your code works?

I added regression tests covering:
- Gemini schemas with local `$ref` entries that also include unsupported sibling fields
- unresolved `$ref` entries, which should retain only Gemini-allowed fields
- non-Gemini providers, which should remain unchanged

I also ran:
- `bun test test/provider/transform.test.ts --timeout 30000`
- `bun run typecheck`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR