### PR TITLE
fix: register acp model and mode commands

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -56,9 +56,20 @@ import { ShellID } from "@/tool/shell/id"
 
 type ModeOption = { id: string; name: string; description?: string }
 type ModelOption = { modelId: string; name: string }
+export type CommandOption = { name: string; description: string }
 const decodeTodos = Schema.decodeUnknownResult(Schema.fromJsonString(Schema.Array(Todo.Info)))
 
 const DEFAULT_VARIANT_VALUE = "default"
+
+export function addCommandFallbacks(commands: CommandOption[]) {
+  const names = new Set(commands.map((c) => c.name))
+  const fallbacks: CommandOption[] = [
+    { name: "compact", description: "compact the session" },
+    { name: "model", description: "change the session model" },
+    { name: "mode", description: "change the session mode" },
+  ]
+  commands.push(...fallbacks.filter((command) => !names.has(command.name)))
+}
 
 const log = Log.create({ service: "acp-agent" })
 
@@ -1137,12 +1148,7 @@ export class Agent implements ACPAgent {
       name: command.name,
       description: command.description ?? "",
     }))
-    const names = new Set(availableCommands.map((c) => c.name))
-    if (!names.has("compact"))
-      availableCommands.push({
-        name: "compact",
-        description: "compact the session",
-      })
+    addCommandFallbacks(availableCommands)
 
     const mcpServers: Record<string, ConfigMCP.Info> = {}
     for (const server of params.mcpServers) {

--- a/packages/opencode/test/acp/command-fallbacks.test.ts
+++ b/packages/opencode/test/acp/command-fallbacks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { ACP } from "../../src/acp/agent"
+
+describe("acp command fallbacks", () => {
+  test("registers built-in session commands when they are missing", () => {
+    const commands: ACP.CommandOption[] = []
+
+    ACP.addCommandFallbacks(commands)
+
+    expect(commands.map((command) => command.name)).toEqual(["compact", "model", "mode"])
+  })
+
+  test("does not duplicate commands returned by the server", () => {
+    const commands: ACP.CommandOption[] = [{ name: "model", description: "custom model command" }]
+
+    ACP.addCommandFallbacks(commands)
+
+    expect(commands.filter((command) => command.name === "model")).toHaveLength(1)
+    expect(commands.map((command) => command.name)).toEqual(["model", "compact", "mode"])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #27942

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ACP session loading now includes `model` and `mode` in the available command fallback list, alongside `compact`, when the command API does not return them. This lets ACP clients discover and dispatch those built-in session commands.

### How did you verify your code works?

- `bun test test/acp/command-fallbacks.test.ts test/acp/agent-interface.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun run lint packages/opencode/src/acp/agent.ts packages/opencode/test/acp/command-fallbacks.test.ts` from repo root (0 errors; existing warnings in `agent.ts`)
- `git diff --check origin/dev...HEAD`
- push hook: `bun turbo typecheck`

### Screenshots / recordings

N/A; behavior is covered by unit tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR