### PR TITLE
fix(core): fix file references in workspaces

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-tag.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-tag.tsx
@@ -1,12 +1,14 @@
 import { createMemo, createResource } from "solid-js"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
+import { useProject } from "@tui/context/project"
 import { useSDK } from "@tui/context/sdk"
 import { createStore } from "solid-js/store"
 
 export function DialogTag(props: { onSelect?: (value: string) => void }) {
   const sdk = useSDK()
   const dialog = useDialog()
+  const project = useProject()
 
   const [store] = createStore({
     filter: "",
@@ -17,6 +19,7 @@ export function DialogTag(props: { onSelect?: (value: string) => void }) {
     async () => {
       const result = await sdk.client.find.files({
         query: store.filter,
+        workspace: project.workspace.current(),
       })
       if (result.error) return []
       const sliced = (result.data ?? []).slice(0, 5)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -6,6 +6,7 @@ import { firstBy } from "remeda"
 import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Show, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useEditorContext } from "@tui/context/editor"
+import { useProject } from "@tui/context/project"
 import { useSDK } from "@tui/context/sdk"
 import { useSync } from "@tui/context/sync"
 import { getScrollAcceleration } from "../../util/scroll"
@@ -85,6 +86,7 @@ export function Autocomplete(props: {
   const editor = useEditorContext()
   const sdk = useSDK()
   const sync = useSync()
+  const project = useProject()
   const command = useCommandPalette()
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
@@ -382,6 +384,7 @@ export function Autocomplete(props: {
       // Get files from SDK
       const result = await sdk.client.find.files({
         query: baseQuery,
+        workspace: project.workspace.current(),
       })
 
       const options: AutocompleteOption[] = []


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix

### What does this PR do?

File reference autocomplete and the tag dialog were calling `sdk.client.find.files` without passing the current workspace, so they searched the wrong (or default) workspace when a project had multiple workspaces. This passes `project.workspace.current()` along with the query in both call sites:

- `packages/opencode/src/cli/cmd/tui/component/dialog-tag.tsx`
- `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`

### How did you verify your code works?

Opened a project with multiple workspaces in the TUI, switched the active workspace, and confirmed that both `@`-autocomplete and the tag dialog return files from the selected workspace instead of the previously-defaulted one.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR