### PR TITLE
fix(desktop): install the latest available update

### DIFF
--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -44,6 +44,7 @@ export async function checkUpdate() {
     })
     const version = result?.updateInfo?.version
     if (result?.isUpdateAvailable === false || !version) {
+      downloadedUpdateVersion = undefined
       logger.log("no update available", {
         reason: "provider returned no newer version",
       })

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -6,8 +6,6 @@ import { initLogging } from "./logging"
 const logger = initLogging()
 const { autoUpdater } = pkg
 
-let downloadedUpdateVersion: string | undefined
-
 export function setupAutoUpdater() {
   if (!UPDATER_ENABLED) return
   autoUpdater.logger = logger
@@ -28,7 +26,6 @@ export async function checkUpdate() {
   if (!UPDATER_ENABLED) return { updateAvailable: false }
   logger.log("checking for updates", {
     currentVersion: app.getVersion(),
-    downloadedUpdateVersion: downloadedUpdateVersion ?? null,
     channel: autoUpdater.channel,
     allowPrerelease: autoUpdater.allowPrerelease,
     allowDowngrade: autoUpdater.allowDowngrade,
@@ -44,7 +41,6 @@ export async function checkUpdate() {
     })
     const version = result?.updateInfo?.version
     if (result?.isUpdateAvailable === false || !version) {
-      downloadedUpdateVersion = undefined
       logger.log("no update available", {
         reason: "provider returned no newer version",
       })
@@ -53,7 +49,6 @@ export async function checkUpdate() {
     logger.log("update available", { version })
     await autoUpdater.downloadUpdate()
     logger.log("update download completed", { version })
-    downloadedUpdateVersion = version
     return { updateAvailable: true, version }
   } catch (error) {
     logger.error("update check failed", error)
@@ -62,14 +57,15 @@ export async function checkUpdate() {
 }
 
 export async function installUpdate(killSidecar: () => Promise<void>) {
-  if (!downloadedUpdateVersion) {
+  const result = await checkUpdate()
+  if (!result.updateAvailable) {
     logger.log("install update skipped", {
-      reason: "no downloaded update ready",
+      reason: result.failed ? "update check failed" : "no update available",
     })
     return
   }
   logger.log("installing downloaded update", {
-    version: downloadedUpdateVersion,
+    version: result.version ?? null,
   })
   await killSidecar()
   autoUpdater.quitAndInstall()

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -26,14 +26,9 @@ export function setupAutoUpdater() {
 
 export async function checkUpdate() {
   if (!UPDATER_ENABLED) return { updateAvailable: false }
-  if (downloadedUpdateVersion) {
-    logger.log("returning cached downloaded update", {
-      version: downloadedUpdateVersion,
-    })
-    return { updateAvailable: true, version: downloadedUpdateVersion }
-  }
   logger.log("checking for updates", {
     currentVersion: app.getVersion(),
+    downloadedUpdateVersion: downloadedUpdateVersion ?? null,
     channel: autoUpdater.channel,
     allowPrerelease: autoUpdater.allowPrerelease,
     allowDowngrade: autoUpdater.allowDowngrade,

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -59,12 +59,8 @@ export async function checkUpdate() {
 export async function installUpdate(killSidecar: () => Promise<void>) {
   const result = await checkUpdate()
   if (!result.updateAvailable) {
-    const failed = result.failed === true
-    logger.log("install update skipped", { reason: failed ? "update check failed" : "no update available" })
-    await dialog.showMessageBox({
-      type: failed ? "error" : "info",
-      message: failed ? "Update check failed." : "You're up to date.",
-      title: failed ? "Update Error" : "No Updates",
+    logger.log("install update skipped", {
+      reason: result.failed ? "update check failed" : "no update available",
     })
     return
   }

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -59,8 +59,12 @@ export async function checkUpdate() {
 export async function installUpdate(killSidecar: () => Promise<void>) {
   const result = await checkUpdate()
   if (!result.updateAvailable) {
-    logger.log("install update skipped", {
-      reason: result.failed ? "update check failed" : "no update available",
+    const failed = result.failed === true
+    logger.log("install update skipped", { reason: failed ? "update check failed" : "no update available" })
+    await dialog.showMessageBox({
+      type: failed ? "error" : "info",
+      message: failed ? "Update check failed." : "You're up to date.",
+      title: failed ? "Update Error" : "No Updates",
     })
     return
   }


### PR DESCRIPTION
Desktop updates could previously download one version, keep that downloaded version in memory, and later install it even if a newer release had appeared. This was especially easy to hit on beta builds where releases can happen quickly: the startup poll downloads update A, the user waits, update B ships, then clicking install still applies A. After relaunch, the app would correctly say another update is available, which makes the updater feel like it did not actually update to latest.

This changes the updater flow so the install path is tied to a fresh update check instead of our own cached version string. Checking for updates now always asks the provider for current metadata. Installing also performs that check first, downloads/validates the update that provider currently reports, and only then calls quitAndInstall. That means an old toast/action cannot install stale in-memory state; the app should install the latest available update at the moment the user chooses to update.

The implementation deliberately removes the local downloadedUpdateVersion cache rather than adding more state around it. electron-updater already owns the downloaded-file cache and validates matching update files, so keeping a second version cache in our code was the source of the stale install behavior.

Verification:
- bun typecheck in packages/desktop
- push hook: bun turbo typecheck