### PR TITLE
fix(tui): keep startup events before project loads

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/event.ts
@@ -16,7 +16,8 @@ export function useEvent() {
         return
       }
 
-      if (event.directory === "global" || event.project === project.project()) {
+      const currentProject = project.project()
+      if (event.directory === "global" || currentProject === undefined || event.project === currentProject) {
         handler(event.payload, { workspace: event.workspace })
       }
     })

--- a/packages/opencode/test/cli/tui/use-event.test.tsx
+++ b/packages/opencode/test/cli/tui/use-event.test.tsx
@@ -65,7 +65,7 @@ function createSource() {
   }
 }
 
-async function mount() {
+async function mount(input: { syncProject?: boolean } = {}) {
   const source = createSource()
   const seen: Event[] = []
   const workspaces: Array<string | undefined> = []
@@ -87,7 +87,7 @@ async function mount() {
         <Probe
           onReady={async (ctx) => {
             project = ctx.project
-            await project.sync()
+            if (input.syncProject !== false) await project.sync()
             done()
           }}
           seen={seen}
@@ -174,6 +174,21 @@ describe("useEvent", () => {
       await wait(() => seen.length === 1)
 
       expect(seen).toEqual([update("1.2.3")])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("delivers project events before the current project finishes loading", async () => {
+    const { app, emit, seen, workspaces } = await mount({ syncProject: false })
+
+    try {
+      emit(event(vcs("startup"), { directory: "/tmp/root", project: projectID, workspace: "ws_start" }))
+
+      await wait(() => seen.length === 1)
+
+      expect(seen).toEqual([vcs("startup")])
+      expect(workspaces).toEqual(["ws_start"])
     } finally {
       app.renderer.destroy()
     }


### PR DESCRIPTION
### Issue for this PR

Fixes #27879

### Type of change

- [x] Bug fix

### What does this PR do?

Preserves non-sync TUI events while the current project is still loading, so startup events such as permission prompts and session status are not silently dropped before `/project/current` resolves.

Adds a regression test for project-scoped events emitted before the project context has synced.

### How did you verify your code works?

- bun test test/cli/tui/use-event.test.tsx --timeout 30000
- bun typecheck
- bunx prettier --check src/cli/cmd/tui/context/event.ts test/cli/tui/use-event.test.tsx
- git diff --check
- git push pre-push hook: bun turbo typecheck

### Screenshots / recordings

Not applicable; event handling regression.

### Checklist

- [x] I have tested this change locally.
- [x] I have added or updated tests where appropriate.
- [x] I have kept the change focused.