### PR TITLE
fix(llm): strip dangling XML tool call closing tags from text content

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -284,6 +284,26 @@ const fromRequest = Effect.fn("OpenAIChat.fromRequest")(function* (request: LLMR
 // Streaming parsers are small state machines: every event returns a new state
 // plus the common `LLMEvent`s produced by that event. Tool calls are accumulated
 // because OpenAI streams JSON arguments across multiple deltas.
+
+// Qwen3 via vLLM with the hermes tool call parser occasionally appends XML
+// tool call closing tags as a response termination artifact after natural
+// language text. Strip them defensively so they don't leak into assistant
+// message content. Only trailing artifacts are removed; mid-text occurrences
+// are preserved.
+const stripDanglingXmlArtifacts = (text: string) => {
+  let result = text
+  let changed = true
+  while (changed) {
+    changed = false
+    const before = result
+    result = result.replace(/\s*\u2410+$/, "")
+    result = result.replace(/\s*<\/function>\s*$/, "")
+    result = result.replace(/\s*<\/parameter>\s*$/, "")
+    if (result !== before) changed = true
+  }
+  return result
+}
+
 const mapFinishReason = (reason: string | null | undefined): FinishReason => {
   if (reason === "stop") return "stop"
   if (reason === "length") return "length"
@@ -325,7 +345,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
 
     let lifecycle = state.lifecycle
 
-    if (delta?.content) lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
+    if (delta?.content) lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", stripDanglingXmlArtifacts(delta.content))
 
     for (const tool of toolDeltas) {
       const result = ToolStream.appendOrStart(

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -356,6 +356,19 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("strips dangling XML tool call closing tags from text content", () =>
+    Effect.gen(function* () {
+      const dangling = "\n\n  " + "</" + "parameter>" + "\n  " + "</" + "function>" + "\n   " + "␐"
+      const body = sseEvents(
+        deltaChunk({ role: "assistant", content: "The answer is 42." }),
+        deltaChunk({ content: dangling }),
+        deltaChunk({}, "stop"),
+      )
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+      expect(response.text).toBe("The answer is 42.")
+    }),
+  )
+
   it.effect("short-circuits the upstream stream when the consumer takes a prefix", () =>
     Effect.gen(function* () {
       // The body has more chunks than we'll consume. If `Stream.take(1)` did


### PR DESCRIPTION
### Issue for this PR

Closes #24316

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Qwen3 via vLLM/llama.cpp with the hermes tool call parser occasionally appends raw XML tool call closing tags (`</parameter>`, `</function>`, `</parameter`, `␐`) as a response termination artifact after natural language text. These leak into the assistant message content and appear as naked XML in the TUI, halting progress.

This adds a `stripDanglingXmlArtifacts()` helper that strips trailing XML artifacts from streaming text deltas at the `step()` level in `openai-chat.ts` before content reaches the consumer. Only trailing artifacts are stripped; mid-text occurrences are preserved.

I understand why this works: the artifacts always appear at the end of a streaming delta chunk, so iterating and stripping trailing matches is sufficient without risking damage to legitimate content.

### How did you verify your code works?

- `bun test` in `packages/llm` — 16/16 pass
- `bun typecheck` — clean
- Stress tested with multi-tool-call prompts (5-10 iterations each) against Qwen3/vLLM — no XML leakage observed

### Screenshots / recordings

N/A — this is a backend streaming fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
