### PR TITLE
fix: set exitCode=1 when non-interactive run encounters session errors

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -737,10 +737,7 @@ export const RunCommand = effectCmd({
 
         if (!args.interactive) {
           const events = await client.event.subscribe()
-          loop(client, events).catch((e) => {
-            console.error(e)
-            process.exit(1)
-          })
+          const loopPromise = loop(client, events)
 
           if (args.command) {
             const result = await client.session.command({
@@ -753,6 +750,14 @@ export const RunCommand = effectCmd({
             })
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+              process.exitCode = 1
+            }
+            try {
+              const sessionError = await loopPromise
+              if (sessionError) {
+                process.exitCode = 1
+              }
+            } catch {
               process.exitCode = 1
             }
             return
@@ -768,6 +773,14 @@ export const RunCommand = effectCmd({
           })
           if (result.error) {
             if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+            process.exitCode = 1
+          }
+          try {
+            const sessionError = await loopPromise
+            if (sessionError) {
+              process.exitCode = 1
+            }
+          } catch {
             process.exitCode = 1
           }
           return


### PR DESCRIPTION
## Summary

The `loop()` function in `run.ts` accumulates `session.error` events (e.g., `ProviderModelNotFoundError`) but was called as fire-and-forget. When such errors occur, the `client.session.prompt()` or `client.session.command()` call returns success (HTTP 204), so `process.exitCode` stayed 0. This causes KubeOpenCode to mark Tasks as **Completed** instead of **Failed**.

## Changes

- Store `loopPromise` from `loop()` instead of fire-and forget
- After prompt/command completion, `await loopPromise` and set `process.exitCode = 1` if session errors were detected
- Wrap `await loopPromise` in try/catch to ensure `exitCode=1` on loop exceptions

## Impact

When a non-interactive `opencode run` encounters session errors, the process now exits with code 1. This allows Kubernetes to correctly detect Pod failure and KubeOpenCode to mark the Task as `Failed`.

## Companion PR

kubeopencode/kubeopencode#220