### PR TITLE
fix(action): remove orphan symlink breaking GitHub Action staging

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/AGENTS.md
+++ b/packages/opencode/src/provider/sdk/copilot/AGENTS.md
@@ -1,1 +1,0 @@
-README.md


### PR DESCRIPTION
## The bug (#27941)

Every workflow using \`uses: anomalyco/opencode@<sha>\` fails at the *Setup Job* stage starting v1.15.3:

\`\`\`
Error: Could not find file '/home/runner/work/_actions/.../packages/opencode/src/provider/sdk/copilot/AGENTS.md'.
\`\`\`

## Root cause

PR #25821 ("core: expose v2 model listing API", May 13) removed the entire copilot SDK directory contents — including \`packages/opencode/src/provider/sdk/copilot/README.md\` — but left behind \`AGENTS.md\` in that directory, which was a symlink pointing at the now-deleted \`README.md\`.

The broken symlink was invisible during normal opencode use:
- Nothing in \`packages/\` imports from \`provider/sdk/copilot\` (\`grep\` returns zero hits)
- The entire \`provider/sdk/\` directory contains only this one orphan file
- No tests exercise the path

But \`actions/checkout\`'s remote-action staging path tries to follow every symlink while copying the repo into \`_actions/.../_staging/\`, hits the broken target, and bails — breaking every workflow that consumes the action.

## The fix

Delete the orphan symlink. The now-empty \`sdk/copilot/\` and \`sdk/\` directories disappear with it (git doesn't track directories). Restores GHA's ability to stage the action cleanly.

\`\`\`
- 1 file changed (deletion)
\`\`\`

## Verification

- \`grep -rn \"sdk/copilot\" packages\` returns no matches → no live code depends on the path.
- \`bun run typecheck\` clean.

Fixes #27941.