### PR TITLE
fix(web): route zht locale to Discord instead of Feishu

### DIFF
--- a/README.zht.md
+++ b/README.zht.md
@@ -137,4 +137,4 @@ OpenCode 內建了兩種 Agent，您可以使用 `Tab` 鍵快速切換。
 
 ---
 
-**加入我們的社群** [飞书](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=738j8655-cd59-4633-a30a-1124e0096789&qr_code=true) | [X.com](https://x.com/opencode)
+**加入我們的社群** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)

--- a/packages/console/app/src/component/footer.tsx
+++ b/packages/console/app/src/component/footer.tsx
@@ -10,7 +10,7 @@ export function Footer() {
   const i18n = useI18n()
   const community = createMemo(() => {
     const locale = language.locale()
-    return locale === "zh" || locale === "zht"
+    return locale === "zh"
       ? ({ key: "footer.feishu", link: language.route("/feishu") } as const)
       : ({ key: "footer.discord", link: language.route("/discord") } as const)
   })

--- a/packages/console/app/src/i18n/zht.ts
+++ b/packages/console/app/src/i18n/zht.ts
@@ -24,7 +24,7 @@ export const dict = {
   "footer.github": "GitHub",
   "footer.docs": "文件",
   "footer.changelog": "更新日誌",
-  "footer.feishu": "飞书",
+  "footer.feishu": "飛書",
   "footer.discord": "Discord",
   "footer.x": "X",
 


### PR DESCRIPTION
### Issue for this PR

Closes #27642.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

#16908 routed both `zh` and `zht` locales to a Feishu group. The Traditional Chinese (`zht`) audience is primarily in Hong Kong, Taiwan, Macau, and overseas communities, where Feishu has very little reach. A few practical barriers to joining via Feishu for that audience:

- Signing up for Feishu requires a phone number, and the flow is heavily   oriented toward mainland Chinese numbers.
- Feishu's primary service is operated out of mainland China, which is   a non-trivial consideration for users in jurisdictions with different data-handling expectations.

This PR keeps Feishu for `zh` (Simplified Chinese) — respecting the intent of #16908 for that audience — and routes `zht` back to the existing Discord community:

- `packages/console/app/src/component/footer.tsx`: narrow the Feishu  branch from `locale === "zh" || locale === "zht"` to `locale === "zh"`.
- `README.zht.md`: restore the Discord link in the community footer.
- `packages/console/app/src/i18n/zht.ts`: correct the `footer.feishu`  translation from the Simplified form `飞书` to the Traditional form `飛書`. The key is kept (matching `en.ts`, which also retains it for dictionary completeness) even though the `zht` locale no longer references it from the footer.

No changes to the `zh` locale, the `en` dict, or the `/feishu` redirect route.

### How did you verify your code works?

- Confirmed `language.locale()` returns `"zht"` for Traditional Chinese visitors, which now falls through to the Discord branch in `footer.tsx`.
- Grepped the repo for other references to `footer.feishu` — only the `zh` and `en` dicts remain, both intentional.
- Diff reviewed; scope is limited to the three files above.

### Screenshots / recordings

Text/link-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
