### PR TITLE
fix(provider): respect disabled_providers and enabled_providers in all provider loading loops

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1234,7 +1234,7 @@ export const layer = Layer.effect(
           if (!p || !models) continue
 
           const providerID = ProviderID.make(p.id)
-          if (disabled.has(providerID)) continue
+          if (!isProviderAllowed(providerID)) continue
 
           const provider = database[providerID]
           if (!provider) continue
@@ -1353,7 +1353,7 @@ export const layer = Layer.effect(
         const envs = yield* env.all()
         for (const [id, provider] of Object.entries(database)) {
           const providerID = ProviderID.make(id)
-          if (disabled.has(providerID)) continue
+          if (!isProviderAllowed(providerID)) continue
           const apiKey = provider.env.map((item) => envs[item]).find(Boolean)
           if (!apiKey) continue
           mergeProvider(providerID, {
@@ -1366,7 +1366,7 @@ export const layer = Layer.effect(
         const auths = yield* auth.all().pipe(Effect.orDie)
         for (const [id, provider] of Object.entries(auths)) {
           const providerID = ProviderID.make(id)
-          if (disabled.has(providerID)) continue
+          if (!isProviderAllowed(providerID)) continue
           if (provider.type === "api") {
             mergeProvider(providerID, {
               source: "api",
@@ -1379,7 +1379,7 @@ export const layer = Layer.effect(
         for (const plugin of plugins) {
           if (!plugin.auth) continue
           const providerID = ProviderID.make(plugin.auth.provider)
-          if (disabled.has(providerID)) continue
+          if (!isProviderAllowed(providerID)) continue
 
           const stored = yield* auth.get(providerID).pipe(Effect.orDie)
           if (!stored) continue
@@ -1398,7 +1398,7 @@ export const layer = Layer.effect(
 
         for (const [id, fn] of Object.entries(custom(dep))) {
           const providerID = ProviderID.make(id)
-          if (disabled.has(providerID)) continue
+          if (!isProviderAllowed(providerID)) continue
           const data = database[providerID]
           if (!data) {
             log.error("Provider does not exist in model list " + providerID)


### PR DESCRIPTION
## Summary

This PR fixes issues #12407 and #3417 where disabled_providers and nabled_providers configurations were not being respected during the provider loading process.

## Problem

Previously, several provider loading loops only checked disabled.has(providerID), which meant:

1. Providers excluded by nabled_providers were still loaded (issue #12407)
2. Disabled providers with credentials in uth.json or environment variables were still loaded and shown in opencode models (issue #3417)

## Changes

Replaced 5 instances of disabled.has(providerID) with !isProviderAllowed(providerID) in the following loading stages:

- Plugin provider models loop
- Environment variable provider loading loop
- Auth key provider loading loop
- Plugin auth loader loop
- Custom loaders loop (restores PR #13289 which was closed without merge)

## Verification

isProviderAllowed() already correctly checks both nabled_providers and disabled_providers at lines 1225-1229. This change ensures all loading stages use the same unified filtering logic.

## Related Issues

Fixes #12407
Fixes #3417