### PR TITLE
fix: use static plugin spinner outside TTY

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -1,3 +1,4 @@
+import { EOL } from "os"
 import { intro, log, outro, spinner } from "@clack/prompts"
 import { Effect } from "effect"
 
@@ -44,8 +45,21 @@ export type PlugCtx = {
   directory: string
 }
 
+export function createPlugSpinner(
+  options: {
+    isTTY?: boolean
+    write?: (msg: string) => void
+  } = {},
+): Spin {
+  if (options.isTTY ?? process.stdout.isTTY) return spinner()
+  return {
+    start: (msg) => (options.write ?? process.stderr.write.bind(process.stderr))(`${msg}${EOL}`),
+    stop: (msg) => (options.write ?? process.stderr.write.bind(process.stderr))(`${msg}${EOL}`),
+  }
+}
+
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => createPlugSpinner(),
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises"
 import path from "path"
 import { parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "@/util/filesystem"
-import { createPlugTask, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
+import { createPlugSpinner, createPlugTask, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
 import { tmpdir } from "../fixture/fixture"
 
 function deps(global: string, target: string | Error): PlugDeps {
@@ -109,6 +109,22 @@ async function read(file: string) {
 }
 
 describe("plugin.install.task", () => {
+  test("uses static spinner output outside TTY", () => {
+    const output: string[] = []
+    const spin = createPlugSpinner({
+      isTTY: false,
+      write: (msg) => output.push(msg),
+    })
+
+    spin.start("Installing plugin package...")
+    spin.stop("Plugin package ready")
+
+    const normalized = output.join("").replaceAll("\r\n", "\n")
+    expect(normalized).toBe("Installing plugin package...\nPlugin package ready\n")
+    expect(normalized).not.toContain("\r")
+    expect(normalized).not.toContain("\x1b[")
+  })
+
   test("writes both server and tui config entries", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server", "tui"])


### PR DESCRIPTION
### Issue for this PR

Closes #27908

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Uses a static plugin install spinner when stdout is not a TTY, so piped/non-interactive runs print one line per step instead of terminal control output. Interactive terminals still use the existing animated spinner.

(AI-assisted)

### How did you verify your code works?

- `bun test test/plugin/install.test.ts`
- `bun typecheck`

### Screenshots / recordings

Not applicable; CLI output behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR