### PR TITLE
fix(sdk): guard generated parameter slots

### DIFF
--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -11,6 +11,83 @@ import { createClient } from "@hey-api/openapi-ts"
 
 const opencode = path.resolve(dir, "../../opencode")
 
+async function hardenGeneratedParams() {
+  for (const file of ["src/gen/core/params.gen.ts", "src/v2/gen/core/params.gen.ts"]) {
+    let source = await Bun.file(file).text()
+
+    if (!source.includes("const getParamSlot =")) {
+      source = source.replace(
+        /const extraPrefixes = Object\.entries\(extraPrefixesMap\)\n+/,
+        `const extraPrefixes = Object.entries(extraPrefixesMap)
+const getParamSlot = (slot: unknown): Slot | undefined => {
+  switch (slot) {
+    case "body":
+    case "headers":
+    case "path":
+    case "query":
+      return slot
+    default:
+      return undefined
+  }
+}
+`,
+      )
+    }
+
+    source = source
+      .replace(
+        `if (config.key) {
+        map.set(config.key, {
+          in: config.in,`,
+        `const slot = getParamSlot(config.in)
+      if (config.key && slot) {
+        map.set(config.key, {
+          in: slot,`,
+      )
+      .replace(
+        `} else if ("key" in config) {
+      map.set(config.key, {
+        map: config.map,
+      })`,
+        `} else if ("key" in config) {
+      const slot = getParamSlot(config.map)
+      if (slot) {
+        map.set(config.key, {
+          map: slot,
+        })
+      }`,
+      )
+      .replaceAll(
+        `const field = map.get(config.key)!
+        const name = field.map || config.key`,
+        `const field = map.get(config.key)
+        if (!field) {
+          continue
+        }
+        const name = field.map || config.key`,
+      )
+      .replaceAll(
+        `} else {
+        params.body = arg`,
+        `} else if (getParamSlot(config.in) === "body") {
+        params.body = arg`,
+      )
+      .replaceAll(
+        `if (allowed) {
+                ;(params[slot as Slot] as Record<string, unknown>)[key] = value`,
+        `const paramSlot = getParamSlot(slot)
+              if (allowed && paramSlot) {
+                ;(params[paramSlot] as Record<string, unknown>)[key] = value`,
+      )
+
+    if (source.includes("getParamSlot") && !source.includes("const getParamSlot =")) {
+      throw new Error(`failed to inject parameter slot guard into ${file}`)
+    }
+
+    await Bun.write(file, source)
+  }
+}
+
 await $`bun dev generate > ${dir}/openapi.json`.cwd(opencode)
 
 await createClient({
@@ -42,6 +119,8 @@ await createClient({
 
 await $`bun prettier --write src/gen`
 await $`bun prettier --write src/v2`
+await hardenGeneratedParams()
+await $`bun prettier --write src/gen/core/params.gen.ts src/v2/gen/core/params.gen.ts`
 await $`rm -rf dist`
 await $`bun tsc`
 await $`rm openapi.json`

--- a/packages/sdk/js/src/gen/core/params.gen.ts
+++ b/packages/sdk/js/src/gen/core/params.gen.ts
@@ -38,6 +38,17 @@ const extraPrefixesMap: Record<string, Slot> = {
   $query_: "query",
 }
 const extraPrefixes = Object.entries(extraPrefixesMap)
+const getParamSlot = (slot: unknown): Slot | undefined => {
+  switch (slot) {
+    case "body":
+    case "headers":
+    case "path":
+    case "query":
+      return slot
+    default:
+      return undefined
+  }
+}
 
 type KeyMap = Map<
   string,
@@ -54,9 +65,10 @@ const buildKeyMap = (fields: FieldsConfig, map?: KeyMap): KeyMap => {
 
   for (const config of fields) {
     if ("in" in config) {
-      if (config.key) {
+      const slot = getParamSlot(config.in)
+      if (config.key && slot) {
         map.set(config.key, {
-          in: config.in,
+          in: slot,
           map: config.map,
         })
       }
@@ -106,10 +118,13 @@ export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsCo
 
     if ("in" in config) {
       if (config.key) {
-        const field = map.get(config.key)!
+        const field = map.get(config.key)
+        if (!field) {
+          continue
+        }
         const name = field.map || config.key
         ;(params[field.in] as Record<string, unknown>)[name] = arg
-      } else {
+      } else if (getParamSlot(config.in) === "body") {
         params.body = arg
       }
     } else {
@@ -127,8 +142,9 @@ export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsCo
             ;(params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value
           } else {
             for (const [slot, allowed] of Object.entries(config.allowExtra ?? {})) {
-              if (allowed) {
-                ;(params[slot as Slot] as Record<string, unknown>)[key] = value
+              const paramSlot = getParamSlot(slot)
+              if (allowed && paramSlot) {
+                ;(params[paramSlot] as Record<string, unknown>)[key] = value
                 break
               }
             }

--- a/packages/sdk/js/src/v2/gen/core/params.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/params.gen.ts
@@ -49,7 +49,17 @@ const extraPrefixesMap: Record<string, Slot> = {
   $query_: "query",
 }
 const extraPrefixes = Object.entries(extraPrefixesMap)
-
+const getParamSlot = (slot: unknown): Slot | undefined => {
+  switch (slot) {
+    case "body":
+    case "headers":
+    case "path":
+    case "query":
+      return slot
+    default:
+      return undefined
+  }
+}
 type KeyMap = Map<
   string,
   | {
@@ -69,16 +79,20 @@ const buildKeyMap = (fields: FieldsConfig, map?: KeyMap): KeyMap => {
 
   for (const config of fields) {
     if ("in" in config) {
-      if (config.key) {
+      const slot = getParamSlot(config.in)
+      if (config.key && slot) {
         map.set(config.key, {
-          in: config.in,
+          in: slot,
           map: config.map,
         })
       }
     } else if ("key" in config) {
-      map.set(config.key, {
-        map: config.map,
-      })
+      const slot = getParamSlot(config.map)
+      if (slot) {
+        map.set(config.key, {
+          map: slot,
+        })
+      }
     } else if (config.args) {
       buildKeyMap(config.args, map)
     }
@@ -125,12 +139,15 @@ export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsCo
 
     if ("in" in config) {
       if (config.key) {
-        const field = map.get(config.key)!
+        const field = map.get(config.key)
+        if (!field) {
+          continue
+        }
         const name = field.map || config.key
         if (field.in) {
           ;(params[field.in] as Record<string, unknown>)[name] = arg
         }
-      } else {
+      } else if (getParamSlot(config.in) === "body") {
         params.body = arg
       }
     } else {
@@ -152,8 +169,9 @@ export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsCo
             ;(params[slot] as Record<string, unknown>)[key.slice(prefix.length)] = value
           } else if ("allowExtra" in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
-              if (allowed) {
-                ;(params[slot as Slot] as Record<string, unknown>)[key] = value
+              const paramSlot = getParamSlot(slot)
+              if (allowed && paramSlot) {
+                ;(params[paramSlot] as Record<string, unknown>)[key] = value
                 break
               }
             }

--- a/packages/sdk/js/test/params.test.ts
+++ b/packages/sdk/js/test/params.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  buildClientParams as buildClientParamsV1,
+  type FieldsConfig as FieldsConfigV1,
+} from "../src/gen/core/params.gen"
+import {
+  buildClientParams as buildClientParamsV2,
+  type FieldsConfig as FieldsConfigV2,
+} from "../src/v2/gen/core/params.gen"
+
+const pollutedKey = "__opencode_sdk_polluted__"
+
+afterEach(() => {
+  delete (Object.prototype as Record<string, unknown>)[pollutedKey]
+})
+
+describe("buildClientParams", () => {
+  test("ignores runtime parameter slots outside the generated slot allowlist", () => {
+    const fields = [{ in: "__proto__", key: pollutedKey }] as unknown as FieldsConfigV1
+
+    const params = buildClientParamsV1([true], fields)
+
+    expect(({} as Record<string, unknown>)[pollutedKey]).toBeUndefined()
+    expect(params).toEqual({})
+  })
+
+  test("ignores invalid allowExtra slots", () => {
+    const fields = [
+      {
+        allowExtra: JSON.parse('{"__proto__":true}'),
+      },
+    ] as unknown as FieldsConfigV1
+
+    const params = buildClientParamsV1([{ [pollutedKey]: true }], fields)
+
+    expect(({} as Record<string, unknown>)[pollutedKey]).toBeUndefined()
+    expect(params).toEqual({})
+  })
+
+  test("keeps valid runtime slots working", () => {
+    const params = buildClientParamsV1([{ id: "abc" }], [{ allowExtra: { query: true } }])
+
+    expect(params).toEqual({ query: { id: "abc" } })
+  })
+})
+
+describe("buildClientParams v2", () => {
+  test("ignores runtime parameter slots outside the generated slot allowlist", () => {
+    const fields = [{ in: "__proto__", key: pollutedKey }] as unknown as FieldsConfigV2
+
+    const params = buildClientParamsV2([true], fields)
+
+    expect(({} as Record<string, unknown>)[pollutedKey]).toBeUndefined()
+    expect(params).toEqual({})
+  })
+
+  test("ignores invalid map-only transport slots", () => {
+    const fields = [{ key: pollutedKey, map: "__proto__" }] as unknown as FieldsConfigV2
+
+    const params = buildClientParamsV2([{ [pollutedKey]: true }], fields)
+
+    expect(({} as Record<string, unknown>)[pollutedKey]).toBeUndefined()
+    expect(params).toEqual({})
+  })
+
+  test("keeps valid map-only transport slots working", () => {
+    const params = buildClientParamsV2([{ location: "tokyo" }], [{ key: "location", map: "query" }])
+
+    expect(params).toEqual({ query: "tokyo" })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #28125

### Type of change

- [x] Bug fix

### What does this PR do?

Adds a runtime slot allowlist in the generated SDK parameter builder so malformed field metadata cannot write through inherited object keys.

The SDK build script now reapplies the hardening after regeneration, and both v1 and v2 SDK builders have regression coverage.

### How did you verify your code works?

- bun test test/params.test.ts
- bun run --cwd packages/sdk/js typecheck
- bun run --cwd packages/sdk/js build
- git diff --check

### Screenshots / recordings

Not applicable; SDK parameter handling regression.

### Checklist

- [x] I have tested this change locally.
- [x] I have added or updated tests where appropriate.
- [x] I have kept the change focused.