### PR TITLE
fix(opencode): resolve GitHub Copilot base URL from token

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -13,19 +13,72 @@ const CLIENT_ID = "Ov23li8tweQw6odWQebz"
 // Add a small safety buffer when polling to avoid hitting the server
 // slightly too early due to clock skew / timer drift.
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000 // 3 seconds
-function normalizeDomain(url: string) {
-  return url.replace(/^https?:\/\//, "").replace(/\/$/, "")
+const COPILOT_HEADERS = {
+  "User-Agent": "GitHubCopilotChat/0.35.0",
+  "Editor-Version": "vscode/1.107.0",
+  "Editor-Plugin-Version": "copilot-chat/0.35.0",
+  "Copilot-Integration-Id": "vscode-chat",
+}
+
+function normalizeDomain(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return ""
+
+  try {
+    const url = trimmed.includes("://") ? new URL(trimmed) : new URL(`https://${trimmed}`)
+    return url.hostname
+  } catch {
+    return trimmed.replace(/^https?:\/\//, "").replace(/\/$/, "")
+  }
 }
 
 function getUrls(domain: string) {
   return {
     DEVICE_CODE_URL: `https://${domain}/login/device/code`,
     ACCESS_TOKEN_URL: `https://${domain}/login/oauth/access_token`,
+    COPILOT_TOKEN_URL: `https://api.${domain}/copilot_internal/v2/token`,
   }
 }
 
-function base(enterpriseUrl?: string) {
-  return enterpriseUrl ? `https://copilot-api.${normalizeDomain(enterpriseUrl)}` : "https://api.githubcopilot.com"
+function baseFromToken(token?: string) {
+  if (!token) return
+  const match = token.match(/(?:^|;)proxy-ep=([^;]+)/)
+  if (!match?.[1]) return
+  const apiHost = match[1].replace(/^proxy\./, "api.")
+  return `https://${apiHost}`
+}
+
+function base(token?: string, enterpriseUrl?: string) {
+  return baseFromToken(token) ||
+    (enterpriseUrl ? `https://copilot-api.${normalizeDomain(enterpriseUrl)}` : "https://api.individual.githubcopilot.com")
+}
+
+async function exchangeCopilotToken(domain: string, githubToken: string) {
+  const response = await fetch(getUrls(domain).COPILOT_TOKEN_URL, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${githubToken}`,
+      ...COPILOT_HEADERS,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to exchange GitHub token for Copilot token: ${response.status}`)
+  }
+
+  const data = (await response.json()) as {
+    token?: string
+    expires_at?: number
+  }
+
+  if (!data.token || !data.expires_at) {
+    throw new Error("Invalid Copilot token response")
+  }
+
+  return {
+    access: data.token,
+    expires: data.expires_at * 1000 - 5 * 60 * 1000,
+  }
 }
 
 // Check if a message is a synthetic user msg used to attach an image from a tool call
@@ -67,16 +120,16 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         const auth = ctx.auth
 
         return CopilotModels.get(
-          base(auth.enterpriseUrl),
+          base(auth.access, auth.enterpriseUrl),
           {
-            Authorization: `Bearer ${auth.refresh}`,
-            "User-Agent": `opencode/${InstallationVersion}`,
+            Authorization: `Bearer ${auth.access}`,
+            ...COPILOT_HEADERS,
           },
           provider.models,
         ).catch((error) => {
           log.error("failed to fetch copilot models", { error })
           return Object.fromEntries(
-            Object.entries(provider.models).map(([id, model]) => [id, fix(model, base(auth.enterpriseUrl))]),
+            Object.entries(provider.models).map(([id, model]) => [id, fix(model, base(auth.access, auth.enterpriseUrl))]),
           )
         })
       },
@@ -92,6 +145,26 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
           async fetch(request: RequestInfo | URL, init?: RequestInit) {
             const info = await getAuth()
             if (info.type !== "oauth") return fetch(request, init)
+
+            const currentAuth = { ...info }
+            const domain = currentAuth.enterpriseUrl ? normalizeDomain(currentAuth.enterpriseUrl) : "github.com"
+
+            if (!currentAuth.access || currentAuth.expires < Date.now()) {
+              log.info("refreshing copilot access token")
+              const tokens = await exchangeCopilotToken(domain, currentAuth.refresh)
+              currentAuth.access = tokens.access
+              currentAuth.expires = tokens.expires
+              await input.client.auth.set({
+                path: { id: "github-copilot" },
+                body: {
+                  type: "oauth",
+                  refresh: currentAuth.refresh,
+                  access: currentAuth.access,
+                  expires: currentAuth.expires,
+                  ...(currentAuth.enterpriseUrl ? { enterpriseUrl: currentAuth.enterpriseUrl } : {}),
+                },
+              })
+            }
 
             const url = request instanceof URL ? request.href : typeof request === "string" ? request : request.url
             const { isVision, isAgent } = iife(() => {
@@ -150,8 +223,8 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             const headers: Record<string, string> = {
               "x-initiator": isAgent ? "agent" : "user",
               ...(init?.headers as Record<string, string>),
-              "User-Agent": `opencode/${InstallationVersion}`,
-              Authorization: `Bearer ${info.refresh}`,
+              ...COPILOT_HEADERS,
+              Authorization: `Bearer ${currentAuth.access}`,
               "Openai-Intent": "conversation-edits",
             }
 
@@ -274,6 +347,8 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                   }
 
                   if (data.access_token) {
+                    const tokens = await exchangeCopilotToken(domain, data.access_token)
+
                     const result: {
                       type: "success"
                       refresh: string
@@ -284,8 +359,8 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                     } = {
                       type: "success",
                       refresh: data.access_token,
-                      access: data.access_token,
-                      expires: 0,
+                      access: tokens.access,
+                      expires: tokens.expires,
                     }
 
                     if (deploymentType === "enterprise") {

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -259,3 +259,122 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
   expect(models.claude.api.url).toBe("https://copilot-api.ghe.example.com")
   expect(models.claude.api.npm).toBe("@ai-sdk/github-copilot")
 })
+
+test("remaps fallback oauth model urls using proxy-ep from the copilot token", async () => {
+  globalThis.fetch = mock(() => Promise.reject(new Error("timeout"))) as unknown as typeof fetch
+
+  const hooks = await CopilotAuthPlugin({
+    client: {} as never,
+    project: {} as never,
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {} as never,
+  })
+
+  const models = await hooks.provider!.models!(
+    {
+      id: "github-copilot",
+      models: {
+        claude: {
+          id: "claude",
+          providerID: "github-copilot",
+          api: {
+            id: "claude-sonnet-4.5",
+            url: "https://api.githubcopilot.com/v1",
+            npm: "@ai-sdk/anthropic",
+          },
+        },
+      },
+    } as never,
+    {
+      auth: {
+        type: "oauth",
+        refresh: "github-token",
+        access: "tid=123;exp=456;proxy-ep=proxy.individual.githubcopilot.com;foo=bar",
+        expires: Date.now() + 60_000,
+      } as never,
+    },
+  )
+
+  expect(models.claude.api.url).toBe("https://api.individual.githubcopilot.com")
+  expect(models.claude.api.npm).toBe("@ai-sdk/github-copilot")
+})
+
+test("oauth loader refreshes the copilot token and uses the refreshed base headers", async () => {
+  const setAuth = mock(async () => undefined)
+  const requests: Array<{ url: string; headers: Headers }> = []
+
+  globalThis.fetch = mock(async (request: RequestInfo | URL, init?: RequestInit) => {
+    const url = request instanceof URL ? request.href : typeof request === "string" ? request : request.url
+    const headers = new Headers(init?.headers)
+    requests.push({ url, headers })
+
+    if (url === "https://api.github.com/copilot_internal/v2/token") {
+      return new Response(
+        JSON.stringify({
+          token: "tid=123;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;foo=bar",
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        }),
+        { status: 200 },
+      )
+    }
+
+    return new Response(JSON.stringify({ ok: true }), { status: 200 })
+  }) as unknown as typeof fetch
+
+  const hooks = await CopilotAuthPlugin({
+    client: {
+      auth: {
+        set: setAuth,
+      },
+    } as never,
+    project: {} as never,
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {} as never,
+  })
+
+  const loader = await hooks.auth!.loader!(
+    async () => ({
+      type: "oauth",
+      refresh: "github-token",
+      access: "",
+      expires: 0,
+    }),
+    {
+      id: "github-copilot",
+      models: {},
+    } as never,
+  )
+
+  await loader.fetch!("https://api.individual.githubcopilot.com/chat/completions", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer dummy",
+      "x-api-key": "dummy",
+    },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  })
+
+  expect(requests[0]?.url).toBe("https://api.github.com/copilot_internal/v2/token")
+  expect(requests[0]?.headers.get("authorization")).toBe("Bearer github-token")
+
+  expect(requests[1]?.url).toBe("https://api.individual.githubcopilot.com/chat/completions")
+  expect(requests[1]?.headers.get("authorization")).toBe(
+    "Bearer tid=123;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;foo=bar",
+  )
+  expect(requests[1]?.headers.get("openai-intent")).toBe("conversation-edits")
+  expect(requests[1]?.headers.get("x-initiator")).toBe("user")
+
+  expect(setAuth).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #23540

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes GitHub Copilot endpoint selection when the Copilot token encodes a different API host than the default one.

Today the plugin assumes a static Copilot base URL. This PR instead derives the base URL from the tokens `proxy-ep` field and falls back to the individual Copilot endpoint when that field is missing. It also keeps refreshed Copilot auth aligned with the token-derived URL and adds tests for the token-derived and fallback cases.

### How did you verify your code works?

- `bun run typecheck`
- `bun test test/plugin/github-copilot-models.test.ts`
- built and smoke-tested the Apple Silicon binary locally

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
