### PR TITLE
docs: add OpenCode Mobile to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -71,6 +71,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [OpenCode Mobile](https://github.com/Risaly-Noroki-Dev-Club/opencode-mobile-app)          | Native Android client with a self-hosted gateway for OpenCode    |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds OpenCode Mobile to the ecosystem Projects list.

OpenCode Mobile is a native Android client for OpenCode. It links to the Android app repository, whose README documents the companion self-hosted gateway.

### How did you verify your code works?

Verified the change is a docs-only update to `packages/web/src/content/docs/ecosystem.mdx` and that the Markdown table row matches the surrounding Projects entries.

### Screenshots / recordings

Not applicable; this is a documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
