### PR TITLE
fix(plugin): `ask` in tools from plugins returns promise instead of effect

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -40,6 +40,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Ripgrep } from "../file/ripgrep"
 import { Format } from "../format"
 import { InstanceState } from "@/effect/instance-state"
+import { EffectBridge } from "@/effect/bridge"
 import { Question } from "../question"
 import { Todo } from "../session/todo"
 import { LSP } from "@/lsp/lsp"
@@ -158,9 +159,12 @@ export const layer: Layer.Layer<
             description: def.description,
             execute: (args, toolCtx) =>
               Effect.gen(function* () {
+                // Bridge the host's Effect-based `ask` into a Promise-returning
+                // function for the plugin to make sure context persists
+                const bridge = yield* EffectBridge.make()
                 const pluginCtx: PluginToolContext = {
                   ...toolCtx,
-                  ask: (req) => toolCtx.ask(req),
+                  ask: (req) => bridge.promise(toolCtx.ask(req)),
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -1,5 +1,4 @@
 import { z } from "zod"
-import { Effect } from "effect"
 
 export type ToolContext = {
   sessionID: string
@@ -17,7 +16,7 @@ export type ToolContext = {
   worktree: string
   abort: AbortSignal
   metadata(input: { title?: string; metadata?: { [key: string]: any } }): void
-  ask(input: AskInput): Effect.Effect<void>
+  ask(input: AskInput): Promise<void>
 }
 
 type AskInput = {


### PR DESCRIPTION
## Summary

Plugins receive a `ToolContext` whose `ask` previously returned an `Effect.Effect<void>`. Since plugin `execute` callbacks are plain async functions, the only way to consume that was `Effect.runPromise(ctx.ask(...))`, which starts a fresh runtime with no `InstanceRef` provided. The host's `Permission.ask` calls `InstanceState.get`, which yields `InstanceRef` and dies with `InstanceRef not provided` (`packages/opencode/src/effect/instance-state.ts:17`) when the ref is absent.

This changes the plugin-facing `ask` signature to return `Promise<void>` and bridges the host's Effect-based `ask` at the registry seam in `fromPlugin`. Each call now builds an `EffectBridge` inside the parent fiber, which captures `InstanceRef` / `WorkspaceRef` from that fiber and re-attaches them when running the effect — matching the AGENTS.md guidance to use `EffectBridge` for plugin callbacks that re-enter Effect services.

Host-internal `Tool.Context.ask` continues to return an Effect; only the plugin-facing adapter is changed.

## Changes

- `packages/plugin/src/tool.ts`: `ToolContext.ask` now returns `Promise<void>`; drop the unused `effect` import.
- `packages/opencode/src/tool/registry.ts`: in `fromPlugin`'s wrapped `execute`, build `EffectBridge.make()` and expose `ask: (req) => bridge.promise(toolCtx.ask(req))` on the plugin context.

## Verification

- `bun typecheck` in `packages/opencode` and `packages/plugin` (both clean).
- Manual repro: a plugin tool calling `await context.ask({...})` resolves cleanly instead of throwing `InstanceRef not provided`.