### PR TITLE
fix(tui): dedupe consecutive prompt history entries

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -27,6 +27,11 @@ export type PromptInfo = {
 
 const MAX_HISTORY_ENTRIES = 50
 
+export function isDuplicateEntry(previous: PromptInfo | undefined, next: PromptInfo): boolean {
+  if (!previous) return false
+  return JSON.stringify(previous) === JSON.stringify(next)
+}
+
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",
   init: () => {
@@ -83,6 +88,10 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
       },
       append(item: PromptInfo) {
         const entry = structuredClone(unwrap(item))
+        if (isDuplicateEntry(store.history.at(-1), entry)) {
+          setStore("index", 0)
+          return
+        }
         let trimmed = false
         setStore(
           produce((draft) => {

--- a/packages/opencode/test/cli/cmd/tui/prompt-history.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-history.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { isDuplicateEntry, type PromptInfo } from "../../../../src/cli/cmd/tui/component/prompt/history"
+
+const entry = (input: string, parts: PromptInfo["parts"] = []): PromptInfo => ({ input, parts })
+
+describe("prompt history dedupe", () => {
+  test("returns false when there is no previous entry", () => {
+    expect(isDuplicateEntry(undefined, entry("hello"))).toBe(false)
+  })
+
+  test("dedupes identical consecutive entries", () => {
+    const a = entry("hello world this is over twenty chars")
+    const b = entry("hello world this is over twenty chars")
+    expect(isDuplicateEntry(a, b)).toBe(true)
+  })
+
+  test("does not dedupe when input text differs", () => {
+    expect(isDuplicateEntry(entry("foo"), entry("bar"))).toBe(false)
+  })
+
+  test("does not dedupe when parts differ", () => {
+    const a = entry("describe this", [
+      {
+        type: "file",
+        mime: "image/png",
+        filename: "a.png",
+        url: "data:image/png;base64,AAA",
+      },
+    ])
+    const b = entry("describe this", [
+      {
+        type: "file",
+        mime: "image/png",
+        filename: "b.png",
+        url: "data:image/png;base64,BBB",
+      },
+    ])
+    expect(isDuplicateEntry(a, b)).toBe(false)
+  })
+
+  test("does not dedupe when mode differs", () => {
+    expect(isDuplicateEntry({ ...entry("ls"), mode: "normal" }, { ...entry("ls"), mode: "shell" })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Clearing a prompt with at least 20 characters saves the draft to prompt history (in-memory + `prompt-history.jsonl`). If you then press the history-previous keybind to restore that entry and clear it again, the same entry was being appended a second time — every cycle adds another duplicate.

The fix is a standard shell-style dedupe: skip the append when the new entry deep-equals the most recent history entry.

## Changes

- `packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx` — new pure helper `isDuplicateEntry(prev, next)` (deep compare via JSON), called at the top of `append()`. On a duplicate, only the index is reset (so navigation stays consistent), and no write hits memory or disk.
- `packages/opencode/test/cli/cmd/tui/prompt-history.test.ts` — unit tests for the dedupe helper covering no-previous, identical, differing input, differing parts, and differing mode.

## Test plan

- [x] `bun run test test/cli/cmd/tui/prompt-history.test.ts` — 5 pass
- [x] `bun run typecheck` — clean
- [ ] Manual: type >20 chars, clear, press ↑, clear again — only one entry in `prompt-history.jsonl`