### PR TITLE
docs(web) correct title casing for MCP servers

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -1,5 +1,5 @@
 ---
-title: MCP servers
+title: MCP Servers
 description: Add local and remote MCP tools.
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

This PR updates the title of the page in documentation from `MCP servers` to `MCP Servers` for casing consistency.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

n/a

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
