### PR TITLE
fix: make postinstall fallback executable

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -37,10 +37,11 @@ await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
 await Bun.file(`./dist/${pkg.name}/LICENSE`).write(await Bun.file("../../LICENSE").text())
 await Bun.file(`./dist/${pkg.name}/bin/${pkg.name}.exe`).write(
   [
+    "#!/bin/sh",
     `echo "Error: ${pkg.name}-ai's postinstall script was not run." >&2`,
     'echo "" >&2',
     'echo "This occurs when using --ignore-scripts during installation, or when using a" >&2',
-    'echo "package manager like pnpm that does not run postinstall scripts by default." >&2',
+    'echo "package manager like bun or pnpm that does not run postinstall scripts by default." >&2',
     'echo "" >&2',
     'echo "To fix this, run the postinstall script manually:" >&2',
     `echo "  cd node_modules/${pkg.name}-ai && node postinstall.mjs" >&2`,


### PR DESCRIPTION
Fixes #27906.

When lifecycle scripts are skipped, the generated package fallback binary is executed directly. On Unix-like systems it was written without a shebang, so package managers that link the fallback directly can fail with an exec format error before showing the intended postinstall guidance.

This adds a shell shebang to the generated fallback and updates the message to mention Bun alongside pnpm.

Checks:
- bun typecheck
- bunx prettier --check packages/opencode/script/publish.ts
- git diff --check
- fallback shell smoke check