### PR TITLE
fix(tui): ignore empty key sequences

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/keymap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/keymap.tsx
@@ -110,6 +110,7 @@ function formatOptions(config: TuiConfig.Resolved) {
 }
 
 export function formatKeySequence(parts: Parameters<typeof formatKeySequenceExtra>[0], config: TuiConfig.Resolved) {
+  if (!parts?.length) return ""
   return formatKeySequenceExtra(parts, formatOptions(config))
 }
 

--- a/packages/opencode/test/cli/tui/keymap.test.ts
+++ b/packages/opencode/test/cli/tui/keymap.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { formatKeySequence } from "@/cli/cmd/tui/keymap"
+import type { TuiConfig } from "@/cli/cmd/tui/config/tui"
+
+const config = {
+  keybinds: {
+    get: () => [],
+  },
+} as unknown as TuiConfig.Resolved
+
+test("formatKeySequence tolerates missing command bindings", () => {
+  expect(formatKeySequence(undefined, config)).toBe("")
+  expect(formatKeySequence([], config)).toBe("")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #28007

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Guards TUI key sequence formatting so missing or empty command bindings render as an empty shortcut label instead of calling OpenTUI's formatter with an empty sequence. This prevents startup/render crashes when a command has no registered binding.

### How did you verify your code works?

- `bun test test/cli/tui/keymap.test.ts --timeout 30000`
- `bun typecheck`
- `bunx prettier --check src/cli/cmd/tui/keymap.tsx test/cli/tui/keymap.test.ts`
- `git diff --check`
- `git push -u mturac fix/28007-empty-key-sequence` (pre-push `bun turbo typecheck`)

### Screenshots / recordings

Not applicable; this is a TUI key formatting guard covered by a regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR