### PR TITLE
fix: prevent chat history from being covered when input grows (#372)

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1191,6 +1191,7 @@ export default function Page() {
   let scrollStateFrame: number | undefined
   let scrollStateTarget: HTMLDivElement | undefined
   let fillFrame: number | undefined
+  let dockScrollFrame: number | undefined
 
   const jumpThreshold = (el: HTMLDivElement) => Math.max(400, el.clientHeight)
 
@@ -1594,7 +1595,20 @@ export default function Page() {
 
       dockHeight = next
 
-      if (stick) autoScroll.forceScrollToBottom()
+      if (stick) {
+        autoScroll.forceScrollToBottom()
+
+        // When the dock grows, the scroller's clientHeight may not have
+        // updated yet in this frame. Defer a re-scroll to keep the timeline
+        // at the bottom after the layout settles.
+        if (delta > 0) {
+          if (dockScrollFrame !== undefined) cancelAnimationFrame(dockScrollFrame)
+          dockScrollFrame = requestAnimationFrame(() => {
+            dockScrollFrame = undefined
+            if (!autoScroll.userScrolled()) autoScroll.forceScrollToBottom()
+          })
+        }
+      }
 
       if (el) scheduleScrollState(el)
       fill()
@@ -1644,6 +1658,7 @@ export default function Page() {
     if (diffTimer !== undefined) window.clearTimeout(diffTimer)
     if (scrollStateFrame !== undefined) cancelAnimationFrame(scrollStateFrame)
     if (fillFrame !== undefined) cancelAnimationFrame(fillFrame)
+    if (dockScrollFrame !== undefined) cancelAnimationFrame(dockScrollFrame)
   })
 
   useUsageExceededDialogs()

--- a/packages/ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/ui/src/hooks/create-auto-scroll.tsx
@@ -186,6 +186,19 @@ export function createAutoScroll(options: AutoScrollOptions) {
     },
   )
 
+  createResizeObserver(
+    () => store.scrollRef,
+    () => {
+      const el = store.scrollRef
+      if (!el) return
+      if (!canScroll(el)) return
+      if (store.userScrolled) return
+      // When the viewport resizes (e.g. composer grows and shrinks the
+      // scroller), re-anchor to bottom so chat history doesn't get covered.
+      scrollToBottom(false)
+    },
+  )
+
   createEffect(
     on(options.working, (working: boolean) => {
       settling = false


### PR DESCRIPTION
## Summary

- Fixes #372: When the prompt input grows large (e.g. pasting lots of text), the chat history gets covered up and users can't scroll to see the bottom messages.

## Root cause

The session panel uses a flex column layout where the timeline container (`flex-1 min-h-0`) shrinks when the composer/input grows. The auto-scroll hook only observed the content element (`contentRef`) for resizes, not the viewport itself (`scrollRef`). When the composer grows, the viewport shrinks but the scroll position wasn't recalculated for the smaller viewport, leaving the bottom of chat history behind the input box.

## Changes

1. **`packages/ui/src/hooks/create-auto-scroll.tsx`**: Added a `ResizeObserver` on `scrollRef` (the viewport) that re-anchors to the bottom when the viewport resizes and the user is auto-following.

2. **`packages/app/src/pages/session.tsx`**: Added a deferred `requestAnimationFrame` re-scroll in the prompt dock observer when the dock grows, to catch cases where the scroller's `clientHeight` hasn't updated yet when the resize callback fires.

## How verified

- The `createAutoScroll` changes handle any viewport size change (composer growth, window resize, side panel changes) by re-anchoring to bottom when auto-following.
- The prompt dock deferred scroll catches edge cases where `ResizeObserver` fires before the scroller's layout has fully settled.
- Both changes are guarded by `userScrolled` checks - they don't override intentional user scroll position.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR