### PR TITLE
fix(provider): route big-pickle through chat completions

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1043,6 +1043,14 @@ function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
   return result
 }
 
+function modelsDevApiNpm(provider: ModelsDev.Provider, model: ModelsDev.Model) {
+  const npm = model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible"
+  if (provider.id === "opencode" && model.id === "big-pickle" && npm === "@ai-sdk/anthropic") {
+    return "@ai-sdk/openai-compatible"
+  }
+  return npm
+}
+
 function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
   const base: Model = {
     id: ModelID.make(model.id),
@@ -1052,7 +1060,7 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
     api: {
       id: model.id,
       url: model.provider?.api ?? provider.api ?? "",
-      npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
+      npm: modelsDevApiNpm(provider, model),
     },
     status: model.status ?? "active",
     headers: {},

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2160,6 +2160,34 @@ test("models.dev normalization fills required response fields", () => {
   expect(model.release_date).toBe("")
 })
 
+test("models.dev normalization keeps opencode big-pickle on chat completions format", () => {
+  const provider = {
+    id: "opencode",
+    name: "opencode",
+    env: [],
+    npm: "@ai-sdk/anthropic",
+    models: {
+      "big-pickle": {
+        id: "big-pickle",
+        name: "Big Pickle",
+        family: "big-pickle",
+        cost: {
+          input: 0,
+          output: 0,
+        },
+        limit: {
+          context: 256_000,
+          input: 128_000,
+          output: 16_384,
+        },
+      },
+    },
+  } as unknown as ModelsDev.Provider
+
+  const model = Provider.fromModelsDevProvider(provider).models["big-pickle"]
+  expect(model.api.npm).toBe("@ai-sdk/openai-compatible")
+})
+
 test("model variants are generated for reasoning models", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #28138

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Normalizes the opencode `big-pickle` models.dev entry so it uses the chat-completions-compatible SDK route instead of the messages-style route. That keeps requests away from `/zen/v1/messages`, which is the failing path reported in the issue, and adds a regression test for this normalization case.

### How did you verify your code works?

- `bun test test/provider/provider.test.ts --timeout 30000` from `packages/opencode`
- `bun run --cwd packages/opencode typecheck`
- `bunx prettier --check packages/opencode/src/provider/provider.ts packages/opencode/test/provider/provider.test.ts`
- `git diff --check`
- `bunx oxlint packages/opencode/src/provider/provider.ts packages/opencode/test/provider/provider.test.ts` (0 errors; existing warnings only)

### Screenshots / recordings

N/A; provider routing change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR