### PR TITLE
fix: add clipboard fallback for text fields

### DIFF
--- a/packages/ui/src/components/text-field-copy.ts
+++ b/packages/ui/src/components/text-field-copy.ts
@@ -1,0 +1,25 @@
+export async function copyText(value: string) {
+  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard
+  if (clipboard?.writeText) {
+    const copied = await clipboard.writeText(value).then(
+      () => true,
+      () => false,
+    )
+    if (copied) return true
+  }
+
+  const body = typeof document === "undefined" ? undefined : document.body
+  if (!body) return false
+
+  const textarea = document.createElement("textarea")
+  textarea.value = value
+  textarea.setAttribute("readonly", "")
+  textarea.style.position = "fixed"
+  textarea.style.opacity = "0"
+  textarea.style.pointerEvents = "none"
+  body.appendChild(textarea)
+  textarea.select()
+  const copied = document.execCommand("copy")
+  body.removeChild(textarea)
+  return copied
+}

--- a/packages/ui/src/components/text-field.test.ts
+++ b/packages/ui/src/components/text-field.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { copyText } from "./text-field-copy"
+
+const originalNavigator = globalThis.navigator
+const originalDocument = globalThis.document
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  })
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: originalDocument,
+  })
+})
+
+describe("text-field", () => {
+  test("uses navigator clipboard when available", async () => {
+    const writes: string[] = []
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        clipboard: {
+          writeText: async (value: string) => {
+            writes.push(value)
+          },
+        },
+      },
+    })
+
+    expect(await copyText("hello")).toBe(true)
+    expect(writes).toEqual(["hello"])
+  })
+
+  test("falls back to execCommand when navigator clipboard fails", async () => {
+    const appended: Array<{ value: string; select: () => void }> = []
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        clipboard: {
+          writeText: async () => {
+            throw new Error("blocked")
+          },
+        },
+      },
+    })
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {
+        body: {
+          appendChild: (node: { value: string; select: () => void }) => appended.push(node),
+          removeChild: () => {},
+        },
+        createElement: () => ({
+          value: "",
+          style: {},
+          setAttribute: () => {},
+          select: () => {},
+        }),
+        execCommand: (command: string) => command === "copy",
+      },
+    })
+
+    expect(await copyText("fallback")).toBe(true)
+    expect(appended.map((node) => node.value)).toEqual(["fallback"])
+  })
+})

--- a/packages/ui/src/components/text-field.tsx
+++ b/packages/ui/src/components/text-field.tsx
@@ -3,6 +3,7 @@ import { createSignal, Show, splitProps } from "solid-js"
 import type { ComponentProps } from "solid-js"
 import { useI18n } from "../context/i18n"
 import { IconButton } from "./icon-button"
+import { copyText } from "./text-field-copy"
 import { Tooltip } from "./tooltip"
 
 export interface TextFieldProps
@@ -69,7 +70,7 @@ export function TextField(props: TextFieldProps) {
 
   async function handleCopy() {
     const value = local.value ?? local.defaultValue ?? ""
-    await navigator.clipboard.writeText(value)
+    if (!(await copyText(value))) return
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }


### PR DESCRIPTION
### Issue for this PR

Closes #27992
Refs #17553

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

TextField copy buttons now try the Clipboard API first, then fall back to a temporary textarea plus `document.execCommand("copy")` when browser permissions or a non-secure context block `navigator.clipboard.writeText()`. The copied state is only shown after a successful copy.

### How did you verify your code works?

- `bun test src/components/text-field.test.ts` from `packages/ui`
- `bun typecheck` from `packages/ui`
- `bun run lint packages/ui/src/components/text-field.tsx packages/ui/src/components/text-field-copy.ts packages/ui/src/components/text-field.test.ts` from repo root
- push hook: `bun turbo typecheck`

### Screenshots / recordings

N/A; behavior is covered by unit tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR