### PR TITLE
fix: exit alternate screen buffer on shutdown to prevent terminal win…

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -36,6 +36,9 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
           await input.onBeforeExit?.()
           // Reset window title before destroying renderer
           renderer.setTerminalTitle("")
+          // Exit alternate screen buffer to prevent the terminal emulator from
+          // closing the window/tab when the process exits
+          process.stdout.write("\x1b[?1049l")
           renderer.destroy()
           win32FlushInputBuffer()
           if (reason) {


### PR DESCRIPTION
…dow from closing

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents opencode from nuking the terminal emulator on Windows on /exit (Alacritty, WezTerm, Windows Terminal seems immune).

The issue is caused by opencode not switching out of alternate screen buffer mode before exiting, confusing the terminal emulator.

People have claimed this is a feature not a bug, but it's certainly implemented like a bug haha.

To test launch opencode in alacritty (or wezterm) on Windows. Type /exit, wait 2 seconds and notice your terminal emulator exits. Merge this fix into your working tree, run `bun run dev`, then /exit, and note your terminal emulator returns cleanly to the shell prompt.

This restores opencode to the same behaviour as every other TUI app on the planet.

### How did you verify your code works?

I built and executed locally, comparing behaviour before/after the change and with the latest official release.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
