### PR TITLE
fix(app): normalize backslashes in directory select dialog input

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -25,7 +25,10 @@ type Row = {
 
 function cleanInput(value: string) {
   const first = (value ?? "").split(/\r?\n/)[0] ?? ""
-  return first.replace(/[\u0000-\u001F\u007F]/g, "").trim()
+  return first
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .trim()
+    .replaceAll("\\", "/")
 }
 
 function normalizePath(input: string) {
@@ -339,7 +342,11 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           group.category === "recent" ? language.t("home.recentProjects") : language.t("command.project.open")
         }
         ref={(r) => (list = r)}
-        onFilter={(value) => setFilter(cleanInput(value))}
+        onFilter={(value) => {
+          const cleaned = cleanInput(value)
+          setFilter(cleaned)
+          if (value !== cleaned) list?.setFilter(cleaned)
+        }}
         onKeyEvent={(e, item) => {
           if (e.key !== "Tab") return
           if (e.shiftKey) return


### PR DESCRIPTION
### Issue for this PR

https://github.com/anomalyco/opencode/issues/28252

Closes #28252

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, pasting a path with backslashes into the directory select dialog would fail to match because the filter/list uses forward slashes internally. Convert backslashes to forward slashes in cleanInput() and sync the list filter when the cleaned value differs from raw input.


### How did you verify your code works?

i run the dev server to see how it now behaves and copy/paste whole paths or just typing in it will right away convert the \ to a / (even visible)

### Screenshots / recordings

<img width="539" height="344" alt="image" src="https://github.com/user-attachments/assets/aba1f4c5-833f-43f9-bca6-1c96f7024677" />

you can't really see it but i did type \ instead of / but that is just inserted.
Also copy/paste a whole path works.

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
