### PR TITLE
test(cli): subprocess integration tests for opencode serve

### DIFF
--- a/packages/opencode/test/cli/serve/serve-process.test.ts
+++ b/packages/opencode/test/cli/serve/serve-process.test.ts
@@ -7,6 +7,7 @@
 // parsed off the "listening on http://..." line.
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
+import { HttpClient } from "effect/unstable/http"
 import { cliIt } from "../../lib/cli-process"
 
 describe("opencode serve (subprocess)", () => {
@@ -20,12 +21,13 @@ describe("opencode serve (subprocess)", () => {
         expect(server.port).toBeGreaterThan(0)
         expect(server.url).toMatch(/^http:\/\//)
 
-        const res = yield* Effect.promise(() => fetch(`${server.url}/global/health`))
+        const client = yield* HttpClient.HttpClient
+        const res = yield* client.get(`${server.url}/global/health`)
         expect(res.status).toBe(200)
-        const body = (yield* Effect.promise(() => res.json())) as Record<string, unknown>
         // GlobalHealth schema is { success: true, ... } | { success: false, error }.
         // We don't lock in further shape here — any 200 with parseable JSON is
         // enough proof the routing + auth-bypass + instance loading is alive.
+        const body = yield* res.json
         expect(body).toBeDefined()
       }),
     60_000,

--- a/packages/opencode/test/cli/serve/serve-process.test.ts
+++ b/packages/opencode/test/cli/serve/serve-process.test.ts
@@ -8,7 +8,25 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { HttpClient } from "effect/unstable/http"
+import net from "node:net"
 import { cliIt } from "../../lib/cli-process"
+
+// Asks the kernel for a free TCP port, then closes the listener so opencode
+// can claim it. There's a tiny TOCTOU window between close and rebind, but
+// it's vastly better than random-in-a-range — and worst case the kernel
+// errors loudly instead of silently colliding with another test.
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address()
+      if (typeof addr !== "object" || addr === null) return reject(new Error("no address"))
+      server.close(() => resolve(addr.port))
+    })
+  })
+}
 
 describe("opencode serve (subprocess)", () => {
   // Smoke test: server starts, binds a port, and /global/health responds.
@@ -40,10 +58,7 @@ describe("opencode serve (subprocess)", () => {
     "honors --port and reports the bound port on stdout",
     ({ opencode }) =>
       Effect.gen(function* () {
-        // Pick a port range unlikely to collide with anything else on the
-        // dev machine. The OS will still error if it's already taken, which
-        // is the test's intended fail mode.
-        const requested = 38000 + Math.floor(Math.random() * 2000)
+        const requested = yield* Effect.promise(findFreePort)
         const server = yield* opencode.serve({ port: requested })
         expect(server.port).toBe(requested)
       }),

--- a/packages/opencode/test/cli/serve/serve-process.test.ts
+++ b/packages/opencode/test/cli/serve/serve-process.test.ts
@@ -8,25 +8,7 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { HttpClient } from "effect/unstable/http"
-import net from "node:net"
 import { cliIt } from "../../lib/cli-process"
-
-// Asks the kernel for a free TCP port, then closes the listener so opencode
-// can claim it. There's a tiny TOCTOU window between close and rebind, but
-// it's vastly better than random-in-a-range — and worst case the kernel
-// errors loudly instead of silently colliding with another test.
-function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer()
-    server.unref()
-    server.once("error", reject)
-    server.listen(0, "127.0.0.1", () => {
-      const addr = server.address()
-      if (typeof addr !== "object" || addr === null) return reject(new Error("no address"))
-      server.close(() => resolve(addr.port))
-    })
-  })
-}
 
 describe("opencode serve (subprocess)", () => {
   // Smoke test: server starts, binds a port, and /global/health responds.
@@ -47,20 +29,6 @@ describe("opencode serve (subprocess)", () => {
         // enough proof the routing + auth-bypass + instance loading is alive.
         const body = yield* res.json
         expect(body).toBeDefined()
-      }),
-    60_000,
-  )
-
-  // Lock in that `--port` overrides the OS-assigned default. If the CLI
-  // stopped honoring the flag (or stopped emitting the bound port on stdout),
-  // this catches it without depending on a magic value.
-  cliIt.live(
-    "honors --port and reports the bound port on stdout",
-    ({ opencode }) =>
-      Effect.gen(function* () {
-        const requested = yield* Effect.promise(findFreePort)
-        const server = yield* opencode.serve({ port: requested })
-        expect(server.port).toBe(requested)
       }),
     60_000,
   )

--- a/packages/opencode/test/cli/serve/serve-process.test.ts
+++ b/packages/opencode/test/cli/serve/serve-process.test.ts
@@ -1,0 +1,76 @@
+// Subprocess integration tests for `opencode serve`. Spawns the real CLI in
+// headless mode and exercises it over HTTP — this is the only test tier that
+// catches bugs spanning argv → server boot → routing → instance loading.
+//
+// `serve` is long-lived: the harness returns a handle (url/port/kill/exited)
+// and kills the process when the test scope closes. The OS-assigned port is
+// parsed off the "listening on http://..." line.
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../../lib/cli-process"
+
+describe("opencode serve (subprocess)", () => {
+  // Smoke test: server starts, binds a port, and /global/health responds.
+  // If this fails, all other serve tests likely will too — debug here first.
+  cliIt.live(
+    "starts, binds a port, and serves /global/health",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const server = yield* opencode.serve()
+        expect(server.port).toBeGreaterThan(0)
+        expect(server.url).toMatch(/^http:\/\//)
+
+        const res = yield* Effect.promise(() => fetch(`${server.url}/global/health`))
+        expect(res.status).toBe(200)
+        const body = (yield* Effect.promise(() => res.json())) as Record<string, unknown>
+        // GlobalHealth schema is { success: true, ... } | { success: false, error }.
+        // We don't lock in further shape here — any 200 with parseable JSON is
+        // enough proof the routing + auth-bypass + instance loading is alive.
+        expect(body).toBeDefined()
+      }),
+    60_000,
+  )
+
+  // Lock in that `--port` overrides the OS-assigned default. If the CLI
+  // stopped honoring the flag (or stopped emitting the bound port on stdout),
+  // this catches it without depending on a magic value.
+  cliIt.live(
+    "honors --port and reports the bound port on stdout",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        // Pick a port range unlikely to collide with anything else on the
+        // dev machine. The OS will still error if it's already taken, which
+        // is the test's intended fail mode.
+        const requested = 38000 + Math.floor(Math.random() * 2000)
+        const server = yield* opencode.serve({ port: requested })
+        expect(server.port).toBe(requested)
+      }),
+    60_000,
+  )
+
+  // The scope-close finalizer must actually terminate the child. Without this
+  // test a regression in the kill path (e.g. a future refactor that forgets
+  // to wire the finalizer) would leak processes on every test run.
+  cliIt.live(
+    "kills the subprocess on scope close",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        // Inner scope so we can observe `.exited` resolving after it closes.
+        const exitedPromise = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const server = yield* opencode.serve()
+            // Capture the Promise, not the resolved value — scope closes after
+            // this gen returns, at which point the finalizer kills the child.
+            return server.exited
+          }),
+        )
+        // After scope close: finalizer fired, process must have exited.
+        const code = yield* Effect.promise(() => exitedPromise)
+        // Bun reports the exit code; SIGTERM-killed processes return non-null
+        // (typically 143 on POSIX). We just require resolution within a sane
+        // window — anything else means the kill didn't take.
+        expect(typeof code === "number" || code === null).toBe(true)
+      }),
+    60_000,
+  )
+})

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -71,9 +71,40 @@ export type RunOpts = SpawnOpts & {
   readonly extraArgs?: string[]
 }
 
+// `opencode serve` is a long-lived process — it never exits on its own.
+// `serve(opts)` therefore returns a handle inside the caller's Scope: the
+// subprocess is killed when the scope closes (test end), and the URL the
+// server actually bound to (port 0 means OS-assigned) is parsed off stdout.
+export type ServeOpts = SpawnOpts & {
+  readonly port?: number
+  readonly hostname?: string
+  readonly extraArgs?: string[]
+  // How long to wait for the "listening on http://..." line before failing.
+  // Default 15s — startup is dominated by bun's transpile + plugin init, not
+  // the actual listen() call.
+  readonly readyTimeoutMs?: number
+}
+
+export type ServeHandle = {
+  // Full URL the server is bound to, e.g. "http://127.0.0.1:54321". Use this
+  // as the base for HTTP requests in tests — never assume the port.
+  readonly url: string
+  readonly hostname: string
+  readonly port: number
+  // Sends SIGTERM. The scope finalizer also calls this, so tests rarely need
+  // to invoke it directly — useful for tests that assert exit behavior.
+  readonly kill: () => void
+  // Resolves with the exit code once the process exits. Bun returns a number.
+  readonly exited: Promise<number>
+}
+
 export type OpencodeCli = {
   // High-level: run a single prompt against the test model. Short-lived.
   readonly run: (message: string, opts?: RunOpts) => Effect.Effect<RunResult>
+  // Spawn `opencode serve` and wait until it's listening. Long-lived: the
+  // returned handle is killed when the caller's Scope closes. Fails if the
+  // listening line doesn't appear within `readyTimeoutMs`.
+  readonly serve: (opts?: ServeOpts) => Effect.Effect<ServeHandle, Error, Scope.Scope>
   // Escape hatch: any CLI invocation with full control over argv. Used to test
   // commands that don't yet have a typed builder.
   readonly spawn: (args: string[], opts?: SpawnOpts) => Effect.Effect<RunResult>
@@ -85,9 +116,6 @@ export type OpencodeCli = {
   // event (see src/cli/cmd/run.ts `emit`). Throws on a malformed line so
   // tests fail loudly rather than silently skipping data.
   readonly parseJsonEvents: (stdout: string) => Array<Record<string, unknown>>
-  // TODO: long-lived builders for `serve` / `acp` / etc. need a different
-  // return shape — they yield a handle with .url / .kill and live inside the
-  // surrounding Scope. Add when the first long-lived command is tested.
 }
 
 export type CliFixture = {
@@ -101,7 +129,7 @@ export type CliFixture = {
 // the caller doesn't need to wire it up — the fixture's lifetime is tied to
 // the surrounding Scope.
 export function withCliFixture<A, E>(
-  fn: (input: CliFixture) => Effect.Effect<A, E>,
+  fn: (input: CliFixture) => Effect.Effect<A, E, Scope.Scope>,
 ): Effect.Effect<A, E | unknown, Scope.Scope> {
   return Effect.gen(function* () {
     const llm = yield* TestLLMServer
@@ -145,7 +173,114 @@ export function withCliFixture<A, E>(
       return spawn(argv, opts)
     }
 
-    const opencode: OpencodeCli = { run, spawn, expectExit, parseJsonEvents }
+    const serve = (opts?: ServeOpts): Effect.Effect<ServeHandle, Error, Scope.Scope> =>
+      Effect.acquireRelease(
+        Effect.tryPromise({
+          try: async () => {
+            const argv = ["serve"]
+            // Default port 0 — let the OS pick a free port, parse the actual
+            // one off stdout. Hard-coded ports flake under parallel tests.
+            argv.push("--port", String(opts?.port ?? 0))
+            if (opts?.hostname) argv.push("--hostname", opts.hostname)
+            if (opts?.extraArgs) argv.push(...opts.extraArgs)
+
+            const proc = Bun.spawn(["bun", "run", "--conditions=browser", cliEntry, ...argv], {
+              cwd: home,
+              env: { ...process.env, ...env, ...opts?.env },
+              stdout: "pipe",
+              stderr: "pipe",
+            })
+
+            // Drain stderr in background so the OS pipe buffer can't fill and
+            // wedge the child. We don't surface it on success; on failure the
+            // caller can read it from the kill path or test assertion.
+            const stderrChunks: string[] = []
+            void (async () => {
+              const reader = proc.stderr.getReader()
+              const decoder = new TextDecoder()
+              try {
+                while (true) {
+                  const { done, value } = await reader.read()
+                  if (done) return
+                  stderrChunks.push(decoder.decode(value, { stream: true }))
+                }
+              } catch {
+                // Stream closed — fine.
+              }
+            })()
+
+            // Watch stdout for the listening-line. Format (see serve.ts):
+            //   "opencode server listening on http://<host>:<port>"
+            const readyRe = /listening on (http:\/\/([^\s:]+):(\d+))/
+            const reader = proc.stdout.getReader()
+            const decoder = new TextDecoder()
+            let buf = ""
+            const readyTimeoutMs = opts?.readyTimeoutMs ?? 15_000
+
+            const timeout = new Promise<never>((_resolve, reject) =>
+              setTimeout(
+                () => reject(new Error(`opencode serve did not become ready within ${readyTimeoutMs}ms`)),
+                readyTimeoutMs,
+              ),
+            )
+            const findReady = (async () => {
+              while (true) {
+                const { done, value } = await reader.read()
+                if (done) throw new Error("opencode serve exited before becoming ready")
+                buf += decoder.decode(value, { stream: true })
+                const m = buf.match(readyRe)
+                if (m) return { url: m[1], hostname: m[2], port: Number(m[3]) }
+              }
+            })()
+            let match: { url: string; hostname: string; port: number }
+            try {
+              match = await Promise.race([findReady, timeout])
+            } catch (err) {
+              proc.kill()
+              try {
+                await proc.exited
+              } catch {
+                // ignore
+              }
+              const stderrTail = stderrChunks.join("").slice(-2000)
+              throw new Error(`${(err as Error).message}\nstderr (last 2000):\n${stderrTail}`)
+            }
+
+            // Continue draining stdout post-startup. Without this, the OS pipe
+            // buffer eventually fills and the server blocks on its next log.
+            void (async () => {
+              try {
+                while (true) {
+                  const { done } = await reader.read()
+                  if (done) return
+                }
+              } catch {
+                // Stream closed — fine.
+              }
+            })()
+
+            return {
+              url: match.url,
+              hostname: match.hostname,
+              port: match.port,
+              kill: () => proc.kill(),
+              exited: proc.exited as Promise<number>,
+            }
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }),
+        (handle) =>
+          Effect.promise(async () => {
+            handle.kill()
+            try {
+              await handle.exited
+            } catch {
+              // ignore
+            }
+          }),
+      )
+
+    const opencode: OpencodeCli = { run, serve, spawn, expectExit, parseJsonEvents }
 
     return yield* fn({ llm, home, opencode })
   }).pipe(Effect.provide(TestLLMServer.layer))
@@ -180,7 +315,13 @@ function expectExit(result: RunResult, expected: number, label = "opencode") {
 // Only `.live` is exposed because subprocess tests must run against the real
 // clock — a TestClock-paused environment can't drive a child process. If you
 // need `.only` or `.skip`, fall back to `it.live` + `withCliFixture` directly.
+// Body's R is `Scope.Scope | never` so tests can yield* scope-requiring
+// resources (e.g. `opencode.serve`) without an extra `Effect.scoped` wrapper —
+// `withCliFixture`'s outer scope is the natural lifetime.
 export const cliIt = {
-  live: <A, E>(name: string, body: (input: CliFixture) => Effect.Effect<A, E>, opts?: number | TestOptions) =>
-    it.live(name, () => withCliFixture(body), opts),
+  live: <A, E>(
+    name: string,
+    body: (input: CliFixture) => Effect.Effect<A, E, Scope.Scope>,
+    opts?: number | TestOptions,
+  ) => it.live(name, () => withCliFixture(body), opts),
 }

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -18,7 +18,8 @@
 // without changing the fixture. Long-lived commands like `serve` will need a
 // different return shape — see the TODO at the bottom of OpencodeCli.
 import type { TestOptions } from "bun:test"
-import { Deferred, Duration, Effect, Scope, Stream } from "effect"
+import { Deferred, Duration, Effect, Layer, Scope, Stream } from "effect"
+import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import path from "node:path"
 import fs from "node:fs/promises"
 import os from "node:os"
@@ -128,7 +129,7 @@ export type CliFixture = {
 // the caller doesn't need to wire it up — the fixture's lifetime is tied to
 // the surrounding Scope.
 export function withCliFixture<A, E>(
-  fn: (input: CliFixture) => Effect.Effect<A, E, Scope.Scope>,
+  fn: (input: CliFixture) => Effect.Effect<A, E, Scope.Scope | HttpClient.HttpClient>,
 ): Effect.Effect<A, E | unknown, Scope.Scope> {
   return Effect.gen(function* () {
     const llm = yield* TestLLMServer
@@ -264,7 +265,9 @@ export function withCliFixture<A, E>(
     const opencode: OpencodeCli = { run, serve, spawn, expectExit, parseJsonEvents }
 
     return yield* fn({ llm, home, opencode })
-  }).pipe(Effect.provide(TestLLMServer.layer))
+    // FetchHttpClient is provided so test bodies can `yield* HttpClient.HttpClient`
+    // and hit endpoints on `opencode.serve()` without rolling their own fetch.
+  }).pipe(Effect.provide(Layer.mergeAll(TestLLMServer.layer, FetchHttpClient.layer)))
 }
 
 function parseJsonEvents(stdout: string): Array<Record<string, unknown>> {
@@ -302,7 +305,7 @@ function expectExit(result: RunResult, expected: number, label = "opencode") {
 export const cliIt = {
   live: <A, E>(
     name: string,
-    body: (input: CliFixture) => Effect.Effect<A, E, Scope.Scope>,
+    body: (input: CliFixture) => Effect.Effect<A, E, Scope.Scope | HttpClient.HttpClient>,
     opts?: number | TestOptions,
   ) => it.live(name, () => withCliFixture(body), opts),
 }

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -18,8 +18,7 @@
 // without changing the fixture. Long-lived commands like `serve` will need a
 // different return shape — see the TODO at the bottom of OpencodeCli.
 import type { TestOptions } from "bun:test"
-import * as Scope from "effect/Scope"
-import { Effect } from "effect"
+import { Deferred, Duration, Effect, Scope, Stream } from "effect"
 import path from "node:path"
 import fs from "node:fs/promises"
 import os from "node:os"
@@ -173,112 +172,94 @@ export function withCliFixture<A, E>(
       return spawn(argv, opts)
     }
 
-    const serve = (opts?: ServeOpts): Effect.Effect<ServeHandle, Error, Scope.Scope> =>
-      Effect.acquireRelease(
-        Effect.tryPromise({
-          try: async () => {
-            const argv = ["serve"]
-            // Default port 0 — let the OS pick a free port, parse the actual
-            // one off stdout. Hard-coded ports flake under parallel tests.
-            argv.push("--port", String(opts?.port ?? 0))
-            if (opts?.hostname) argv.push("--hostname", opts.hostname)
-            if (opts?.extraArgs) argv.push(...opts.extraArgs)
+    const serve = Effect.fn("opencode.serve")(function* (opts?: ServeOpts) {
+      const argv = ["serve"]
+      // Default port 0 — let the OS pick a free port, parse the actual one
+      // off stdout. Hard-coded ports flake under parallel tests.
+      argv.push("--port", String(opts?.port ?? 0))
+      if (opts?.hostname) argv.push("--hostname", opts.hostname)
+      if (opts?.extraArgs) argv.push(...opts.extraArgs)
 
-            const proc = Bun.spawn(["bun", "run", "--conditions=browser", cliEntry, ...argv], {
-              cwd: home,
-              env: { ...process.env, ...env, ...opts?.env },
-              stdout: "pipe",
-              stderr: "pipe",
-            })
-
-            // Drain stderr in background so the OS pipe buffer can't fill and
-            // wedge the child. We don't surface it on success; on failure the
-            // caller can read it from the kill path or test assertion.
-            const stderrChunks: string[] = []
-            void (async () => {
-              const reader = proc.stderr.getReader()
-              const decoder = new TextDecoder()
-              try {
-                while (true) {
-                  const { done, value } = await reader.read()
-                  if (done) return
-                  stderrChunks.push(decoder.decode(value, { stream: true }))
-                }
-              } catch {
-                // Stream closed — fine.
-              }
-            })()
-
-            // Watch stdout for the listening-line. Format (see serve.ts):
-            //   "opencode server listening on http://<host>:<port>"
-            const readyRe = /listening on (http:\/\/([^\s:]+):(\d+))/
-            const reader = proc.stdout.getReader()
-            const decoder = new TextDecoder()
-            let buf = ""
-            const readyTimeoutMs = opts?.readyTimeoutMs ?? 15_000
-
-            const timeout = new Promise<never>((_resolve, reject) =>
-              setTimeout(
-                () => reject(new Error(`opencode serve did not become ready within ${readyTimeoutMs}ms`)),
-                readyTimeoutMs,
-              ),
-            )
-            const findReady = (async () => {
-              while (true) {
-                const { done, value } = await reader.read()
-                if (done) throw new Error("opencode serve exited before becoming ready")
-                buf += decoder.decode(value, { stream: true })
-                const m = buf.match(readyRe)
-                if (m) return { url: m[1], hostname: m[2], port: Number(m[3]) }
-              }
-            })()
-            let match: { url: string; hostname: string; port: number }
-            try {
-              match = await Promise.race([findReady, timeout])
-            } catch (err) {
-              proc.kill()
-              try {
-                await proc.exited
-              } catch {
-                // ignore
-              }
-              const stderrTail = stderrChunks.join("").slice(-2000)
-              throw new Error(`${(err as Error).message}\nstderr (last 2000):\n${stderrTail}`)
-            }
-
-            // Continue draining stdout post-startup. Without this, the OS pipe
-            // buffer eventually fills and the server blocks on its next log.
-            void (async () => {
-              try {
-                while (true) {
-                  const { done } = await reader.read()
-                  if (done) return
-                }
-              } catch {
-                // Stream closed — fine.
-              }
-            })()
-
-            return {
-              url: match.url,
-              hostname: match.hostname,
-              port: match.port,
-              kill: () => proc.kill(),
-              exited: proc.exited as Promise<number>,
-            }
-          },
-          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-        }),
-        (handle) =>
-          Effect.promise(async () => {
-            handle.kill()
-            try {
-              await handle.exited
-            } catch {
-              // ignore
-            }
+      // Acquire the subprocess; release sends SIGTERM and awaits exit on
+      // scope close. Wrapped in Effect.ignore so a flaky kill doesn't surface
+      // as a finalizer error during test teardown.
+      const proc = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.spawn(["bun", "run", "--conditions=browser", cliEntry, ...argv], {
+            cwd: home,
+            env: { ...process.env, ...env, ...opts?.env },
+            stdout: "pipe",
+            stderr: "pipe",
           }),
+        ),
+        (p) =>
+          Effect.promise(() => {
+            p.kill()
+            return p.exited
+          }).pipe(Effect.ignore),
       )
+
+      // Drain stderr in a scope-bound fork. Without this the OS pipe buffer
+      // eventually fills and the child blocks on its next log call. Kept as a
+      // tail buffer so timeout failures can include context.
+      const stderrChunks: string[] = []
+      yield* Effect.forkScoped(
+        Stream.fromReadableStream({
+          evaluate: () => proc.stderr,
+          onError: () => new Error("stderr stream error"),
+        }).pipe(
+          Stream.decodeText(),
+          Stream.runForEach((chunk) => Effect.sync(() => stderrChunks.push(chunk))),
+          Effect.ignore,
+        ),
+      )
+
+      // Watch stdout line-by-line for the listening sentinel. Format
+      // (see src/cli/cmd/serve.ts):
+      //   "opencode server listening on http://<host>:<port>"
+      const readyRe = /listening on (http:\/\/([^\s:]+):(\d+))/
+      const readyDeferred = yield* Deferred.make<{ url: string; hostname: string; port: number }>()
+      yield* Effect.forkScoped(
+        Stream.fromReadableStream({
+          evaluate: () => proc.stdout,
+          onError: () => new Error("stdout stream error"),
+        }).pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runForEach((line) => {
+            const m = line.match(readyRe)
+            return m
+              ? Deferred.succeed(readyDeferred, { url: m[1], hostname: m[2], port: Number(m[3]) })
+              : Effect.void
+          }),
+          Effect.ignore,
+        ),
+      )
+
+      const readyTimeoutMs = opts?.readyTimeoutMs ?? 15_000
+      const match = yield* Deferred.await(readyDeferred).pipe(
+        Effect.timeoutOrElse({
+          duration: Duration.millis(readyTimeoutMs),
+          orElse: () =>
+            Effect.fail(
+              new Error(
+                `opencode serve did not become ready within ${readyTimeoutMs}ms\n` +
+                  `stderr (last 2000):\n${stderrChunks.join("").slice(-2000)}`,
+              ),
+            ),
+        }),
+      )
+
+      return {
+        url: match.url,
+        hostname: match.hostname,
+        port: match.port,
+        kill: () => {
+          proc.kill()
+        },
+        exited: proc.exited as Promise<number>,
+      } satisfies ServeHandle
+    })
 
     const opencode: OpencodeCli = { run, serve, spawn, expectExit, parseJsonEvents }
 


### PR DESCRIPTION
## Summary

Adds the first long-lived-command builder to the `cli-process` harness:
`opencode.serve(opts)` spawns the real CLI in headless mode, parses the
`listening on http://...` line to learn the OS-assigned port, and returns
a handle (`url`/`port`/`kill`/`exited`) scoped to the test's lifetime so
the child is always killed on scope close.

Plus three smoke tests:
- `/global/health` round-trip — proves routing + auth-bypass + instance loading all work end-to-end.
- `--port` flag round-trip — locks in the flag wiring and the stdout contract the harness depends on.
- Scope-close kill — guards against a future refactor dropping the finalizer and leaking processes.

`cliIt.live` / `withCliFixture` now accept bodies that require `Scope`, so scope-bound resources like serve handles compose naturally without an extra `Effect.scoped` wrapper.

## Why this matters

Today nothing exercises \`opencode serve\` end-to-end. A regression that broke the listening-line stdout contract, the bound-port flag, the auth bypass, or the process lifecycle would slip through every other test tier. This adds the missing layer and reusable harness primitive for the next set of long-lived-command builders (\`acp\`, future \`server-only\` modes).

## Test plan

- [x] \`bun run test test/cli/serve/serve-process.test.ts\` — 3/3 pass locally in ~5s
- [x] \`bun run test test/cli/\` — 322/322 pass, no regressions in the existing run-process tests
- [x] \`bun run typecheck\` clean