### PR TITLE
fix: keep paste badges readable

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -773,7 +773,7 @@ function getSyntaxRules(theme: Theme) {
     {
       scope: ["extmark.paste"],
       style: {
-        foreground: theme.background,
+        foreground: selectedForeground(theme, theme.warning),
         background: theme.warning,
         bold: true,
       },

--- a/packages/opencode/test/cli/tui/theme.test.ts
+++ b/packages/opencode/test/cli/tui/theme.test.ts
@@ -1,0 +1,14 @@
+import { RGBA } from "@opentui/core"
+import { describe, expect, test } from "bun:test"
+
+const { DEFAULT_THEMES, resolveTheme, selectedForeground } = await import("../../../src/cli/cmd/tui/context/theme")
+
+describe("selectedForeground", () => {
+  test("contrasts against the selected background when theme background is transparent", () => {
+    const transparentTheme = structuredClone(DEFAULT_THEMES.opencode)
+    transparentTheme.theme.background = "transparent"
+    const theme = resolveTheme(transparentTheme, "dark")
+
+    expect(selectedForeground(theme, RGBA.fromInts(245, 158, 11))).toEqual(RGBA.fromInts(0, 0, 0))
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #27968

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Paste summary badges used the theme background color as their foreground. That can be transparent in the system theme and custom transparent themes, making the badge text unreadable. This changes the paste badge to use the existing selected foreground contrast helper against the warning badge background, preserving the old opaque-theme fallback behavior.

This PR also adds a regression test for transparent theme backgrounds.

### How did you verify your code works?

- `bun test test/cli/tui/theme.test.ts`
- `bun typecheck`
- `bun run lint packages/opencode/src/cli/cmd/tui/context/theme.tsx packages/opencode/test/cli/tui/theme.test.ts` (0 errors; existing warnings in `theme.tsx`)
- `git diff --check origin/dev...HEAD`
- Push hook: `bun turbo typecheck`

### Screenshots / recordings

Not included; this is a small color-selection change covered by a regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
