### PR TITLE
fix: sync PWA status bar theme-color with app color scheme

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -10,7 +10,6 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v3.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#F8F7F7" />
-    <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
     <meta property="og:image" content="/social-share.png" />
     <meta property="twitter:image" content="/social-share.png" />
     <script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>

--- a/packages/app/public/oc-theme-preload.js
+++ b/packages/app/public/oc-theme-preload.js
@@ -16,6 +16,10 @@
   document.documentElement.dataset.theme = themeId
   document.documentElement.dataset.colorScheme = mode
 
+  // Update theme-color meta tag to match app color scheme
+  var metas = document.querySelectorAll("meta[name='theme-color']")
+  if (metas.length > 0) metas[0].setAttribute("content", isDark ? "#131010" : "#F8F7F7")
+
   if (themeId === "oc-2") return
 
   var css = localStorage.getItem("opencode-theme-css-" + mode)

--- a/packages/desktop/src/renderer/index.html
+++ b/packages/desktop/src/renderer/index.html
@@ -9,7 +9,6 @@
     <link rel="shortcut icon" href="./favicon-v3.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon-v3.png" />
     <meta name="theme-color" content="#F8F7F7" />
-    <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
     <meta property="og:image" content="./social-share.png" />
     <meta property="twitter:image" content="./social-share.png" />
     <script id="oc-theme-preload-script" src="./oc-theme-preload.js"></script>

--- a/packages/desktop/src/renderer/loading.html
+++ b/packages/desktop/src/renderer/loading.html
@@ -9,7 +9,6 @@
     <link rel="shortcut icon" href="./favicon-v3.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon-v3.png" />
     <meta name="theme-color" content="#F8F7F7" />
-    <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
     <meta property="og:image" content="./social-share.png" />
     <meta property="twitter:image" content="./social-share.png" />
     <script id="oc-theme-preload-script" src="./oc-theme-preload.js"></script>

--- a/packages/enterprise/src/entry-server.tsx
+++ b/packages/enterprise/src/entry-server.tsx
@@ -25,7 +25,6 @@ export default createHandler(() => (
             <meta name="viewport" content="width=device-width, initial-scale=1" />
             <title>OpenCode</title>
             <meta name="theme-color" content="#F8F7F7" />
-            <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
             {assets}
           </head>
           <body class="antialiased overscroll-none text-12-regular">

--- a/packages/ui/src/theme/context.tsx
+++ b/packages/ui/src/theme/context.tsx
@@ -147,6 +147,10 @@ function applyThemeCss(theme: DesktopTheme, themeId: string, mode: "light" | "da
   ensureThemeStyleElement().textContent = fullCss
   document.documentElement.dataset.theme = themeId
   document.documentElement.dataset.colorScheme = mode
+
+  // Update theme-color meta tag to match light/dark mode
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) meta.setAttribute("content", isDark ? "#131010" : "#F8F7F7")
 }
 
 function cacheThemeVariants(theme: DesktopTheme, themeId: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #17663

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the app is installed as a PWA on mobile Chrome, the top status bar color doesn't match the app's actual theme — it stays `#F8F7F7` (light) regardless of whether the user has selected light or dark mode.

The HTML had two `<meta name="theme-color">` tags — the second one with `media="(prefers-color-scheme: dark)"` was supposed to kick in when the system is in dark mode, but it never actually worked. According to the WHATWG HTML Living Standard algorithm for obtaining a page's theme color (https://html.spec.whatwg.org/multipage/semantics.html#meta-theme-color), browsers walk meta tags in tree order and return the first one whose `media` matches. Our first tag has no `media` attribute at all, which means it unconditionally matches — the second tag is never even checked.

The fix removes the dead second tag and instead dynamically updates the single remaining meta tag's `content` in `oc-theme-preload.js` (runs synchronously before paint) and the theme context (handles runtime changes).

### How did you verify your code works?

Confirmed on a mobile Chrome PWA install: before the fix the status bar was always light, after the fix it correctly follows the app's light/dark theme setting.

### Screenshots / recordings

before

<img width="1200" height="372" alt="IMG_20260517_182332" src="https://github.com/user-attachments/assets/16b8b7c0-76a5-4eae-924b-bc50f2c94fe3" />


after

<img width="1200" height="443" alt="IMG_20260517_182320" src="https://github.com/user-attachments/assets/279cb31a-5270-4243-9d10-9114eb125520" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
