### PR TITLE
fix(session): hide skill template text from chat and terminal UIs

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1757,7 +1757,13 @@ export const layer = Layer.effect(
               prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
             },
           ]
-        : [...templateParts, ...(input.parts ?? [])]
+        : cmd.source === "skill"
+          ? [
+              { type: "text" as const, text: `/${input.command}` },
+              ...templateParts.map((p) => (p.type === "text" ? { ...p, synthetic: true } : p)),
+              ...(input.parts ?? []),
+            ]
+          : [...templateParts, ...(input.parts ?? [])]
 
       const userAgent = isSubtask ? (input.agent ?? (yield* agents.defaultInfo()).name) : agent.name
       const userModel = isSubtask


### PR DESCRIPTION
### Issue for this PR

Closes #27686
Closes #26185

### Type of change

- [x] Bug fix

### What does this PR do?

When a skill is invoked via slash command (e.g. `/my-skill`), the full contents of `SKILL.md` were being stored as a non-synthetic text part of the user message and rendered verbatim in both the web/desktop and terminal UIs. The user typed `/my-skill` but the chat displayed something they never wrote.

The fix is in `SessionPrompt.command`: for commands with `source === "skill"`, a short non-synthetic text part (`/<command-name>`) is prepended and all template text parts are marked `synthetic: true`. Both UIs already respect the `synthetic` flag — the web UI's `textPart()` memo skips synthetic parts, and the terminal UI's `formatPart` does the same. The LLM is unaffected since `buildMessages` does not filter on `synthetic`, so the full skill content is still delivered as context.

As a side effect, this also fixes the double-loading issue described in #26185: since the skill content is now marked synthetic rather than injected as a visible user message, well-behaved models are less likely to re-invoke the `skill` tool thinking the content hasn't been loaded yet.

### How did you verify your code works?

I tested this locally in the desktop and TUI.

### Screenshots / recordings

https://github.com/user-attachments/assets/09f03da6-0df2-41d6-8bbc-74f749c6b92c


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR