### PR TITLE
test(config-markdown): lock in unquoted-colon-in-description handling

### DIFF
--- a/packages/opencode/test/config/fixtures/subagent-colon-description.md
+++ b/packages/opencode/test/config/fixtures/subagent-colon-description.md
@@ -1,0 +1,6 @@
+---
+description: Reviews changes: returns a verdict.
+mode: subagent
+hidden: true
+---
+Agent prompt text.

--- a/packages/opencode/test/config/markdown.test.ts
+++ b/packages/opencode/test/config/markdown.test.ts
@@ -226,3 +226,28 @@ describe("ConfigMarkdown: frontmatter has weird model id", async () => {
     expect(result.content.trim()).toBe("Strictly follow da rules")
   })
 })
+
+describe("ConfigMarkdown: subagent with unquoted colon in description (#25315)", async () => {
+  const result = await ConfigMarkdown.parse(import.meta.dir + "/fixtures/subagent-colon-description.md")
+
+  test("should parse without throwing", () => {
+    expect(result).toBeDefined()
+    expect(result.data).toBeDefined()
+  })
+
+  test("should preserve description with unquoted colon", () => {
+    expect(result.data["description"]).toBe("Reviews changes: returns a verdict.")
+  })
+
+  test("should preserve mode: subagent", () => {
+    expect(result.data["mode"]).toBe("subagent")
+  })
+
+  test("should preserve hidden: true", () => {
+    expect(result.data["hidden"]).toBe(true)
+  })
+
+  test("should extract prompt content", () => {
+    expect(result.content.trim()).toBe("Agent prompt text.")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #25315

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The bug reported in #25315 (v1.14.30: hidden subagents leak into the web UI when their frontmatter `description` contains an unquoted colon, e.g. `description: Reviews changes: returns a verdict.`) appears already resolved on current `dev`. `gray-matter` parses the multi-token value correctly and `mode`, `hidden`, `description`, and the body are all preserved.

This PR is test-only — no source changes. It adds a fixture `test/config/fixtures/subagent-colon-description.md` and 5 assertions in `test/config/markdown.test.ts` so the correct parsing is locked in against future regressions.

### How did you verify your code works?

`cd packages/opencode && bun test test/config/markdown.test.ts` — 42 pass, 0 fail. The 5 new assertions verify `mode: subagent`, `hidden: true`, the full unquoted-colon description string, and the body content are all parsed correctly from the fixture.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR