### PR TITLE
fix(plugin): scope digitalocean oauth to genai

### DIFF
--- a/packages/opencode/src/plugin/digitalocean.ts
+++ b/packages/opencode/src/plugin/digitalocean.ts
@@ -59,7 +59,7 @@ function buildAuthorizeUrl(state: string): string {
     response_type: "token",
     client_id: DO_OAUTH_CLIENT_ID,
     redirect_uri: redirectUri(),
-    scope: "read write",
+    scope: "genai:create genai:read",
     state,
   })
   return `${DO_AUTHORIZE_URL}?${params.toString()}`


### PR DESCRIPTION
### Issue for this PR

Closes #27600

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The DigitalOcean OAuth flow currently requests `read write`, which expands to account-wide `api:read`/`api:write` — far more than the inference hub needs. This narrows the authorize request to `genai:create genai:read`, which is the minimum required to create a Model Access Key and list Inference Routers.

### How did you verify your code works?

Ran `bun typecheck` from `packages/opencode` (passes) and manually walked through `/connect` to confirm DigitalOcean's consent screen now shows only the GenAI scopes instead of account-wide read/write.

### Screenshots / recordings

_n/a — no UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR