### PR TITLE
fix(tui): use backgroundPanel for code block left border instead of background

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -634,7 +634,7 @@ function BlockTool(props: {
       gap={1}
       backgroundColor={hover() ? theme.backgroundMenu : theme.backgroundPanel}
       customBorderChars={SplitBorder.customBorderChars}
-      borderColor={theme.background}
+      borderColor={theme.backgroundPanel}
       onMouseOver={() => props.onClick && setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1787,7 +1787,7 @@ function BlockTool(props: {
       gap={1}
       backgroundColor={hover() ? theme.backgroundMenu : theme.backgroundPanel}
       customBorderChars={SplitBorder.customBorderChars}
-      borderColor={theme.background}
+      borderColor={theme.backgroundPanel}
       onMouseOver={() => props.onClick && setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {


### PR DESCRIPTION
### Issue for this PR

Closes #27590

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `BlockTool` component renders code blocks with a left-border character (`┃`) using `borderColor={theme.background}`. When a theme sets `background` to `"none"` (transparent), the theme resolver creates `RGBA(0,0,0,0)` — pure black at zero alpha. The OpenTUI renderer does not alpha-blend character foregrounds, causing the border to render as solid black pixels (`#000000`).

Changed `borderColor={theme.background}` → `borderColor={theme.backgroundPanel}` in both `BlockTool` component locations. This ensures the border character inherits the code block's surface color (`backgroundPanel`) instead of the transparent background. The `┃` no longer renders as pure black but as a muted dark color matching the block surface.

**Note:** For themes using transparent backgrounds, the border will still be a visible solid-color strip since the renderer drops alpha on character foregrounds. True transparency would require renderer-level alpha handling or removing the border entirely.

### How did you verify your code works?

Reproduced with a custom theme using `"background": "none"`. Before: `┃` rendered as `#000000`. After: `┃` renders as `backgroundPanel` color (verified as `#2D292D`). Built-in themes (Dracula, Material, Tokyonight, etc.) are unaffected.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR