### PR TITLE
fix(plugin): refresh mutable specs during install

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -23,8 +23,12 @@ export interface EntryPoint {
   readonly entrypoint: Option.Option<string>
 }
 
+export interface AddOptions {
+  readonly refresh?: boolean
+}
+
 export interface Interface {
-  readonly add: (pkg: string) => Effect.Effect<EntryPoint, InstallFailedError | EffectFlock.LockError>
+  readonly add: (pkg: string, options?: AddOptions) => Effect.Effect<EntryPoint, InstallFailedError | EffectFlock.LockError>
   readonly install: (
     dir: string,
     input?: {
@@ -112,7 +116,7 @@ export const layer = Layer.effect(
         }),
       )
 
-    const add = Effect.fn("Npm.add")(function* (pkg: string) {
+    const add = Effect.fn("Npm.add")(function* (pkg: string, options?: AddOptions) {
       const dir = directory(pkg)
       const name = (() => {
         try {
@@ -122,7 +126,7 @@ export const layer = Layer.effect(
         }
       })()
 
-      if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
+      if (!options?.refresh && (yield* afs.existsSafe(path.join(dir, "node_modules", name)))) {
         return resolveEntryPoint(name, path.join(dir, "node_modules", name))
       }
 

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -43,6 +43,12 @@ describe("Npm.sanitize", () => {
 })
 
 describe("Npm.add", () => {
+  const add = (spec: string, cache: string, options?: Npm.AddOptions) =>
+    Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      return yield* npm.add(spec, options)
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(cache)), Effect.runPromise)
+
   test("reifies when package cache directory exists without the package installed", async () => {
     await using tmp = await tmpdir()
     await fs.mkdir(path.join(tmp.path, "fixture-provider"))
@@ -55,12 +61,56 @@ describe("Npm.add", () => {
     const spec = `fixture-provider@file:${path.join(tmp.path, "fixture-provider")}`
     await fs.mkdir(path.join(tmp.path, "cache", "packages", Npm.sanitize(spec)), { recursive: true })
 
-    const entry = await Effect.gen(function* () {
-      const npm = yield* Npm.Service
-      return yield* npm.add(spec)
-    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+    const entry = await add(spec, path.join(tmp.path, "cache"))
 
     expect(Option.isSome(entry.entrypoint)).toBe(true)
+  })
+
+  test("refreshes an existing package cache when requested", async () => {
+    await using tmp = await tmpdir()
+    const cache = path.join(tmp.path, "cache")
+    const oldSource = path.join(tmp.path, "fixture-provider-old")
+    const source = path.join(tmp.path, "fixture-provider-new")
+    const spec = `fixture-provider@file:${source}`
+    const dir = path.join(cache, "packages", Npm.sanitize(spec))
+    const cached = path.join(cache, "packages", Npm.sanitize(spec), "node_modules", "fixture-provider")
+
+    await fs.mkdir(oldSource, { recursive: true })
+    await writePackage(oldSource, {
+      name: "fixture-provider",
+      version: "1.0.0",
+      main: "index.js",
+    })
+    await Bun.write(path.join(oldSource, "index.js"), "export const fixture = false\n")
+    await fs.mkdir(source, { recursive: true })
+    await writePackage(source, {
+      name: "fixture-provider",
+      version: "2.0.0",
+      main: "index.js",
+    })
+    await Bun.write(path.join(source, "index.js"), "export const fixture = true\n")
+    await fs.mkdir(dir, { recursive: true })
+    await writePackage(dir, {
+      dependencies: {
+        "fixture-provider": `file:${oldSource}`,
+      },
+    })
+    await fs.mkdir(cached, { recursive: true })
+    await writePackage(cached, {
+      name: "fixture-provider",
+      version: "1.0.0",
+      main: "index.js",
+    })
+    await Bun.write(path.join(cached, "index.js"), "export const cached = true\n")
+
+    await add(spec, cache)
+    expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("1.0.0")
+
+    await add(spec, cache, { refresh: true })
+    expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("2.0.0")
+    expect(JSON.parse(await Bun.file(path.join(dir, "package.json")).text()).dependencies["fixture-provider"]).toContain(
+      "fixture-provider-new",
+    )
   })
 })
 

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect"
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@opencode-ai/core/global"
 import { installPlugin, patchPluginConfig, readPluginManifest } from "../../plugin/install"
-import { resolvePluginTarget } from "../../plugin/shared"
+import { resolvePluginTarget, type ResolvePluginTargetOptions } from "../../plugin/shared"
 import { errorMessage } from "../../util/error"
 import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
@@ -24,7 +24,7 @@ export type PlugDeps = {
     info: (msg: string) => void
     success: (msg: string) => void
   }
-  resolve: (spec: string) => Promise<string>
+  resolve: (spec: string, options?: ResolvePluginTargetOptions) => Promise<string>
   readText: (file: string) => Promise<string>
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
@@ -51,7 +51,7 @@ const defaultPlugDeps: PlugDeps = {
     info: (msg) => log.info(msg),
     success: (msg) => log.success(msg),
   },
-  resolve: (spec) => resolvePluginTarget(spec),
+  resolve: (spec, options) => resolvePluginTarget(spec, options),
   readText: (file) => Filesystem.readText(file),
   write: async (file, text) => {
     await Filesystem.write(file, text)

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -13,7 +13,14 @@ import { Filesystem } from "@/util/filesystem"
 import { Flock } from "@opencode-ai/core/util/flock"
 import { isRecord } from "@/util/record"
 
-import { parsePluginSpecifier, readPackageThemes, readPluginPackage, resolvePluginTarget } from "./shared"
+import {
+  parsePluginSpecifier,
+  readPackageThemes,
+  readPluginPackage,
+  resolvePluginTarget,
+  type ResolvePluginTargetOptions,
+  shouldRefreshPluginTarget,
+} from "./shared"
 
 type Mode = "noop" | "add" | "replace"
 type Kind = "server" | "tui"
@@ -24,7 +31,7 @@ export type Target = {
 }
 
 export type InstallDeps = {
-  resolve: (spec: string) => Promise<string>
+  resolve: (spec: string, options?: ResolvePluginTargetOptions) => Promise<string>
 }
 
 export type PatchDeps = {
@@ -76,7 +83,7 @@ type PatchOne = Ok<{ item: PatchItem }> | PatchErr
 export type PatchResult = Ok<{ dir: string; items: PatchItem[] }> | (PatchErr & { dir: string })
 
 const defaultInstallDeps: InstallDeps = {
-  resolve: (spec) => resolvePluginTarget(spec),
+  resolve: (spec, options) => resolvePluginTarget(spec, options),
 }
 
 const defaultPatchDeps: PatchDeps = {
@@ -257,7 +264,7 @@ function patchPluginList(
 }
 
 export async function installPlugin(spec: string, dep: InstallDeps = defaultInstallDeps): Promise<InstallResult> {
-  const target = await dep.resolve(spec).then(
+  const target = await dep.resolve(spec, { refresh: shouldRefreshPluginTarget(spec) }).then(
     (item) => ({
       ok: true as const,
       item,

--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -35,6 +35,7 @@ export function parsePluginSpecifier(spec: string) {
 
 export type PluginSource = "file" | "npm"
 export type PluginKind = "server" | "tui"
+export type ResolvePluginTargetOptions = Npm.AddOptions
 type PluginMode = "strict" | "detect"
 
 export type PluginPackage = {
@@ -204,11 +205,23 @@ export async function checkPluginCompatibility(target: string, opencodeVersion: 
   }
 }
 
-export async function resolvePluginTarget(spec: string) {
+export function shouldRefreshPluginTarget(spec: string) {
+  if (isPathPluginSpec(spec)) return false
+  const hit = parse(spec)
+  if (hit?.type === "alias") {
+    const sub = (hit as npa.AliasResult).subSpec
+    return !sub?.rawSpec || sub.rawSpec === "*" || !semver.valid(sub.rawSpec)
+  }
+  if (!hit?.name) return true
+  if (hit.raw === hit.name) return true
+  return !semver.valid(hit.rawSpec)
+}
+
+export async function resolvePluginTarget(spec: string, options?: ResolvePluginTargetOptions) {
   if (isPathPluginSpec(spec)) return resolvePathPluginTarget(spec)
   const hit = parse(spec)
   const pkg = hit?.name && hit.raw === hit.name ? `${hit.name}@latest` : spec
-  const result = await Npm.add(pkg)
+  const result = await Npm.add(pkg, options)
   return result.directory
 }
 

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -128,6 +128,52 @@ describe("plugin.install.task", () => {
     expect(tui.plugin).toEqual(["acme@1.2.3"])
   })
 
+  test("refreshes package cache for mutable package installs", async () => {
+    await using tmp = await tmpdir()
+    const target = await plugin(tmp.path, ["tui"])
+    const dep = deps(path.join(tmp.path, "global"), target)
+    const refresh = new Array<boolean | undefined>()
+    const run = createPlugTask(
+      {
+        mod: "acme",
+      },
+      {
+        ...dep,
+        resolve: async (_spec, options) => {
+          refresh.push(options?.refresh)
+          return target
+        },
+      },
+    )
+
+    const ok = await run(ctx(tmp.path))
+    expect(ok).toBe(true)
+    expect(refresh).toEqual([true])
+  })
+
+  test("keeps package cache for exact version installs", async () => {
+    await using tmp = await tmpdir()
+    const target = await plugin(tmp.path, ["tui"])
+    const dep = deps(path.join(tmp.path, "global"), target)
+    const refresh = new Array<boolean | undefined>()
+    const run = createPlugTask(
+      {
+        mod: "acme@1.2.3",
+      },
+      {
+        ...dep,
+        resolve: async (_spec, options) => {
+          refresh.push(options?.refresh)
+          return target
+        },
+      },
+    )
+
+    const ok = await run(ctx(tmp.path))
+    expect(ok).toBe(true)
+    expect(refresh).toEqual([false])
+  })
+
   test("writes default options from exports config metadata", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server", "tui"], {

--- a/packages/opencode/test/plugin/shared.test.ts
+++ b/packages/opencode/test/plugin/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { parsePluginSpecifier } from "../../src/plugin/shared"
+import { parsePluginSpecifier, shouldRefreshPluginTarget } from "../../src/plugin/shared"
 
 describe("parsePluginSpecifier", () => {
   test("parses standard npm package without version", () => {
@@ -84,5 +84,23 @@ describe("parsePluginSpecifier", () => {
       pkg: "@opencode/acme",
       version: "latest",
     })
+  })
+})
+
+describe("shouldRefreshPluginTarget", () => {
+  test("refreshes mutable package specs", () => {
+    expect(shouldRefreshPluginTarget("acme")).toBe(true)
+    expect(shouldRefreshPluginTarget("acme@latest")).toBe(true)
+    expect(shouldRefreshPluginTarget("acme@^1.0.0")).toBe(true)
+    expect(shouldRefreshPluginTarget("acme@git+https://github.com/opencode/acme.git")).toBe(true)
+    expect(shouldRefreshPluginTarget("npm:@opencode/acme")).toBe(true)
+  })
+
+  test("keeps cache for exact package versions and paths", () => {
+    expect(shouldRefreshPluginTarget("acme@1.0.0")).toBe(false)
+    expect(shouldRefreshPluginTarget("@opencode/acme@1.0.0")).toBe(false)
+    expect(shouldRefreshPluginTarget("acme@npm:@opencode/acme@1.0.0")).toBe(false)
+    expect(shouldRefreshPluginTarget("npm:@opencode/acme@1.0.0")).toBe(false)
+    expect(shouldRefreshPluginTarget("./plugin")).toBe(false)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #21609

Addresses the explicit install/update subcase of #25293. Startup auto-refresh for already-configured floating plugin specs remains out of scope for this PR.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Explicit plugin installs now refresh mutable package specs instead of reusing a stale package cache entry forever.

The cache fast path is still used for exact versions and for normal plugin loading. Only install/update paths pass `refresh: true` for mutable specs such as bare package names, `@latest`, ranges, git specs, and unpinned npm aliases.

This is intentionally narrower than auto-updating plugins during startup. It fixes stale `@latest` behavior for explicit plugin installs without adding registry checks to normal TUI boot.

Related: #25293, #26215, #18544, #23143, #23502.

### How did you verify your code works?

- `bun test test/npm.test.ts` from `packages/core`
- `bun test test/plugin/shared.test.ts test/plugin/install.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/opencode`
- `git diff --check`
- pre-push `bun turbo typecheck` completed successfully

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR