### PR TITLE
fix(server): implement findSymbol endpoint via LSP workspaceSymbol

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -1,6 +1,7 @@
 import * as InstanceState from "@/effect/instance-state"
 import { File } from "@/file"
 import { Ripgrep } from "@/file/ripgrep"
+import { LSP } from "@/lsp/lsp"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
@@ -9,6 +10,7 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
   Effect.gen(function* () {
     const svc = yield* File.Service
     const ripgrep = yield* Ripgrep.Service
+    const lsp = yield* LSP.Service
 
     const findText = Effect.fn("FileHttpApi.findText")(function* (ctx: { query: { pattern: string } }) {
       return (yield* ripgrep
@@ -27,8 +29,8 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
       })
     })
 
-    const findSymbol = Effect.fn("FileHttpApi.findSymbol")(function* () {
-      return []
+    const findSymbol = Effect.fn("FileHttpApi.findSymbol")(function* (ctx: { query: { query: string } }) {
+      return yield* lsp.workspaceSymbol(ctx.query.query)
     })
 
     const list = Effect.fn("FileHttpApi.list")(function* (ctx: { query: { path: string } }) {

--- a/packages/opencode/test/server/httpapi-file.test.ts
+++ b/packages/opencode/test/server/httpapi-file.test.ts
@@ -72,6 +72,8 @@ describe("file HttpApi", () => {
     expect(await files.json()).toContain("hello.txt")
 
     expect(symbols.status).toBe(200)
-    expect(await symbols.json()).toEqual([])
+    // No LSP server is active in the test environment, so the result is an empty array.
+    // The endpoint delegates to LSP.workspaceSymbol — it no longer returns a hardcoded stub.
+    expect(await symbols.json()).toBeArray()
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #27650

### Type of change

- [x] Bug fix

### What does this PR do?

`findSymbol` in `handlers/file.ts` was a stub returning `[]` unconditionally. Wires it to `LSP.Service.workspaceSymbol` so the endpoint actually queries active LSP servers. Also updates the test assertion which was asserting the stub behavior.

Note: PR #27643 addresses the same issue but is submitted from the `dev` branch directly. This PR uses a dedicated fix branch and includes a test update.

### How did you verify your code works?

- `bun typecheck` — no new errors
- `bun test test/server/httpapi-file.test.ts --timeout 30000` — endpoint returns 200 with array response

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR