### PR TITLE
feat(opencode): add /yolo toggle for auto-approving permissions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -152,6 +152,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "permission.asked": {
           const request = event.properties
+          if (kv.get("yolo_mode", false)) {
+            void sdk.client.permission.reply({
+              requestID: request.id,
+              reply: "once",
+            })
+            break
+          }
           const requests = store.permission[request.sessionID]
           if (!requests) {
             setStore("permission", request.sessionID, [request])

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -5,11 +5,13 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/use-connected"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import { useKV } from "../../context/kv"
 
 export function Footer() {
   const { theme } = useTheme()
   const sync = useSync()
   const route = useRoute()
+  const kv = useKV()
   const mcp = createMemo(() => Object.values(sync.data.mcp).filter((x) => x.status === "connected").length)
   const mcpError = createMemo(() => Object.values(sync.data.mcp).some((x) => x.status === "failed"))
   const lsp = createMemo(() => Object.keys(sync.data.lsp))
@@ -81,6 +83,9 @@ export function Footer() {
                 </Switch>
                 {mcp()} MCP
               </text>
+            </Show>
+            <Show when={kv.get("yolo_mode", false)}>
+              <text fg={theme.warning}>YOLO</text>
             </Show>
             <text fg={theme.textMuted}>/status</text>
           </Match>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -134,6 +134,7 @@ const sessionBindingCommands = [
   "session.toggle.actions",
   "session.toggle.scrollbar",
   "session.toggle.generic_tool_output",
+  "session.toggle.yolo",
   "session.page.up",
   "session.page.down",
   "session.line.up",
@@ -226,6 +227,7 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const [yoloMode, setYoloMode] = kv.signal("yolo_mode", false)
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -727,6 +729,23 @@ export function Session() {
       category: "Session",
       run: () => {
         setShowGenericToolOutput((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
+      title: yoloMode() ? "Disable YOLO mode" : "Enable YOLO mode",
+      value: "session.toggle.yolo",
+      category: "Session",
+      slash: {
+        name: "yolo",
+      },
+      run: () => {
+        const next = !yoloMode()
+        setYoloMode(next)
+        toast.show({
+          message: next ? "YOLO mode enabled — permissions will be auto-approved" : "YOLO mode disabled",
+          variant: next ? "warning" : "success",
+        })
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "../../context/theme"
 import { useTuiConfig } from "../../context/tui-config"
 import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
+import { useKV } from "../../context/kv"
 
 import { getScrollAcceleration } from "../../util/scroll"
 import { WorkspaceLabel } from "../../component/workspace-label"
@@ -14,6 +15,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const sync = useSync()
   const { theme } = useTheme()
   const tuiConfig = useTuiConfig()
+  const kv = useKV()
   const session = createMemo(() => sync.session.get(props.sessionID))
   const workspace = () => {
     const workspaceID = session()?.workspaceID
@@ -85,7 +87,12 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
           </box>
         </scrollbox>
 
-        <box flexShrink={0} gap={1} paddingTop={1}>
+        <box flexShrink={0} gap={1} paddingTop={1} flexDirection="column">
+          <Show when={kv.get("yolo_mode", false)}>
+            <text fg={theme.warning}>
+              <b>YOLO MODE</b>
+            </text>
+          </Show>
           <TuiPluginRuntime.Slot name="sidebar_footer" mode="single_winner" session_id={props.sessionID}>
             <text fg={theme.textMuted}>
               <span style={{ fg: theme.success }}>•</span> <b>Open</b>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] New feature

### What does this PR do?

Adds a new `/yolo` slash command in the TUI session that toggles auto-approval of all permission requests without prompting the user. This is useful for power users who want to skip repetitive permission dialogs during a session while keeping the permission system intact.

The implementation uses the existing KV store to persist the toggle state across the session, and auto-replies to `permission.asked` events when the mode is active.

Changes:
- **TUI session commands**: new `/yolo` slash command in the command palette (toggles on/off)
- **KV store**: persists `yolo_mode` state across the session
- **TUI footer**: shows `YOLO` indicator in warning color when active
- **TUI sidebar**: shows `YOLO MODE` badge above the version footer
- **TUI sync**: auto-replies permissions with `reply: "once"` when `kv.get('yolo_mode')` is true

### How did you verify your code works?

- Verified the `/yolo` command appears in the session command palette
- Verified toggling updates the KV store and shows the correct toast message
- Verified the footer and sidebar indicators render conditionally based on KV state
- Verified the sync handler auto-replies permission events when the mode is enabled

### Screenshots / recordings

N/A — TUI terminal UI, no graphical screenshots.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
