### PR TITLE
fix(cli): default console login url

### DIFF
--- a/packages/opencode/src/cli/cmd/account.ts
+++ b/packages/opencode/src/cli/cmd/account.ts
@@ -15,6 +15,8 @@ const dim = (value: string) => UI.Style.TEXT_DIM + value + UI.Style.TEXT_NORMAL
 
 const activeSuffix = (isActive: boolean) => (isActive ? dim(" (active)") : "")
 
+export const defaultConsoleUrl = "https://console.opencode.ai"
+
 export const formatAccountLabel = (account: { email: string; url: string }, isActive: boolean) =>
   `${account.email} ${dim(account.url)}${activeSuffix(isActive)}`
 
@@ -173,18 +175,17 @@ const openEffect = Effect.fn("open")(function* () {
 })
 
 export const LoginCommand = effectCmd({
-  command: "login <url>",
+  command: "login [url]",
   describe: false,
   instance: false,
   builder: (yargs) =>
     yargs.positional("url", {
       describe: "server URL",
       type: "string",
-      demandOption: true,
     }),
   handler: Effect.fn("Cli.account.login")(function* (args) {
     UI.empty()
-    yield* Effect.orDie(loginEffect(args.url))
+    yield* Effect.orDie(loginEffect(args.url ?? defaultConsoleUrl))
   }),
 })
 

--- a/packages/opencode/test/cli/account.test.ts
+++ b/packages/opencode/test/cli/account.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import stripAnsi from "strip-ansi"
 
-import { formatAccountLabel, formatOrgLine } from "../../src/cli/cmd/account"
+import { defaultConsoleUrl, formatAccountLabel, formatOrgLine } from "../../src/cli/cmd/account"
 
 describe("console account display", () => {
+  test("uses console.opencode.ai as the default login URL", () => {
+    expect(defaultConsoleUrl).toBe("https://console.opencode.ai")
+  })
+
   test("includes the account url in account labels", () => {
     expect(stripAnsi(formatAccountLabel({ email: "one@example.com", url: "https://one.example.com" }, false))).toBe(
       "one@example.com https://one.example.com",


### PR DESCRIPTION
## Summary
- make console login URL optional
- default console login to https://console.opencode.ai
- add coverage for the default URL

## Testing
- bun typecheck (fails: tsgo not found)
- bun test test/cli/account.test.ts (fails: preload not found @opentui/solid/preload)