### PR TITLE
fix(llm): coerce all non-string enum types to string for Gemini

### DIFF
--- a/packages/llm/src/protocols/utils/gemini-tool-schema.ts
+++ b/packages/llm/src/protocols/utils/gemini-tool-schema.ts
@@ -38,7 +38,7 @@ const sanitizeNode = (schema: unknown): unknown => {
     ]),
   )
 
-  if (Array.isArray(result.enum) && (result.type === "integer" || result.type === "number")) result.type = "string"
+  if (Array.isArray(result.enum) && typeof result.type === "string" && result.type !== "string") result.type = "string"
 
   const properties = result.properties
   if (result.type === "object" && isRecord(properties) && Array.isArray(result.required)) {

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -110,7 +110,7 @@ describe("Gemini route", () => {
     }),
   )
 
-  it.effect("sanitizes integer enums, dangling required, untyped arrays, and scalar object keys", () =>
+  it.effect("sanitizes non-string enums, dangling required, untyped arrays, and scalar object keys", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare(
         LLM.request({
@@ -126,6 +126,7 @@ describe("Gemini route", () => {
                 required: ["status", "missing"],
                 properties: {
                   status: { type: "integer", enum: [1, 2] },
+                  active: { type: "boolean", enum: [true, false] },
                   tags: { type: "array" },
                   name: { type: "string", properties: { ignored: { type: "string" } }, required: ["ignored"] },
                 },
@@ -145,6 +146,7 @@ describe("Gemini route", () => {
                   required: ["status"],
                   properties: {
                     status: { type: "string", enum: ["1", "2"] },
+                    active: { type: "string", enum: ["true", "false"] },
                     tags: { type: "array", items: { type: "string" } },
                     name: { type: "string" },
                   },


### PR DESCRIPTION
### Issue for this PR

Closes #28397

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Google's Gemini API only allows `.enum` on STRING type properties. The existing `gemini-tool-schema.ts` sanitizer coerces `integer`/`number` enum properties to `string`, but misses `boolean` and other non-string types — causing the API to reject tool declarations with: ``.enum: only allowed for STRING type``.

The fix generalizes the type guard from checking `integer || number` to checking `type !== "string"`, so any non-string typed property with an enum gets coerced. This is safe because the preceding line already stringifies all enum values.

### How did you verify your code works?

Extended the existing Gemini test to include a boolean enum property and confirmed it gets coerced to string type. All 11 Gemini tests pass.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
