### PR TITLE
fix(mcp): authenticate on toggle in TUI MCP picker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
@@ -4,11 +4,18 @@ import { useSync } from "@tui/context/sync"
 import { map, pipe, entries, sortBy } from "remeda"
 import { DialogSelect, type DialogSelectRef, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { useTheme } from "../context/theme"
+import { useToast } from "@tui/ui/toast"
 import { TextAttributes } from "@opentui/core"
 import { useSDK } from "@tui/context/sdk"
 
-function Status(props: { enabled: boolean; loading: boolean }) {
+type LoadingKind = "toggle" | "authenticating"
+type LoadingState = { name: string; kind: LoadingKind }
+
+function Status(props: { enabled: boolean; loading: LoadingKind | null }) {
   const { theme } = useTheme()
+  if (props.loading === "authenticating") {
+    return <span style={{ fg: theme.textMuted }}>⋯ Authenticating (complete in browser)</span>
+  }
   if (props.loading) {
     return <span style={{ fg: theme.textMuted }}>⋯ Loading</span>
   }
@@ -22,13 +29,14 @@ export function DialogMcp() {
   const local = useLocal()
   const sync = useSync()
   const sdk = useSDK()
+  const toast = useToast()
   const [, setRef] = createSignal<DialogSelectRef<unknown>>()
-  const [loading, setLoading] = createSignal<string | null>(null)
+  const [loading, setLoading] = createSignal<LoadingState | null>(null)
 
   const options = createMemo(() => {
     // Track sync data and loading state to trigger re-render when they change
     const mcpData = sync.data.mcp
-    const loadingMcp = loading()
+    const loadingState = loading()
 
     return pipe(
       mcpData ?? {},
@@ -38,11 +46,26 @@ export function DialogMcp() {
         value: name,
         title: name,
         description: status.status === "failed" ? "failed" : status.status,
-        footer: <Status enabled={local.mcp.isEnabled(name)} loading={loadingMcp === name} />,
+        footer: (
+          <Status
+            enabled={local.mcp.isEnabled(name)}
+            loading={loadingState?.name === name ? loadingState.kind : null}
+          />
+        ),
         category: undefined,
       })),
     )
   })
+
+  // Refresh MCP status from server and apply to sync store.
+  const refreshStatus = async () => {
+    const status = await sdk.client.mcp.status()
+    if (status.data) {
+      sync.set("mcp", status.data)
+    } else {
+      console.error("Failed to refresh MCP status: no data returned")
+    }
+  }
 
   const actions = createMemo(() => [
     {
@@ -52,16 +75,51 @@ export function DialogMcp() {
         // Prevent toggling while an operation is already in progress
         if (loading() !== null) return
 
-        setLoading(option.value)
-        try {
-          await local.mcp.toggle(option.value)
-          // Refresh MCP status from server
-          const status = await sdk.client.mcp.status()
-          if (status.data) {
-            sync.set("mcp", status.data)
-          } else {
-            console.error("Failed to refresh MCP status: no data returned")
+        const name = option.value
+        const status = sync.data.mcp[name]
+
+        // For MCPs that need OAuth, run the full authenticate flow instead of
+        // re-running connect (which would only re-trigger the same
+        // UnauthorizedError loop). The server opens the browser, starts the
+        // OAuth callback listener, waits for the redirect, exchanges the
+        // code, and rebuilds the transport.
+        if (status?.status === "needs_auth") {
+          setLoading({ name, kind: "authenticating" })
+          try {
+            // This call blocks for up to 5 minutes (the callback timeout)
+            // while the user completes the OAuth flow in their browser. If
+            // the browser fails to open (headless / SSH / no `open`
+            // binary), the server publishes a `BrowserOpenFailed` event
+            // that surfaces as a toast carrying the URL for manual
+            // opening.
+            const result = await sdk.client.mcp.auth.authenticate({ name })
+            await refreshStatus()
+            if (result.data?.status === "failed") {
+              toast.show({
+                variant: "error",
+                title: "Authentication failed",
+                message: result.data.error,
+                duration: 8000,
+              })
+            }
+          } catch (error) {
+            console.error("Failed to authenticate MCP:", error)
+            toast.show({
+              variant: "error",
+              title: "Authentication failed",
+              message: error instanceof Error ? error.message : String(error),
+              duration: 8000,
+            })
+          } finally {
+            setLoading(null)
           }
+          return
+        }
+
+        setLoading({ name, kind: "toggle" })
+        try {
+          await local.mcp.toggle(name)
+          await refreshStatus()
         } catch (error) {
           console.error("Failed to toggle MCP:", error)
         } finally {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -377,7 +377,7 @@ export const layer = Layer.effect(
                 return bus
                   .publish(TuiEvent.ToastShow, {
                     title: "MCP Authentication Required",
-                    message: `Server "${key}" requires authentication. Run: opencode mcp auth ${key}`,
+                    message: `Server "${key}" requires authentication. Run /mcps or opencode mcp auth ${key} to authenticate`,
                     variant: "warning",
                     duration: 8000,
                   })


### PR DESCRIPTION
### Issue for this PR

Closes #16893

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pressing space on a `needs_auth` MCP in the picker (`/mcps`) now runs the full OAuth flow instead of looping `mcp.connect()`. Previously, toggling a `needs_auth` row called `mcp.connect()`, which immediately re-failed with `UnauthorizedError`, kept the row at `needs_auth`, and emitted a "Run: opencode mcp auth <name>" toast. There was no in-TUI path that actually completed OAuth.

This now calls `mcp.auth.authenticate`, which already exists server-side: opens the browser, awaits the callback, exchanges the code, and rebuilds the transport.

A second loading kind (`authenticating`) is rendered in the row footer while the long-blocking call sits open.

The startup toast for `needs_auth` MCPs is also updated to point at `/mcps` first and the shell command second.

Related: #21702 (broader, not addressed here).

### How did you verify your code works?

- `bun run typecheck` clean (passes pre-push hook).
- Cleared tokens for a Keycloak-backed MCP, opened `/mcps`, pressed space. Browser opened, OAuth completed, row transitioned to `connected`. Repeated on a second MCP.
- Confirmed the original symptom (space did nothing useful) reproduces on `dev` before applying the patch.

### Screenshots / recordings

_None — terminal-only keybinding-behavior change; reproduce locally._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
