### PR TITLE
fix(transform): disable tool streaming for specific Claude models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1039,7 +1039,13 @@ export function options(input: {
 
   if (
     input.model.api.npm === "@ai-sdk/google-vertex/anthropic" ||
-    (!input.model.api.id.includes("claude") && input.model.api.npm === "@ai-sdk/anthropic")
+    (!input.model.api.id.includes("claude") && input.model.api.npm === "@ai-sdk/anthropic") ||
+    // Bedrock and Bedrock-compatible proxies reject eager_input_streaming for
+    // claude-3.x and claude-sonnet-4-5; disable tool streaming for these models.
+    (input.model.api.npm === "@ai-sdk/anthropic" && (
+      input.model.api.id.includes("claude-3") ||
+      input.model.api.id.includes("claude-sonnet-4-5")
+    ))
   ) {
     result["toolStreaming"] = false
   }


### PR DESCRIPTION

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Claude low-version model request 400 error

`
InvokeModelWithResponseStream: operation error Bedrock Runtime: InvokeModelWithResponseStream, https response error StatusCode: 400
`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

