### PR TITLE
fix(opencode): treat replaceAll edit replacements literally

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -694,7 +694,7 @@ export function replace(content: string, oldString: string, newString: string, r
       if (index === -1) continue
       notFound = false
       if (replaceAll) {
-        return content.replaceAll(search, newString)
+        return content.replaceAll(search, () => newString)
       }
       const lastIndex = content.lastIndexOf(search)
       if (index !== lastIndex) continue

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -222,6 +222,18 @@ describe("tool.edit", () => {
       }),
     )
 
+    it.instance("treats replaceAll replacement as literal file content", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "file.txt")
+        yield* put(filepath, "foo foo")
+
+        yield* run({ filePath: filepath, oldString: "foo", newString: "$&", replaceAll: true })
+
+        expect(yield* load(filepath)).toBe("$& $&")
+      }),
+    )
+
     it.instance("emits change event for existing files", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance


### PR DESCRIPTION
## Summary
- Fix `edit` tool `replaceAll` so replacement text is inserted literally.
- Add a regression test for replacement strings containing JavaScript replacement tokens such as `$&`.

## Why
`String.prototype.replaceAll(search, replacement)` interprets `$&`, `$$`, and related sequences in `replacement`. The edit tool should write the requested `newString` as literal file content, not reinterpret it as a JavaScript replacement pattern.

## Test plan
- `mise exec bun@1.3.13 -- bun test test/tool/edit.test.ts -t "treats replaceAll replacement as literal file content"`
- `mise exec bun@1.3.13 -- bun test test/tool/edit.test.ts`
- `mise exec bun@1.3.13 -- bun run typecheck` from `packages/opencode`
- `mise exec bun@1.3.13 -- bun run lint` from repo root — exits 0 with existing warnings
