### PR TITLE
fix(app): hide prompt placeholder for whitespace input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -858,7 +858,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         ? rawParts[0].content
         : rawParts.map((p) => ("content" in p ? p.content : "")).join("")
     const hasNonText = rawParts.some((part) => part.type !== "text")
-    const shouldReset = rawText.length === 0 && !hasNonText && images.length === 0
+    const textContent = (editorRef.textContent ?? "").replace(/\u200B/g, "")
+    const shouldReset = textContent.length === 0 && rawText.replace(/\n/g, "").length === 0 && !hasNonText && images.length === 0
 
     if (shouldReset) {
       closePopover()

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -99,8 +99,6 @@ const EXAMPLES = [
   "prompt.example.25",
 ] as const
 
-const NON_EMPTY_TEXT = /[^\s\u200B]/
-
 export const PromptInput: Component<PromptInputProps> = (props) => {
   const sdk = useSDK()
   const queryOptions = useQueryOptions()
@@ -860,7 +858,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         ? rawParts[0].content
         : rawParts.map((p) => ("content" in p ? p.content : "")).join("")
     const hasNonText = rawParts.some((part) => part.type !== "text")
-    const shouldReset = !NON_EMPTY_TEXT.test(rawText) && !hasNonText && images.length === 0
+    const shouldReset = rawText.length === 0 && !hasNonText && images.length === 0
 
     if (shouldReset) {
       closePopover()


### PR DESCRIPTION
### Issue for this PR

Closes #28099

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The prompt composer treated whitespace-only input as empty while reconciling editor state. That kept `prompt.dirty()` false, so the placeholder overlay stayed visible after typing spaces.

This updates the reset check to distinguish typed whitespace from browser-generated empty contenteditable line breaks. Spaces now hide the placeholder, while deleting everything resets the prompt so the placeholder comes back. Whitespace-only prompts remain unsendable because submit still uses the existing trim-based empty prompt guard.

### How did you verify your code works?

- Ran `bun test --preload ./happydom.ts ./src/components/prompt-input` from `packages/app`
- Ran `bun typecheck` from `packages/app`
- Pre-push hook ran `bun turbo typecheck` successfully
- Started `bun run --cwd packages/desktop dev` and checked the prompt behavior locally

### Screenshots / recordings

Before: typing spaces leaves the placeholder visible over the caret.

After: typing spaces hides the placeholder; deleting all content restores it. Submit remains disabled for whitespace-only input.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._