### PR TITLE
fix(session): ignore instruction lookup errors

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -118,7 +118,9 @@ export const layer: Layer.Layer<
       // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
       if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
         for (const file of FILES) {
-          const matches = yield* fs.findUp(file, ctx.directory, ctx.worktree)
+          const matches = yield* fs
+            .findUp(file, ctx.directory, ctx.worktree)
+            .pipe(Effect.catch(() => Effect.succeed([])))
           if (matches.length > 0) {
             matches.forEach((item) => paths.add(path.resolve(item)))
             break


### PR DESCRIPTION
## Summary
- Ignore project instruction lookup failures while discovering `AGENTS.md`/`CLAUDE.md`.
- Prevent filesystem discovery errors from aborting prompt preparation before the model stream starts.

## Testing
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`