### PR TITLE
feat: expose OPENCODE_SESSION_ID env var to child processes

### DIFF
--- a/packages/core/src/util/opencode-process.ts
+++ b/packages/core/src/util/opencode-process.ts
@@ -1,5 +1,6 @@
 export const OPENCODE_RUN_ID = "OPENCODE_RUN_ID"
 export const OPENCODE_PROCESS_ROLE = "OPENCODE_PROCESS_ROLE"
+export const OPENCODE_SESSION_ID = "OPENCODE_SESSION_ID"
 
 export function ensureRunID() {
   return (process.env[OPENCODE_RUN_ID] ??= crypto.randomUUID())

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -45,6 +45,7 @@ import { Truncate } from "@/tool/truncate"
 import { Image } from "@/image/image"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
+import { OPENCODE_SESSION_ID } from "@opencode-ai/core/util/opencode-process"
 import { Cause, Effect, Exit, Latch, Layer, Option, Scope, Context, Schema, Types } from "effect"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
 import { InstanceState } from "@/effect/instance-state"
@@ -1614,6 +1615,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts, Image.Error> = Effect.fn(
       "SessionPrompt.prompt",
     )(function* (input: PromptInput) {
+      process.env[OPENCODE_SESSION_ID] = input.sessionID
       const session = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
       yield* revert.cleanup(session)
       const message = yield* createUserMessage(input)
@@ -1883,11 +1885,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts, Session.BusyError> = Effect.fn(
       "SessionPrompt.shell",
     )(function* (input: ShellInput) {
+      process.env[OPENCODE_SESSION_ID] = input.sessionID
       const ready = yield* Latch.make()
       return yield* state.startShell(input.sessionID, lastAssistant(input.sessionID), shellImpl(input, ready), ready)
     })
 
     const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
+      process.env[OPENCODE_SESSION_ID] = input.sessionID
       yield* elog.info("command", { sessionID: input.sessionID, command: input.command, agent: input.agent })
       const cmd = yield* commands.get(input.command)
       if (!cmd) {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -18,6 +18,7 @@ import { ShellID } from "./shell/id"
 
 import * as Truncate from "./truncate"
 import { Plugin } from "@/plugin"
+import { OPENCODE_SESSION_ID } from "@opencode-ai/core/util/opencode-process"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { ShellPrompt, type Parameters } from "./shell/prompt"
@@ -418,6 +419,7 @@ export const ShellTool = Tool.define(
       return {
         ...process.env,
         ...extra.env,
+        [OPENCODE_SESSION_ID]: ctx.sessionID,
       }
     })
 

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -186,6 +186,20 @@ describe("tool.shell", () => {
     ),
   )
 
+  each("passes OPENCODE_SESSION_ID to child process", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const result = yield* run({
+          command: `${bin} -e "process.stdout.write(process.env.OPENCODE_SESSION_ID || '')"`,
+          description: "Print session ID env var",
+        })
+        expect(result.metadata.exit).toBe(0)
+        expect(result.metadata.output).toContain(ctx.sessionID)
+      }),
+    ),
+  )
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })


### PR DESCRIPTION
Getting the session ID is extremely tedious inside a running session or terminal, most accurately involving AI analysis of possible session from the session database. This exposes that.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Sets `OPENCODE_SESSION_ID` in `process.env` whenever a session prompt, shell, or command is initiated. This makes the active session ID available to all spawned child processes (shell tool, MCP servers, PTY sessions) without requiring them to query the database.

**Why it's needed:** External tooling (tmux session restore, wrapper scripts, terminal multiplexer integrations) currently has no way to discover which opencode session is active in a given terminal. The only workaround is querying the SQLite database post-hoc with heuristics (directory + time window), which is fragile and ambiguous when multiple sessions share a working directory.

**What changed:**

1. `packages/core/src/util/opencode-process.ts` — Added `OPENCODE_SESSION_ID` constant (follows existing pattern of `OPENCODE_RUN_ID`, `OPENCODE_PROCESS_ROLE`)
2. `packages/opencode/src/session/prompt.ts` — Set `process.env[OPENCODE_SESSION_ID]` at entry of `prompt()`, `shell()`, and `command()` handlers so the worker process env reflects the current session for all child process spawning
3. `packages/opencode/src/tool/shell.ts` — Explicitly include `[OPENCODE_SESSION_ID]: ctx.sessionID` in shell env composition for per-invocation correctness even if session changes between tool calls

**Why it works:** The env var is set at the same level as existing env vars (`OPENCODE_PID`, `OPENCODE_RUN_ID`). The worker process spawns all tool child processes, so setting it on `process.env` before spawn means all children inherit it. The explicit shell tool placement (after `...extra.env`) prevents plugins from accidentally overriding it via the `shell.env` hook.

Zero breaking changes — purely additive.

### How did you verify your code works?

Added a test in `packages/opencode/test/tool/shell.test.ts` that spawns a child process via the shell tool and asserts `process.env.OPENCODE_SESSION_ID` contains the active session ID. Test passes (22 pass total, 2 pre-existing timeout failures unrelated to this change).

```
bun test test/tool/shell.test.ts --test-name-pattern "passes OPENCODE"
# 1 pass, 0 fail
```

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR