### PR TITLE
fix(session): publish next delta events

### DIFF
--- a/packages/core/src/session-event.ts
+++ b/packages/core/src/session-event.ts
@@ -157,7 +157,6 @@ export namespace Text {
 
   export const Delta = EventV2.define({
     type: "session.next.text.delta",
-    ...options,
     schema: {
       ...Base,
       delta: Schema.String,
@@ -189,7 +188,6 @@ export namespace Reasoning {
 
   export const Delta = EventV2.define({
     type: "session.next.reasoning.delta",
-    ...options,
     schema: {
       ...Base,
       reasoningID: Schema.String,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -243,6 +243,13 @@ export const layer = Layer.effect(
             if (!(value.id in ctx.reasoningMap)) return
             ctx.reasoningMap[value.id].text += value.text
             if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
+            if (flags.experimentalEventSystem)
+              yield* events.publish(SessionEvent.Reasoning.Delta, {
+                sessionID: ctx.reasoningMap[value.id].sessionID,
+                reasoningID: value.id,
+                delta: value.text,
+                timestamp: DateTime.makeUnsafe(Date.now()),
+              })
             yield* session.updatePartDelta({
               sessionID: ctx.reasoningMap[value.id].sessionID,
               messageID: ctx.reasoningMap[value.id].messageID,
@@ -579,6 +586,12 @@ export const layer = Layer.effect(
             if (!ctx.currentText) return
             ctx.currentText.text += value.text
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
+            if (flags.experimentalEventSystem)
+              yield* events.publish(SessionEvent.Text.Delta, {
+                delta: value.text,
+                sessionID: ctx.currentText.sessionID,
+                timestamp: DateTime.makeUnsafe(Date.now()),
+              })
             yield* session.updatePartDelta({
               sessionID: ctx.currentText.sessionID,
               messageID: ctx.currentText.messageID,

--- a/packages/opencode/src/session/projectors-next.ts
+++ b/packages/opencode/src/session/projectors-next.ts
@@ -164,14 +164,12 @@ export default [
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Text.Started), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.text.started", data })
   }),
-  SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Text.Delta), () => {}),
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Text.Ended), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.text.ended", data })
   }),
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Tool.Input.Started), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.tool.input.started", data })
   }),
-  SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Tool.Input.Delta), () => {}),
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Tool.Input.Ended), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.tool.input.ended", data })
   }),
@@ -187,7 +185,6 @@ export default [
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Reasoning.Started), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.reasoning.started", data })
   }),
-  SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Reasoning.Delta), () => {}),
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Reasoning.Ended), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.reasoning.ended", data })
   }),
@@ -197,7 +194,6 @@ export default [
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Compaction.Started), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.compaction.started", data })
   }),
-  SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Compaction.Delta), () => {}),
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Compaction.Ended), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.compaction.ended", data })
   }),


### PR DESCRIPTION
## Summary
- publish text and reasoning delta events when the experimental event system is enabled
- keep transient delta events out of session projection storage
- remove skip persistence options from next text/reasoning delta definitions

## Verification
- bun typecheck (packages/core)
- bun typecheck (packages/opencode)
- git push hook: bun turbo typecheck