### PR TITLE
fix(llm): forward reasoning_content in experimental OpenAI Chat assistant messages

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -187,11 +187,10 @@ const lowerToolCall = (part: ToolCallPart): OpenAIChatAssistantToolCall => ({
 
 const openAICompatibleReasoningContent = (native: unknown) => {
   if (!isRecord(native)) return undefined
-  const po = native["providerOptions"]
-  if (!isRecord(po)) return undefined
-  const oc = po["openaiCompatible"]
-  if (!isRecord(oc)) return undefined
-  return typeof oc["reasoning_content"] === "string" ? oc["reasoning_content"] : undefined
+  if (!isRecord(native["providerOptions"])) return undefined
+  if (!isRecord(native["providerOptions"]["openaiCompatible"])) return undefined
+  const reasoning = native["providerOptions"]["openaiCompatible"]["reasoning_content"]
+  return typeof reasoning === "string" ? reasoning : undefined
 }
 
 const lowerUserMessage = Effect.fn("OpenAIChat.lowerUserMessage")(function* (message: OpenAIChatRequestMessage) {

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -185,8 +185,14 @@ const lowerToolCall = (part: ToolCallPart): OpenAIChatAssistantToolCall => ({
   },
 })
 
-const openAICompatibleReasoningContent = (native: unknown) =>
-  isRecord(native) && typeof native.reasoning_content === "string" ? native.reasoning_content : undefined
+const openAICompatibleReasoningContent = (native: unknown) => {
+  if (!isRecord(native)) return undefined
+  const po = native["providerOptions"]
+  if (!isRecord(po)) return undefined
+  const oc = po["openaiCompatible"]
+  if (!isRecord(oc)) return undefined
+  return typeof oc["reasoning_content"] === "string" ? oc["reasoning_content"] : undefined
+}
 
 const lowerUserMessage = Effect.fn("OpenAIChat.lowerUserMessage")(function* (message: OpenAIChatRequestMessage) {
   const content: TextPart[] = []
@@ -219,7 +225,7 @@ const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(func
     role: "assistant" as const,
     content: content.length === 0 ? null : ProviderShared.joinText(content),
     tool_calls: toolCalls.length === 0 ? undefined : toolCalls,
-    reasoning_content: openAICompatibleReasoningContent(message.native?.providerOptions?.openaiCompatible),
+    reasoning_content: openAICompatibleReasoningContent(message.native),
   }
 })
 

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -219,7 +219,7 @@ const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(func
     role: "assistant" as const,
     content: content.length === 0 ? null : ProviderShared.joinText(content),
     tool_calls: toolCalls.length === 0 ? undefined : toolCalls,
-    reasoning_content: openAICompatibleReasoningContent(message.native?.openaiCompatible),
+    reasoning_content: openAICompatibleReasoningContent(message.native?.providerOptions?.openaiCompatible),
   }
 })
 

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -179,6 +179,38 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("prepares assistant tool-call message with reasoning_content from native providerOptions", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          id: "req_reasoning_tool_call",
+          model,
+          messages: [
+            Message.user("What is the weather?"),
+            new Message({
+              role: "assistant",
+              content: [ToolCallPart.make({ id: "call_1", name: "lookup", input: { query: "weather" } })],
+              native: { providerOptions: { openaiCompatible: { reasoning_content: "thinking about weather" } } },
+            }),
+          ],
+        }),
+      )
+
+      expect(prepared.body.messages[1]).toEqual({
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "lookup", arguments: encodeJson({ query: "weather" }) },
+          },
+        ],
+        reasoning_content: "thinking about weather",
+      })
+    }),
+  )
+
   it.effect("rejects unsupported user media content", () =>
     Effect.gen(function* () {
       const error = yield* LLMClient.prepare(


### PR DESCRIPTION
### Issue for this PR

Closes #19081

_Note: This is fixing a future bug with experimental code; the current production issue is still being investigated against the AI SDK._

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The OpenAI Chat protocol was reading `message.native?.openaiCompatible` but the actual structure after the transform chain is `message.native.providerOptions.openaiCompatible`. This caused `reasoning_content` to be stripped from historical assistant messages during tool-call workflows, destroying KV cache optimization on multi-turn conversations with local reasoning models.

The `openAICompatibleReasoningContent` helper in `packages/llm/src/protocols/openai-chat.ts` was looking for `message.native?.openaiCompatible`, but the only place that populates `message.native` is `native-request.ts:118`, which wraps provider options as `{ providerOptions: { openaiCompatible: { reasoning_content: "..." } } }`. The function always returned `undefined`.

This only affects the experimental native LLM adapter (`OPENCODE_EXPERIMENTAL_NATIVE_LLM=true`). The default AI SDK path handles reasoning content separately and is not impacted.

The fix passes `message.native` directly to the helper and navigates the actual structure with explicit `isRecord` guards at each level: `native → providerOptions → openaiCompatible → reasoning_content`. This restores `reasoning_content` on historical assistant messages so the LLM receives the full conversation history including reasoning from previous turns.

### How did you verify your code works?

- Added a unit test in `packages/llm/test/provider/openai-chat.test.ts` that constructs a message with the correct `native` shape and asserts `reasoning_content` appears in the prepared body.
- Ran a live session with `local/qwen3.6-35b-a3b` through a tool-call workflow — KV cache hit rate went from 0% to ~87% on turn 2.

### Screenshots / recordings

N/A — no UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR