### PR TITLE
fix(shell): avoid non-string stdout parsing in cygpath path resolution

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -342,10 +342,17 @@ export const ShellTool = Tool.define(
     const plugin = yield* Plugin.Service
 
     const cygpath = Effect.fn("ShellTool.cygpath")(function* (shell: string, text: string) {
-      const lines = yield* spawner
-        .lines(ChildProcess.make(shell, ["-lc", 'cygpath -w -- "$1"', "_", text]))
-        .pipe(Effect.catch(() => Effect.succeed([] as string[])))
-      const file = lines[0]?.trim()
+      const file = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const handle = yield* spawner.spawn(ChildProcess.make(shell, ["-lc", 'cygpath -w -- "$1"', "_", text]))
+          const [exitCode, stdout] = yield* Effect.all([
+            handle.exitCode,
+            Stream.runFold(Stream.decodeText(handle.stdout), () => "", (acc, chunk) => acc + chunk),
+          ])
+          if (exitCode !== 0) return
+          return stdout.split("\n")[0]?.trim()
+        }),
+      ).pipe(Effect.catch(() => Effect.succeed(undefined)))
       if (!file) return
       return AppFileSystem.normalizePath(file)
     })


### PR DESCRIPTION
### Issue for this PR

Closes #26932

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a bash-tool failure where a non-string stdout shape could flow into a split path during Windows `cygpath` resolution. I replaced the `spawner.lines(...)` call with explicit `spawn` + stdout stream decode + exit-code check, then only parse the first line when the command succeeds.

This keeps the same fallback behavior (`undefined` on failure) but removes the non-string split hazard that could abort tool execution.

### How did you verify your code works?

- Ran `bun test test/tool/shell.test.ts` from `packages/opencode` (22 passing tests)
- Push hook ran `bun turbo typecheck` successfully before branch push

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR