### PR TITLE
docs(ecosystem): add opencode-ask to plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -23,7 +23,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                              |
-| [opencode-ask](https://github.com/MRZ07/ask)                                                      | Read-only Q&A agent — ask questions about your codebase, get answers with source citations        |
+| [opencode-ask](https://github.com/MRZ07/opencode-ask)                                                      | Read-only Q&A agent — ask questions about your codebase, get answers with source citations        |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                             |

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -23,6 +23,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                              |
+| [opencode-ask](https://github.com/MRZ07/ask)                                                      | Read-only Q&A agent — ask questions about your codebase, get answers with source citations        |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                             |


### PR DESCRIPTION
### Issue for this PR

N/A — just adding a plugin to the ecosystem list.

### Type of change

- [X] Documentation

### What does this PR do?

Adds opencode-ask to the plugins table in the ecosystem docs. It's a read-only Q&A agent that lets you ask questions about your codebase and get answers with source citations.

### How did you verify your code works?

Confirmed the entry renders correctly in the markdown table and the link points to the correct repo.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR