### PR TITLE
fix: strip inline env var prefixes from bash permission patterns

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -119,10 +119,6 @@ function parts(node: Node) {
   return out
 }
 
-function source(node: Node) {
-  return (node.parent?.type === "redirected_statement" ? node.parent.text : node.text).trim()
-}
-
 function commands(node: Node) {
   return node.descendantsOfType("command").filter((child): child is Node => Boolean(child))
 }
@@ -401,7 +397,20 @@ export const ShellTool = Tool.define(
         }
 
         if (tokens.length && (!cmd || !CWD.has(cmd))) {
-          scan.patterns.add(source(node))
+          // Build the pattern from parts() tokens, which already exclude variable_assignment
+          // nodes (e.g. GITHUB_TOKEN=x), so the pattern only contains the actual command.
+          let pattern = tokens.join(" ")
+          if (node.parent?.type === "redirected_statement") {
+            // Re-attach any redirection suffix (e.g. "2>&1", "> file") that lives on
+            // the parent but outside the command node itself.
+            // Guard with startsWith: tree-sitter guarantees child ranges are within
+            // parent ranges, but .text is a string slice so we verify before slicing.
+            if (node.parent.text.startsWith(node.text)) {
+              const redirectSuffix = node.parent.text.slice(node.text.length).trim()
+              if (redirectSuffix) pattern = pattern + " " + redirectSuffix
+            }
+          }
+          scan.patterns.add(pattern)
           scan.always.add(BashArity.prefix(tokens).join(" ") + " *")
         }
       }

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1023,6 +1023,69 @@ describe("tool.shell permissions", () => {
       )
     }),
   )
+
+  each("strips inline env var prefix from permission pattern", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+          yield* fail(
+            { command: 'CI=true git commit -m "test"', description: "Commit with env prefix" },
+            capture(requests, err),
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.patterns).toContain('git commit -m "test"')
+          expect(bashReq!.patterns).not.toContain('CI=true git commit -m "test"')
+        }),
+      )
+    }),
+  )
+
+  each("strips multiple inline env var prefixes from permission pattern", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+          yield* fail(
+            { command: "FOO=1 BAR=2 echo hello", description: "Echo with multiple env prefixes" },
+            capture(requests, err),
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.patterns).toContain("echo hello")
+          expect(bashReq!.patterns).not.toContain("FOO=1")
+        }),
+      )
+    }),
+  )
+
+  each("strips env var prefix and preserves redirection in permission pattern", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+          yield* fail(
+            { command: "CI=true echo hello > output.txt", description: "Redirect with env prefix" },
+            capture(requests, err),
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.patterns).toContain("echo hello > output.txt")
+          expect(bashReq!.patterns).not.toContain("CI=true")
+        }),
+      )
+    }),
+  )
 })
 
 describe("tool.shell abort", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #16075

### Type of change

- [x] Bug fix

### What does this PR do?

In `collect()` inside `shell.ts`, the permission pattern for a command was built by calling `source(node)`, which returns the raw `node.text`. For a command like `GITHUB_TOKEN=x git push --force`, tree-sitter parses the `variable_assignment` as a child of the `command` node, so `node.text` includes it. The resulting pattern `GITHUB_TOKEN=x git push --force` does not match a rule like `"git push --force*": deny`, allowing the bypass.

The `parts()` function already walks the command node's children and intentionally skips `variable_assignment` nodes — it's what builds the `tokens` array used for the `always` pattern, which was already correct. The fix replaces `source(node)` with `tokens.join(" ")` for the `patterns` entry, bringing it in line with how `always` was already computed. Redirection suffixes (e.g. `> output.txt`, `2>&1`) are re-attached from the parent `redirected_statement` node so that existing redirect-pattern matching continues to work.

The now-dead `source()` function is removed.

### How did you verify your code works?

Ran `bun test test/tool/shell.test.ts --timeout 60000` — 26 pass, 0 fail.

Three new integration tests exercise the permission-scanning path directly via the `capture()` helper (halting execution at the permission prompt):

- `CI=true git commit -m "test"` → pattern must be `git commit -m "test"`, not contain `CI=true`
- `FOO=1 BAR=2 echo hello` → pattern must be `echo hello`, not contain `FOO=1`
- `CI=true echo hello > output.txt` → pattern must be `echo hello > output.txt`, not contain `CI=true` (exercises both branches simultaneously)

The existing redirect test (`echo test > output.txt` → `echo test > output.txt`) continues to pass, confirming the redirection re-attachment is correct.

Test groundwork from #16086.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR