### PR TITLE
test(session): de-flake shell-cancel tests by waiting for busy state

### DIFF
--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -336,6 +336,21 @@ const pollWithTimeout = <A, E, R>(
     }),
   )
 
+// Wait for a session's runner to enter a busy state. SessionStatus is flipped to
+// "busy" inside Runner.startShell's modifyEffect at the same moment the runner
+// is registered, so this is a deterministic readiness signal — cancel can't
+// no-op once we observe it.
+const waitForBusy = (sessionID: SessionID, duration: Duration.Input = "2 seconds") =>
+  pollWithTimeout(
+    Effect.gen(function* () {
+      const status = yield* SessionStatus.Service
+      const s = yield* status.get(sessionID)
+      return s.type === "busy" ? (true as const) : undefined
+    }),
+    `session ${sessionID} never became busy`,
+    duration,
+  )
+
 const hasBash = Effect.sync(() => Bun.which("bash") !== null)
 
 const deferredAsPromise = <A>(deferred: Deferred.Deferred<A>): PromiseLike<A> => ({
@@ -1597,7 +1612,7 @@ unix(
         const sh = yield* prompt
           .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
           .pipe(Effect.forkChild)
-        yield* Effect.sleep(50)
+        yield* waitForBusy(chat.id)
 
         yield* prompt.cancel(chat.id)
 
@@ -1721,7 +1736,7 @@ unix(
       const { prompt, chat } = yield* boot()
 
       const sh = yield* prompt.shell({ sessionID: chat.id, agent: "build", command: "sleep 30" }).pipe(Effect.forkChild)
-      yield* Effect.sleep(50)
+      yield* waitForBusy(chat.id)
 
       const loop = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
       yield* Effect.sleep(50)
@@ -1751,7 +1766,7 @@ unix(
         const a = yield* prompt
           .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
           .pipe(Effect.forkChild)
-        yield* Effect.sleep(50)
+        yield* waitForBusy(chat.id)
 
         const exit = yield* prompt.shell({ sessionID: chat.id, agent: "build", command: "echo hi" }).pipe(Effect.exit)
         expect(Exit.isFailure(exit)).toBe(true)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1508,7 +1508,7 @@ it.instance(
       const sh = yield* prompt
         .shell({ sessionID: chat.id, agent: "build", command: "sleep 0.2" })
         .pipe(Effect.forkChild)
-      yield* Effect.sleep(50)
+      yield* waitForBusy(chat.id)
 
       const loop = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
       yield* Effect.sleep(50)
@@ -1545,7 +1545,7 @@ it.instance(
       const sh = yield* prompt
         .shell({ sessionID: chat.id, agent: "build", command: "sleep 0.2" })
         .pipe(Effect.forkChild)
-      yield* Effect.sleep(50)
+      yield* waitForBusy(chat.id)
 
       const a = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
       const b = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)


### PR DESCRIPTION
## Summary

Three shell-cancel tests in `packages/opencode/test/session/prompt.test.ts` used a fixed `Effect.sleep(50)` between forking `prompt.shell` and calling `prompt.cancel`. If the forked fiber hadn't reached `SessionRunState.startShell` within 50 ms, the runner wasn't yet in `data.runners` and `cancel` became a silent no-op (`packages/opencode/src/session/run-state.ts:76-85`), letting the shell run the full `sleep 30` until the 30 s test deadline.

Replaces those sleeps with a `waitForBusy` helper that polls `SessionStatus`. Status flips to `busy` inside `Runner.startShell`'s `modifyEffect` at the same moment the runner is registered, so it's a deterministic readiness signal — `cancel` can't no-op once it's observed.

- New helper next to existing `pollWithTimeout` (`prompt.test.ts:339`).
- Three call sites updated:
  - `cancel interrupts shell and resolves cleanly` (the originally failing test)
  - `cancel interrupts loop queued behind shell`
  - `shell rejects when another shell is already running`

No SUT changes; `cancel`'s "no runner → silently idle" semantics are preserved (they're fine for production where the cancel affordance only appears when status is busy).

## Test plan
- [x] `bun run test test/session/prompt.test.ts -t "cancel interrupts shell and resolves cleanly|cancel interrupts loop queued behind shell|shell rejects when another shell is already running"` — 3/3 pass
- [x] Full file: `bun run test test/session/prompt.test.ts` — 53/53 pass, 3 consecutive runs (~25.7 s each)
- [x] `bun run typecheck` — clean