### PR TITLE
test(opencode/run): skip Windows-only scrollback replay failure

### DIFF
--- a/packages/opencode/test/cli/run/scrollback.surface.test.ts
+++ b/packages/opencode/test/cli/run/scrollback.surface.test.ts
@@ -403,38 +403,82 @@ test("inserts spacers for new visible groups", async () => {
   }
 })
 
-test("renders replayed user, reasoning, and assistant output after completion", async () => {
-  const out = await setup()
+// TODO(windows): Re-enable on Windows once the streaming CodeRenderable
+// flush race is fixed. The reasoning commit is delivered as a `<code>`
+// renderable with `filetype="markdown"`, `streaming=true`, and
+// `drawUnstyledText=false`. On Windows the first paragraph of the reasoning
+// body (here `_Thinking:_ **Plan**`) is dropped from the committed rows —
+// the failing assertion shows only `Say hello.` survives, while Linux
+// (where `useThread` is forced off in `@opentui/core/testing`) and macOS
+// both pass.
+//
+// Investigation summary (see PR description for the link to this work):
+//   1. `reasoning("Thinking: ...", "progress")` enters `entry.body.ts`
+//      `reasoningBody`, which becomes a `code` body with filetype="markdown".
+//   2. `RunScrollbackStream.writeStreaming` sets `renderable.content = ...`
+//      while `streaming=true`. `CodeRenderable.set content` short-circuits
+//      (does NOT call `textBuffer.setText`) when streaming, drawUnstyledText
+//      is false, and a filetype is set — it relies on the next
+//      `startHighlight()` cycle to populate the buffer.
+//   3. `ScrollbackSurface.settle()` renders the surface, kicks the
+//      highlight via `renderSelf` → `startHighlight`, waits on
+//      `highlightingDone`, and re-renders. With `MockTreeSitterClient`
+//      returning `{highlights: []}`, the final branch (`else
+//      this.textBuffer.setText(content)`) populates the buffer and
+//      `_shouldRenderTextBuffer = true`.
+//   4. `flushActive` then commits rows `[0, surface.height - 1)` during
+//      streaming. On Windows the committed rows are blank for the first
+//      paragraph — suggesting the height/text-buffer state is observed
+//      before/after the highlight resolution in a way that drops rows on
+//      that platform.
+//
+// The Linux pass path takes `useThread = false` (see
+// `@opentui/core/testing.js` line ~540) which serializes the FFI render
+// thread. macOS passes despite `useThread = true`, so the divergence is
+// likely either Bun's microtask scheduling on Windows or a Zig-side
+// threading interaction during the second `renderSurface()` pass in
+// `settleSurface`. A real fix probably belongs in opentui (either force
+// `useThread=false` for testing on Windows, or eagerly call
+// `textBuffer.setText` in `CodeRenderable.set content` when streaming
+// updates a non-empty body).
+//
+// Skipping on win32 unblocks unrelated PRs; the assertion is still
+// exercised on Linux and macOS in CI.
+test.skipIf(process.platform === "win32")(
+  "renders replayed user, reasoning, and assistant output after completion",
+  async () => {
+    const out = await setup()
 
-  try {
-    const lines: string[] = []
-    const take = () => {
-      const commits = claim(out.renderer)
-      try {
-        lines.push(...commits.flatMap((commit) => renderRows(commit).flatMap((row) => row.split("\n"))))
-      } finally {
-        destroy(commits)
+    try {
+      const lines: string[] = []
+      const take = () => {
+        const commits = claim(out.renderer)
+        try {
+          lines.push(...commits.flatMap((commit) => renderRows(commit).flatMap((row) => row.split("\n"))))
+        } finally {
+          destroy(commits)
+        }
       }
+
+      await out.scrollback.append(user("Hello you"))
+      take()
+      await out.scrollback.append(reasoning("Thinking: **Plan**\n\nSay hello.", "progress"))
+      await out.scrollback.complete()
+      take()
+      await out.scrollback.append(assistant("Hello.", "progress"))
+      await out.scrollback.complete()
+      take()
+
+      const output = lines.join("\n")
+      expect(output).toContain("› Hello you")
+      expect(output).toContain("Thinking:")
+      expect(output).toContain("Plan")
+      expect(output).toContain("Hello.")
+    } finally {
+      out.scrollback.destroy()
     }
-
-    await out.scrollback.append(user("Hello you"))
-    take()
-    await out.scrollback.append(reasoning("Thinking: **Plan**\n\nSay hello.", "progress"))
-    await out.scrollback.complete()
-    take()
-    await out.scrollback.append(assistant("Hello.", "progress"))
-    await out.scrollback.complete()
-    take()
-
-    const output = lines.join("\n")
-    expect(output).toContain("› Hello you")
-    expect(output).toContain("Thinking:")
-    expect(output).toContain("Plan")
-    expect(output).toContain("Hello.")
-  } finally {
-    out.scrollback.destroy()
-  }
-})
+  },
+)
 
 test("coalesces same-line tool progress into one snapshot", async () => {
   const out = await setup()


### PR DESCRIPTION
## Summary

`scrollback.surface.test.ts > "renders replayed user, reasoning, and assistant output after completion"` fails reliably on Windows CI while passing on Linux and macOS. It blocks every unrelated PR through branch protection (most recently seen on #28253). Skipping the case on `win32` unblocks the queue without dropping coverage on the other two platforms.

The test assertion `expect(output).toContain("Thinking:")` fails on Windows; the received string is `"› Hello you\nSay hello.\n\nHello."` — only the *second* paragraph of the reasoning body survives. The first paragraph (`_Thinking:_ **Plan**`) never makes it into the committed rows.

## Investigation

The reasoning input flows through:

1. `entry.body.ts` `reasoningBody()` rewrites `"Thinking: …"` to `"_Thinking:_ …"` and returns a `code` body with `filetype="markdown"`.
2. `RunScrollbackStream.writeStreaming` creates a `CodeRenderable` with `streaming: true`, `drawUnstyledText: false`, `filetype: "markdown"`.
3. During `flushActive(false, false)`, `renderable.content = active.content` is set. `CodeRenderable.set content` short-circuits in this combination — it does **not** call `textBuffer.setText(value)` while streaming, relying on the next `startHighlight()` cycle to populate the buffer.
4. `await active.surface.settle()` renders the surface, kicks off `startHighlight()` via `renderSelf`, awaits `highlightingDone`, and re-renders. With `MockTreeSitterClient` returning `{ highlights: [] }`, control reaches the `else this.textBuffer.setText(content)` branch in `startHighlight()` and sets `_shouldRenderTextBuffer = true`.
5. `flushActive` then commits rows `[0, surface.height - 1)` while streaming.

On Windows the row commit emerges without the first paragraph. Linux uniquely forces `useThread = false` in `@opentui/core/testing` (see `testing.js` line ~540), so it serializes the FFI render thread and never trips this race. macOS happens to be timing-stable despite `useThread = true`. Windows is not. The smoking gun is most likely either Bun's microtask scheduling on Windows or a Zig-side threading interaction during the second `renderSurface()` pass inside `settleSurface`. A real fix probably belongs in opentui — either force `useThread = false` for testing on Windows, or eagerly call `textBuffer.setText` in `CodeRenderable.set content` when streaming updates a non-empty body.

I spent ~1 hour tracing the streaming path through `CodeRenderable` and `ScrollbackSurface.settle` (`@opentui/core/index-*.js`), with a local repro that produced the expected output on macOS. Going further into the Zig/FFI render path felt out of scope for a CI-unblock change, so this PR applies the fallback discussed in the task brief: `test.skipIf(process.platform === "win32")` with a detailed inline `TODO(windows)` summarising what's been ruled in/out.

## What changed

- `packages/opencode/test/cli/run/scrollback.surface.test.ts`: wrap the one failing case in `test.skipIf(process.platform === "win32")(...)` and prepend a detailed investigation comment for the next person.

The other 12 cases in this file (which all rely on the same rendering machinery but don't hit this exact streaming-code path) continue to run on every platform.

## Test plan

- [x] `bun run test test/cli/run/scrollback.surface.test.ts` — 13 pass / 0 fail on macOS (the skipped case still executes here because `process.platform !== "win32"`).
- [x] `bun run typecheck` — clean.
- [ ] CI Windows run on this PR should show the test reported as skipped (not failed); Linux/macOS unchanged.