### PR TITLE
feat(ui): add context-aware timestamps to assistant and user messages

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -2,28 +2,28 @@ export function titlecase(str: string) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-export function time(input: number): string {
+export function time(input: number, locale?: string): string {
   const date = new Date(input)
-  return date.toLocaleTimeString(undefined, { timeStyle: "short" })
+  return date.toLocaleTimeString(locale, { timeStyle: "short" })
 }
 
-export function datetime(input: number): string {
+export function datetime(input: number, locale?: string): string {
   const date = new Date(input)
-  const localTime = time(input)
-  const localDate = date.toLocaleDateString()
+  const localTime = time(input, locale)
+  const localDate = date.toLocaleDateString(locale)
   return `${localTime} · ${localDate}`
 }
 
-export function todayTimeOrDateTime(input: number): string {
+export function todayTimeOrDateTime(input: number, locale?: string): string {
   const date = new Date(input)
   const now = new Date()
   const isToday =
     date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth() && date.getDate() === now.getDate()
 
   if (isToday) {
-    return time(input)
+    return time(input, locale)
   } else {
-    return datetime(input)
+    return datetime(input, locale)
   }
 }
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -47,6 +47,7 @@ import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
 import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/core/util/path"
 import { checksum } from "@opencode-ai/core/util/encode"
+import { Locale } from "opencode/util/locale"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
 import { Spinner } from "./spinner"
@@ -1073,12 +1074,10 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
     const match = data.store.provider?.all?.get(providerID)
     return match?.models?.[modelID]?.name ?? modelID
   })
-  const timefmt = createMemo(() => new Intl.DateTimeFormat(i18n.locale(), { timeStyle: "short" }))
-
   const stamp = createMemo(() => {
     const created = props.message.time?.created
     if (typeof created !== "number") return ""
-    return timefmt().format(created)
+    return Locale.todayTimeOrDateTime(created, i18n.locale())
   })
 
   const metaHead = createMemo(() => {
@@ -1503,12 +1502,18 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     })
   })
 
+  const timeStamp = createMemo(() => {
+    if (props.message.role !== "assistant") return ""
+    return Locale.todayTimeOrDateTime((props.message as AssistantMessage).time.created, i18n.locale())
+  })
+
   const meta = createMemo(() => {
     if (props.message.role !== "assistant") return ""
     const agent = (props.message as AssistantMessage).agent
     const items = [
       agent ? agent[0]?.toUpperCase() + agent.slice(1) : "",
       model(),
+      timeStamp(),
       duration(),
       interrupted() ? i18n.t("ui.message.interrupted") : "",
     ]


### PR DESCRIPTION
### Issue for this PR

Closes #8634

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Changes the user messages template: adds date for past messages (currently it shows only time)
Changes the AI messages template: adds date and time similarly

### How did you verify your code works?

Visually in the UI

### Screenshots / recordings

**User past message:**

<img width="1005" height="65" alt="1" src="https://github.com/user-attachments/assets/f4e74c7f-9b69-45bf-b646-9ddacd10d402" />


**AI's past message:**

<img width="1006" height="149" alt="2" src="https://github.com/user-attachments/assets/b494b8ab-ffbf-48b1-aa1c-8701de712eda" />


**AI's today message:**

<img width="1006" height="149" alt="3" src="https://github.com/user-attachments/assets/ddb1ce46-a0b6-4b33-b8f3-2dac97235c16" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


