### PR TITLE
fix: add cross-process file locking for parallel session isolation

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -6,6 +6,7 @@ import { AppProcess } from "@opencode-ai/core/process"
 import { InstanceState } from "@/effect/instance-state"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Hash } from "@opencode-ai/core/util/hash"
+import { Flock } from "@opencode-ai/core/util/flock"
 import { Config } from "@/config/config"
 import { Global } from "@opencode-ai/core/global"
 import * as Log from "@opencode-ai/core/util/log"
@@ -163,7 +164,14 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
           const exists = (file: string) => fs.exists(file).pipe(Effect.orDie)
           const read = (file: string) => fs.readFileString(file).pipe(Effect.catch(() => Effect.succeed("")))
           const remove = (file: string) => fs.remove(file).pipe(Effect.catch(() => Effect.void))
-          const locked = <A, E, R>(fx: Effect.Effect<A, E, R>) => lock(state.gitdir).withPermits(1)(fx)
+          const locked = <A, E, R>(fx: Effect.Effect<A, E, R>) =>
+            lock(state.gitdir).withPermits(1)(
+              Effect.acquireUseRelease(
+                Effect.promise((signal) => Flock.acquire(`snapshot:${state.gitdir}`, { signal, staleMs: 30_000 })),
+                () => fx,
+                (lease) => Effect.promise(() => lease.release()),
+              ),
+            )
 
           const enabled = Effect.fnUntraced(function* () {
             if (state.vcs !== "git") return false

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -10,6 +10,7 @@ import { assertExternalDirectoryEffect } from "./external-directory"
 import { trimDiff } from "./edit"
 import { LSP } from "@/lsp/lsp"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Flock } from "@opencode-ai/core/util/flock"
 import DESCRIPTION from "./apply_patch.txt"
 import { File } from "../file"
 import { Format } from "../format"
@@ -217,45 +218,58 @@ export const ApplyPatchTool = Tool.define(
       // Apply the changes
       const updates: Array<{ file: string; event: "add" | "change" | "unlink" }> = []
 
-      for (const change of fileChanges) {
-        const edited = change.type === "delete" ? undefined : (change.movePath ?? change.filePath)
-        switch (change.type) {
-          case "add":
-            // Create parent directories (recursive: true is safe on existing/root dirs)
+      // Acquire cross-process locks for all affected files to prevent races with parallel sessions
+      const affectedFiles = Array.from(
+        new Set(fileChanges.flatMap((c) => [c.filePath, ...(c.movePath ? [c.movePath] : [])])),
+      ).sort()
+      yield* Effect.acquireUseRelease(
+        Effect.forEach(affectedFiles, (file) =>
+          Effect.promise((signal) => Flock.acquire(`edit:${file}`, { signal, staleMs: 30_000 })),
+        ),
+        (leases) =>
+          Effect.gen(function* () {
+            for (const change of fileChanges) {
+              const edited = change.type === "delete" ? undefined : (change.movePath ?? change.filePath)
+              switch (change.type) {
+                case "add":
+                  // Create parent directories (recursive: true is safe on existing/root dirs)
 
-            yield* afs.writeWithDirs(change.filePath, Bom.join(change.newContent, change.bom))
-            updates.push({ file: change.filePath, event: "add" })
-            break
+                  yield* afs.writeWithDirs(change.filePath, Bom.join(change.newContent, change.bom))
+                  updates.push({ file: change.filePath, event: "add" })
+                  break
 
-          case "update":
-            yield* afs.writeWithDirs(change.filePath, Bom.join(change.newContent, change.bom))
-            updates.push({ file: change.filePath, event: "change" })
-            break
+                case "update":
+                  yield* afs.writeWithDirs(change.filePath, Bom.join(change.newContent, change.bom))
+                  updates.push({ file: change.filePath, event: "change" })
+                  break
 
-          case "move":
-            if (change.movePath) {
-              // Create parent directories (recursive: true is safe on existing/root dirs)
+                case "move":
+                  if (change.movePath) {
+                    // Create parent directories (recursive: true is safe on existing/root dirs)
 
-              yield* afs.writeWithDirs(change.movePath!, Bom.join(change.newContent, change.bom))
-              yield* afs.remove(change.filePath)
-              updates.push({ file: change.filePath, event: "unlink" })
-              updates.push({ file: change.movePath, event: "add" })
+                    yield* afs.writeWithDirs(change.movePath!, Bom.join(change.newContent, change.bom))
+                    yield* afs.remove(change.filePath)
+                    updates.push({ file: change.filePath, event: "unlink" })
+                    updates.push({ file: change.movePath, event: "add" })
+                  }
+                  break
+
+                case "delete":
+                  yield* afs.remove(change.filePath)
+                  updates.push({ file: change.filePath, event: "unlink" })
+                  break
+              }
+
+              if (edited) {
+                if (yield* format.file(edited)) {
+                  yield* Bom.syncFile(afs, edited, change.bom)
+                }
+                yield* bus.publish(File.Event.Edited, { file: edited })
+              }
             }
-            break
-
-          case "delete":
-            yield* afs.remove(change.filePath)
-            updates.push({ file: change.filePath, event: "unlink" })
-            break
-        }
-
-        if (edited) {
-          if (yield* format.file(edited)) {
-            yield* Bom.syncFile(afs, edited, change.bom)
-          }
-          yield* bus.publish(File.Event.Edited, { file: edited })
-        }
-      }
+          }),
+        (leases) => Effect.promise(() => Promise.all(leases.map((l) => l.release().catch(() => {})))),
+      )
 
       // Publish file change events
       for (const update of updates) {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -17,6 +17,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Flock } from "@opencode-ai/core/util/flock"
 import * as Bom from "@/util/bom"
 
 function normalizeLineEndings(text: string): string {
@@ -34,7 +35,7 @@ function convertToLineEnding(text: string, ending: "\n" | "\r\n"): string {
 
 const locks = new Map<string, Semaphore.Semaphore>()
 
-function lock(filePath: string) {
+function inProcessLock(filePath: string) {
   const resolvedFilePath = AppFileSystem.resolve(filePath)
   const hit = locks.get(resolvedFilePath)
   if (hit) return hit
@@ -42,6 +43,17 @@ function lock(filePath: string) {
   const next = Semaphore.makeUnsafe(1)
   locks.set(resolvedFilePath, next)
   return next
+}
+
+function lock<A, E, R>(filePath: string, fx: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> {
+  const resolved = AppFileSystem.resolve(filePath)
+  return inProcessLock(resolved).withPermits(1)(
+    Effect.acquireUseRelease(
+      Effect.promise((signal) => Flock.acquire(`edit:${resolved}`, { signal, staleMs: 30_000 })),
+      () => fx,
+      (lease) => Effect.promise(() => lease.release()),
+    ),
+  )
 }
 
 export const Parameters = Schema.Struct({
@@ -85,7 +97,7 @@ export const EditTool = Tool.define(
           let diff = ""
           let contentOld = ""
           let contentNew = ""
-          yield* lock(filePath).withPermits(1)(
+          yield* lock(filePath,
             Effect.gen(function* () {
               if (params.oldString === "") {
                 const existed = yield* afs.existsSafe(filePath)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -10,6 +10,7 @@ import { File } from "../file"
 import { FileWatcher } from "../file/watcher"
 import { Format } from "../format"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Flock } from "@opencode-ai/core/util/flock"
 import { InstanceState } from "@/effect/instance-state"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
@@ -43,61 +44,69 @@ export const WriteTool = Tool.define(
             : path.join(instance.directory, params.filePath)
           yield* assertExternalDirectoryEffect(ctx, filepath)
 
-          const exists = yield* fs.existsSafe(filepath)
-          const source = exists ? yield* Bom.readFile(fs, filepath) : { bom: false, text: "" }
-          const next = Bom.split(params.content)
-          const desiredBom = source.bom || next.bom
-          const contentOld = source.text
-          const contentNew = next.text
+          const resolved = AppFileSystem.resolve(filepath)
+          return yield* Effect.acquireUseRelease(
+            Effect.promise((signal) => Flock.acquire(`edit:${resolved}`, { signal, staleMs: 30_000 })),
+            () =>
+              Effect.gen(function* () {
+                const exists = yield* fs.existsSafe(filepath)
+                const source = exists ? yield* Bom.readFile(fs, filepath) : { bom: false, text: "" }
+                const next = Bom.split(params.content)
+                const desiredBom = source.bom || next.bom
+                const contentOld = source.text
+                const contentNew = next.text
 
-          const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, contentNew))
-          yield* ctx.ask({
-            permission: "edit",
-            patterns: [path.relative(instance.worktree, filepath)],
-            always: ["*"],
-            metadata: {
-              filepath,
-              diff,
-            },
-          })
+                const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, contentNew))
+                yield* ctx.ask({
+                  permission: "edit",
+                  patterns: [path.relative(instance.worktree, filepath)],
+                  always: ["*"],
+                  metadata: {
+                    filepath,
+                    diff,
+                  },
+                })
 
-          yield* fs.writeWithDirs(filepath, Bom.join(contentNew, desiredBom))
-          if (yield* format.file(filepath)) {
-            yield* Bom.syncFile(fs, filepath, desiredBom)
-          }
-          yield* bus.publish(File.Event.Edited, { file: filepath })
-          yield* bus.publish(FileWatcher.Event.Updated, {
-            file: filepath,
-            event: exists ? "change" : "add",
-          })
+                yield* fs.writeWithDirs(filepath, Bom.join(contentNew, desiredBom))
+                if (yield* format.file(filepath)) {
+                  yield* Bom.syncFile(fs, filepath, desiredBom)
+                }
+                yield* bus.publish(File.Event.Edited, { file: filepath })
+                yield* bus.publish(FileWatcher.Event.Updated, {
+                  file: filepath,
+                  event: exists ? "change" : "add",
+                })
 
-          let output = "Wrote file successfully."
-          yield* lsp.touchFile(filepath, "document")
-          const diagnostics = yield* lsp.diagnostics()
-          const normalizedFilepath = AppFileSystem.normalizePath(filepath)
-          let projectDiagnosticsCount = 0
-          for (const [file, issues] of Object.entries(diagnostics)) {
-            const current = file === normalizedFilepath
-            if (!current && projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
-            const block = LSP.Diagnostic.report(current ? filepath : file, issues)
-            if (!block) continue
-            if (current) {
-              output += `\n\nLSP errors detected in this file, please fix:\n${block}`
-              continue
-            }
-            projectDiagnosticsCount++
-            output += `\n\nLSP errors detected in other files:\n${block}`
-          }
+                let output = "Wrote file successfully."
+                yield* lsp.touchFile(filepath, "document")
+                const diagnostics = yield* lsp.diagnostics()
+                const normalizedFilepath = AppFileSystem.normalizePath(filepath)
+                let projectDiagnosticsCount = 0
+                for (const [file, issues] of Object.entries(diagnostics)) {
+                  const current = file === normalizedFilepath
+                  if (!current && projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
+                  const block = LSP.Diagnostic.report(current ? filepath : file, issues)
+                  if (!block) continue
+                  if (current) {
+                    output += `\n\nLSP errors detected in this file, please fix:\n${block}`
+                    continue
+                  }
+                  projectDiagnosticsCount++
+                  output += `\n\nLSP errors detected in other files:\n${block}`
+                }
 
-          return {
-            title: path.relative(instance.worktree, filepath),
-            metadata: {
-              diagnostics,
-              filepath,
-              exists: exists,
-            },
-            output,
-          }
+                return {
+                  title: path.relative(instance.worktree, filepath),
+                  metadata: {
+                    diagnostics,
+                    filepath,
+                    exists: exists,
+                  },
+                  output,
+                }
+              }),
+            (lease) => Effect.promise(() => lease.release()),
+          )
         }).pipe(Effect.orDie),
     }
   }),


### PR DESCRIPTION
Fixes #28249

## Summary

Adds cross-process file locking to prevent parallel opencode sessions from corrupting each other's file edits and snapshot state.

## What changed

When multiple opencode instances run in parallel on the same project, they share the same snapshot git directory and working directory files. The existing in-memory `Semaphore` locks only protect within a single process, so concurrent processes can corrupt snapshot state and overwrite each other's file edits.

Added cross-process file locking using the existing `Flock` utility (directory-based locks with heartbeat and stale detection):

- **Snapshot module** (`src/snapshot/index.ts`): Wraps all git operations with a cross-process lock keyed by the snapshot gitdir path
- **Edit tool** (`src/tool/edit.ts`): Combines in-process Semaphore with cross-process Flock per file path
- **Write tool** (`src/tool/write.ts`): Wraps file write operations with cross-process Flock lock
- **Apply patch tool** (`src/tool/apply_patch.ts`): Acquires sorted cross-process locks for all affected files before writing (prevents deadlocks)

The in-memory Semaphore is retained as a fast-path for in-process concurrency. Locks use a 30-second stale timeout for automatic recovery from crashed processes.

## Testing

All existing tests pass:
- 52 snapshot tests ✓
- 27 edit tool tests ✓ (including concurrent editing)
- 15 write tool tests ✓
- 27 apply_patch tests ✓
- 1 snapshot-tool-race test ✓