### PR TITLE
fix(task): subagent explicit edit:allow overrides parent edit:deny

### DIFF
--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -9,6 +9,9 @@ import type { Agent } from "./agent"
  *    restriction lives on the agent ruleset, not on the session, so a
  *    subagent that only inherited the parent SESSION's permission would
  *    silently bypass it. (#26514)
+ *    Only inherited if the subagent does NOT explicitly allow edit — a
+ *    subagent with `edit: allow` should not have its capability reduced by
+ *    a more-restricted parent.
  * 2. The parent **session's** deny rules and external_directory rules —
  *    same forwarding the original code already did.
  * 3. Default `todowrite` and `task` denies if the subagent's own ruleset
@@ -21,8 +24,23 @@ export function deriveSubagentSessionPermission(input: {
 }): Permission.Ruleset {
   const canTask = input.subagent.permission.some((rule) => rule.permission === "task")
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
+
+  // Only inherit parent edit:deny if the subagent does NOT explicitly allow edit.
+  // A subagent with `edit: allow` (or `edit: { "*": "allow" }`) declares its own
+  // capability — the parent's deny should not override it.
+  // A subagent without explicit edit declaration (implicit deny) inherits the
+  // parent's deny as a ceiling.
+  const subagentAllowsEdit = input.subagent.permission.some(
+    (rule) => rule.permission === "edit" && rule.action === "allow" && rule.pattern === "*",
+  )
+
   const parentAgentDenies =
-    input.parentAgent?.permission.filter((rule) => rule.action === "deny" && rule.permission === "edit") ?? []
+    !subagentAllowsEdit
+      ? (input.parentAgent?.permission.filter(
+          (rule) => rule.action === "deny" && rule.permission === "edit",
+        ) ?? [])
+      : []
+
   return [
     ...parentAgentDenies,
     ...input.parentSessionPermission.filter(

--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -26,12 +26,12 @@ export function deriveSubagentSessionPermission(input: {
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
 
   // Only inherit parent edit:deny if the subagent does NOT explicitly allow edit.
-  // A subagent with `edit: allow` (or `edit: { "*": "allow" }`) declares its own
-  // capability — the parent's deny should not override it.
+  // A subagent with any `edit: allow` rule — whether wildcard or scoped — declares
+  // its own edit capability, and the parent's deny should not override it.
   // A subagent without explicit edit declaration (implicit deny) inherits the
   // parent's deny as a ceiling.
   const subagentAllowsEdit = input.subagent.permission.some(
-    (rule) => rule.permission === "edit" && rule.action === "allow" && rule.pattern === "*",
+    (rule) => rule.permission === "edit" && rule.action === "allow",
   )
 
   const parentAgentDenies =

--- a/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
+++ b/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
@@ -210,3 +210,137 @@ it.effect("subagent inherits parent session deny rules as hard runtime ceilings"
     expect(Permission.evaluate("bash", "git status", effective).action).toBe("deny")
   }),
 )
+
+it.effect("subagent with explicit edit:allow overrides parent edit:deny", () =>
+  Effect.sync(() => {
+    const restrictedParent = testAgent({
+      name: "restricted-parent",
+      mode: "primary",
+      permission: {
+        edit: "deny",
+        bash: "deny",
+        read: "allow",
+        task: {
+          "*": "deny",
+          capableChild: "allow",
+        },
+      },
+    })
+    const capableChild = testAgent({
+      name: "capable-child",
+      mode: "subagent",
+      permission: {
+        edit: "allow",
+        write: "allow",
+        bash: "allow",
+        read: "allow",
+        task: "deny",
+      },
+    })
+
+    const effective = Permission.merge(
+      capableChild.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: [],
+        parentAgent: restrictedParent,
+        subagent: capableChild,
+      }),
+    )
+
+    // Child explicitly allows edit — parent deny should not override
+    expect(Permission.evaluate("edit", "/some/file.ts", effective).action).toBe("allow")
+    expect(Permission.disabled(["edit", "write", "apply_patch"], effective)).toEqual(new Set())
+  }),
+)
+
+it.effect("subagent without explicit edit permission inherits parent edit:deny", () =>
+  Effect.sync(() => {
+    const restrictedParent = testAgent({
+      name: "restricted-parent",
+      mode: "primary",
+      permission: {
+        edit: "deny",
+        read: "allow",
+        task: {
+          "*": "deny",
+          silentChild: "allow",
+        },
+      },
+    })
+    const silentChild = testAgent({
+      name: "silent-child",
+      mode: "subagent",
+      permission: {
+        read: "allow",
+        bash: "allow",
+        task: "deny",
+      },
+    })
+
+    const effective = Permission.merge(
+      silentChild.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: [],
+        parentAgent: restrictedParent,
+        subagent: silentChild,
+      }),
+    )
+
+    // Child has no explicit edit declaration — parent deny should be inherited
+    expect(Permission.evaluate("edit", "/some/file.ts", effective).action).toBe("deny")
+    expect(Permission.disabled(["edit", "write", "apply_patch"], effective)).toEqual(
+      new Set(["edit", "write", "apply_patch"]),
+    )
+  }),
+)
+
+it.effect("[orchestrator-pattern] parent edit:deny does not override subagent explicit edit:allow", () =>
+  Effect.sync(() => {
+    const orchestrator = testAgent({
+      name: "orchestrator",
+      mode: "primary",
+      permission: {
+        edit: "deny",
+        bash: "deny",
+        read: "allow",
+        glob: "allow",
+        grep: "allow",
+        task: {
+          "*": "deny",
+          editor: "allow",
+        },
+        todowrite: "allow",
+        question: "allow",
+        webfetch: "allow",
+      },
+    })
+    const editor = testAgent({
+      name: "editor",
+      mode: "subagent",
+      permission: {
+        edit: "allow",
+        write: "allow",
+        bash: "allow",
+        read: "allow",
+        glob: "allow",
+        grep: "allow",
+        task: "deny",
+        todowrite: "allow",
+      },
+    })
+
+    const effective = Permission.merge(
+      editor.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: [],
+        parentAgent: orchestrator,
+        subagent: editor,
+      }),
+    )
+
+    // Editor should have edit available because it explicitly allows it
+    expect(Permission.evaluate("edit", "/some/file.ts", effective).action).toBe("allow")
+    // edit/write/apply_patch tools should NOT be in disabled set
+    expect(Permission.disabled(["edit", "write", "apply_patch"], effective)).toEqual(new Set())
+  }),
+)

--- a/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
+++ b/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
@@ -253,6 +253,49 @@ it.effect("subagent with explicit edit:allow overrides parent edit:deny", () =>
   }),
 )
 
+it.effect("subagent with scoped edit:allow overrides parent edit:deny", () =>
+  Effect.sync(() => {
+    const restrictedParent = testAgent({
+      name: "restricted-parent",
+      mode: "primary",
+      permission: {
+        edit: { "*": "deny", "src/**": "allow" },
+        bash: "deny",
+        read: "allow",
+        task: {
+          "*": "deny",
+          capableChild: "allow",
+        },
+      },
+    })
+    const scopedChild = testAgent({
+      name: "scoped-child",
+      mode: "subagent",
+      permission: {
+        edit: { "lib/**": "allow" },
+        read: "allow",
+        bash: "allow",
+        task: "deny",
+      },
+    })
+
+    const effective = Permission.merge(
+      scopedChild.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: [],
+        parentAgent: restrictedParent,
+        subagent: scopedChild,
+      }),
+    )
+
+    // Child has scoped edit:allow — parent edit:deny should not be inherited
+    expect(Permission.evaluate("edit", "lib/foo.ts", effective).action).toBe("allow")
+    // Even for paths outside the child's scope, edit should not be blanket denied
+    // (it would be "ask" since there's no matching rule, not "deny")
+    expect(Permission.evaluate("edit", "other/file.ts", effective).action).toBe("ask")
+  }),
+)
+
 it.effect("subagent without explicit edit permission inherits parent edit:deny", () =>
   Effect.sync(() => {
     const restrictedParent = testAgent({


### PR DESCRIPTION
### Issue for this PR

Closes #26758

### Type of change

- [x] Bug fix

### What does this PR do?

`deriveSubagentSessionPermission` unconditionally inherits the parent agent's `edit: deny` rules into the subagent's session. Because permission evaluation is last-match-wins, the inherited deny overrides the subagent's own `edit: allow`. The subagent loses the edit tool entirely.

This breaks any setup where a restricted parent (like an orchestrator with `edit: deny`) deliberately delegates to a capable subagent (like an editor with `edit: allow`).

The fix: only inherit the parent's `edit: deny` when the subagent does NOT explicitly declare `edit: allow`. If a subagent says it can edit, the parent's self-restriction shouldn't override that. If the subagent has no edit rule, the parent's deny still applies as a ceiling.

This works because the permission system is all about ordering — rules that appear last in the merged array win. By not injecting the parent's deny into the session when the subagent explicitly allows edit, the subagent's own allow rule is the last match and wins. The core `evaluate()`, `merge()`, and `disabled()` functions are not touched.

### How did you verify your code works?

Added 3 new tests in `plan-mode-subagent-bypass.test.ts`:
- subagent with explicit `edit: allow` overrides parent `edit: deny`
- subagent without explicit edit inherits parent `edit: deny`
- orchestrator pattern: parent `edit: deny` does not override subagent `edit: allow`

All existing Plan Mode security tests still pass because `general` and `explore` don't have explicit `edit: allow` — so they still inherit the plan agent's deny.

Full test run: 114 tests pass (8 subagent-bypass + 85 permission + 21 permission-task).

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR