### PR TITLE
feat(tui): show sidebar file diff totals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/files.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/files.tsx
@@ -8,6 +8,15 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
   const list = createMemo(() => props.api.state.session.diff(props.session_id))
+  const totals = createMemo(() =>
+    list().reduce(
+      (acc, item) => ({
+        additions: acc.additions + item.additions,
+        deletions: acc.deletions + item.deletions,
+      }),
+      { additions: 0, deletions: 0 },
+    ),
+  )
 
   return (
     <Show when={list().length > 0}>
@@ -19,6 +28,14 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
           <text fg={theme().text}>
             <b>Modified Files</b>
           </text>
+          <box flexDirection="row" gap={1}>
+            <Show when={totals().additions}>
+              <text fg={theme().diffAdded}>+{totals().additions}</text>
+            </Show>
+            <Show when={totals().deletions}>
+              <text fg={theme().diffRemoved}>-{totals().deletions}</text>
+            </Show>
+          </box>
         </box>
         <Show when={list().length <= 2 || open()}>
           <For each={list()}>

--- a/packages/opencode/test/cli/tui/sidebar-files.test.tsx
+++ b/packages/opencode/test/cli/tui/sidebar-files.test.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { TuiPluginApi, TuiSlotPlugin } from "@opencode-ai/plugin/tui"
+import SidebarFiles from "@/cli/cmd/tui/feature-plugins/sidebar/files"
+import { createTuiPluginApi } from "../../fixture/tui-plugin"
+
+test("sidebar files renders aggregate additions and deletions in the header", async () => {
+  let sidebarContent: TuiSlotPlugin["slots"]["sidebar_content"]
+  const base = createTuiPluginApi({
+    state: {
+      session: {
+        diff(sessionID) {
+          if (sessionID !== "ses_test") return []
+          return [
+            { file: "src/one.ts", additions: 2, deletions: 1 },
+            { file: "src/two.ts", additions: 4, deletions: 0 },
+            { file: "src/three.ts", additions: 0, deletions: 3 },
+          ]
+        },
+      },
+    },
+  })
+  const api: TuiPluginApi = {
+    ...base,
+    slots: {
+      register(plugin: TuiSlotPlugin) {
+        sidebarContent = plugin.slots.sidebar_content
+        return "internal:sidebar-files"
+      },
+    },
+  }
+
+  await SidebarFiles.tui(api, undefined, {
+    id: "internal:sidebar-files",
+    source: "internal",
+    spec: "internal:sidebar-files",
+    target: "internal:sidebar-files",
+    first_time: 0,
+    last_time: 0,
+    time_changed: 0,
+    load_count: 1,
+    fingerprint: "internal",
+    state: "same",
+  })
+
+  if (!sidebarContent) throw new Error("sidebar files slot was not registered")
+  const renderSidebarContent = sidebarContent
+
+  const app = await testRender(
+    () => (
+      <box width={80} height={8}>
+        {renderSidebarContent({ theme: api.theme }, { session_id: "ses_test" })}
+      </box>
+    ),
+    {
+      width: 80,
+      height: 8,
+    },
+  )
+
+  try {
+    await app.renderOnce()
+
+    const frame = app.captureCharFrame().replace(/ +/g, " ")
+    expect(frame).toContain("Modified Files +6 -4")
+    expect(frame).toContain("src/one.ts")
+    expect(frame).toContain("+2")
+    expect(frame).toContain("-1")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #27793

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shows the total additon/deletion count next to Modified Files in the TUI sidebar, using the same theme colors as each file row.

This makes the sidebar a bit closer to a PR file list, so you can see the overal diff size without doing math in your head. I just find this quicker / easier especially when I run "cleanup" agents to actually quickly see if there is more red than green =) 

### How did you verify your code works?

- bun test test/cli/tui/sidebar-files.test.tsx
- bun typecheck
- bun test test/cli/tui
- git push pre-push typecheck also passed

### Screenshots / recordings

<img width="298" height="331" alt="Screenshot 2026-05-15 at 23 13 21" src="https://github.com/user-attachments/assets/12470858-7c6d-4d7b-b724-2e31e9377e9f" />
<img width="293" height="257" alt="Screenshot 2026-05-15 at 23 14 12" src="https://github.com/user-attachments/assets/eef8b74b-8a6a-4bf1-bb75-38fa64603975" />
<img width="291" height="92" alt="Screenshot 2026-05-15 at 23 14 24" src="https://github.com/user-attachments/assets/de3ccbd4-0bc0-4a84-bacd-bbfd8e4b19af" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._