### PR TITLE
fix(opencode): resolve TypeScript from workspace root

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -115,12 +115,22 @@ export const Deno: Info = {
 export const Typescript: Info = {
   id: "typescript",
   root: NearestRoot(
-    ["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"],
+    [
+      "package.json",
+      "tsconfig.json",
+      "jsconfig.json",
+      "package-lock.json",
+      "bun.lockb",
+      "bun.lock",
+      "pnpm-lock.yaml",
+      "yarn.lock",
+    ],
     ["deno.json", "deno.jsonc"],
   ),
   extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
   async spawn(root, ctx) {
-    const tsserver = Module.resolve("typescript/lib/tsserver.js", ctx.directory)
+    const tsserver =
+      Module.resolve("typescript/lib/tsserver.js", root) ?? Module.resolve("typescript/lib/tsserver.js", ctx.directory)
     if (!tsserver) return
     const bin = await Npm.which("typescript-language-server")
     if (!bin) return

--- a/packages/opencode/test/lsp/server.test.ts
+++ b/packages/opencode/test/lsp/server.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { Effect } from "effect"
+import fs from "fs/promises"
+import path from "path"
+import { Npm } from "@opencode-ai/core/npm"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import type { InstanceContext } from "@/project/instance-context"
+import * as LSPServer from "@/lsp/server"
+import { tmpdir } from "../fixture/fixture"
+
+const createContext = (directory: string): InstanceContext => ({
+  directory,
+  worktree: directory,
+  project: {
+    id: ProjectV2.ID.global,
+    worktree: directory,
+    time: {
+      created: 0,
+      updated: 0,
+    },
+    sandboxes: [],
+  },
+})
+
+const flags = () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* RuntimeFlags.Service
+    }).pipe(Effect.provide(RuntimeFlags.layer())),
+  )
+
+const writeTypescript = async (dir: string) => {
+  const tsserver = path.join(dir, "node_modules", "typescript", "lib", "tsserver.js")
+  await fs.mkdir(path.dirname(tsserver), { recursive: true })
+  await Bun.write(path.join(dir, "package.json"), "{}")
+  await Bun.write(path.join(dir, "node_modules", "typescript", "package.json"), '{"name":"typescript"}')
+  await Bun.write(tsserver, "")
+  return tsserver
+}
+
+describe("LSP server definitions", () => {
+  test("TypeScript root detects child package configuration", async () => {
+    await using tmp = await tmpdir()
+
+    for (const marker of ["package.json", "tsconfig.json", "jsconfig.json"]) {
+      const root = path.join(tmp.path, marker)
+      await fs.mkdir(path.join(root, "src"), { recursive: true })
+      await Bun.write(path.join(root, marker), "{}")
+
+      expect(await LSPServer.Typescript.root(path.join(root, "src", "server.ts"), createContext(tmp.path))).toBe(root)
+    }
+  })
+
+  test("TypeScript spawn prefers the child root tsserver", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(tmp.path, "apps", "api")
+    const childTsserver = await writeTypescript(root)
+    await writeTypescript(tmp.path)
+    const npmWhich = spyOn(Npm, "which").mockResolvedValue(process.execPath)
+
+    try {
+      const result = await LSPServer.Typescript.spawn(root, createContext(tmp.path), await flags())
+
+      expect(result?.initialization?.tsserver).toEqual({ path: childTsserver })
+      result?.process.kill()
+    } finally {
+      npmWhich.mockRestore()
+    }
+  })
+
+  test("TypeScript spawn falls back to the launch directory tsserver", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(tmp.path, "workspace", "apps", "api")
+    const directory = path.join(tmp.path, "launch")
+    await fs.mkdir(root, { recursive: true })
+    const launchTsserver = await writeTypescript(directory)
+    const npmWhich = spyOn(Npm, "which").mockResolvedValue(process.execPath)
+
+    try {
+      const result = await LSPServer.Typescript.spawn(root, createContext(directory), await flags())
+
+      expect(result?.initialization?.tsserver).toEqual({ path: launchTsserver })
+      result?.process.kill()
+    } finally {
+      npmWhich.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #18694
Addresses the TypeScript-specific case from #7690.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When OpenCode starts at a monorepo root, a TypeScript file may belong to a child package with its own `package.json` or tsconfig. The server detected only lockfile roots and resolved `tsserver.js` from the launch directory.

This makes TypeScript root detection recognize `package.json`, `tsconfig.json`, and `jsconfig.json`, then resolves `typescript/lib/tsserver.js` from that detected root before preserving the launch-directory fallback. The refreshed PR is intentionally TypeScript-only.

### How did you verify your code works?

- `bun test test/lsp --timeout 30000` (61 passed)
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`
- Prettier and `git diff --check`

Tests cover child root detection, root-first `tsserver.js` selection, and launch-directory fallback.

### Screenshots / recordings

N/A. This is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR