### PR TITLE
fix(share): show session turn labels in desktop MessageNav

### DIFF
--- a/packages/enterprise/src/routes/share/[shareID].tsx
+++ b/packages/enterprise/src/routes/share/[shareID].tsx
@@ -321,7 +321,7 @@ export default function () {
                                       class="sticky top-0 shrink-0 py-2 pl-4"
                                       messages={messages()}
                                       current={activeMessage()}
-                                      size="compact"
+                                      size="normal"
                                       onMessageSelect={setActiveMessage}
                                     />
                                   </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #23958

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop share page uses `size="compact"` for MessageNav, which renders invisible tick marks instead of readable turn labels. Users can't discover navigation and only see the first turn. Switching to `size="normal"` shows diff bars and message titles (240px wide) — the CSS and component already support both sizes.

### How did you verify your code works?

- Verified the change is only at `md:flex`/`lg:flex` breakpoints (desktop layout only)
- Mobile already renders all turns in a scrollable list via `turns()` — unaffected
- CSS for `[data-size="normal"]` already exists in `message-nav.css`
- `lsp_diagnostics` clean on the changed file

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR