### PR TITLE
fix(tui): clear question dock after reply

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -1,4 +1,4 @@
-import { createStore } from "solid-js/store"
+import { createStore, produce } from "solid-js/store"
 import { createMemo, createSignal, For, Show } from "solid-js"
 import { useRenderer } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
@@ -9,9 +9,11 @@ import { SplitBorder } from "../../component/border"
 import { useDialog } from "../../ui/dialog"
 import { useTuiConfig } from "../../context/tui-config"
 import { useBindings } from "../../keymap"
+import { useSync } from "../../context/sync"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
+  const sync = useSync()
   const { theme } = useTheme()
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
@@ -43,18 +45,41 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     return store.answers[store.tab]?.includes(value) ?? false
   })
 
-  function submit() {
-    const answers = questions().map((_, i) => store.answers[i] ?? [])
-    void sdk.client.question.reply({
+  function clearPendingQuestion() {
+    const requests = sync.data.question[props.request.sessionID]
+    const index = requests?.findIndex((request) => request.id === props.request.id) ?? -1
+    if (index === -1) return
+    sync.set(
+      "question",
+      props.request.sessionID,
+      produce((draft) => {
+        draft.splice(index, 1)
+      }),
+    )
+  }
+
+  async function reply(answers: QuestionAnswer[]) {
+    await sdk.client.question.reply({
       requestID: props.request.id,
       answers,
     })
+    clearPendingQuestion()
+  }
+
+  async function rejectQuestion() {
+    await sdk.client.question.reject({
+      requestID: props.request.id,
+    })
+    clearPendingQuestion()
+  }
+
+  function submit() {
+    const answers = questions().map((_, i) => store.answers[i] ?? [])
+    void reply(answers)
   }
 
   function reject() {
-    void sdk.client.question.reject({
-      requestID: props.request.id,
-    })
+    void rejectQuestion()
   }
 
   function pick(answer: string, custom: boolean = false) {
@@ -67,10 +92,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       setStore("custom", inputs)
     }
     if (single()) {
-      void sdk.client.question.reply({
-        requestID: props.request.id,
-        answers: [[answer]],
-      })
+      void reply([[answer]])
       return
     }
     setStore("tab", store.tab + 1)


### PR DESCRIPTION
### Issue for this PR

Closes #27976
Closes #27977

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After a question is successfully replied to or rejected in the TUI, the matching pending question is cleared from local sync state immediately. The existing event-driven cleanup still handles delayed `question.replied` and `question.rejected` events, so this only removes the stale UI window between a successful request and the sync event.

### How did you verify your code works?

- `bun test test/config/tui.test.ts --timeout 30000`
- `bun typecheck`
- `bun turbo typecheck`
- `bunx prettier --write packages/opencode/src/cli/cmd/tui/routes/session/question.tsx`
- `git diff --check`

### Screenshots / recordings

Not included. This is a state cleanup fix covered by the TUI regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR