### PR TITLE
feat(provider): add Aperture gateway provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -121,6 +121,8 @@ type CustomVarsLoader = (options: Record<string, any>) => Record<string, string>
 type CustomDiscoverModels = () => Promise<Record<string, Model>>
 type CustomLoader = (provider: Info) => Effect.Effect<{
   autoload: boolean
+  name?: string
+  env?: string[]
   getModel?: CustomModelLoader
   vars?: CustomVarsLoader
   options?: Record<string, any>
@@ -838,6 +840,138 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    aperture: Effect.fnUntraced(function* (_input: Info) {
+      const env = yield* dep.env()
+      const baseUrl = env["APERTURE_BASE_URL"]
+      if (!baseUrl) return { autoload: false }
+
+      return {
+        autoload: true,
+        name: "Aperture",
+        env: ["APERTURE_BASE_URL"],
+        options: {
+          apiKey: "not-required",
+        },
+        async discoverModels(): Promise<Record<string, Model>> {
+          try {
+            const res = await fetch(`${baseUrl}/v1/models`)
+            if (!res.ok) {
+              log.warn("aperture model discovery failed", { status: res.status })
+              return {}
+            }
+            const json = (await res.json()) as {
+              data: Array<{
+                id: string
+                name?: string
+                metadata?: { provider?: { id?: string } }
+                pricing?: {
+                  input?: string
+                  output?: string
+                  input_cache_read?: string
+                  input_cache_write?: string
+                }
+              }>
+            }
+
+            const models: Record<string, Model> = {}
+            for (const m of json.data) {
+              const providerId = m.metadata?.provider?.id ?? ""
+              const modelId = m.id
+              const isClaude = modelId.includes("claude") || modelId.includes("anthropic")
+              const isGPT = providerId === "openai"
+              const isGemini = modelId.includes("gemini")
+
+              const npm = iife(() => {
+                switch (providerId) {
+                  case "anthropic":
+                  case "mantle-anthropic":
+                  case "mantle":
+                  case "bedrock":
+                    return "@ai-sdk/anthropic"
+                  case "vertex":
+                    return isClaude ? "@ai-sdk/anthropic" : "@ai-sdk/openai-compatible"
+                  case "openai":
+                    return "@ai-sdk/openai"
+                  case "openrouter":
+                    return "@ai-sdk/openai-compatible"
+                  default:
+                    return "@ai-sdk/openai-compatible"
+                }
+              })
+
+              const limit = iife(() => {
+                if (isClaude) return { context: 200000, output: 16384 }
+                if (isGPT) return { context: 128000, output: 16384 }
+                if (isGemini) return { context: 1000000, output: 8192 }
+                return { context: 128000, output: 4096 }
+              })
+
+              const pricing = m.pricing
+              const parsePrice = (v?: string) => {
+                const n = v ? parseFloat(v) : 0
+                return Number.isFinite(n) ? n : 0
+              }
+
+              models[modelId] = {
+                id: ModelID.make(modelId),
+                providerID: ProviderID.make("aperture"),
+                name: m.name ?? modelId,
+                family: "",
+                api: {
+                  id: modelId,
+                  url: baseUrl.replace(/\/+$/, "").replace(/\/v1$/, "") + "/v1",
+                  npm,
+                },
+                status: "active",
+                headers: {},
+                options: {},
+                cost: {
+                  input: parsePrice(pricing?.input),
+                  output: parsePrice(pricing?.output),
+                  cache: {
+                    read: parsePrice(pricing?.input_cache_read),
+                    write: parsePrice(pricing?.input_cache_write),
+                  },
+                },
+                limit,
+                capabilities: {
+                  toolcall: true,
+                  temperature: true,
+                  reasoning: false,
+                  attachment: isClaude,
+                  input: {
+                    text: true,
+                    image: isClaude || isGPT,
+                    audio: false,
+                    video: false,
+                    pdf: false,
+                  },
+                  output: {
+                    text: true,
+                    audio: false,
+                    image: false,
+                    video: false,
+                    pdf: false,
+                  },
+                  interleaved: false,
+                },
+                release_date: "",
+                variants: {},
+              }
+            }
+
+            log.info("aperture model discovery complete", {
+              count: Object.keys(models).length,
+              models: Object.keys(models),
+            })
+            return models
+          } catch (e) {
+            log.warn("aperture model discovery failed", { error: e })
+            return {}
+          }
+        },
+      }
+    }),
   }
 }
 
@@ -1399,19 +1533,37 @@ export const layer = Layer.effect(
         for (const [id, fn] of Object.entries(custom(dep))) {
           const providerID = ProviderID.make(id)
           if (disabled.has(providerID)) continue
-          const data = database[providerID]
-          if (!data) {
-            log.error("Provider does not exist in model list " + providerID)
-            continue
-          }
+
+          const existing = database[providerID]
+          const data =
+            existing ??
+            ({
+              id: providerID,
+              name: id,
+              env: [] as string[],
+              options: {},
+              source: "custom" as const,
+              models: {},
+            } as Info)
+
           const result = yield* fn(data)
-          if (result && (result.autoload || providers[providerID])) {
-            if (result.getModel) modelLoaders[providerID] = result.getModel
-            if (result.vars) varsLoaders[providerID] = result.vars
-            if (result.discoverModels) discoveryLoaders[providerID] = result.discoverModels
-            const opts = result.options ?? {}
-            const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
-            mergeProvider(providerID, patch)
+          if (!result || (!result.autoload && !providers[providerID])) continue
+
+          if (!existing) {
+            if (result.name) data.name = result.name
+            if (result.env) data.env = result.env
+            database[providerID] = data
+          }
+
+          if (result.getModel) modelLoaders[providerID] = result.getModel
+          if (result.vars) varsLoaders[providerID] = result.vars
+          if (result.discoverModels) discoveryLoaders[providerID] = result.discoverModels
+          const opts = result.options ?? {}
+          if (providers[providerID]) {
+            mergeProvider(providerID, { options: opts })
+          } else {
+            const source = !existing && data.env.some((e) => envs[e]) ? "env" : "custom"
+            mergeProvider(providerID, { source, options: opts } as Partial<Info>)
           }
         }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1425,18 +1425,19 @@ export const layer = Layer.effect(
           mergeProvider(providerID, partial)
         }
 
-        const gitlab = ProviderID.make("gitlab")
-        if (discoveryLoaders[gitlab] && providers[gitlab] && isProviderAllowed(gitlab)) {
+        for (const [id, loader] of Object.entries(discoveryLoaders)) {
+          const providerID = ProviderID.make(id)
+          if (!providers[providerID] || !isProviderAllowed(providerID)) continue
           yield* Effect.promise(async () => {
             try {
-              const discovered = await discoveryLoaders[gitlab]()
+              const discovered = await loader()
               for (const [modelID, model] of Object.entries(discovered)) {
-                if (!providers[gitlab].models[modelID]) {
-                  providers[gitlab].models[modelID] = model
+                if (!providers[providerID].models[modelID]) {
+                  providers[providerID].models[modelID] = model
                 }
               }
             } catch (e) {
-              log.warn("state discovery error", { id: "gitlab", error: e })
+              log.warn("state discovery error", { id, error: e })
             }
           })
         }

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -20,6 +20,7 @@ export const ProviderID = providerIdSchema.pipe(
     openrouter: schema.make("openrouter"),
     mistral: schema.make("mistral"),
     gitlab: schema.make("gitlab"),
+    aperture: schema.make("aperture"),
   })),
 )
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -366,7 +366,8 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
     const useMessageLevelOptions =
       model.providerID === "anthropic" ||
       model.providerID.includes("bedrock") ||
-      model.api.npm === "@ai-sdk/amazon-bedrock"
+      model.api.npm === "@ai-sdk/amazon-bedrock" ||
+      model.api.npm === "@ai-sdk/anthropic"
     const shouldUseContentOptions = !useMessageLevelOptions && Array.isArray(msg.content) && msg.content.length > 0
 
     if (shouldUseContentOptions) {
@@ -1084,7 +1085,7 @@ export function options(input: {
     }
   }
 
-  if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {
+  if (input.model.providerID === "openai" || input.model.api.npm === "@ai-sdk/openai" || input.providerOptions?.setCacheKey) {
     result["promptCacheKey"] = input.sessionID
   }
 

--- a/packages/opencode/test/provider/aperture.test.ts
+++ b/packages/opencode/test/provider/aperture.test.ts
@@ -1,0 +1,348 @@
+import { test, expect, describe, afterEach } from "bun:test"
+import path from "path"
+
+import { ProviderID } from "../../src/provider/schema"
+import { tmpdir } from "../fixture/fixture"
+import { WithInstance } from "../../src/project/with-instance"
+import { Provider } from "@/provider/provider"
+import { Env } from "../../src/env"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { makeRuntime } from "../../src/effect/run-service"
+
+const env = makeRuntime(Env.Service, Env.defaultLayer)
+const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
+
+async function list() {
+  return AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      return yield* provider.list()
+    }),
+  )
+}
+
+const originalFetch = globalThis.fetch
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    return handler(url, init)
+  }
+}
+
+function apertureModel(overrides: {
+  id: string
+  name?: string
+  providerId?: string
+  pricing?: {
+    input?: string
+    output?: string
+    input_cache_read?: string
+    input_cache_write?: string
+  }
+}) {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    metadata: overrides.providerId !== undefined ? { provider: { id: overrides.providerId } } : undefined,
+    pricing: overrides.pricing,
+  }
+}
+
+function mockModelsResponse(models: ReturnType<typeof apertureModel>[]) {
+  return Response.json({ data: models })
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+async function withAperture(
+  models: ReturnType<typeof apertureModel>[],
+  fn: (providers: Record<string, any>) => void | Promise<void>,
+  baseUrl: string | false = "http://aperture.test",
+) {
+  mockFetch((url) => {
+    if (url.includes("/v1/models")) return mockModelsResponse(models)
+    return new Response("not found", { status: 404 })
+  })
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json" }))
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      if (baseUrl !== false) set("APERTURE_BASE_URL", baseUrl)
+      const providers = await list()
+      await fn(providers)
+    },
+  })
+}
+
+async function withApertureCustomFetch(
+  fetchHandler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+  fn: (providers: Record<string, any>) => void | Promise<void>,
+) {
+  mockFetch(fetchHandler)
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json" }))
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      set("APERTURE_BASE_URL", "http://aperture.test")
+      const providers = await list()
+      await fn(providers)
+    },
+  })
+}
+
+describe("Aperture provider", () => {
+  test("SDK mapping", async () => {
+    const cases = [
+      { providerId: "anthropic", modelId: "claude-haiku-4-5", expectedNpm: "@ai-sdk/anthropic" },
+      { providerId: "mantle-anthropic", modelId: "claude-haiku-4-5", expectedNpm: "@ai-sdk/anthropic" },
+      { providerId: "mantle", modelId: "anthropic.claude-opus-4-7", expectedNpm: "@ai-sdk/anthropic" },
+      { providerId: "bedrock", modelId: "us.anthropic.claude-haiku-4-5-20251001-v1:0", expectedNpm: "@ai-sdk/anthropic" },
+      { providerId: "vertex", modelId: "claude-sonnet-4-20250514", expectedNpm: "@ai-sdk/anthropic" },
+      { providerId: "vertex", modelId: "gemini-2.5-pro", expectedNpm: "@ai-sdk/openai-compatible" },
+      { providerId: "openai", modelId: "gpt-4o", expectedNpm: "@ai-sdk/openai" },
+      { providerId: "openrouter", modelId: "meta-llama/llama-3.2-3b-instruct", expectedNpm: "@ai-sdk/openai-compatible" },
+      { providerId: "some-unknown-provider", modelId: "some-model", expectedNpm: "@ai-sdk/openai-compatible" },
+    ]
+    for (const c of cases) {
+      await withAperture([apertureModel({ id: c.modelId, providerId: c.providerId })], (providers) => {
+        expect(providers[ProviderID.aperture]).toBeDefined()
+        const model = providers[ProviderID.aperture].models[c.modelId]
+        expect(model).toBeDefined()
+        expect(model.api.npm).toBe(c.expectedNpm)
+      })
+    }
+  })
+
+  test("normal pricing values", async () => {
+    await withAperture(
+      [apertureModel({ id: "test-model", providerId: "anthropic", pricing: { input: "0.00000100", output: "0.00000500", input_cache_read: "0.00000050", input_cache_write: "0.00000200" } })],
+      (providers) => {
+        const model = providers[ProviderID.aperture].models["test-model"]
+        expect(model.cost.input).toBe(0.000001)
+        expect(model.cost.output).toBe(0.000005)
+        expect(model.cost.cache.read).toBe(0.0000005)
+        expect(model.cost.cache.write).toBe(0.000002)
+      },
+    )
+  })
+
+  test("missing pricing defaults to zero", async () => {
+    await withAperture([apertureModel({ id: "no-price-model", providerId: "anthropic" })], (providers) => {
+      const model = providers[ProviderID.aperture].models["no-price-model"]
+      expect(model.cost.input).toBe(0)
+      expect(model.cost.output).toBe(0)
+      expect(model.cost.cache.read).toBe(0)
+      expect(model.cost.cache.write).toBe(0)
+    })
+  })
+
+  test("malformed pricing (NaN) defaults to zero", async () => {
+    await withAperture(
+      [apertureModel({ id: "free-model", providerId: "openai", pricing: { input: "free", output: "also-free" } })],
+      (providers) => {
+        const model = providers[ProviderID.aperture].models["free-model"]
+        expect(model.cost.input).toBe(0)
+        expect(model.cost.output).toBe(0)
+      },
+    )
+  })
+
+  test("partial cache pricing", async () => {
+    await withAperture(
+      [apertureModel({ id: "partial-cache", providerId: "anthropic", pricing: { input: "0.001", output: "0.002", input_cache_read: "0.0005" } })],
+      (providers) => {
+        const model = providers[ProviderID.aperture].models["partial-cache"]
+        expect(model.cost.cache.read).toBe(0.0005)
+        expect(model.cost.cache.write).toBe(0)
+      },
+    )
+  })
+
+  test("capability detection", async () => {
+    const cases = [
+      { id: "claude-sonnet-4", providerId: "anthropic", attachment: true, image: true },
+      { id: "gpt-4o", providerId: "openai", attachment: false, image: true },
+      { id: "gemini-2.5-pro", providerId: "vertex", attachment: false, image: false },
+      { id: "unknown-model", providerId: "some-provider", attachment: false, image: false },
+    ]
+    for (const c of cases) {
+      await withAperture([apertureModel({ id: c.id, providerId: c.providerId })], (providers) => {
+        const model = providers[ProviderID.aperture].models[c.id]
+        expect(model.capabilities.attachment).toBe(c.attachment)
+        expect(model.capabilities.input.image).toBe(c.image)
+      })
+    }
+    // unknown models also get toolcall and temperature
+    await withAperture([apertureModel({ id: "unknown-model", providerId: "some-provider" })], (providers) => {
+      const model = providers[ProviderID.aperture].models["unknown-model"]
+      expect(model.capabilities.toolcall).toBe(true)
+      expect(model.capabilities.temperature).toBe(true)
+    })
+  })
+
+  test("context limit detection", async () => {
+    const cases = [
+      { id: "claude-haiku-4-5", providerId: "anthropic", context: 200000, output: 16384 },
+      { id: "gpt-4o-mini", providerId: "openai", context: 128000, output: 16384 },
+      { id: "gemini-2.5-flash", providerId: "vertex", context: 1000000, output: 8192 },
+      { id: "mystery-model", providerId: "unknown", context: 128000, output: 4096 },
+    ]
+    for (const c of cases) {
+      await withAperture([apertureModel({ id: c.id, providerId: c.providerId })], (providers) => {
+        const model = providers[ProviderID.aperture].models[c.id]
+        expect(model.limit.context).toBe(c.context)
+        expect(model.limit.output).toBe(c.output)
+      })
+    }
+  })
+
+  test("URL normalization", async () => {
+    const cases = [
+      { baseUrl: "http://ai", expected: "http://ai/v1" },
+      { baseUrl: "http://ai/", expected: "http://ai/v1" },
+      { baseUrl: "http://ai/v1", expected: "http://ai/v1" },
+      { baseUrl: "http://ai/v1/", expected: "http://ai/v1" },
+    ]
+    for (const c of cases) {
+      await withAperture([apertureModel({ id: "m1", providerId: "anthropic" })], (providers) => {
+        const model = providers[ProviderID.aperture].models["m1"]
+        expect(model.api.url).toBe(c.expected)
+      }, c.baseUrl)
+    }
+  })
+
+  test("happy path: returns discovered models with names", async () => {
+    await withAperture(
+      [
+        apertureModel({ id: "claude-sonnet-4", name: "Claude Sonnet 4", providerId: "anthropic" }),
+        apertureModel({ id: "gpt-4o", name: "GPT-4o", providerId: "openai" }),
+      ],
+      (providers) => {
+        expect(providers[ProviderID.aperture]).toBeDefined()
+        expect(providers[ProviderID.aperture].models["claude-sonnet-4"]).toBeDefined()
+        expect(providers[ProviderID.aperture].models["claude-sonnet-4"].name).toBe("Claude Sonnet 4")
+        expect(providers[ProviderID.aperture].models["gpt-4o"]).toBeDefined()
+        expect(providers[ProviderID.aperture].models["gpt-4o"].name).toBe("GPT-4o")
+      },
+    )
+  })
+
+  test("empty response removes provider", async () => {
+    await withAperture([], (providers) => {
+      expect(providers[ProviderID.aperture]).toBeUndefined()
+    })
+  })
+
+  test("HTTP 500 error removes provider", async () => {
+    await withApertureCustomFetch(
+      (url) => {
+        if (url.includes("/v1/models")) return new Response("Internal Server Error", { status: 500 })
+        return new Response("not found", { status: 404 })
+      },
+      (providers) => {
+        expect(providers[ProviderID.aperture]).toBeUndefined()
+      },
+    )
+  })
+
+  test("network error removes provider", async () => {
+    await withApertureCustomFetch(
+      () => { throw new TypeError("fetch failed") },
+      (providers) => {
+        expect(providers[ProviderID.aperture]).toBeUndefined()
+      },
+    )
+  })
+
+  test("model with missing metadata falls back to defaults", async () => {
+    await withApertureCustomFetch(
+      (url) => {
+        if (url.includes("/v1/models")) return Response.json({ data: [{ id: "no-metadata-model" }] })
+        return new Response("not found", { status: 404 })
+      },
+      (providers) => {
+        const model = providers[ProviderID.aperture].models["no-metadata-model"]
+        expect(model).toBeDefined()
+        expect(model.name).toBe("no-metadata-model")
+        expect(model.api.npm).toBe("@ai-sdk/openai-compatible")
+        expect(model.limit.context).toBe(128000)
+        expect(model.limit.output).toBe(4096)
+        expect(model.cost.input).toBe(0)
+        expect(model.cost.output).toBe(0)
+      },
+    )
+  })
+
+  test("model ID formats", async () => {
+    const idCases = [
+      { id: "claude-haiku-4-5", providerId: "anthropic" },
+      { id: "claude-haiku-4-5@20251001", providerId: "anthropic" },
+      { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", providerId: "bedrock" },
+      { id: "meta-llama/llama-3.2-3b-instruct", providerId: "openrouter" },
+      { id: "anthropic.claude-opus-4-7", providerId: "mantle" },
+    ]
+    for (const c of idCases) {
+      await withAperture([apertureModel({ id: c.id, providerId: c.providerId })], (providers) => {
+        expect(providers[ProviderID.aperture].models[c.id]).toBeDefined()
+      })
+    }
+    // bedrock ARN-style IDs: contains "anthropic" so isClaude
+    await withAperture([apertureModel({ id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", providerId: "bedrock" })], (providers) => {
+      const model = providers[ProviderID.aperture].models["us.anthropic.claude-haiku-4-5-20251001-v1:0"]
+      expect(model.capabilities.attachment).toBe(true)
+      expect(model.api.npm).toBe("@ai-sdk/anthropic")
+    })
+    // mantle prefixed IDs: "anthropic" in model ID so isClaude
+    await withAperture([apertureModel({ id: "anthropic.claude-opus-4-7", providerId: "mantle" })], (providers) => {
+      const model = providers[ProviderID.aperture].models["anthropic.claude-opus-4-7"]
+      expect(model.capabilities.attachment).toBe(true)
+      expect(model.api.npm).toBe("@ai-sdk/anthropic")
+    })
+  })
+
+  test("aperture provider not loaded without APERTURE_BASE_URL", async () => {
+    await withAperture([], (providers) => {
+      expect(providers[ProviderID.aperture]).toBeUndefined()
+    }, false)
+  })
+
+  test("aperture provider loaded with APERTURE_BASE_URL set", async () => {
+    await withAperture([apertureModel({ id: "test-model", providerId: "anthropic" })], (providers) => {
+      expect(providers[ProviderID.aperture]).toBeDefined()
+      expect(providers[ProviderID.aperture].name).toBe("Aperture")
+      expect(providers[ProviderID.aperture].source).toBe("env")
+    })
+  })
+
+  test("model name defaults to model ID when name not provided", async () => {
+    await withApertureCustomFetch(
+      (url) => {
+        if (url.includes("/v1/models")) return Response.json({ data: [{ id: "nameless-model", metadata: { provider: { id: "openai" } } }] })
+        return new Response("not found", { status: 404 })
+      },
+      (providers) => {
+        const model = providers[ProviderID.aperture].models["nameless-model"]
+        expect(model.name).toBe("nameless-model")
+      },
+    )
+  })
+
+  test("model providerID is set to aperture", async () => {
+    await withAperture([apertureModel({ id: "test-model", providerId: "openai" })], (providers) => {
+      const model = providers[ProviderID.aperture].models["test-model"]
+      expect(String(model.providerID)).toBe("aperture")
+    })
+  })
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -66,6 +66,17 @@ const providerLayer = (flags: Partial<RuntimeFlags.Info> = {}) =>
     Layer.provide(RuntimeFlags.layer(flags)),
   )
 
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+function mockFetch(handler: (url: string) => Response) {
+  globalThis.fetch = async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    return handler(url)
+  }
+}
+
 async function run<A, E>(ctx: InstanceContext, fn: (provider: Provider.Interface) => Effect.Effect<A, E, never>) {
   return AppRuntime.runPromise(
     Effect.gen(function* () {
@@ -2675,4 +2686,29 @@ test("opencode loader keeps paid models when auth exists", async () => {
       } catch {}
     }
   }
+})
+
+test("discovery loop merges dynamically discovered models into provider", async () => {
+  mockFetch((url) => {
+    if (url.includes("/v1/models"))
+      return Response.json({
+        data: [{ id: "discovered-model", name: "Discovered", metadata: { provider: { id: "anthropic" } } }],
+      })
+    return new Response("not found", { status: 404 })
+  })
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json" }))
+    },
+  })
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      await set(ctx, "APERTURE_BASE_URL", "http://test.local")
+      const providers = await list(ctx)
+      expect(providers[ProviderID.aperture]).toBeDefined()
+      expect(providers[ProviderID.aperture].models["discovered-model"]).toBeDefined()
+      expect(providers[ProviderID.aperture].models["discovered-model"].name).toBe("Discovered")
+    },
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #28386

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds [Aperture](https://aperture.tailscale.com/) (Tailscale's AI gateway) as a built-in provider. Set `APERTURE_BASE_URL` and the provider discovers available models at startup via `GET {base}/v1/models`, routing each to the correct AI SDK based on upstream provider metadata:

- anthropic, mantle, bedrock: `@ai-sdk/anthropic`
- openai: `@ai-sdk/openai`
- vertex (claude): `@ai-sdk/anthropic`
- vertex (gemini), openrouter, others: `@ai-sdk/openai-compatible`

Aperture model lists are specific to each Aperture instance, so there is no hardcoded list and can't be loaded from [models.dev](https://models.dev/). The gateway returns what's available, so the provider stays current as upstream models change.

**Two commits:**

1. **Generalize the model discovery loop.** The existing loop was hardcoded to GitLab. This replaces it with a `for...of` over all registered `discoveryLoaders`, so any provider with a `discoverModels` function participates. Failures are isolated per provider. Also adds `name` and `env` to the `CustomLoader` return type so dynamic providers can self-describe without needing a static database entry.

2. **Add the Aperture provider.** A new entry in `custom()` that reads `APERTURE_BASE_URL` from the environment, calls the models endpoint, and constructs full `Model` objects with SDK routing, pricing, capability detection, and context limits based on upstream provider ID and model name heuristics.

### How did you verify your code works?

- 18 tests in `test/provider/aperture.test.ts` covering SDK mapping, price parsing, capability detection, URL normalization, error handling, and model ID format variations
- 1 integration test in `test/provider/provider.test.ts` for the generalized discovery loop
- `bun test test/provider/aperture.test.ts` -- all pass
- `bun test test/provider/provider.test.ts` -- all pass
- `bun run typecheck` -- clean

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR