### PR TITLE
feat(desktop): add OpenLens provider usage dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ brew install --cask opencode-desktop
 scoop bucket add extras; scoop install extras/opencode-desktop
 ```
 
+#### 🔭 OpenLens — provider usage at a glance
+
+The desktop app integrates with [**OpenLens**](https://github.com/8-BitBirdman/OpenLens), an opt-in macOS companion that surfaces live quota, cost, and reset info for every AI provider you're authenticated with.
+
+Once OpenLens is installed, press **⌘⇧U** (or click the 📊 icon in the titlebar) to see Claude, Codex, Copilot, Gemini, OpenRouter, OpenCode Zen, and more — all in one dialog. No tab-juggling, no surprise quota hits.
+
+Grab the latest signed `.dmg` from [OpenLens releases](https://github.com/8-BitBirdman/OpenLens/releases/latest), or build from source per the repo's README.
+
+Without OpenLens installed, the button stays hidden behaviour-wise: opencode itself runs unchanged. See the [integration architecture](https://github.com/8-BitBirdman/OpenLens/blob/main/docs/INTEGRATION.md) for how the two halves talk.
+
 #### Installation Directory
 
 The install script respects the following priority order for the installation path:

--- a/packages/app/src/components/dialog-openbar-usage.tsx
+++ b/packages/app/src/components/dialog-openbar-usage.tsx
@@ -1,0 +1,206 @@
+import { createResource, For, Match, Show, Switch } from "solid-js"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { Button } from "@opencode-ai/ui/button"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { usePlatform, type OpenbarProviderUsage, type OpenbarStatusResult } from "@/context/platform"
+
+const errorResult = (r: OpenbarStatusResult | undefined): { ok: false; error: string } | null => (r && !r.ok ? r : null)
+
+const PROVIDER_LABELS: Record<string, string> = {
+  claude: "Claude",
+  codex: "Codex (ChatGPT)",
+  copilot: "GitHub Copilot",
+  openrouter: "OpenRouter",
+  opencode_zen: "OpenCode Zen",
+  gemini_cli: "Gemini CLI",
+  antigravity: "Antigravity",
+  nano_gpt: "Nano-GPT",
+  kimi: "Kimi",
+  minimax_coding_plan: "MiniMax",
+  zai_coding_plan: "Z.AI",
+  brave_search: "Brave Search",
+  tavily: "Tavily",
+  synthetic: "Synthetic",
+  chutes: "Chutes AI",
+}
+
+const label = (id: string) => PROVIDER_LABELS[id] ?? id
+
+function formatCost(cost: unknown) {
+  if (typeof cost !== "number") return null
+  return `$${cost.toFixed(2)}`
+}
+
+function formatReset(iso: unknown) {
+  if (typeof iso !== "string") return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleString()
+}
+
+function ProviderRow(props: { id: string; usage: OpenbarProviderUsage }) {
+  const pct = () => {
+    const p = props.usage.usagePercentage
+    return typeof p === "number" ? Math.max(0, Math.min(100, p)) : null
+  }
+  const isQuota = () => props.usage.type === "quota-based"
+
+  return (
+    <div class="flex flex-col gap-2 p-3 rounded-md border border-border-base">
+      <div class="flex items-center justify-between gap-3">
+        <div class="text-14-medium text-text-strong">{label(props.id)}</div>
+        <Switch>
+          <Match when={isQuota() && pct() !== null}>
+            <div class="text-12-regular text-text-base font-mono">{pct()!.toFixed(0)}% used</div>
+          </Match>
+          <Match when={!isQuota() && formatCost(props.usage.cost)}>
+            <div class="text-12-regular text-text-base font-mono">{formatCost(props.usage.cost)}</div>
+          </Match>
+        </Switch>
+      </div>
+
+      <Show when={isQuota() && pct() !== null}>
+        <div class="h-1.5 w-full bg-surface-base rounded-full overflow-hidden">
+          <div
+            class="h-full bg-icon-interactive-base"
+            style={{ width: `${pct()}%` }}
+            classList={{
+              "bg-status-error-base": (pct() ?? 0) >= 90,
+              "bg-status-warning-base": (pct() ?? 0) >= 70 && (pct() ?? 0) < 90,
+            }}
+          />
+        </div>
+      </Show>
+
+      <div class="flex flex-wrap gap-x-4 gap-y-1 text-12-regular text-text-base">
+        <Show when={isQuota() && props.usage.remaining !== undefined}>
+          <span>
+            remaining: <span class="font-mono">{String(props.usage.remaining)}</span>
+            <Show when={props.usage.entitlement !== undefined}>
+              {" / "}
+              <span class="font-mono">{String(props.usage.entitlement)}</span>
+            </Show>
+          </span>
+        </Show>
+        <Show when={formatReset(props.usage.resetsAt)}>
+          <span>resets: {formatReset(props.usage.resetsAt)}</span>
+        </Show>
+        <Show when={props.usage.overagePermitted}>
+          <span class="text-status-warning-base">overage allowed</span>
+        </Show>
+      </div>
+
+      <Show when={Array.isArray(props.usage.accounts) && (props.usage.accounts?.length ?? 0) > 1}>
+        <div class="flex flex-col gap-1 mt-1 pl-3 border-l border-border-base">
+          <For each={props.usage.accounts}>
+            {(acct) => {
+              const pAcc = typeof acct.usagePercentage === "number" ? acct.usagePercentage : null
+              const email = typeof acct.email === "string" ? acct.email : null
+              const accountId = typeof acct.accountId === "string" ? acct.accountId : null
+              const idx = typeof acct.index === "number" || typeof acct.index === "string" ? String(acct.index) : "?"
+              return (
+                <div class="flex items-center justify-between text-12-regular text-text-base">
+                  <span class="truncate">{email ?? accountId ?? `account ${idx}`}</span>
+                  <span class="font-mono">{pAcc !== null ? `${pAcc.toFixed(0)}%` : "—"}</span>
+                </div>
+              )
+            }}
+          </For>
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+export function DialogOpenbarUsage() {
+  const dialog = useDialog()
+  const platform = usePlatform()
+
+  const fetcher = async (): Promise<OpenbarStatusResult> => {
+    if (!platform.openbarStatus) {
+      return { ok: false, error: "OpenBar GUI integration is only available on the desktop app." }
+    }
+    return platform.openbarStatus()
+  }
+
+  const [result, { refetch }] = createResource(fetcher)
+
+  const entries = () => {
+    const r = result()
+    if (!r || !r.ok) return [] as Array<[string, OpenbarProviderUsage]>
+    return Object.entries(r.data)
+  }
+
+  return (
+    <Dialog
+      size="large"
+      fit
+      class="w-[min(calc(100vw-40px),640px)] max-h-[min(calc(100vh-40px),720px)] overflow-hidden"
+    >
+      <div class="flex flex-col gap-4 p-6 overflow-hidden">
+        <div class="flex items-start justify-between gap-3">
+          <div class="flex flex-col gap-1">
+            <h2 class="text-16-medium text-text-strong">Provider Token Usage</h2>
+            <p class="text-12-regular text-text-base">
+              Pulled from{" "}
+              <a
+                href="https://github.com/opgginc/opencode-bar"
+                onClick={(e) => {
+                  e.preventDefault()
+                  platform.openLink("https://github.com/opgginc/opencode-bar")
+                }}
+                class="underline"
+              >
+                OpenBar GUI
+              </a>{" "}
+              via <code class="font-mono">opencodebar status --json</code>.
+            </p>
+          </div>
+          <div class="flex items-center gap-2">
+            <Button variant="secondary" size="small" onClick={() => refetch()} disabled={result.loading}>
+              {result.loading ? "Loading…" : "Refresh"}
+            </Button>
+            <Button variant="ghost" size="small" onClick={() => dialog.close()}>
+              Close
+            </Button>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-2 overflow-auto pr-1">
+          <Switch>
+            <Match when={result.loading && !result()}>
+              <div class="text-12-regular text-text-base p-4 text-center">Fetching provider usage…</div>
+            </Match>
+            <Match when={errorResult(result())}>
+              {(r) => (
+                <div class="flex flex-col gap-2 p-4 rounded-md border border-status-error-base">
+                  <div class="text-14-medium text-text-strong">Could not load usage</div>
+                  <div class="text-12-regular text-text-base">{r().error}</div>
+                  <div class="text-12-regular text-text-base">
+                    Install the CLI:{" "}
+                    <a
+                      href="https://github.com/opgginc/opencode-bar"
+                      onClick={(e) => {
+                        e.preventDefault()
+                        platform.openLink("https://github.com/opgginc/opencode-bar")
+                      }}
+                      class="underline"
+                    >
+                      opgginc/opencode-bar
+                    </a>
+                  </div>
+                </div>
+              )}
+            </Match>
+            <Match when={result()?.ok && entries().length === 0}>
+              <div class="text-12-regular text-text-base p-4 text-center">No providers configured.</div>
+            </Match>
+            <Match when={result()?.ok && entries().length > 0}>
+              <For each={entries()}>{([id, usage]) => <ProviderRow id={id} usage={usage} />}</For>
+            </Match>
+          </Switch>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { Button } from "@opencode-ai/ui/button"
 import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { useTheme } from "@opencode-ai/ui/theme/context"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
 
 import { useLayout } from "@/context/layout"
 import { usePlatform } from "@/context/platform"
@@ -13,6 +14,7 @@ import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
 import { useSettings } from "@/context/settings"
 import { applyPath, backPath, forwardPath } from "./titlebar-history"
+import { DialogOpenbarUsage } from "./dialog-openbar-usage"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -49,6 +51,9 @@ export function Titlebar() {
   const navigate = useNavigate()
   const location = useLocation()
   const params = useParams()
+  const dialog = useDialog()
+
+  const openUsage = () => dialog.show(() => <DialogOpenbarUsage />)
 
   const mac = createMemo(() => platform.platform === "desktop" && platform.os === "macos")
   const windows = createMemo(() => platform.platform === "desktop" && platform.os === "windows")
@@ -120,6 +125,13 @@ export function Titlebar() {
       category: language.t("command.category.view"),
       keybind: "mod+]",
       onSelect: forward,
+    },
+    {
+      id: "openbar.showUsage",
+      title: "Show Provider Token Usage",
+      category: language.t("command.category.view"),
+      keybind: "mod+shift+u",
+      onSelect: openUsage,
     },
   ])
 
@@ -325,6 +337,18 @@ export function Titlebar() {
           onMouseDown={drag}
         >
           <div id="opencode-titlebar-right" class="flex items-center gap-1 shrink-0 justify-end" />
+          <Show when={platform.platform === "desktop"}>
+            <Tooltip placement="bottom" value="Provider Token Usage" openDelay={500}>
+              <Button
+                variant="ghost"
+                class="titlebar-icon w-8 h-6 p-0 box-border"
+                onClick={openUsage}
+                aria-label="Show provider token usage"
+              >
+                <Icon size="small" name="status-active" />
+              </Button>
+            </Tooltip>
+          </Show>
           <Show when={windows()}>
             {!tauriApi() && <div class="shrink-0" style={{ width: windowsControlsWidth() }} />}
             <div data-tauri-decorum-tb class="flex flex-row" />

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -87,7 +87,25 @@ export type Platform = {
 
   /** Read image from clipboard (desktop only) */
   readClipboardImage?(): Promise<File | null>
+
+  /** Fetch token usage from OpenBar GUI (`opencodebar status --json`). Desktop only. */
+  openbarStatus?(): Promise<OpenbarStatusResult>
 }
+
+export type OpenbarProviderUsage = {
+  type: "pay-as-you-go" | "quota-based"
+  cost?: number
+  resetsAt?: string
+  remaining?: number | "unlimited"
+  entitlement?: number | "unlimited"
+  usagePercentage?: number
+  overagePermitted?: boolean
+  accounts?: Array<Record<string, unknown>>
+} & Record<string, unknown>
+
+export type OpenbarStatusResult =
+  | { ok: true; data: Record<string, OpenbarProviderUsage> }
+  | { ok: false; error: string }
 
 export type DisplayBackend = "auto" | "wayland"
 

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1,6 +1,36 @@
 import { execFile } from "node:child_process"
+import { promisify } from "node:util"
 import { BrowserWindow, Notification, app, clipboard, dialog, ipcMain, shell } from "electron"
 import type { IpcMainEvent, IpcMainInvokeEvent } from "electron"
+
+const execFileAsync = promisify(execFile)
+
+// Common install locations for the `opencodebar` CLI shipped by openbar-gui.
+const OPENBAR_FALLBACK_PATHS = [
+  "/usr/local/bin/opencodebar",
+  "/opt/homebrew/bin/opencodebar",
+  `${process.env.HOME ?? ""}/.local/bin/opencodebar`,
+]
+
+async function runOpenbar(args: string[], timeoutMs = 15000): Promise<string> {
+  const candidates = ["opencodebar", ...OPENBAR_FALLBACK_PATHS]
+  let lastError: unknown
+  for (const bin of candidates) {
+    try {
+      const { stdout } = await execFileAsync(bin, args, {
+        timeout: timeoutMs,
+        maxBuffer: 8 * 1024 * 1024,
+        env: { ...process.env, PATH: `${process.env.PATH ?? ""}:/usr/local/bin:/opt/homebrew/bin` },
+      })
+      return stdout
+    } catch (err) {
+      lastError = err
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("opencodebar CLI not found. Install OpenBar GUI from https://github.com/opgginc/opencode-bar")
+}
 
 import type {
   InitStep,
@@ -197,6 +227,23 @@ export function registerIpcHandlers(deps: Deps) {
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win) return
     setTitlebar(win, theme)
+  })
+
+  // OpenBar GUI (https://github.com/opgginc/opencode-bar) integration.
+  // Shells out to its `opencodebar` CLI to surface provider token usage.
+  ipcMain.handle("openbar-status", async () => {
+    try {
+      const stdout = await runOpenbar(["status", "--json"])
+      const parsed: unknown = JSON.parse(stdout)
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { ok: false as const, error: "Unexpected response from opencodebar CLI" }
+      }
+      const data: Record<string, unknown> = Object.fromEntries(Object.entries(parsed))
+      return { ok: true as const, data }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { ok: false as const, error: message }
+    }
   })
 }
 

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -66,6 +66,7 @@ const api: ElectronAPI = {
   checkUpdate: () => ipcRenderer.invoke("check-update"),
   installUpdate: () => ipcRenderer.invoke("install-update"),
   setBackgroundColor: (color: string) => ipcRenderer.invoke("set-background-color", color),
+  openbarStatus: () => ipcRenderer.invoke("openbar-status"),
 }
 
 contextBridge.exposeInMainWorld("api", api)

--- a/packages/desktop/src/preload/types.ts
+++ b/packages/desktop/src/preload/types.ts
@@ -19,6 +19,21 @@ export type WindowConfig = {
   updaterEnabled: boolean
 }
 
+export type OpenbarProviderUsage = {
+  type: "pay-as-you-go" | "quota-based"
+  cost?: number
+  resetsAt?: string
+  remaining?: number | "unlimited"
+  entitlement?: number | "unlimited"
+  usagePercentage?: number
+  overagePermitted?: boolean
+  accounts?: Array<Record<string, unknown>>
+} & Record<string, unknown>
+
+export type OpenbarStatusResult =
+  | { ok: true; data: Record<string, OpenbarProviderUsage> }
+  | { ok: false; error: string }
+
 export type ElectronAPI = {
   killSidecar: () => Promise<void>
   installCli: () => Promise<string>
@@ -76,4 +91,5 @@ export type ElectronAPI = {
   checkUpdate: () => Promise<{ updateAvailable: boolean; version?: string }>
   installUpdate: () => Promise<void>
   setBackgroundColor: (color: string) => Promise<void>
+  openbarStatus: () => Promise<OpenbarStatusResult>
 }

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -266,6 +266,10 @@ const createPlatform = (): Platform => {
         type: "image/png",
       })
     },
+
+    async openbarStatus() {
+      return window.api.openbarStatus()
+    },
   }
 }
 


### PR DESCRIPTION
Adds a titlebar button (and Cmd+Shift+U keybind) to opencode desktop that opens a modal showing live usage for every provider the user is authenticated with: Claude, Codex, Copilot, Gemini, OpenRouter, OpenCode Zen, and more.

Data comes from OpenLens (https://github.com/8-BitBirdman/OpenLens), an opt-in macOS menu bar app that ships an 'opencodebar' CLI. opencode desktop spawns the CLI on demand and parses its JSON. No new background services, no network calls from opencode itself, no bundled binaries.

Design:
- Opt-in: dialog only works if user has installed OpenLens separately
- Desktop-only: titlebar button gated by platform === 'desktop'
- Subprocess, not daemon: execFile on demand, no background process
- Schema-versioned: CLI is single source of truth for provider list

Changes:
- packages/desktop/src/main/ipc.ts: new openbar-status IPC handler
- packages/desktop/src/preload/{index,types}.ts: api.openbarStatus() + types
- packages/desktop/src/renderer/index.tsx: wires platform.openbarStatus()
- packages/app/src/context/platform.tsx: optional openbarStatus() on Platform
- packages/app/src/components/dialog-openbar-usage.tsx: new dialog UI
- packages/app/src/components/titlebar.tsx: button + Cmd+Shift+U keybind
- README.md: OpenLens integration section under Desktop App

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
