### PR TITLE
fix(opencode): set KimiCLI/1.5 User-Agent for kimi-for-coding provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -149,6 +149,16 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    "kimi-for-coding": () =>
+      Effect.succeed({
+        autoload: false,
+        options: {
+          headers: {
+            // Kimi's /coding gateway 429s requests from non-whitelisted User-Agents
+            "User-Agent": "KimiCLI/1.5",
+          },
+        },
+      }),
     opencode: Effect.fnUntraced(function* (input: Info) {
       const env = yield* dep.env()
       const hasKey = iife(() => {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -149,16 +149,6 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
-    "kimi-for-coding": () =>
-      Effect.succeed({
-        autoload: false,
-        options: {
-          headers: {
-            // Kimi's /coding gateway 429s requests from non-whitelisted User-Agents
-            "User-Agent": "KimiCLI/1.5",
-          },
-        },
-      }),
     opencode: Effect.fnUntraced(function* (input: Info) {
       const env = yield* dep.env()
       const hasKey = iife(() => {
@@ -989,7 +979,9 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
       npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
     },
     status: model.status ?? "active",
-    headers: {},
+    // Kimi's /coding gateway 429s non-whitelisted User-Agents; model.headers
+    // is spread after the default opencode UA in llm.ts so it takes precedence
+    headers: provider.id === "kimi-for-coding" ? { "User-Agent": "KimiCLI/1.5" } : {},
     options: {},
     cost: cost(model.cost),
     limit: {


### PR DESCRIPTION
### Issue for this PR

Closes #27902

### Type of change

- [x] Bug fix

### What does this PR do?

The built-in `kimi-for-coding` provider uses `@ai-sdk/anthropic`, which sends `Anthropic/JS x.x.x` as the default `User-Agent`. Kimi's `/coding` gateway intermittently 429s requests from non-whitelisted agents — setting `User-Agent: KimiCLI/1.5` significantly reduces these errors in practice.

The fix sets `User-Agent: KimiCLI/1.5` in `model.headers` inside `fromModelsDevModel`. This is the correct layer because `llm.ts` spreads `input.model.headers` at line 382, after the hardcoded `opencode/${InstallationVersion}` UA at line 380, so model-level headers win.

Setting it in `custom()` via `options.headers` (the pattern used by Cloudflare/GitLab) does not work here — `options.headers` only reaches the SDK constructor level and is overridden by the call-level headers in `llm.ts`. This was broken by the revert in #12072 and is tracked as open issue #24594.

### How did you verify your code works?

Observed significantly fewer 429 "engine overloaded" errors after applying the `User-Agent: KimiCLI/1.5` override. `bun turbo typecheck` passes clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
