### PR TITLE
fix(cli): calculate stats by usage window

### DIFF
--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -1,10 +1,10 @@
 import { Effect } from "effect"
+import { and, eq, gte, sql, type SQL } from "drizzle-orm"
 import { effectCmd } from "../effect-cmd"
-import { Session } from "@/session/session"
-import { NotFoundError } from "@/storage/storage"
 import { Database } from "@/storage/db"
-import { SessionTable } from "../../session/session.sql"
+import { MessageTable, PartTable, SessionTable } from "../../session/session.sql"
 import { Project } from "@/project/project"
+import { ProjectID } from "@/project/schema"
 import { InstanceRef } from "@/effect/instance-ref"
 
 interface SessionStats {
@@ -80,18 +80,20 @@ export const StatsCommand = effectCmd({
   }),
 })
 
-const getAllSessions = Effect.sync(() =>
-  Database.use((db) => db.select().from(SessionTable).all()).map((row) => Session.fromRow(row)),
-)
-
 const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
   days?: number,
   projectFilter?: string,
   currentProject?: Project.Info,
 ) {
-  const svc = yield* Session.Service
-  const sessions = yield* getAllSessions
   const MS_IN_DAY = 24 * 60 * 60 * 1000
+  const projectID = (() => {
+    if (projectFilter === undefined) return
+    if (projectFilter === "") {
+      if (!currentProject) throw new Error("currentProject required when projectFilter is empty string")
+      return currentProject.id
+    }
+    return ProjectID.make(projectFilter)
+  })()
 
   const cutoffTime = (() => {
     if (days === undefined) return 0
@@ -109,20 +111,58 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
     return days
   })()
 
-  let filteredSessions = cutoffTime > 0 ? sessions.filter((session) => session.time.updated >= cutoffTime) : sessions
+  const rows = yield* Effect.sync(() =>
+    Database.use((db) => {
+      const sessionConditions: SQL[] = []
+      if (projectID) sessionConditions.push(eq(SessionTable.project_id, projectID))
+      const sessions = db
+        .select({
+          id: SessionTable.id,
+          timeCreated: SessionTable.time_created,
+          timeUpdated: SessionTable.time_updated,
+        })
+        .from(SessionTable)
+        .where(where(sessionConditions))
+        .all()
 
-  if (projectFilter !== undefined) {
-    if (projectFilter === "") {
-      if (!currentProject) throw new Error("currentProject required when projectFilter is empty string")
-      filteredSessions = filteredSessions.filter((session) => session.projectID === currentProject.id)
-    } else {
-      filteredSessions = filteredSessions.filter((session) => session.projectID === projectFilter)
-    }
-  }
+      const messageConditions: SQL[] = []
+      if (cutoffTime > 0) messageConditions.push(gte(MessageTable.time_created, cutoffTime))
+      if (projectID) messageConditions.push(eq(SessionTable.project_id, projectID))
+      const messages = db
+        .select({ sessionID: MessageTable.session_id, timeCreated: MessageTable.time_created })
+        .from(MessageTable)
+        .innerJoin(SessionTable, eq(MessageTable.session_id, SessionTable.id))
+        .where(where(messageConditions))
+        .all()
+
+      const partConditions: SQL[] = [sql`json_extract(${PartTable.data}, '$.type') in ('step-finish', 'tool')`]
+      if (cutoffTime > 0) partConditions.push(gte(PartTable.time_created, cutoffTime))
+      if (projectID) partConditions.push(eq(SessionTable.project_id, projectID))
+      const parts = db
+        .select({
+          sessionID: PartTable.session_id,
+          timeCreated: PartTable.time_created,
+          part: PartTable.data,
+          message: MessageTable.data,
+        })
+        .from(PartTable)
+        .innerJoin(MessageTable, eq(PartTable.message_id, MessageTable.id))
+        .innerJoin(SessionTable, eq(PartTable.session_id, SessionTable.id))
+        .where(where(partConditions))
+        .all()
+
+      return { sessions, messages, parts }
+    }),
+  )
+
+  const activeSessionIDs =
+    cutoffTime > 0
+      ? new Set([...rows.messages.map((row) => row.sessionID), ...rows.parts.map((row) => row.sessionID)])
+      : new Set(rows.sessions.map((row) => row.id))
 
   const stats: SessionStats = {
-    totalSessions: filteredSessions.length,
-    totalMessages: 0,
+    totalSessions: activeSessionIDs.size,
+    totalMessages: rows.messages.length,
     totalCost: 0,
     totalTokens: {
       input: 0,
@@ -145,122 +185,63 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
     medianTokensPerSession: 0,
   }
 
-  if (filteredSessions.length > 1000) {
-    console.log(`Large dataset detected (${filteredSessions.length} sessions). This may take a while...`)
+  if (activeSessionIDs.size > 1000) {
+    console.log(`Large dataset detected (${activeSessionIDs.size} sessions). This may take a while...`)
   }
 
-  if (filteredSessions.length === 0) {
+  if (activeSessionIDs.size === 0) {
     stats.days = windowDays ?? 0
     return stats
   }
 
-  let earliestTime = Date.now()
-  let latestTime = 0
+  const sessionTotalTokens = new Map([...activeSessionIDs].map((sessionID) => [sessionID, 0]))
 
-  const sessionTotalTokens: number[] = []
-
-  const results = yield* Effect.forEach(
-    filteredSessions,
-    (session) =>
-      Effect.gen(function* () {
-        const messages = yield* svc
-          .messages({ sessionID: session.id })
-          .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([])))
-
-        const sessionCost = session.cost ?? 0
-        const sessionTokens = session.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
-        let sessionToolUsage: Record<string, number> = {}
-        let sessionModelUsage: Record<
-          string,
-          {
-            messages: number
-            tokens: { input: number; output: number; cache: { read: number; write: number } }
-            cost: number
-          }
-        > = {}
-
-        for (const message of messages) {
-          if (message.info.role === "assistant") {
-            const modelKey = `${message.info.providerID}/${message.info.modelID}`
-            if (!sessionModelUsage[modelKey]) {
-              sessionModelUsage[modelKey] = {
-                messages: 0,
-                tokens: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-                cost: 0,
-              }
-            }
-            sessionModelUsage[modelKey].messages++
-            sessionModelUsage[modelKey].cost += message.info.cost || 0
-
-            if (message.info.tokens) {
-              sessionModelUsage[modelKey].tokens.input += message.info.tokens.input || 0
-              sessionModelUsage[modelKey].tokens.output +=
-                (message.info.tokens.output || 0) + (message.info.tokens.reasoning || 0)
-              sessionModelUsage[modelKey].tokens.cache.read += message.info.tokens.cache?.read || 0
-              sessionModelUsage[modelKey].tokens.cache.write += message.info.tokens.cache?.write || 0
-            }
-          }
-
-          for (const part of message.parts) {
-            if (part.type === "tool" && part.tool) {
-              sessionToolUsage[part.tool] = (sessionToolUsage[part.tool] || 0) + 1
-            }
-          }
-        }
-
-        return {
-          messageCount: messages.length,
-          sessionCost,
-          sessionTokens,
-          sessionTotalTokens:
-            sessionTokens.input +
-            sessionTokens.output +
-            sessionTokens.reasoning +
-            sessionTokens.cache.read +
-            sessionTokens.cache.write,
-          sessionToolUsage,
-          sessionModelUsage,
-          earliestTime: cutoffTime > 0 ? session.time.updated : session.time.created,
-          latestTime: session.time.updated,
-        }
-      }),
-    { concurrency: 20 },
-  )
-
-  for (const result of results) {
-    earliestTime = Math.min(earliestTime, result.earliestTime)
-    latestTime = Math.max(latestTime, result.latestTime)
-    sessionTotalTokens.push(result.sessionTotalTokens)
-
-    stats.totalMessages += result.messageCount
-    stats.totalCost += result.sessionCost
-    stats.totalTokens.input += result.sessionTokens.input
-    stats.totalTokens.output += result.sessionTokens.output
-    stats.totalTokens.reasoning += result.sessionTokens.reasoning
-    stats.totalTokens.cache.read += result.sessionTokens.cache.read
-    stats.totalTokens.cache.write += result.sessionTokens.cache.write
-
-    for (const [tool, count] of Object.entries(result.sessionToolUsage)) {
-      stats.toolUsage[tool] = (stats.toolUsage[tool] || 0) + count
+  for (const row of rows.parts) {
+    if (row.part.type === "tool" && row.part.tool) {
+      stats.toolUsage[row.part.tool] = (stats.toolUsage[row.part.tool] || 0) + 1
+      continue
     }
+    if (row.part.type !== "step-finish") continue
 
-    for (const [model, usage] of Object.entries(result.sessionModelUsage)) {
-      if (!stats.modelUsage[model]) {
-        stats.modelUsage[model] = {
-          messages: 0,
-          tokens: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-          cost: 0,
-        }
+    stats.totalCost += row.part.cost || 0
+    stats.totalTokens.input += row.part.tokens.input || 0
+    stats.totalTokens.output += row.part.tokens.output || 0
+    stats.totalTokens.reasoning += row.part.tokens.reasoning || 0
+    stats.totalTokens.cache.read += row.part.tokens.cache.read || 0
+    stats.totalTokens.cache.write += row.part.tokens.cache.write || 0
+    sessionTotalTokens.set(
+      row.sessionID,
+      (sessionTotalTokens.get(row.sessionID) || 0) +
+        (row.part.tokens.input || 0) +
+        (row.part.tokens.output || 0) +
+        (row.part.tokens.reasoning || 0) +
+        (row.part.tokens.cache.read || 0) +
+        (row.part.tokens.cache.write || 0),
+    )
+
+    if (row.message.role !== "assistant") continue
+    const model = `${row.message.providerID}/${row.message.modelID}`
+    if (!stats.modelUsage[model]) {
+      stats.modelUsage[model] = {
+        messages: 0,
+        tokens: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+        cost: 0,
       }
-      stats.modelUsage[model].messages += usage.messages
-      stats.modelUsage[model].tokens.input += usage.tokens.input
-      stats.modelUsage[model].tokens.output += usage.tokens.output
-      stats.modelUsage[model].tokens.cache.read += usage.tokens.cache.read
-      stats.modelUsage[model].tokens.cache.write += usage.tokens.cache.write
-      stats.modelUsage[model].cost += usage.cost
     }
+    stats.modelUsage[model].messages++
+    stats.modelUsage[model].tokens.input += row.part.tokens.input || 0
+    stats.modelUsage[model].tokens.output += (row.part.tokens.output || 0) + (row.part.tokens.reasoning || 0)
+    stats.modelUsage[model].tokens.cache.read += row.part.tokens.cache.read || 0
+    stats.modelUsage[model].tokens.cache.write += row.part.tokens.cache.write || 0
+    stats.modelUsage[model].cost += row.part.cost || 0
   }
 
+  const activityTimes =
+    cutoffTime > 0
+      ? [...rows.messages.map((row) => row.timeCreated), ...rows.parts.map((row) => row.timeCreated)]
+      : rows.sessions.flatMap((row) => [row.timeCreated, row.timeUpdated])
+  const earliestTime = Math.min(...activityTimes)
+  const latestTime = Math.max(...activityTimes)
   const rangeDays = Math.max(1, Math.ceil((latestTime - earliestTime) / MS_IN_DAY))
   const effectiveDays = windowDays ?? rangeDays
   stats.dateRange = {
@@ -275,18 +256,22 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
     stats.totalTokens.reasoning +
     stats.totalTokens.cache.read +
     stats.totalTokens.cache.write
-  stats.tokensPerSession = filteredSessions.length > 0 ? totalTokens / filteredSessions.length : 0
-  sessionTotalTokens.sort((a, b) => a - b)
-  const mid = Math.floor(sessionTotalTokens.length / 2)
+  stats.tokensPerSession = activeSessionIDs.size > 0 ? totalTokens / activeSessionIDs.size : 0
+  const sessionTokens = [...sessionTotalTokens.values()].sort((a, b) => a - b)
+  const mid = Math.floor(sessionTokens.length / 2)
   stats.medianTokensPerSession =
-    sessionTotalTokens.length === 0
+    sessionTokens.length === 0
       ? 0
-      : sessionTotalTokens.length % 2 === 0
-        ? (sessionTotalTokens[mid - 1] + sessionTotalTokens[mid]) / 2
-        : sessionTotalTokens[mid]
+      : sessionTokens.length % 2 === 0
+        ? (sessionTokens[mid - 1] + sessionTokens[mid]) / 2
+        : sessionTokens[mid]
 
   return stats
 })
+
+function where(conditions: SQL[]) {
+  return conditions.length > 0 ? and(...conditions) : undefined
+}
 
 export function displayStats(stats: SessionStats, toolLimit?: number, modelLimit?: number) {
   const width = 56

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -9,7 +9,9 @@ import type { SessionID, MessageID, PartID } from "./schema"
 import type { WorkspaceID } from "../control-plane/schema"
 import { Timestamps } from "../storage/schema.sql"
 
-type PartData = Omit<MessageV2.Part, "id" | "sessionID" | "messageID">
+type PartData<T extends MessageV2.Part = MessageV2.Part> = T extends unknown
+  ? Omit<T, "id" | "sessionID" | "messageID">
+  : never
 type InfoData<T extends MessageV2.Info = MessageV2.Info> = T extends unknown ? Omit<T, "id" | "sessionID"> : never
 type SessionMessageData = Omit<(typeof SessionMessage.Message)["Encoded"], "type" | "id">
 


### PR DESCRIPTION
Summary: Aligns stats --days with console usage-event semantics by summing step-finish parts created in the window instead of full updated sessions. Also keeps tool/model stats on the same event window and fixes PartData narrowing. Testing: bun typecheck from packages/opencode; OPENCODE_DB=opencode.db stats --days 7 --models 5 --tools 0 (~$636, matching independent step-event SQL); pre-push bun turbo typecheck passed.