### PR TITLE
fix: reduce TUI fenced code streaming flicker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -91,6 +91,7 @@ import { getRevertDiffFiles } from "../../util/revert-diff"
 import { useCommandPalette } from "../../context/command-palette"
 import { useBindings, useCommandShortcut } from "../../keymap"
 import { PathFormatterProvider, usePathFormatter } from "../../context/path-format"
+import { splitStreamingMarkdown } from "./streaming-markdown"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1579,19 +1580,57 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const content = createMemo(() => props.part.text.trim())
+  const split = createMemo(() => splitStreamingMarkdown(content()))
+  const tail = createMemo(() => split().tail)
+  const messageStreaming = createMemo(() => props.message.time.completed === undefined)
   return (
-    <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
-        <markdown
-          syntaxStyle={syntax()}
-          streaming={true}
-          internalBlockMode="top-level"
-          content={props.part.text.trim()}
-          tableOptions={{ style: "grid" }}
-          conceal={ctx.conceal()}
-          fg={theme.markdownText}
-          bg={theme.background}
-        />
+    <Show when={content()}>
+      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0} flexDirection="column">
+        <Show
+          when={tail()}
+          fallback={
+            <markdown
+              syntaxStyle={syntax()}
+              streaming={true}
+              internalBlockMode="top-level"
+              content={content()}
+              tableOptions={{ style: "grid" }}
+              conceal={ctx.conceal()}
+              fg={theme.markdownText}
+              bg={theme.background}
+            />
+          }
+        >
+          <>
+            <Show when={split().head}>
+              <markdown
+                syntaxStyle={syntax()}
+                streaming={false}
+                internalBlockMode="top-level"
+                content={split().head}
+                tableOptions={{ style: "grid" }}
+                conceal={ctx.conceal()}
+                fg={theme.markdownText}
+                bg={theme.background}
+              />
+            </Show>
+            {/* Keep settled markdown stable while the trailing code block grows separately. */}
+            <code
+              filetype={tail()!.filetype}
+              drawUnstyledText={false}
+              // Let OpenTUI use its streaming code path until the
+              // assistant message fully settles. Switching modes as
+              // soon as the fence closes caused highlight flicker.
+              streaming={messageStreaming()}
+              syntaxStyle={syntax()}
+              content={tail()!.content}
+              conceal={ctx.conceal()}
+              fg={theme.markdownText}
+              bg={theme.background}
+            />
+          </>
+        </Show>
       </box>
     </Show>
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/streaming-markdown.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/streaming-markdown.ts
@@ -1,0 +1,110 @@
+export type StreamingMarkdownTail = {
+  content: string
+  filetype: string
+}
+
+export type StreamingMarkdownSplit = {
+  head: string
+  tail?: StreamingMarkdownTail
+}
+
+type FenceBlock = {
+  headEnd: number
+  contentStart: number
+  filetype: string
+}
+
+const FENCE_FILETYPE_ALIASES: Record<string, string> = {
+  bash: "shellscript",
+  sh: "shellscript",
+  zsh: "shellscript",
+  shell: "shellscript",
+  console: "shellscript",
+  js: "typescript",
+  jsx: "typescript",
+  mjs: "typescript",
+  cjs: "typescript",
+  javascript: "typescript",
+  ts: "typescript",
+  tsx: "typescript",
+  typescript: "typescript",
+  py: "python",
+}
+
+function normalizeFenceFiletype(info: string) {
+  const language = info.trim().split(/\s+/)[0]?.toLowerCase() ?? ""
+  if (!language) return "none"
+  return FENCE_FILETYPE_ALIASES[language] ?? language
+}
+
+export function splitStreamingMarkdown(text: string): StreamingMarkdownSplit {
+  const lines = text.split("\n")
+  let offset = 0
+  let trailing: (FenceBlock & { tailEnd: number }) | undefined
+  let open:
+    | (FenceBlock & {
+        char: string
+        size: number
+      })
+    | undefined
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index] ?? ""
+    const lineStart = offset
+    const lineEnd = lineStart + line.length
+    const contentStart = lineEnd < text.length ? lineEnd + 1 : lineEnd
+
+    if (!open) {
+      const match = line.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/)
+      if (match) {
+        const mark = match[1]
+        if (mark) {
+          trailing = undefined
+          open = {
+            headEnd: lineStart,
+            contentStart,
+            char: mark[0] ?? "`",
+            size: mark.length,
+            filetype: normalizeFenceFiletype(match[2] ?? ""),
+          }
+        }
+      } else if (line.trim()) {
+        trailing = undefined
+      }
+      offset = contentStart
+      continue
+    }
+
+    const close = new RegExp(`^[\\t ]{0,3}${open.char}{${open.size},}[\\t ]*$`)
+    if (close.test(line)) {
+      trailing = {
+        headEnd: open.headEnd,
+        contentStart: open.contentStart,
+        tailEnd: lineStart,
+        filetype: open.filetype,
+      }
+      open = undefined
+    }
+    offset = contentStart
+  }
+
+  if (open) {
+    return {
+      head: text.slice(0, open.headEnd),
+      tail: {
+        content: text.slice(open.contentStart),
+        filetype: open.filetype,
+      },
+    }
+  }
+
+  if (!trailing) return { head: text }
+
+  return {
+    head: text.slice(0, trailing.headEnd),
+    tail: {
+      content: text.slice(trailing.contentStart, trailing.tailEnd),
+      filetype: trailing.filetype,
+    },
+  }
+}

--- a/packages/opencode/test/cli/tui/streaming-markdown.test.ts
+++ b/packages/opencode/test/cli/tui/streaming-markdown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { splitStreamingMarkdown } from "../../../src/cli/cmd/tui/routes/session/streaming-markdown"
+
+describe("splitStreamingMarkdown", () => {
+  test("keeps settled markdown intact when no trailing code fence remains", () => {
+    const text = "Intro\n\n```ts\nconst x = 1\n```\n\nDone"
+    expect(splitStreamingMarkdown(text)).toEqual({ head: text })
+  })
+
+  test("keeps a trailing closed fence isolated from settled head markdown", () => {
+    expect(splitStreamingMarkdown("Intro\n\n```ts\nconst x = 1\n```\n")).toEqual({
+      head: "Intro\n\n",
+      tail: { content: "const x = 1\n", filetype: "typescript" },
+    })
+  })
+
+  test("splits the trailing open fence from the settled head", () => {
+    expect(splitStreamingMarkdown("Intro\n\n```python\nprint('hi')")).toEqual({
+      head: "Intro\n\n",
+      tail: { content: "print('hi')", filetype: "python" },
+    })
+  })
+
+  test("supports fences without a language hint", () => {
+    expect(splitStreamingMarkdown("```\nplain text")).toEqual({
+      head: "",
+      tail: { content: "plain text", filetype: "none" },
+    })
+  })
+
+  test("normalizes common fence aliases for syntax highlighting", () => {
+    expect(splitStreamingMarkdown("```bash\necho hi")).toEqual({
+      head: "",
+      tail: { content: "echo hi", filetype: "shellscript" },
+    })
+  })
+
+  test("falls back to plain markdown when the trailing fence is not the last block", () => {
+    const text = "```ts\nconst x = 1\n```\n\nDone"
+    expect(splitStreamingMarkdown(text)).toEqual({ head: text })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #27897

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This reduces the TUI flicker when an assistant response is streaming a fenced code block.

The main change is to stop re-rendering the already-settled markdown above the code block on every token. If the last block is a fenced code block, I split the rendered content into:
- a settled markdown head
- a trailing code tail

The head is rendered once as stable markdown, while the tail keeps updating as code. This avoids most of the large redraws that happen while the fence is growing.

This does not fully eliminate the last 1-2 flashes when the message settles, but it reduces the continuous flicker a lot in local testing.

### How did you verify your code works?

- Ran `bun test test/cli/tui/streaming-markdown.test.ts`
- Ran `bun run typecheck`
- Tested locally in the TUI by streaming fenced Python code blocks and comparing behavior before/after the change

### Screenshots / recordings

I do not have a clean recording attached in this PR yet.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
