### PR TITLE
fix(app): preserve composer draft through permission prompts

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -77,7 +77,7 @@ async function setAutoAccept(page: any, enabled: boolean) {
 
 async function expectQuestionBlocked(page: any) {
   await expect(page.locator(questionDockSelector)).toBeVisible()
-  await expect(page.locator(promptSelector)).toHaveCount(0)
+  await expect(page.locator(promptSelector)).toBeHidden()
 }
 
 async function expectQuestionOpen(page: any) {
@@ -87,7 +87,7 @@ async function expectQuestionOpen(page: any) {
 
 async function expectPermissionBlocked(page: any) {
   await expect(page.locator(permissionDockSelector)).toBeVisible()
-  await expect(page.locator(promptSelector)).toHaveCount(0)
+  await expect(page.locator(promptSelector)).toBeHidden()
 }
 
 async function expectPermissionOpen(page: any) {
@@ -268,6 +268,9 @@ async function withMockPermission<T>(
     if (sessionList) await page.unroute("**/session?*", sessionList)
   }
 }
+
+const promptText = async (page: any) =>
+  ((await page.locator(promptSelector).textContent()) ?? "").replace(/\u200B/g, "").trim()
 
 test("default dock shows prompt input", async ({ page, project }) => {
   await project.open()
@@ -486,6 +489,49 @@ test("blocked permission flow supports allow always", async ({ page, project }) 
   )
 })
 
+test("blocked permission flow preserves typed draft", async ({ page, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock permission preserves draft",
+    async (session) => {
+      await project.gotoSession(session.id)
+      await setAutoAccept(page, false)
+
+      const value = `followup ${Date.now()}`
+      const prompt = page.locator(promptSelector)
+
+      await prompt.click()
+      await page.keyboard.type(value)
+      await expect.poll(() => promptText(page)).toBe(value)
+
+      await withMockPermission(
+        page,
+        {
+          id: "per_e2e_preserve_draft",
+          sessionID: session.id,
+          permission: "bash",
+          patterns: ["/tmp/opencode-e2e-preserve-draft"],
+          metadata: { description: "Need permission while draft exists" },
+        },
+        undefined,
+        async (state) => {
+          await page.goto(page.url())
+          await expectPermissionBlocked(page)
+
+          await clearPermissionDock(page, /allow once/i)
+          await state.resolved()
+          await page.goto(page.url())
+
+          await expectPermissionOpen(page)
+          await expect.poll(() => promptText(page)).toBe(value)
+        },
+      )
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
 test("child session question request blocks parent dock and unblocks after submit", async ({ page, llm, project }) => {
   const questions = [
     {
@@ -647,7 +693,7 @@ test("keyboard focus stays off prompt while blocked", async ({ page, llm, projec
 
         await page.locator("main").click({ position: { x: 5, y: 5 } })
         await page.keyboard.type("abc")
-        await expect(page.locator(promptSelector)).toHaveCount(0)
+        await expect(page.locator(promptSelector)).toBeHidden()
       })
     },
     { trackSession: project.trackSession },

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -249,7 +249,12 @@ export function SessionComposerRegion(props: {
               <Show
                 when={child()}
                 fallback={
-                  <Show when={!props.state.blocked()}>
+                  <div
+                    aria-hidden={props.state.blocked() ? "true" : undefined}
+                    classList={{
+                      hidden: props.state.blocked(),
+                    }}
+                  >
                     <PromptInput
                       ref={props.inputRef}
                       newSessionWorktree={props.newSessionWorktree}
@@ -261,7 +266,7 @@ export function SessionComposerRegion(props: {
                       onAbort={props.followup?.onAbort}
                       onSubmit={props.onSubmit}
                     />
-                  </Show>
+                  </div>
                 }
               >
                 <div


### PR DESCRIPTION
### Issue for this PR

Closes #28228

### Type of change

- [x] Bug fix

### What does this PR do?

The composer wraps \<PromptInput>\ in \<Show when={!props.state.blocked()}>\. SolidJS's \<Show>\ unmounts the component when the condition turns false, so any text typed into the prompt is destroyed the moment a permission request blocks the UI.

The fix is to replace \<Show>\ with a plain \<div>\ that keeps \PromptInput>\ mounted at all times, hiding it with a CSS \hidden\ class and \ria-hidden\ when blocked. The draft stays in the DOM through the permission flow and is still there after the user allows/rejects.

Two E2E helper functions (\expectQuestionBlocked\, \expectPermissionBlocked\) previously asserted \.toHaveCount(0)\ — that no longer works since the element is always present. Updated both to \.toBeHidden()\. Added a new test \locked permission flow preserves typed draft\ that types a value, triggers a mock permission, resolves it, and checks the value is still there.

### How did you verify your code works?

Ran the E2E tests locally. Manually tested by typing in the composer, triggering a permission prompt, allowing it, and confirming the text was still there.

### Screenshots / recordings

_No visual change — the prompt looks identical when not blocked._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR