### PR TITLE
feat(skills): add default skill registry fetched on startup

### DIFF
--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -18,6 +18,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   disableChannelDb: bool("OPENCODE_DISABLE_CHANNEL_DB"),
   disableEmbeddedWebUi: bool("OPENCODE_DISABLE_EMBEDDED_WEB_UI"),
   disableExternalSkills: bool("OPENCODE_DISABLE_EXTERNAL_SKILLS"),
+  disableDefaultSkills: bool("OPENCODE_DISABLE_DEFAULT_SKILLS"),
   disableLspDownload: bool("OPENCODE_DISABLE_LSP_DOWNLOAD"),
   skipMigrations: bool("OPENCODE_SKIP_MIGRATIONS"),
   disableClaudeCodePrompt: Config.all({

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -217,10 +217,12 @@ const discoverSkills = Effect.fnUntraced(function* (
   }
 
   // Default skill URLs ship with the binary and are fetched automatically.
+  // Suppressed when external skills are disabled (air-gapped / privacy mode)
+  // or when OPENCODE_DISABLE_DEFAULT_SKILLS=1 is set.
   // User-configured URLs are appended after, so they take precedence on name
   // collisions (last write wins in the state map).
   const allUrls = [
-    ...(disableDefaultSkills ? [] : DEFAULT_SKILL_URLS),
+    ...(!disableExternalSkills && !disableDefaultSkills ? DEFAULT_SKILL_URLS : []),
     ...(cfg.skills?.urls ?? []),
   ]
   for (const url of allUrls) {

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -24,6 +24,12 @@ const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
 const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"
 const SKILL_PATTERN = "**/SKILL.md"
 
+// Default hosted skill registry — fetched automatically on first run and
+// cached locally. Ships native-skill stubs for Claude Code, Codex, and other
+// AI CLI tools so they appear in <available_skills> out of the box.
+// Set OPENCODE_DISABLE_DEFAULT_SKILLS=1 to opt out.
+const DEFAULT_SKILL_URLS = ["https://antoinedc.github.io/bui-skills"]
+
 // Built-in skill that ships with opencode. The model's intuition for what an
 // opencode.json should look like is often wrong, and opencode hard-fails on
 // invalid config, so users hit cryptic startup errors. Loading this skill
@@ -167,6 +173,7 @@ const discoverSkills = Effect.fnUntraced(function* (
   global: Global.Interface,
   disableExternalSkills: boolean,
   disableClaudeCodeSkills: boolean,
+  disableDefaultSkills: boolean,
   directory: string,
   worktree: string,
 ) {
@@ -209,7 +216,14 @@ const discoverSkills = Effect.fnUntraced(function* (
     yield* scan(state, dir, SKILL_PATTERN)
   }
 
-  for (const url of cfg.skills?.urls ?? []) {
+  // Default skill URLs ship with the binary and are fetched automatically.
+  // User-configured URLs are appended after, so they take precedence on name
+  // collisions (last write wins in the state map).
+  const allUrls = [
+    ...(disableDefaultSkills ? [] : DEFAULT_SKILL_URLS),
+    ...(cfg.skills?.urls ?? []),
+  ]
+  for (const url of allUrls) {
     const pulledDirs = yield* discovery.pull(url)
     for (const dir of pulledDirs) {
       yield* scan(state, dir, SKILL_PATTERN)
@@ -251,6 +265,7 @@ export const layer = Layer.effect(
           global,
           flags.disableExternalSkills,
           flags.disableClaudeCodeSkills,
+          flags.disableDefaultSkills,
           ctx.directory,
           ctx.worktree,
         )


### PR DESCRIPTION
## Problem

Native bundled skills from Claude Code (`/review`, `/batch`, `/debug`, etc.) and Codex (`/review`, `$skill-creator`, etc.) don't appear in `<available_skills>` for new OpenCode installs because they aren't `SKILL.md` files on disk — they're built into those CLIs' binaries.

## Solution

Add a default skill registry URL that OpenCode fetches automatically on startup, so every fresh install gets native-skill stubs out of the box with zero configuration.

## Changes

**`packages/opencode/src/skill/index.ts`**
- Add `DEFAULT_SKILL_URLS` constant pointing at the hosted registry
- Prepend default URLs before user-configured `skills.urls` (user entries still take precedence on name collisions — last write wins)

**`packages/opencode/src/effect/runtime-flags.ts`**
- Add `disableDefaultSkills` flag controlled by `OPENCODE_DISABLE_DEFAULT_SKILLS=1`

## Hosted registry

`https://antoinedc.github.io/bui-skills` — source at https://github.com/antoinedc/bui-skills

Currently ships stubs for:

| Skill | Mirrors |
|---|---|
| `claude-review` | Claude Code `/review` |
| `claude-security-review` | Claude Code `/security-review` |
| `claude-simplify` | Claude Code `/simplify` |
| `claude-batch` | Claude Code `/batch` |
| `claude-debug` | Claude Code `/debug` |
| `claude-loop` | Claude Code `/loop` |
| `claude-fewer-permission-prompts` | Claude Code `/fewer-permission-prompts` |
| `claude-api` | Claude Code `/claude-api` |
| `codex-review` | Codex `/review` |
| `codex-skill-creator` | Codex `$skill-creator` |
| `codex-skill-installer` | Codex `$skill-installer` |

## Behaviour

- Default URLs are fetched and cached on startup (same `Discovery.pull` path as `skills.urls`)
- User-configured `skills.urls` are appended after, so they override on collision
- Opt out with `OPENCODE_DISABLE_DEFAULT_SKILLS=1`
- No config schema changes needed — `skills.urls` already exists and works as before

## Notes

The registry URL should be moved to `skills.opencode.ai` before this lands (just a CNAME + repo transfer). The hosted index and SKILL.md files are intentionally thin stubs — they describe what each native skill does and how OpenCode should replicate the behaviour, not reimplementations.