### PR TITLE
fix(core): Copilot Responses reasoning summary fallback

### DIFF
--- a/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
@@ -1226,14 +1226,17 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             } else if (isResponseReasoningSummaryPartAddedChunk(value)) {
               const activeItem =
                 currentReasoningOutputIndex !== null ? activeReasoning[currentReasoningOutputIndex] : null
+              const summaryIndex = value.summary_index ?? 0
 
-              // the first reasoning start is pushed in isResponseOutputItemAddedReasoningChunk.
-              if (activeItem && value.summary_index > 0) {
-                activeItem.summaryParts.push(value.summary_index)
+              // Some Copilot-compatible Responses implementations omit summary_index for
+              // the first summary part. Normalize it to 0 so deltas attach to the
+              // reasoning-start emitted from response.output_item.added.
+              if (activeItem && summaryIndex > 0) {
+                activeItem.summaryParts.push(summaryIndex)
 
                 controller.enqueue({
                   type: "reasoning-start",
-                  id: `${activeItem.canonicalId}:${value.summary_index}`,
+                  id: `${activeItem.canonicalId}:${summaryIndex}`,
                   providerMetadata: {
                     openai: {
                       itemId: activeItem.canonicalId,
@@ -1245,11 +1248,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             } else if (isResponseReasoningSummaryTextDeltaChunk(value)) {
               const activeItem =
                 currentReasoningOutputIndex !== null ? activeReasoning[currentReasoningOutputIndex] : null
+              const summaryIndex = value.summary_index ?? 0
 
               if (activeItem) {
                 controller.enqueue({
                   type: "reasoning-delta",
-                  id: `${activeItem.canonicalId}:${value.summary_index}`,
+                  id: `${activeItem.canonicalId}:${summaryIndex}`,
                   delta: value.delta,
                   providerMetadata: {
                     openai: {
@@ -1542,13 +1546,13 @@ const responseAnnotationAddedSchema = z.object({
 const responseReasoningSummaryPartAddedSchema = z.object({
   type: z.literal("response.reasoning_summary_part.added"),
   item_id: z.string(),
-  summary_index: z.number(),
+  summary_index: z.number().optional().default(0),
 })
 
 const responseReasoningSummaryTextDeltaSchema = z.object({
   type: z.literal("response.reasoning_summary_text.delta"),
   item_id: z.string(),
-  summary_index: z.number(),
+  summary_index: z.number().optional().default(0),
   delta: z.string(),
 })
 

--- a/packages/core/test/github-copilot/copilot-responses-model.test.ts
+++ b/packages/core/test/github-copilot/copilot-responses-model.test.ts
@@ -1,0 +1,132 @@
+import { OpenAIResponsesLanguageModel } from "@opencode-ai/core/github-copilot/responses/openai-responses-language-model"
+import { describe, expect, mock, test } from "bun:test"
+import type { LanguageModelV3Prompt } from "@ai-sdk/provider"
+
+async function convertReadableStreamToArray<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader()
+  const result: T[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result.push(value)
+  }
+  return result
+}
+
+const TEST_PROMPT: LanguageModelV3Prompt = [{ role: "user", content: [{ type: "text", text: "Hello" }] }]
+
+const FIXTURES = {
+  missingSummaryIndex: [
+    [
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp-1","created_at":1,"model":"gpt-5.4"}}',
+    ].join("\n"),
+    [
+      "event: response.output_item.added",
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"canonical-reasoning-id","encrypted_content":"enc-start"}}',
+    ].join("\n"),
+    [
+      "event: response.reasoning_summary_part.added",
+      'data: {"type":"response.reasoning_summary_part.added","output_index":0,"item_id":"rotating-item-1"}',
+    ].join("\n"),
+    [
+      "event: response.reasoning_summary_text.delta",
+      'data: {"type":"response.reasoning_summary_text.delta","output_index":0,"item_id":"rotating-item-2","delta":"Thinking..."}',
+    ].join("\n"),
+    [
+      "event: response.output_item.done",
+      'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"canonical-reasoning-id","encrypted_content":"enc-end"}}',
+    ].join("\n"),
+    [
+      "event: response.completed",
+      'data: {"type":"response.completed","response":{"incomplete_details":null,"usage":{"input_tokens":1,"input_tokens_details":{"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":1}},"service_tier":"default"}}',
+    ].join("\n"),
+  ],
+}
+
+function createMockFetch(chunks: string[]) {
+  return mock(async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(new TextEncoder().encode(chunk + "\n\n"))
+        }
+        controller.close()
+      },
+    })
+
+    return new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    })
+  })
+}
+
+function createModel(fetchFn: ReturnType<typeof mock>) {
+  return new OpenAIResponsesLanguageModel("gpt-5.4", {
+    provider: "copilot.responses",
+    url: () => "https://api.test.com/responses",
+    headers: () => ({ Authorization: "Bearer test-token" }),
+    fetch: fetchFn as any,
+  })
+}
+
+describe("OpenAIResponsesLanguageModel.doStream", () => {
+  test("falls back to summary index 0 when Copilot omits summary_index", async () => {
+    const mockFetch = createMockFetch(FIXTURES.missingSummaryIndex)
+    const model = createModel(mockFetch)
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: {
+        copilot: {
+          reasoningEffort: "high",
+          reasoningSummary: "auto",
+          include: ["reasoning.encrypted_content"],
+        },
+      },
+    })
+
+    const parts = await convertReadableStreamToArray(stream)
+
+    expect(parts.find((part) => part.type === "error")).toBeUndefined()
+
+    const reasoningParts = parts.filter(
+      (part) => part.type === "reasoning-start" || part.type === "reasoning-delta" || part.type === "reasoning-end",
+    )
+
+    expect(reasoningParts).toMatchObject([
+      {
+        type: "reasoning-start",
+        id: "canonical-reasoning-id:0",
+        providerMetadata: {
+          openai: {
+            itemId: "canonical-reasoning-id",
+            reasoningEncryptedContent: "enc-start",
+          },
+        },
+      },
+      {
+        type: "reasoning-delta",
+        id: "canonical-reasoning-id:0",
+        delta: "Thinking...",
+        providerMetadata: {
+          openai: {
+            itemId: "canonical-reasoning-id",
+          },
+        },
+      },
+      {
+        type: "reasoning-end",
+        id: "canonical-reasoning-id:0",
+        providerMetadata: {
+          openai: {
+            itemId: "canonical-reasoning-id",
+            reasoningEncryptedContent: "enc-end",
+          },
+        },
+      },
+    ])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #28447

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Copilot Responses reasoning streams when summary_index is missing from reasoning summary events.

Some Copilot-compatible Responses backends emit `response.reasoning_summary_part.added` / `response.reasoning_summary_text.delta` without `summary_index`, which caused OpenCode to generate reasoning IDs ending in `:undefined` and fail with:

 ```text
   reasoning part <id>:undefined not found
 ```

This change treats missing `summary_index` as 0, matching the initial reasoning part ID, and adds a regression test for that case.

### How did you verify your code works?

By building "localcode", running the built opencode in the same folder and using the same provider, model, variant and prompt.

### Screenshots / recordings

Not a UI change but proof that works:

<img width="320" alt="Screenshot 2026-05-20 at 11 13 50" src="https://github.com/user-attachments/assets/2942f496-d36f-44b0-a667-fbec934345e4" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
