### PR TITLE
fix(task-tool): sanitize zero-width-space and BOM from subagent_type

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -16,6 +16,19 @@ import { Cause, Effect, Exit, Option, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 
+/**
+ * Strip leading/trailing whitespace and zero-width / BOM characters from a
+ * subagent_type string before it is used for agent lookup.  Defensive fix for
+ * issue #24276 where upstream skill emitters can prefix the value with a
+ * zero-width space (U+200B), causing ProviderModelNotFoundError.
+ *
+ * Characters removed: U+200B ZERO-WIDTH SPACE, U+200C ZERO-WIDTH NON-JOINER,
+ * U+200D ZERO-WIDTH JOINER, U+FEFF BOM / ZERO-WIDTH NO-BREAK SPACE.
+ */
+export function sanitizeAgentTypeId(value: string): string {
+  return value.replace(/[​‌‍﻿]/g, "").trim()
+}
+
 export interface TaskPromptOps {
   cancel(sessionID: SessionID): Effect.Effect<void>
   resolvePromptParts(template: string): Effect.Effect<SessionPrompt.PromptInput["parts"]>
@@ -136,9 +149,10 @@ export const TaskTool = Tool.define(
         })
       }
 
-      const next = yield* agent.get(params.subagent_type)
+      const agentTypeId = sanitizeAgentTypeId(params.subagent_type)
+      const next = yield* agent.get(agentTypeId)
       if (!next) {
-        return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
+        return yield* Effect.fail(new Error(`Unknown agent type: ${agentTypeId} is not a valid agent type`))
       }
 
       const taskID = params.task_id

--- a/packages/opencode/test/tool/parameters.test.ts
+++ b/packages/opencode/test/tool/parameters.test.ts
@@ -20,7 +20,7 @@ import { Parameters as Question } from "../../src/tool/question"
 import { Parameters as Read } from "../../src/tool/read"
 import { Parameters as Shell } from "../../src/tool/shell"
 import { Parameters as Skill } from "../../src/tool/skill"
-import { Parameters as Task } from "../../src/tool/task"
+import { Parameters as Task, sanitizeAgentTypeId } from "../../src/tool/task"
 import { Parameters as Todo } from "../../src/tool/todo"
 import { Parameters as WebFetch } from "../../src/tool/webfetch"
 import { Parameters as WebSearch } from "../../src/tool/websearch"
@@ -241,6 +241,25 @@ describe("tool parameters", () => {
     })
     test("rejects missing prompt", () => {
       expect(accepts(Task, { description: "d", subagent_type: "general" })).toBe(false)
+    })
+  })
+
+  describe("sanitizeAgentTypeId", () => {
+    test("strips leading zero-width space (U+200B) from subagent_type", () => {
+      // The string below has a U+200B prepended — matches the issue #24276 repro
+      expect(sanitizeAgentTypeId("​Sisyphus - Ultraworker")).toBe("Sisyphus - Ultraworker")
+    })
+    test("leaves a clean subagent_type string unchanged", () => {
+      expect(sanitizeAgentTypeId("Sisyphus - Ultraworker")).toBe("Sisyphus - Ultraworker")
+    })
+    test("trims leading and trailing whitespace", () => {
+      expect(sanitizeAgentTypeId("   Sisyphus - Ultraworker   ")).toBe("Sisyphus - Ultraworker")
+    })
+    test("strips all zero-width characters (U+200B, U+200C, U+200D, U+FEFF)", () => {
+      expect(sanitizeAgentTypeId("​‌‍﻿explore")).toBe("explore")
+    })
+    test("strips embedded zero-width characters mid-string", () => {
+      expect(sanitizeAgentTypeId("gene​ral")).toBe("general")
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #24276

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some skill emitters (e.g. oh-my-openagent's review-work) prefix `subagent_type` with a zero-width space (U+200B). `agent.get(params.subagent_type)` then returns undefined, and the call surfaces as `ProviderModelNotFoundError` with an unresolvable model id.

This PR strips U+200B, U+200C, U+200D, and U+FEFF and trims surrounding whitespace before the agent lookup in `packages/opencode/src/tool/task.ts`. The cleanup lives in a small helper `sanitizeAgentTypeId()` so it can be reused if other entry points need it.

### How did you verify your code works?

`cd packages/opencode && bun test test/tool/parameters.test.ts` — 63 pass, 0 fail. 5 new assertions cover: ZWSP-prefix repro from the issue, clean-string passthrough, whitespace trimming, multi-character zero-width stripping, and mid-string embedded ZWSP.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR