### PR TITLE
refactor(ui): extract readPartText helper with regression test for #28212

### DIFF
--- a/packages/ui/src/components/message-part-text.ts
+++ b/packages/ui/src/components/message-part-text.ts
@@ -1,0 +1,6 @@
+export function readPartText(
+  accum: Record<string, string> | undefined,
+  part: { id: string; text?: string },
+): string {
+  return (accum?.[part.id] ?? part.text ?? "").trim()
+}

--- a/packages/ui/src/components/message-part.test.ts
+++ b/packages/ui/src/components/message-part.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { readPartText } from "./message-part-text"
+
+describe("readPartText", () => {
+  test("returns empty string when accum is undefined and part text is undefined", () => {
+    expect(readPartText(undefined, { id: "part_1" })).toBe("")
+  })
+
+  test("returns trimmed part text when accum is undefined", () => {
+    expect(readPartText(undefined, { id: "part_1", text: "  hello  " })).toBe("hello")
+  })
+
+  test("prefers accum value over part text when accum has a hit", () => {
+    expect(readPartText({ part_1: "  from accum  " }, { id: "part_1", text: "from part" })).toBe("from accum")
+  })
+
+  test("falls back to part text when accum misses", () => {
+    expect(readPartText({ other_part: "ignored" }, { id: "part_1", text: "  from part  " })).toBe("from part")
+  })
+
+  test("returns empty string for whitespace-only text", () => {
+    expect(readPartText(undefined, { id: "part_1", text: "   \n\t  " })).toBe("")
+  })
+
+  test("trims leading and trailing whitespace", () => {
+    expect(readPartText(undefined, { id: "part_1", text: "\n  body  \n" })).toBe("body")
+  })
+})

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -57,6 +57,7 @@ import { patchFiles } from "./apply-patch-file"
 import { animate } from "motion"
 import { useLocation } from "@solidjs/router"
 import { attached, inline, kind } from "./message-file"
+import { readPartText } from "./message-part-text"
 
 async function writeClipboard(text: string): Promise<boolean> {
   const body = typeof document === "undefined" ? undefined : document.body
@@ -1497,7 +1498,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const streaming = createMemo(
     () => props.message.role === "assistant" && typeof (props.message as AssistantMessage).time.completed !== "number",
   )
-  const text = () => (data.store.part_text_accum_delta?.[part().id] ?? part().text ?? "").trim()
+  const text = () => readPartText(data.store.part_text_accum_delta, part())
   const isLastTextPart = createMemo(() => {
     const last = (data.store.part?.[props.message.id] ?? [])
       .filter((item): item is TextPart => item?.type === "text" && !!item.text?.trim())
@@ -1563,7 +1564,7 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
   const streaming = createMemo(
     () => props.message.role === "assistant" && typeof (props.message as AssistantMessage).time.completed !== "number",
   )
-  const text = () => (data.store.part_text_accum_delta?.[part().id] ?? part().text ?? "").trim()
+  const text = () => readPartText(data.store.part_text_accum_delta, part())
 
   return (
     <Show when={text()}>


### PR DESCRIPTION
## Summary

Follow-up to PR #28222 / issue #28212 paying down the test debt from the rushed fix.

PR #28222 added a `?? ""` guard to the reasoning renderer to stop it crashing on undefined text, but landed without a regression test and left two identical copies of the text-extraction expression in `message-part.tsx` (in `TextPartDisplay` and `ReasoningPartDisplay`).

This PR:

- Extracts the duplicated expression into a pure helper `readPartText(accum, part)` in `packages/ui/src/components/message-part-text.ts` (separate module so the helper is unit-testable without pulling in Solid component dependencies).
- Replaces both call sites in `message-part.tsx` to use the helper.
- Adds 6 unit tests in `message-part.test.ts` pinning the behavior the fix relied on, including the undefined-text case that caused #28212.

No behavior change.

## Test plan

- [x] `bun test src/components/message-part.test.ts` from `packages/ui` (6 pass)
- [x] `bun run typecheck` from `packages/ui` (clean)
- [ ] Reasoning parts continue to render without crashing when `text` is undefined
- [ ] Streaming text parts continue to prefer `part_text_accum_delta` over `part.text`