### PR TITLE
fix: wire pluginAutoInstall config to plugin install behavior

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -65,4 +65,7 @@ export const Flag = {
   get OPENCODE_CLIENT() {
     return process.env["OPENCODE_CLIENT"] ?? "cli"
   },
+  get OPENCODE_DISABLE_PLUGIN_INSTALL() {
+    return truthy("OPENCODE_DISABLE_PLUGIN_INSTALL")
+  },
 }

--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -9,6 +9,7 @@ import { Global } from "./global"
 import { EffectFlock } from "./util/effect-flock"
 import { makeRuntime } from "./effect/runtime"
 import { NpmConfig } from "./npm-config"
+import { Flag } from "./flag/flag"
 
 export class InstallFailedError extends Schema.TaggedErrorClass<InstallFailedError>()("NpmInstallFailedError", {
   add: Schema.Array(Schema.String).pipe(Schema.optional),
@@ -111,6 +112,9 @@ export const layer = Layer.effect(
       )
 
     const add = Effect.fn("Npm.add")(function* (pkg: string) {
+      if (Flag.OPENCODE_DISABLE_PLUGIN_INSTALL) {
+        return resolveEntryPoint(pkg, "")
+      }
       const dir = directory(pkg)
       const name = (() => {
         try {
@@ -135,6 +139,8 @@ export const layer = Layer.effect(
     }, Effect.scoped)
 
     const install: Interface["install"] = Effect.fn("Npm.install")(function* (dir, input) {
+      if (Flag.OPENCODE_DISABLE_PLUGIN_INSTALL) return
+
       const canWrite = yield* afs.access(dir, { writable: true }).pipe(
         Effect.as(true),
         Effect.orElseSucceed(() => false),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -156,6 +156,10 @@ export const Info = Schema.Struct({
     description:
       "Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications",
   }),
+  pluginAutoInstall: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Enable or disable automatic plugin installation. When false, plugins will not be auto-installed (equivalent to OPENCODE_DISABLE_PLUGIN_INSTALL=true)",
+  }),
   disabled_providers: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Disable providers that are loaded automatically",
   }),
@@ -730,6 +734,10 @@ export const layer = Layer.effect(
         }
         if (Flag.OPENCODE_DISABLE_PRUNE) {
           result.compaction = { ...result.compaction, prune: false }
+        }
+
+        if (result.pluginAutoInstall === false) {
+          process.env["OPENCODE_DISABLE_PLUGIN_INSTALL"] = "true"
         }
 
         return {


### PR DESCRIPTION
### Issue for this PR

Closes #27923

### Type of change

- [x] Bug fix

### What does this PR do?

The `pluginAutoInstall` config field exists in the schema but has no effect — setting `pluginAutoInstall: false` doesn't prevent plugin auto-installation. Only the undocumented `OPENCODE_DISABLE_PLUGIN_INSTALL=true` env var works.

**Three minimal changes:**

1. **`packages/core/src/flag/flag.ts`** — Add `OPENCODE_DISABLE_PLUGIN_INSTALL` as a runtime-evaluated getter (consistent with other `OPENCODE_DISABLE_*` flags)

2. **`packages/core/src/npm.ts`** — Add early returns in `add()` and `install()` when `Flag.OPENCODE_DISABLE_PLUGIN_INSTALL` is true

3. **`packages/opencode/src/config/config.ts`** — Add `pluginAutoInstall` to the schema, and wire it: when `pluginAutoInstall === false`, set `process.env["OPENCODE_DISABLE_PLUGIN_INSTALL"] = "true"` so the flag check picks it up

Usage:
```jsonc
// opencode.json
{
  "pluginAutoInstall": false
}
```

### How did you verify your code works?

This fix has been running in our fork (based on v1.14.41) for several days. Verified that:
- Setting `pluginAutoInstall: false` in opencode.json prevents all plugin auto-installation
- The `OPENCODE_DISABLE_PLUGIN_INSTALL` env var still works independently
- Plugin loading from `file://` paths continues to work normally

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR