### PR TITLE
feat(vim): add prompt vim mode with toggle plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2168,7 +2168,7 @@
 
     "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }, "sha512-7JjjA49VGNOsMRI8QRUhVudZmv0CnJ18SliSgK1ojszs/c3ijftgVkzvXdkSLN4miDTzbkXewf65D6ZBo6W+GQ=="],
+    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
@@ -3266,7 +3266,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.8", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-J87BxkLXykmisLQ+KA4x2+O6rVf+PJrtFUO8lGyiRg4lyxJLJ8/v0sRAKdVZQOy6tR6lMRAF1NqzCf9BQijm0w=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#20bd361", {}, "anomalyco-ghostty-web-20bd361", "sha512-dW0nwaiBBcun9y5WJSvm3HxDLe5o9V0xLCndQvWonRVubU8CS1PHxZpLffyPt1YujPWC13ez03aWxcuKBPYYGQ=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#20bd361", {}, "anomalyco-ghostty-web-20bd361"],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/opencode-dev-wrapper.sh
+++ b/opencode-dev-wrapper.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "/var/folders/dy/1gn60jd91d9gvjb9789n7s340000gn/T/opencode/opencode/packages/opencode"
+exec bun run --conditions=browser ./src/index.ts "$@"

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -14,7 +14,8 @@
     "fix-node-pty": "bun run script/fix-node-pty.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",
     "dev:temporary": "bun run --conditions=browser ./src/temporary.ts",
-    "db": "bun drizzle-kit"
+    "db": "bun drizzle-kit",
+    "test:e2e:vim": "python3 ../script/e2e_vim_pty.py"
   },
   "bin": {
     "opencode": "./bin/opencode"

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -2,6 +2,7 @@ import {
   BoxRenderable,
   RGBA,
   TextareaRenderable,
+  type KeyBinding as TextareaKeyBinding,
   MouseEvent,
   PasteEvent,
   decodePasteBytes,
@@ -13,6 +14,7 @@ import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, S
 import "opentui-spinner/solid"
 import path from "path"
 import { fileURLToPath } from "url"
+import { appendFileSync, writeFileSync } from "fs"
 import { Filesystem } from "@/util/filesystem"
 import { useLocal } from "@tui/context/local"
 import { tint, useTheme } from "@tui/context/theme"
@@ -29,6 +31,7 @@ import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { computePromptTraits } from "./traits"
 import { assign } from "./part"
+import { createVimTextareaBindings, handleVimPromptKeyDown, type VimLastFind, type VimMode, type VimPendingFind, type VimPendingOperator } from "./vim"
 import { usePromptStash } from "./stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
@@ -88,6 +91,8 @@ export type PromptRef = {
   focus(): void
   submit(): void
 }
+
+const VIM_MARKER_PATH = process.env.OPENCODE_VIM_PROMPT_MARKER
 
 const money = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -160,6 +165,12 @@ export function Prompt(props: PromptProps) {
   const dimensions = useTerminalDimensions()
   const { theme, syntax } = useTheme()
   const kv = useKV()
+  const vimEnabled = createMemo(() => kv.get("vim_mode_enabled", true))
+  const [vimMode, setVimMode] = createSignal<VimMode>("insert")
+  const [pendingG, setPendingG] = createSignal(false)
+  const [pendingVimOperator, setPendingVimOperator] = createSignal<VimPendingOperator>()
+  const [pendingVimFind, setPendingVimFind] = createSignal<VimPendingFind>()
+  const [lastVimFind, setLastVimFind] = createSignal<VimLastFind>()
   const animationsEnabled = createMemo(() => kv.get("animations_enabled", true))
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
@@ -337,7 +348,6 @@ export function Prompt(props: PromptProps) {
 
   const usage = createMemo(() => {
     if (!props.sessionID) return
-    const session = sync.session.get(props.sessionID)
     const msg = sync.data.message[props.sessionID] ?? []
     const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
     if (!last) return
@@ -348,7 +358,7 @@ export function Prompt(props: PromptProps) {
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
-    const cost = session?.cost ?? 0
+    const cost = msg.reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0)
     return {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
       cost: cost > 0 ? money.format(cost) : undefined,
@@ -371,6 +381,85 @@ export function Prompt(props: PromptProps) {
     extmarkToPartIndex: new Map(),
     interrupt: 0,
   })
+
+  function writeVimMarker(phase: string) {
+    if (!VIM_MARKER_PATH || !input || input.isDestroyed) return
+    try {
+      const payload = {
+        phase,
+        enabled: vimEnabled(),
+        mode: vimMode(),
+        cursor: input.cursorOffset,
+        input: input.plainText,
+      }
+      writeFileSync(VIM_MARKER_PATH, JSON.stringify(payload, null, 2))
+      appendFileSync(`${VIM_MARKER_PATH}.events`, `${JSON.stringify(payload)}\n`)
+    } catch (error) {
+      if (process.env.OPENCODE_VIM_PROMPT_MARKER_DEBUG === "1") process.stderr.write(`${String(error)}\n`)
+    }
+  }
+
+  function syncPromptInput() {
+    if (!input || input.isDestroyed) return
+    setStore("prompt", "input", input.plainText)
+    syncExtmarksWithPromptParts()
+    setCursorVersion((value) => value + 1)
+    writeVimMarker("sync")
+  }
+
+  function moveCursor(offset: number) {
+    if (!input || input.isDestroyed) return
+    input.cursorOffset = Math.max(0, Math.min(offset, input.plainText.length))
+    setCursorVersion((value) => value + 1)
+    writeVimMarker("move")
+  }
+
+  function createVimRuntime() {
+    const text = input?.plainText ?? ""
+    const cursor = input?.cursorOffset ?? 0
+    return {
+      text,
+      cursor,
+      enabled: store.mode === "normal" && vimEnabled(),
+      mode: vimMode(),
+      pendingG: pendingG(),
+      pendingOperator: pendingVimOperator(),
+      pendingFind: pendingVimFind(),
+      lastFind: lastVimFind(),
+      setMode(mode: VimMode) {
+        setVimMode(mode)
+        setCursorVersion((value) => value + 1)
+      },
+      setPendingG(value: boolean) {
+        setPendingG(value)
+      },
+      setPendingOperator(value: VimPendingOperator | undefined) {
+        setPendingVimOperator(value)
+      },
+      setPendingFind(value: VimPendingFind | undefined) {
+        setPendingVimFind(value)
+      },
+      setLastFind(value: VimLastFind | undefined) {
+        setLastVimFind(value)
+      },
+      moveCursor,
+      replaceText(text: string) {
+        if (!input || input.isDestroyed) return
+        input.setText(text)
+      },
+      syncPromptInput,
+      writeMarker: writeVimMarker,
+    }
+  }
+
+  function handlePromptKeyDown(event: KeyEvent) {
+    if (props.disabled) {
+      event.preventDefault()
+      return
+    }
+    if (!input || input.isDestroyed) return
+    handleVimPromptKeyDown(event, createVimRuntime())
+  }
 
   createEffect(
     on(
@@ -713,6 +802,7 @@ export function Prompt(props: PromptProps) {
       ...input.traits,
       ...computePromptTraits({
         mode: store.mode,
+        disabled: !!props.disabled,
         autocompleteVisible: !!auto()?.visible,
       }),
     }
@@ -927,7 +1017,13 @@ export function Prompt(props: PromptProps) {
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
-        return inputTarget() !== undefined && !props.disabled && !auto()?.visible && input !== undefined
+        return (
+          inputTarget() !== undefined &&
+          !props.disabled &&
+          !auto()?.visible &&
+          input !== undefined &&
+          (input.cursorOffset === 0 || input.visualCursor.visualRow === 0)
+        )
       })(),
       commands: [
         {
@@ -936,12 +1032,12 @@ export function Prompt(props: PromptProps) {
           category: "Prompt",
           run() {
             if (input.cursorOffset !== 0) {
-              if (input.scrollY + input.visualCursor.visualRow === 0) input.cursorOffset = 0
-              return false
+              input.cursorOffset = 0
+              return
             }
 
             const item = history.move(-1, input.plainText)
-            if (!item) return false
+            if (!item) return
             input.setText(item.input)
             setStore("prompt", item)
             setStore("mode", item.mode ?? "normal")
@@ -959,7 +1055,13 @@ export function Prompt(props: PromptProps) {
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
-        return inputTarget() !== undefined && !props.disabled && !auto()?.visible && input !== undefined
+        return (
+          inputTarget() !== undefined &&
+          !props.disabled &&
+          !auto()?.visible &&
+          input !== undefined &&
+          (input.cursorOffset === input.plainText.length || input.visualCursor.visualRow === input.height - 1)
+        )
       })(),
       commands: [
         {
@@ -968,16 +1070,12 @@ export function Prompt(props: PromptProps) {
           category: "Prompt",
           run() {
             if (input.cursorOffset !== input.plainText.length) {
-              if (
-                input.scrollY + input.visualCursor.visualRow ===
-                Math.max(0, input.editorView.getTotalVirtualLineCount() - 1)
-              )
-                input.cursorOffset = input.plainText.length
-              return false
+              input.cursorOffset = input.plainText.length
+              return
             }
 
             const item = history.move(1, input.plainText)
-            if (!item) return false
+            if (!item) return
             input.setText(item.input)
             setStore("prompt", item)
             setStore("mode", item.mode ?? "normal")
@@ -990,24 +1088,7 @@ export function Prompt(props: PromptProps) {
     }
   })
 
-  let submitting = false
   async function submit() {
-    // Prevent overlapping invocations (e.g. a double-pressed Enter, or the
-    // input's native onSubmit racing another dispatch). Without this guard,
-    // a second call slips past the empty-input check before the first call
-    // clears `store.prompt.input`, then awaits its own `session.create` and
-    // ultimately reads the now-empty store — sending a phantom empty prompt
-    // to a freshly created session.
-    if (submitting) return false
-    submitting = true
-    try {
-      return await submitInner()
-    } finally {
-      submitting = false
-    }
-  }
-
-  async function submitInner() {
     setWarpNotice(undefined)
 
     // IME: double-defer may fire before onContentChange flushes the last
@@ -1268,7 +1349,9 @@ export function Prompt(props: PromptProps) {
       if (raw.startsWith("file://")) {
         try {
           return fileURLToPath(raw)
-        } catch {}
+        } catch {
+          return raw
+        }
       }
       if (process.platform === "win32") return raw
       return raw.replace(/\\(.)/g, "$1")
@@ -1279,7 +1362,7 @@ export function Prompt(props: PromptProps) {
         const mime = await Filesystem.mimeType(filepath)
         const filename = path.basename(filepath)
         if (mime === "image/svg+xml") {
-          const content = await Filesystem.readText(filepath).catch(() => {})
+          const content = await Filesystem.readText(filepath).catch(() => undefined)
           if (content) {
             pasteText(content, `[SVG: ${filename ?? "image"}]`)
             return
@@ -1288,7 +1371,7 @@ export function Prompt(props: PromptProps) {
         if (mime.startsWith("image/") || mime === "application/pdf") {
           const content = await Filesystem.readArrayBuffer(filepath)
             .then((buffer) => Buffer.from(buffer).toString("base64"))
-            .catch(() => {})
+            .catch(() => undefined)
           if (content) {
             await pasteAttachment({
               filename,
@@ -1299,7 +1382,9 @@ export function Prompt(props: PromptProps) {
             return
           }
         }
-      } catch {}
+      } catch {
+        // Treat unresolved local paths as plain pasted text.
+      }
     }
 
     const lineCount = (pastedContent.match(/\n/g)?.length ?? 0) + 1
@@ -1406,6 +1491,9 @@ export function Prompt(props: PromptProps) {
     animationsEnabled,
   )
   const borderHighlight = createMemo(() => tint(theme.border, highlight(), agentMetaAlpha()))
+  const vimTextareaBindings = createMemo<TextareaKeyBinding[]>(() =>
+    createVimTextareaBindings(store.mode === "normal" && vimEnabled(), vimMode()),
+  )
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined
@@ -1504,14 +1592,10 @@ export function Prompt(props: PromptProps) {
                 auto()?.onInput(value)
                 syncExtmarksWithPromptParts()
                 setCursorVersion((value) => value + 1)
+                writeVimMarker("content")
               }}
               onCursorChange={() => setCursorVersion((value) => value + 1)}
-              onKeyDown={(e: { preventDefault(): void }) => {
-                if (props.disabled) {
-                  e.preventDefault()
-                  return
-                }
-              }}
+              onKeyDown={(event) => handlePromptKeyDown(event)}
               onSubmit={() => {
                 // IME: double-defer so the last composed character (e.g. Korean
                 // hangul) is flushed to plainText before we read it for submission.
@@ -1548,6 +1632,7 @@ export function Prompt(props: PromptProps) {
                 if (promptPartTypeId === 0) {
                   promptPartTypeId = input.extmarks.registerType("prompt-part")
                 }
+                writeVimMarker("mount")
                 props.ref?.(ref)
                 setTimeout(() => {
                   // setTimeout is a workaround and needs to be addressed properly
@@ -1558,6 +1643,7 @@ export function Prompt(props: PromptProps) {
               onMouseDown={(r: MouseEvent) => r.target?.focus()}
               focusedBackgroundColor={theme.backgroundElement}
               cursorColor={props.disabled ? theme.backgroundElement : theme.text}
+              keyBindings={vimTextareaBindings()}
               syntaxStyle={syntax()}
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">
@@ -1568,6 +1654,12 @@ export function Prompt(props: PromptProps) {
                       <text fg={fadeColor(highlight(), agentMetaAlpha())}>
                         {store.mode === "shell" ? "Shell" : Locale.titlecase(agent().name)}
                       </text>
+                      <Show when={store.mode === "normal" && vimEnabled()}>
+                        <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>·</text>
+                        <text fg={fadeColor(vimMode() === "normal" ? theme.warning : theme.success, modelMetaAlpha())}>
+                          {vimMode() === "normal" ? "NORMAL" : "INSERT"}
+                        </text>
+                      </Show>
                       <Show when={store.mode === "normal"}>
                         <box flexDirection="row" gap={1}>
                           <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>·</text>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/vim-keys.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/vim-keys.ts
@@ -1,0 +1,21 @@
+import type { PromptKeyEvent, VimFindType } from "./vim-types"
+
+export function vimKeyName(event: PromptKeyEvent) {
+  if (event.name === "4" && event.shift) return "$"
+  if (event.name === "6" && event.shift) return "^"
+  if (event.name === "f" && event.shift) return "F"
+  if (event.name === "t" && event.shift) return "T"
+  if (event.name.length === 1 && event.shift && /[a-z]/.test(event.name)) return event.name.toUpperCase()
+  return event.name
+}
+
+export function isFindKey(name: string): name is VimFindType {
+  return name === "f" || name === "F" || name === "t" || name === "T"
+}
+
+export function reverseFind(find: VimFindType): VimFindType {
+  if (find === "f") return "F"
+  if (find === "F") return "f"
+  if (find === "t") return "T"
+  return "t"
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/vim-motion.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/vim-motion.ts
@@ -1,0 +1,164 @@
+import type { VimFindType } from "./vim-types"
+
+export type TextRange = {
+  start: number
+  end: number
+}
+
+export type OperatorMotion = "b" | "e" | "w" | "0" | "$"
+
+export function clampOffset(text: string, offset: number) {
+  return Math.max(0, Math.min(offset, text.length))
+}
+
+export function lineBounds(text: string, offset: number) {
+  const clamped = clampOffset(text, offset)
+  const start = text.lastIndexOf("\n", Math.max(0, clamped - 1)) + 1
+  const endIndex = text.indexOf("\n", clamped)
+  const end = endIndex === -1 ? text.length : endIndex
+  return { start, end }
+}
+
+export function lineOffset(text: string, cursor: number, delta: number) {
+  const current = lineBounds(text, cursor)
+  const column = cursor - current.start
+  const lines = text.split("\n")
+  let lineIndex = 0
+  let total = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineLength = lines[i].length
+    if (cursor <= total + lineLength) {
+      lineIndex = i
+      break
+    }
+    total += lineLength + 1
+    lineIndex = i + 1
+  }
+
+  const nextIndex = Math.max(0, Math.min(lineIndex + delta, lines.length - 1))
+  let nextStart = 0
+  for (let i = 0; i < nextIndex; i++) {
+    nextStart += lines[i].length + 1
+  }
+  return nextStart + Math.min(column, lines[nextIndex].length)
+}
+
+export function firstNonBlankInLine(text: string, cursor: number) {
+  const bounds = lineBounds(text, cursor)
+  let index = bounds.start
+  while (index < bounds.end && /\s/.test(text[index]!)) index += 1
+  return index
+}
+
+export function nextWordStart(text: string, cursor: number) {
+  let index = Math.min(cursor + 1, text.length)
+  while (index < text.length && !/\s/.test(text[index]!)) index += 1
+  while (index < text.length && /\s/.test(text[index]!)) index += 1
+  return index
+}
+
+export function prevWordStart(text: string, cursor: number) {
+  let index = Math.max(0, cursor - 1)
+  while (index > 0 && /\s/.test(text[index]!)) index -= 1
+  while (index > 0 && !/\s/.test(text[index - 1]!)) index -= 1
+  return index
+}
+
+export function wordEnd(text: string, cursor: number) {
+  let index = Math.min(cursor, Math.max(0, text.length - 1))
+  while (index < text.length && /\s/.test(text[index]!)) index += 1
+  while (index < text.length - 1 && !/\s/.test(text[index + 1]!)) index += 1
+  return index
+}
+
+export function findCharacter(text: string, cursor: number, char: string, find: VimFindType) {
+  const forward = find === "f" || find === "t"
+  const till = find === "t" || find === "T"
+
+  if (forward) {
+    let index = clampOffset(text, cursor) + 1
+    while (index < text.length) {
+      if (text[index] === char) return till ? Math.max(cursor, index - 1) : index
+      index += 1
+    }
+    return
+  }
+
+  let index = clampOffset(text, cursor) - 1
+  while (index >= 0) {
+    if (text[index] === char) return till ? Math.min(cursor, index + 1) : index
+    index -= 1
+  }
+}
+
+function isWordChar(char: string) {
+  return /[A-Za-z0-9_]/.test(char)
+}
+
+function charGroup(text: string, index: number) {
+  const char = text[index]
+  if (!char) return "none"
+  if (isWordChar(char)) return "word"
+  if (/\s/.test(char)) return "space"
+  return "punctuation"
+}
+
+export function innerWordRange(text: string, cursor: number): TextRange | undefined {
+  if (!text) return
+  const index = clampOffset(text, cursor === text.length ? cursor - 1 : cursor)
+  const group = charGroup(text, index)
+  if (group === "none") return
+
+  let start = index
+  let end = index + 1
+  while (start > 0 && charGroup(text, start - 1) === group) start -= 1
+  while (end < text.length && charGroup(text, end) === group) end += 1
+  return { start, end }
+}
+
+export function aroundWordRange(text: string, cursor: number): TextRange | undefined {
+  const range = innerWordRange(text, cursor)
+  if (!range) return
+
+  let start = range.start
+  let end = range.end
+  while (end < text.length && /\s/.test(text[end]!)) end += 1
+  if (end !== range.end) return { start, end }
+
+  while (start > 0 && /\s/.test(text[start - 1]!)) start -= 1
+  return { start, end }
+}
+
+export function operatorMotionRange(text: string, cursor: number, motion: OperatorMotion): TextRange | undefined {
+  const clampedCursor = clampOffset(text, cursor)
+  if (motion === "0") {
+    const start = lineBounds(text, clampedCursor).start
+    if (start >= clampedCursor) return
+    return { start, end: clampedCursor }
+  }
+  if (motion === "$") {
+    const end = lineBounds(text, clampedCursor).end
+    if (end < clampedCursor) return
+    return { start: clampedCursor, end }
+  }
+
+  const target = motion === "b" ? prevWordStart(text, clampedCursor) : motion === "w" ? nextWordStart(text, clampedCursor) : wordEnd(text, clampedCursor)
+  if (motion === "w") {
+    if (target <= clampedCursor) return
+    return { start: clampedCursor, end: target }
+  }
+  if (motion === "e") {
+    const end = Math.min(text.length, target + 1)
+    if (end <= clampedCursor) return
+    return { start: clampedCursor, end }
+  }
+  if (target >= clampedCursor) return
+  return { start: target, end: clampedCursor }
+}
+
+export function operatorFindRange(text: string, cursor: number, char: string, find: VimFindType): TextRange | undefined {
+  const target = findCharacter(text, cursor, char, find)
+  if (target === undefined) return
+  return { start: Math.min(cursor, target), end: Math.min(text.length, Math.max(cursor, target) + 1) }
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/vim-types.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/vim-types.ts
@@ -1,0 +1,48 @@
+export type VimMode = "insert" | "normal"
+
+export type VimOperator = "delete" | "change"
+
+export type VimFindType = "f" | "F" | "t" | "T"
+
+export type VimPendingOperator = {
+  op: VimOperator
+  textObjectScope?: "inner" | "around"
+  find?: VimFindType
+}
+
+export type VimPendingFind = {
+  find: VimFindType
+}
+
+export type VimLastFind = {
+  find: VimFindType
+  char: string
+}
+
+export type PromptKeyEvent = {
+  name: string
+  ctrl: boolean
+  meta: boolean
+  shift: boolean
+  preventDefault(): void
+}
+
+export type VimRuntime = {
+  readonly text: string
+  readonly cursor: number
+  readonly enabled: boolean
+  readonly mode: VimMode
+  readonly pendingG: boolean
+  readonly pendingOperator: VimPendingOperator | undefined
+  readonly pendingFind: VimPendingFind | undefined
+  readonly lastFind: VimLastFind | undefined
+  setMode(mode: VimMode): void
+  setPendingG(value: boolean): void
+  setPendingOperator(value: VimPendingOperator | undefined): void
+  setPendingFind(value: VimPendingFind | undefined): void
+  setLastFind(value: VimLastFind | undefined): void
+  moveCursor(offset: number): void
+  replaceText(text: string): void
+  syncPromptInput(): void
+  writeMarker(phase: string): void
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/vim.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/vim.ts
@@ -1,0 +1,269 @@
+import type { KeyBinding as TextareaKeyBinding } from "@opentui/core"
+import { isFindKey, reverseFind, vimKeyName } from "./vim-keys"
+import {
+  clampOffset,
+  findCharacter,
+  firstNonBlankInLine,
+  aroundWordRange,
+  innerWordRange,
+  lineBounds,
+  lineOffset,
+  nextWordStart,
+  operatorFindRange,
+  operatorMotionRange,
+  prevWordStart,
+  wordEnd,
+  type OperatorMotion,
+  type TextRange,
+} from "./vim-motion"
+import type { PromptKeyEvent, VimMode, VimOperator, VimRuntime } from "./vim-types"
+
+export type { PromptKeyEvent, VimFindType, VimLastFind, VimMode, VimOperator, VimPendingFind, VimPendingOperator, VimRuntime } from "./vim-types"
+export { lineBounds } from "./vim-motion"
+
+export function createVimTextareaBindings(enabled: boolean, mode: VimMode): TextareaKeyBinding[] {
+  if (!enabled || mode !== "normal") return []
+  return [{ name: "return", action: "submit" }]
+}
+
+function clearPendingG(runtime: VimRuntime) {
+  if (runtime.pendingG) runtime.setPendingG(false)
+}
+
+function clearPending(runtime: VimRuntime) {
+  clearPendingG(runtime)
+  if (runtime.pendingOperator) runtime.setPendingOperator(undefined)
+  if (runtime.pendingFind) runtime.setPendingFind(undefined)
+}
+
+function moveCursorLine(runtime: VimRuntime, delta: number) {
+  runtime.moveCursor(lineOffset(runtime.text, runtime.cursor, delta))
+}
+
+function applyOperator(runtime: VimRuntime, op: VimOperator, range: TextRange) {
+  const from = clampOffset(runtime.text, Math.min(range.start, range.end))
+  const to = clampOffset(runtime.text, Math.max(range.start, range.end))
+  if (from === to) return
+
+  const nextText = `${runtime.text.slice(0, from)}${runtime.text.slice(to)}`
+  runtime.replaceText(nextText)
+  runtime.moveCursor(Math.min(from, nextText.length))
+  runtime.syncPromptInput()
+  clearPending(runtime)
+
+  if (op === "change") {
+    runtime.setMode("insert")
+    runtime.writeMarker("change")
+  }
+}
+
+function handlePendingOperator(event: PromptKeyEvent, runtime: VimRuntime) {
+  const pending = runtime.pendingOperator
+  if (!pending || event.ctrl || event.meta) return false
+
+  const name = vimKeyName(event)
+  event.preventDefault()
+
+  if (name === "escape") {
+    clearPending(runtime)
+    return true
+  }
+
+  if (pending.find) {
+    const range = operatorFindRange(runtime.text, runtime.cursor, name, pending.find)
+    if (range) {
+      applyOperator(runtime, pending.op, range)
+      runtime.setLastFind({ find: pending.find, char: name })
+    } else {
+      clearPending(runtime)
+    }
+    return true
+  }
+
+  if (!pending.textObjectScope && (name === "i" || name === "a")) {
+    runtime.setPendingOperator({ op: pending.op, textObjectScope: name === "i" ? "inner" : "around" })
+    runtime.writeMarker(`pending-${pending.op}-${name}`)
+    return true
+  }
+
+  if (pending.textObjectScope && name === "w") {
+    const range = pending.textObjectScope === "around" ? aroundWordRange(runtime.text, runtime.cursor) : innerWordRange(runtime.text, runtime.cursor)
+    if (range) applyOperator(runtime, pending.op, range)
+    else clearPending(runtime)
+    return true
+  }
+
+  if (!pending.textObjectScope && isOperatorMotion(name)) {
+    const range = operatorMotionRange(runtime.text, runtime.cursor, name)
+    if (range) applyOperator(runtime, pending.op, range)
+    else clearPending(runtime)
+    return true
+  }
+
+  if (!pending.textObjectScope && isFindKey(name)) {
+    runtime.setPendingOperator({ op: pending.op, find: name })
+    runtime.writeMarker(`pending-${pending.op}-${name}`)
+    return true
+  }
+
+  clearPending(runtime)
+  return true
+}
+
+function handlePendingFind(event: PromptKeyEvent, runtime: VimRuntime) {
+  const pending = runtime.pendingFind
+  if (!pending || event.ctrl || event.meta) return false
+
+  const name = vimKeyName(event)
+  event.preventDefault()
+
+  if (name === "escape") {
+    clearPending(runtime)
+    return true
+  }
+
+  const target = findCharacter(runtime.text, runtime.cursor, name, pending.find)
+  if (target !== undefined) {
+    runtime.moveCursor(target)
+    runtime.setLastFind({ find: pending.find, char: name })
+  }
+  clearPending(runtime)
+  return true
+}
+
+function repeatFind(runtime: VimRuntime, reverse: boolean) {
+  const lastFind = runtime.lastFind
+  if (!lastFind) return
+  const find = reverse ? reverseFind(lastFind.find) : lastFind.find
+  const cursor = find === "t" ? runtime.cursor + 1 : find === "T" ? runtime.cursor - 1 : runtime.cursor
+  const target = findCharacter(runtime.text, cursor, lastFind.char, find)
+  if (target !== undefined) runtime.moveCursor(target)
+}
+
+function enterInsert(runtime: VimRuntime, kind: "insert" | "append") {
+  clearPending(runtime)
+  if (kind === "append" && runtime.cursor < runtime.text.length) runtime.moveCursor(runtime.cursor + 1)
+  runtime.setMode("insert")
+  runtime.writeMarker(kind === "append" ? "append" : "insert")
+}
+
+function exitInsert(runtime: VimRuntime) {
+  clearPending(runtime)
+  if (runtime.cursor > 0) runtime.moveCursor(runtime.cursor - 1)
+  runtime.setMode("normal")
+  runtime.writeMarker("normal")
+}
+
+function openLine(runtime: VimRuntime, direction: "above" | "below") {
+  const bounds = lineBounds(runtime.text, runtime.cursor)
+  const insertAt = direction === "below" ? bounds.end : bounds.start
+  const prefix = runtime.text.slice(0, insertAt)
+  const suffix = runtime.text.slice(insertAt)
+  const newline = direction === "below" ? "\n" : ""
+  const nextText = direction === "below" ? `${prefix}${newline}${suffix}` : `${prefix}\n${suffix}`
+  runtime.replaceText(nextText)
+  runtime.moveCursor(direction === "below" ? insertAt + 1 : insertAt)
+  runtime.syncPromptInput()
+  enterInsert(runtime, "insert")
+}
+
+function deleteCharacter(runtime: VimRuntime) {
+  if (runtime.cursor >= runtime.text.length) return
+  const nextText = `${runtime.text.slice(0, runtime.cursor)}${runtime.text.slice(runtime.cursor + 1)}`
+  runtime.replaceText(nextText)
+  runtime.moveCursor(Math.min(runtime.cursor, nextText.length))
+  runtime.syncPromptInput()
+}
+
+function isOperatorMotion(name: string): name is OperatorMotion {
+  return name === "b" || name === "e" || name === "w" || name === "0" || name === "$"
+}
+
+function startOperator(runtime: VimRuntime, op: VimOperator) {
+  runtime.setPendingOperator({ op })
+  runtime.writeMarker(op === "delete" ? "pending-delete" : "pending-change")
+}
+
+function handleNormalCommand(name: string, event: PromptKeyEvent, runtime: VimRuntime) {
+  if (event.ctrl && event.name === "d") return prevent(event, () => moveCursorLine(runtime, 3))
+  if (event.ctrl && event.name === "u") return prevent(event, () => moveCursorLine(runtime, -3))
+  if (event.name === "escape") return prevent(event, () => clearPending(runtime))
+  if (!event.ctrl && !event.meta && name === "g") return prevent(event, () => handleG(runtime))
+  if (!event.ctrl && !event.meta && name === "G") return prevent(event, () => runtime.moveCursor(runtime.text.length))
+
+  clearPending(runtime)
+
+  if (!event.ctrl && !event.meta && name === "d") return prevent(event, () => startOperator(runtime, "delete"))
+  if (!event.ctrl && !event.meta && name === "c") return prevent(event, () => startOperator(runtime, "change"))
+  if (!event.ctrl && !event.meta && name === "i") return prevent(event, () => enterInsert(runtime, "insert"))
+  if (!event.ctrl && !event.meta && name === "I") return prevent(event, () => enterInsertAt(runtime, firstNonBlankInLine(runtime.text, runtime.cursor)))
+  if (!event.ctrl && !event.meta && name === "a") return prevent(event, () => enterInsert(runtime, "append"))
+  if (!event.ctrl && !event.meta && name === "A") return prevent(event, () => enterInsertAt(runtime, lineBounds(runtime.text, runtime.cursor).end))
+  if (!event.ctrl && !event.meta && name === "h") return prevent(event, () => runtime.moveCursor(runtime.cursor - 1))
+  if (!event.ctrl && !event.meta && name === "l") return prevent(event, () => runtime.moveCursor(runtime.cursor + 1))
+  if (!event.ctrl && !event.meta && name === "j") return prevent(event, () => moveCursorLine(runtime, 1))
+  if (!event.ctrl && !event.meta && name === "k") return prevent(event, () => moveCursorLine(runtime, -1))
+  if (!event.ctrl && !event.meta && name === "0") return prevent(event, () => runtime.moveCursor(lineBounds(runtime.text, runtime.cursor).start))
+  if (!event.ctrl && !event.meta && name === "$") return prevent(event, () => runtime.moveCursor(lineBounds(runtime.text, runtime.cursor).end))
+  if (!event.ctrl && !event.meta && name === "^") return prevent(event, () => runtime.moveCursor(firstNonBlankInLine(runtime.text, runtime.cursor)))
+  if (!event.ctrl && !event.meta && (name === "w" || name === "W")) return prevent(event, () => runtime.moveCursor(nextWordStart(runtime.text, runtime.cursor)))
+  if (!event.ctrl && !event.meta && (name === "b" || name === "B")) return prevent(event, () => runtime.moveCursor(prevWordStart(runtime.text, runtime.cursor)))
+  if (!event.ctrl && !event.meta && (name === "e" || name === "E")) return prevent(event, () => runtime.moveCursor(wordEnd(runtime.text, runtime.cursor)))
+  if (!event.ctrl && !event.meta && name === "x") return prevent(event, () => deleteCharacter(runtime))
+  if (!event.ctrl && !event.meta && name === "o") return prevent(event, () => openLine(runtime, "below"))
+  if (!event.ctrl && !event.meta && name === "O") return prevent(event, () => openLine(runtime, "above"))
+  if (!event.ctrl && !event.meta && isFindKey(name)) return prevent(event, () => startFind(runtime, name))
+  if (!event.ctrl && !event.meta && (name === ";" || name === ",")) return prevent(event, () => repeatFind(runtime, name === ","))
+
+  event.preventDefault()
+}
+
+function prevent(event: PromptKeyEvent, action: () => void) {
+  event.preventDefault()
+  action()
+}
+
+function handleG(runtime: VimRuntime) {
+  if (runtime.pendingG) {
+    runtime.setPendingG(false)
+    runtime.moveCursor(0)
+    return
+  }
+  runtime.setPendingG(true)
+  runtime.writeMarker("pending-g")
+}
+
+function enterInsertAt(runtime: VimRuntime, offset: number) {
+  runtime.moveCursor(offset)
+  enterInsert(runtime, "insert")
+}
+
+function startFind(runtime: VimRuntime, find: "f" | "F" | "t" | "T") {
+  runtime.setPendingFind({ find })
+  runtime.writeMarker(`pending-${find}`)
+}
+
+export function handleVimPromptKeyDown(event: PromptKeyEvent, runtime: VimRuntime) {
+  if (!runtime.enabled) {
+    clearPending(runtime)
+    return
+  }
+
+  if (runtime.mode === "insert") {
+    if (event.name === "escape") {
+      event.preventDefault()
+      exitInsert(runtime)
+    }
+    return
+  }
+
+  if (event.name === "return" && !event.ctrl && !event.meta && !event.shift) {
+    clearPending(runtime)
+    return
+  }
+
+  if (handlePendingOperator(event, runtime)) return
+  if (handlePendingFind(event, runtime)) return
+
+  handleNormalCommand(vimKeyName(event), event, runtime)
+}

--- a/packages/opencode/test/cli/cmd/tui/prompt-vim.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-vim.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from "bun:test"
+import { createVimTextareaBindings, handleVimPromptKeyDown, type PromptKeyEvent, type VimLastFind, type VimMode, type VimPendingFind, type VimPendingOperator, type VimRuntime } from "../../../../src/cli/cmd/tui/component/prompt/vim"
+
+type State = {
+  text: string
+  cursor: number
+  enabled: boolean
+  mode: VimMode
+  pendingG: boolean
+  pendingOperator: VimPendingOperator | undefined
+  pendingFind: VimPendingFind | undefined
+  lastFind: VimLastFind | undefined
+  markers: string[]
+}
+
+function runtime(state: State): VimRuntime {
+  return {
+    get text() {
+      return state.text
+    },
+    get cursor() {
+      return state.cursor
+    },
+    get enabled() {
+      return state.enabled
+    },
+    get mode() {
+      return state.mode
+    },
+    get pendingG() {
+      return state.pendingG
+    },
+    get pendingOperator() {
+      return state.pendingOperator
+    },
+    get pendingFind() {
+      return state.pendingFind
+    },
+    get lastFind() {
+      return state.lastFind
+    },
+    setMode(mode) {
+      state.mode = mode
+    },
+    setPendingG(value) {
+      state.pendingG = value
+    },
+    setPendingOperator(value) {
+      state.pendingOperator = value
+    },
+    setPendingFind(value) {
+      state.pendingFind = value
+    },
+    setLastFind(value) {
+      state.lastFind = value
+    },
+    moveCursor(offset) {
+      state.cursor = Math.max(0, Math.min(offset, state.text.length))
+    },
+    replaceText(text) {
+      state.text = text
+    },
+    syncPromptInput() {},
+    writeMarker(phase) {
+      state.markers.push(phase)
+    },
+  }
+}
+
+function createState(overrides: Partial<State> = {}): State {
+  return { text: "", cursor: 0, enabled: true, mode: "normal", pendingG: false, pendingOperator: undefined, pendingFind: undefined, lastFind: undefined, markers: [], ...overrides }
+}
+
+function pressKeys(target: State, keys: string[]) {
+  for (const key of keys) handleVimPromptKeyDown(event(key), runtime(target))
+}
+
+function event(name: string, opts: Partial<PromptKeyEvent> = {}) {
+  let prevented = false
+  return {
+    name,
+    ctrl: false,
+    meta: false,
+    shift: false,
+    preventDefault() {
+      prevented = true
+    },
+    get prevented() {
+      return prevented
+    },
+    ...opts,
+  }
+}
+
+describe("prompt vim", () => {
+  test("textarea bindings exist only in normal mode", () => {
+    expect(createVimTextareaBindings(true, "normal").map((item) => item.name)).toEqual(["return"])
+    expect(createVimTextareaBindings(true, "insert")).toEqual([])
+    expect(createVimTextareaBindings(false, "normal")).toEqual([])
+  })
+
+  test("escape exits insert mode and shifts cursor left by one", () => {
+    const state: State = createState({ text: "hello", cursor: 5, mode: "insert" })
+    const e = event("escape")
+    handleVimPromptKeyDown(e, runtime(state))
+    expect(state.mode).toBe("normal")
+    expect(state.cursor).toBe(4)
+    expect(state.markers).toContain("normal")
+  })
+
+  test("i, I, a, A enter insert at correct positions", () => {
+    const start = (): State => createState({ text: "  abc", cursor: 4 })
+
+    const iState = start()
+    handleVimPromptKeyDown(event("i"), runtime(iState))
+    expect(iState.mode).toBe("insert")
+    expect(iState.cursor).toBe(4)
+
+    const IState = start()
+    handleVimPromptKeyDown(event("i", { shift: true }), runtime(IState))
+    expect(IState.mode).toBe("insert")
+    expect(IState.cursor).toBe(2)
+
+    const aState = start()
+    handleVimPromptKeyDown(event("a"), runtime(aState))
+    expect(aState.mode).toBe("insert")
+    expect(aState.cursor).toBe(5)
+
+    const AState = start()
+    handleVimPromptKeyDown(event("a", { shift: true }), runtime(AState))
+    expect(AState.mode).toBe("insert")
+    expect(AState.cursor).toBe(5)
+  })
+
+  test("word motions b/B and e/E move to expected offsets", () => {
+    const wState: State = createState({ text: "alpha beta", cursor: 0 })
+    handleVimPromptKeyDown(event("w"), runtime(wState))
+    expect(wState.cursor).toBe(6)
+
+    const bState: State = createState({ text: "alpha beta", cursor: 9 })
+    handleVimPromptKeyDown(event("b"), runtime(bState))
+    expect(bState.cursor).toBe(6)
+
+    const BState: State = createState({ text: "alpha beta", cursor: 9 })
+    handleVimPromptKeyDown(event("b", { shift: true }), runtime(BState))
+    expect(BState.cursor).toBe(6)
+
+    const eState: State = createState({ text: "alpha beta", cursor: 6 })
+    handleVimPromptKeyDown(event("e"), runtime(eState))
+    expect(eState.cursor).toBe(9)
+
+    const EState: State = createState({ text: "alpha beta", cursor: 6 })
+    handleVimPromptKeyDown(event("e", { shift: true }), runtime(EState))
+    expect(EState.cursor).toBe(9)
+  })
+
+  test("line motions 0, caret, and dollar move to expected offsets", () => {
+    const startState = createState({ text: "  alpha beta", cursor: 8 })
+    handleVimPromptKeyDown(event("0"), runtime(startState))
+    expect(startState.cursor).toBe(0)
+
+    const firstTextState = createState({ text: "  alpha beta", cursor: 8 })
+    handleVimPromptKeyDown(event("6", { shift: true }), runtime(firstTextState))
+    expect(firstTextState.cursor).toBe(2)
+
+    const endState = createState({ text: "  alpha beta", cursor: 2 })
+    handleVimPromptKeyDown(event("4", { shift: true }), runtime(endState))
+    expect(endState.cursor).toBe(12)
+  })
+
+  test("o and O open lines and enter insert", () => {
+    const below: State = createState({ text: "alpha", cursor: 4 })
+    handleVimPromptKeyDown(event("o"), runtime(below))
+    expect(below.text).toBe("alpha\n")
+    expect(below.mode).toBe("insert")
+    expect(below.cursor).toBe(6)
+
+    const above: State = createState({ text: "alpha", cursor: 4 })
+    handleVimPromptKeyDown(event("o", { shift: true }), runtime(above))
+    expect(above.text).toBe("\nalpha")
+    expect(above.mode).toBe("insert")
+    expect(above.cursor).toBe(0)
+  })
+
+  test("gg and G move to start and end", () => {
+    const ggState: State = createState({ text: "a\nb\nc", cursor: 4 })
+    handleVimPromptKeyDown(event("g"), runtime(ggState))
+    expect(ggState.pendingG).toBe(true)
+    handleVimPromptKeyDown(event("g"), runtime(ggState))
+    expect(ggState.cursor).toBe(0)
+    expect(ggState.pendingG).toBe(false)
+
+    const GState: State = createState({ text: "a\nb\nc", cursor: 0 })
+    handleVimPromptKeyDown(event("g", { shift: true }), runtime(GState))
+    expect(GState.cursor).toBe(5)
+  })
+
+  test("ctrl+d and ctrl+u move across lines", () => {
+    const state: State = createState({ text: "a\nb\nc\nd\ne", cursor: 0 })
+    handleVimPromptKeyDown(event("d", { ctrl: true }), runtime(state))
+    expect(state.cursor).toBe(6)
+    handleVimPromptKeyDown(event("u", { ctrl: true }), runtime(state))
+    expect(state.cursor).toBe(0)
+  })
+
+  test("disabled vim does nothing", () => {
+    const state: State = createState({ text: "hello", cursor: 5, enabled: false })
+    handleVimPromptKeyDown(event("i"), runtime(state))
+    expect(state.mode).toBe("normal")
+    expect(state.cursor).toBe(5)
+  })
+
+  test("disabled vim clears pending operator without editing", () => {
+    const disabled = createState({ text: "alpha beta", cursor: 7, enabled: false, pendingOperator: { op: "delete" } })
+    handleVimPromptKeyDown(event("w"), runtime(disabled))
+    expect(disabled.text).toBe("alpha beta")
+    expect(disabled.cursor).toBe(7)
+    expect(disabled.mode).toBe("normal")
+    expect(disabled.pendingOperator).toBeUndefined()
+  })
+
+  test("delete and change operators execute word text objects", () => {
+    const deleteInnerWord = createState({ text: "alpha beta gamma", cursor: 7 })
+    pressKeys(deleteInnerWord, ["d", "i", "w"])
+    expect(deleteInnerWord.text).toBe("alpha  gamma")
+    expect(deleteInnerWord.cursor).toBe(6)
+    expect(deleteInnerWord.mode).toBe("normal")
+    expect(deleteInnerWord.pendingOperator).toBeUndefined()
+
+    const changeInnerWord = createState({ text: "alpha beta gamma", cursor: 7 })
+    pressKeys(changeInnerWord, ["c", "i", "w"])
+    expect(changeInnerWord.text).toBe("alpha  gamma")
+    expect(changeInnerWord.cursor).toBe(6)
+    expect(changeInnerWord.mode).toBe("insert")
+    expect(changeInnerWord.pendingOperator).toBeUndefined()
+
+    const deleteAroundWord = createState({ text: "alpha beta gamma", cursor: 7 })
+    pressKeys(deleteAroundWord, ["d", "a", "w"])
+    expect(deleteAroundWord.text).toBe("alpha gamma")
+    expect(deleteAroundWord.cursor).toBe(6)
+    expect(deleteAroundWord.mode).toBe("normal")
+    expect(deleteAroundWord.pendingOperator).toBeUndefined()
+
+    const changeAroundWord = createState({ text: "alpha beta gamma", cursor: 7 })
+    pressKeys(changeAroundWord, ["c", "a", "w"])
+    expect(changeAroundWord.text).toBe("alpha gamma")
+    expect(changeAroundWord.cursor).toBe(6)
+    expect(changeAroundWord.mode).toBe("insert")
+    expect(changeAroundWord.pendingOperator).toBeUndefined()
+  })
+
+  test("delete operator executes e and b motions", () => {
+    const deleteToEnd = createState({ text: "alpha beta gamma", cursor: 6 })
+    pressKeys(deleteToEnd, ["d", "e"])
+    expect(deleteToEnd.text).toBe("alpha  gamma")
+    expect(deleteToEnd.cursor).toBe(6)
+    expect(deleteToEnd.mode).toBe("normal")
+    expect(deleteToEnd.pendingOperator).toBeUndefined()
+
+    const deleteBack = createState({ text: "alpha beta gamma", cursor: 9 })
+    pressKeys(deleteBack, ["d", "b"])
+    expect(deleteBack.text).toBe("alpha a gamma")
+    expect(deleteBack.cursor).toBe(6)
+    expect(deleteBack.mode).toBe("normal")
+    expect(deleteBack.pendingOperator).toBeUndefined()
+  })
+
+  test("pending operator cancels on escape and invalid keys", () => {
+    const escapeState = createState({ text: "alpha beta", cursor: 6 })
+    pressKeys(escapeState, ["d", "escape"])
+    expect(escapeState.text).toBe("alpha beta")
+    expect(escapeState.cursor).toBe(6)
+    expect(escapeState.pendingOperator).toBeUndefined()
+
+    const invalidState = createState({ text: "alpha beta", cursor: 6 })
+    pressKeys(invalidState, ["d", "z"])
+    expect(invalidState.text).toBe("alpha beta")
+    expect(invalidState.cursor).toBe(6)
+    expect(invalidState.pendingOperator).toBeUndefined()
+  })
+
+  test("normal find motions and repeat find match Vim f/t behavior", () => {
+    const forwardTo = createState({ text: "alpha; beta; gamma", cursor: 0 })
+    pressKeys(forwardTo, ["f", ";"])
+    expect(forwardTo.cursor).toBe(5)
+    expect(forwardTo.lastFind).toEqual({ find: "f", char: ";" })
+
+    pressKeys(forwardTo, [";"])
+    expect(forwardTo.cursor).toBe(11)
+    pressKeys(forwardTo, [","])
+    expect(forwardTo.cursor).toBe(5)
+
+    const forwardTill = createState({ text: "alpha; beta", cursor: 0 })
+    pressKeys(forwardTill, ["t", ";"])
+    expect(forwardTill.cursor).toBe(4)
+
+    const repeatForwardTill = createState({ text: "alpha; beta; gamma", cursor: 0 })
+    pressKeys(repeatForwardTill, ["t", ";", ";", ","])
+    expect(repeatForwardTill.cursor).toBe(6)
+
+    const backwardTo = createState({ text: "alpha; beta", cursor: 10 })
+    handleVimPromptKeyDown(event("f", { shift: true }), runtime(backwardTo))
+    handleVimPromptKeyDown(event(";"), runtime(backwardTo))
+    expect(backwardTo.cursor).toBe(5)
+
+    const backwardTill = createState({ text: "alpha; beta", cursor: 10 })
+    handleVimPromptKeyDown(event("t", { shift: true }), runtime(backwardTill))
+    handleVimPromptKeyDown(event(";"), runtime(backwardTill))
+    expect(backwardTill.cursor).toBe(6)
+  })
+
+  test("delete operator executes find motions", () => {
+    const deleteFind = createState({ text: "alpha; beta", cursor: 0 })
+    pressKeys(deleteFind, ["d", "f", ";"])
+    expect(deleteFind.text).toBe(" beta")
+    expect(deleteFind.cursor).toBe(0)
+    expect(deleteFind.mode).toBe("normal")
+    expect(deleteFind.lastFind).toEqual({ find: "f", char: ";" })
+    expect(deleteFind.pendingOperator).toBeUndefined()
+
+    const deleteTill = createState({ text: "alpha; beta", cursor: 0 })
+    pressKeys(deleteTill, ["d", "t", ";"])
+    expect(deleteTill.text).toBe("; beta")
+    expect(deleteTill.cursor).toBe(0)
+    expect(deleteTill.mode).toBe("normal")
+    expect(deleteTill.lastFind).toEqual({ find: "t", char: ";" })
+    expect(deleteTill.pendingOperator).toBeUndefined()
+
+    const deleteBackwardFind = createState({ text: "alpha; beta", cursor: 10 })
+    handleVimPromptKeyDown(event("d"), runtime(deleteBackwardFind))
+    handleVimPromptKeyDown(event("f", { shift: true }), runtime(deleteBackwardFind))
+    handleVimPromptKeyDown(event(";"), runtime(deleteBackwardFind))
+    expect(deleteBackwardFind.text).toBe("alpha")
+    expect(deleteBackwardFind.cursor).toBe(5)
+    expect(deleteBackwardFind.lastFind).toEqual({ find: "F", char: ";" })
+    expect(deleteBackwardFind.pendingOperator).toBeUndefined()
+
+    const deleteBackwardTill = createState({ text: "alpha; beta", cursor: 10 })
+    handleVimPromptKeyDown(event("d"), runtime(deleteBackwardTill))
+    handleVimPromptKeyDown(event("t", { shift: true }), runtime(deleteBackwardTill))
+    handleVimPromptKeyDown(event(";"), runtime(deleteBackwardTill))
+    expect(deleteBackwardTill.text).toBe("alpha;")
+    expect(deleteBackwardTill.cursor).toBe(6)
+    expect(deleteBackwardTill.lastFind).toEqual({ find: "T", char: ";" })
+    expect(deleteBackwardTill.pendingOperator).toBeUndefined()
+  })
+})

--- a/script/e2e_vim.sh
+++ b/script/e2e_vim.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec python3 script/e2e_vim_pty.py "$@"

--- a/script/e2e_vim_pty.py
+++ b/script/e2e_vim_pty.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+import json
+import os
+import pty
+import select
+import signal
+import tempfile
+import time
+
+OPENCODE = "/Users/mohamed/.opencode/bin/opencode"
+
+def send(fd, value):
+    os.write(fd, value.encode())
+    time.sleep(0.18)
+
+def send_key(fd, key):
+    mapping = {
+        "esc": "\x1b[27;1u",
+        "ctrl-d": "\x1b[100;5u",
+        "ctrl-u": "\x1b[117;5u",
+    }
+    send(fd, mapping.get(key, key))
+    if key == "esc":
+        time.sleep(0.9)
+
+def drain(fd, seconds=0.2):
+    end = time.time() + seconds
+    chunks = []
+    while time.time() < end:
+        ready, _, _ = select.select([fd], [], [], 0.03)
+        if not ready:
+            continue
+        try:
+            chunks.append(os.read(fd, 65536))
+        except OSError:
+            break
+    return b"".join(chunks)
+
+def wait_marker(marker, timeout=8):
+    end = time.time() + timeout
+    last = None
+    while time.time() < end:
+        if os.path.exists(marker):
+            try:
+                with open(marker) as handle:
+                    last = json.load(handle)
+                return last
+            except (json.JSONDecodeError, OSError):
+                pass
+        time.sleep(0.05)
+    raise AssertionError(f"marker not written: {marker}; last={last}")
+
+def read_marker(marker):
+    with open(marker) as handle:
+        return json.load(handle)
+
+def launch(marker, workdir):
+    if not os.path.exists(OPENCODE):
+        raise AssertionError(f"expected local opencode executable missing: {OPENCODE}")
+    pid, fd = pty.fork()
+    if pid == 0:
+        env = os.environ.copy()
+        env["OPENCODE_VIM_PROMPT_MARKER"] = marker
+        env["OPENCODE_DISABLE_AUTOUPDATE"] = "1"
+        env["TERM"] = "xterm-256color"
+        os.chdir(workdir)
+        os.execvpe(OPENCODE, [OPENCODE], env)
+    return pid, fd
+
+def stop(pid, fd):
+    end = time.time() + 2
+    while time.time() < end:
+        try:
+            done, _ = os.waitpid(pid, os.WNOHANG)
+            if done:
+                return
+        except ChildProcessError:
+            return
+        time.sleep(0.05)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError:
+        pass
+
+def assert_state(case, actual, expected):
+    for key, value in expected.items():
+        if actual.get(key) != value:
+            raise AssertionError(f"{case}: expected {key}={value!r}, got {actual.get(key)!r}; state={actual}")
+
+def seed_text(fd, text):
+    if "\n" in text:
+        send(fd, f"\x1b[200~{text}\x1b[201~")
+        time.sleep(0.5)
+        return
+    send(fd, text)
+
+def run_steps(fd, steps):
+    for step in steps:
+        if isinstance(step, dict):
+            seed_text(fd, step["text"])
+        else:
+            send_key(fd, step)
+
+def run_case(case):
+    temp = tempfile.mkdtemp(prefix="opencode-vim-e2e-")
+    marker = os.path.join(temp, "marker.json")
+    pid, fd = launch(marker, temp)
+    try:
+        output = ""
+        end = time.time() + 25
+        while time.time() < end:
+            output += drain(fd, 0.25).decode(errors="replace")
+            if "Ask anything" in output or "Run a command" in output or "INSERT" in output or "]12;" in output:
+                break
+            time.sleep(0.1)
+
+        seed_text(fd, case["text"])
+        send_key(fd, "esc")
+        try:
+            wait_marker(marker)
+        except AssertionError as error:
+            output = drain(fd, 2.0).decode(errors="replace")
+            raise AssertionError(f"{error}\nPTY output tail:\n{output[-4000:]}") from error
+
+        run_steps(fd, case.get("setup", []))
+        if case.get("setup"):
+            time.sleep(0.5)
+            wait_marker(marker)
+        run_steps(fd, case["keys"])
+        time.sleep(0.35)
+        drain(fd, 0.5)
+        actual = read_marker(marker)
+        assert_state(case["name"], actual, case["expect"])
+        print(f"PASS {case['name']}: cursor={actual.get('cursor')} mode={actual.get('mode')} input={actual.get('input')!r}", flush=True)
+    finally:
+        stop(pid, fd)
+        for filename in os.listdir(temp):
+            try:
+                os.remove(os.path.join(temp, filename))
+            except IsADirectoryError:
+                pass
+        os.rmdir(temp)
+
+CASES = [
+    {"name": "0 start", "text": "  alpha beta", "keys": ["0"], "expect": {"enabled": True, "mode": "normal", "cursor": 0, "input": "  alpha beta"}},
+    {"name": "caret first nonblank", "text": "  alpha beta", "keys": ["^"], "expect": {"enabled": True, "mode": "normal", "cursor": 2, "input": "  alpha beta"}},
+    {"name": "dollar line end", "text": "  alpha beta", "keys": ["0", "$"], "expect": {"enabled": True, "mode": "normal", "cursor": 12, "input": "  alpha beta"}},
+    {"name": "h l", "text": "hello", "keys": ["h", "l"], "expect": {"enabled": True, "mode": "normal", "cursor": 4, "input": "hello"}},
+    {"name": "w", "text": "alpha beta", "keys": ["0", "w"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha beta"}},
+    {"name": "b", "text": "alpha beta", "keys": ["b"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha beta"}},
+    {"name": "e", "text": "alpha beta", "keys": ["0", "w", "e"], "expect": {"enabled": True, "mode": "normal", "cursor": 9, "input": "alpha beta"}},
+    {"name": "x", "text": "hello", "keys": ["0", "x"], "expect": {"enabled": True, "mode": "normal", "cursor": 0, "input": "ello"}},
+    {"name": "G end", "text": "a", "setup": ["o", {"text": "b"}, "esc", "o", {"text": "c"}, "esc"], "keys": ["0", "G"], "expect": {"enabled": True, "mode": "normal", "cursor": 5, "input": "a\nb\nc"}},
+    {"name": "gg start", "text": "a", "setup": ["o", {"text": "b"}, "esc", "o", {"text": "c"}, "esc"], "keys": ["G", "g", "g"], "expect": {"enabled": True, "mode": "normal", "cursor": 0, "input": "a\nb\nc"}},
+    {"name": "j k", "text": "aa", "setup": ["o", {"text": "bb"}, "esc", "o", {"text": "cc"}, "esc"], "keys": ["0", "j", "j", "k"], "expect": {"enabled": True, "mode": "normal", "cursor": 3, "input": "aa\nbb\ncc"}},
+    {"name": "o below", "text": "alpha", "keys": ["o"], "expect": {"enabled": True, "mode": "insert", "cursor": 6, "input": "alpha\n"}},
+    {"name": "O above", "text": "alpha", "keys": ["O"], "expect": {"enabled": True, "mode": "insert", "cursor": 0, "input": "\nalpha"}},
+    {"name": "f repeat reverse", "text": "alpha; beta; gamma", "keys": ["0", "f", ";", ";", ","], "expect": {"enabled": True, "mode": "normal", "cursor": 5, "input": "alpha; beta; gamma"}},
+    {"name": "t repeat", "text": "alpha; beta; gamma", "keys": ["0", "t", ";", ";"], "expect": {"enabled": True, "mode": "normal", "cursor": 10, "input": "alpha; beta; gamma"}},
+    {"name": "F backward", "text": "alpha; beta", "keys": ["F", ";"], "expect": {"enabled": True, "mode": "normal", "cursor": 5, "input": "alpha; beta"}},
+    {"name": "T backward", "text": "alpha; beta", "keys": ["T", ";"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha; beta"}},
+    {"name": "diw", "text": "alpha beta gamma", "keys": ["0", "w", "d", "i", "w"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha  gamma"}},
+    {"name": "ciw", "text": "alpha beta gamma", "keys": ["0", "w", "c", "i", "w"], "expect": {"enabled": True, "mode": "insert", "cursor": 6, "input": "alpha  gamma"}},
+    {"name": "daw", "text": "alpha beta gamma", "keys": ["0", "w", "d", "a", "w"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha gamma"}},
+    {"name": "caw", "text": "alpha beta gamma", "keys": ["0", "w", "c", "a", "w"], "expect": {"enabled": True, "mode": "insert", "cursor": 6, "input": "alpha gamma"}},
+    {"name": "de", "text": "alpha beta gamma", "keys": ["0", "w", "d", "e"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha  gamma"}},
+    {"name": "db", "text": "alpha beta gamma", "keys": ["0", "w", "e", "d", "b"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha a gamma"}},
+    {"name": "df char", "text": "alpha; beta", "keys": ["0", "d", "f", ";"], "expect": {"enabled": True, "mode": "normal", "cursor": 0, "input": " beta"}},
+    {"name": "dt char", "text": "alpha; beta", "keys": ["0", "d", "t", ";"], "expect": {"enabled": True, "mode": "normal", "cursor": 0, "input": "; beta"}},
+    {"name": "dF char", "text": "alpha; beta", "keys": ["d", "F", ";"], "expect": {"enabled": True, "mode": "normal", "cursor": 5, "input": "alpha"}},
+    {"name": "dT char", "text": "alpha; beta", "keys": ["d", "T", ";"], "expect": {"enabled": True, "mode": "normal", "cursor": 6, "input": "alpha;"}},
+    {"name": "i insert", "text": "abc", "keys": ["0", "i"], "expect": {"enabled": True, "mode": "insert", "cursor": 0, "input": "abc"}},
+    {"name": "I insert first nonblank", "text": "  abc", "keys": ["I"], "expect": {"enabled": True, "mode": "insert", "cursor": 2, "input": "  abc"}},
+    {"name": "a append", "text": "abc", "keys": ["0", "a"], "expect": {"enabled": True, "mode": "insert", "cursor": 1, "input": "abc"}},
+    {"name": "A append line", "text": "abc", "keys": ["0", "A"], "expect": {"enabled": True, "mode": "insert", "cursor": 3, "input": "abc"}},
+]
+
+for item in CASES:
+    run_case(item)
+
+print(f"E2E complete: {len(CASES)} cases", flush=True)


### PR DESCRIPTION
Adds Vim-style editing for the TUI prompt behind the existing `vim_mode_enabled` KV toggle.

The change keeps prompt input behavior isolated in small modules:
- `vim.ts` handles dispatch/state transitions.
- `vim-motion.ts` handles cursor/range math.
- `vim-keys.ts` normalizes terminal key names.
- `vim-types.ts` keeps shared prompt Vim types.

Supported behavior includes insert/normal mode, common motions (`h/j/k/l`, `w/b/e`, `0/^/$`, `gg/G`), operators (`x`, `d`, `c`), word text objects (`iw`, `aw`), find motions (`f/t/F/T`), and `;`/`,` repeat.

### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds Claude-Code-inspired Vim prompt editing to the OpenCode TUI prompt. The prompt adapter reads `vim_mode_enabled` from KV, exposes `INSERT`/`NORMAL` status, and delegates Vim key handling to the new prompt Vim modules.

The implementation is split so motion/range logic can be tested without booting the TUI. The prompt adapter only wires TUI state, cursor movement, text replacement, and the toggle.

### How did you verify your code works?

- `bun test test/cli/cmd/tui/prompt-vim.test.ts` -> 15 pass, 96 assertions.
- `bun run --cwd packages/opencode typecheck` -> clean.
- `opencode --version` and `opencode --help` from the patched local launcher -> worked.
- Real PTY E2E run against local OpenCode -> 31 cases passed, covering motions, operators, text objects, find/repeat, and insert/append commands.

### Screenshots / recordings

Not included. This is terminal prompt input behavior; verification is covered by unit tests and PTY E2E.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
