### PR TITLE
docs(copilot): fix duplicated words in filter comment

### DIFF
--- a/packages/core/src/github-copilot/responses/openai-responses-api-types.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-api-types.ts
@@ -121,11 +121,11 @@ export type OpenAIResponsesFileSearchToolComparisonFilter = {
 }
 
 /**
- * Combine multiple filters using and or or.
+ * Combine multiple filters using `and` or `or`.
  */
 export type OpenAIResponsesFileSearchToolCompoundFilter = {
   /**
-   * Type of operation: and or or.
+   * Type of operation: `and` or `or`.
    */
   type: "and" | "or"
 


### PR DESCRIPTION
## Summary
- fix duplicated wording in the OpenAI responses file-search filter type comments
- clarify the allowed operator names as `and` or `or`

## Testing
- sed -n '121,131p' packages/core/src/github-copilot/responses/openai-responses-api-types.ts