### PR TITLE
feat(desktop): add notification permission for renderer

### DIFF
--- a/packages/desktop/src/main/windows.ts
+++ b/packages/desktop/src/main/windows.ts
@@ -9,6 +9,8 @@ const rendererRoot = join(root, "../renderer")
 const rendererProtocol = "oc"
 const rendererHost = "renderer"
 const clipboardWritePermission = "clipboard-sanitized-write"
+const notificationPermission = "notifications"
+const rendererPermissions = new Set([clipboardWritePermission, notificationPermission])
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -109,7 +111,7 @@ export function createMainWindow() {
     },
   })
 
-  allowClipboardWrite(win)
+  allowRendererPermissions(win)
 
   win.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
     const { requestHeaders } = details
@@ -162,7 +164,7 @@ export function createLoadingWindow() {
     },
   })
 
-  allowClipboardWrite(win)
+  allowRendererPermissions(win)
 
   loadWindow(win, "loading.html")
 
@@ -199,16 +201,16 @@ function loadWindow(win: BrowserWindow, html: string) {
   void win.loadURL(`${rendererProtocol}://${rendererHost}/${html}`)
 }
 
-function allowClipboardWrite(win: BrowserWindow) {
+function allowRendererPermissions(win: BrowserWindow) {
   win.webContents.session.setPermissionRequestHandler((webContents, permission, callback, details) => {
     callback(
-      permission === clipboardWritePermission &&
+      rendererPermissions.has(permission) &&
         isTrustedRendererUrl(details.requestingUrl) &&
         webContents.id === win.webContents.id,
     )
   })
   win.webContents.session.setPermissionCheckHandler((webContents, permission, requestingOrigin, details) => {
-    if (permission !== clipboardWritePermission) return false
+    if (!rendererPermissions.has(permission)) return false
     if (webContents && webContents.id !== win.webContents.id) return false
     return isTrustedRendererUrl(details.requestingUrl) || isTrustedRendererUrl(requestingOrigin)
   })


### PR DESCRIPTION
## Summary
Fixes #26226
Extends the desktop renderer permission system to support notifications in addition to the existing clipboard-sanitized-write permission.

## Changes
- Adds `notificationPermission` constant alongside `clipboardWritePermission`
- Introduces `rendererPermissions` Set to manage allowed permissions
- Renames `allowClipboardWrite` → `allowRendererPermissions` to reflect broader scope
- Updates permission request and check handlers to validate against the permission set