### PR TITLE
fix(server): add Cache-Control headers to static assets

### DIFF
--- a/packages/opencode/src/server/shared/ui.ts
+++ b/packages/opencode/src/server/shared/ui.ts
@@ -52,9 +52,18 @@ function notFound() {
   return HttpServerResponse.jsonUnsafe({ error: "Not Found" }, { status: 404 })
 }
 
+// Vite content-hashed filenames contain a hash segment (e.g. index-abc123.js)
+const HASHED_ASSET_REGEX = /[-.][\da-f]{8,}\.\w+$/
+
+function cacheControl(file: string, mime: string) {
+  if (mime.startsWith("text/html")) return "no-cache"
+  if (HASHED_ASSET_REGEX.test(file)) return "public, max-age=31536000, immutable"
+  return "public, max-age=3600"
+}
+
 function embeddedUIResponse(file: string, body: Uint8Array) {
   const mime = FSUtil.mimeType(file)
-  const headers = new Headers({ "content-type": mime })
+  const headers = new Headers({ "content-type": mime, "cache-control": cacheControl(file, mime) })
   if (mime.startsWith("text/html")) {
     headers.set("content-security-policy", cspForHtml(new TextDecoder().decode(body)))
   }


### PR DESCRIPTION
### Issue for this PR

Closes #27931

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `Cache-Control` headers to the embedded web UI asset responses in `server/shared/ui.ts`:

- **Hashed assets** (Vite content-hashed filenames like `index-abc123.js`): `public, max-age=31536000, immutable` — these filenames change when content changes, so they can be cached indefinitely.
- **HTML**: `no-cache` — always revalidate to pick up new asset references.
- **Other static files** (favicons, manifest, etc.): `public, max-age=3600` — reasonable 1hr cache.

A regex detects Vite's content-hash pattern (`-` or `.` followed by 8+ hex chars before the extension).

### How did you verify your code works?

Tested locally by checking response headers on static assets served by the embedded web UI. Verified hashed assets get `immutable`, HTML gets `no-cache`, and other files get 1hr cache.

### Screenshots / recordings

_N/A — response header change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR