### PR TITLE
feat(config): load commands from .agents

### DIFF
--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -23,6 +23,15 @@ export type Info = Schema.Schema.Type<typeof Info>
 
 const decodeInfo = Schema.decodeUnknownExit(Info)
 
+const patterns = [
+  ".opencode/command/",
+  ".opencode/commands/",
+  ".agents/commands/",
+  ".agents/command/",
+  "command/",
+  "commands/",
+]
+
 export async function load(dir: string) {
   const result: Record<string, Info> = {}
   for (const item of await Glob.scan("{command,commands}/**/*.md", {
@@ -37,7 +46,7 @@ export async function load(dir: string) {
     })
     if (!md) continue
 
-    const name = configEntryNameFromPath(path.relative(dir, item), ["command/", "commands/"])
+    const name = configEntryNameFromPath(path.relative(path.dirname(dir), item), patterns)
 
     const config = {
       name,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -610,12 +610,25 @@ export const layer = Layer.effect(
         result.plugin = result.plugin || []
 
         const directories = yield* ConfigPaths.directories(ctx.directory, ctx.worktree)
+        const globalAgentsDir = path.join(Global.Path.home, ".agents")
+        const externalCommandDirs = [
+          ...(existsSync(globalAgentsDir) ? [globalAgentsDir] : []),
+          ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
+            ? yield* fs.up({ targets: [".agents"], start: ctx.directory, stop: ctx.worktree }).pipe(
+                Effect.catch(() => Effect.succeed([] as string[])),
+              )
+            : []),
+        ]
 
         if (Flag.OPENCODE_CONFIG_DIR) {
           log.debug("loading config from OPENCODE_CONFIG_DIR", { path: Flag.OPENCODE_CONFIG_DIR })
         }
 
         const deps: Fiber.Fiber<void>[] = []
+
+        for (const dir of externalCommandDirs) {
+          result.command = mergeDeep(result.command ?? {}, yield* Effect.promise(() => ConfigCommand.load(dir)))
+        }
 
         for (const dir of directories) {
           if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -868,6 +868,39 @@ Nested command template`,
   }),
 )
 
+it.instance("loads commands from .agents/commands", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* AppFileSystem.use.writeWithDirs(
+      path.join(test.directory, ".agents", "commands", "hello.md"),
+      `---
+description: Test command
+---
+Hello from agents commands`,
+    )
+
+    yield* AppFileSystem.use.writeWithDirs(
+      path.join(test.directory, ".agents", "commands", "nested", "child.md"),
+      `---
+description: Nested command
+---
+Nested command template`,
+    )
+
+    const config = yield* Config.use.get()
+
+    expect(config.command?.["hello"]).toEqual({
+      description: "Test command",
+      template: "Hello from agents commands",
+    })
+
+    expect(config.command?.["nested/child"]).toEqual({
+      description: "Nested command",
+      template: "Nested command template",
+    })
+  }),
+)
+
 it.instance("updates config and writes to file", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #27972

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds command discovery from `.agents/commands/**/*.md`, matching the existing `.agents/skills` convention.

Previously slash command markdown was discovered from `.opencode/command` and `.opencode/commands` only. This change scans project `.agents` directories and global `~/.agents`, then reuses the existing command loader. The command-name derivation now recognizes `.agents/commands`, so nested commands keep the existing `nested/name` behavior.

Prior related work: #12486 requested the same `.agents/commands` support and was closed as stale, and #12488 was an unmerged duplicate implementation PR that was also closed as stale. #14240 is related but broader because it asks for configurable command and agent search paths.

### How did you verify your code works?

Ran:

- `bun test test/config/config.test.ts --timeout 30000 --test-name-pattern "loads commands"`
- `bun typecheck`

Also ran a manual loader probe against a temporary `.agents/commands` tree containing `qa.md` and `nested/check.md`, and confirmed both commands loaded with the expected names and templates.

### Screenshots / recordings

Not applicable; this is a config loading change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
