### PR TITLE
fix(opencode): report clipboard copy failures

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/error-component.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/error-component.tsx
@@ -30,6 +30,7 @@ export function ErrorComponent(props: {
     }
   })
   const [copied, setCopied] = createSignal(false)
+  const [copyError, setCopyError] = createSignal("")
 
   const issueURL = new URL("https://github.com/anomalyco/opencode/issues/new?template=bug-report.yml")
 
@@ -56,9 +57,14 @@ export function ErrorComponent(props: {
   issueURL.searchParams.set("opencode-version", InstallationVersion)
 
   const copyIssueURL = () => {
-    void Clipboard.copy(issueURL.toString()).then(() => {
-      setCopied(true)
-    })
+    Clipboard.copy(issueURL.toString())
+      .then(() => {
+        setCopied(true)
+        setCopyError("")
+      })
+      .catch((e) => {
+        setCopyError(Clipboard.failureMessage(e))
+      })
   }
 
   return (
@@ -73,6 +79,7 @@ export function ErrorComponent(props: {
           </text>
         </box>
         {copied() && <text fg={colors.muted}>Successfully copied</text>}
+        {copyError() && <text fg={colors.muted}>{copyError()}</text>}
       </box>
       <box flexDirection="row" gap={2} alignItems="center">
         <text fg={colors.text}>A fatal error occurred!</text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -458,7 +458,7 @@ export function Session() {
         const copy = (url: string) =>
           Clipboard.copy(url)
             .then(() => toast.show({ message: "Share URL copied to clipboard!", variant: "success" }))
-            .catch(() => toast.show({ message: "Failed to copy URL to clipboard", variant: "error" }))
+            .catch((e) => toast.show({ message: Clipboard.failureMessage(e), variant: "error" }))
         const url = session()?.share?.url
         if (url) {
           await copy(url)
@@ -893,7 +893,7 @@ export function Session() {
 
         Clipboard.copy(text)
           .then(() => toast.show({ message: "Message copied to clipboard!", variant: "success" }))
-          .catch(() => toast.show({ message: "Failed to copy to clipboard", variant: "error" }))
+          .catch((e) => toast.show({ message: Clipboard.failureMessage(e), variant: "error" }))
         dialog.clear()
       },
     },
@@ -921,8 +921,8 @@ export function Session() {
           )
           await Clipboard.copy(transcript)
           toast.show({ message: "Session transcript copied to clipboard!", variant: "success" })
-        } catch {
-          toast.show({ message: "Failed to copy session transcript", variant: "error" })
+        } catch (e) {
+          toast.show({ message: Clipboard.failureMessage(e), variant: "error" })
         }
         dialog.clear()
       },

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -175,7 +175,25 @@ const getCopyMethod = lazy(async () => {
 export async function copy(text: string): Promise<void> {
   writeOsc52(text)
   const method = await getCopyMethod()
-  await method(text)
+  try {
+    await method(text)
+  } catch (error) {
+    if (platform() === "linux") {
+      throw new Error(
+        "Clipboard command failed. Ensure a clipboard backend is installed: xclip, xsel, or wl-clipboard (wl-copy).",
+        { cause: error },
+      )
+    }
+    throw error
+  }
+}
+
+const LINUX_CLIPBOARD_GUIDANCE = "Ensure a clipboard backend is installed: xclip, xsel, or wl-clipboard (wl-copy)."
+
+export function failureMessage(error: unknown): string {
+  const msg = error instanceof Error ? error.message : String(error)
+  if (msg) return msg
+  return `Clipboard failed. ${LINUX_CLIPBOARD_GUIDANCE}`
 }
 
 export * as Clipboard from "./clipboard"

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -12,11 +12,11 @@ import * as Process from "../../../../util/process"
 const writeWithStdin = (cmd: string[], text: string): Promise<void> =>
   Effect.runPromise(
     AppProcess.Service.use((svc) => svc.run(ChildProcess.make(cmd[0]!, cmd.slice(1)), { stdin: text })).pipe(
+      Effect.flatMap(AppProcess.requireSuccess),
       Effect.provide(AppProcess.defaultLayer),
-      Effect.catch(() => Effect.void),
       Effect.asVoid,
     ),
-  ).catch(() => undefined)
+  )
 
 // Lazy load which and clipboardy to avoid expensive execa/which/isexe chain at startup
 const getWhich = lazy(async () => {
@@ -130,7 +130,7 @@ const getCopyMethod = lazy(async () => {
     console.log("clipboard: using osascript")
     return async (text: string) => {
       const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-      await Process.run(["osascript", "-e", `set the clipboard to "${escaped}"`], { nothrow: true })
+      await Process.run(["osascript", "-e", `set the clipboard to "${escaped}"`])
     }
   }
 
@@ -168,7 +168,7 @@ const getCopyMethod = lazy(async () => {
   console.log("clipboard: no native support")
   return async (text: string) => {
     const clipboardy = await getClipboardy()
-    await clipboardy.write(text).catch(() => {})
+    await clipboardy.write(text)
   }
 })
 

--- a/packages/opencode/test/cli/cmd/tui/clipboard.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/clipboard.test.ts
@@ -51,4 +51,60 @@ try {
       await rm(directory, { recursive: true, force: true })
     }
   })
+
+  test("failing Linux clipboard command rejects with non-empty actionable message", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "opencode-clipboard-"))
+
+    try {
+      const xclip = path.join(directory, "xclip")
+      await writeFile(xclip, "#!/bin/sh\necho fake xclip failure >&2\nexit 7\n")
+      await chmod(xclip, 0o755)
+
+      const clipboard = path.resolve(import.meta.dir, "../../../../src/cli/cmd/tui/util/clipboard.ts")
+      const msgFile = path.join(directory, "msg.txt")
+      const script = path.join(directory, "copy-message.mjs")
+      await writeFile(
+        script,
+        `
+import { writeFileSync } from "fs"
+import * as Clipboard from ${JSON.stringify(pathToFileURL(clipboard).href)}
+
+try {
+  await Clipboard.copy("hello")
+  console.error("copy resolved")
+  process.exit(1)
+} catch (error) {
+  const msg = error instanceof Error ? error.message : String(error)
+  writeFileSync(${JSON.stringify(msgFile)}, msg)
+  process.exit(0)
+}
+`.trimStart(),
+      )
+
+      const proc = Bun.spawn([process.execPath, script], {
+        env: {
+          ...process.env,
+          PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+          WAYLAND_DISPLAY: "",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+
+      expect(`${stdout}${stderr}`).not.toContain("copy resolved")
+      expect(code).toBe(0)
+      const msg = await Bun.file(msgFile).text()
+      expect(msg.length).toBeGreaterThan(0)
+      expect(msg).toContain("xclip")
+      expect(msg).toContain("xsel")
+      expect(msg).toMatch(/wl-clipboard|wl-copy/)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/opencode/test/cli/cmd/tui/clipboard.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/clipboard.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import { chmod, mkdtemp, rm, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { pathToFileURL } from "url"
+
+describe("TUI clipboard", () => {
+  test("rejects when the selected native clipboard command fails", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "opencode-clipboard-"))
+
+    try {
+      const xclip = path.join(directory, "xclip")
+      await writeFile(xclip, "#!/bin/sh\nexit 7\n")
+      await chmod(xclip, 0o755)
+
+      const clipboard = path.resolve(import.meta.dir, "../../../../src/cli/cmd/tui/util/clipboard.ts")
+      const script = path.join(directory, "copy-fails.mjs")
+      await writeFile(
+        script,
+        `
+import * as Clipboard from ${JSON.stringify(pathToFileURL(clipboard).href)}
+
+try {
+  await Clipboard.copy("hello")
+  console.error("copy resolved")
+  process.exit(1)
+} catch {
+  process.exit(0)
+}
+`.trimStart(),
+      )
+
+      const proc = Bun.spawn([process.execPath, script], {
+        env: {
+          ...process.env,
+          PATH: `${directory}${path.delimiter}${process.env.PATH ?? ""}`,
+          WAYLAND_DISPLAY: "",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+
+      expect(`${stdout}${stderr}`).not.toContain("copy resolved")
+      expect(code).toBe(0)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #4283

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Clipboard copy operations in the TUI could report success even when the selected backend failed. That made mouse selection copy show `Copied to clipboard` while the clipboard was unchanged.

This changes clipboard writes so backend failures propagate instead of being swallowed:
- native stdin-based clipboard commands now require a successful exit code
- `osascript` write failures now reject
- `clipboardy.write()` failures now reject

The existing toast/error handlers can then show the real clipboard failure instead of a false success message.

### How did you verify your code works?

- Added a regression test for a failing native clipboard command.
- Ran `bun test --timeout 30000 test/cli/cmd/tui/clipboard.test.ts`.
- Ran `bun run typecheck` from `packages/opencode`.
- Ran the pre-push hook, which completed `bun turbo typecheck`.
- Manually verified on Ubuntu 24.04, Linux 6.17.0-23-generic, X11 (`DISPLAY=:1`, no `WAYLAND_DISPLAY`). With `xclip`, `xsel`, and `wl-copy` absent and `DISPLAY=` set, the patched TUI surfaces the Linux clipboard backend error instead of showing `Copied to clipboard`.
- Manually verified normal copy succeeds when a clipboard backend is available.

### Screenshots / recordings

N/A. This is a terminal clipboard error-handling change; the relevant behavior is covered by the regression test and manual verification above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR