### PR TITLE
fix(mcp): persist disabled MCP state across config reloads

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -284,7 +284,10 @@ export const layer = Layer.effect(
           return new Set(obj.disabledMcpServerIds.filter((x): x is string => typeof x === "string"))
         }),
         Effect.catchCause((cause) => {
-          log.warn("failed to read mcp-state.json", { cause: Cause.squash(cause) })
+          const err = Cause.squash(cause)
+          if (err && typeof err === "object" && "_tag" in err && err._tag === "NotFound")
+            return Effect.succeed(new Set<string>())
+          log.warn("failed to read mcp-state.json", { cause: err })
           return Effect.succeed(new Set<string>())
         }),
       )

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -1,3 +1,5 @@
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
 import { dynamicTool, type Tool, jsonSchema, type JSONSchema7 } from "ai"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
@@ -26,7 +28,7 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
-import { Effect, Exit, Layer, Option, Context, Schema, Stream } from "effect"
+import { Cause, Effect, Exit, Layer, Option, Context, Schema, Stream } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
@@ -233,6 +235,7 @@ interface State {
   status: Record<string, Status>
   clients: Record<string, MCPClient>
   defs: Record<string, MCPToolDef[]>
+  disabledFromPersistence: Set<string>
 }
 
 export interface Interface {
@@ -270,6 +273,33 @@ export const layer = Layer.effect(
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const auth = yield* McpAuth.Service
     const bus = yield* Bus.Service
+    const fs = yield* AppFileSystem.Service
+
+    const readDisabledState = Effect.fnUntraced(function* () {
+      return yield* fs.readJson(path.join(Global.Path.state, "mcp-state.json")).pipe(
+        Effect.map((data) => {
+          if (data === null || typeof data !== "object") return new Set<string>()
+          const obj = data as Record<string, unknown>
+          if (!Array.isArray(obj.disabledMcpServerIds)) return new Set<string>()
+          return new Set(obj.disabledMcpServerIds.filter((x): x is string => typeof x === "string"))
+        }),
+        Effect.catchCause((cause) => {
+          log.warn("failed to read mcp-state.json", { cause: Cause.squash(cause) })
+          return Effect.succeed(new Set<string>())
+        }),
+      )
+    })
+
+    const writeDisabledState = Effect.fnUntraced(function* (ids: Set<string>) {
+      yield* fs
+        .writeJson(path.join(Global.Path.state, "mcp-state.json"), { disabledMcpServerIds: [...ids].sort() }, 0o600)
+        .pipe(
+          Effect.catch((error) => {
+            log.error("failed to write mcp-state.json", { error })
+            return Effect.void
+          }),
+        )
+    })
 
     type Transport = StdioClientTransport | StreamableHTTPClientTransport | SSEClientTransport
 
@@ -515,10 +545,12 @@ export const layer = Layer.effect(
         const cfg = yield* cfgSvc.get()
         const bridge = yield* EffectBridge.make()
         const config = cfg.mcp ?? {}
+        const disabled = yield* readDisabledState()
         const s: State = {
           status: {},
           clients: {},
           defs: {},
+          disabledFromPersistence: disabled,
         }
 
         yield* Effect.forEach(
@@ -531,6 +563,11 @@ export const layer = Layer.effect(
               }
 
               if (mcp.enabled === false) {
+                s.status[key] = { status: "disabled" }
+                return
+              }
+
+              if (s.disabledFromPersistence.has(key)) {
                 s.status[key] = { status: "disabled" }
                 return
               }
@@ -644,6 +681,9 @@ export const layer = Layer.effect(
         log.error("MCP config not found or invalid", { name })
         return
       }
+      const s = yield* InstanceState.get(state)
+      s.disabledFromPersistence.delete(name)
+      yield* writeDisabledState(s.disabledFromPersistence)
       yield* createAndStore(name, { ...mcp, enabled: true })
     })
 
@@ -652,6 +692,8 @@ export const layer = Layer.effect(
       yield* closeClient(s, name)
       delete s.clients[name]
       s.status[name] = { status: "disabled" }
+      s.disabledFromPersistence.add(name)
+      yield* writeDisabledState(s.disabledFromPersistence)
     })
 
     const tools = Effect.fn("MCP.tools")(function* () {

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -6,6 +6,7 @@ import path from "path"
 import { Effect, Context, Layer, ManagedRuntime } from "effect"
 import type * as PlatformError from "effect/PlatformError"
 import type * as Scope from "effect/Scope"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import type { Config } from "@/config/config"
@@ -209,7 +210,7 @@ export const withTmpdirInstance =
     Effect.gen(function* () {
       const directory = yield* tmpdirScoped(options)
       return yield* self.pipe(Effect.provideService(TestInstance, { directory }), provideInstanceEffect(directory))
-    }).pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+    }).pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(AppFileSystem.defaultLayer), Effect.provide(CrossSpawnSpawner.defaultLayer))
 
 export function provideTmpdirServer<A, E, R>(
   self: (input: { dir: string; llm: TestLLMServer["Service"] }) => Effect.Effect<A, E, R>,

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -2,6 +2,9 @@ import { expect, mock, beforeEach } from "bun:test"
 import { Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { testEffect } from "../lib/effect"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Global } from "@opencode-ai/core/global"
+import path from "path"
 
 // --- Mock infrastructure ---
 
@@ -879,4 +882,203 @@ it.instance(
       }),
     ),
   { config: { mcp: {} } },
+)
+
+// ========================================================================
+// Persistence Tests: MCP Disabled State Persistence (mcp-state.json)
+// ========================================================================
+
+it.instance(
+  "disconnect persists disabled ID to mcp-state.json",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "persist-disc-server"
+        getOrCreateClientState("persist-disc-server")
+
+        yield* mcp.add("persist-disc-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+        yield* mcp.disconnect("persist-disc-server")
+
+        const fs = yield* AppFileSystem.Service
+        const data = yield* fs
+          .readJson(path.join(Global.Path.state, "mcp-state.json"))
+          .pipe(Effect.catch(() => Effect.succeed(null)))
+        expect(data).not.toBeNull()
+        const arr = (data as any).disabledMcpServerIds
+        expect(Array.isArray(arr)).toBe(true)
+        expect(arr).toContain("persist-disc-server")
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "connect removes disabled ID from mcp-state.json",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "reconn-persist-server"
+        const serverState = getOrCreateClientState("reconn-persist-server")
+        serverState.tools = [
+          { name: "my_tool", description: "a tool", inputSchema: { type: "object", properties: {} } },
+        ]
+
+        yield* mcp.add("reconn-persist-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+        yield* mcp.disconnect("reconn-persist-server")
+
+        lastCreatedClientName = "reconn-persist-server"
+        yield* mcp.connect("reconn-persist-server")
+
+        const fs = yield* AppFileSystem.Service
+        const data = yield* fs.readJson(path.join(Global.Path.state, "mcp-state.json"))
+        const arr = (data as any).disabledMcpServerIds
+        expect(Array.isArray(arr)).toBe(true)
+        expect(arr).not.toContain("reconn-persist-server")
+      }),
+    ),
+  {
+    config: {
+      mcp: {
+        "reconn-persist-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "init reads disabled state from pre-written mcp-state.json",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filepath = path.join(Global.Path.state, "mcp-state.json")
+      yield* fs.remove(filepath).pipe(Effect.catch(() => Effect.void))
+      yield* fs.writeJson(filepath, { disabledMcpServerIds: ["pre-disabled-server"] }, 0o600)
+
+      const mcp = yield* MCP.Service
+      const status = yield* mcp.status()
+      expect(status["pre-disabled-server"]?.status).toBe("disabled")
+    }),
+  {
+    config: {
+      mcp: {
+        "pre-disabled-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "missing mcp-state.json defaults to all MCPs enabled",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filepath = path.join(Global.Path.state, "mcp-state.json")
+      yield* fs.remove(filepath).pipe(Effect.catch(() => Effect.void))
+
+      lastCreatedClientName = "no-state-server"
+      getOrCreateClientState("no-state-server")
+
+      const mcp = yield* MCP.Service
+      const status = yield* mcp.status()
+      expect(status["no-state-server"]?.status).toBe("connected")
+    }),
+  {
+    config: {
+      mcp: {
+        "no-state-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "corrupt mcp-state.json defaults to all MCPs enabled",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filepath = path.join(Global.Path.state, "mcp-state.json")
+      yield* fs.remove(filepath).pipe(Effect.catch(() => Effect.void))
+      yield* fs.writeFileString(filepath, "{invalid json!!!")
+
+      lastCreatedClientName = "corrupt-state-server"
+      getOrCreateClientState("corrupt-state-server")
+
+      const mcp = yield* MCP.Service
+      const status = yield* mcp.status()
+      expect(status["corrupt-state-server"]?.status).toBe("connected")
+    }),
+  {
+    config: {
+      mcp: {
+        "corrupt-state-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "config enabled:false takes precedence over persisted state",
+  () =>
+    Effect.gen(function* () {
+      const mcp = yield* MCP.Service
+      const status = yield* mcp.status()
+      expect(status["config-disabled-server"]?.status).toBe("disabled")
+    }),
+  {
+    config: {
+      mcp: {
+        "config-disabled-server": {
+          type: "local",
+          command: ["echo", "test"],
+          enabled: false,
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "stale disabled ID in mcp-state.json is silently ignored",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filepath = path.join(Global.Path.state, "mcp-state.json")
+      yield* fs.remove(filepath).pipe(Effect.catch(() => Effect.void))
+      yield* fs.writeJson(filepath, { disabledMcpServerIds: ["removed-mcp", "stale-id"] }, 0o600)
+
+      lastCreatedClientName = "active-server"
+      getOrCreateClientState("active-server")
+
+      const mcp = yield* MCP.Service
+      const status = yield* mcp.status()
+      expect(status["active-server"]?.status).toBe("connected")
+    }),
+  {
+    config: {
+      mcp: {
+        "active-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
 )


### PR DESCRIPTION
### Issue for this PR

Closes #28428

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `/mcps` toggle only stores disabled state in memory. Any config change that triggers an Instance reload (e.g., editing a provider in `opencode.json`) wipes that state and re-enables all MCPs.

This persists disabled MCP IDs to `Global.Path.state/mcp-state.json` — same directory and pattern as `model.json`. `MCP.state()` reads this file during init, so disabled servers stay off across reloads and restarts.

Files changed:
- `src/mcp/index.ts`: `readDisabledState` / `writeDisabledState` helpers, wired into `state()` / `connect()` / `disconnect()`. Uses `Effect.catchCause` so corrupt JSON doesn't crash.
- `test/fixture/fixture.ts`: added `AppFileSystem.defaultLayer` so tests can exercise file I/O.
- `test/mcp/lifecycle.test.ts`: 7 tests covering missing file, corrupt file, stale entries, config `enabled: false` precedence, and the full toggle→persist→reload cycle.

### How did you verify your code works?

`bun test test/mcp/lifecycle.test.ts` — 28 pass, 0 fail. The 7 new persistence tests verify:
- disconnect writes the disabled ID to `mcp-state.json`
- connect removes it
- pre-written state file is respected on init
- missing file defaults to all enabled (first run)
- corrupt JSON is handled without crashing
- `enabled: false` in config always takes precedence
- stale entries for removed MCPs are ignored

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR