### PR TITLE
fix(tui): allow file_context to be disabled

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -752,8 +752,13 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
       {
         name: "app.toggle.file_context",
-        title: kv.get("file_context_enabled", true) ? "Disable file context" : "Enable file context",
+        title: tuiConfig.file_context === false
+          ? "File context disabled in tui.json"
+          : kv.get("file_context_enabled", true)
+            ? "Disable file context"
+            : "Enable file context",
         category: "System",
+        enabled: tuiConfig.file_context !== false,
         run: () => {
           kv.set("file_context_enabled", !kv.get("file_context_enabled", true))
           dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -161,7 +161,7 @@ export function Prompt(props: PromptProps) {
   const animationsEnabled = createMemo(() => kv.get("animations_enabled", true))
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
-  const fileContextEnabled = createMemo(() => kv.get("file_context_enabled", true))
+  const fileContextEnabled = createMemo(() => tuiConfig.file_context !== false && kv.get("file_context_enabled", true))
   const [dismissedEditorSelectionKey, setDismissedEditorSelectionKey] = createSignal<string>()
   const editorContext = createMemo(() => {
     const selection = fileContextEnabled() ? editor.selection() : undefined

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -73,6 +73,9 @@ export const TuiInfo = Schema.Struct({
     description: "TUI scroll speed",
   }),
   scroll_acceleration: Schema.optional(ScrollAcceleration),
+  file_context: Schema.optional(Schema.Boolean).annotate({
+    description: "Show and submit editor open-file context in the prompt footer (default: true)",
+  }),
   diff_style: Schema.optional(DiffStyle),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
 })

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -178,6 +178,21 @@ it.instance("resolves attention config defaults and overrides", () =>
   ),
 )
 
+it.instance("loads file context display option", () =>
+  withCleanState(
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const test = yield* TestInstance
+
+      expect((yield* getTuiConfig(test.directory)).file_context).toBeUndefined()
+
+      yield* fs.writeJson(path.join(test.directory, "tui.json"), { file_context: false })
+
+      expect((yield* getTuiConfig(test.directory)).file_context).toBe(false)
+    }),
+  ),
+)
+
 it.instance("migrates tui-specific keys from opencode.json when tui.json does not exist", () =>
   withCleanState(
     Effect.gen(function* () {


### PR DESCRIPTION

### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/24582

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This allows the user to disable the functionality that was added here: https://github.com/anomalyco/opencode/pull/24034

It allows the user to disable the `file_context` as it causes issues and also maybe I don't want to give my editor the current file context as I'm working on something else and just want to use opencode in my separate terminal, not connected to my editor. 

Add it to the `tui.json` like this:

```json
{
  "file_context": false
}
```

### How did you verify your code works?

I ran it and verified that the open file does not appear

### Screenshots / recordings

<img width="1816" height="1204" alt="image" src="https://github.com/user-attachments/assets/3b8672e4-4a0f-4a07-a7b3-2e2cda8e7cf0" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
