### PR TITLE
feat(plugin): add Microsoft Foundry as a built-in auth provider

### DIFF
--- a/packages/opencode/src/plugin/foundry.ts
+++ b/packages/opencode/src/plugin/foundry.ts
@@ -1,0 +1,79 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+
+// Microsoft Foundry auth plugin.
+//
+// Foundry exposes models behind project-scoped URLs of the form:
+//   https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1
+// authenticated via either `Authorization: Bearer <key>` or `api-key: <key>`.
+//
+// Deployments are user-defined (e.g. `gpt-5.5`, `gpt-4o-mini`) and not present in
+// the models.dev catalog, so the user supplies them as part of `/login` and then
+// references them in their own `opencode.json` provider entry. Example:
+//
+//   {
+//     "provider": {
+//       "foundry": {
+//         "npm": "@ai-sdk/openai-compatible",
+//         "options": {
+//           "baseURL": "https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1"
+//         },
+//         "models": { "gpt-5.5": { "name": "GPT-5.5", "reasoning": false } }
+//       }
+//     }
+//   }
+//
+// Foundry rejects some params that the openai-compatible SDK emits for gpt-5.x
+// deployments (`reasoningSummary`, `reasoningEffort`, `textVerbosity`) plus
+// `max_tokens` (must be `max_completion_tokens`, which the SDK doesn't rename).
+// The `chat.params` hook strips them when the provider id is `foundry`.
+export async function FoundryAuthPlugin(_input: PluginInput): Promise<Hooks> {
+  return {
+    auth: {
+      provider: "foundry",
+      methods: [
+        {
+          type: "api",
+          label: "API key",
+          prompts: [
+            {
+              type: "text",
+              key: "resourceName",
+              message: "Foundry resource hostname",
+              placeholder: "e.g. faraday-resource.services.ai.azure.com",
+              validate: (value: string) => (value.includes(".") ? undefined : "Must be a fully-qualified hostname"),
+            },
+            {
+              type: "text",
+              key: "projectName",
+              message: "Foundry project name",
+              placeholder: "e.g. faraday-agents",
+              validate: (value: string) => (value.trim() ? undefined : "Project name is required"),
+            },
+            {
+              type: "text",
+              key: "deployments",
+              message: "Deployment names (comma-separated, used in opencode.json)",
+              placeholder: "e.g. gpt-5.5,gpt-4o-mini",
+            },
+          ],
+        },
+      ],
+    },
+
+    "chat.params": async (incoming, output) => {
+      if (incoming.model.providerID !== "foundry") return
+      const opts = output.options as Record<string, any> | undefined
+      if (opts) {
+        delete opts.reasoningEffort
+        delete opts.reasoningSummary
+        delete opts.textVerbosity
+        delete opts.include
+        delete opts.promptCacheKey
+      }
+      // The openai-compatible SDK emits `max_tokens`; gpt-5.x Foundry deployments
+      // require `max_completion_tokens` instead. Dropping the cap lets the model
+      // use its default output budget rather than failing the request.
+      output.maxOutputTokens = undefined
+    },
+  }
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -19,6 +19,7 @@ import { PoeAuthPlugin } from "opencode-poe-auth"
 import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cloudflare"
 import { AzureAuthPlugin } from "./azure"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
+import { FoundryAuthPlugin } from "./foundry"
 import { Effect, Layer, Context, Stream } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
@@ -66,6 +67,7 @@ const INTERNAL_PLUGINS: PluginInstance[] = [
   CloudflareAIGatewayAuthPlugin,
   AzureAuthPlugin,
   DigitalOceanAuthPlugin,
+  FoundryAuthPlugin,
 ]
 
 function isServerPlugin(value: unknown): value is PluginInstance {


### PR DESCRIPTION
### Issue for this PR

Closes #14879

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It adds Microsoft Foundry as a provider option in `/login` and a small `chat.params` hook so Foundry gpt-5.x deployments don't fail on every request.

A note on the CONTRIBUTING rule "new providers should go to models.dev first": Foundry doesn't fit that model. A Foundry "provider" is a *user's own Azure resource + project + deployments*. There's no fixed model list to put in the catalog — every user has different deployment names. So the catalog can't represent it; the right place is a plugin.

Two things were needed:

1. The `/login` flow asks the user for their resource hostname, project name and the deployment names they have. The credential is saved under the `foundry` provider id and the user then references it from their own `opencode.json` (the JSDoc in `foundry.ts` has the minimal shape).

2. Foundry's OpenAI-compatible endpoint on gpt-5.x returns 400 for `reasoningSummary`, `reasoningEffort`, `textVerbosity`, and won't accept `max_tokens` (wants `max_completion_tokens` instead). The openai-compatible SDK emits all of those. So when `model.providerID === "foundry"` the hook strips them from `output.options` and clears `maxOutputTokens`. Other providers aren't touched.

### How did you verify your code works?

Tested against a real Foundry project end to end:

1. `bun run typecheck` — clean (also caught a missing `client.auth.get` I had to remove before re-running)
2. `bun run dev` — boots and logs `name=FoundryAuthPlugin loading internal plugin`
3. `bun run dev auth list` — shows registered providers
4. Wrote a minimal `opencode.json` pointing at `https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1` with one model `gpt-5.5`, then ran:
   ```
   bun run dev run -m foundry/gpt-5.5 "Say pong"
   ```
   → returned `pong`. Before the hook this errored with `Unknown parameter: 'reasoningSummary'`.

Curl probes (before writing the hook, to confirm what Foundry actually rejects):

| Param the openai-compatible SDK emits | Foundry response |
| --- | --- |
| `reasoningSummary` / `reasoningEffort` / `textVerbosity` | 400 `Unknown parameter` |
| `max_tokens` | 400 `use 'max_completion_tokens'` |
| `temperature: 0.5` | 400 `Only the default (1) value is supported` |

### Screenshots / recordings

No UI change. The only user-visible surface is the `/login` flow — three text prompts in the same style as the existing Azure plugin (resource hostname, project name, deployments comma-separated).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Notes

This lands the OpenAI-compatible path on Foundry, which is the common case (gpt-4o-mini, gpt-5.5, etc.). The original reporter on #14879 was hitting `/anthropic/v1/messages` on Foundry — Claude on Foundry uses a different SDK (`@ai-sdk/anthropic`) and URL pattern. Happy to do that as a follow-up if this lands.