### PR TITLE
refactor(acp): extract runtime reentry

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -39,29 +39,19 @@ import { Filesystem } from "@/util/filesystem"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { ACPSessionManager } from "./session"
 import type { ACPConfig } from "./types"
+import { ACPRuntime } from "./runtime"
 import { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
-import { Agent as AgentModule } from "../agent/agent"
-import { AppRuntime } from "@/effect/app-runtime"
-import { InstanceRef } from "@/effect/instance-ref"
-import { InstanceRuntime } from "@/project/instance-runtime"
 import { Installation } from "@/installation"
 import { MessageV2 } from "@/session/message-v2"
 import { Config } from "@/config/config"
 import { ConfigMCP } from "@/config/mcp"
 import { Todo } from "@/session/todo"
-import { Effect, Result, Schema } from "effect"
+import { Result, Schema } from "effect"
 import { LoadAPIKeyError } from "ai"
 import type { AssistantMessage, Event, OpencodeClient, SessionMessageResponse, ToolPart } from "@opencode-ai/sdk/v2"
 import { applyPatch } from "diff"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
-
-const defaultAgentInfo = async (directory: string) => {
-  const ctx = await InstanceRuntime.load({ directory })
-  return AppRuntime.runPromise(
-    AgentModule.Service.use((svc) => svc.defaultInfo()).pipe(Effect.provideService(InstanceRef, ctx)),
-  )
-}
 import { ShellID } from "@/tool/shell/id"
 
 type ModeOption = { id: string; name: string; description?: string }
@@ -1103,7 +1093,7 @@ export class Agent implements ACPAgent {
 
     const currentModeId = await (async () => {
       if (!availableModes.length) return undefined
-      const defaultAgent = await defaultAgentInfo(directory)
+      const defaultAgent = await ACPRuntime.defaultAgentInfo(directory)
       const resolvedModeId = availableModes.find((mode) => mode.name === defaultAgent.name)?.id ?? availableModes[0].id
       this.sessionManager.setMode(sessionId, resolvedModeId)
       return resolvedModeId
@@ -1337,7 +1327,7 @@ export class Agent implements ACPAgent {
     if (!current) {
       this.sessionManager.setModel(session.id, model)
     }
-    const agent = session.modeId ?? (await defaultAgentInfo(directory)).name
+    const agent = session.modeId ?? (await ACPRuntime.defaultAgentInfo(directory)).name
 
     const parts: Array<
       | { type: "text"; text: string; synthetic?: boolean; ignored?: boolean }

--- a/packages/opencode/src/acp/runtime.ts
+++ b/packages/opencode/src/acp/runtime.ts
@@ -1,0 +1,22 @@
+import { Agent } from "@/agent/agent"
+import { AppRuntime, type AppServices } from "@/effect/app-runtime"
+import { InstanceRef } from "@/effect/instance-ref"
+import { InstanceRuntime } from "@/project/instance-runtime"
+import { Effect } from "effect"
+
+// Global ACP Effect re-entry: no project InstanceRef is provided.
+export const runGlobal = AppRuntime.runPromise
+
+// Directory-scoped ACP Effect re-entry: load the project instance and provide InstanceRef.
+export async function runDirectory<A, E>(input: { directory: string; effect: Effect.Effect<A, E, AppServices> }) {
+  const ctx = await InstanceRuntime.load({ directory: input.directory })
+  return AppRuntime.runPromise(input.effect.pipe(Effect.provideService(InstanceRef, ctx)))
+}
+
+export const defaultAgentInfo = (directory: string) =>
+  runDirectory({
+    directory,
+    effect: Agent.Service.use((svc) => svc.defaultInfo()),
+  })
+
+export * as ACPRuntime from "./runtime"


### PR DESCRIPTION
## summary
- extract ACP-local Effect re-entry into `src/acp/runtime.ts`
- make directory-scoped re-entry provide `InstanceRef` via `InstanceRuntime.load`

## testing
- `bun test "test/acp/event-subscription.test.ts"`
- `bun typecheck`
- pre-push `bun turbo typecheck`