### PR TITLE
test(provider): guarantee @ai-sdk/openai defaults to responses

### DIFF
--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -55,6 +55,33 @@ describe("OpenAIPlugin", () => {
     }),
   )
 
+  it.effect("defaults @ai-sdk/openai languageModel() to the Responses API", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      yield* plugin.add(OpenAIPlugin)
+
+      const result = yield* plugin.trigger(
+        "aisdk.sdk",
+        {
+          model: model("custom-openai", "alias", {
+            apiID: ModelV2.ID.make("gpt-5"),
+            endpoint: {
+              type: "aisdk",
+              package: "@ai-sdk/openai",
+            },
+          }),
+          package: "@ai-sdk/openai",
+          options: { name: "custom-openai", apiKey: "test" },
+        },
+        {},
+      )
+
+      const provider = result.sdk?.languageModel("gpt-5").provider
+      expect(provider).toMatch(/\.responses$/)
+      expect(provider).not.toMatch(/\.chat$/)
+    }),
+  )
+
   it.effect("ignores non-OpenAI providers", () =>
     Effect.gen(function* () {
       const plugin = yield* PluginV2.Service


### PR DESCRIPTION
### Issue for this PR

Closes #28535

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a regression test proving that `@ai-sdk/openai` keeps the default `languageModel()` path on the Responses API.

This matters for me and other OpenCode developers because custom provider work often uses provider IDs other than `openai` while still relying on `@ai-sdk/openai` under the hood. OpenCode has an explicit `responses()` override for the built-in `openai` provider, but custom providers fall back to `sdk.languageModel(...)`. Without this guarantee in the test suite, a future SDK or integration change could silently move custom OpenAI-backed providers onto the wrong protocol and break proxy/provider integrations in a way that is easy to miss in review.

### How did you verify your code works?

Ran:
- `bun test test/plugin/provider-openai.test.ts`

The new test asserts that a custom provider created with `@ai-sdk/openai` resolves `languageModel("gpt-5")` to the `.responses` provider path.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR