### PR TITLE
style(tui): mute markdown h3 headings

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -974,7 +974,7 @@ function getSyntaxRules(theme: Theme) {
     {
       scope: ["markup.heading.3"],
       style: {
-        foreground: theme.markdownHeading,
+        foreground: theme.textMuted,
         bold: true,
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -974,7 +974,7 @@ function getSyntaxRules(theme: Theme) {
     {
       scope: ["markup.heading.3"],
       style: {
-        foreground: theme.textMuted,
+        foreground: tint(theme.textMuted, theme.markdownHeading, 0.6),
         bold: true,
       },
     },


### PR DESCRIPTION
## Summary
- Render Markdown H3 headings with the muted text color while keeping them bold.
- Leave H1, H2, and H4-H6 heading styles unchanged.

## Verification
- bunx prettier --write src/cli/cmd/tui/context/theme.tsx
- bun typecheck from packages/opencode
- bunx oxlint packages/opencode/src/cli/cmd/tui/context/theme.tsx (existing warnings, 0 errors)

## Notes
- Root pre-push typecheck currently fails in packages/core with unrelated Response/Headers type errors, so this branch was pushed with the pre-push hook skipped after prior confirmation.