### PR TITLE
fix(native-llm): prefer console opencode token

### DIFF
--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -42,12 +42,7 @@ export function status(input: Pick<StreamInput, "model" | "provider" | "auth">):
   if (input.model.api.npm !== "@ai-sdk/openai") return { type: "unsupported", reason: "provider package is not OpenAI" }
   if (input.auth?.type === "oauth") return { type: "unsupported", reason: "OAuth auth is not supported" }
 
-  const apiKey =
-    input.auth?.type === "api"
-      ? input.auth.key
-      : typeof input.provider.options.apiKey === "string"
-        ? input.provider.options.apiKey
-        : undefined
+  const apiKey = typeof input.provider.options.apiKey === "string" ? input.provider.options.apiKey : input.provider.key
   if (!apiKey) return { type: "unsupported", reason: "OpenAI API key is not configured" }
 
   return {

--- a/packages/opencode/test/session/llm-native.test.ts
+++ b/packages/opencode/test/session/llm-native.test.ts
@@ -292,6 +292,34 @@ describe("session.llm-native.request", () => {
     ).toEqual({ type: "unsupported", reason: "OpenAI API key is not configured" })
   })
 
+  test("prefers console provider api key over stored opencode auth", () => {
+    expect(
+      LLMNativeRuntime.status({
+        model: { ...baseModel, providerID: ProviderID.make("opencode") },
+        provider: {
+          ...providerInfo,
+          id: ProviderID.make("opencode"),
+          options: { apiKey: "console-token" },
+          key: "zen-token",
+        },
+        auth: { type: "api", key: "zen-token" },
+      }),
+    ).toMatchObject({
+      type: "supported",
+      apiKey: "console-token",
+    })
+    expect(
+      LLMNativeRuntime.status({
+        model: baseModel,
+        provider: { ...providerInfo, options: {}, key: "provider-key" },
+        auth: undefined,
+      }),
+    ).toMatchObject({
+      type: "supported",
+      apiKey: "provider-key",
+    })
+  })
+
   test("native tool wrapper converts thrown errors into typed ToolFailure", async () => {
     const wrapped = LLMNativeRuntime.nativeTools(
       {


### PR DESCRIPTION
## Summary
- Make native LLM auth selection match provider resolution by preferring provider options apiKey before provider key fallback
- Prevent stored opencode/Zen auth from overriding the console-managed token for opencode proxy models
- Add a regression test for console token precedence when stored opencode auth is also present

## Verification
- bun run test -- test/session/llm-native.test.ts test/session/llm-native-recorded.test.ts
- bun typecheck
- bunx prettier --check packages/opencode/src/session/llm/native-runtime.ts packages/opencode/test/session/llm-native.test.ts
- bun run oxlint packages/opencode/src/session/llm/native-runtime.ts packages/opencode/test/session/llm-native.test.ts (warnings only, existing assertions/casts)
- git push hook: bun turbo typecheck

## Notes
- Broader scan found provider-specific custom loaders with their own env/auth precedence, but no other opencode console/native path using stored auth over console provider options.