### PR TITLE
fix(plugin): resolve plugin paths relative to project root

### DIFF
--- a/packages/opencode/src/config/plugin.ts
+++ b/packages/opencode/src/config/plugin.ts
@@ -51,7 +51,8 @@ export async function resolvePluginSpec(plugin: Spec, configFilepath: string): P
   const spec = pluginSpecifier(plugin)
   if (!isPathPluginSpec(spec)) return plugin
 
-  const base = path.dirname(configFilepath)
+  const configDir = path.dirname(configFilepath)
+  const base = path.basename(configDir) === ".opencode" ? path.dirname(configDir) : configDir
   const file = (() => {
     if (spec.startsWith("file://")) return spec
     if (path.isAbsolute(spec) || /^[A-Za-z]:[\\/]/.test(spec)) return pathToFileURL(spec).href


### PR DESCRIPTION
### Issue for this PR

Closes #28384

### Type of change

- [x] Bug fix

### What does this PR do?

When a plugin path like `.opencode/plugins/graphify.js` is configured in `.opencode/opencode.json`, the path was being resolved relative to the config file's directory (`.opencode/`), causing the `.opencode` segment to be doubled:

```
.opencode/plugins/graphify.js
→ resolved against <root>/.opencode
→ <root>/.opencode/.opencode/plugins/graphify.js  ← wrong
```

The fix detects when the config file lives inside a `.opencode` directory and resolves relative plugin paths against the project root (one level up) instead. Absolute paths and `file://` URLs are unaffected.

```diff
- const base = path.dirname(configFilepath)
+ const configDir = path.dirname(configFilepath)
+ const base = path.basename(configDir) === ".opencode" ? path.dirname(configDir) : configDir
```

### How did you verify your code works?

Created a test project with `.opencode/plugins/graphify.js` and configured it in `.opencode/opencode.json` as `.opencode/plugins/graphify.js`.

Before fix — log shows doubled path and module not found:
```
INFO  path=file:///.../.opencode/.opencode/plugins/graphify.js loading plugin
ERROR Cannot find module '...\.opencode\.opencode\plugins\graphify.js'
```

After fix — path is correct, plugin file is found:
```
INFO  path=file:///.../.opencode/plugins/graphify.js loading plugin
```

### Screenshots / recordings

Before (bug — doubled path):

<img width="1609" height="346" alt="屏幕截图 2026-05-20 180643" src="https://github.com/user-attachments/assets/65f49097-8231-4ffe-b99c-a7e1e364a706" />


After (fix — correct path):

<img width="1601" height="166" alt="屏幕截图 2026-05-20 181634" src="https://github.com/user-attachments/assets/b7afaa7c-6440-4728-a093-7251a8bec9be" />
### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
