### PR TITLE
fix(tui): simplify thinking toggle styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,14 @@
 - The default branch in this repo is `dev`.
 - Local `main` ref may not exist; use `dev` or `origin/dev` for diffs.
 - Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
-- Use conventional commit-style messages and PR titles: `type(scope): summary`.
-- Valid types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`.
-- Scopes are optional; use the affected package or area when helpful, e.g. `core`, `opencode`, `tui`, `app`, `desktop`, `sdk`, or `plugin`.
-- Examples: `fix(tui): simplify thinking toggle styling`, `docs: update contributing guide`, `chore(sdk): regenerate types`.
+
+## Commits and PR Titles
+
+Use conventional commit-style messages and PR titles: `type(scope): summary`.
+
+Valid types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`. Scopes are optional; use the affected package or area when helpful, e.g. `core`, `opencode`, `tui`, `app`, `desktop`, `sdk`, or `plugin`.
+
+Examples: `fix(tui): simplify thinking toggle styling`, `docs: update contributing guide`, `chore(sdk): regenerate types`.
 
 ## Style Guide
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 - The default branch in this repo is `dev`.
 - Local `main` ref may not exist; use `dev` or `origin/dev` for diffs.
 - Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
+- Use conventional commit-style messages and PR titles: `type(scope): summary`.
+- Valid types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`.
+- Scopes are optional; use the affected package or area when helpful, e.g. `core`, `opencode`, `tui`, `app`, `desktop`, `sdk`, or `plugin`.
+- Examples: `fix(tui): simplify thinking toggle styling`, `docs: update contributing guide`, `chore(sdk): regenerate types`.
 
 ## Style Guide
 

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -411,12 +411,9 @@ function AssistantReasoning(props: {
       <Switch>
         <Match when={!inMinimal() || expanded()}>
           <box
-            paddingLeft={2}
+            paddingLeft={3}
             marginTop={1}
             flexDirection="column"
-            border={["left"]}
-            customBorderChars={SplitBorder.customBorderChars}
-            borderColor={theme.backgroundElement}
             flexShrink={0}
             onMouseUp={toggle}
           >
@@ -425,17 +422,20 @@ function AssistantReasoning(props: {
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={props.subtleSyntax}
-              content={(inMinimal() ? "▼ " : "") + "_Thinking:_ " + content()}
+              content={(inMinimal() ? "- " : "") + "_Thinking:_ " + content()}
               conceal={true}
               fg={theme.textMuted}
             />
           </box>
         </Match>
         <Match when={isDone()}>
-          <box paddingLeft={3} marginTop={1} flexShrink={0} onMouseUp={toggle}>
-            <text fg={theme.textMuted} wrapMode="none">
-              {title() ? "▶ Thought: " + title() : "▶ Thought"}
-            </text>
+          <box
+            paddingLeft={3}
+            marginTop={1}
+            flexShrink={0}
+            onMouseUp={toggle}
+          >
+            <CollapsedReasoningText title={title()} />
           </box>
         </Match>
         <Match when={true}>
@@ -445,6 +445,16 @@ function AssistantReasoning(props: {
         </Match>
       </Switch>
     </Show>
+  )
+}
+
+function CollapsedReasoningText(props: { title: string | null }) {
+  const { theme } = useTheme()
+
+  return (
+    <text fg={theme.warning} wrapMode="none">
+      <span style={{ fg: theme.warning, italic: true }}>{props.title ? "+ Thought · " + props.title : "+ Thought"}</span>
+    </text>
   )
 }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1533,12 +1533,9 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
           {/* Full markdown block: `show` mode, or `hide` after the user opens it. */}
           <box
             id={"text-" + props.part.id}
-            paddingLeft={2}
+            paddingLeft={3}
             marginTop={1}
             flexDirection="column"
-            border={["left"]}
-            customBorderChars={SplitBorder.customBorderChars}
-            borderColor={theme.backgroundElement}
             onMouseUp={toggle}
           >
             <code
@@ -1546,32 +1543,43 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={subtleSyntax()}
-              content={(inMinimal() ? "▼ " : "") + (isDone() ? "_Thought:_ " : "_Thinking:_ ") + content()}
+              content={(inMinimal() ? "- " : "") + (isDone() ? "_Thought:_ " : "_Thinking:_ ") + content()}
               conceal={ctx.conceal()}
               fg={theme.textMuted}
             />
           </box>
         </Match>
         <Match when={isDone()}>
-          {/* Settled: ▶ at the start as the click-to-expand cue. */}
-          <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0} onMouseUp={toggle}>
-            <text fg={theme.textMuted} wrapMode="none">
-              {"▶ " +
-                (title()
-                  ? "Thought: " + title() + " · " + Locale.duration(duration())
-                  : "Thought for " + Locale.duration(duration()))}
-            </text>
+          <box
+            id={"text-" + props.part.id}
+            paddingLeft={3}
+            marginTop={1}
+            flexShrink={0}
+            onMouseUp={toggle}
+          >
+            <CollapsedReasoningText title={title()} duration={duration()} />
           </box>
         </Match>
         <Match when={true}>
-          {/* Streaming: leading animated spinner, no disclosure arrow yet — it
-              snaps in once reasoning settles, signalling "done, click to expand". */}
           <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0} onMouseUp={toggle}>
             <Spinner color={theme.textMuted}>{title() ? "Thinking: " + title() : "Thinking"}</Spinner>
           </box>
         </Match>
       </Switch>
     </Show>
+  )
+}
+
+function CollapsedReasoningText(props: { title: string | null; duration: number }) {
+  const { theme } = useTheme()
+  const duration = () => Locale.duration(props.duration)
+
+  return (
+    <text fg={theme.warning} wrapMode="none">
+      <span style={{ fg: theme.warning, italic: true }}>
+        {props.title ? "+ Thought · " + props.title + " · " + duration() : "+ Thought · " + duration()}
+      </span>
+    </text>
   )
 }
 


### PR DESCRIPTION
## Summary
- replace collapsed/expanded thinking arrows with + / - markers
- remove the left border from thinking blocks
- keep parsed reasoning titles in the collapsed label when available

## Testing
- bun typecheck


--- Default Thinking ---

<img width="865" height="155" alt="Screenshot 2026-05-20 at 11 14 28 AM" src="https://github.com/user-attachments/assets/2a055123-67c6-4086-9ff8-633612d87110" />

<img width="954" height="232" alt="Screenshot 2026-05-20 at 11 14 45 AM" src="https://github.com/user-attachments/assets/5837e38e-8dd3-455d-8063-272671c1a5c9" />

--- OpenAI Thinking ---

<img width="763" height="151" alt="Screenshot 2026-05-20 at 11 15 01 AM" src="https://github.com/user-attachments/assets/93bcaebc-4c92-40ab-9d25-5d1f9f84c6cb" />

<img width="868" height="178" alt="Screenshot 2026-05-20 at 11 15 10 AM" src="https://github.com/user-attachments/assets/c46a88fa-1904-44a8-b29a-46b4e4b34cc4" />


