### PR TITLE
feat(tui): aggregate subagent costs into sidebar spent total

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -14,7 +14,19 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
-  const cost = createMemo(() => session()?.cost ?? 0)
+  const cost = createMemo(() => {
+    const rootID = session()?.id ?? props.session_id
+    let total = 0
+    let stack = [rootID]
+    while (stack.length > 0) {
+      const id = stack.pop()!
+      const s = props.api.state.session.get(id)
+      if (s != null) total += s.cost ?? 0
+      const children = props.api.state.session.all().filter((x) => x.parentID === id)
+      stack.push(...children.map((c) => c.id))
+    }
+    return total
+  })
 
   const state = createMemo(() => {
     const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -15,7 +15,8 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
   const cost = createMemo(() => {
-    const rootID = session()?.id ?? props.session_id
+    const rootID = session()?.id
+    if (!rootID) return 0
     let total = 0
     let stack = [rootID]
     while (stack.length > 0) {

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -148,6 +148,9 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       count() {
         return sync.data.session.length
       },
+      all() {
+        return sync.data.session
+      },
       get(sessionID) {
         return sync.session.get(sessionID)
       },

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -381,6 +381,7 @@ export type TuiState = {
   readonly vcs: { branch?: string } | undefined
   session: {
     count: () => number
+    all: () => ReadonlyArray<Session>
     get: (sessionID: string) => Session | undefined
     diff: (sessionID: string) => ReadonlyArray<TuiSidebarFileItem>
     todo: (sessionID: string) => ReadonlyArray<TuiSidebarTodoItem>


### PR DESCRIPTION
When subagents are spawned during a session, their spending does not show up in the sidebar total. Only the parent session own cost is displayed. This PR fixes it by summing the existing cost values already tracked for each child and grandchild session into the spent display, so the number reflects what was actually spent across the entire session tree. Viewing a subagent shows its own cost plus all of its descendants costs. No new data needs to be stored or collected. All prior sessions will reflect the correct total immediately once this is deployed.

The TUI sidebar shows $ spent from session.cost, which only tracks the current session own usage. Subagents spawned via the task tool have their costs tracked in separate child sessions (parentID not null) and never appear in the parent total.

A parent session running 3 subagents at $0.50 each would show $0.25 (its own cost) rather than the actual $1.75 spent.

### Changes

**`packages/plugin/src/tui.ts`** Add `all(): ReadonlyArray<Session>` to `TuiPluginState.session`. Previously only exposed `count()` and `get(id)`.

**`packages/opencode/src/cli/cmd/tui/plugin/api.tsx`** Implement `all()` returning `sync.data.session`.

**`packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx`** Replace `session()?.cost ?? 0` with iterative DFS over descendants (children, grandchildren, etc.). Display stays unchanged, just $X.XX spent.

### Notes

- Only includes sessions reachable via `parentID` from the currently viewed session. Unrelated sessions from sibling directories are not included.
- No DB changes. Purely display-time computation. Child sessions already share the same `directory` as their parent, so they are always loaded together in `sync.data.session`.
- If viewing a subagent directly, shows its own cost plus its descendants (not aggregated upward).