### PR TITLE
fix: merge adjacent reasoning cycles

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -79,6 +79,7 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
+  previousReasoning: MessageV2.ReasoningPart | undefined
 }
 
 type StreamEvent = Event
@@ -119,6 +120,7 @@ export const layer = Layer.effect(
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        previousReasoning: undefined,
       }
       let aborted = false
       const slog = log.clone().tag("session.id", input.sessionID).tag("messageID", input.assistantMessage.id)
@@ -219,6 +221,11 @@ export const layer = Layer.effect(
 
           case "reasoning-start":
             if (value.id in ctx.reasoningMap) return
+            if (ctx.previousReasoning) {
+              ctx.reasoningMap[value.id] = ctx.previousReasoning
+              ctx.previousReasoning = undefined
+              return
+            }
             // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
             if (flags.experimentalEventSystem) {
               yield* events.publish(SessionEvent.Reasoning.Started, {
@@ -268,10 +275,12 @@ export const layer = Layer.effect(
             ctx.reasoningMap[value.id].time = { ...ctx.reasoningMap[value.id].time, end: Date.now() }
             if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
             yield* session.updatePart(ctx.reasoningMap[value.id])
+            ctx.previousReasoning = ctx.reasoningMap[value.id]
             delete ctx.reasoningMap[value.id]
             return
 
           case "tool-input-start":
+            ctx.previousReasoning = undefined
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
             }
@@ -554,6 +563,7 @@ export const layer = Layer.effect(
           }
 
           case "text-start":
+            ctx.previousReasoning = undefined
             if (!ctx.assistantMessage.summary) {
               // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
               if (flags.experimentalEventSystem) {
@@ -660,6 +670,7 @@ export const layer = Layer.effect(
           })
         }
         ctx.reasoningMap = {}
+        ctx.previousReasoning = undefined
 
         yield* Effect.forEach(
           Object.values(ctx.toolcalls),
@@ -727,6 +738,7 @@ export const layer = Layer.effect(
           yield* Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.reasoningMap = {}
+            ctx.previousReasoning = undefined
             const stream = llm.stream(streamInput)
 
             yield* stream.pipe(

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -429,6 +429,52 @@ it.live("session.processor effect tests capture reasoning from http mock", () =>
   ),
 )
 
+it.live("session.processor effect tests merge adjacent reasoning cycles", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(reply().reason("thi").reason("nk").text("done").stop())
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "reason")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "reason" }],
+          tools: {},
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const reasoning = parts.filter((part): part is MessageV2.ReasoningPart => part.type === "reasoning")
+
+        expect(value).toBe("continue")
+        expect(reasoning).toHaveLength(1)
+        expect(reasoning[0]?.text).toBe("think")
+      }),
+    { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests reset reasoning state across retries", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>


### PR DESCRIPTION
Fixes #22241
Fixes #27987

## Summary
- reuse the previous reasoning part when providers emit adjacent reasoning start/end cycles
- clear the reusable reasoning state when text/tool output starts or when processing is reset
- add regression coverage for split reasoning chunks rendering as a single part

## Verification
- bun test test/session/processor-effect.test.ts --timeout 30000
- bun typecheck
- bunx prettier --check src/session/processor.ts test/session/processor-effect.test.ts
- git diff --check
- bun turbo typecheck