### PR TITLE
fix(opencode): order messages by (time.created, id) at runLoop exit

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1672,7 +1672,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            (lastUser.time.created < lastAssistant.time.created ||
+              (lastUser.time.created === lastAssistant.time.created && lastUser.id < lastAssistant.id))
           ) {
             yield* slog.info("exiting loop")
             break
@@ -1791,7 +1792,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             if (step > 1 && lastFinished) {
               for (const m of msgs) {
-                if (m.info.role !== "user" || m.info.id <= lastFinished.id) continue
+                if (
+                  m.info.role !== "user" ||
+                  m.info.time.created < lastFinished.time.created ||
+                  (m.info.time.created === lastFinished.time.created && m.info.id <= lastFinished.id)
+                )
+                  continue
                 for (const p of m.parts) {
                   if (p.type !== "text" || p.ignored || p.synthetic) continue
                   if (!p.text.trim()) continue


### PR DESCRIPTION
### Issue for this PR

Closes #20699 (maybe also #25270 and #27928)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Time zone suffering. The user's messageIDs are [minted](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/id/id.ts#L60) client-side with `Date.now() * 4096 + counter`, whereas the assistant's are minted server-side, so server/client time differences can hose the ordering used for the loop exit, ultimately causing a dupe. You end up with all kinds of weird issues where people say it works fine in one environment and but dupes responses in another.

### How did you verify your code works?

I ran it in-browser with some misbehaving models, and saw that they now behaved as one would expect.

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
