### PR TITLE
feat(plugin): add experimental.message.store.before hook

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -35,6 +35,7 @@ import { SessionID, MessageID, PartID } from "./schema"
 import { ModelID, ProviderID } from "@/provider/schema"
 
 import type { Provider } from "@/provider/provider"
+import { Plugin } from "../plugin"
 import { Permission } from "@/permission"
 import { Global } from "@opencode-ai/core/global"
 import { Effect, Layer, Option, Context, Schema, Types } from "effect"
@@ -621,6 +622,15 @@ export const layer: Layer.Layer<
 
     const updatePart = <T extends MessageV2.Part>(part: T): Effect.Effect<T> =>
       Effect.gen(function* () {
+        const pluginOpt = yield* Effect.serviceOption(Plugin.Service)
+        if (Option.isSome(pluginOpt)) {
+          const output = yield* pluginOpt.value.trigger("experimental.message.store.before", {
+            sessionID: part.sessionID,
+            messageID: part.messageID,
+            partID: part.id,
+          }, { part })
+          part = output.part as T
+        }
         yield* sync.run(MessageV2.Event.PartUpdated, {
           sessionID: part.sessionID,
           part: structuredClone(part),

--- a/packages/opencode/test/plugin/message-store-before.test.ts
+++ b/packages/opencode/test/plugin/message-store-before.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer, Option } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config"
+import { Env } from "../../src/env"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { Plugin } from "../../src/plugin/index"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { NpmTest } from "../fake/npm"
+
+const emptyAccount = Layer.mock(Account.Service)({
+  active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
+})
+const emptyAuth = Layer.mock(Auth.Service)({
+  all: () => Effect.succeed({}),
+})
+const configLayer = Config.layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(Env.defaultLayer),
+  Layer.provide(emptyAuth),
+  Layer.provide(emptyAccount),
+  Layer.provide(NpmTest.noop),
+)
+const it = testEffect(
+  Layer.mergeAll(
+    Plugin.layer.pipe(
+      Layer.provide(Bus.layer),
+      Layer.provide(configLayer),
+      Layer.provide(RuntimeFlags.layer({ disableDefaultPlugins: true })),
+    ),
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
+
+const hookName = "experimental.message.store.before"
+
+function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+  return provideTmpdirInstance((dir) =>
+    Effect.gen(function* () {
+      const file = path.join(dir, "plugin.ts")
+      yield* Effect.all(
+        [
+          Effect.promise(() => Bun.write(file, source)),
+          Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify(
+                {
+                  $schema: "https://opencode.ai/config.json",
+                  plugin: [pathToFileURL(file).href],
+                },
+                null,
+                2,
+              ),
+            ),
+          ),
+        ],
+        { discard: true, concurrency: 2 },
+      )
+      return yield* self
+    }),
+  )
+}
+
+describe("experimental.message.store.before", () => {
+  it.live("mutates part text before storage", () =>
+    withProject(
+      [
+        "export default async () => ({",
+        `  ${JSON.stringify(hookName)}: async (_input, output) => {`,
+        '    if (output.part.type === "text") {',
+        '      output.part = { ...output.part, text: output.part.text.replace(/secret123/g, "***REDACTED***") }',
+        "    }",
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        const plugin = yield* Plugin.Service
+        const part = {
+          id: "part_test1",
+          sessionID: "ses_test1",
+          messageID: "msg_test1",
+          type: "text" as const,
+          text: "my password is secret123",
+        }
+        const out = yield* plugin.trigger(hookName, {
+          sessionID: part.sessionID,
+          messageID: part.messageID,
+          partID: part.id,
+        }, { part })
+        expect(out.part.text).toBe("my password is ***REDACTED***")
+      }),
+    ),
+  )
+
+  it.live("passes input metadata to the hook", () =>
+    withProject(
+      [
+        "export default async () => ({",
+        `  ${JSON.stringify(hookName)}: async (input, output) => {`,
+        '    if (output.part.type === "text") {',
+        "      output.part = { ...output.part, text: `${input.sessionID}:${input.messageID}:${input.partID}` }",
+        "    }",
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        const plugin = yield* Plugin.Service
+        const part = {
+          id: "part_abc",
+          sessionID: "ses_xyz",
+          messageID: "msg_def",
+          type: "text" as const,
+          text: "original",
+        }
+        const out = yield* plugin.trigger(hookName, {
+          sessionID: part.sessionID,
+          messageID: part.messageID,
+          partID: part.id,
+        }, { part })
+        expect(out.part.text).toBe("ses_xyz:msg_def:part_abc")
+      }),
+    ),
+  )
+
+  it.live("leaves non-text parts unmodified when hook only handles text", () =>
+    withProject(
+      [
+        "export default async () => ({",
+        `  ${JSON.stringify(hookName)}: async (_input, output) => {`,
+        '    if (output.part.type === "text") {',
+        '      output.part = { ...output.part, text: "REDACTED" }',
+        "    }",
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        const plugin = yield* Plugin.Service
+        const part = {
+          id: "part_tool1",
+          sessionID: "ses_test1",
+          messageID: "msg_test1",
+          type: "step-start" as const,
+          title: "Running build",
+        }
+        const out = yield* plugin.trigger(hookName, {
+          sessionID: part.sessionID,
+          messageID: part.messageID,
+          partID: part.id,
+        }, { part })
+        expect(out.part).toEqual(part)
+      }),
+    ),
+  )
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -330,4 +330,17 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  /**
+   * Called before a message part is persisted to the database.
+   * Allows plugins to redact or transform part data before it hits disk.
+   *
+   * - `part`: The mutable part object about to be stored. Modify its fields
+   *   (e.g. `part.text`, `part.state.output`) to change what is persisted.
+   *
+   * Use cases: PII/secret redaction at rest, content filtering, audit logging.
+   */
+  "experimental.message.store.before"?: (
+    input: { sessionID: string; messageID: string; partID: string },
+    output: { part: Part },
+  ) => Promise<void>
 }


### PR DESCRIPTION
### Issue for this PR

Closes #28223

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `experimental.message.store.before` — a plugin hook that fires inside `updatePart()` before a message part is written to SQLite. Plugins can mutate `output.part` to redact sensitive content before it hits disk.

**Why this is needed:** The existing `experimental.chat.messages.transform` hook only redacts what goes to the LLM API. Raw message text (including PII and secrets) still persists in the local database. There is no way for a plugin to prevent that today.

**How it works:** `updatePart()` is the single function all part writes flow through (prompt, processor, compaction, plan, reminders, HTTP API). I added `Effect.serviceOption(Plugin.Service)` before the `sync.run(PartUpdated)` call so the hook fires only when the Plugin service is available — zero cost when no plugins register it.

The hook signature follows the same `(input, output) => Promise<void>` pattern as every other trigger hook.

### How did you verify your code works?

- `npx tsc --noEmit` passes on both `packages/opencode` and `packages/plugin`
- Added 3 tests in `test/plugin/message-store-before.test.ts`:
  1. Text part mutation (redaction use case)
  2. Input metadata correctly passed (sessionID, messageID, partID)
  3. Non-text parts unaffected by text-only hook
- Existing `test/plugin/trigger.test.ts` still passes (2/2)

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR