### PR TITLE
fix(server): add zstd HTTP compression with gzip fallback

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
@@ -13,11 +13,12 @@ const STREAMING_POST_REGEX = /^\/session\/[^/]+\/(?:message|prompt_async)$/
 
 const THRESHOLD_BYTES = 1024
 
-type Encoding = "gzip" | "deflate"
+type Encoding = "zstd" | "gzip" | "deflate"
 
 function pickEncoding(acceptEncoding: string | undefined): Encoding | undefined {
   if (!acceptEncoding) return undefined
   const lower = acceptEncoding.toLowerCase()
+  if (lower.includes("zstd")) return "zstd"
   if (lower.includes("gzip")) return "gzip"
   if (lower.includes("deflate")) return "deflate"
   return undefined
@@ -54,7 +55,12 @@ export const compressionLayer = HttpRouter.middleware<{ handles: unknown }>()((e
     const encoding = pickEncoding(request.headers["accept-encoding"])
     if (!encoding) return response
 
-    const compressed = encoding === "gzip" ? gzipSync(body.body) : deflateSync(body.body)
+    const compressed =
+      encoding === "zstd"
+        ? Bun.zstdCompressSync(body.body)
+        : encoding === "gzip"
+          ? gzipSync(body.body)
+          : deflateSync(body.body)
     return HttpServerResponse.setHeader(
       HttpServerResponse.setBody(response, HttpBody.uint8Array(compressed, contentType)),
       "content-encoding",


### PR DESCRIPTION
### Issue for this PR

Closes #27932

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds zstd as the preferred compression encoding in the HTTP compression middleware, falling back to gzip and deflate. Modern browsers (Chrome 123+, Firefox 126+, Safari 18+) automatically send `zstd` in `Accept-Encoding`.

Zstd provides ~30-40% better compression than gzip at similar CPU cost. Uses `Bun.zstdCompressSync()` which is available natively in Bun.

Changes:
- Add `"zstd"` to the `Encoding` type union
- Check for `zstd` before `gzip` in `pickEncoding` to prefer it
- Add `Bun.zstdCompressSync()` call for zstd encoding

All existing guards (SSE exclusion, threshold, no-transform, etc.) apply to zstd as well.

### How did you verify your code works?

Tested locally by sending requests with `Accept-Encoding: zstd, gzip` and verifying the response uses `Content-Encoding: zstd`. Verified fallback to gzip when zstd is not in Accept-Encoding.

### Screenshots / recordings

_N/A — network-level improvement._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR