### PR TITLE
docs(ecosystem): add opencode-gpt-imagegen to plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -53,6 +53,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                         |
+| [opencode-gpt-imagegen](https://github.com/yuji-hatakeyama/opencode-gpt-imagegen)                  | Generate gpt-image-2 images using your ChatGPT subscription                                       |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

No related issue.

### Type of change

- [x] Documentation

### What does this PR do?

Adds `opencode-gpt-imagegen` to the `Plugins` list on the ecosystem page.

- GitHub: https://github.com/yuji-hatakeyama/opencode-gpt-imagegen
- npm: https://www.npmjs.com/package/opencode-gpt-imagegen

Community plugin (not affiliated with OpenCode).

### How did you verify your code works?

Opened `packages/web/src/content/docs/ecosystem.mdx` and verified the new row matches the existing table formatting. Confirmed the GitHub and npm links resolve.

### Screenshots / recordings

N/A — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
