### PR TITLE
fix(app): only run session.updated archive logic if archive state changes

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -125,18 +125,16 @@ export function applyDirectoryEvent(input: {
       const info = (event.properties as { info: Session }).info
       const result = Binary.search(input.store.session, info.id, (s) => s.id)
       if (info.time.archived) {
-        const resultData = input.store.session[result.index]!
-        if (resultData.time.archived !== info.time.archived) {
-          if (result.found) {
-            input.setStore(
-              "session",
-              produce((draft) => {
-                draft.splice(result.index, 1)
-              }),
-            )
-          }
-          cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
+        if (input.store.session[result.index]!.time.archived === info.time.archived) break
+        if (result.found) {
+          input.setStore(
+            "session",
+            produce((draft) => {
+              draft.splice(result.index, 1)
+            }),
+          )
         }
+        cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
         if (info.parentID) break
         input.setStore("sessionTotal", (value) => Math.max(0, value - 1))
         break

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -126,13 +126,15 @@ export function applyDirectoryEvent(input: {
       const result = Binary.search(input.store.session, info.id, (s) => s.id)
       if (info.time.archived) {
         const resultData = input.store.session[result.index]!
-        if (result.found && resultData.time.archived !== info.time.archived) {
-          input.setStore(
-            "session",
-            produce((draft) => {
-              draft.splice(result.index, 1)
-            }),
-          )
+        if (resultData.time.archived !== info.time.archived) {
+          if (result.found) {
+            input.setStore(
+              "session",
+              produce((draft) => {
+                draft.splice(result.index, 1)
+              }),
+            )
+          }
           cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
         }
         if (info.parentID) break

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -125,15 +125,16 @@ export function applyDirectoryEvent(input: {
       const info = (event.properties as { info: Session }).info
       const result = Binary.search(input.store.session, info.id, (s) => s.id)
       if (info.time.archived) {
-        if (result.found) {
+        const resultData = input.store.session[result.index]!
+        if (result.found && resultData.time.archived !== info.time.archived) {
           input.setStore(
             "session",
             produce((draft) => {
               draft.splice(result.index, 1)
             }),
           )
+          cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
         }
-        cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
         if (info.parentID) break
         input.setStore("sessionTotal", (value) => Math.max(0, value - 1))
         break


### PR DESCRIPTION
If we already know that a session is archived, there's no need to cleanup the session cache and decrease the session count again. Without this check the session and messages list get cleared immediately after prompting an archived session