### PR TITLE
fix(tui): allow session interrupt (ESC) when dialog is open

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -471,7 +471,6 @@ export function Prompt(props: PromptProps) {
         enabled: status().type !== "idle",
         run: () => {
           if (auto()?.visible) return
-          if (!input.focused) return
           // TODO: this should be its own command
           if (store.mode === "shell") {
             setStore("mode", "normal")
@@ -628,6 +627,14 @@ export function Prompt(props: PromptProps) {
     commands: promptCommands(),
   }))
 
+  // session.interrupt must always be reachable, even when a dialog is open.
+  // Without this, pressing ESC when a permission prompt is showing would only
+  // dismiss the dialog — the model then retries the tool and re-opens it,
+  // trapping the user in an infinite dialog loop.
+  useBindings(() => ({
+    bindings: tuiConfig.keybinds.gather("prompt.interrupt", ["session.interrupt"]),
+  }))
+
   useBindings(() => ({
     enabled: command.matcher,
     bindings: tuiConfig.keybinds.gather("prompt.palette", [
@@ -637,7 +644,6 @@ export function Prompt(props: PromptProps) {
       "prompt.stash",
       "prompt.stash.pop",
       "prompt.stash.list",
-      "session.interrupt",
       "workspace.set",
     ]),
   }))


### PR DESCRIPTION
### Issue for this PR

Closes #27922

### Type of change

- [x] Bug fix

### What does this PR do?

When a permission dialog (or any dialog) is open in the TUI, the `session_interrupt` keybind (double ESC) is completely blocked because `dialog.stack.length > 0` disables all keybindings. This creates an infinite dialog loop where the user can only dismiss one dialog at a time while the model keeps retrying.

**Two changes in `component/prompt/index.tsx`:**

1. **Split `session.interrupt` into its own `useBindings` call** without the `enabled: command.matcher` guard, so it's always reachable regardless of dialog state.

2. **Remove the `if (!input.focused) return` check** from the interrupt handler, so it works even when the prompt input is blurred by an open dialog.

These are minimal changes — all other keybinds remain correctly blocked when dialogs are open. Only `session.interrupt` is exempted.

### How did you verify your code works?

This fix has been running in our fork (based on v1.14.41) for several days. Verified that:
- Double-ESC cancels the session even when a permission dialog is showing
- Single ESC still dismisses individual dialogs as before
- Other keybinds remain blocked during dialog display
- No regressions in normal dialog flow

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR