### PR TITLE
fix(provider): camel-case openai-compatible option key

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1200,6 +1200,12 @@ const SLUG_OVERRIDES: Record<string, string> = {
   amazon: "bedrock",
 }
 
+function openAICompatibleProviderOptionsKey(providerID: string) {
+  return providerID
+    .split(".")[0]
+    .replace(/[-_]+([a-zA-Z0-9])/g, (_, char: string) => char.toUpperCase())
+}
+
 export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
   if (model.api.npm === "@ai-sdk/gateway") {
     // Gateway providerOptions are split across two namespaces:
@@ -1236,11 +1242,14 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   // logic here so the key we write matches the key they read.
   // Other SDKs (xai, mistral, groq, cohere, etc.) use hardcoded keys
   // like "xai" or "cohere" - applying .split(".")[0] would break those.
-  const usesDotSplitOptions =
-    model.api.npm === "@ai-sdk/openai-compatible" ||
-    model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/anthropic"
-  const key = sdkKey(model.api.npm) ?? (usesDotSplitOptions ? model.providerID.split(".")[0] : model.providerID)
+  const usesDotSplitOptions = model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/anthropic"
+  const key =
+    sdkKey(model.api.npm) ??
+    (model.api.npm === "@ai-sdk/openai-compatible"
+      ? openAICompatibleProviderOptionsKey(model.providerID)
+      : usesDotSplitOptions
+        ? model.providerID.split(".")[0]
+        : model.providerID)
   // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
   // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
   // "azure" first. Pass both so model options work on either code path.

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -575,6 +575,36 @@ describe("ProviderTransform.providerOptions", () => {
       groq: { reasoningFormat: "parsed" },
     })
   })
+
+  test("camel-cases openai-compatible provider id for provider options", () => {
+    const model = createModel({
+      providerID: "my-newapi",
+      api: {
+        id: "glm-4.7",
+        url: "https://api.example.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "high" })).toEqual({
+      myNewapi: { reasoningEffort: "high" },
+    })
+  })
+
+  test("keeps dotted openai-compatible provider id prefix for provider options", () => {
+    const model = createModel({
+      providerID: "example.com",
+      api: {
+        id: "custom-model",
+        url: "https://api.example.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { reasoningEffort: "high" })).toEqual({
+      example: { reasoningEffort: "high" },
+    })
+  })
 })
 
 describe("ProviderTransform.schema - gemini array items", () => {


### PR DESCRIPTION
### Issue for this PR

Fixes #5674

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

For custom `@ai-sdk/openai-compatible` providers, OpenCode builds the provider with `name: model.providerID`. The AI SDK expects provider-specific options under a camelCase key derived from that provider name; for example, a provider named `my-newapi` reads `providerOptions.myNewapi`, not `providerOptions["my-newapi"]`.

OpenCode already handled the dotted-provider case by splitting `example.com` to `example`, but hyphenated or underscored custom provider IDs were still passed through literally. That means model options like `reasoningEffort`, `thinking`, or other provider-specific fields could be silently dropped before reaching the OpenAI-compatible adapter.

This patch adds a small OpenAI-compatible key normalizer that:

- keeps the existing dotted-provider behavior (`example.com` -> `example`)
- camel-cases `-` / `_` separators (`my-newapi` -> `myNewapi`)
- leaves other provider packages on their existing hardcoded/dot-split paths

### How did you verify your code works?

- Added regression tests for hyphenated and dotted OpenAI-compatible provider IDs in `ProviderTransform.providerOptions`
- `git diff --check`

### Screenshots / recordings

_n/a — provider option routing change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
