### PR TITLE
fix(config): preserve description from markdown agent frontmatter

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -93,7 +93,8 @@ const normalize = (agent: Schema.Schema.Type<typeof AgentSchema>): Schema.Schema
   globalThis.Object.assign(permission, agent.permission)
 
   const steps = agent.steps ?? agent.maxSteps
-  return { ...agent, options, permission, ...(steps !== undefined ? { steps } : {}) }
+  const description = "description" in agent ? agent.description : undefined
+  return { ...agent, options, permission, description, ...(steps !== undefined ? { steps } : {}) }
 }
 
 export const Info = AgentSchema.pipe(
@@ -131,7 +132,11 @@ export async function load(dir: string) {
       ...md.data,
       prompt: md.content.trim(),
     }
-    result[config.name] = ConfigParse.schema(Info, config, item)
+    const parsed = ConfigParse.schema(Info, config, item)
+    if ("description" in config && !parsed.description) {
+      parsed.description = config.description
+    }
+    result[config.name] = parsed
   }
   return result
 }


### PR DESCRIPTION
### Issue for this PR

Closes #27831

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom markdown-defined subagents showed "should only be called manually" instead of their description in the Task tool tooltip.

Root cause: when loading markdown-defined agents, the description field from frontmatter was dropped during schema decode/normalize in config/agent.ts.

- normalize() now explicitly carries description in the return value
- load() falls back to raw frontmatter description if schema-decoded result lacks it

### How did you verify your code works?

Ran bun test for config/agent-color, config/config, config/markdown tests - all 162 pass (1 unrelated timeout in agent.test.ts). Also bun run typecheck passes with no errors.

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
