### PR TITLE
fix(session): compact finished overflowed turns

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -504,6 +504,16 @@ export const layer = Layer.effect(
         }
 
         if (!replay) {
+          const lastNonSummaryAssistant = [...input.messages]
+            .reverse()
+            .find((m) => m.info.role === "assistant" && !m.info.summary)?.info as MessageV2.Assistant | undefined
+          const shouldAutoContinue =
+            !lastNonSummaryAssistant?.finish ||
+            lastNonSummaryAssistant.finish === "tool-calls" ||
+            lastNonSummaryAssistant.finish === "unknown"
+
+          if (!shouldAutoContinue) return result
+
           const info = yield* provider.getProvider(userMessage.model.providerID)
           if (
             (yield* plugin.trigger(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1265,6 +1265,19 @@ export const layer = Layer.effect(
           const hasToolCalls =
             lastAssistantMsg?.parts.some((part) => part.type === "tool" && !part.metadata?.providerExecuted) ?? false
 
+          if (lastFinished && lastFinished.summary !== true) {
+            const modelForCompaction = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID).pipe(
+              Effect.exit,
+            )
+            if (
+              Exit.isSuccess(modelForCompaction) &&
+              (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model: modelForCompaction.value }))
+            ) {
+              yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+              continue
+            }
+          }
+
           if (
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
@@ -1301,15 +1314,6 @@ export const layer = Layer.effect(
               overflow: task.overflow,
             })
             if (result === "stop") break
-            continue
-          }
-
-          if (
-            lastFinished &&
-            lastFinished.summary !== true &&
-            (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
-          ) {
-            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
             continue
           }
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -906,6 +906,40 @@ describe("session.compaction.process", () => {
   )
 
   itCompaction.instance(
+    "does not add synthetic continue prompt when auto compacting after a finished response",
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const ssn = yield* SessionNs.Service
+      const session = yield* ssn.create({})
+      const msg = yield* createUserMessage(session.id, "hello")
+      yield* createAssistantMessage(session.id, msg.id, test.directory)
+      yield* createSummaryCompaction(session.id)
+      const msgs = yield* ssn.messages({ sessionID: session.id })
+      const parent = msgs.at(-1)?.info.id
+      expect(parent).toBeTruthy()
+
+      const result = yield* SessionCompaction.use.process({
+        parentID: parent!,
+        messages: msgs,
+        sessionID: session.id,
+        auto: true,
+      })
+
+      const all = yield* ssn.messages({ sessionID: session.id })
+      expect(result).toBe("continue")
+      expect(
+        all.some(
+          (msg) =>
+            msg.info.role === "user" &&
+            msg.parts.some(
+              (part) => part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps"),
+            ),
+        ),
+      ).toBe(false)
+    }).pipe(withCompaction()),
+  )
+
+  itCompaction.instance(
     "persists tail_start_id for retained recent turns",
     Effect.gen(function* () {
       const ssn = yield* SessionNs.Service

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -164,7 +164,22 @@ const blockingProcessor = Layer.succeed(
   }),
 )
 
-function makeHttp(input?: { processor?: "blocking" }) {
+let fakeCompactionCreateCount = 0
+const fakeOverflowCompaction = Layer.succeed(
+  SessionCompaction.Service,
+  SessionCompaction.Service.of({
+    isOverflow: () => Effect.succeed(true),
+    prune: () => Effect.void,
+    process: () => Effect.succeed("stop" as const),
+    create: () =>
+      Effect.sync(() => {
+        fakeCompactionCreateCount++
+        throw new Error("fake compaction create called")
+      }),
+  }),
+)
+
+function makeHttp(input?: { processor?: "blocking"; compaction?: Layer.Layer<SessionCompaction.Service> }) {
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -210,11 +225,13 @@ function makeHttp(input?: { processor?: "blocking" }) {
           Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
           Layer.provideMerge(deps),
         )
-  const compact = SessionCompaction.layer.pipe(
-    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
-    Layer.provideMerge(proc),
-    Layer.provideMerge(deps),
-  )
+  const compact =
+    input?.compaction ??
+    SessionCompaction.layer.pipe(
+      Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+      Layer.provideMerge(proc),
+      Layer.provideMerge(deps),
+    )
   return Layer.mergeAll(
     TestLLMServer.layer,
     SessionPrompt.layer.pipe(
@@ -237,6 +254,7 @@ function makeHttp(input?: { processor?: "blocking" }) {
 
 const it = testEffect(makeHttp())
 const race = testEffect(makeHttp({ processor: "blocking" }))
+const overflow = testEffect(makeHttp({ compaction: fakeOverflowCompaction }))
 const unix = process.platform !== "win32" ? it.instance : it.instance.skip
 
 // Config that registers a custom "test" provider with a "test-model" model
@@ -471,6 +489,35 @@ it.instance("loop calls LLM and returns assistant message", () =>
     expect(parts.some((p) => p.type === "text" && p.text === "world")).toBe(true)
     expect(yield* llm.hits).toHaveLength(1)
   }),
+)
+
+overflow.instance(
+  "loop creates compaction before exiting when the last finished assistant overflowed",
+  () =>
+    Effect.gen(function* () {
+      fakeCompactionCreateCount = 0
+      yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Overflow finished" })
+      const { assistant } = yield* seed(chat.id, { finish: "stop" })
+
+      yield* sessions.updateMessage({
+        ...assistant,
+        tokens: {
+          total: 120_000,
+          input: 120_000,
+          output: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+      })
+
+      const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(fakeCompactionCreateCount).toBe(1)
+    }),
+  { git: true },
 )
 
 it.instance("prompt emits v2 prompted and synthetic events", () =>


### PR DESCRIPTION
### Issue for this PR

Fixes #15533

Related: #20247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Auto-compaction had two adjacent edge cases when the assistant had already finished normally:

1. The prompt loop exited before checking whether the finished assistant turn had overflowed, so a finished turn over the compaction threshold could skip auto-compaction.
2. When auto-compaction did run after a naturally finished turn, it could inject a synthetic `Continue...` prompt and start another agent response instead of waiting for the next real user message.

This PR moves the finished-turn overflow check before the normal loop exit and skips synthetic auto-continue when the last non-summary assistant has already finished with a non-tool-call finish reason.

### How did you verify your code works?

- `bun test test/session/prompt.test.ts --timeout 30000`
- `bun test test/session/compaction.test.ts --timeout 30000`
- `bun run typecheck`

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR