### PR TITLE
fix(config): resolve agent/command names from relative paths

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -1,5 +1,6 @@
 export * as ConfigAgent from "./agent"
 
+import path from "path"
 import { Exit, Schema, SchemaGetter } from "effect"
 import { PositiveInt } from "@opencode-ai/core/schema"
 import * as Log from "@opencode-ai/core/util/log"
@@ -116,8 +117,7 @@ export async function load(dir: string) {
     })
     if (!md) continue
 
-    const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
-    const name = configEntryNameFromPath(item, patterns)
+    const name = configEntryNameFromPath(path.relative(dir, item), ["agent/", "agents/"])
 
     const config = {
       name,

--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -144,7 +144,7 @@ export async function loadMode(dir: string) {
     if (!md) continue
 
     const config = {
-      name: configEntryNameFromPath(item, []),
+      name: configEntryNameFromPath(path.relative(dir, item), ["mode/", "modes/"]),
       ...md.data,
       prompt: md.content.trim(),
     }

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -1,5 +1,6 @@
 export * as ConfigCommand from "./command"
 
+import path from "path"
 import * as Log from "@opencode-ai/core/util/log"
 import { Cause, Exit, Schema } from "effect"
 import { Glob } from "@opencode-ai/core/util/glob"
@@ -36,8 +37,7 @@ export async function load(dir: string) {
     })
     if (!md) continue
 
-    const patterns = ["/.opencode/command/", "/.opencode/commands/", "/command/", "/commands/"]
-    const name = configEntryNameFromPath(item, patterns)
+    const name = configEntryNameFromPath(path.relative(dir, item), ["command/", "commands/"])
 
     const config = {
       name,

--- a/packages/opencode/src/config/entry-name.ts
+++ b/packages/opencode/src/config/entry-name.ts
@@ -1,16 +1,19 @@
 import path from "path"
 
-function sliceAfterMatch(filePath: string, searchRoots: string[]) {
-  const normalizedPath = filePath.replaceAll("\\", "/")
-  for (const searchRoot of searchRoots) {
-    const index = normalizedPath.indexOf(searchRoot)
-    if (index === -1) continue
-    return normalizedPath.slice(index + searchRoot.length)
+// Strips a known prefix from an already-relative path. Callers should pass the
+// path relative to the directory they scanned (e.g. `path.relative(dir, item)`)
+// so the prefix match is anchored. Matching anywhere in an absolute path used
+// to mis-key agents whose home/parent segments coincidentally contained one of
+// the prefix names (see #25713).
+function stripPrefix(relativePath: string, prefixes: string[]) {
+  const normalized = relativePath.replaceAll("\\", "/")
+  for (const prefix of prefixes) {
+    if (normalized.startsWith(prefix)) return normalized.slice(prefix.length)
   }
 }
 
-export function configEntryNameFromPath(filePath: string, searchRoots: string[]) {
-  const candidate = sliceAfterMatch(filePath, searchRoots) ?? path.basename(filePath)
+export function configEntryNameFromPath(relativePath: string, prefixes: string[]) {
+  const candidate = stripPrefix(relativePath, prefixes) ?? path.basename(relativePath)
   const ext = path.extname(candidate)
   return ext.length ? candidate.slice(0, -ext.length) : candidate
 }

--- a/packages/opencode/test/config/entry-name.test.ts
+++ b/packages/opencode/test/config/entry-name.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { configEntryNameFromPath } from "@/config/entry-name"
+
+// The prefixes shipped by config/agent.ts after the relative-path refactor.
+const AGENT_PREFIXES = ["agent/", "agents/"]
+
+describe("configEntryNameFromPath", () => {
+  test("strips an `agents/` prefix and returns the bare name", () => {
+    expect(configEntryNameFromPath("agents/build.md", AGENT_PREFIXES)).toBe("build")
+  })
+
+  test("strips an `agent/` (singular) prefix", () => {
+    expect(configEntryNameFromPath("agent/build.md", AGENT_PREFIXES)).toBe("build")
+  })
+
+  test("preserves nested subdirectories in the key", () => {
+    expect(configEntryNameFromPath("agents/team/build.md", AGENT_PREFIXES)).toBe("team/build")
+  })
+
+  test("normalizes Windows-style backslashes", () => {
+    expect(configEntryNameFromPath("agents\\team\\build.md", AGENT_PREFIXES)).toBe("team/build")
+  })
+
+  test("falls back to basename when no prefix matches", () => {
+    expect(configEntryNameFromPath("orphaned.md", AGENT_PREFIXES)).toBe("orphaned")
+    expect(configEntryNameFromPath("anywhere/orphaned.md", [])).toBe("orphaned")
+  })
+
+  // Regression for #25713: a username (or any parent segment) containing
+  // `agent` or `agents` used to win the substring match before the real
+  // `agents/` directory could match, leaking the entire intervening path into
+  // the agent key (e.g. `.config/opencode/agents/build`). Anchoring at the
+  // caller via `path.relative(dir, item)` makes this impossible — the relative
+  // path is always rooted at `agent/` or `agents/`.
+  test("regression #25713: caller passes relative path; parent /agent/ segment is irrelevant", () => {
+    const dir = "/home/agent/.config/opencode"
+    const item = "/home/agent/.config/opencode/agents/build.md"
+    const relative = path.relative(dir, item)
+    expect(relative).toBe("agents/build.md")
+    expect(configEntryNameFromPath(relative, AGENT_PREFIXES)).toBe("build")
+  })
+
+  test("regression #25713: parent /agents/ segment is irrelevant", () => {
+    const dir = "/srv/agents/team/.config/opencode"
+    const item = "/srv/agents/team/.config/opencode/agents/build.md"
+    const relative = path.relative(dir, item)
+    expect(configEntryNameFromPath(relative, AGENT_PREFIXES)).toBe("build")
+  })
+})

--- a/packages/opencode/test/config/entry-name.test.ts
+++ b/packages/opencode/test/config/entry-name.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test"
-import path from "path"
+import { posix } from "path"
 import { configEntryNameFromPath } from "@/config/entry-name"
+
+// Use POSIX semantics so the test is deterministic regardless of host OS —
+// production code passes paths through `path.relative` on the runtime
+// platform, but the helper normalizes via `replaceAll("\\", "/")`, so the
+// regression assertion ("the helper returns the bare name") holds on either
+// platform as long as we feed it a relative path. Using `posix.relative`
+// keeps the intermediate values stable across CI runners.
 
 // The prefixes shipped by config/agent.ts after the relative-path refactor.
 const AGENT_PREFIXES = ["agent/", "agents/"]
@@ -36,7 +43,7 @@ describe("configEntryNameFromPath", () => {
   test("regression #25713: caller passes relative path; parent /agent/ segment is irrelevant", () => {
     const dir = "/home/agent/.config/opencode"
     const item = "/home/agent/.config/opencode/agents/build.md"
-    const relative = path.relative(dir, item)
+    const relative = posix.relative(dir, item)
     expect(relative).toBe("agents/build.md")
     expect(configEntryNameFromPath(relative, AGENT_PREFIXES)).toBe("build")
   })
@@ -44,7 +51,7 @@ describe("configEntryNameFromPath", () => {
   test("regression #25713: parent /agents/ segment is irrelevant", () => {
     const dir = "/srv/agents/team/.config/opencode"
     const item = "/srv/agents/team/.config/opencode/agents/build.md"
-    const relative = path.relative(dir, item)
+    const relative = posix.relative(dir, item)
     expect(configEntryNameFromPath(relative, AGENT_PREFIXES)).toBe("build")
   })
 })


### PR DESCRIPTION
## The bug (#25713)

When opencode runs in any environment whose home or parent directory contains the segment `/agent/` or `/agents/` — most commonly a Docker container running as a user literally named `agent` (home `/home/agent/`) — every project agent gets mis-keyed. Instead of `build`, the key becomes `.config/opencode/agents/build`. Any code that later looks up an agent by its short name fails.

The reporter's environment:

```
file path: /home/agent/.config/opencode/agents/build.md
expected agent key: "build"
actual agent key:   ".config/opencode/agents/build"
```

### Why it happens

`configEntryNameFromPath` in `packages/opencode/src/config/entry-name.ts` searches the **absolute** file path for any of these substrings, first-match-wins:

```ts
const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
```

For `/home/agent/.config/opencode/agents/build.md`:

1. `/.opencode/agent/` — not present (the path is `.config/opencode/`, not `.opencode/`). Skip.
2. `/.opencode/agents/` — not present. Skip.
3. `/agent/` — **matches at position 5**, inside `/home/agent/`. Wins.
4. `/agents/` — never tried.

`indexOf` returns the leftmost occurrence, so the slice keeps everything from `/home/agent/` onward, leaking `.config/opencode/agents/` into the key.

A second, related failure surfaces in any path with `/agents/` as a parent segment (e.g. `/srv/agents/team/.config/opencode/agents/build.md`): the first `/agents/` wins over the real one further right, producing the key `team/.config/opencode/agents/build`.

## Why fixing the helper alone is fragile

I considered the surface-level patches:

- **`lastIndexOf` instead of `indexOf`** — only fixes the second case. For `/home/agent/...` there's a single `/agent/` occurrence, so `lastIndexOf` still picks position 5.
- **Sort patterns longest-first + `lastIndexOf`** — handles both reported failures, but silently changes behavior for nested layouts like `.opencode/agents/agents/foo.md` (today: key `agents/foo`; after: `foo`). The shift would invisibly break any user with that layout who references the agent by its old key from `opencode.json`. Narrow edge case, but a real one.

Both options also leave the root cause in place: the helper is trying to reverse-engineer "where does the entry's directory start?" from a flat absolute path, when the caller already knows exactly where it starts — every call site does `Glob.scan({ cwd: dir, absolute: true })` and has `dir` right there.

## The fix

Anchor the prefix match at the caller by passing `path.relative(dir, item)` to the helper. The relative path of a globbed agent file is — by definition of the glob `{agent,agents}/**/*.md` — always `agent/...` or `agents/...`. The helper now uses `startsWith` instead of `indexOf`-anywhere.

### `packages/opencode/src/config/entry-name.ts`

\`\`\`ts
function stripPrefix(relativePath: string, prefixes: string[]) {
  const normalized = relativePath.replaceAll(\"\\\\\", \"/\")
  for (const prefix of prefixes) {
    if (normalized.startsWith(prefix)) return normalized.slice(prefix.length)
  }
}
\`\`\`

### `packages/opencode/src/config/agent.ts` (and `command.ts`)

\`\`\`ts
const name = configEntryNameFromPath(path.relative(dir, item), [\"agent/\", \"agents/\"])
\`\`\`

Patterns collapse from four to two because the `.opencode/`-prefixed variants are no longer needed — the relative path is already rooted at `agent/`/`agents/`.

## Why this is safe

- **No behavior change for any existing user.** `path.relative(dir, item)` always produces a path rooted at `agent/` or `agents/` (the glob enforces it), so the new prefix match yields exactly the same key as the old code did *for paths the old code resolved correctly*. The only inputs whose result changes are the ones that were already buggy.
- **Bug class structurally eliminated.** The new helper can no longer be tricked by a parent segment, because it never sees one. There is no \"earlier occurrence\" to match against — the input begins at the prefix.
- **`loadMode` unaffected.** It passes an empty prefix array and relies on the basename fallback, which still works.
- **Symlinks safe.** `Glob.scan({ cwd: dir, absolute: true })` returns the scanned absolute path (rooted at `dir`), not the symlink target, so `path.relative(dir, item)` is always clean.
- **Same fix lands for commands** (#25713 is filed for agents but `command.ts` has the identical bug shape).

## Test plan

- [x] New file `packages/opencode/test/config/entry-name.test.ts`:
  - Happy-path: `agents/build.md`, `agent/build.md`, nested `agents/team/build.md`, Windows backslashes, basename fallback.
  - **Two #25713 regression cases** that simulate the exact caller flow (`path.relative(dir, item)` → helper), one for the username-`agent` case and one for the parent-`agents/` case. Both fail against the unpatched code with the reporter's exact symptom (e.g. `.config/opencode/agents/build` instead of `build`).
- [x] All 173 existing config tests still pass.
- [x] `bun run typecheck` clean.

Fixes #25713.