### PR TITLE
chore(nix): update bun to 1.3.14

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776683584,
-        "narHash": "sha256-NuTLMrr10Tng72hurYG8jYQ4XKK8wnpJmOGcPiis96g=",
+        "lastModified": 1778688106,
+        "narHash": "sha256-5AflZ/P4D9ZC19WSdUTcs/xVowJETiNTtGvWhPeHCME=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9dd5558b06dbdacbf635a3dd36dce1b1a7ee3a89",
+        "rev": "943e4c3c705a1b3025348d82d6aada3c442327ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Issue for this PR

Closes #28389

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates flake.lock to a nixpkgs with bun 1.3.14

### How did you verify your code works?

opencode-desktop works due to only requiring bun at build time
opencode tui crashes with a segfault (tracked by https://github.com/oven-sh/bun/issues/31023)

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
