### PR TITLE
refactor(instance): remove remaining bind call sites

### DIFF
--- a/packages/opencode/src/effect/bridge.ts
+++ b/packages/opencode/src/effect/bridge.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Fiber } from "effect"
+import { Context, Effect, Exit, Fiber } from "effect"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Instance } from "@/project/instance"
 import type { InstanceContext } from "@/project/instance-context"
@@ -11,6 +11,7 @@ export interface Shape {
   readonly promise: <A, E, R>(effect: Effect.Effect<A, E, R>) => Promise<A>
   readonly fork: <A, E, R>(effect: Effect.Effect<A, E, R>) => Fiber.Fiber<A, E>
   readonly run: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E>
+  readonly bind: <Args extends readonly unknown[], Result>(fn: (...args: Args) => Result) => (...args: Args) => Result
 }
 
 function restore<R>(instance: InstanceContext | undefined, workspace: WorkspaceID | undefined, fn: () => R): R {
@@ -20,6 +21,28 @@ function restore<R>(instance: InstanceContext | undefined, workspace: WorkspaceI
   if (instance) return Instance.restore(instance, fn)
   if (workspace !== undefined) return WorkspaceContext.restore(workspace, fn)
   return fn()
+}
+
+function captureSync() {
+  const fiber = Fiber.getCurrent()
+  const value = fiber ? Context.getReferenceUnsafe(fiber.context, InstanceRef) : undefined
+  const instance =
+    value ??
+    (() => {
+      try {
+        return Instance.current
+      } catch (err) {
+        if (!(err instanceof LocalContext.NotFound)) throw err
+      }
+    })()
+  const workspace = (fiber ? Context.getReferenceUnsafe(fiber.context, WorkspaceRef) : undefined) ??
+    WorkspaceContext.workspaceID
+  return { instance, workspace }
+}
+
+export const bind = <Args extends readonly unknown[], Result>(fn: (...args: Args) => Result) => {
+  const captured = captureSync()
+  return (...args: Args) => restore(captured.instance, captured.workspace, () => fn(...args))
 }
 
 /**
@@ -45,16 +68,9 @@ export function make(): Effect.Effect<Shape> {
   return Effect.gen(function* () {
     const ctx = yield* Effect.context()
     const value = yield* InstanceRef
-    const instance =
-      value ??
-      (() => {
-        try {
-          return Instance.current
-        } catch (err) {
-          if (!(err instanceof LocalContext.NotFound)) throw err
-        }
-      })()
-    const workspace = (yield* WorkspaceRef) ?? WorkspaceContext.workspaceID
+    const captured = captureSync()
+    const instance = value ?? captured.instance
+    const workspace = (yield* WorkspaceRef) ?? captured.workspace
     const attach = <A, E, R>(effect: Effect.Effect<A, E, R>) => attachWith(effect, { instance, workspace })
     const wrap = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
       attach(effect).pipe(Effect.provide(ctx)) as Effect.Effect<A, E, never>
@@ -72,6 +88,10 @@ export function make(): Effect.Effect<Shape> {
             ),
           )
         }),
+      bind:
+        <Args extends readonly unknown[], Result>(fn: (...args: Args) => Result) =>
+        (...args: Args) =>
+          restore(instance, workspace, () => fn(...args)),
     } satisfies Shape
   })
 }

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -95,17 +95,14 @@ export const layer = Layer.effect(
             Effect.promise(() => Promise.allSettled(subs.map((sub) => sub.unsubscribe()))),
           )
 
-          const cb: ParcelWatcher.SubscribeCallback = (err, evts) => {
+          const cb: ParcelWatcher.SubscribeCallback = bridge.bind((err, evts) => {
             if (err) return
             for (const evt of evts) {
-              if (evt.type === "create")
-                bridge.fork(Effect.promise(() => Bus.publish(Event.Updated, { file: evt.path, event: "add" })))
-              if (evt.type === "update")
-                bridge.fork(Effect.promise(() => Bus.publish(Event.Updated, { file: evt.path, event: "change" })))
-              if (evt.type === "delete")
-                bridge.fork(Effect.promise(() => Bus.publish(Event.Updated, { file: evt.path, event: "unlink" })))
+              if (evt.type === "create") void Bus.publish(Event.Updated, { file: evt.path, event: "add" })
+              if (evt.type === "update") void Bus.publish(Event.Updated, { file: evt.path, event: "change" })
+              if (evt.type === "delete") void Bus.publish(Event.Updated, { file: evt.path, event: "unlink" })
             }
-          }
+          })
 
           const subscribe = (dir: string, ignore: string[]) => {
             const pending = w.subscribe(dir, cb, { ignore, backend })

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -6,6 +6,7 @@ import { readdir, realpath } from "fs/promises"
 import path from "path"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
+import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Git } from "@/git"
@@ -88,20 +89,23 @@ export const layer = Layer.effect(
           if (!w) return
 
           log.info("watcher backend", { directory: ctx.directory, platform: process.platform, backend })
-
+          const bridge = yield* EffectBridge.make()
           const subs: ParcelWatcher.AsyncSubscription[] = []
           yield* Effect.addFinalizer(() =>
             Effect.promise(() => Promise.allSettled(subs.map((sub) => sub.unsubscribe()))),
           )
 
-          const cb: ParcelWatcher.SubscribeCallback = InstanceState.bind((err, evts) => {
+          const cb: ParcelWatcher.SubscribeCallback = (err, evts) => {
             if (err) return
             for (const evt of evts) {
-              if (evt.type === "create") void Bus.publish(Event.Updated, { file: evt.path, event: "add" })
-              if (evt.type === "update") void Bus.publish(Event.Updated, { file: evt.path, event: "change" })
-              if (evt.type === "delete") void Bus.publish(Event.Updated, { file: evt.path, event: "unlink" })
+              if (evt.type === "create")
+                bridge.fork(Effect.promise(() => Bus.publish(Event.Updated, { file: evt.path, event: "add" })))
+              if (evt.type === "update")
+                bridge.fork(Effect.promise(() => Bus.publish(Event.Updated, { file: evt.path, event: "change" })))
+              if (evt.type === "delete")
+                bridge.fork(Effect.promise(() => Bus.publish(Event.Updated, { file: evt.path, event: "unlink" })))
             }
-          })
+          }
 
           const subscribe = (dir: string, ignore: string[]) => {
             const pending = w.subscribe(dir, cb, { ignore, backend })

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -256,7 +256,7 @@ const live: Layer.Layer<
 
         const bridge = yield* EffectBridge.make()
         const approvedToolsForSession = new Set<string>()
-        workflowModel.approvalHandler = async (approvalTools) => {
+        workflowModel.approvalHandler = bridge.bind(async (approvalTools) => {
           const uniqueNames = [...new Set(approvalTools.map((t: { name: string }) => t.name))] as string[]
           // Auto-approve tools that were already approved in this session
           // (prevents infinite approval loops for server-side MCP tools)
@@ -267,13 +267,9 @@ const live: Layer.Layer<
           const id = PermissionID.ascending()
           let unsub: (() => void) | undefined
           try {
-            unsub = await bridge.promise(
-              Effect.sync(() =>
-                Bus.subscribe(Permission.Event.Replied, (evt) => {
-                  if (evt.properties.requestID === id) void evt.properties.reply
-                }),
-              ),
-            )
+            unsub = Bus.subscribe(Permission.Event.Replied, (evt) => {
+              if (evt.properties.requestID === id) void evt.properties.reply
+            })
             const toolPatterns = approvalTools.map((t: { name: string; args: string }) => {
               try {
                 const parsed = JSON.parse(t.args) as Record<string, unknown>
@@ -303,7 +299,7 @@ const live: Layer.Layer<
           } finally {
             unsub?.()
           }
-        }
+        })
       }
 
       const tracer = cfg.experimental?.openTelemetry

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -256,7 +256,7 @@ const live: Layer.Layer<
 
         const bridge = yield* EffectBridge.make()
         const approvedToolsForSession = new Set<string>()
-        workflowModel.approvalHandler = InstanceState.bind(async (approvalTools) => {
+        workflowModel.approvalHandler = async (approvalTools) => {
           const uniqueNames = [...new Set(approvalTools.map((t: { name: string }) => t.name))] as string[]
           // Auto-approve tools that were already approved in this session
           // (prevents infinite approval loops for server-side MCP tools)
@@ -267,9 +267,13 @@ const live: Layer.Layer<
           const id = PermissionID.ascending()
           let unsub: (() => void) | undefined
           try {
-            unsub = Bus.subscribe(Permission.Event.Replied, (evt) => {
-              if (evt.properties.requestID === id) void evt.properties.reply
-            })
+            unsub = await bridge.promise(
+              Effect.sync(() =>
+                Bus.subscribe(Permission.Event.Replied, (evt) => {
+                  if (evt.properties.requestID === id) void evt.properties.reply
+                }),
+              ),
+            )
             const toolPatterns = approvalTools.map((t: { name: string; args: string }) => {
               try {
                 const parsed = JSON.parse(t.args) as Record<string, unknown>
@@ -299,7 +303,7 @@ const live: Layer.Layer<
           } finally {
             unsub?.()
           }
-        })
+        }
       }
 
       const tracer = cfg.experimental?.openTelemetry

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -11,11 +11,9 @@ import path from "path"
 import { readFileSync, readdirSync, existsSync } from "fs"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
-import { WorkspaceContext } from "@/control-plane/workspace-context"
-import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
-import { context as instanceContext } from "@/project/instance-context"
+import { EffectBridge } from "@/effect/bridge"
 import { init } from "#db"
-import { Context, Effect, Fiber, Schema } from "effect"
+import { Effect, Schema } from "effect"
 
 declare const OPENCODE_MIGRATIONS: { sql: string; timestamp: number; name: string }[] | undefined
 
@@ -200,24 +198,7 @@ export function transaction<T>(
 }
 
 function bindInstanceRef<Args extends readonly unknown[], Result>(fn: (...args: Args) => Result) {
-  const fiber = Fiber.getCurrent()
-  const instance = fiber
-    ? Context.getReferenceUnsafe(fiber.context, InstanceRef)
-    : (() => {
-        try {
-          return instanceContext.use()
-        } catch (err) {
-          if (!(err instanceof LocalContext.NotFound)) throw err
-        }
-      })()
-  const workspace = fiber ? Context.getReferenceUnsafe(fiber.context, WorkspaceRef) : WorkspaceContext.workspaceID
-  if (!instance && workspace === undefined) return fn
-  return (...args: Args) => {
-    const run = () => fn(...args)
-    const withInstance = instance ? () => instanceContext.provide(instance, run) : run
-    if (workspace === undefined) return withInstance()
-    return WorkspaceContext.restore(workspace, withInstance)
-  }
+  return EffectBridge.bind(fn)
 }
 
 export * as Database from "./db"

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -167,7 +167,7 @@ export function use<T>(callback: (trx: TxOrDb) => T): T {
 }
 
 export function effect(fn: () => any | Promise<any>) {
-  const bound = bindInstanceRef(fn)
+  const bound = EffectBridge.bind(fn)
   try {
     ctx.use().effects.push(bound)
   } catch {
@@ -188,17 +188,13 @@ export function transaction<T>(
   } catch (err) {
     if (err instanceof LocalContext.NotFound) {
       const effects: (() => void | Promise<void>)[] = []
-      const txCallback = bindInstanceRef((tx: TxOrDb) => ctx.provide({ tx, effects }, () => callback(tx)))
+      const txCallback = EffectBridge.bind((tx: TxOrDb) => ctx.provide({ tx, effects }, () => callback(tx)))
       const result = Client().transaction(txCallback, { behavior: options?.behavior })
       for (const effect of effects) effect()
       return result as NotPromise<T>
     }
     throw err
   }
-}
-
-function bindInstanceRef<Args extends readonly unknown[], Result>(fn: (...args: Args) => Result) {
-  return EffectBridge.bind(fn)
 }
 
 export * as Database from "./db"

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -11,9 +11,11 @@ import path from "path"
 import { readFileSync, readdirSync, existsSync } from "fs"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
-import { InstanceState } from "@/effect/instance-state"
+import { WorkspaceContext } from "@/control-plane/workspace-context"
+import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
+import { context as instanceContext } from "@/project/instance-context"
 import { init } from "#db"
-import { Effect, Schema } from "effect"
+import { Context, Effect, Fiber, Schema } from "effect"
 
 declare const OPENCODE_MIGRATIONS: { sql: string; timestamp: number; name: string }[] | undefined
 
@@ -167,7 +169,7 @@ export function use<T>(callback: (trx: TxOrDb) => T): T {
 }
 
 export function effect(fn: () => any | Promise<any>) {
-  const bound = InstanceState.bind(fn)
+  const bound = bindInstanceRef(fn)
   try {
     ctx.use().effects.push(bound)
   } catch {
@@ -188,12 +190,33 @@ export function transaction<T>(
   } catch (err) {
     if (err instanceof LocalContext.NotFound) {
       const effects: (() => void | Promise<void>)[] = []
-      const txCallback = InstanceState.bind((tx: TxOrDb) => ctx.provide({ tx, effects }, () => callback(tx)))
+      const txCallback = bindInstanceRef((tx: TxOrDb) => ctx.provide({ tx, effects }, () => callback(tx)))
       const result = Client().transaction(txCallback, { behavior: options?.behavior })
       for (const effect of effects) effect()
       return result as NotPromise<T>
     }
     throw err
+  }
+}
+
+function bindInstanceRef<Args extends readonly unknown[], Result>(fn: (...args: Args) => Result) {
+  const fiber = Fiber.getCurrent()
+  const instance = fiber
+    ? Context.getReferenceUnsafe(fiber.context, InstanceRef)
+    : (() => {
+        try {
+          return instanceContext.use()
+        } catch (err) {
+          if (!(err instanceof LocalContext.NotFound)) throw err
+        }
+      })()
+  const workspace = fiber ? Context.getReferenceUnsafe(fiber.context, WorkspaceRef) : WorkspaceContext.workspaceID
+  if (!instance && workspace === undefined) return fn
+  return (...args: Args) => {
+    const run = () => fn(...args)
+    const withInstance = instance ? () => instanceContext.provide(instance, run) : run
+    if (workspace === undefined) return withInstance()
+    return WorkspaceContext.restore(workspace, withInstance)
   }
 }
 


### PR DESCRIPTION
## summary
- centralize instance/workspace callback restoration in EffectBridge.bind
- migrate file watcher, workflow approval, and database callbacks off InstanceState.bind
- keep callback owners simple while preserving sync watcher/DB behavior and async approval flow

## testing
- bun typecheck
- bun test \"test/session/llm.test.ts\"
- bun test \"test/storage/db.test.ts\" \"test/sync/index.test.ts\"
- bun test \"test/file/watcher.test.ts\" *(5 watcher cases pass; the symlinked .git case times out locally, and the same timeout reproduces with the original callback restored on dev)*