### PR TITLE
refactor(tool): read repo overview directory from instance state

### DIFF
--- a/packages/opencode/src/tool/repo_overview.ts
+++ b/packages/opencode/src/tool/repo_overview.ts
@@ -6,7 +6,7 @@ import { assertExternalDirectoryEffect } from "./external-directory"
 import DESCRIPTION from "./repo_overview.txt"
 import * as Tool from "./tool"
 import { parseRepositoryReference, repositoryCachePath } from "@/util/repository"
-import { Instance } from "@/project/instance"
+import { InstanceState } from "@/effect/instance-state"
 
 export const Parameters = Schema.Struct({
   repository: Schema.optional(Schema.String).annotate({
@@ -108,7 +108,7 @@ export const RepoOverviewTool = Tool.define<typeof Parameters, Metadata, AppFile
       params: Schema.Schema.Type<typeof Parameters>,
     ) {
       if (params.path) {
-        const full = path.isAbsolute(params.path) ? params.path : path.resolve(Instance.directory, params.path)
+        const full = path.isAbsolute(params.path) ? params.path : path.resolve(yield* InstanceState.directory, params.path)
         return { path: full, repository: params.repository }
       }
 

--- a/packages/opencode/test/tool/repo_overview.test.ts
+++ b/packages/opencode/test/tool/repo_overview.test.ts
@@ -97,6 +97,21 @@ describe("tool.repo_overview", () => {
     ),
   )
 
+  it.live("resolves relative paths from the instance directory", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        yield* fs.writeWithDirs(path.join(dir, "nested", "README.md"), "# Nested\n")
+
+        const tool = yield* init()
+        const result = yield* tool.execute({ path: "nested" }, ctx)
+
+        expect(result.metadata.path).toBe(path.join(dir, "nested"))
+        expect(result.output).toContain("README.md")
+      }),
+    ),
+  )
+
   it.live("resolves a cached repository from repository shorthand", () =>
     provideTmpdirInstance((_dir) =>
       Effect.gen(function* () {


### PR DESCRIPTION
## summary
- replace the repo_overview tool's legacy Instance.directory read with InstanceState.directory
- add coverage for resolving relative repo_overview paths from the active instance directory

## testing
- bun test test/tool/repo_overview.test.ts
- bun typecheck