### PR TITLE
fix(cli): use process cwd for run root

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -51,6 +51,10 @@ function resolveRunInput(value?: string, piped?: string): string | undefined {
   return value + "\n" + piped
 }
 
+export function resolveRunRoot() {
+  return Filesystem.resolve(process.cwd())
+}
+
 type FilePart = {
   type: "file"
   url: string
@@ -278,7 +282,7 @@ export const RunCommand = effectCmd({
         }
       }
 
-      const root = Filesystem.resolve(process.env.PWD ?? process.cwd())
+      const root = resolveRunRoot()
       const directory = (() => {
         if (!args.dir) return args.attach ? undefined : root
         if (args.attach) return args.dir

--- a/packages/opencode/test/cli/run/root.test.ts
+++ b/packages/opencode/test/cli/run/root.test.ts
@@ -1,0 +1,28 @@
+import { expect, spyOn, test } from "bun:test"
+import { mkdtemp, rm } from "fs/promises"
+import os from "os"
+import path from "path"
+import { resolveRunRoot } from "@/cli/cmd/run"
+import { Filesystem } from "@/util/filesystem"
+
+test("run root uses process cwd instead of stale PWD", async () => {
+  const stale = await mkdtemp(path.join(os.tmpdir(), "opencode-run-stale-"))
+  const target = await mkdtemp(path.join(os.tmpdir(), "opencode-run-target-"))
+  const originalPwd = process.env.PWD
+  const cwd = spyOn(process, "cwd").mockImplementation(() => target)
+
+  try {
+    process.env.PWD = stale
+
+    expect(resolveRunRoot()).toBe(Filesystem.resolve(target))
+  } finally {
+    cwd.mockRestore()
+    if (originalPwd === undefined) {
+      delete process.env.PWD
+    } else {
+      process.env.PWD = originalPwd
+    }
+    await rm(stale, { recursive: true, force: true })
+    await rm(target, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #27392

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run` used `process.env.PWD` when deriving the run root. Programmatic callers can start a child process with `cwd` while inheriting a stale `PWD`, so the run command could resolve files and project context from the wrong directory.

This changes the run root to use `process.cwd()` as the source of truth and adds a regression test that sets a stale `PWD` while mocking the child cwd.

### How did you verify your code works?

- `bun test test/cli/run/root.test.ts`
- `bun typecheck`
- `git diff --check`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR