### PR TITLE
fix(app): clear question dock after successful reply

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -8,6 +8,7 @@ import { showToast } from "@opencode-ai/ui/toast"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
+import { useSync } from "@/context/sync"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 
@@ -60,6 +61,7 @@ function Option(props: {
 
 export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit: () => void }> = (props) => {
   const sdk = useSDK()
+  const sync = useSync()
   const language = useLanguage()
 
   const questions = createMemo(() => props.request.questions)
@@ -212,6 +214,9 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     onSuccess: () => {
       replied = true
       cache.delete(props.request.id)
+      sync.set("question", props.request.sessionID, (current: QuestionRequest[] = []) =>
+        current.filter((question) => question.id !== props.request.id),
+      )
     },
     onError: fail,
   }))
@@ -224,6 +229,9 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     onSuccess: () => {
       replied = true
       cache.delete(props.request.id)
+      sync.set("question", props.request.sessionID, (current: QuestionRequest[] = []) =>
+        current.filter((question) => question.id !== props.request.id),
+      )
     },
     onError: fail,
   }))


### PR DESCRIPTION
## Summary
- clear the pending local question on successful reply/reject in the web question dock
- keep the dock UI from staying stuck when the reply API succeeds but the sync event is delayed or missed
- link the reported bug to issue #27977

## Testing
- Oracle code review: passed; patch mirrors existing `question.replied` / `question.rejected` reducer behavior
- `bun typecheck` in `packages/app` could not run in this checkout because `tsgo` is not installed locally
- `bun run test:unit` in `packages/app` could not run in this checkout because dependencies are not installed (`@happy-dom/global-registrator` missing, no `node_modules` present)

Closes #27977