### PR TITLE
fix(ui): fallback to execCommand for clipboard copy when navigator.clipboard fails

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -58,6 +58,27 @@ import { animate } from "motion"
 import { useLocation } from "@solidjs/router"
 import { attached, inline, kind } from "./message-file"
 
+async function writeClipboard(text: string): Promise<boolean> {
+  const body = typeof document === "undefined" ? undefined : document.body
+  if (body) {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.setAttribute("readonly", "")
+    textarea.style.position = "fixed"
+    textarea.style.opacity = "0"
+    textarea.style.pointerEvents = "none"
+    body.appendChild(textarea)
+    textarea.select()
+    const copied = document.execCommand("copy")
+    body.removeChild(textarea)
+    if (copied) return true
+  }
+
+  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard
+  if (!clipboard?.writeText) return false
+  return clipboard.writeText(text).then(() => true, () => false)
+}
+
 function ShellSubmessage(props: { text: string; animate?: boolean }) {
   let widthRef: HTMLSpanElement | undefined
   let valueRef: HTMLSpanElement | undefined
@@ -1057,9 +1078,10 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   const handleCopy = async () => {
     const content = text()
     if (!content) return
-    await navigator.clipboard.writeText(content)
-    setState("copied", true)
-    setTimeout(() => setState("copied", false), 2000)
+    if (await writeClipboard(content)) {
+      setState("copied", true)
+      setTimeout(() => setState("copied", false), 2000)
+    }
   }
 
   const revert = () => {
@@ -1480,9 +1502,10 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const handleCopy = async () => {
     const content = text()
     if (!content) return
-    await navigator.clipboard.writeText(content)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    if (await writeClipboard(content)) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
   }
 
   return (
@@ -1824,9 +1847,10 @@ ToolRegistry.register({
     const handleCopy = async () => {
       const content = text()
       if (!content) return
-      await navigator.clipboard.writeText(content)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      if (await writeClipboard(content)) {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }
     }
 
     return (


### PR DESCRIPTION
### Issue for this PR

Closes #27992

### Type of change

- [x] Bug fix

### What does this PR do?

`navigator.clipboard.writeText()` can silently fail in:
- Non-HTTPS contexts (e.g., localhost during development)
- Environments where the Clipboard API is blocked by browser permissions

This PR adds a `writeClipboard()` helper that:
1. First attempts to copy via `document.execCommand("copy")` using a temporary textarea (works in all browser contexts)
2. Falls back to `navigator.clipboard.writeText()` if the execCommand approach fails
3. Only updates the "copied" visual state when the copy actually succeeds

This fixes the copy button appearing to do nothing on the web UI.

### How did you verify your code works?

Tested manually on the web interface by verifying copy works. The execCommand fallback is a well-known pattern for clipboard operations in web applications.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR