### PR TITLE
fix(config): catch schema validation errors in agent scanning loop

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -131,7 +131,15 @@ export async function load(dir: string) {
       ...md.data,
       prompt: md.content.trim(),
     }
-    result[config.name] = ConfigParse.schema(Info, config, item)
+    try {
+      result[config.name] = ConfigParse.schema(Info, config, item)
+    } catch (err) {
+      const { Session } = await import("@/session/session")
+      void Bus.publish(Session.Event.Error, {
+        error: new NamedError.Unknown({ message: `Failed to validate agent ${item}` }).toObject(),
+      })
+      log.error("failed to validate agent", { agent: item, err })
+    }
   }
   return result
 }


### PR DESCRIPTION
### Issue for this PR

Closes #27988

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ConfigAgent.load()` iterates over all `{agent,agents}/**/*.md` files using a `for...of` loop. The markdown parsing step (`ConfigMarkdown.parse`) is wrapped in a `.catch()` that logs the error and continues, but the subsequent `ConfigParse.schema()` call has no error handling. When any agent file fails schema validation (e.g. invalid frontmatter types), the thrown `InvalidError` propagates up and aborts the entire loop.

Since `glob` returns files in alphabetical order, every agent file sorted after the failing one is silently dropped. This explains the symptom in #27988: 184 files exist but only ~119 register, with the missing ones clustering at the alphabetical tail.

The fix wraps `ConfigParse.schema()` in a `try/catch` that mirrors the existing error handling pattern for `ConfigMarkdown.parse()`: publish a `Session.Event.Error`, log the failure with the file path, and continue loading remaining agents.

### How did you verify your code works?

- `bun test test/config/` — 163 pass, 0 fail
- `bun test test/agent/` — 47 pass, 0 fail
- Reviewed that `loadMode()` already handles this correctly via `Schema.decodeUnknownExit` + `Exit.isSuccess` check, confirming this is specifically a `load()` gap

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR