### PR TITLE
fix(worktree): accept missing create payload

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
@@ -166,8 +166,9 @@ export const ExperimentalApi = HttpApi.make("experimental")
           }),
         ),
         HttpApiEndpoint.post("worktreeCreate", ExperimentalPaths.worktree, {
+          disableCodecs: true,
           query: WorkspaceRoutingQuery,
-          payload: Schema.optional(Worktree.CreateInput),
+          payload: Schema.UndefinedOr(Worktree.CreateInput),
           success: described(Worktree.Info, "Worktree created"),
           error: WorktreeApiError,
         }).annotateMerge(

--- a/packages/opencode/test/server/worktree-endpoint-repro.test.ts
+++ b/packages/opencode/test/server/worktree-endpoint-repro.test.ts
@@ -211,6 +211,26 @@ describe("worktree endpoint reproduction", () => {
   )
 
   worktreeTest(
+    "direct HttpApi worktree create accepts missing content type and body",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const server = yield* serverScoped()
+
+        const response = yield* createWorktreeScoped({
+          server,
+          directory: test.directory,
+          path: `${ExperimentalPaths.worktree}?directory=${encodeURIComponent(test.directory)}`,
+          init: { method: "POST" },
+          timeoutLabel: "direct worktree create without content type or body",
+        })
+
+        expect(response).toMatchObject({ directory: expect.any(String) })
+      }),
+    { git: true },
+  )
+
+  worktreeTest(
     "workspace worktree create does not hang",
     () =>
       Effect.gen(function* () {

--- a/packages/opencode/test/server/worktree-endpoint-repro.test.ts
+++ b/packages/opencode/test/server/worktree-endpoint-repro.test.ts
@@ -129,6 +129,10 @@ function createWorktreeScoped(input: {
         input.timeoutLabel,
         input.timeoutMs,
       )
+      if (response.status !== 200) {
+        const message = yield* Effect.promise(() => response.text())
+        throw new Error(`${input.timeoutLabel} failed: ${response.status} ${message}`)
+      }
       expect(response.status).toBe(200)
       const body = yield* json<CreatedWorktree>(response)
       return { directory: body.directory, body, ready: waitReady(body.directory) } satisfies ScopedWorktree
@@ -179,6 +183,26 @@ describe("worktree endpoint reproduction", () => {
             body: JSON.stringify({}),
           },
           timeoutLabel: "direct worktree create",
+        })
+
+        expect(response).toMatchObject({ directory: expect.any(String) })
+      }),
+    { git: true },
+  )
+
+  worktreeTest(
+    "direct HttpApi worktree create accepts missing body",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const server = yield* serverScoped()
+
+        const response = yield* createWorktreeScoped({
+          server,
+          directory: test.directory,
+          path: `${ExperimentalPaths.worktree}?directory=${encodeURIComponent(test.directory)}`,
+          init: { method: "POST", headers: { "content-type": "application/json" } },
+          timeoutLabel: "direct worktree create without body",
         })
 
         expect(response).toMatchObject({ directory: expect.any(String) })


### PR DESCRIPTION
## Summary
- Fix worktree creation when clients send an optional JSON request body as empty/missing.
- Keep the SDK contract intact by accepting an undefined payload at the HttpApi endpoint instead of requiring frontend callers to send `{}`.
- Add regression coverage for `POST /experimental/worktree` with `Content-Type: application/json` and no body.

## Testing
- `bun prettier --write packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts packages/opencode/test/server/worktree-endpoint-repro.test.ts`
- `bun oxlint packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts packages/opencode/test/server/worktree-endpoint-repro.test.ts` (existing warning in test helper: `no-unsafe-type-assertion`)
- `bun typecheck` from `packages/opencode`
- `bun test --timeout 5000 test/server/worktree-endpoint-repro.test.ts` from `packages/opencode`
- `bun test --timeout 5000 src/components/prompt-input/submit.test.ts` from `packages/app`