### PR TITLE
fix(session): break infinite compaction loop

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1646,6 +1646,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const slog = elog.with({ sessionID })
         let structured: unknown
         let step = 0
+        let compactionAttempts = 0
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1712,9 +1713,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
+            compactionAttempts++
+            if (compactionAttempts >= 2) {
+              yield* slog.info("compaction loop detected at overflow check, breaking", { compactionAttempts })
+              break
+            }
             yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
             continue
           }
+
+          compactionAttempts = 0
 
           const agent = yield* agents.get(lastUser.agent)
           if (!agent) {
@@ -1852,6 +1860,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             if (result === "stop") return "break" as const
             if (result === "compact") {
+              compactionAttempts++
+              if (compactionAttempts >= 2) {
+                yield* slog.info("compaction loop detected, breaking", { compactionAttempts })
+                return "break" as const
+              }
               yield* compaction.create({
                 sessionID,
                 agent: lastUser.agent,


### PR DESCRIPTION
### Issue for this PR

Closes #27924

### Type of change

- [x] Bug fix

### What does this PR do?

The session loop in `prompt.ts` can enter an infinite compaction loop when compression fails to reduce the context below the token limit. The loop spins indefinitely consuming API credits without making progress.

**Change in `session/prompt.ts`:**

Add a `compactionAttempts` counter in the loop:
- Increment before each compaction attempt (both overflow and compact paths)
- If counter >= 2, break the loop with a log message
- Reset counter to 0 when normal processing progresses (i.e., agent/tool call path)

This is a safety guard, not a fix for underlying compaction failure. The counter is per-loop-invocation (reset on each new `runLoop` call), so it doesn't persist across sessions.

### How did you verify your code works?

This fix has been running in our fork (based on v1.14.41) for several days without issues. The change was manually applied to the current `dev` branch rather than cherry-picked due to significant code divergence.

Verified that:
- Infinite compaction loop is broken after 2 attempts
- Normal compaction (when it succeeds) is unaffected
- No regressions in session flow

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR