### PR TITLE
fix(mcp): normalize hyphenated tool ids

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -108,7 +108,7 @@ function isMcpConfigured(entry: McpEntry): entry is ConfigMCP.Info {
   return typeof entry === "object" && entry !== null && "type" in entry
 }
 
-const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_")
+const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_]/g, "_")
 
 function remoteURL(key: string, value: string) {
   if (URL.canParse(value)) return new URL(value)

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -774,9 +774,10 @@ it.instance(
         const tools = yield* mcp.tools()
         const keys = Object.keys(tools)
 
-        // Server name dots should be replaced with underscores
-        expect(keys.some((k) => k.startsWith("my_special-server_"))).toBe(true)
-        // Tool name dots should be replaced with underscores
+        // Server name dots and dashes should be replaced with underscores
+        expect(keys.some((k) => k.startsWith("my_special_server_"))).toBe(true)
+        // Tool name dots and dashes should be replaced with underscores
+        expect(keys.some((k) => k.endsWith("tool_a"))).toBe(true)
         expect(keys.some((k) => k.endsWith("tool_b"))).toBe(true)
         expect(keys.length).toBe(2)
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #27396

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP tool ids were preserving hyphens while the model-visible tool names use underscores. That made tools such as `documents-get-by-id` unreachable because the model called the underscore form, but the registry exposed the hyphen form.

This changes MCP id sanitization to replace hyphens with underscores too, and updates the existing MCP lifecycle test to cover hyphenated server and tool names.

### How did you verify your code works?

- `bun test test/mcp/lifecycle.test.ts -t "prefixes tool names"`
- `bun typecheck`
- `git diff --check`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR