### PR TITLE
fix: normalize forward slashes to backslashes for Windows directory matching

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -20,6 +20,7 @@ import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
+import { normalizeDirectory } from "../middleware/workspace-routing"
 import {
   CommandPayload,
   DiffQuery,
@@ -60,7 +61,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
 
     const list = Effect.fn("SessionHttpApi.list")(function* (ctx: { query: typeof ListQuery.Type }) {
       return yield* session.list({
-        directory: ctx.query.scope === "project" ? undefined : ctx.query.directory,
+        directory: ctx.query.scope === "project" ? undefined : ctx.query.directory ? normalizeDirectory(ctx.query.directory) : undefined,
         scope: ctx.query.scope,
         path: ctx.query.path,
         roots: ctx.query.roots,

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -68,8 +68,18 @@ function selectedWorkspaceID(url: URL, sessionWorkspaceID?: WorkspaceID): Worksp
   return sessionWorkspaceID ?? (workspaceParam ? WorkspaceID.make(workspaceParam) : undefined)
 }
 
+export function normalizeDirectory(dir: string): string {
+  if (process.platform !== "win32") return dir
+  if (dir.length >= 2 && dir[1] === ":" && dir.includes("/")) return dir.replaceAll("/", "\\")
+  return dir
+}
+
 function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string {
-  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
+  const fromQuery = url.searchParams.get("directory")
+  if (fromQuery) return normalizeDirectory(fromQuery)
+  const fromHeader = request.headers["x-opencode-directory"]
+  if (fromHeader) return normalizeDirectory(decodeURIComponent(fromHeader))
+  return process.cwd()
 }
 
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {


### PR DESCRIPTION
### Issue for this PR

https://github.com/anomalyco/opencode/issues/28242

Closes #28242

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, the web UI frontend normalizes paths to forward slashes (C:/Users/...) but the database stores backslashes (C:\Users\...). This caused session list queries to return 0 results after a page refresh, because the directory filter did an exact string match.

Add normalizeDirectory() that converts forward slashes to backslashes on Windows when the path looks like a drive letter path (X:/...). Apply it in the workspace-routing middleware and the session list handler.

### How did you verify your code works?

i run the dev server and opened a project  made some sessions and just refresh the page
Or just restart the server and let the browser reload itself, mostly on windows you loose all the sessions (or keep only 1 for some reason)

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
