### PR TITLE
fix(opencode): clarify GitHub remote detection error

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -257,7 +257,9 @@ export const GithubInstallCommand = effectCmd({
           )
           const parsed = parseGitHubRemote(info)
           if (!parsed) {
-            prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
+            prompts.log.error(
+              `Could not detect a GitHub repository from your Git remote. Please set \`origin\` to a GitHub repo and try again.`,
+            )
             throw new UI.CancelledError()
           }
           return { owner: parsed.owner, repo: parsed.repo, root: ctx.worktree }


### PR DESCRIPTION
### Issue for this PR

Closes #28233

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Clarifies the error shown when `opencode github install` cannot detect a GitHub repository from the configured Git remote.

### How did you verify your code works?

Installed locally and ran `opencode github install` in a repo with no `origin` remote.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR