### PR TITLE
feat: implement configuration schema and loading utilities for openco…

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -703,7 +703,11 @@ export const layer = Layer.effect(
         }
 
         if (Flag.OPENCODE_PERMISSION) {
-          result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.OPENCODE_PERMISSION))
+          try {
+            result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.OPENCODE_PERMISSION))
+          } catch {
+            Log.warn("OPENCODE_PERMISSION contains invalid JSON, skipping")
+          }
         }
 
         if (result.tools) {


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `OPENCODE_PERMISSION` environment variable was parsed using `JSON.parse()` without error handling. If the value contains invalid JSON, the application crashes immediately on startup with an unhandled exception, preventing the app from starting.

The fix wraps `JSON.parse()` in a try/catch block. When parsing fails, a warning is logged and the permission config is skipped instead of crashing:

```ts
if (Flag.OPENCODE_PERMISSION) {
  try {
    result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.OPENCODE_PERMISSION))
  } catch {
    Log.warn("OPENCODE_PERMISSION contains invalid JSON, skipping")
  }
}
```

### How did you verify your code works?

Tested by setting `OPENCODE_PERMISSION` to malformed JSON (`OPENCODE_PERMISSION="{invalid"`) and confirming the app no longer crashes and instead logs a warning.

### Screenshots / recordings

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR