### PR TITLE
docs: add LiteLLM plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -19,6 +19,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [opencode-daytona](https://github.com/daytonaio/daytona/tree/main/libs/opencode-plugin)            | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                                |
+| [@finger_xie/opencode-plugin-litellm](https://github.com/yuyu1025/opencode-plugin-litellm)         | Connect OpenCode to LiteLLM with `/connect` support and automatic model discovery                 |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |


### PR DESCRIPTION
## Summary\n\n- add @finger_xie/opencode-plugin-litellm to the ecosystem Plugins table\n- link to the plugin repo and describe /connect support plus automatic LiteLLM model discovery\n\n## Context\n\nThe package is published on npm: https://www.npmjs.com/package/@finger_xie/opencode-plugin-litellm\n\nTracks #27835.\n\n## Validation\n\nDocs-only change. No local test run.