### PR TITLE
fix(app): invalidate provider queries after config update to show custom providers immediately

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -422,7 +422,13 @@ function createGlobalSync() {
 
   const updateConfigMutation = useMutation(() => ({
     mutationFn: (config: Config) => globalSDK.client.global.config.update({ config }),
-    onSuccess: () => bootstrap.refetch(),
+    onSuccess: () => {
+      bootstrap.refetch()
+      // Invalidate all provider queries so newly configured custom providers
+      // appear immediately in the available provider list across all directories.
+      queryClient.invalidateQueries({ queryKey: [null, "providers"] })
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[1] === "providers" })
+    },
   }))
 
   return {


### PR DESCRIPTION
### Issue for this PR

Closes #24818

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the issue where custom providers configured in Desktop settings do not appear in the model selection list until the app is restarted.

The root cause: `updateConfigMutation.onSuccess` in `global-sync.tsx` only called `bootstrap.refetch()`, which refreshes global provider data but does not invalidate per-directory provider queries cached in `child-store.ts`. Each project directory maintains its own provider list with queryKey `[directory, "providers"]`, so these stayed stale after config update.

The fix adds `queryClient.invalidateQueries()` calls to clear both global and per-directory provider caches after a successful config update, so the newly added custom provider shows up immediately.

### How did you verify your code works?

The change targets the query cache invalidation path. `invalidateQueries` is the standard TanStack Query API for this purpose - when the provider config is updated, invalidating all `[*, "providers"]` queries forces a refetch on next access, which will include the newly configured custom provider.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR