### PR TITLE
feat: add OrcaRouter as a native provider

### DIFF
--- a/packages/core/src/plugin/provider.ts
+++ b/packages/core/src/plugin/provider.ts
@@ -22,6 +22,7 @@ import { OpenAIPlugin } from "./provider/openai"
 import { OpenAICompatiblePlugin } from "./provider/openai-compatible"
 import { OpencodePlugin } from "./provider/opencode"
 import { OpenRouterPlugin } from "./provider/openrouter"
+import { OrcaRouterPlugin } from "./provider/orcarouter"
 import { PerplexityPlugin } from "./provider/perplexity"
 import { SapAICorePlugin } from "./provider/sap-ai-core"
 import { TogetherAIPlugin } from "./provider/togetherai"
@@ -56,6 +57,7 @@ export const ProviderPlugins = [
   OpenAICompatiblePlugin,
   OpenAIPlugin,
   OpenRouterPlugin,
+  OrcaRouterPlugin,
   PerplexityPlugin,
   SapAICorePlugin,
   TogetherAIPlugin,

--- a/packages/core/src/plugin/provider/orcarouter.ts
+++ b/packages/core/src/plugin/provider/orcarouter.ts
@@ -1,0 +1,21 @@
+import { Effect } from "effect"
+import { PluginV2 } from "../../plugin"
+
+export const OrcaRouterPlugin = PluginV2.define({
+  id: PluginV2.ID.make("orcarouter"),
+  effect: Effect.gen(function* () {
+    return {
+      "catalog.transform": Effect.fn(function* (evt) {
+        for (const item of evt.provider.list()) {
+          if (item.provider.endpoint.type !== "aisdk") continue
+          if (item.provider.endpoint.package !== "@ai-sdk/openai-compatible") continue
+          if (item.provider.endpoint.url !== "https://api.orcarouter.ai/v1") continue
+          evt.provider.update(item.provider.id, (provider) => {
+            provider.options.headers["HTTP-Referer"] ??= "https://opencode.ai/"
+            provider.options.headers["X-Title"] ??= "opencode"
+          })
+        }
+      }),
+    }
+  }),
+})

--- a/packages/core/test/plugin/provider-orcarouter.test.ts
+++ b/packages/core/test/plugin/provider-orcarouter.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { Catalog } from "@opencode-ai/core/catalog"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { ProviderPlugins } from "@opencode-ai/core/plugin/provider"
+import { OrcaRouterPlugin } from "@opencode-ai/core/plugin/provider/orcarouter"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { expectPluginRegistered, it, provider } from "./provider-helper"
+
+describe("OrcaRouterPlugin", () => {
+  it.effect("is registered so legacy referer headers can be applied", () =>
+    Effect.sync(() =>
+      expectPluginRegistered(
+        ProviderPlugins.map((item) => item.id),
+        "orcarouter",
+      ),
+    ),
+  )
+
+  it.effect("applies the exact OrcaRouter headers", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const catalog = yield* Catalog.Service
+      yield* plugin.add(OrcaRouterPlugin)
+      const transform = yield* catalog.transform()
+      yield* transform((catalog) => {
+        const item = provider("orcarouter", {
+          endpoint: { type: "aisdk", package: "@ai-sdk/openai-compatible", url: "https://api.orcarouter.ai/v1" },
+        })
+        catalog.provider.update(item.id, (draft) => {
+          draft.endpoint = item.endpoint
+        })
+      })
+      const result = yield* catalog.provider.get(ProviderV2.ID.make("orcarouter"))
+      expect(result.options.headers).toEqual({ "HTTP-Referer": "https://opencode.ai/", "X-Title": "opencode" })
+      expect(Object.keys(result.options.headers).sort()).toEqual(["HTTP-Referer", "X-Title"])
+    }),
+  )
+
+  it.effect("merges OrcaRouter headers with existing headers", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const catalog = yield* Catalog.Service
+      yield* plugin.add(OrcaRouterPlugin)
+      const transform = yield* catalog.transform()
+      yield* transform((catalog) => {
+        const item = provider("orcarouter", {
+          endpoint: { type: "aisdk", package: "@ai-sdk/openai-compatible", url: "https://api.orcarouter.ai/v1" },
+          options: { headers: { Existing: "value" }, body: {}, aisdk: { provider: {}, request: {} } },
+        })
+        catalog.provider.update(item.id, (draft) => {
+          draft.endpoint = item.endpoint
+          draft.options = item.options
+        })
+      })
+
+      expect((yield* catalog.provider.get(ProviderV2.ID.make("orcarouter"))).options.headers).toEqual({
+        Existing: "value",
+        "HTTP-Referer": "https://opencode.ai/",
+        "X-Title": "opencode",
+      })
+    }),
+  )
+
+  it.effect("lets configured OrcaRouter headers override defaults", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const catalog = yield* Catalog.Service
+      yield* plugin.add(OrcaRouterPlugin)
+      const transform = yield* catalog.transform()
+      yield* transform((catalog) => {
+        const item = provider("orcarouter", {
+          endpoint: { type: "aisdk", package: "@ai-sdk/openai-compatible", url: "https://api.orcarouter.ai/v1" },
+          options: {
+            headers: { "HTTP-Referer": "https://example.com/", "X-Title": "custom-title" },
+            body: {},
+            aisdk: { provider: {}, request: {} },
+          },
+        })
+        catalog.provider.update(item.id, (draft) => {
+          draft.endpoint = item.endpoint
+          draft.options = item.options
+        })
+      })
+
+      expect((yield* catalog.provider.get(ProviderV2.ID.make("orcarouter"))).options.headers).toEqual({
+        "HTTP-Referer": "https://example.com/",
+        "X-Title": "custom-title",
+      })
+    }),
+  )
+
+  it.effect("guards OrcaRouter headers to the exact endpoint URL", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const catalog = yield* Catalog.Service
+      yield* plugin.add(OrcaRouterPlugin)
+      const transform = yield* catalog.transform()
+      yield* transform((catalog) => {
+        const item = provider("openrouter", {
+          endpoint: { type: "aisdk", package: "@ai-sdk/openai-compatible", url: "https://openrouter.ai/api/v1" },
+          options: {
+            headers: { "HTTP-Referer": "https://example.com/", "X-Title": "custom-title" },
+            body: {},
+            aisdk: { provider: {}, request: {} },
+          },
+        })
+        catalog.provider.update(item.id, (draft) => {
+          draft.endpoint = item.endpoint
+          draft.options = item.options
+        })
+      })
+
+      expect((yield* catalog.provider.get(ProviderV2.ID.openrouter)).options.headers).toEqual({
+        "HTTP-Referer": "https://example.com/",
+        "X-Title": "custom-title",
+      })
+    }),
+  )
+})

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -439,6 +439,16 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    orcarouter: () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
+          },
+        },
+      }),
     nvidia: (provider) =>
       Effect.succeed({
         autoload: provider.source === "config",

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1728,6 +1728,76 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible router that aggregates 150+ models from OpenAI, Anthropic, Google, xAI, DeepSeek and others behind a single API key, and exposes a virtual `orcarouter/auto` router that picks an upstream per request based on a configurable strategy (`cheapest` / `balanced` / `quality` / `adaptive` / `gated_adaptive`). The adaptive strategy is a LinUCB contextual bandit that learns from your own traffic — same endpoint, but a 50-token summary may be routed to a cheap model while a 30K-token refactor goes to a premium one, without any client-side dispatch logic. Routing strategies, model pools, and reward weights are admin-tunable from [the routing console](https://www.orcarouter.ai/console/routing).
+
+1. Head over to the [OrcaRouter dashboard](https://www.orcarouter.ai/console), click **Create API Key**, and copy the key.
+
+2. Run the `/connect` command and search for OrcaRouter.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter the API key for the provider.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Many OrcaRouter models are preloaded by default, run the `/models` command to select the one you want. The smart-routing entry is `orcarouter/auto`.
+
+   ```txt
+   /models
+   ```
+
+   You can also add additional models through your opencode config.
+
+   ```json title="opencode.json" {6}
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "orcarouter": {
+         "models": {
+           "somecoolnewmodel": {}
+         }
+       }
+     }
+   }
+   ```
+
+5. You can also pass OrcaRouter's `extra_body` routing preferences (fallback model list, route mode) per-model. See the [routing docs](https://docs.orcarouter.ai) for the full schema.
+
+   ```json title="opencode.json"
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "orcarouter": {
+         "models": {
+           "openai/gpt-5": {
+             "options": {
+               "extra_body": {
+                 "models": ["openai/gpt-4o-mini", "openai/gpt-4o"],
+                 "route": "fallback"
+               }
+             }
+           }
+         }
+       }
+     }
+   }
+   ```
+
+   :::note
+   A few OrcaRouter models (e.g. `anthropic/claude-opus-4.7` and other reasoning-only models) reject `temperature` upstream. If you see a 400 from those models, drop `temperature` from your config.
+   :::
+
+---
+
 ### LLM Gateway
 
 1. Head over to the [LLM Gateway dashboard](https://llmgateway.io/dashboard), click **Create API Key**, and copy the key.


### PR DESCRIPTION
### Issue for this PR

Closes #

_No tracking issue — OrcaRouter is already listed in models.dev ([anomalyco/models.dev#1778](https://github.com/anomalyco/models.dev/pull/1778), merged), and this PR is the standard opencode-side glue (attribution headers + docs) that mirrors what every other meta-router (OpenRouter, ZenMux, Kilo, LLM Gateway) ships._

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds [OrcaRouter](https://www.orcarouter.ai) as a native provider. OrcaRouter is an OpenAI-compatible meta-router that routes a single API key across 80+ upstream LLMs (OpenAI, Anthropic, Google, xAI, DeepSeek, Qwen, Kimi, MiniMax, z.ai). It also exposes a virtual `orcarouter/auto` router that picks an upstream per request based on a per-workspace strategy (`cheapest` / `balanced` / `quality` / `adaptive` / `gated_adaptive`).

Same pattern as the existing OpenRouter / ZenMux / Kilo / LLM Gateway plugins — five files, the only functional change is stamping `HTTP-Referer: https://opencode.ai/` and `X-Title: opencode` so OrcaRouter can attribute traffic to opencode in its console:

- `packages/core/src/plugin/provider/orcarouter.ts` (new) — v2 `OrcaRouterPlugin`, fires on `provider.update`.
- `packages/core/src/plugin/provider/index.ts` — register the plugin.
- `packages/opencode/src/provider/provider.ts` — legacy `custom()` entry for the same headers.
- `packages/core/test/plugin/provider-orcarouter.test.ts` (new) — 5 unit tests mirroring the OpenRouter / Kilo coverage.
- `packages/web/src/content/docs/providers.mdx` — OrcaRouter section.

Disclosure: I work on the OrcaRouter team.

### How did you verify your code works?

- Unit tests: `cd packages/core && bun test test/plugin/provider-orcarouter.test.ts` — 5/5 pass. Re-ran the sibling tests (openrouter / zenmux / kilo / llmgateway / nvidia), 19/19 still pass.
- Typecheck: `bun typecheck` clean in `packages/core` and `packages/opencode`.
- End-to-end with my own OrcaRouter API key: launched the TUI (`bun run dev .`), the model picker shows the full OrcaRouter catalog (87 entries including `orcarouter/orcarouter/auto`). Sent prompts against a pinned model (`orcarouter/openai/gpt-5`) and against `orcarouter/auto`; both completed and the OrcaRouter console showed the requests with the `HTTP-Referer` / `X-Title` headers from this PR.
- Wrong-token path: confirmed a bogus key returns a clean `Invalid token` error instead of crashing.

### Screenshots / recordings

_Not a UI change — provider registration, plugin, docs._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
