### PR TITLE
fix(core): add exit fallback for child process close hangs

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -273,6 +273,11 @@ export const make = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
+        setTimeout(() => {
+          if (end) return
+          end = true
+          Deferred.doneUnsafe(signal, Exit.succeed(args))
+        }, 2_000)
       })
       proc.on("close", (...args) => {
         if (end) return

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -282,6 +282,29 @@ describe("cross-spawn spawner", () => {
         expect(running).toBe(false)
       }),
     )
+
+    fx.effect(
+      "exit fallback resolves when close hangs due to grandchild holding pipe",
+      Effect.gen(function* () {
+        if (process.platform !== "win32") return
+
+        const started = Date.now()
+        const handle = yield* js(`
+          const { spawn } = require("child_process")
+          spawn(process.execPath, ["-e", "setTimeout(() => {}, 10000)"], {
+            stdio: ["ignore", process.stdout, "ignore"],
+            detached: true,
+          })
+          process.exit(0)
+        `)
+        const code = yield* handle.exitCode
+        const elapsed = Date.now() - started
+
+        expect(elapsed).toBeGreaterThan(1_500)
+        expect(elapsed).toBeLessThan(5_000)
+        expect(code).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+    )
   })
 
   describe("error handling", () => {


### PR DESCRIPTION
## Summary
- add a minimal exit-event fallback in packages/core/src/cross-spawn-spawner.ts
- keep the current close-first behavior in the normal case
- add a Windows regression test for grandchild stdout handle inheritance

## Why
Commands such as Gradle / dotnet / hvigor can finish successfully while a daemon or grandchild process still holds inherited stdout/stderr handles open. In that case Node's close event may be delayed indefinitely even though exit has already fired, which leaves shell/task execution stuck waiting for handle.exitCode.

This patch keeps existing behavior when close arrives promptly, but falls back to the cached exit result after 2 seconds when close never arrives.

## Related
- fixes the same root cause discussed in #24784
- also matches reports like #25038 and #24926

## Testing
- Added a Windows-only regression test for the grandchild-pipe scenario
- Local un is not available in this environment, so I could not run un typecheck / package tests here
