### PR TITLE
feat: namespace nested skill names

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -113,22 +113,37 @@ const add = Effect.fnUntraced(function* (state: State, match: string, bus: Bus.I
 
   if (!isSkillFrontmatter(md.data)) return
 
-  if (state.skills[md.data.name]) {
+  const name = namespaceSkillName(match, md.data.name)
+
+  if (state.skills[name]) {
     log.warn("duplicate skill name", {
-      name: md.data.name,
-      existing: state.skills[md.data.name].location,
+      name,
+      existing: state.skills[name].location,
       duplicate: match,
     })
   }
 
   state.dirs.add(path.dirname(match))
-  state.skills[md.data.name] = {
-    name: md.data.name,
+  state.skills[name] = {
+    name,
     description: md.data.description,
     location: match,
     content: md.content,
   }
 })
+
+function namespaceSkillName(match: string, name: string) {
+  if (name.includes(":")) return name
+
+  const parts = path.normalize(match).split(path.sep)
+  const skillRoot = Math.max(parts.lastIndexOf("skills"), parts.lastIndexOf("skill"))
+  if (skillRoot === -1) return name
+
+  const skillDirs = parts.slice(skillRoot + 1, -1)
+  if (skillDirs.length <= 1) return name
+
+  return [...skillDirs.slice(0, -1), name].join(":")
+}
 
 const scan = Effect.fnUntraced(function* (
   state: ScanState,

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -174,6 +174,55 @@ description: Second test skill.
     ),
   )
 
+  it.live("prefixes nested skill names with their directory namespace", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".opencode", "skills", "deploy", "SKILL.md"),
+                `---
+name: deploy
+description: Flat deploy skill.
+---
+
+# Deploy
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".opencode", "skills", "team-a", "deploy", "SKILL.md"),
+                `---
+name: deploy
+description: Team A deploy skill.
+---
+
+# Team A Deploy
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".opencode", "skills", "org", "team", "deploy", "SKILL.md"),
+                `---
+name: deploy
+description: Org team deploy skill.
+---
+
+# Org Team Deploy
+`,
+              ),
+            ]),
+          )
+
+          const skill = yield* Skill.Service
+          const list = (yield* skill.all()).filter((s) => s.location !== "<built-in>")
+          expect(list.map((s) => s.name).sort()).toEqual(["deploy", "org:team:deploy", "team-a:deploy"])
+          expect(yield* skill.get("team-a:deploy")).toBeDefined()
+          expect(yield* skill.get("org:team:deploy")).toBeDefined()
+        }),
+      { git: true },
+    ),
+  )
+
   it.live("skips skills with missing frontmatter", () =>
     provideTmpdirInstance(
       (dir) =>


### PR DESCRIPTION
Fixes #27979

## Summary
- keep flat skill names unchanged
- prefix nested skill names from their directory path, e.g. `team-a:deploy`
- add coverage for flat and nested skill discovery

## Verification
- `bun test test/skill/skill.test.ts --timeout 30000`
- `bun typecheck`
- `bunx prettier --check src/skill/index.ts test/skill/skill.test.ts`
- `git diff --check`