### PR TITLE
fix: sort v2 session list by updated time

### DIFF
--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -41,6 +41,7 @@ export function trimSessions(
     .filter((s) => !s.time?.archived)
     .sort((a, b) => cmp(a.id, b.id))
   const roots = all.filter((s) => !s.parentID)
+  roots.sort(compareSessionRecent)
   const children = all.filter((s) => !!s.parentID)
   const base = roots.slice(0, limit)
   const recent = takeRecentSessions(roots.slice(limit), SESSION_RECENT_LIMIT, cutoff)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/session.ts
@@ -1,6 +1,6 @@
 import { WorkspaceID } from "@/control-plane/schema"
 import { SessionV2 } from "@/v2/session"
-import { Effect, Schema } from "effect"
+import { DateTime, Effect, Schema } from "effect"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../../api"
 
@@ -55,7 +55,7 @@ const sessionCursor = {
     filters: Pick<SessionCursor, "directory" | "path" | "workspaceID" | "roots" | "start" | "search">,
   ) {
     return Buffer.from(
-      JSON.stringify({ id: session.id, time: session.time.created, order, direction, ...filters }),
+      JSON.stringify({ ...filters, id: session.id, time: DateTime.toEpochMillis(session.time.updated), order, direction }),
     ).toString("base64url")
   },
   decode(input: string) {

--- a/packages/opencode/src/v2/session.ts
+++ b/packages/opencode/src/v2/session.ts
@@ -177,6 +177,8 @@ export const layer = Layer.effect(
       list: Effect.fn("V2Session.list")(function* (input) {
         const direction = input.cursor?.direction ?? "next"
         let order = input.order ?? "desc"
+        // This is a load bearing sort, desktop relies on this
+        const sortColumn = SessionTable.time_updated
         // Query the adjacent rows in reverse, then flip them back into the requested order below.
         if (direction === "previous" && order === "asc") order = "desc"
         if (direction === "previous" && order === "desc") order = "asc"
@@ -186,18 +188,18 @@ export const layer = Layer.effect(
           conditions.push(or(eq(SessionTable.path, input.path), like(SessionTable.path, `${input.path}/%`))!)
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
         if (input.roots) conditions.push(isNull(SessionTable.parent_id))
-        if (input.start) conditions.push(gte(SessionTable.time_created, input.start))
+        if (input.start) conditions.push(gte(sortColumn, input.start))
         if (input.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
         if (input.cursor) {
           conditions.push(
             order === "asc"
               ? or(
-                  gt(SessionTable.time_created, input.cursor.time),
-                  and(eq(SessionTable.time_created, input.cursor.time), gt(SessionTable.id, input.cursor.id)),
+                  gt(sortColumn, input.cursor.time),
+                  and(eq(sortColumn, input.cursor.time), gt(SessionTable.id, input.cursor.id)),
                 )!
               : or(
-                  lt(SessionTable.time_created, input.cursor.time),
-                  and(eq(SessionTable.time_created, input.cursor.time), lt(SessionTable.id, input.cursor.id)),
+                  lt(sortColumn, input.cursor.time),
+                  and(eq(sortColumn, input.cursor.time), lt(SessionTable.id, input.cursor.id)),
                 )!,
           )
         }
@@ -206,7 +208,7 @@ export const layer = Layer.effect(
           .from(SessionTable)
           .where(conditions.length > 0 ? and(...conditions) : undefined)
           .orderBy(
-            order === "asc" ? asc(SessionTable.time_created) : desc(SessionTable.time_created),
+            order === "asc" ? asc(sortColumn) : desc(sortColumn),
             order === "asc" ? asc(SessionTable.id) : desc(SessionTable.id),
           )
 


### PR DESCRIPTION
TL;DR: "Load more" looked random because the backend and sidebar disagreed on what "newest" meant.

From the actual local DB investigation, the API was selecting/paginating root sessions by created time, but the app sidebar displays sessions by updated time. That means a session created days ago but touched recently can be outside the first page, then appear near the top after clicking Load more. Concrete example from the repro data: "fix: ResizeObserver crash" now ranks #7 by updated time in C:\Repos\sst\opencode, so it belongs in the initial page.

Per review feedback, this removes the proposed sort parameter and just flips v2 session list ordering to updated time. Nothing was using the v2 endpoint yet.

Summary:
- Sort v2 session list pagination by updated time.
- Encode cursor boundaries with updated time.
- Trim app sidebar root sessions by updated order.

Diff size:
- 3 files
- 10 insertions / 8 deletions

Validation:
- Verified against real local DB: 697 root non-archived sessions, target session rank #7, page 2 all below page 1 by updated time.
- bun test src/context/global-sync.test.ts src/context/global-sync/session-trim.test.ts (packages/app)
- bun test --timeout 30000 test/server/httpapi-session.test.ts (packages/opencode)
- bun typecheck (packages/opencode, packages/app)