### PR TITLE
fix(tool): prevent crash when plugin tool has invalid or missing args

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -142,7 +142,7 @@ export const layer: Layer.Layer<
         function fromPlugin(id: string, def: ToolDefinition): Tool.Def {
           // Plugin tools still expose Zod args publicly; keep that compatibility
           // boxed at the registry boundary and give the LLM the original JSON Schema.
-          const entries = Object.entries(def.args)
+          const entries = Object.entries(def.args ?? {})
           const allZod = entries.every((entry) => isZodType(entry[1]))
           const zodParams = allZod ? z.object(def.args) : undefined
           const jsonSchema = zodParams ? zodJsonSchema(zodParams) : legacyJsonSchema(entries)
@@ -210,6 +210,10 @@ export const layer: Layer.Layer<
         const plugins = yield* plugin.list()
         for (const p of plugins) {
           for (const [id, def] of Object.entries(p.tool ?? {})) {
+            if (!isPluginTool(def)) {
+              log.warn("plugin tool skipped: invalid definition, missing args/description/execute", { id })
+              continue
+            }
             custom.push(fromPlugin(id, def))
           }
         }


### PR DESCRIPTION
### Issue for this PR

Closes #27630

### Type of change

- [x] Bug fix

### What does this PR do?

When a plugin registers a tool using a raw `parameters` JSON Schema field instead of the `@opencode-ai/plugin` `tool()` SDK helper, `tool.args` is `undefined`. `ToolRegistry.fromPlugin()` then calls `Object.entries(def.args)` and throws `TypeError: Object.entries requires that input parameter not be null or undefined`. This crash happens during tool resolution on every session start, causing opencode to silently stop responding to messages.

Two fixes:

1. `Object.entries(def.args ?? {})` — guard against `undefined` args so a malformed tool produces an empty schema instead of a crash
2. Add `isPluginTool()` validation in the plugin hooks loop before calling `fromPlugin()` — the file-based tools path already had this guard, the plugin hooks path (`p.tool`) did not. Invalid definitions are now logged as a warning and skipped.

Related plugin fix: [charfeng1/opencode-ralph-loop#5](https://github.com/charfeng1/opencode-ralph-loop/pull/5).

### How did you verify your code works?

All 13 existing `tool.registry` tests pass. Also verified the fix directly: `Object.entries(undefined)` throws, `Object.entries(undefined ?? {})` returns `[]`.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR