### PR TITLE
fix: prevent sidecar crash when apply_patch deletes a large/binary file

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -169,7 +169,13 @@ export const ApplyPatchTool = Tool.define(
               ),
             )
             const contentToDelete = source.text
-            const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
+            // Skip diff for large/binary files to prevent storing hundreds of MB in SQLite.
+            // V8 string limit is ~512MB; a 142MB binary file produces a 380MB+ diff.
+            const DIFF_SIZE_LIMIT = 512 * 1024 // 512 KB
+            const deleteDiff =
+              contentToDelete.length > DIFF_SIZE_LIMIT
+                ? ""
+                : trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
 
             const deletions = contentToDelete.split("\n").length
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -635,7 +635,10 @@ export const ContextAwareReplacer: Replacer = function* (content, find) {
   }
 }
 
+const DIFF_MAX_BYTES = 512 * 1024 // 512 KB — keeps SQLite rows manageable and well under V8's string limit
+
 export function trimDiff(diff: string): string {
+  if (diff.length > DIFF_MAX_BYTES) return ""
   const lines = diff.split("\n")
   const contentLines = lines.filter(
     (line) =>


### PR DESCRIPTION
### Issue for this PR

Closes #27657

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `apply_patch` handles a `delete` operation, it calls `createTwoFilesPatch(filePath, filePath, entireContent, "")` and stores the result in the SQLite `part.data` column. For a binary or large file (e.g. a 142 MB `.dmg`) this produces a diff string of ~380 MB. The next time any query runs `StatementSync.all()` over that session's parts, Node's sqlite module passes that 380 MB `char*` directly to `v8::String::NewFromUtf8`. V8 has an internal size assertion that fires at that scale, producing a `SIGTRAP` / `EXC_BREAKPOINT` that kills the entire sidecar process.

The fix in `apply_patch.ts` is a simple pre-flight size check: if the file content exceeds 512 KB we skip diff generation entirely and store an empty string instead. This keeps SQLite rows at a safe size without losing any functional behavior (the deletion still happens; we just don't record a visual diff for it).

The fix in `edit.ts`'s `trimDiff` is a matching early-return guard: if the diff string itself already exceeds 512 KB we return `""` immediately, before the `split("\n")` call that would allocate another equally large array. This protects every call site that goes through `trimDiff`, not just the delete path.

### How did you verify your code works?

Reproduced the crash locally: asked the AI to delete a 142 MB `.dmg` file via `apply_patch`. Before the fix the sidecar hit `SIGTRAP` inside `v8::String::NewFromUtf8` and the crash report showed the exact stack from the issue. After the fix the deletion completes cleanly, the sidecar stays up, and querying the session's parts returns normally.

### Screenshots / recordings

_No UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR