### PR TITLE
fix(acp): register and execute /model and /mode commands for ACP clients

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1143,6 +1143,16 @@ export class Agent implements ACPAgent {
         name: "compact",
         description: "compact the session",
       })
+    if (!names.has("model"))
+      availableCommands.push({
+        name: "model",
+        description: "change AI model",
+      })
+    if (!names.has("mode"))
+      availableCommands.push({
+        name: "mode",
+        description: "change session mode",
+      })
 
     const mcpServers: Record<string, ConfigMCP.Info> = {}
     for (const server of params.mcpServers) {
@@ -1489,6 +1499,16 @@ export class Agent implements ACPAgent {
           },
           { throwOnError: true },
         )
+        break
+      case "model":
+        if (cmd.args) {
+          await this.setSessionConfigOption({ sessionId: sessionID, configId: "model", value: cmd.args })
+        }
+        break
+      case "mode":
+        if (cmd.args) {
+          await this.setSessionConfigOption({ sessionId: sessionID, configId: "mode", value: cmd.args })
+        }
         break
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #27942

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two bugs in `packages/opencode/src/acp/agent.ts` caused `/model` and `/mode` to silently fail when used via ACP clients like OpenACP.

First, neither command was included in the `available_commands_update` payload. Clients check this list before dispatching, so commands missing from it get dropped before they reach OpenCode.

Second, even with discovery fixed, the `prompt()` switch block only handled `"compact"`. So when a client forwarded the command, OpenCode parsed it but fell through the switch doing nothing.

Fixed by adding `model` and `mode` to the `available_commands_update` fallback block, and adding the corresponding `case` statements in the switch that call `setSessionConfigOption`.

### How did you verify your code works?

Tested with Telegram + OpenACP + OpenCode + LMStudio. Sent `/model lmstudio/<id>` and `/mode <id>` — both now apply correctly. `/compact` and regular prompts are unaffected.

### Screenshots / recordings

_No UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
