### PR TITLE
fix(cli): resolve agent before Effect.promise to preserve InstanceRef

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -236,6 +236,7 @@ export const RunCommand = effectCmd({
   handler: Effect.fn("Cli.run")(function* (args) {
     const agentSvc = yield* Agent.Service
     const flags = yield* RuntimeFlags.Service
+    const entry = args.agent && !args.attach ? yield* agentSvc.get(args.agent) : undefined
     yield* Effect.promise(async () => {
       const rawMessage = [...args.message, ...(args["--"] || [])].join(" ")
       const thinking = args.interactive ? (args.thinking ?? true) : (args.thinking ?? false)
@@ -508,7 +509,6 @@ export const RunCommand = effectCmd({
         if (!args.agent) return undefined
         const name = args.agent
 
-        const entry = await Effect.runPromise(agentSvc.get(name))
         if (!entry) {
           UI.println(
             UI.Style.TEXT_WARNING_BOLD + "!",


### PR DESCRIPTION
### Issue for this PR

Closes #27829
Closes #27833
See #27838
See #27857

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --agent <name>` crashes with `InstanceRef not provided` because `agentSvc.get()` was called via `Effect.runPromise` inside an `Effect.promise` callback, where the Effect fiber context is not available.

The fix moves the agent resolution to the Effect fiber handler scope (where `InstanceRef` is provided by `effectCmd`), and guards with `!args.attach` since attach mode does not provide `InstanceRef` and uses its own remote agent lookup via `attachAgent()`.

### How did you verify your code works?

Built the project (`cd packages/opencode && bun run build`) and tested:

- `opencode run --agent build "say hello"` — no InstanceRef error, agent resolves correctly
- `opencode run "say hello"` (without --agent) — regression check, works as before
- `opencode run --agent nonexistent "hi"` — warning + fallback, no crash
- `opencode run --agent general "hi"` (subagent) — subagent warning + fallback, no crash
- `--attach --agent` combination — guarded by `!args.attach`, skips local resolution

Typecheck passes across all 14 packages.

### Screenshots / recordings

N/A (CLI bug fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR