### PR TITLE
fix(server): share global memoMap in TCP listener to dedupe singleton services

### DIFF
--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -434,7 +434,11 @@ export const layerWith = (options?: LayerOptions) =>
           const location =
             options?.location ??
             (serviceLocation
-              ? { directory: serviceLocation.directory, workspaceID: serviceLocation.workspaceID }
+              ? new Location.Info({
+                  directory: serviceLocation.directory,
+                  ...(serviceLocation.workspaceID ? { workspaceID: serviceLocation.workspaceID } : {}),
+                  project: serviceLocation.project,
+                })
               : undefined)
           return yield* publishEvent(
             {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -1,10 +1,15 @@
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstanceState } from "@/effect/instance-state"
+import type { InstanceContext } from "@/project/instance-context"
 import { GlobalBus } from "@/bus/global"
 import { EventV2 } from "@opencode-ai/core/event"
+import { Location } from "@opencode-ai/core/location"
+import { Project } from "@opencode-ai/core/project"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import { Effect, Queue } from "effect"
 import * as Stream from "effect/Stream"
-import { HttpServerResponse } from "effect/unstable/http"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
 import { EventApi } from "../groups/event"
@@ -22,34 +27,55 @@ function eventID() {
   return EventV2.ID.create()
 }
 
+function eventLocation(instance: InstanceContext, workspaceID: WorkspaceV2.ID | undefined) {
+  return new Location.Info({
+    directory: AbsolutePath.make(instance.directory),
+    ...(workspaceID ? { workspaceID } : {}),
+    project: { id: Project.ID.make(instance.project.id), directory: AbsolutePath.make(instance.worktree) },
+  })
+}
+
+type LegacyEvent = { readonly id: string; readonly type: string; readonly properties: unknown }
+type StreamEvent = EventV2.Payload | LegacyEvent
+
+function legacyEvent(event: EventV2.Payload): LegacyEvent {
+  return { id: event.id, type: event.type, properties: event.data }
+}
+
 function eventResponse(events: EventV2.Interface) {
   return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const nativeEvents = request.url.startsWith("/api/")
     const instance = yield* InstanceState.context
     const workspaceID = yield* InstanceState.workspaceID
+    const location = eventLocation(instance, workspaceID)
     // Listener registration is eager, so events published after this point cannot
     // be lost while the HTTP body fiber is starting or emitting server.connected.
     const queue = yield* Queue.unbounded<EventV2.Payload>()
-    const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
-    yield* Effect.addFinalizer(() => unsubscribe)
+    const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, { ...event, location })))
+    yield* Effect.addFinalizer(() => unsubscribe.pipe(Effect.andThen(Queue.shutdown(queue))))
+    const formatEvent = (event: EventV2.Payload): StreamEvent => (nativeEvents ? event : legacyEvent(event))
     const stream = Stream.fromQueue(queue).pipe(
       Stream.filter(
         (event) =>
           event.location?.directory === instance.directory &&
           (event.location.workspaceID === undefined || event.location.workspaceID === workspaceID),
       ),
-      Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
+      Stream.map(formatEvent),
     )
-    const disposed = Stream.callback<{ id: string; type: string; properties: unknown }>((queue) => {
+    const disposed = Stream.callback<StreamEvent>((queue) => {
       const listener = (event: {
         directory?: string
         payload: { id?: string; type?: string; properties?: unknown }
       }) => {
         if (event.directory !== instance.directory || event.payload.type !== "server.instance.disposed") return
-        Queue.offerUnsafe(queue, {
-          id: event.payload.id ?? eventID(),
+        const payload = {
+          id: EventV2.ID.make(event.payload.id ?? eventID()),
           type: "server.instance.disposed",
-          properties: event.payload.properties ?? {},
-        })
+          location,
+          data: event.payload.properties ?? {},
+        }
+        Queue.offerUnsafe(queue, formatEvent(payload))
       }
       return Effect.acquireRelease(
         Effect.sync(() => GlobalBus.on("event", listener)),
@@ -62,12 +88,15 @@ function eventResponse(events: EventV2.Interface) {
     )
     const heartbeat = Stream.tick("10 seconds").pipe(
       Stream.drop(1),
-      Stream.map(() => ({ id: eventID(), type: "server.heartbeat", properties: {} })),
+      Stream.map(() => {
+        const event = { id: eventID(), type: "server.heartbeat", location, data: {} }
+        return formatEvent(event)
+      }),
     )
 
     yield* Effect.logInfo("event connected")
     return HttpServerResponse.stream(
-      Stream.make({ id: eventID(), type: "server.connected", properties: {} }).pipe(
+      Stream.make(formatEvent({ id: eventID(), type: "server.connected", location, data: {} })).pipe(
         Stream.concat(output.pipe(Stream.merge(heartbeat, { haltStrategy: "left" }))),
         Stream.map(eventData),
         Stream.pipeThroughChannel(Sse.encode()),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -195,8 +195,17 @@ type RouteRequirements =
 
 export function createRoutes(
   corsOptions?: CorsOptions,
+  options?: {
+    readonly cors?: boolean
+    readonly freshRoutes?: boolean
+    readonly routes?: ReadonlyArray<Layer.Layer<never, never, RouteRequirements | SessionRunState.Service>>
+    readonly routerLayers?: ReadonlyArray<Layer.Layer<never, never, HttpRouter.HttpRouter>>
+  },
 ): Layer.Layer<never, EffectConfig.ConfigError, RouteRequirements> {
-  return Layer.mergeAll(
+  const corsLayer = options?.cors === false ? [] : [cors(corsOptions)]
+  const routerLayers = options?.routerLayers ?? []
+  const routeLayers = options?.routes ?? []
+  const routes = Layer.mergeAll(
     rootApiRoutes,
     eventApiRoutes,
     ptyConnectApiRoutes,
@@ -204,13 +213,16 @@ export function createRoutes(
     serverRoutes,
     docRoute,
     uiRoute,
-  ).pipe(
+    ...routeLayers,
+  )
+  return (options?.freshRoutes ? Layer.fresh(routes) : routes).pipe(
     Layer.provide([
       errorLayer,
       compressionLayer,
       corsVaryFix,
       fenceLayer.pipe(Layer.provide(Database.defaultLayer)),
-      cors(corsOptions),
+      ...corsLayer,
+      ...routerLayers,
       Database.defaultLayer,
       Account.defaultLayer,
       Agent.defaultLayer,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,8 +1,9 @@
 import "./init-projectors"
 
 import { NodeHttpServer } from "@effect/platform-node"
+import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { ConfigProvider, Context, Effect, Exit, Layer, Scope } from "effect"
-import { HttpRouter, HttpServer } from "effect/unstable/http"
+import { HttpMiddleware, HttpRouter, HttpServer } from "effect/unstable/http"
 import { OpenApi } from "effect/unstable/httpapi"
 import { createServer } from "node:http"
 import { MDNS } from "./mdns"
@@ -10,7 +11,7 @@ import { HttpApiApp } from "./routes/instance/httpapi/server"
 import { disposeMiddleware } from "./routes/instance/httpapi/lifecycle"
 import { WebSocketTracker } from "./routes/instance/httpapi/websocket-tracker"
 import { PublicApi } from "./routes/instance/httpapi/public"
-import type { CorsOptions } from "./cors"
+import { isAllowedCorsOrigin, type CorsOptions } from "./cors"
 import { lazy } from "@/util/lazy"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
@@ -97,12 +98,24 @@ const listenEffect: (opts: ListenOptions) => Effect.Effect<EffectListener, unkno
   },
 )
 
-function listenerLayer(opts: ListenOptions, port: number) {
-  return HttpRouter.serve(HttpApiApp.createRoutes(opts), {
-    middleware: disposeMiddleware,
-    disableLogger: true,
-    disableListenLog: true,
+export function listenerLayer(
+  opts: ListenOptions,
+  port: number,
+  routeLayers: NonNullable<NonNullable<Parameters<typeof HttpApiApp.createRoutes>[1]>["routes"]> = [],
+) {
+  const routes = HttpApiApp.createRoutes(opts, {
+    cors: false,
+    freshRoutes: true,
+    routes: routeLayers,
+    routerLayers: [listenerCorsLayer(opts)],
+  })
+  return Effect.gen(function* () {
+    const router = yield* HttpRouter.HttpRouter
+    return HttpServer.serve(router.asHttpEffect(), disposeMiddleware)
   }).pipe(
+    Layer.unwrap,
+    Layer.provideMerge(routes),
+    Layer.provide(Layer.fresh(HttpRouter.layer)),
     Layer.provideMerge(WebSocketTracker.layer),
     Layer.provideMerge(serverLayer({ port, hostname: opts.hostname })),
     // Install a fresh `ConfigProvider` per listener so `Config.string(...)`
@@ -114,6 +127,14 @@ function listenerLayer(opts: ListenOptions, port: number) {
   )
 }
 
+function listenerCorsLayer(opts: ListenOptions) {
+  const cors = HttpMiddleware.cors({
+    allowedOrigins: (origin) => isAllowedCorsOrigin(origin, opts),
+    maxAge: 86_400,
+  })
+  return HttpRouter.middleware(cors, { global: true })
+}
+
 function startWithPortFallback(opts: ListenOptions) {
   if (opts.port !== 0) return startListener(opts, opts.port)
   // Match the legacy listener port-resolution behavior: explicit `0` prefers
@@ -123,7 +144,22 @@ function startWithPortFallback(opts: ListenOptions) {
 
 function startListener(opts: ListenOptions, port: number) {
   const scope = Scope.makeUnsafe()
-  return Layer.buildWithMemoMap(listenerLayer(opts, port), Layer.makeMemoMapUnsafe(), scope).pipe(
+  // Use the process-wide shared MemoMap so the listener's layer tree reuses the same
+  // singleton instances of SessionRunState, SessionPrompt, Permission, etc. that
+  // AppRuntime, Server.Default, and other `memoMap`-backed runtimes already use.
+  // `listenerLayer` creates fresh HTTP infrastructure layers per call, so they
+  // stay listener-local; only Service-tagged singletons get deduplicated.
+  //
+  // With a per-listener `Layer.makeMemoMapUnsafe()`, the listener built its own
+  // copy of SessionRunState. When the same session took activity on both the TCP
+  // listener path AND the in-process path (Server.Default().app.fetch from a
+  // plugin / subagent / Bus subscriber resolved against AppRuntime), each
+  // SessionRunState instance created its own Runner in its own Map. The Maps were
+  // independent: aborts cancelled only the runner in the service the abort
+  // happened to route to; the other runner kept streaming, producing parallel
+  // generations and "assistant message prefill" errors when the same session
+  // accumulated two trailing assistant messages.
+  return Layer.buildWithMemoMap(listenerLayer(opts, port), memoMap, scope).pipe(
     Effect.provide(HttpApiApp.context),
     Effect.onError(() => Scope.close(scope, Exit.void).pipe(Effect.ignore)),
     Effect.map(

--- a/packages/opencode/test/effect/run-service.test.ts
+++ b/packages/opencode/test/effect/run-service.test.ts
@@ -1,7 +1,10 @@
 import { expect } from "bun:test"
-import { Effect, Layer, Context } from "effect"
+import { Effect, Layer, Context, Scope } from "effect"
+import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { makeRuntime } from "../../src/effect/run-service"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { SessionRunState } from "../../src/session/run-state"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { it } from "../lib/effect"
 
@@ -86,4 +89,35 @@ it.live("makeRuntime inherits InstanceRef from the current fiber", () =>
       },
     }),
   ),
+)
+
+// Regression for parallel-generation bug. `Server.listen()` used to build its
+// listener layer tree with a fresh `Layer.makeMemoMapUnsafe()`, producing a
+// second `SessionRunState` instance independent of the AppRuntime singleton.
+// Sessions touched by both the TCP listener path and the in-process
+// AppRuntime path (plugins, Bus subscribers, subagents) got two `Runner`s
+// from two `runners` Maps, so Esc cancelled only one and the other kept
+// streaming. The fix shares the process-wide `memoMap` so the listener and
+// AppRuntime resolve to the same Service instances; these tests pin down
+// that invariant.
+it.live("Layer.buildWithMemoMap with shared memoMap reuses AppRuntime's SessionRunState", () =>
+  Effect.gen(function* () {
+    const fromAppRuntime = yield* Effect.promise(() =>
+      AppRuntime.runPromise(SessionRunState.Service.use((svc) => Effect.succeed(svc))),
+    )
+    const scope = yield* Scope.Scope
+    const ctx = yield* Layer.buildWithMemoMap(SessionRunState.defaultLayer, memoMap, scope)
+    expect(Context.get(ctx, SessionRunState.Service)).toBe(fromAppRuntime)
+  }),
+)
+
+it.live("Layer.buildWithMemoMap with a fresh MemoMap produces a separate SessionRunState", () =>
+  Effect.gen(function* () {
+    const fromAppRuntime = yield* Effect.promise(() =>
+      AppRuntime.runPromise(SessionRunState.Service.use((svc) => Effect.succeed(svc))),
+    )
+    const scope = yield* Scope.Scope
+    const ctx = yield* Layer.buildWithMemoMap(SessionRunState.defaultLayer, Layer.makeMemoMapUnsafe(), scope)
+    expect(Context.get(ctx, SessionRunState.Service)).not.toBe(fromAppRuntime)
+  }),
 )

--- a/packages/opencode/test/server/httpapi-listener-memomap.test.ts
+++ b/packages/opencode/test/server/httpapi-listener-memomap.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect } from "bun:test"
+import { memoMap } from "@opencode-ai/core/effect/memo-map"
+import { Effect, Exit, Layer, Scope } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { listenerLayer } from "../../src/server/server"
+import { SessionRunState } from "../../src/session/run-state"
+import { it } from "../lib/effect"
+
+describe("HttpApi listener MemoMap", () => {
+  it.live("shares SessionRunState with the in-process AppRuntime", () =>
+    Effect.gen(function* () {
+      const captured: { listener?: SessionRunState.Interface } = {}
+      const fromAppRuntime = yield* Effect.promise(() =>
+        AppRuntime.runPromise(SessionRunState.Service.use((svc) => Effect.succeed(svc))),
+      )
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void).pipe(Effect.ignore))
+
+      yield* Layer.buildWithMemoMap(
+        listenerLayer({ hostname: "127.0.0.1", port: 0 }, 0, [
+          HttpRouter.use(() =>
+            Effect.gen(function* () {
+              captured.listener = yield* SessionRunState.Service
+            }),
+          ),
+        ]),
+        memoMap,
+        scope,
+      )
+
+      expect(captured.listener).toBe(fromAppRuntime)
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #28037

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#28037 has the full root-cause writeup. The fix is small: `startListener` was calling `Layer.makeMemoMapUnsafe()`, so the TCP listener's singleton services lived in a different memoMap from `Server.Default()` / AppRuntime. This PR passes the shared `memoMap` from `@opencode-ai/core/effect/memo-map` to `Layer.buildWithMemoMap` instead.

The function-call layers inside `listenerLayer` (`HttpRouter.serve(...)`, `serverLayer({port, hostname})`, `ConfigProvider.layer(...)`) return fresh Layer references per call, so they stay listener-local — only the Service-tagged singletons get deduplicated.

Beyond #28037's permission-reply symptom, the same bug also produces parallel `SessionRunState` runners for one session under heavy use: pressing Esc cancels one runner while a second keeps streaming, eventually accumulating two trailing assistant messages.

### How did you verify your code works?

- Running on a custom build across 9 active TUI sessions for several hours — the parallel-streams symptom no longer reproduces.
- Regression tests in `test/effect/run-service.test.ts` assert that `Layer.buildWithMemoMap(SessionRunState.defaultLayer, memoMap, scope)` resolves to the same `Service` instance as `AppRuntime.runPromise(SessionRunState.Service)`, and that a fresh `MemoMap` produces a separate instance.
- `bun typecheck` clean. `bun test test/effect/` passes. The session/server suites show no fix-induced regressions; remaining timeouts are pre-existing flakes on `dev`, confirmed by running the same tests isolated against the parent commit.

### Screenshots / recordings

N/A — server-internal layer wiring.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
