### PR TITLE
fix: show legacy sessions in workspace lists

### DIFF
--- a/packages/opencode/src/v2/session.ts
+++ b/packages/opencode/src/v2/session.ts
@@ -3,7 +3,7 @@ import { SessionID } from "@/session/schema"
 import { WorkspaceID } from "@/control-plane/schema"
 import { and, asc, desc, eq, gt, gte, isNull, like, lt, or, type SQL } from "@/storage/db"
 import * as Database from "@/storage/db"
-import { Context, DateTime, Effect, Layer, Option, Schema } from "effect"
+import { Context, DateTime, Effect, Layer, Schema } from "effect"
 import { SessionMessage } from "@opencode-ai/core/session-message"
 import type { Prompt } from "@opencode-ai/core/session-prompt"
 import { ProjectID } from "@/project/schema"
@@ -186,7 +186,13 @@ export const layer = Layer.effect(
         if (input.directory) conditions.push(eq(SessionTable.directory, input.directory))
         if (input.path)
           conditions.push(or(eq(SessionTable.path, input.path), like(SessionTable.path, `${input.path}/%`))!)
-        if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
+        if (input.workspaceID) {
+          conditions.push(
+            input.directory || input.path
+              ? or(eq(SessionTable.workspace_id, input.workspaceID), isNull(SessionTable.workspace_id))!
+              : eq(SessionTable.workspace_id, input.workspaceID),
+          )
+        }
         if (input.roots) conditions.push(isNull(SessionTable.parent_id))
         if (input.start) conditions.push(gte(sortColumn, input.start))
         if (input.search) conditions.push(like(SessionTable.title, `%${input.search}%`))

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -434,6 +434,34 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "includes local legacy sessions when listing a workspace-scoped directory",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
+        const project = yield* Project.use.fromDirectory(test.directory)
+        const workspace = yield* createLocalWorkspace({
+          projectID: project.project.id,
+          type: "session-list-workspace",
+          directory: path.join(test.directory, ".workspace-local"),
+        })
+
+        const legacy = yield* createSession({ title: "legacy visible" })
+        const workspaceSession = yield* createSession({ title: "workspace visible", workspaceID: workspace.id })
+
+        const params = new URLSearchParams({ workspace: workspace.id, directory: test.directory })
+        const response = yield* requestJson<{ items: Session.Info[] }>(`/api/session?${params}`, {
+          headers: { "x-opencode-directory": test.directory },
+        })
+        const ids = response.items.map((item) => item.id)
+
+        expect(ids).toContain(legacy.id)
+        expect(ids).toContain(workspaceSession.id)
+      }),
+    { git: true, config: { formatter: false, lsp: false, share: "disabled" } },
+  )
+
+  it.instance(
     "validates archived timestamp values",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #28083

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v2 session list endpoint accepted a workspace filter but only matched sessions with that exact workspace_id. Web and Desktop can pass both workspace and directory while older local sessions still have NULL workspace_id, which leaves existing chat history hidden even though the session/message rows are present.

This keeps exact workspace filtering when no local scope is provided. When the request is scoped by directory or path, it also includes legacy NULL-workspace sessions from that same local scope.

### How did you verify your code works?

- bun test test/server/httpapi-session.test.ts --timeout 30000
- bun run --cwd packages/opencode typecheck
- bunx prettier --check packages/opencode/src/v2/session.ts packages/opencode/test/server/httpapi-session.test.ts
- git diff --check
- bunx oxlint packages/opencode/src/v2/session.ts packages/opencode/test/server/httpapi-session.test.ts (0 errors; existing warnings only)

### Screenshots / recordings

Not a visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
