### PR TITLE
fix(app): eliminate session switch latency — deferRender, Suspense flash, instant rendering

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -536,12 +536,6 @@ export default function Page() {
 
   createComputed((prev) => {
     const key = sessionKey()
-    if (key !== prev) {
-      setStore("deferRender", true)
-      requestAnimationFrame(() => {
-        setTimeout(() => setStore("deferRender", false), 0)
-      })
-    }
     return key
   }, sessionKey())
 
@@ -1124,7 +1118,7 @@ export default function Page() {
     loadingClass: string
     emptyClass: string
   }) => (
-    <Show when={!store.deferRender}>
+    <Show when={true}>
       <SessionReviewTab
         title={changesTitle()}
         empty={reviewEmpty(input)}
@@ -1882,7 +1876,7 @@ export default function Page() {
 
           <SessionComposerRegion
             state={composer}
-            ready={!store.deferRender && messagesReady()}
+            ready={messagesReady()}
             centered={centered()}
             inputRef={(el) => {
               inputRef = el

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -450,7 +450,8 @@ export default function Page() {
   const messagesReady = createMemo(() => {
     const id = params.id
     if (!id) return true
-    return sync.data.message[id] !== undefined
+    // Ready if messages are loaded OR the session exists in the list (show immediately, load in background)
+    return sync.data.message[id] !== undefined || sync.session.get(id) !== undefined
   })
   const historyMore = createMemo(() => {
     const id = params.id

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -749,7 +749,7 @@ export default function Page() {
 
   const hasScrollGesture = () => Date.now() - ui.scrollGesture < scrollGestureWindowMs
 
-  const [sessionSync] = createResource(
+  createResource(
     () => [sdk.directory, params.id] as const,
     ([directory, id]) => {
       if (refreshFrame !== undefined) cancelAnimationFrame(refreshFrame)
@@ -1783,7 +1783,6 @@ export default function Page() {
 
   return (
     <div class="relative bg-background-base size-full overflow-hidden flex flex-col">
-      {sessionSync() ?? ""}
       <SessionHeader />
       <div class="flex-1 min-h-0 flex flex-col md:flex-row">
         <Show when={!isDesktop() && !!params.id}>

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -99,7 +99,6 @@ export function SessionComposerRegion(props: {
   createEffect(() => {
     route.sessionKey()
     const ready = props.ready
-    const delay = 140
 
     clear()
     setStore("ready", false)
@@ -107,10 +106,7 @@ export function SessionComposerRegion(props: {
 
     frame = requestAnimationFrame(() => {
       frame = undefined
-      timer = window.setTimeout(() => {
-        setStore("ready", true)
-        timer = undefined
-      }, delay)
+      setStore("ready", true)
     })
   })
 

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1021,6 +1021,11 @@ export function MessageTimeline(props: {
                   </Button>
                 </div>
               </Show>
+              <Show when={props.renderedUserMessages.length === 0 && props.historyLoading}>
+                <div class="flex items-center justify-center py-12">
+                  <Spinner />
+                </div>
+              </Show>
               <For each={rendered()}>
                 {(messageID) => {
                   const active = createMemo(() => activeMessageID() === messageID)


### PR DESCRIPTION
### Issue for this PR

Closes #27910, closes #19793

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes three compounding session-switch responsiveness issues:

1. **Remove deferRender mechanism** — eliminates the one-frame blank + 140ms `setTimeout` in `session-composer-region` that caused a ~170ms gap where the composer was invisible on every session switch. The composer now re-shows after a single rAF yield (~16ms).

2. **Remove sessionSync JSX read** — `{sessionSync() ?? ""}` was read in JSX, triggering the app-level `<Suspense>` boundary (splash screen) on every session switch. Since the resource returns void, the read is removed entirely — the fetcher still runs reactively from its source signal.

3. **Widen messagesReady gate** — allow rendering when the session exists in the session list, even before messages have loaded. Shows a spinner in the timeline while messages load in the background, eliminating the blank screen on session switch.

### How did you verify your code works?

Tested locally by rapidly switching between sessions in the web UI. Verified no blank flashes, no splash screen flicker, and the composer appears instantly. Messages load in the background with a spinner shown during loading.

### Screenshots / recordings

_N/A — performance/latency improvement._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR