### PR TITLE
fix(console): strip reasoning from OpenAI-compatible history

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -31,9 +31,10 @@ export const oaCompatHelper: ProviderHelper = ({ adjustCacheUsage }) => ({
     headers.set("x-session-affinity", headers.get("x-opencode-session") ?? "")
   },
   modifyBody: (body: Record<string, any>, _workspaceID?: string) => {
+    const sanitized = stripNonStandardMessageFields(body)
     return {
-      ...body,
-      ...(body.stream ? { stream_options: { include_usage: true } } : {}),
+      ...sanitized,
+      ...(sanitized.stream ? { stream_options: { include_usage: true } } : {}),
     }
   },
   createBinaryStreamDecoder: () => undefined,
@@ -79,6 +80,17 @@ export const oaCompatHelper: ProviderHelper = ({ adjustCacheUsage }) => ({
     }
   },
 })
+
+function stripNonStandardMessageFields(body: Record<string, any>) {
+  if (!Array.isArray(body.messages)) return body
+  return {
+    ...body,
+    messages: body.messages.map((message) => {
+      if (!message || typeof message !== "object") return message
+      return Object.fromEntries(Object.entries(message).filter(([key]) => key !== "reasoning"))
+    }),
+  }
+}
 
 export function fromOaCompatibleRequest(body: any): CommonRequest {
   if (!body || typeof body !== "object") return body

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -87,7 +87,8 @@ function stripNonStandardMessageFields(body: Record<string, any>) {
     ...body,
     messages: body.messages.map((message) => {
       if (!message || typeof message !== "object") return message
-      return Object.fromEntries(Object.entries(message).filter(([key]) => key !== "reasoning"))
+      const { reasoning: _reasoning, ...sanitized } = message
+      return sanitized
     }),
   }
 }

--- a/packages/console/app/test/openai-compatible.test.ts
+++ b/packages/console/app/test/openai-compatible.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { createBodyConverter } from "../src/routes/zen/util/provider/provider"
+import { oaCompatHelper } from "../src/routes/zen/util/provider/openai-compatible"
+
+describe("oa-compatible provider requests", () => {
+  test("strips non-standard reasoning fields from assistant history on same-format requests", () => {
+    const converted = createBodyConverter("oa-compat", "oa-compat")({
+      model: "kimi-k2.6",
+      messages: [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: "hi",
+          reasoning: "thinking text that some clients preserve",
+        },
+      ],
+      stream: false,
+    })
+
+    const outgoing = oaCompatHelper({ reqModel: "kimi-k2.6", providerModel: "kimi-k2.6" }).modifyBody(converted)
+
+    expect(outgoing.messages[1]).toEqual({ role: "assistant", content: "hi" })
+  })
+})

--- a/packages/console/app/test/openai-compatible.test.ts
+++ b/packages/console/app/test/openai-compatible.test.ts
@@ -3,11 +3,15 @@ import { createBodyConverter } from "../src/routes/zen/util/provider/provider"
 import { oaCompatHelper } from "../src/routes/zen/util/provider/openai-compatible"
 
 describe("oa-compatible provider requests", () => {
-  test("strips non-standard reasoning fields from assistant history on same-format requests", () => {
+  test("strips non-standard reasoning fields from chat history on same-format requests", () => {
     const converted = createBodyConverter("oa-compat", "oa-compat")({
       model: "kimi-k2.6",
       messages: [
-        { role: "user", content: "hello" },
+        {
+          role: "user",
+          content: "hello",
+          reasoning: "client-side reasoning metadata",
+        },
         {
           role: "assistant",
           content: "hi",
@@ -19,6 +23,9 @@ describe("oa-compatible provider requests", () => {
 
     const outgoing = oaCompatHelper({ reqModel: "kimi-k2.6", providerModel: "kimi-k2.6" }).modifyBody(converted)
 
-    expect(outgoing.messages[1]).toEqual({ role: "assistant", content: "hi" })
+    expect(outgoing.messages).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ])
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #27852

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI-compatible requests could bypass request normalization when the incoming request format and provider format were both `oa-compat`.

That meant non-standard fields preserved by some clients, such as `messages[].reasoning`, could be forwarded directly to the provider. For `kimi-k2.6` through OpenCode Go, this caused a 400 error because the gateway rejected `messages[X].reasoning`.

This PR strips the non-standard `reasoning` field from chat history messages before sending OpenAI-compatible provider requests. It does not remove top-level reasoning settings or provider-specific reasoning fields such as `reasoning_content`.

### How did you verify your code works?

Added a regression test for the `oa-compat -> oa-compat` path and ran:

```bash
cd packages/console/app
bun test