### PR TITLE
Fix: queued prompts starting before active response completes

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1208,8 +1208,8 @@ export const layer = Layer.effect(
       return { info, parts }
     }, Effect.scoped)
 
-    const prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts, Image.Error> = Effect.fn(
-      "SessionPrompt.prompt",
+    const persistPrompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts, Image.Error> = Effect.fn(
+      "SessionPrompt.persistPrompt",
     )(function* (input: PromptInput) {
       const session = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
       yield* revert.cleanup(session)
@@ -1225,8 +1225,7 @@ export const layer = Layer.effect(
         yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
       }
 
-      if (input.noReply === true) return message
-      return yield* loop({ sessionID: input.sessionID })
+      return message
     })
 
     const lastAssistant = Effect.fnUntraced(function* (sessionID: SessionID) {
@@ -1236,6 +1235,26 @@ export const layer = Layer.effect(
       if (msgs.length > 0) return msgs[0]
       throw new Error("Impossible")
     })
+
+    interface QueuedTurnState {
+      active?: MessageID
+      draining: boolean
+      messageIDs: MessageID[]
+    }
+
+    const queuedTurns = new Map<SessionID, QueuedTurnState>()
+
+    function queuedState(sessionID: SessionID) {
+      const existing = queuedTurns.get(sessionID)
+      if (existing) return existing
+      const next: QueuedTurnState = { draining: false, messageIDs: [] }
+      queuedTurns.set(sessionID, next)
+      return next
+    }
+
+    function queuedMessageIDs(sessionID: SessionID) {
+      return new Set(queuedTurns.get(sessionID)?.messageIDs ?? [])
+    }
 
     const runLoop: (sessionID: SessionID) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
@@ -1250,6 +1269,8 @@ export const layer = Layer.effect(
           yield* slog.info("loop", { step })
 
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
+          const queued = queuedMessageIDs(sessionID)
+          if (queued.size > 0) msgs = msgs.filter((msg) => !queued.has(msg.info.id))
 
           const { user: lastUser, assistant: lastAssistant, finished: lastFinished, tasks } = MessageV2.latest(msgs)
 
@@ -1264,12 +1285,16 @@ export const layer = Layer.effect(
           // provider's stream (e.g. DWS Agent Platform) and don't need a re-loop.
           const hasToolCalls =
             lastAssistantMsg?.parts.some((part) => part.type === "tool" && !part.metadata?.providerExecuted) ?? false
+          const activeQueuedMessageID = queuedTurns.get(sessionID)?.active
+          const activeQueuedAwaitingAnswer =
+            lastUser.id === activeQueuedMessageID && lastAssistant?.parentID !== activeQueuedMessageID
 
           if (
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastUser.id < lastAssistant.id &&
+            !activeQueuedAwaitingAnswer
           ) {
             yield* slog.info("exiting loop")
             break
@@ -1486,6 +1511,69 @@ export const layer = Layer.effect(
       input: LoopInput,
     ) {
       return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID))
+    })
+
+    const drainQueuedTurns = Effect.fn("SessionPrompt.drainQueuedTurns")(function* (sessionID: SessionID) {
+      const queue = queuedState(sessionID)
+      if (queue.draining) return
+      queue.draining = true
+      try {
+        while (queue.messageIDs.length > 0) {
+          let messageID: MessageID | undefined
+          yield* Effect.gen(function* () {
+            yield* loop({ sessionID })
+            messageID = queue.messageIDs.shift()
+            yield* status.setQueued(sessionID, queue.messageIDs)
+            if (messageID) {
+              queue.active = messageID
+              yield* runLoop(sessionID).pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    if (queue.active === messageID) delete queue.active
+                  }),
+                ),
+              )
+            }
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Effect.gen(function* () {
+                if (messageID) queue.messageIDs.unshift(messageID)
+                yield* status.setQueued(sessionID, queue.messageIDs)
+                return yield* Effect.failCause(cause)
+              }),
+            ),
+          )
+        }
+      } finally {
+        queue.draining = false
+        if (queue.messageIDs.length === 0) {
+          queuedTurns.delete(sessionID)
+          yield* status.setQueued(sessionID, [])
+        }
+      }
+    })
+
+    const prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts, Image.Error> = Effect.fn(
+      "SessionPrompt.prompt",
+    )(function* (input: PromptInput) {
+      if (input.noReply === true) return yield* persistPrompt(input)
+      const existingQueue = queuedTurns.get(input.sessionID)
+      const busy =
+        existingQueue?.draining === true ||
+        (yield* state.assertNotBusy(input.sessionID).pipe(
+          Effect.as(false),
+          Effect.catchCause(() => Effect.succeed(true)),
+        ))
+      if (!busy) {
+        yield* persistPrompt(input)
+        return yield* loop({ sessionID: input.sessionID })
+      }
+      const message = yield* persistPrompt(input)
+      const queue = queuedState(input.sessionID)
+      queue.messageIDs.push(message.info.id)
+      yield* status.setQueued(input.sessionID, queue.messageIDs)
+      yield* drainQueuedTurns(input.sessionID).pipe(Effect.forkIn(scope))
+      return message
     })
 
     const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts, Session.BusyError> = Effect.fn(

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -1,7 +1,7 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
-import { SessionID } from "./schema"
+import { MessageID, SessionID } from "./schema"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
 import { Effect, Layer, Context, Schema } from "effect"
 
@@ -27,6 +27,7 @@ export const Info = Schema.Union([
   }),
   Schema.Struct({
     type: Schema.Literal("busy"),
+    queued: Schema.optional(Schema.Array(MessageID)),
   }),
 ]).annotate({ identifier: "SessionStatus" })
 export type Info = Schema.Schema.Type<typeof Info>
@@ -52,6 +53,7 @@ export interface Interface {
   readonly get: (sessionID: SessionID) => Effect.Effect<Info>
   readonly list: () => Effect.Effect<Map<SessionID, Info>>
   readonly set: (sessionID: SessionID, status: Info) => Effect.Effect<void>
+  readonly setQueued: (sessionID: SessionID, messageIDs: MessageID[]) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionStatus") {}
@@ -64,19 +66,39 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make(
       Effect.fn("SessionStatus.state")(() => Effect.succeed(new Map<SessionID, Info>())),
     )
+    const queued = yield* InstanceState.make(
+      Effect.fn("SessionStatus.queued")(() => Effect.succeed(new Map<SessionID, MessageID[]>())),
+    )
+
+    function attachQueued(status: Info, messageIDs: MessageID[] | undefined): Info {
+      if (!messageIDs?.length) return status
+      if (status.type === "retry") return status
+      if (status.type === "idle") return { type: "busy", queued: messageIDs }
+      return { ...status, queued: messageIDs }
+    }
 
     const get = Effect.fn("SessionStatus.get")(function* (sessionID: SessionID) {
       const data = yield* InstanceState.get(state)
-      return data.get(sessionID) ?? { type: "idle" as const }
+      const queuedData = yield* InstanceState.get(queued)
+      return attachQueued(data.get(sessionID) ?? { type: "idle" as const }, queuedData.get(sessionID))
     })
 
     const list = Effect.fn("SessionStatus.list")(function* () {
-      return new Map(yield* InstanceState.get(state))
+      const data = yield* InstanceState.get(state)
+      const queuedData = yield* InstanceState.get(queued)
+      const result = new Map(
+        Array.from(data, ([sessionID, status]) => [sessionID, attachQueued(status, queuedData.get(sessionID))]),
+      )
+      for (const [sessionID, messageIDs] of queuedData) {
+        if (!result.has(sessionID)) result.set(sessionID, attachQueued({ type: "idle" }, messageIDs))
+      }
+      return result
     })
 
     const set = Effect.fn("SessionStatus.set")(function* (sessionID: SessionID, status: Info) {
       const data = yield* InstanceState.get(state)
-      yield* bus.publish(Event.Status, { sessionID, status })
+      const queuedData = yield* InstanceState.get(queued)
+      yield* bus.publish(Event.Status, { sessionID, status: attachQueued(status, queuedData.get(sessionID)) })
       if (status.type === "idle") {
         yield* bus.publish(Event.Idle, { sessionID })
         data.delete(sessionID)
@@ -85,7 +107,14 @@ export const layer = Layer.effect(
       data.set(sessionID, status)
     })
 
-    return Service.of({ get, list, set })
+    const setQueued = Effect.fn("SessionStatus.setQueued")(function* (sessionID: SessionID, messageIDs: MessageID[]) {
+      const data = yield* InstanceState.get(queued)
+      if (messageIDs.length) data.set(sessionID, [...messageIDs])
+      else data.delete(sessionID)
+      yield* bus.publish(Event.Status, { sessionID, status: yield* get(sessionID) })
+    })
+
+    return Service.of({ get, list, set, setQueued })
   }),
 )
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -345,6 +345,15 @@ const deferredAsPromise = <A>(deferred: Deferred.Deferred<A>): PromiseLike<A> =>
   },
 })
 
+function nonSystemMessages(input: Record<string, unknown> | undefined) {
+  const messages = input?.messages
+  if (!Array.isArray(messages)) return []
+  return messages.filter((message) => {
+    if (!message || typeof message !== "object") return true
+    return !("role" in message) || message.role !== "system"
+  })
+}
+
 function defer<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
   const promise = new Promise<T>((done) => {
@@ -1114,13 +1123,14 @@ it.instance(
 )
 
 it.instance(
-  "prompt submitted during an active run is included in the next LLM input",
+  "queued prompt waits for the active answer before starting the next LLM call",
   () =>
     Effect.gen(function* () {
       const { llm } = yield* useServerConfig(providerCfg)
       const gate = yield* Deferred.make<void>()
       const prompt = yield* SessionPrompt.Service
       const sessions = yield* Session.Service
+      const status = yield* SessionStatus.Service
       const chat = yield* sessions.create({ title: "Pinned" })
 
       yield* llm.hold("first", deferredAsPromise(gate))
@@ -1136,6 +1146,7 @@ it.instance(
         .pipe(Effect.forkChild)
 
       yield* llm.wait(1)
+      expect(yield* llm.calls).toBe(1)
 
       const id = MessageID.ascending()
       const b = yield* prompt
@@ -1159,12 +1170,44 @@ it.instance(
         "timed out waiting for second prompt to save",
       )
 
+      const queuedExit = yield* Fiber.await(b)
+      expect(Exit.isSuccess(queuedExit)).toBe(true)
+      if (Exit.isSuccess(queuedExit)) expect(queuedExit.value.info.role).toBe("user")
+      expect(yield* llm.calls).toBe(1)
+      expect(yield* status.get(chat.id)).toEqual({ type: "busy", queued: [id] })
+
+      const beforeRelease = yield* llm.inputs
+      const beforeReleaseMessages = nonSystemMessages(beforeRelease.at(0))
+      expect(beforeRelease).toHaveLength(1)
+      expect(JSON.stringify(beforeReleaseMessages)).toContain("first")
+      expect(JSON.stringify(beforeReleaseMessages)).not.toContain("second")
+
       yield* Deferred.succeed(gate, void 0)
 
-      const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
+      const ea = yield* Fiber.await(a)
       expect(Exit.isSuccess(ea)).toBe(true)
-      expect(Exit.isSuccess(eb)).toBe(true)
+      if (Exit.isSuccess(ea)) {
+        expect(ea.value.info.role).toBe("assistant")
+        expect(ea.value.parts.some((part) => part.type === "text" && part.text === "first")).toBe(true)
+      }
+      yield* llm.wait(2)
       expect(yield* llm.calls).toBe(2)
+
+      yield* pollWithTimeout(
+        sessions.messages({ sessionID: chat.id }).pipe(
+          Effect.map((messages) =>
+            messages.some(
+              (message) =>
+                message.info.role === "assistant" &&
+                message.info.parentID === id &&
+                message.parts.some((part) => part.type === "text" && part.text === "second"),
+            )
+              ? true
+              : undefined,
+          ),
+        ),
+        "timed out waiting for queued assistant response",
+      )
 
       const msgs = yield* sessions.messages({ sessionID: chat.id })
       const assistants = msgs.filter((msg) => msg.info.role === "assistant")
@@ -1175,8 +1218,9 @@ it.instance(
       expect(last.parts.some((part) => part.type === "text" && part.text === "second")).toBe(true)
 
       const inputs = yield* llm.inputs
+      const lastInputMessages = nonSystemMessages(inputs.at(-1))
       expect(inputs).toHaveLength(2)
-      expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("second")
+      expect(JSON.stringify(lastInputMessages)).toContain("second")
     }),
   3_000,
 )


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes prompt queue ordering when a prompt is submitted while a session is already running.

Before this change, the queued prompt could be included in the active loop’s next model input before the active response had completed. This patch keeps queued user messages out of the active loop, tracks them separately, and drains them only after joining the currently running prompt loop. That preserves the expected turn order: active user message, active assistant response, queued user message, queued assistant response.

It also exposes queued message IDs on busy session status so callers can see that work is waiting.

### How did you verify your code works?

Ran:

```sh
bun typecheck
bun test test/session/prompt.test.ts -t "queued prompt waits for the active answer before starting the next LLM call"
bun test test/session/prompt.test.ts
```

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


I’m also interested in contributing to opencode more directly. If there are engineering opportunities on the team, I’d be grateful to be considered.