### PR TITLE
docs: add opencode-vision MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -509,3 +509,49 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### opencode-vision
+
+Add vision capabilities to **any** text-only model. When your model can't process images natively (e.g., big-pickle, DeepSeek, MiMo), this MCP server handles image analysis via **Google Gemini Vision API** (FREE tier) and **local tesseract OCR**, returning text descriptions that any model can understand.
+
+**Requirements:**
+- Python >= 3.10
+- Google Gemini API key (get one free at [aistudio.google.com](https://aistudio.google.com/))
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "vision": {
+      "type": "local",
+      "command": ["python3", "-m", "opencode_vision.server"],
+      "enabled": true,
+      "timeout": 30000
+    }
+  }
+}
+```
+
+**Setup:**
+
+1. Install the server:
+   ```bash
+   pip install opencode-vision
+   ```
+2. Set your Gemini API key in `~/.config/opencode/.env`:
+   ```bash
+   echo 'GOOGLE_API_KEY=your_key_here' >> ~/.config/opencode/.env
+   ```
+3. Restart OpenCode.
+
+**Available tools:**
+
+| Tool | Description |
+|------|-------------|
+| `vision_describe(path, prompt?)` | Describe an image's composition, colors, text, and context |
+| `vision_ocr(path)` | Extract text from images via tesseract + Gemini fallback |
+| `vision_analyze(path)` | Full analysis: metadata + description + OCR |
+
+Learn more at [github.com/NickRivers1983/opencode-vision](https://github.com/NickRivers1983/opencode-vision) or `pip install opencode-vision`.


### PR DESCRIPTION
### Issue for this PR

N/A — community contribution, no existing issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-vision](https://pypi.org/project/opencode-vision) to the MCP servers examples section of the docs.

opencode-vision is a Python MCP server that allows text-only models (big-pickle, DeepSeek, etc.) to analyze images via Google Gemini Vision API + local tesseract OCR. It returns text descriptions that any LLM can understand.

The entry includes:
- A configuration example for opencode.json
- Setup instructions (pip install + API key)
- A tool reference table

### How did you verify your code works?

The server was built and tested locally with real images (LinkedIn banner, Canva evaluation slide) before packaging. PyPI package was built (`pip install opencode-vision`) and verified the entry point works. The fork was created from the upstream repo and the docs change was applied to the correct file at `packages/web/src/content/docs/mcp-servers.mdx`.

### Screenshots / recordings

N/A — documentation change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR