### PR TITLE
feat(opencode): map .gd files to gdscript

### DIFF
--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -32,6 +32,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".fsi": "fsharp",
   ".fsx": "fsharp",
   ".fsscript": "fsharp",
+  ".gd": "gdscript",
   ".gitcommit": "git-commit",
   ".gitrebase": "git-rebase",
   ".go": "go",


### PR DESCRIPTION
### Issue for this PR

Closes #28304

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `.gd` -> `gdscript` to the LSP language mapping.

This is a narrow change for GDScript support. OpenCode already uses this mapping to choose the `languageId` sent when opening files over LSP, so adding the missing `.gd` mapping lets GDScript files open with the correct language ID.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Ran `bun test` in `packages/opencode`
- Verified locally against a GDScript project that LSP queries returned results after the mapping change

Note: the package test suite currently has unrelated failures in `test/file/watcher.test.ts` and `test/format/format.test.ts`. This change does not touch those areas.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR