### PR TITLE
feat(task-tool): emit diagnostic when subagent returns no text part

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -208,7 +208,19 @@ export const TaskTool = Tool.define(
           },
           parts,
         })
-        return result.parts.findLast((item) => item.type === "text")?.text ?? ""
+        const textPart = result.parts.findLast((item) => item.type === "text")
+        const info = result.info.role === "assistant" ? result.info : undefined
+
+        const body =
+          textPart?.text ??
+          [
+            "Subagent completed without a text response.",
+            `finish: ${info?.finish ?? "unknown"}`,
+            `error: ${info?.error ? JSON.stringify(info.error) : "none"}`,
+            `parts: ${result.parts.map((part) => part.type).join(", ") || "none"}`,
+          ].join("\n")
+
+        return body
       })
 
       const resumeWhenIdle: (input: { userID: MessageID; state: "completed" | "error" }) => Effect.Effect<void> =

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -725,6 +725,126 @@ describe("tool.task", () => {
     }),
   )
 
+  it.instance("execute body is text when subagent returns a text part with content", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const promptOps = stubOps({ text: "the actual result" })
+
+      const result = yield* def.execute(
+        {
+          description: "some task",
+          prompt: "do something",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps, bypassAgentCheck: true },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("the actual result")
+    }),
+  )
+
+  it.instance("execute body is empty string when subagent returns an intentionally empty text part", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const promptOps = stubOps({ text: "" })
+
+      const result = yield* def.execute(
+        {
+          description: "some task",
+          prompt: "do something",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps, bypassAgentCheck: true },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      // intentional empty text part → body is empty string, no diagnostic block
+      expect(result.output).toContain("<task_result>\n\n</task_result>")
+      expect(result.output).not.toContain("Subagent completed without a text response.")
+    }),
+  )
+
+  it.instance("execute body is diagnostic block when subagent returns no text part", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+
+      // promptOps whose prompt returns a WithParts with NO text parts
+      const promptOps: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+        prompt: (input) =>
+          Effect.sync(() => {
+            const id = MessageID.ascending()
+            return {
+              info: {
+                id,
+                role: "assistant" as const,
+                parentID: input.messageID ?? MessageID.ascending(),
+                sessionID: input.sessionID,
+                mode: input.agent ?? "general",
+                agent: input.agent ?? "general",
+                cost: 0,
+                path: { cwd: "/tmp", root: "/tmp" },
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                modelID: input.model?.modelID ?? ref.modelID,
+                providerID: input.model?.providerID ?? ref.providerID,
+                time: { created: Date.now() },
+                finish: "tool-calls",
+              },
+              parts: [], // no text parts at all
+            } satisfies MessageV2.WithParts
+          }),
+        loop: (input) => Effect.succeed(reply({ sessionID: input.sessionID, parts: [] }, "done")),
+      }
+
+      const result = yield* def.execute(
+        {
+          description: "some task",
+          prompt: "do something",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps, bypassAgentCheck: true },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("Subagent completed without a text response.")
+      expect(result.output).toContain("finish: tool-calls")
+      expect(result.output).toContain("error: none")
+      expect(result.output).toContain("parts: none")
+    }),
+  )
+
   it.instance("cancelling a parent run recursively cancels descendant background tasks", () =>
     Effect.gen(function* () {
       const jobs = yield* BackgroundJob.Service


### PR DESCRIPTION
## Summary

- `TaskTool.runTask` previously collapsed a missing-text-part scenario into a silent empty string via `result.parts.findLast(…)?.text ?? ""`, giving the parent no indication of _why_ the result was empty.
- This PR emits a structured diagnostic block instead, containing the finish reason, any error details, and the part types that were produced, whenever no text part exists.
- An intentionally empty text part (`text === ""`) is preserved as-is, keeping the existing behaviour for that case.

## Test plan

Three new cases added to `packages/opencode/test/tool/task.test.ts`:

- [ ] Subagent returns a text part with content → `output` contains that text (happy path unchanged)
- [ ] Subagent returns a text part with empty string → `output` wraps `""` in `<task_result></task_result>`, no diagnostic block emitted
- [ ] Subagent returns **no** text part → `output` contains `"Subagent completed without a text response."`, `"finish:"`, `"error:"`, and `"parts:"` lines

## Related

- Closes #24447
- Related: #18423 (subagent observability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)