### PR TITLE
fix(session): include friendly provider name in system identity prompt

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -11,7 +11,7 @@ import PROMPT_KIMI from "./prompt/kimi.txt"
 
 import PROMPT_CODEX from "./prompt/codex.txt"
 import PROMPT_TRINITY from "./prompt/trinity.txt"
-import type { Provider } from "@/provider/provider"
+import { Provider } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
@@ -43,13 +43,17 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const skill = yield* Skill.Service
+    const providerService = yield* Provider.Service
 
     return Service.of({
       environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model) {
         const ctx = yield* InstanceState.context
+        const providerInfo = yield* providerService.getProvider(model.providerID).pipe(Effect.option)
+        const providerName =
+          providerInfo._tag === "Some" ? providerInfo.value.name : model.providerID
         return [
           [
-            `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
+            `You are powered by the model named ${model.name} from provider ${providerName}. The exact model ID is ${model.providerID}/${model.api.id}`,
             `Here is some useful information about the environment you are running in:`,
             `<env>`,
             `  Working directory: ${ctx.directory}`,
@@ -79,6 +83,6 @@ export const layer = Layer.effect(
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(Skill.defaultLayer))
+export const defaultLayer = layer.pipe(Layer.provide(Skill.defaultLayer), Layer.provide(Provider.defaultLayer))
 
 export * as SystemPrompt from "./system"

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -4,6 +4,7 @@ import type { Agent } from "../../src/agent/agent"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Skill } from "../../src/skill"
 import { Permission } from "../../src/permission"
+import { Provider } from "../../src/provider/provider"
 import { SystemPrompt } from "../../src/session/system"
 import { testEffect } from "../lib/effect"
 
@@ -50,6 +51,20 @@ const it = testEffect(
           all: () => Effect.succeed(skills),
           dirs: () => Effect.succeed([]),
           available: () => Effect.succeed(skills),
+        }),
+      ),
+    ),
+    Layer.provide(
+      Layer.succeed(
+        Provider.Service,
+        Provider.Service.of({
+          list: () => Effect.die("not used in this test"),
+          getProvider: () => Effect.die("not used in this test"),
+          getModel: () => Effect.die("not used in this test"),
+          getLanguage: () => Effect.die("not used in this test"),
+          closest: () => Effect.die("not used in this test"),
+          getSmallModel: () => Effect.die("not used in this test"),
+          defaultModel: () => Effect.die("not used in this test"),
         }),
       ),
     ),


### PR DESCRIPTION
### Issue for this PR

Closes #28243

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The identity line in the system prompt names the provider only by its raw id, not its friendly name. For unfamiliar ids that can cause the model to hallucinate (see #28243).

This fix uses the friendly name from the existing Provider service, keeping the raw `<providerID>/<api.id>` alongside for tooling:

```
Before: You are powered by the model named zai-org/GLM-5.1-FP8. The exact model ID is neuralwatt/zai-org/GLM-5.1-FP8
After:  You are powered by the model named GLM 5.1 FP8 from provider Neuralwatt. The exact model ID is neuralwatt/zai-org/GLM-5.1-FP8
```

### How did you verify your code works?

Reproduced the AGENTS.md hallucination locally against a real provider, applied the fix, and confirmed the commit message now uses the real model and provider name. Updated `session/system.test.ts` to provide the Provider stub the layer now depends on.

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
