### PR TITLE
Fix legacy pgup/pgdown TUI keybind aliases

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/keymap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/keymap.tsx
@@ -29,6 +29,8 @@ export type OpenTuiKeymap = ReturnType<typeof useKeymap>
 const KEY_ALIASES = {
   enter: "return",
   esc: "escape",
+  pgdown: "pagedown",
+  pgup: "pageup",
 } as const
 
 function expandKeyAliases(input: string) {

--- a/packages/opencode/test/cli/tui/keymap.test.tsx
+++ b/packages/opencode/test/cli/tui/keymap.test.tsx
@@ -1,0 +1,54 @@
+/** @jsxImportSource @opentui/solid */
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { onCleanup } from "solid-js"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "@/cli/cmd/tui/keymap"
+
+test("legacy page key aliases compile as page keys", async () => {
+  const sequences: Record<string, string[][]> = {}
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig({
+      keybinds: {
+        messages_page_up: "pgup",
+        messages_page_down: "pgdown",
+      },
+    })
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offLayer = keymap.registerLayer({
+      bindings: config.keybinds.gather("session", ["session.page.up", "session.page.down"]),
+    })
+    const bindings = keymap.getCommandBindings({
+      visibility: "registered",
+      commands: ["session.page.up", "session.page.down"],
+    })
+    sequences.up =
+      bindings.get("session.page.up")?.map((binding) => binding.sequence.map((part) => part.stroke.name)) ?? []
+    sequences.down =
+      bindings.get("session.page.down")?.map((binding) => binding.sequence.map((part) => part.stroke.name)) ?? []
+    onCleanup(() => {
+      offLayer()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    expect(sequences).toEqual({
+      up: [["pageup"]],
+      down: [["pagedown"]],
+    })
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
- Fixes #28238.
- Adds TUI keymap aliases for legacy documented pgup and pgdown values.
- Prevents those values from being parsed as multi-key sequences that swallow plain p.