### PR TITLE
chore: add opencode-sync-memory to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
+| [opencode-sync-memory](https://github.com/nutter77-fossmc/opencode-sync-memory)                   | Persistent memory synced across machines via private GitHub repo, with cross-session search       |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-sync-memory](https://github.com/nutter77-fossmc/opencode-sync-memory) to the ecosystem plugins list — a persistent memory plugin for opencode that syncs across machines via a private GitHub repo.

### How did you verify your code works?

The plugin compiles, is published on npm, and follows the existing ecosystem entry format.

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR