### PR TITLE
fix(app): restore session conversation scroll position

### DIFF
--- a/packages/app/src/context/layout-scroll.test.ts
+++ b/packages/app/src/context/layout-scroll.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "bun:test"
-import { createScrollPersistence } from "./layout-scroll"
+import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 
 describe("createScrollPersistence", () => {
   test("debounces persisted scroll writes", () => {
@@ -9,8 +9,8 @@ describe("createScrollPersistence", () => {
         session: {
           review: { x: 0, y: 0 },
         },
-      } as Record<string, Record<string, { x: number; y: number }>>
-      const writes: Array<Record<string, { x: number; y: number }>> = []
+      } as Record<string, Record<string, SessionScroll>>
+      const writes: Array<Record<string, SessionScroll>> = []
       const scroll = createScrollPersistence({
         debounceMs: 10,
         getSnapshot: (sessionKey) => snapshot[sessionKey],
@@ -45,7 +45,7 @@ describe("createScrollPersistence", () => {
   test("reseeds empty cache after persisted snapshot loads", () => {
     const snapshot = {
       session: {},
-    } as Record<string, Record<string, { x: number; y: number }>>
+    } as Record<string, Record<string, SessionScroll>>
 
     const scroll = createScrollPersistence({
       getSnapshot: (sessionKey) => snapshot[sessionKey],
@@ -60,5 +60,36 @@ describe("createScrollPersistence", () => {
 
     expect(scroll.scroll("session", "review")).toEqual({ x: 12, y: 34 })
     scroll.dispose()
+  })
+
+  test("preserves bottom markers", () => {
+    vi.useFakeTimers()
+    try {
+      const snapshot = {
+        session: {
+          messages: { x: 0, y: 120, bottom: true },
+        },
+      } as Record<string, Record<string, SessionScroll>>
+      const writes: Array<Record<string, SessionScroll>> = []
+      const scroll = createScrollPersistence({
+        debounceMs: 10,
+        getSnapshot: (sessionKey) => snapshot[sessionKey],
+        onFlush: (sessionKey, next) => {
+          snapshot[sessionKey] = next
+          writes.push(next)
+        },
+      })
+
+      expect(scroll.scroll("session", "messages")).toEqual({ x: 0, y: 120, bottom: true })
+
+      scroll.setScroll("session", "messages", { x: 0, y: 120 })
+      vi.advanceTimersByTime(10)
+
+      expect(writes).toHaveLength(1)
+      expect(writes[0]?.messages).toEqual({ x: 0, y: 120 })
+      scroll.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/app/src/context/layout-scroll.ts
+++ b/packages/app/src/context/layout-scroll.ts
@@ -3,6 +3,7 @@ import { createStore, produce } from "solid-js/store"
 export type SessionScroll = {
   x: number
   y: number
+  bottom?: boolean
 }
 
 type ScrollMap = Record<string, SessionScroll>
@@ -26,7 +27,7 @@ export function createScrollPersistence(opts: Options) {
     for (const key of Object.keys(input)) {
       const pos = input[key]
       if (!pos) continue
-      out[key] = { x: pos.x, y: pos.y }
+      out[key] = { x: pos.x, y: pos.y, ...(pos.bottom ? { bottom: true } : {}) }
     }
 
     return out
@@ -63,9 +64,14 @@ export function createScrollPersistence(opts: Options) {
     seed(sessionKey)
 
     const prev = cache[sessionKey]?.[tab]
-    if (prev?.x === pos.x && prev?.y === pos.y) return
+    if (prev?.x === pos.x && prev?.y === pos.y && !!prev.bottom === !!pos.bottom) return
 
-    setCache(sessionKey, tab, { x: pos.x, y: pos.y })
+    setCache(
+      produce((draft) => {
+        if (!draft[sessionKey]) draft[sessionKey] = {}
+        draft[sessionKey][tab] = { x: pos.x, y: pos.y, ...(pos.bottom ? { bottom: true } : {}) }
+      }),
+    )
     dirty.add(sessionKey)
     schedule(sessionKey)
   }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -57,6 +57,7 @@ import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
+import { createSessionScrollDefaultGuard } from "@/pages/session/use-session-hash-scroll-default"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
 import { Identifier } from "@/utils/id"
 import { diffs as list } from "@/utils/diffs"
@@ -1191,8 +1192,89 @@ export default function Page() {
   let scrollStateFrame: number | undefined
   let scrollStateTarget: HTMLDivElement | undefined
   let fillFrame: number | undefined
+  let sessionScrollProgrammaticFrame: number | undefined
+  let sessionScrollProgrammatic = false
+  const sessionScrollDefault = createSessionScrollDefaultGuard()
 
   const jumpThreshold = (el: HTMLDivElement) => Math.max(400, el.clientHeight)
+
+  const markProgrammaticSessionScroll = () => {
+    sessionScrollProgrammatic = true
+    if (sessionScrollProgrammaticFrame !== undefined) cancelAnimationFrame(sessionScrollProgrammaticFrame)
+
+    sessionScrollProgrammaticFrame = requestAnimationFrame(() => {
+      sessionScrollProgrammaticFrame = undefined
+      sessionScrollProgrammatic = false
+    })
+  }
+
+  const sessionScrollSnapshot = (el: HTMLDivElement) => {
+    const max = Math.max(0, el.scrollHeight - el.clientHeight)
+    const bottom = max <= 1 || max - el.scrollTop <= 2
+    return { x: el.scrollLeft, y: el.scrollTop, ...(bottom ? { bottom: true } : {}) }
+  }
+
+  const sessionScrollRoute = () => ({ sessionKey: sessionKey(), sessionID: params.id })
+
+  const saveSessionScroll = (force = false) => {
+    const route = sessionScrollRoute()
+    if (!force && !sessionScrollDefault.canSave(route)) return
+    if (!force && (sessionScrollProgrammatic || location.hash || ui.pendingMessage)) return
+    if (!params.id || !layout.ready()) return
+
+    const el = scroller
+    if (!el || el.clientHeight === 0 || el.clientWidth === 0) return
+
+    if (!force) sessionScrollDefault.consumeDefault(route)
+    view().setScroll("session", sessionScrollSnapshot(el))
+  }
+
+  const canRestoreSessionScroll = () => sessionScrollDefault.canRestore(sessionScrollRoute())
+
+  const consumeDefaultSessionScroll = () => sessionScrollDefault.consumeDefault(sessionScrollRoute())
+
+  createEffect(() => {
+    sessionScrollDefault.enter(sessionScrollRoute())
+  })
+
+  const restoreSessionScroll = () => {
+    if (!params.id || !layout.ready()) return
+    if (!canRestoreSessionScroll()) return false
+    sessionScrollDefault.allowSave(sessionScrollRoute())
+
+    const el = scroller
+    if (!el || el.clientHeight === 0 || el.clientWidth === 0) {
+      sessionScrollDefault.deferRestore(sessionScrollRoute())
+      return
+    }
+
+    consumeDefaultSessionScroll()
+
+    const saved = view().scroll("session")
+    if (!saved) {
+      markProgrammaticSessionScroll()
+      autoScroll.forceScrollToBottom()
+      scheduleScrollState(el)
+      return true
+    }
+
+    if (saved.bottom) {
+      markProgrammaticSessionScroll()
+      autoScroll.forceScrollToBottom()
+      scheduleScrollState(el)
+      return true
+    }
+
+    const targetY = Math.min(saved.y, Math.max(0, el.scrollHeight - el.clientHeight))
+    const targetX = Math.min(saved.x, Math.max(0, el.scrollWidth - el.clientWidth))
+
+    autoScroll.pause()
+    markProgrammaticSessionScroll()
+    if (el.scrollTop !== targetY) el.scrollTop = targetY
+    if (el.scrollLeft !== targetX) el.scrollLeft = targetX
+    scheduleScrollState(el)
+    return true
+  }
 
   const updateScrollState = (el: HTMLDivElement) => {
     const max = el.scrollHeight - el.clientHeight
@@ -1222,11 +1304,16 @@ export default function Page() {
 
   const resumeScroll = () => {
     setStore("messageId", undefined)
+    consumeDefaultSessionScroll()
+    markProgrammaticSessionScroll()
     autoScroll.forceScrollToBottom()
     clearMessageHash()
 
     const el = scroller
-    if (el) scheduleScrollState(el)
+    if (el) {
+      scheduleScrollState(el)
+      saveSessionScroll(true)
+    }
   }
 
   // When the user returns to the bottom, treat the active message as "latest".
@@ -1236,7 +1323,9 @@ export default function Page() {
       (scrolled) => {
         if (scrolled) return
         setStore("messageId", undefined)
+        consumeDefaultSessionScroll()
         clearMessageHash()
+        if (!sessionScrollProgrammatic) saveSessionScroll(true)
       },
       { defer: true },
     ),
@@ -1244,16 +1333,24 @@ export default function Page() {
 
   let fill = () => {}
 
+  const retrySessionScrollRestore = () => {
+    if (location.hash || ui.pendingMessage) return
+    if (!sessionScrollDefault.shouldRetry(sessionScrollRoute())) return
+    restoreSessionScroll()
+  }
+
   const setScrollRef = (el: HTMLDivElement | undefined) => {
     scroller = el
     autoScroll.scrollRef(el)
     if (!el) return
     scheduleScrollState(el)
+    retrySessionScrollRestore()
     fill()
   }
 
   const markUserScroll = () => {
     scrollMark += 1
+    saveSessionScroll()
   }
 
   createResizeObserver(
@@ -1261,6 +1358,7 @@ export default function Page() {
     () => {
       const el = scroller
       if (el) scheduleScrollState(el)
+      retrySessionScrollRestore()
       fill()
     },
   )
@@ -1618,7 +1716,12 @@ export default function Page() {
     anchor,
     revealMessage: (id) => revealMessage(id),
     scheduleScrollState,
-    consumePendingMessage: layout.pendingMessage.consume,
+    consumePendingMessage: (key) => layout.pendingMessage.consume(key),
+    defaultScrollReady: layout.ready,
+    canRestoreScroll: canRestoreSessionScroll,
+    restoreScroll: restoreSessionScroll,
+    consumeDefaultScroll: consumeDefaultSessionScroll,
+    markProgrammaticScroll: markProgrammaticSessionScroll,
   })
 
   createEffect(
@@ -1644,6 +1747,7 @@ export default function Page() {
     if (diffTimer !== undefined) window.clearTimeout(diffTimer)
     if (scrollStateFrame !== undefined) cancelAnimationFrame(scrollStateFrame)
     if (fillFrame !== undefined) cancelAnimationFrame(fillFrame)
+    if (sessionScrollProgrammaticFrame !== undefined) cancelAnimationFrame(sessionScrollProgrammaticFrame)
   })
 
   useUsageExceededDialogs()
@@ -1716,6 +1820,7 @@ export default function Page() {
                     onAutoScrollHandleScroll={autoScroll.handleScroll}
                     onMarkScrollGesture={markScrollGesture}
                     hasScrollGesture={hasScrollGesture}
+                    onSessionScroll={saveSessionScroll}
                     onUserScroll={markUserScroll}
                     onHistoryScroll={historyLoader.onScrollerScroll}
                     onAutoScrollInteraction={autoScroll.handleInteraction}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -274,6 +274,7 @@ export function MessageTimeline(props: {
   onAutoScrollHandleScroll: () => void
   onMarkScrollGesture: (target?: EventTarget | null) => void
   hasScrollGesture: () => boolean
+  onSessionScroll: () => void
   onUserScroll: () => void
   onHistoryScroll: () => void
   onAutoScrollInteraction: (event: MouseEvent) => void
@@ -689,6 +690,7 @@ export function MessageTimeline(props: {
     measuredBottomAnchored = isMeasuredBottom(event.currentTarget)
     props.onScheduleScrollState(event.currentTarget)
     props.onHistoryScroll()
+    props.onSessionScroll()
     if (!props.hasScrollGesture()) return
     props.onUserScroll()
     props.onAutoScrollHandleScroll()

--- a/packages/app/src/pages/session/use-session-hash-scroll-default.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll-default.ts
@@ -1,0 +1,130 @@
+type NoHashScrollResult = "pending" | "restored" | "deferred" | "bottom" | "skipped"
+
+type SessionScrollRoute = {
+  sessionKey: string
+  sessionID: string | undefined
+}
+
+export function createSessionScrollDefaultGuard() {
+  let activeKey: string | undefined
+  let activeSessionID: string | undefined
+  let entry = 0
+  let consumedEntry = 0
+  let retryEntry = 0
+  let saveEntry = 0
+
+  const enter = (route: SessionScrollRoute) => {
+    if (activeKey === route.sessionKey && activeSessionID === route.sessionID) return entry
+
+    activeKey = route.sessionKey
+    activeSessionID = route.sessionID
+    entry += 1
+    retryEntry = 0
+    saveEntry = 0
+    return entry
+  }
+
+  const canRestore = (route: SessionScrollRoute) => {
+    const token = enter(route)
+    return !!route.sessionID && consumedEntry !== token
+  }
+
+  const consumeDefault = (route: SessionScrollRoute) => {
+    const token = enter(route)
+    consumedEntry = token
+    retryEntry = 0
+    saveEntry = route.sessionID ? token : 0
+  }
+
+  const allowSave = (route: SessionScrollRoute) => {
+    const token = enter(route)
+    if (!route.sessionID) return
+    saveEntry = token
+  }
+
+  const deferRestore = (route: SessionScrollRoute) => {
+    const token = enter(route)
+    if (!route.sessionID) return
+    retryEntry = token
+    saveEntry = token
+  }
+
+  const shouldRetry = (route: SessionScrollRoute) => {
+    const token = enter(route)
+    return !!route.sessionID && retryEntry === token
+  }
+
+  const canSave = (route: SessionScrollRoute) => {
+    const token = enter(route)
+    return !!route.sessionID && saveEntry === token
+  }
+
+  return {
+    enter,
+    canRestore,
+    consumeDefault,
+    allowSave,
+    deferRestore,
+    shouldRetry,
+    canSave,
+  }
+}
+
+export function resolvePendingMessage(input: {
+  sessionKey: string
+  pendingKey: string
+  pendingMessage: string | undefined
+  consumePendingMessage: (key: string) => string | undefined
+  setPendingMessage: (value: string | undefined) => void
+}) {
+  if (input.pendingMessage) return { pendingKey: input.pendingKey, target: input.pendingMessage }
+  if (input.pendingKey === input.sessionKey) return { pendingKey: input.pendingKey, target: undefined }
+
+  const target = input.consumePendingMessage(input.sessionKey)
+  if (!target) return { pendingKey: input.sessionKey, target: undefined }
+
+  input.setPendingMessage(target)
+  return { pendingKey: input.sessionKey, target }
+}
+
+export function applyNoHashScroll(input: {
+  sessionKey: string
+  pendingKey: string
+  pendingMessage: string | undefined
+  consumePendingMessage: (key: string) => string | undefined
+  setPendingMessage: (value: string | undefined) => void
+  canRestoreScroll?: () => boolean
+  restoreScroll?: () => boolean | undefined
+  consumeDefaultScroll?: () => void
+  markProgrammaticScroll?: () => void
+  forceScrollToBottom: () => void
+  scroller: () => HTMLDivElement | undefined
+  scheduleScrollState: (el: HTMLDivElement) => void
+}) {
+  const pending = resolvePendingMessage(input)
+  if (pending.target) {
+    input.consumeDefaultScroll?.()
+    return { pendingKey: pending.pendingKey, result: "pending" as NoHashScrollResult }
+  }
+
+  const shouldRestore = input.restoreScroll ? (input.canRestoreScroll?.() ?? true) : false
+  if (shouldRestore && input.restoreScroll) {
+    const restored = input.restoreScroll()
+    if (restored === undefined) return { pendingKey: pending.pendingKey, result: "deferred" as NoHashScrollResult }
+    if (restored) {
+      input.consumeDefaultScroll?.()
+      return { pendingKey: pending.pendingKey, result: "restored" as NoHashScrollResult }
+    }
+  }
+
+  if (input.restoreScroll && !shouldRestore) return { pendingKey: pending.pendingKey, result: "skipped" as NoHashScrollResult }
+
+  input.consumeDefaultScroll?.()
+  input.markProgrammaticScroll?.()
+  input.forceScrollToBottom()
+
+  const el = input.scroller()
+  if (el) input.scheduleScrollState(el)
+
+  return { pendingKey: pending.pendingKey, result: "bottom" as NoHashScrollResult }
+}

--- a/packages/app/src/pages/session/use-session-hash-scroll.test.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, test, vi } from "bun:test"
+import { applyNoHashScroll, createSessionScrollDefaultGuard } from "./use-session-hash-scroll-default"
 import { messageIdFromHash } from "./message-id-from-hash"
 
 describe("messageIdFromHash", () => {
@@ -12,5 +13,160 @@ describe("messageIdFromHash", () => {
 
   test("ignores non-message anchors", () => {
     expect(messageIdFromHash("#review-panel")).toBeUndefined()
+  })
+})
+
+describe("applyNoHashScroll", () => {
+  test("uses a pending message before restoring or forcing bottom", () => {
+    const setPendingMessage = vi.fn()
+    const restoreScroll = vi.fn(() => true)
+    const forceScrollToBottom = vi.fn()
+
+    const next = applyNoHashScroll({
+      sessionKey: "session",
+      pendingKey: "",
+      pendingMessage: undefined,
+      consumePendingMessage: () => "message-1",
+      setPendingMessage,
+      restoreScroll,
+      forceScrollToBottom,
+      scroller: () => undefined,
+      scheduleScrollState: () => {},
+    })
+
+    expect(next).toEqual({ pendingKey: "session", result: "pending" })
+    expect(setPendingMessage).toHaveBeenCalledWith("message-1")
+    expect(restoreScroll).not.toHaveBeenCalled()
+    expect(forceScrollToBottom).not.toHaveBeenCalled()
+  })
+
+  test("uses generic restore before forcing bottom", () => {
+    const restoreScroll = vi.fn(() => true)
+    const forceScrollToBottom = vi.fn()
+
+    const next = applyNoHashScroll({
+      sessionKey: "session",
+      pendingKey: "",
+      pendingMessage: undefined,
+      consumePendingMessage: () => undefined,
+      setPendingMessage: () => {},
+      restoreScroll,
+      forceScrollToBottom,
+      scroller: () => undefined,
+      scheduleScrollState: () => {},
+    })
+
+    expect(next).toEqual({ pendingKey: "session", result: "restored" })
+    expect(restoreScroll).toHaveBeenCalledTimes(1)
+    expect(forceScrollToBottom).not.toHaveBeenCalled()
+  })
+
+  test("forces bottom when generic restore cannot restore", () => {
+    const restoreScroll = vi.fn(() => false)
+    const markProgrammaticScroll = vi.fn()
+    const forceScrollToBottom = vi.fn()
+
+    const next = applyNoHashScroll({
+      sessionKey: "session",
+      pendingKey: "",
+      pendingMessage: undefined,
+      consumePendingMessage: () => undefined,
+      setPendingMessage: () => {},
+      restoreScroll,
+      markProgrammaticScroll,
+      forceScrollToBottom,
+      scroller: () => undefined,
+      scheduleScrollState: () => {},
+    })
+
+    expect(next).toEqual({ pendingKey: "session", result: "bottom" })
+    expect(restoreScroll).toHaveBeenCalledTimes(1)
+    expect(markProgrammaticScroll).toHaveBeenCalledTimes(1)
+    expect(forceScrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not rerun generic restore after the session already consumed default scroll", () => {
+    const restoreScroll = vi.fn(() => true)
+    const forceScrollToBottom = vi.fn()
+
+    const next = applyNoHashScroll({
+      sessionKey: "session",
+      pendingKey: "session",
+      pendingMessage: undefined,
+      consumePendingMessage: () => undefined,
+      setPendingMessage: () => {},
+      canRestoreScroll: () => false,
+      restoreScroll,
+      forceScrollToBottom,
+      scroller: () => undefined,
+      scheduleScrollState: () => {},
+    })
+
+    expect(next).toEqual({ pendingKey: "session", result: "skipped" })
+    expect(restoreScroll).not.toHaveBeenCalled()
+    expect(forceScrollToBottom).not.toHaveBeenCalled()
+  })
+
+  test("defers fallback when generic restore is not ready", () => {
+    const restoreScroll = vi.fn(() => undefined)
+    const forceScrollToBottom = vi.fn()
+
+    const next = applyNoHashScroll({
+      sessionKey: "session",
+      pendingKey: "",
+      pendingMessage: undefined,
+      consumePendingMessage: () => undefined,
+      setPendingMessage: () => {},
+      restoreScroll,
+      forceScrollToBottom,
+      scroller: () => undefined,
+      scheduleScrollState: () => {},
+    })
+
+    expect(next).toEqual({ pendingKey: "session", result: "deferred" })
+    expect(restoreScroll).toHaveBeenCalledTimes(1)
+    expect(forceScrollToBottom).not.toHaveBeenCalled()
+  })
+})
+
+describe("createSessionScrollDefaultGuard", () => {
+  test("allows restore again after leaving to the no-id route and returning", () => {
+    const guard = createSessionScrollDefaultGuard()
+
+    guard.consumeDefault({ sessionKey: "workspace/session-a", sessionID: "session-a" })
+    guard.enter({ sessionKey: "workspace", sessionID: undefined })
+
+    expect(guard.canRestore({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(true)
+  })
+
+  test("allows restore again after visiting another unconsumed session entry", () => {
+    const guard = createSessionScrollDefaultGuard()
+
+    guard.consumeDefault({ sessionKey: "workspace/session-a", sessionID: "session-a" })
+    guard.enter({ sessionKey: "workspace/session-b", sessionID: "session-b" })
+
+    expect(guard.canRestore({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(true)
+    expect(guard.shouldRetry({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(false)
+  })
+
+  test("skips stale restore after hash clearing within the same session entry", () => {
+    const guard = createSessionScrollDefaultGuard()
+
+    guard.consumeDefault({ sessionKey: "workspace/session-a", sessionID: "session-a" })
+
+    expect(guard.canRestore({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(false)
+  })
+
+  test("resets retry and save gates on route entry changes", () => {
+    const guard = createSessionScrollDefaultGuard()
+
+    guard.deferRestore({ sessionKey: "workspace/session-a", sessionID: "session-a" })
+    expect(guard.shouldRetry({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(true)
+    expect(guard.canSave({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(true)
+
+    guard.enter({ sessionKey: "workspace", sessionID: undefined })
+
+    expect(guard.shouldRetry({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(false)
+    expect(guard.canSave({ sessionKey: "workspace/session-a", sessionID: "session-a" })).toBe(false)
   })
 })

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -2,6 +2,7 @@ import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { useLocation, useNavigate } from "@solidjs/router"
 import { createEffect, createMemo, onCleanup, onMount } from "solid-js"
 import { messageIdFromHash } from "./message-id-from-hash"
+import { applyNoHashScroll, resolvePendingMessage } from "./use-session-hash-scroll-default"
 
 export const useSessionHashScroll = (input: {
   sessionKey: () => string
@@ -21,6 +22,11 @@ export const useSessionHashScroll = (input: {
   revealMessage?: (id: string) => void
   scheduleScrollState: (el: HTMLDivElement) => void
   consumePendingMessage: (key: string) => string | undefined
+  defaultScrollReady?: () => boolean
+  canRestoreScroll?: () => boolean
+  restoreScroll?: () => boolean | undefined
+  consumeDefaultScroll?: () => void
+  markProgrammaticScroll?: () => void
 }) => {
   const visibleUserMessages = createMemo(() => input.visibleUserMessages())
   const messageById = createMemo(() => new Map(visibleUserMessages().map((m) => [m.id, m])))
@@ -61,6 +67,19 @@ export const useSessionHashScroll = (input: {
     })
   }
 
+  const pendingTarget = () => {
+    const pending = resolvePendingMessage({
+      sessionKey: input.sessionKey(),
+      pendingKey,
+      pendingMessage: input.pendingMessage(),
+      consumePendingMessage: input.consumePendingMessage,
+      setPendingMessage: input.setPendingMessage,
+    })
+    pendingKey = pending.pendingKey
+    if (pending.target) input.consumeDefaultScroll?.()
+    return pending.target
+  }
+
   const scrollToElement = (el: HTMLElement, behavior: ScrollBehavior) => {
     const root = input.scroller()
     if (!root) return false
@@ -70,6 +89,7 @@ export const useSessionHashScroll = (input: {
     const sticky = root.querySelector("[data-session-title]")
     const inset = sticky instanceof HTMLElement ? sticky.offsetHeight : 0
     const top = Math.max(0, a.top - b.top + root.scrollTop - inset)
+    input.markProgrammaticScroll?.()
     root.scrollTo({ top, behavior })
     return true
   }
@@ -101,11 +121,25 @@ export const useSessionHashScroll = (input: {
   const applyHash = (behavior: ScrollBehavior) => {
     const hash = location.hash.slice(1)
     if (!hash) {
-      input.autoScroll.forceScrollToBottom()
-      const el = input.scroller()
-      if (el) input.scheduleScrollState(el)
+      const next = applyNoHashScroll({
+        sessionKey: input.sessionKey(),
+        pendingKey,
+        pendingMessage: input.pendingMessage(),
+        consumePendingMessage: input.consumePendingMessage,
+        setPendingMessage: input.setPendingMessage,
+        canRestoreScroll: input.canRestoreScroll,
+        restoreScroll: input.restoreScroll,
+        consumeDefaultScroll: input.consumeDefaultScroll,
+        markProgrammaticScroll: input.markProgrammaticScroll,
+        forceScrollToBottom: input.autoScroll.forceScrollToBottom,
+        scroller: input.scroller,
+        scheduleScrollState: input.scheduleScrollState,
+      })
+      pendingKey = next.pendingKey
       return
     }
+
+    input.consumeDefaultScroll?.()
 
     const messageId = messageIdFromHash(hash)
     if (messageId) {
@@ -125,6 +159,7 @@ export const useSessionHashScroll = (input: {
       return
     }
 
+    input.markProgrammaticScroll?.()
     input.autoScroll.forceScrollToBottom()
     const el = input.scroller()
     if (el) input.scheduleScrollState(el)
@@ -132,8 +167,9 @@ export const useSessionHashScroll = (input: {
 
   createEffect(() => {
     const hash = location.hash
+    const ready = hash ? true : (input.defaultScrollReady?.() ?? true)
     if (!hash) clearing = false
-    if (!input.sessionID() || !input.messagesReady()) return
+    if (!input.sessionID() || !input.messagesReady() || !ready) return
     cancel()
     queue(() => applyHash("auto"))
   })
@@ -143,18 +179,7 @@ export const useSessionHashScroll = (input: {
 
     visibleUserMessages()
 
-    let targetId = input.pendingMessage()
-    if (!targetId) {
-      const key = input.sessionKey()
-      if (pendingKey !== key) {
-        pendingKey = key
-        const next = input.consumePendingMessage(key)
-        if (next) {
-          input.setPendingMessage(next)
-          targetId = next
-        }
-      }
-    }
+    let targetId = pendingTarget()
 
     if (!targetId && !clearing) targetId = messageIdFromHash(location.hash)
     if (!targetId) return


### PR DESCRIPTION
### Issue for this PR

Fixes #28120

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Persists the main session conversation viewport in the existing per-session layout scroll store, restores it when returning to a session, keeps bottom-pinned sessions at bottom, and leaves hash/pending-message navigation ahead of generic restoration while preventing stale restores after hash clearing.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/pages/session/use-session-hash-scroll.test.ts ./src/context/layout-scroll.test.ts` from `packages/app`
- `bun typecheck` from `packages/app` passed with a local Windows symlink workaround for `packages/app/src/custom-elements.d.ts`; the file was restored clean afterward
- `git diff --check`

### Screenshots / recordings

Not included; behavior is covered by targeted scroll-state unit tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
