### PR TITLE
fix(ui): fix question dock overflow and message part flex layout

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -469,7 +469,9 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
         </>
       }
     >
-      <div data-slot="question-text">{question()?.question}</div>
+      <div data-slot="question-text" class="overflow-auto">
+        {question()?.question}
+      </div>
       <Show when={multi()} fallback={<div data-slot="question-hint">{language.t("ui.question.singleHint")}</div>}>
         <div data-slot="question-hint">{language.t("ui.question.multiHint")}</div>
       </Show>

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -935,7 +935,7 @@
     gap: 6px;
     margin-top: 12px;
     padding: 1px 1px 8px;
-    flex: 1;
+    flex-shrink: 0;
     min-height: 0;
     overflow-y: auto;
     scrollbar-width: none;


### PR DESCRIPTION
## Summary
- Add `overflow-auto` to question dock text container to prevent content overflow
- Change message part CSS from `flex: 1` to `flex-shrink: 0` to fix layout compression issues