### PR TITLE
feat(tui): add syntax highlighting for elixir, fsharp, r, make, vim, xml, agda

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -296,5 +296,81 @@ export default {
         ],
       },
     },
+    {
+      filetype: "elixir",
+      wasm: "https://github.com/elixir-lang/tree-sitter-elixir/releases/download/v0.3.5/tree-sitter-elixir.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/elixir/highlights.scm",
+        ],
+        locals: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/elixir/locals.scm",
+        ],
+      },
+    },
+    {
+      filetype: "fsharp",
+      wasm: "https://github.com/ionide/tree-sitter-fsharp/releases/download/0.3.0/tree-sitter-fsharp.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/fsharp/highlights.scm",
+        ],
+      },
+    },
+    {
+      filetype: "r",
+      wasm: "https://github.com/r-lib/tree-sitter-r/releases/download/v1.2.0/tree-sitter-r.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/r/highlights.scm",
+        ],
+        locals: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/r/locals.scm",
+        ],
+      },
+    },
+    {
+      filetype: "make",
+      aliases: ["makefile"],
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-make/releases/download/v1.1.1/tree-sitter-make.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/make/highlights.scm",
+        ],
+      },
+    },
+    {
+      filetype: "vim",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-vim/releases/download/v0.8.1/tree-sitter-vim.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/vim/highlights.scm",
+        ],
+        locals: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/vim/locals.scm",
+        ],
+      },
+    },
+    {
+      filetype: "xml",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-xml/releases/download/v0.7.0/tree-sitter-xml.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/xml/highlights.scm",
+        ],
+        locals: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/xml/locals.scm",
+        ],
+      },
+    },
+    {
+      filetype: "agda",
+      wasm: "https://github.com/tree-sitter/tree-sitter-agda/releases/download/v1.3.3/tree-sitter-agda.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/agda/highlights.scm",
+        ],
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Adds seven new tree-sitter parsers to `packages/opencode/parsers-config.ts`:

| Language | Source | Tag |
|---|---|---|
| Elixir | `elixir-lang/tree-sitter-elixir` | v0.3.5 |
| F# | `ionide/tree-sitter-fsharp` | 0.3.0 |
| R | `r-lib/tree-sitter-r` | v1.2.0 |
| Make (aliases: `makefile`) | `tree-sitter-grammars/tree-sitter-make` | v1.1.1 |
| Vim script | `tree-sitter-grammars/tree-sitter-vim` | v0.8.1 |
| XML | `tree-sitter-grammars/tree-sitter-xml` | v0.7.0 |
| Agda | `tree-sitter/tree-sitter-agda` | v1.3.3 |

Selection criteria: each grammar (a) has a tagged release with a prebuilt `.wasm` asset that opentui can fetch directly, (b) comes from the language's canonical org or the existing `tree-sitter-grammars/*` community org already used in this file, and (c) has a corresponding `highlights.scm` (and `locals.scm` where applicable) in nvim-treesitter.

No new infrastructure: parsers are registered eagerly but the wasm and query assets load lazily on first use of each filetype, cached to `$XDG_DATA_HOME`.

Out of scope (would need self-hosted wasm builds since the grammar repos don't ship `.wasm` releases): Vue, Svelte, Dart, SQL, Dockerfile, GraphQL, Protobuf, Solidity, PowerShell, LaTeX, Objective-C, Erlang.

## Test plan

- [ ] Open a `.ex` / `.exs` file in the TUI and verify Elixir highlighting
- [ ] Open `.fs` / `.fsx` and verify F# highlighting
- [ ] Open `.r` / `.R` and verify R highlighting
- [ ] Open a `Makefile` and verify Make highlighting (also test ` ```makefile ` fenced block)
- [ ] Open a `.vim` file and verify Vim highlighting
- [ ] Open an `.xml` file and verify XML highlighting
- [ ] Open a `.agda` file and verify Agda highlighting
- [ ] Confirm first-time fetch of each wasm + scm succeeds and is cached