### PR TITLE
feat(core): add Model.prefill capability for trailing-assistant support

### DIFF
--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -57,6 +57,25 @@ export const Model = Schema.Struct({
       }),
     ]),
   ),
+  // Whether the model's chat template accepts an assistant turn as the LAST
+  // message (a.k.a. "prefill" / "response continuation").
+  //
+  // Default (undefined) is treated as `true` for backwards compatibility.
+  //
+  // Set to `false` for thinking-on-by-default models whose chat template
+  // rejects trailing-assistant when thinking is enabled. Affected families
+  // (non-exhaustive, 2025-2026):
+  //   - Qwen3 hybrid (all sizes), Qwen3-Thinking-2507, Qwen3-VL,
+  //     Qwen3.5, Qwen3.6, QwQ-32B  ->  llama.cpp "Assistant response prefill
+  //     is incompatible with enable_thinking" (ggml-org/llama.cpp#20861,
+  //     #21889; mastra-ai/mastra#15234)
+  //   - DeepSeek-R1 / R1-0528 / V4  (vllm-project/vllm#12999)
+  //   - GLM-4.6 / 4.7 thinking      (ggml-org/llama.cpp#15401)
+  //   - Kimi-K2-Thinking, MiniMax-M2
+  //
+  // Qwen3-Coder, Qwen3-Instruct-2507, Qwen2.5 keep `true` — their templates
+  // do not branch on `enable_thinking`, so prefill is safe.
+  prefill: Schema.optional(Schema.Boolean),
   cost: Schema.optional(Cost),
   limit: Schema.Struct({
     context: Schema.Finite,

--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -19,6 +19,15 @@ export const Model = Schema.Struct({
       }),
     ]),
   ),
+  prefill: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Whether the model accepts an assistant turn as the last message. " +
+      "Set false for thinking-on-by-default templates whose chat template " +
+      "rejects trailing-assistant (Qwen3 hybrid/3.5/3.6, QwQ, DeepSeek-R1, " +
+      "GLM-4.6/4.7 thinking, Kimi-K2-Thinking, MiniMax-M2). Defaults to " +
+      "true for non-openai-compatible providers, false for openai-compatible " +
+      "with reasoning enabled.",
+  }),
   cost: Schema.optional(
     Schema.Struct({
       input: Schema.Finite,


### PR DESCRIPTION
### Issue for this PR

Closes #27920

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `prefill: boolean` on the `Model` schema (and on the user-facing provider config schema) without any consumer-side wiring. A first-class capability lets every host consult one canonical source instead of guessing from npm package + reasoning flag.

Anthropic-style providers accept (and rely on) an assistant message as the last turn in a conversation ("response continuation" / "prefill"). Most thinking-on-by-default templates reject it outright — llama.cpp returns `HTTP 400 "Assistant response prefill is incompatible with enable_thinking"` on Qwen3-family templates, and vLLM/TGI have equivalent behaviour for DeepSeek-R1, GLM-4.6 thinking, Kimi-K2-Thinking, etc.

Default (`undefined`) is treated as `true`, so all existing models are unaffected by this PR alone.

Models intended to carry `prefill: false` in a follow-up `sst/models.dev` data PR:

- Qwen: Qwen3 hybrid (0.6B/1.7B/4B/8B/14B/32B/235B), Qwen3-Thinking-2507, Qwen3-VL, Qwen3.5, Qwen3.6, QwQ-32B
- DeepSeek: R1, R1-0528, V4 (when thinking on)
- Z.AI / GLM: GLM-4.6 thinking, GLM-4.7 thinking
- Moonshot: Kimi-K2-Thinking
- MiniMax: M2

Unchanged (still allow prefill): Qwen2.5, Qwen3-Coder, Qwen3-Instruct-2507, all Anthropic / OpenAI / Azure / Google / Bedrock-Anthropic.

Files:

- `packages/core/src/models.ts` — add `prefill: Schema.optional(Schema.Boolean)` with a per-family list in the schema comment.
- `packages/opencode/src/config/provider.ts` — mirror the field on the user-facing config schema with an annotation describing when to set it.

The consumer is split into a separate PR (`ProviderTransform.canAcceptTrailingAssistant`, MAX_STEPS role routing in `session/prompt.ts`, and a runtime probe of llama.cpp's `/props` endpoint).

### How did you verify your code works?

`bun run typecheck` clean. No runtime behaviour change in this PR — the field is read by code that arrives in the follow-up.

### Screenshots / recordings

_N/A — schema-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
