### PR TITLE
feat(httpapi): add v2 public error schemas

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/errors.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/errors.ts
@@ -1,5 +1,127 @@
 import { Schema } from "effect"
 
+export class InvalidRequestError extends Schema.TaggedErrorClass<InvalidRequestError>()(
+  "InvalidRequestError",
+  {
+    message: Schema.String,
+    kind: Schema.optional(Schema.String),
+    field: Schema.optional(Schema.String),
+  },
+  { httpApiStatus: 400 },
+) {}
+
+export class UnauthorizedError extends Schema.TaggedErrorClass<UnauthorizedError>()(
+  "UnauthorizedError",
+  { message: Schema.String },
+  { httpApiStatus: 401 },
+) {}
+
+export class ForbiddenError extends Schema.TaggedErrorClass<ForbiddenError>()(
+  "ForbiddenError",
+  { message: Schema.String },
+  { httpApiStatus: 403 },
+) {}
+
+export class ConflictError extends Schema.TaggedErrorClass<ConflictError>()(
+  "ConflictError",
+  {
+    message: Schema.String,
+    resource: Schema.optional(Schema.String),
+  },
+  { httpApiStatus: 409 },
+) {}
+
+export class UpstreamError extends Schema.TaggedErrorClass<UpstreamError>()(
+  "UpstreamError",
+  {
+    message: Schema.String,
+    service: Schema.optional(Schema.String),
+    status: Schema.optional(Schema.Number),
+  },
+  { httpApiStatus: 502 },
+) {}
+
+export class ServiceUnavailableError extends Schema.TaggedErrorClass<ServiceUnavailableError>()(
+  "ServiceUnavailableError",
+  {
+    message: Schema.String,
+    service: Schema.optional(Schema.String),
+  },
+  { httpApiStatus: 503 },
+) {}
+
+export class TimeoutError extends Schema.TaggedErrorClass<TimeoutError>()(
+  "TimeoutError",
+  {
+    message: Schema.String,
+    operation: Schema.optional(Schema.String),
+  },
+  { httpApiStatus: 504 },
+) {}
+
+export class UnknownError extends Schema.TaggedErrorClass<UnknownError>()(
+  "UnknownError",
+  {
+    message: Schema.String,
+    ref: Schema.optional(Schema.String),
+  },
+  { httpApiStatus: 500 },
+) {}
+
+export class ProviderNotFoundError extends Schema.TaggedErrorClass<ProviderNotFoundError>()(
+  "ProviderNotFoundError",
+  {
+    providerID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
+export class ModelNotFoundError extends Schema.TaggedErrorClass<ModelNotFoundError>()(
+  "ModelNotFoundError",
+  {
+    providerID: Schema.String,
+    modelID: Schema.String,
+    suggestions: Schema.Array(Schema.String),
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
+export class SessionNotFoundError extends Schema.TaggedErrorClass<SessionNotFoundError>()(
+  "SessionNotFoundError",
+  {
+    sessionID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
+export class MessageNotFoundError extends Schema.TaggedErrorClass<MessageNotFoundError>()(
+  "MessageNotFoundError",
+  {
+    sessionID: Schema.String,
+    messageID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
+export class InvalidCursorError extends Schema.TaggedErrorClass<InvalidCursorError>()(
+  "InvalidCursorError",
+  { message: Schema.String },
+  { httpApiStatus: 400 },
+) {}
+
+export class SessionBusyError extends Schema.TaggedErrorClass<SessionBusyError>()(
+  "SessionBusyError",
+  {
+    sessionID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 409 },
+) {}
+
 export class ApiNotFoundError extends Schema.ErrorClass<ApiNotFoundError>("NotFoundError")(
   {
     name: Schema.Literal("NotFoundError"),


### PR DESCRIPTION
## summary
- add reusable v2 public HTTP error schemas with status annotations
- keep legacy ApiNotFoundError unchanged and avoid wiring the new errors into routes yet

## testing
- bun typecheck
- push hook ran bun turbo typecheck