### PR TITLE
fix(tui): sync missing parts for late attach deltas

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/event.ts
@@ -1,6 +1,7 @@
 import type { Event } from "@opencode-ai/sdk/v2"
 import { useProject } from "./project"
 import { useSDK } from "./sdk"
+import { useArgs } from "./args"
 
 type EventMetadata = {
   workspace: string | undefined
@@ -9,6 +10,16 @@ type EventMetadata = {
 export function useEvent() {
   const project = useProject()
   const sdk = useSDK()
+  const args = useArgs()
+
+  function eventSessionID(event: Event) {
+    const properties = event.properties as {
+      sessionID?: string
+      info?: { id?: string; sessionID?: string }
+      part?: { sessionID?: string }
+    }
+    return properties.sessionID ?? properties.info?.sessionID ?? properties.info?.id ?? properties.part?.sessionID
+  }
 
   function subscribe(handler: (event: Event, metadata: EventMetadata) => void) {
     return sdk.event.on("event", (event) => {
@@ -16,7 +27,12 @@ export function useEvent() {
         return
       }
 
-      if (event.directory === "global" || event.project === project.project()) {
+      const sessionID = args.sessionID
+      if (
+        event.directory === "global" ||
+        event.project === project.project() ||
+        (sessionID && eventSessionID(event.payload) === sessionID)
+      ) {
         handler(event.payload, { workspace: event.workspace })
       }
     })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -113,6 +113,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const kv = useKV()
 
     const fullSyncedSessions = new Set<string>()
+    const messageSyncs = new Set<string>()
+    const pendingPartDeltas = new Map<string, Array<{ field: string; delta: string }>>()
 
     function sessionListQuery(): { scope?: "project"; path?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
@@ -131,6 +133,57 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     }
 
     event.subscribe((event, { workspace }) => {
+      const queuePartDelta = (messageID: string, partID: string, field: string, delta: string) => {
+        const key = `${messageID}:${partID}`
+        pendingPartDeltas.set(key, [...(pendingPartDeltas.get(key) ?? []), { field, delta }])
+      }
+
+      const applyPendingPartDeltas = (messageID: string, partID: string, part: Part) => {
+        const key = `${messageID}:${partID}`
+        const deltas = pendingPartDeltas.get(key)
+        if (!deltas) return
+        for (const pending of deltas) {
+          const field = pending.field as keyof typeof part
+          const existing = part[field] as string | undefined
+          ;(part[field] as string) = (existing ?? "") + pending.delta
+        }
+        pendingPartDeltas.delete(key)
+      }
+
+      const syncMessage = (sessionID: string, messageID: string) => {
+        const key = `${sessionID}:${messageID}`
+        if (messageSyncs.has(key)) return
+        messageSyncs.add(key)
+        void sdk.client.session
+          .message({ sessionID, messageID, workspace })
+          .then((response) => {
+            const message = response.data
+            if (!message) return
+            setStore(
+              produce((draft) => {
+                const messages = (draft.message[sessionID] ??= [])
+                const result = Binary.search(messages, message.info.id, (m) => m.id)
+                if (result.found) messages[result.index] = message.info
+                if (!result.found) messages.splice(result.index, 0, message.info)
+                draft.part[message.info.id] = message.parts
+                for (const part of draft.part[message.info.id] ?? []) {
+                  applyPendingPartDeltas(message.info.id, part.id, part)
+                }
+              }),
+            )
+          })
+          .catch((error) => {
+            Log.Default.debug("failed to sync message after late part delta", {
+              sessionID,
+              messageID,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          })
+          .finally(() => {
+            messageSyncs.delete(key)
+          })
+      }
+
       switch (event.type) {
         case "server.instance.disposed":
           void bootstrap()
@@ -326,9 +379,27 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "message.part.delta": {
           const parts = store.part[event.properties.messageID]
-          if (!parts) break
+          if (!parts) {
+            queuePartDelta(
+              event.properties.messageID,
+              event.properties.partID,
+              event.properties.field,
+              event.properties.delta,
+            )
+            syncMessage(event.properties.sessionID, event.properties.messageID)
+            break
+          }
           const result = Binary.search(parts, event.properties.partID, (p) => p.id)
-          if (!result.found) break
+          if (!result.found) {
+            queuePartDelta(
+              event.properties.messageID,
+              event.properties.partID,
+              event.properties.field,
+              event.properties.delta,
+            )
+            syncMessage(event.properties.sessionID, event.properties.messageID)
+            break
+          }
           setStore(
             "part",
             event.properties.messageID,

--- a/packages/opencode/test/cli/tui/use-event.test.tsx
+++ b/packages/opencode/test/cli/tui/use-event.test.tsx
@@ -6,6 +6,7 @@ import { onMount } from "solid-js"
 import { ProjectProvider, useProject } from "../../../src/cli/cmd/tui/context/project"
 import { SDKProvider } from "../../../src/cli/cmd/tui/context/sdk"
 import { useEvent } from "../../../src/cli/cmd/tui/context/event"
+import { ArgsProvider } from "../../../src/cli/cmd/tui/context/args"
 
 const projectID = "proj_test"
 
@@ -46,6 +47,17 @@ function update(version: string): Event {
   }
 }
 
+function sessionStatus(sessionID: string): Event {
+  return {
+    id: `evt_session_status_${sessionID}`,
+    type: "session.status",
+    properties: {
+      sessionID,
+      status: { type: "busy" },
+    },
+  }
+}
+
 function createSource() {
   let fn: ((event: GlobalEvent) => void) | undefined
 
@@ -65,7 +77,7 @@ function createSource() {
   }
 }
 
-async function mount() {
+async function mount(input: { sessionID?: string } = {}) {
   const source = createSource()
   const seen: Event[] = []
   const workspaces: Array<string | undefined> = []
@@ -82,19 +94,21 @@ async function mount() {
   })
 
   const app = await testRender(() => (
-    <SDKProvider url="http://test" directory="/tmp/root" events={source.source} fetch={fetch}>
-      <ProjectProvider>
-        <Probe
-          onReady={async (ctx) => {
-            project = ctx.project
-            await project.sync()
-            done()
-          }}
-          seen={seen}
-          workspaces={workspaces}
-        />
-      </ProjectProvider>
-    </SDKProvider>
+    <ArgsProvider sessionID={input.sessionID}>
+      <SDKProvider url="http://test" directory="/tmp/root" events={source.source} fetch={fetch}>
+        <ProjectProvider>
+          <Probe
+            onReady={async (ctx) => {
+              project = ctx.project
+              await project.sync()
+              done()
+            }}
+            seen={seen}
+            workspaces={workspaces}
+          />
+        </ProjectProvider>
+      </SDKProvider>
+    </ArgsProvider>
   ))
 
   await ready
@@ -174,6 +188,33 @@ describe("useEvent", () => {
       await wait(() => seen.length === 1)
 
       expect(seen).toEqual([update("1.2.3")])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("delivers selected session events even when project metadata does not match", async () => {
+    const { app, emit, seen } = await mount({ sessionID: "ses_selected" })
+
+    try {
+      emit(event(sessionStatus("ses_selected"), { directory: "/tmp/other", project: "proj_other" }))
+
+      await wait(() => seen.length === 1)
+
+      expect(seen).toEqual([sessionStatus("ses_selected")])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("ignores other session events when project metadata does not match", async () => {
+    const { app, emit, seen } = await mount({ sessionID: "ses_selected" })
+
+    try {
+      emit(event(sessionStatus("ses_other"), { directory: "/tmp/other", project: "proj_other" }))
+      await Bun.sleep(30)
+
+      expect(seen).toHaveLength(0)
     } finally {
       app.renderer.destroy()
     }


### PR DESCRIPTION
## Summary
- recover missing message parts when a TUI receives part deltas before the part has been seeded
- route events for the explicitly selected session even when project metadata is not initialized or does not match
- fetch the message through the existing session.message API and replay buffered deltas
- fixes late attach clients that otherwise render only the initial prompt after joining an active child session

## Validation
- bun test test/cli/tui/use-event.test.tsx (from packages/opencode)
- bun run --cwd packages/opencode typecheck
- git push hook: bun turbo typecheck