### PR TITLE
refactor(sync): publish via EffectBridge.fork for codebase consistency

### DIFF
--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -17,7 +17,6 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { serviceUse } from "@/effect/service-use"
 import { InstanceState } from "@/effect/instance-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
-import { attachWith } from "@/effect/run-service"
 import { EffectBridge } from "@/effect/bridge"
 
 // Keep `Event["data"]` mutable because projectors mutate the persisted shape
@@ -78,13 +77,6 @@ export const layer = Layer.effect(Service)(
   Effect.gen(function* () {
     const flags = yield* RuntimeFlags.Service
     const bus = yield* ProjectBus.Service
-    // Capture the layer's full Effect context once at construction. Used by
-    // `process` below to fork the publish callback through the bridge, so the
-    // post-DB-commit fire-and-forget runs with the layer's services available
-    // (logger, telemetry, anything else the layer's deps provide). The
-    // previous `Effect.runPromise(attachWith(...))` shape only carried
-    // InstanceRef/WorkspaceRef and dropped everything else.
-    const bridge = yield* EffectBridge.make()
 
     const replay: Interface["replay"] = Effect.fn("SyncEvent.replay")(function* (event, options) {
       const def = registry.get(event.type)
@@ -121,6 +113,10 @@ export const layer = Layer.effect(Service)(
             workspace: yield* InstanceState.workspaceID,
           }
         : undefined
+      // Bridge captures handler-fiber refs (InstanceRef/WorkspaceRef) and the
+      // full Effect context, so the forked publish runs with the right state
+      // without an explicit attachWith.
+      const bridge = publish ? yield* EffectBridge.make() : undefined
       process(def, event, {
         bus,
         bridge,
@@ -169,6 +165,7 @@ export const layer = Layer.effect(Service)(
             workspace: yield* InstanceState.workspaceID,
           }
         : undefined
+      const bridge = publish ? yield* EffectBridge.make() : undefined
 
       // Note that this is an "immediate" transaction which is critical.
       // We need to make sure we can safely read and write with nothing
@@ -317,7 +314,7 @@ function process<Def extends Definition>(
   event: Event<Def>,
   options: {
     bus: ProjectBus.Interface
-    bridge: EffectBridge.Shape
+    bridge: EffectBridge.Shape | undefined
     publish: boolean
     context?: PublishContext
     ownerID?: string
@@ -367,13 +364,12 @@ function process<Def extends Definition>(
         }
 
         const result = convertEvent(def.type, event.data)
+        // The bridge was built inside the caller's fiber so it already carries
+        // InstanceRef/WorkspaceRef and the full Effect context — no per-call
+        // attachWith needed.
+        const bridge = options.bridge!
         const publish = (data: unknown) =>
-          options.bridge.fork(
-            attachWith(options.bus.publish(def, data as Properties<Def>, { id: event.id }), {
-              instance: options.context?.instance,
-              workspace: options.context?.workspace,
-            }),
-          )
+          bridge.fork(options.bus.publish(def, data as Properties<Def>, { id: event.id }))
         if (result instanceof Promise) {
           void result.then(publish)
         } else {

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -18,6 +18,7 @@ import { serviceUse } from "@/effect/service-use"
 import { InstanceState } from "@/effect/instance-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { attachWith } from "@/effect/run-service"
+import { EffectBridge } from "@/effect/bridge"
 
 // Keep `Event["data"]` mutable because projectors mutate the persisted shape
 // when writing to the database. Bus payloads (`Properties`) stay readonly —
@@ -77,6 +78,13 @@ export const layer = Layer.effect(Service)(
   Effect.gen(function* () {
     const flags = yield* RuntimeFlags.Service
     const bus = yield* ProjectBus.Service
+    // Capture the layer's full Effect context once at construction. Used by
+    // `process` below to fork the publish callback through the bridge, so the
+    // post-DB-commit fire-and-forget runs with the layer's services available
+    // (logger, telemetry, anything else the layer's deps provide). The
+    // previous `Effect.runPromise(attachWith(...))` shape only carried
+    // InstanceRef/WorkspaceRef and dropped everything else.
+    const bridge = yield* EffectBridge.make()
 
     const replay: Interface["replay"] = Effect.fn("SyncEvent.replay")(function* (event, options) {
       const def = registry.get(event.type)
@@ -115,6 +123,7 @@ export const layer = Layer.effect(Service)(
         : undefined
       process(def, event, {
         bus,
+        bridge,
         publish,
         context,
         ownerID: options?.ownerID,
@@ -175,7 +184,7 @@ export const layer = Layer.effect(Service)(
           const seq = row?.seq != null ? row.seq + 1 : 0
 
           const event = { id, seq, aggregateID: agg, data }
-          process(def, event, { bus, publish, context, experimentalWorkspaces: flags.experimentalWorkspaces })
+          process(def, event, { bus, bridge, publish, context, experimentalWorkspaces: flags.experimentalWorkspaces })
         },
         {
           behavior: "immediate",
@@ -308,6 +317,7 @@ function process<Def extends Definition>(
   event: Event<Def>,
   options: {
     bus: ProjectBus.Interface
+    bridge: EffectBridge.Shape
     publish: boolean
     context?: PublishContext
     ownerID?: string
@@ -358,7 +368,7 @@ function process<Def extends Definition>(
 
         const result = convertEvent(def.type, event.data)
         const publish = (data: unknown) =>
-          Effect.runPromise(
+          options.bridge.fork(
             attachWith(options.bus.publish(def, data as Properties<Def>, { id: event.id }), {
               instance: options.context?.instance,
               workspace: options.context?.workspace,
@@ -367,7 +377,7 @@ function process<Def extends Definition>(
         if (result instanceof Promise) {
           void result.then(publish)
         } else {
-          void publish(result)
+          publish(result)
         }
 
         GlobalBus.emit("event", {

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -115,8 +115,8 @@ export const layer = Layer.effect(Service)(
         : undefined
       // Bridge captures handler-fiber refs (InstanceRef/WorkspaceRef) and the
       // full Effect context, so the forked publish runs with the right state
-      // without an explicit attachWith.
-      const bridge = publish ? yield* EffectBridge.make() : undefined
+      // without a per-call attachWith.
+      const bridge = yield* EffectBridge.make()
       process(def, event, {
         bus,
         bridge,
@@ -165,7 +165,7 @@ export const layer = Layer.effect(Service)(
             workspace: yield* InstanceState.workspaceID,
           }
         : undefined
-      const bridge = publish ? yield* EffectBridge.make() : undefined
+      const bridge = yield* EffectBridge.make()
 
       // Note that this is an "immediate" transaction which is critical.
       // We need to make sure we can safely read and write with nothing
@@ -314,7 +314,7 @@ function process<Def extends Definition>(
   event: Event<Def>,
   options: {
     bus: ProjectBus.Interface
-    bridge: EffectBridge.Shape | undefined
+    bridge: EffectBridge.Shape
     publish: boolean
     context?: PublishContext
     ownerID?: string
@@ -367,9 +367,8 @@ function process<Def extends Definition>(
         // The bridge was built inside the caller's fiber so it already carries
         // InstanceRef/WorkspaceRef and the full Effect context — no per-call
         // attachWith needed.
-        const bridge = options.bridge!
         const publish = (data: unknown) =>
-          bridge.fork(options.bus.publish(def, data as Properties<Def>, { id: event.id }))
+          options.bridge.fork(options.bus.publish(def, data as Properties<Def>, { id: event.id }))
         if (result instanceof Promise) {
           void result.then(publish)
         } else {

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -101,9 +101,6 @@ export const layer = Layer.effect(Service)(
       }
 
       const publish = !!options?.publish
-      // Assert InstanceRef is set before going async — surfaces "missing
-      // instance" failures synchronously instead of inside the forked publish.
-      if (publish) yield* InstanceState.context
       // Bridge captures handler-fiber refs (InstanceRef/WorkspaceRef) and the
       // full Effect context, so the forked publish + GlobalBus emit run with
       // the right state without a per-call attachWith.
@@ -149,7 +146,6 @@ export const layer = Layer.effect(Service)(
       }
 
       const { publish = true } = options || {}
-      if (publish) yield* InstanceState.context
       const bridge = yield* EffectBridge.make()
 
       // Note that this is an "immediate" transaction which is critical.

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -7,9 +7,7 @@ import { eq } from "drizzle-orm"
 import { GlobalBus } from "@/bus/global"
 import { Bus as ProjectBus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
-import type { InstanceContext } from "@/project/instance-context"
 import { EventSequenceTable, EventTable } from "./event.sql"
-import type { WorkspaceID } from "@/control-plane/schema"
 import { EventID } from "./schema"
 import { Context, Effect, Layer, Schema as EffectSchema } from "effect"
 import type { DeepMutable } from "@opencode-ai/core/schema"
@@ -51,10 +49,6 @@ export type SerializedEvent<Def extends Definition = Definition> = Event<Def> & 
 
 type ProjectorFunc = (db: Database.TxOrDb, data: unknown, event: Event) => void
 type ConvertEvent = (type: string, data: Event["data"]) => unknown | Promise<unknown>
-type PublishContext = {
-  instance?: InstanceContext
-  workspace?: WorkspaceID
-}
 
 export interface Interface {
   readonly run: <Def extends Definition>(
@@ -107,21 +101,17 @@ export const layer = Layer.effect(Service)(
       }
 
       const publish = !!options?.publish
-      const context = publish
-        ? {
-            instance: yield* InstanceState.context,
-            workspace: yield* InstanceState.workspaceID,
-          }
-        : undefined
+      // Assert InstanceRef is set before going async — surfaces "missing
+      // instance" failures synchronously instead of inside the forked publish.
+      if (publish) yield* InstanceState.context
       // Bridge captures handler-fiber refs (InstanceRef/WorkspaceRef) and the
-      // full Effect context, so the forked publish runs with the right state
-      // without a per-call attachWith.
+      // full Effect context, so the forked publish + GlobalBus emit run with
+      // the right state without a per-call attachWith.
       const bridge = yield* EffectBridge.make()
       process(def, event, {
         bus,
         bridge,
         publish,
-        context,
         ownerID: options?.ownerID,
         experimentalWorkspaces: flags.experimentalWorkspaces,
       })
@@ -159,12 +149,7 @@ export const layer = Layer.effect(Service)(
       }
 
       const { publish = true } = options || {}
-      const context = publish
-        ? {
-            instance: yield* InstanceState.context,
-            workspace: yield* InstanceState.workspaceID,
-          }
-        : undefined
+      if (publish) yield* InstanceState.context
       const bridge = yield* EffectBridge.make()
 
       // Note that this is an "immediate" transaction which is critical.
@@ -181,7 +166,7 @@ export const layer = Layer.effect(Service)(
           const seq = row?.seq != null ? row.seq + 1 : 0
 
           const event = { id, seq, aggregateID: agg, data }
-          process(def, event, { bus, bridge, publish, context, experimentalWorkspaces: flags.experimentalWorkspaces })
+          process(def, event, { bus, bridge, publish, experimentalWorkspaces: flags.experimentalWorkspaces })
         },
         {
           behavior: "immediate",
@@ -316,7 +301,6 @@ function process<Def extends Definition>(
     bus: ProjectBus.Interface
     bridge: EffectBridge.Shape
     publish: boolean
-    context?: PublishContext
     ownerID?: string
     experimentalWorkspaces: boolean
   },
@@ -358,35 +342,36 @@ function process<Def extends Definition>(
     }
 
     Database.effect(() => {
-      if (options?.publish) {
-        if (!options.context?.instance) {
-          throw new Error("SyncEvent.process: publish requires instance context")
-        }
-
-        const result = convertEvent(def.type, event.data)
-        // The bridge was built inside the caller's fiber so it already carries
-        // InstanceRef/WorkspaceRef and the full Effect context — no per-call
-        // attachWith needed.
-        const publish = (data: unknown) =>
-          options.bridge.fork(options.bus.publish(def, data as Properties<Def>, { id: event.id }))
-        if (result instanceof Promise) {
-          void result.then(publish)
-        } else {
-          publish(result)
-        }
-
-        GlobalBus.emit("event", {
-          directory: options.context.instance.directory,
-          project: options.context.instance.project.id,
-          workspace: options.context.workspace,
-          payload: {
-            type: "sync",
-            syncEvent: {
-              type: versionedType(def.type, def.version),
-              ...event,
-            },
-          },
-        })
+      if (!options.publish) return
+      const result = convertEvent(def.type, event.data)
+      // The bridge was built inside the caller's fiber so it already carries
+      // InstanceRef/WorkspaceRef and the full Effect context. Both the bus
+      // publish and the GlobalBus emit run inside the forked Effect so they
+      // share the same instance/workspace lookup.
+      const publish = (data: unknown) =>
+        options.bridge.fork(
+          Effect.gen(function* () {
+            yield* options.bus.publish(def, data as Properties<Def>, { id: event.id })
+            const instance = yield* InstanceState.context
+            const workspace = yield* InstanceState.workspaceID
+            GlobalBus.emit("event", {
+              directory: instance.directory,
+              project: instance.project.id,
+              workspace,
+              payload: {
+                type: "sync",
+                syncEvent: {
+                  type: versionedType(def.type, def.version),
+                  ...event,
+                },
+              },
+            })
+          }),
+        )
+      if (result instanceof Promise) {
+        void result.then(publish)
+      } else {
+        publish(result)
       }
     })
   })

--- a/packages/opencode/test/sync/index.test.ts
+++ b/packages/opencode/test/sync/index.test.ts
@@ -3,6 +3,7 @@ import { provideTmpdirInstance } from "../fixture/fixture"
 import { Effect, Layer, Schema } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Bus } from "../../src/bus"
+import { GlobalBus, type GlobalEvent } from "../../src/bus/global"
 import { SyncEvent } from "../../src/sync"
 import { Database, eq } from "@/storage/db"
 import { EventSequenceTable, EventTable } from "../../src/sync/event.sql"
@@ -135,6 +136,42 @@ describe("SyncEvent", () => {
             })
           } finally {
             dispose()
+          }
+        }),
+      ),
+    )
+
+    // Regression for the EffectBridge migration. GlobalBus.emit used to fire
+    // synchronously inside the Database.effect post-commit callback. After the
+    // migration it fires inside the forked publish Effect, AFTER bus.publish
+    // completes. Consumers don't care about microsecond-level ordering, but
+    // we still need to prove the emit actually fires.
+    it.live(
+      "emits sync events to GlobalBus after publishing to ProjectBus",
+      provideTmpdirInstance(() =>
+        Effect.gen(function* () {
+          const { Created } = setup()
+          const captured: GlobalEvent[] = []
+          const handler = (evt: GlobalEvent) => {
+            if (evt.payload?.type === "sync") captured.push(evt)
+          }
+          GlobalBus.on("event", handler)
+          try {
+            yield* SyncEvent.use.run(Created, { id: "evt_global_1", name: "global" })
+            // bridge.fork is fire-and-forget. Poll briefly so the forked
+            // publish has time to reach the GlobalBus.emit call.
+            const deadline = Date.now() + 1_000
+            while (captured.length === 0 && Date.now() < deadline) {
+              yield* Effect.sleep("10 millis")
+            }
+            expect(captured.length).toBeGreaterThanOrEqual(1)
+            const event = captured[0]
+            expect(event.payload).toMatchObject({
+              type: "sync",
+              syncEvent: { type: "item.created.1" },
+            })
+          } finally {
+            GlobalBus.off("event", handler)
           }
         }),
       ),

--- a/packages/opencode/test/sync/index.test.ts
+++ b/packages/opencode/test/sync/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, beforeEach, afterAll } from "bun:test"
 import { provideTmpdirInstance } from "../fixture/fixture"
-import { Effect, Layer, Schema } from "effect"
+import { Deferred, Effect, Layer, Schema } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Bus } from "../../src/bus"
 import { GlobalBus, type GlobalEvent } from "../../src/bus/global"
@@ -9,7 +9,7 @@ import { Database, eq } from "@/storage/db"
 import { EventSequenceTable, EventTable } from "../../src/sync/event.sql"
 import { MessageID } from "../../src/session/schema"
 import { initProjectors } from "../../src/server/projectors"
-import { testEffect } from "../lib/effect"
+import { awaitWithTimeout, testEffect } from "../lib/effect"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 
 const it = testEffect(
@@ -151,24 +151,25 @@ describe("SyncEvent", () => {
       provideTmpdirInstance(() =>
         Effect.gen(function* () {
           const { Created } = setup()
-          const captured: GlobalEvent[] = []
+          // Filter for OUR specific event in the handler so we ignore any
+          // stray sync events from other tests' lingering forks.
+          const received = yield* Deferred.make<GlobalEvent>()
           const handler = (evt: GlobalEvent) => {
-            if (evt.payload?.type === "sync") captured.push(evt)
+            if (evt.payload?.type === "sync" && evt.payload?.syncEvent?.type === "item.created.1") {
+              Deferred.doneUnsafe(received, Effect.succeed(evt))
+            }
           }
           GlobalBus.on("event", handler)
           try {
             yield* SyncEvent.use.run(Created, { id: "evt_global_1", name: "global" })
-            // bridge.fork is fire-and-forget. Poll briefly so the forked
-            // publish has time to reach the GlobalBus.emit call.
-            const deadline = Date.now() + 1_000
-            while (captured.length === 0 && Date.now() < deadline) {
-              yield* Effect.sleep("10 millis")
-            }
-            expect(captured.length).toBeGreaterThanOrEqual(1)
-            const event = captured[0]
+            const event = yield* awaitWithTimeout(
+              Deferred.await(received),
+              "timed out waiting for sync event on GlobalBus",
+              "2 seconds",
+            )
             expect(event.payload).toMatchObject({
               type: "sync",
-              syncEvent: { type: "item.created.1" },
+              syncEvent: { type: "item.created.1", data: { id: "evt_global_1", name: "global" } },
             })
           } finally {
             GlobalBus.off("event", handler)


### PR DESCRIPTION
## Summary

`sync/index.ts` was the lone outlier in opencode using `Effect.runPromise(attachWith(...))` to bridge from a synchronous `Database.effect(...)` callback back into Effect-land for publishing. Every other sync→Effect bridge in the codebase (`pty/`, `plugin/`, `bus/`, `command/`, `session/llm`, `mcp/`, `provider/`, `tool/task`, `file/watcher`) uses `EffectBridge.fork`.

This PR migrates sync's publish callback to the same pattern. The bridge is captured inside `run`/`replay` (per-call, in the handler fiber) so it picks up the right `InstanceRef`/`WorkspaceRef` and the layer's full Effect context — eliminating the per-call `attachWith` plumbing.

A second pass moved `GlobalBus.emit` inside the forked publish Effect, which let the eager `options.context` snapshot, the `PublishContext` type, and a defensive throw all be dropped.

## Why

For the current `Bus.Interface` (which declares `R = never` for `publish`), the old `Effect.runPromise` and the new `bridge.fork` are observationally identical. The migration is hygiene, not a bug fix:

- Removes the inconsistency with every other sync→Effect bridge in the codebase.
- Forward-compatible: if anyone widens `bus.publish`'s `R`, the bridge silently does the right thing.
- Drops ~50 lines of context-plumbing code along the way.

## Behavioral changes (verified non-breaking)

| Property | Old | New | Impact |
|---|---|---|---|
| Order of `GlobalBus.emit` vs `bus.publish` | emit first (sync), publish later (microtask) | publish first, emit after | Verified: no consumer subscribes to both and depends on ordering. `/global/event` SSE handler, TUI worker, workspace replay, `stream.transport` all consume GlobalBus only. |
| `GlobalBus.emit` timing | sync after commit | microseconds later, in the forked fiber | No listener has microsecond-level expectations. |
| `bus.publish` failure | irrelevant to GlobalBus | short-circuits the gen, `GlobalBus.emit` does not fire | Intentional — if PubSub publish failed, no point emitting a notification. |
| Missing `InstanceRef` | sync throw inside `Database.effect`, surfaces to caller | `InstanceState.context` dies inside the forked fiber, logged by Effect runtime | Minor regression in error visibility. Only affects misuse from outside a handler context. |
| Service context available to `bus.publish` | only `InstanceRef` + `WorkspaceRef` via `attachWith` | full layer context via the bridge | Forward-compatible cleanup. |

## What's dropped

- `attachWith` import (no longer used)
- `PublishContext` type
- `InstanceContext` / `WorkspaceID` type imports
- Eager `options.context` snapshot in `run` and `replay`
- Defensive `if (!options.context?.instance) throw` (now naturally surfaces in fork)

## Regression coverage

- **`test/sync/index.test.ts > emits events`** — pre-existing. `sync.run` → ProjectBus subscriber receives event.
- **`test/sync/index.test.ts > emits sync events to GlobalBus after publishing to ProjectBus`** — **new in this PR**. Captures via `GlobalBus.on("event", ...)`, triggers `sync.run`, asserts the sync-typed event arrives. Verified to catch regressions: commenting out the `GlobalBus.emit` call in `sync/index.ts` flips it to red.
- **`test/server/httpapi-event-diagnostics.test.ts` D1-D7** — broader bus pipeline. Unchanged.
- **`test/server/httpapi-sdk.test.ts > streams sync-backed part updates to /event subscribers`** — full SDK E2E. Unchanged.

## Test plan

- [x] \`bun run test test/sync/index.test.ts\` — 12/12 green (includes the new GlobalBus test)
- [x] \`bun run test test/bus/bus-effect.test.ts test/server/httpapi-event.test.ts test/server/httpapi-event-diagnostics.test.ts\` — 29/29 green
- [x] \`bun run test test/server/httpapi-sdk.test.ts -t "streams sync-backed"\` — green
- [x] \`bun run typecheck\` — clean
- [x] Full \`bun run test\` — passes except the pre-existing FileWatcher symlink test that also fails on dev without this change; unrelated.

## Related

- Builds on #27959 (bus eager-subscribe refactor).
- Completes the audit of #27825 (sync publish bus injection).

## Net diff

\`\`\`
packages/opencode/src/sync/index.ts       | 92 +++++++++++++------------------
packages/opencode/test/sync/index.test.ts | 37 +++++++++++++
2 files changed, 76 insertions(+), 53 deletions(-)
\`\`\`