### PR TITLE
feat(app): persist model selection per agent 

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -386,6 +386,30 @@ export const SettingsGeneral: Component = () => {
             />
           </div>
         </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.persistModelPerAgent.title")}
+          description={language.t("settings.general.row.persistModelPerAgent.description")}
+        >
+          <div data-action="settings-persist-model-per-agent">
+            <Switch
+              checked={settings.general.persistModelPerAgent()}
+              onChange={(checked) => settings.general.setPersistModelPerAgent(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.persistModelAcrossSessions.title")}
+          description={language.t("settings.general.row.persistModelAcrossSessions.description")}
+        >
+          <div data-action="settings-persist-model-across-sessions">
+            <Switch
+              checked={settings.general.persistModelAcrossSessions()}
+              onChange={(checked) => settings.general.setPersistModelAcrossSessions(checked)}
+            />
+          </div>
+        </SettingsRow>
       </SettingsList>
     </div>
   )
@@ -729,7 +753,6 @@ export const SettingsGeneral: Component = () => {
     </div>
   )
 
-  console.log(import.meta.env)
   return (
     <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
       <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-stronger-non-alpha)_calc(100%_-_24px),transparent)]">

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -9,6 +9,7 @@ import { Persist, persisted } from "@/utils/persist"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
+import { useSettings } from "@/context/settings"
 
 export type ModelKey = { providerID: string; modelID: string; variant?: string }
 
@@ -20,6 +21,7 @@ type State = {
 
 type Saved = {
   session: Record<string, State | undefined>
+  agent: Record<string, State | undefined>
 }
 
 const WORKSPACE_KEY = "__workspace__"
@@ -59,6 +61,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sync = useSync()
     const providers = useProviders()
     const models = useModels()
+    const settings = useSettings()
 
     const id = createMemo(() => params.id || undefined)
     const list = createMemo(() => sync.data.agent.filter((item) => item.mode !== "subagent" && !item.hidden))
@@ -71,6 +74,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       },
       createStore<Saved>({
         session: {},
+        agent: {},
       }),
     )
 
@@ -192,6 +196,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             variant: item.variant ?? null,
           })
           const prev = scope()
+          if (settings.general.persistModelPerAgent()) {
+            if (prev?.agent) {
+              setSaved("agent", prev.agent, clone(prev))
+            }
+          }
           const next = {
             agent: item.name,
             model: item.model ?? prev?.model,
@@ -222,9 +231,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     }
 
     const current = () => {
+      const a = agent.current()
       const item = firstModel(
+        () => settings.general.persistModelPerAgent() && a ? saved.agent[a.name]?.model : undefined,
         () => scope()?.model,
-        () => agent.current()?.model,
+        () => a?.model,
         fallback,
       )
       if (!item) return
@@ -241,7 +252,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       })
     }
 
-    const selected = () => scope()?.variant
+    const selected = () => {
+      if (settings.general.persistModelPerAgent()) {
+        const a = agent.current()
+        if (a?.name && saved.agent[a.name]) {
+          return saved.agent[a.name]!.variant
+        }
+      }
+      return scope()?.variant
+    }
 
     const snapshot = () => {
       const model = current()
@@ -258,9 +277,19 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         ...next,
       } satisfies State
 
+      if (settings.general.persistModelPerAgent() && state.agent) {
+        setSaved("agent", state.agent, {
+          agent: state.agent,
+          model: state.model,
+          variant: state.variant ?? null,
+        })
+      }
+
       const session = id()
       if (session) {
-        setSaved("session", session, state)
+        if (settings.general.persistModelAcrossSessions()) {
+          setSaved("session", session, state)
+        }
         return
       }
       setStore("draft", state)
@@ -371,6 +400,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const next = clone(snapshot())
           if (!next) return
 
+          if (settings.general.persistModelPerAgent() && next.agent) {
+            setSaved("agent", next.agent, next)
+          }
+
           if (dir === sdk.directory) {
             setSaved("session", session, next)
             setStore("draft", undefined)
@@ -387,11 +420,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (saved.session[session] !== undefined) return
           if (handoff.has(handoffKey(sdk.directory, session))) return
 
-          setSaved("session", session, {
+          const state = {
             agent: msg.agent,
             model: msg.model,
             variant: msg.model?.variant ?? null,
-          })
+          }
+          if (settings.general.persistModelPerAgent() && msg.agent) {
+            setSaved("agent", msg.agent, state)
+          }
+          setSaved("session", session, state)
         },
       },
     }

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -32,6 +32,8 @@ export interface Settings {
     shellToolPartsExpanded: boolean
     editToolPartsExpanded: boolean
     showSessionProgressBar: boolean
+    persistModelPerAgent: boolean
+    persistModelAcrossSessions: boolean
   }
   updates: {
     startup: boolean
@@ -117,6 +119,8 @@ const defaultSettings: Settings = {
     shellToolPartsExpanded: false,
     editToolPartsExpanded: false,
     showSessionProgressBar: true,
+    persistModelPerAgent: false,
+    persistModelAcrossSessions: true,
   },
   updates: {
     startup: true,
@@ -235,6 +239,20 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setShowSessionProgressBar(value: boolean) {
           setStore("general", "showSessionProgressBar", value)
+        },
+        persistModelPerAgent: withFallback(
+          () => store.general?.persistModelPerAgent,
+          defaultSettings.general.persistModelPerAgent,
+        ),
+        setPersistModelPerAgent(value: boolean) {
+          setStore("general", "persistModelPerAgent", value)
+        },
+        persistModelAcrossSessions: withFallback(
+          () => store.general?.persistModelAcrossSessions,
+          defaultSettings.general.persistModelAcrossSessions,
+        ),
+        setPersistModelAcrossSessions(value: boolean) {
+          setStore("general", "persistModelAcrossSessions", value)
         },
       },
       updates: {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -775,6 +775,13 @@ export const dict = {
   "settings.general.row.showSessionProgressBar.description":
     "Display the animated progress bar at the top of the session when the agent is working",
 
+  "settings.general.row.persistModelPerAgent.title": "Persist model per agent",
+  "settings.general.row.persistModelPerAgent.description":
+    "Remember the selected model for each agent when switching between them",
+  "settings.general.row.persistModelAcrossSessions.title": "Persist model across sessions",
+  "settings.general.row.persistModelAcrossSessions.description":
+    "Keep the selected model when moving between sessions",
+
   "settings.general.row.wayland.title": "Use native Wayland",
   "settings.general.row.wayland.description": "Disable X11 fallback on Wayland. Requires restart.",
   "settings.general.row.wayland.tooltip":


### PR DESCRIPTION

### Issue for this PR

Closes #18359

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Persist model selection per agent with user-configurable settings

Add two settings toggles to control model persistence:
- Persist model per agent (opt-in): stores model/variant per agent name
- Persist model across sessions (default: on): controls session-scoped persistence

When per-agent is enabled, switching agents restores that agent's last used model, matching the TUI behavior.

(Also removes stray console.log(import.meta.env) in settings-general.tsx)


### How did you verify your code works?
I tested it locally

### Screenshots / recordings

<img width="709" height="152" alt="image" src="https://github.com/user-attachments/assets/d5d0d06e-7209-43ed-baa7-29cbad96dd21" />

### Checklist
- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

