### PR TITLE
fix(acp): register model and mode commands

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1138,11 +1138,13 @@ export class Agent implements ACPAgent {
       description: command.description ?? "",
     }))
     const names = new Set(availableCommands.map((c) => c.name))
-    if (!names.has("compact"))
-      availableCommands.push({
-        name: "compact",
-        description: "compact the session",
-      })
+    for (const command of [
+      { name: "compact", description: "compact the session" },
+      { name: "model", description: "switch model" },
+      { name: "mode", description: "switch mode" },
+    ]) {
+      if (!names.has(command.name)) availableCommands.push(command)
+    }
 
     const mcpServers: Record<string, ConfigMCP.Info> = {}
     for (const server of params.mcpServers) {

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -330,6 +330,36 @@ function createFakeAgent() {
 }
 
 describe("acp.agent event subscription", () => {
+  test("registers built-in ACP commands when the command list is empty", async () => {
+    await using tmp = await tmpdir()
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, sessionUpdates, stop } = createFakeAgent()
+
+        const sessionId = await agent.newSession({ cwd: tmp.path, mcpServers: [] } as any).then((x) => x.sessionId)
+        const update = await pollUntil(
+          () =>
+            sessionUpdates.find(
+              (entry) => entry.sessionId === sessionId && entry.update.sessionUpdate === "available_commands_update",
+            ),
+          "available_commands_update was not sent",
+        )
+
+        expect(update.update).toMatchObject({
+          sessionUpdate: "available_commands_update",
+          availableCommands: [
+            { name: "compact", description: "compact the session" },
+            { name: "model", description: "switch model" },
+            { name: "mode", description: "switch mode" },
+          ],
+        })
+
+        stop()
+      },
+    })
+  })
+
   test("routes message.part.delta by the event sessionID (no cross-session pollution)", async () => {
     await using tmp = await tmpdir()
     await provideTestInstance({


### PR DESCRIPTION
## Summary
- include built-in `model` and `mode` commands in ACP available command updates
- keep existing command definitions from being duplicated
- add regression coverage for the empty command-list fallback

Fixes #27942

## Testing
- bunx prettier --write packages/opencode/src/acp/agent.ts packages/opencode/test/acp/event-subscription.test.ts
- bun test test/acp/event-subscription.test.ts --timeout 30000
- bun typecheck
- push hook: bun turbo typecheck