### PR TITLE
fix(opencode): ignore MCP resource file downloads

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -705,8 +705,13 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             type: "text",
             text: part.text,
           })
-        // text/plain and directory files are converted into text parts, ignore them
-        if (part.type === "file" && part.mime !== "text/plain" && part.mime !== "application/x-directory") {
+        // text/plain, directory files, and MCP resources are converted into text parts, ignore them
+        if (
+          part.type === "file" &&
+          part.mime !== "text/plain" &&
+          part.mime !== "application/x-directory" &&
+          part.source?.type !== "resource"
+        ) {
           if (options?.stripMedia && isMedia(part.mime)) {
             userMessage.parts.push({
               type: "text",

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -316,6 +316,53 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("does not forward resolved MCP resource parts as file downloads", async () => {
+    const messageID = "m-user"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(messageID),
+        parts: [
+          {
+            ...basePart(messageID, "p1"),
+            type: "text",
+            text: "Reading MCP resource: status (status://info)",
+            synthetic: true,
+          },
+          {
+            ...basePart(messageID, "p2"),
+            type: "text",
+            text: '{"ok":true}',
+            synthetic: true,
+          },
+          {
+            ...basePart(messageID, "p3"),
+            type: "file",
+            mime: "application/json",
+            filename: "status",
+            url: "status://info",
+            source: {
+              type: "resource",
+              clientName: "status-server",
+              uri: "status://info",
+              text: { value: "@status", start: 0, end: 7 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Reading MCP resource: status (status://info)" },
+          { type: "text", text: '{"ok":true}' },
+        ],
+      },
+    ])
+  })
+
   test("converts assistant tool completion into tool-call + tool-result messages with attachments", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"


### PR DESCRIPTION
### Issue for this PR

Closes #14753 #8920 #29245

Partial Fix #15535

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP resource @mentions are resolved through `resources/read`, then stored as file parts with the original resource URI. For non-`text/plain` resources, model message conversion was forwarding that original custom URI to the AI SDK as a downloadable file, which caused schemes like `status://` or `simplifier://` to fail URL validation.

This keeps resolved MCP resource content in the prompt as text, but skips forwarding the original MCP resource file part to the model. The stored part remains available for history/UI, while the AI SDK no longer tries to download custom MCP schemes directly.

### How did you verify your code works?

Ran the built artifact from the PR branch and verified that custom file URIs worked.

### Screenshots / recordings

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/be177e09-7c94-41bd-967c-11cd7f8198dd" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
