### PR TITLE
fix(provider): prefer per-model temperature over agent override

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -169,7 +169,7 @@ const live: Layer.Layer<
         },
         {
           temperature: input.model.capabilities.temperature
-            ? (input.agent.temperature ?? ProviderTransform.temperature(input.model))
+            ? (ProviderTransform.temperature(input.model) ?? input.agent.temperature)
             : undefined,
           topP: input.agent.topP ?? ProviderTransform.topP(input.model),
           topK: ProviderTransform.topK(input.model),


### PR DESCRIPTION
## Problem

`ProviderTransform.temperature(model)` in `src/provider/transform.ts` returns the temperature value a given model family requires (kimi-k2.* -> 1.0 or 0.6; gemini / glm-4.6 / glm-4.7 / minimax-m2 -> 1.0; qwen -> 0.55). Several of these are hard requirements: Moonshot rejects any other value for the kimi-k2 family with `HTTP 400 invalid temperature: only 1 is allowed for this model`.

The call site in `packages/opencode/src/session/llm.ts:172` consults that function in the wrong order:

```ts
input.agent.temperature ?? ProviderTransform.temperature(input.model)
```

The built-in `title` agent (`packages/opencode/src/agent/agent.ts:253`) hard-codes `temperature: 0.5`. Because `??` short-circuits on the first non-nullish operand, the agent default always wins and a temperature of 0.5 is sent to e.g. kimi-k2.6, which then 400s.

I observed this in production telemetry across multiple users on kimi-k2.6 (the most common case). The same code path will trip whenever an agent sets a temperature on any of the strict-required model families.

## Fix

Swap the operands at the single call site:

```ts
ProviderTransform.temperature(input.model) ?? input.agent.temperature
```

The transform function exists precisely because it encodes model-aware knowledge of what each family expects; that knowledge should beat a generic agent default. For models *not* covered by the transform map (claude, openai, etc.), the function returns `undefined` and the agent preference still applies through normal `??` fallthrough - so the only behavior change is on the families already flagged as needing specific values.

This also aligns temperature with the adjacent `topK` (no agent override) and brings it closer to `topP` (still `agent ?? transform`, but `topP` has no known strict-required cases today).

## Diff

```
 packages/opencode/src/session/llm.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Notes

This was originally fixed in a downstream fork (browser-use/browsercode#64) where it was hit in production telemetry. The same code is unchanged on `dev` here, so opening the equivalent upstream PR.