### PR TITLE
fix: desktop build script

### DIFF
--- a/packages/desktop/scripts/prebuild.ts
+++ b/packages/desktop/scripts/prebuild.ts
@@ -4,6 +4,8 @@ import { $ } from "bun"
 import { resolveChannel } from "./utils"
 
 const channel = resolveChannel()
+Bun.env.OPENCODE_CHANNEL = channel
+
 await $`bun ./scripts/copy-icons.ts ${channel}`
 await $`bun ./scripts/copy-metainfo.ts ${channel}`
 

--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -51,6 +51,7 @@ await Bun.build({
   sourcemap: "linked",
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_MIGRATIONS: JSON.stringify(migrations),
     OPENCODE_MODELS_DEV: generated.modelsData,
     OPENCODE_CHANNEL: `'${Script.channel}'`,


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes desktop builds trying to install `@opencode-ai/plugin@local`

The desktop prebuild builds the embedded opencode server through `packages/opencode/script/build-node.ts`. That build embedded `OPENCODE_CHANNEL`, but did not embed `OPENCODE_VERSION`. At runtime this meant the server was treated as a non-local build, while InstallationVersion still fell back to "local"

Config dependency install uses that state to decide the plugin dependency version, so it produced the invalid npm spec `@opencode-ai/plugin@local`

This PR embeds `OPENCODE_VERSION` in the node server build and makes the desktop prebuild pass its resolved `OPENCODE_CHANNEL` into that build explicitly. With both values present, packaged desktop installs the matching published plugin version instead of local.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

set these envs

$env:OPENCODE_VERSION = "1.15.4"
$env:OPENCODE_CHANNEL = "dev"


1. `bun run build` 
2. `bun run package:win`
3. .\dist\win-unpacked\"OpenCode Dev.exe"
4. No more error logs 

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
