### PR TITLE
fix(ui): guard reasoning renderer against undefined text

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1563,7 +1563,7 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
   const streaming = createMemo(
     () => props.message.role === "assistant" && typeof (props.message as AssistantMessage).time.completed !== "number",
   )
-  const text = () => (data.store.part_text_accum_delta?.[part().id] ?? part().text).trim()
+  const text = () => (data.store.part_text_accum_delta?.[part().id] ?? part().text ?? "").trim()
 
   return (
     <Show when={text()}>


### PR DESCRIPTION
## Summary

`ReasoningPartDisplay` in `packages/ui/src/components/message-part.tsx` crashes with `TypeError: Cannot read properties of undefined (reading 'trim')` when a reasoning part has no `part_text_accum_delta` entry and `part().text` is `undefined` (e.g. a reasoning-start / reasoning-end pair with no deltas in between).

Adds `?? ""` to the fallback chain so `.trim()` always sees a string. This mirrors the existing guard in `TextPartDisplay` ten lines above (line 1500), which was already written defensively:

```ts
const text = () => (data.store.part_text_accum_delta?.[part().id] ?? part().text ?? "").trim()
```

Closes #28212

## Why no regression test

The crash lives inside an inline closure in a Solid component (`message-part.tsx`). The package's existing test pattern (`message-file.test.ts`, etc.) covers exported pure helpers — there is no component-render harness in `packages/ui`. Extracting the one-liner just to test it would over-abstract for a one-character fix, so I verified by inspection against the working sibling on line 1500.

## Test plan

- [x] `bun run typecheck` clean in `packages/ui`
- [x] Workspace `turbo typecheck` clean (ran via pre-commit hook)
- [x] Existing `bun test src/components/message-file.test.ts` still passes
- [ ] Manual: open a session containing a reasoning-start/reasoning-end pair with no deltas and confirm no crash