### PR TITLE
fix(opencode): prevent same-parent assistant siblings during concurrent prompts (#28202)

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -99,6 +99,24 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   return part.state.status === "error" && part.state.metadata?.interrupted === true
 }
 
+function nextUnansweredUser(messages: SessionV1.WithParts[], after: MessageID) {
+  // Find the next user message after `after` that has no terminal assistant
+  // parented to it. Used to drain queued prompts within the same loop invocation
+  // without rebinding the active turn's user (#28202).
+  return messages.find((message): message is SessionV1.WithParts & { info: SessionV1.User } => {
+    if (message.info.role !== "user" || message.info.id <= after) {
+      return false
+    }
+    return !messages.some(
+      (candidate) =>
+        candidate.info.role === "assistant" &&
+        candidate.info.parentID === message.info.id &&
+        candidate.info.finish &&
+        !["tool-calls"].includes(candidate.info.finish),
+    )
+  })
+}
+
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
@@ -1083,7 +1101,18 @@ const layer = Layer.effect(
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
+        let initialUser: SessionV1.User
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
+
+        // Pin the turn's user once, before the loop. Iterations that used to re-resolve
+        // `lastUser` from MessageV2.latest(msgs) now reference `initialUser` so a prompt
+        // arriving mid tool-round-trip cannot rebind the continuation to the newer user
+        // and emit assistants under the wrong parentID (#28202).
+        const initialMsgs = yield* MessageV2.filterCompactedEffect(sessionID).pipe(
+          Effect.provideService(Database.Service, database),
+        )
+        initialUser = MessageV2.latest(initialMsgs).user!
+        if (!initialUser) throw new Error("No user message found in stream. This should never happen.")
 
         while (true) {
           yield* status.set(sessionID, { type: "busy" })
@@ -1093,9 +1122,7 @@ const layer = Layer.effect(
             Effect.provideService(Database.Service, database),
           )
 
-          const { user: lastUser, assistant: lastAssistant, finished: lastFinished, tasks } = MessageV2.latest(msgs)
-
-          if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
+          const { assistant: lastAssistant, finished: lastFinished, tasks } = MessageV2.latest(msgs)
 
           const lastAssistantMsg = msgs.findLast(
             (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
@@ -1112,7 +1139,7 @@ const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastAssistant.parentID === initialUser.id
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),
@@ -1125,6 +1152,19 @@ const layer = Layer.effect(
                 callID: orphan.callID,
               })
             }
+
+            // Drain queued user messages within the same loop invocation. dev relied
+            // on `lastUser` being re-resolved each iteration to serve U(n+1) after
+            // U(n)'s turn completes. Pinning `initialUser` removed that re-resolution,
+            // so we explicitly check for the next unanswered user and re-pin here.
+            const queuedUser = nextUnansweredUser(msgs, initialUser.id)?.info
+            if (queuedUser) {
+              yield* Effect.logInfo("draining queued user", { "session.id": sessionID, nextUserID: queuedUser.id })
+              initialUser = queuedUser
+              structured = undefined
+              step = 0
+              continue
+            }
             yield* Effect.logInfo("exiting loop", { "session.id": sessionID })
             break
           }
@@ -1133,23 +1173,23 @@ const layer = Layer.effect(
           if (step === 1)
             yield* title({
               session,
-              modelID: lastUser.model.modelID,
-              providerID: lastUser.model.providerID,
+              modelID: initialUser.model.modelID,
+              providerID: initialUser.model.providerID,
               history: msgs,
             }).pipe(Effect.ignore, Effect.forkIn(scope))
 
-          const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
+          const model = yield* getModel(initialUser.model.providerID, initialUser.model.modelID, sessionID)
           const task = tasks.pop()
 
           if (task?.type === "subtask") {
-            yield* handleSubtask({ task, model, lastUser, sessionID, session, msgs })
+            yield* handleSubtask({ task, model, lastUser: initialUser, sessionID, session, msgs })
             continue
           }
 
           if (task?.type === "compaction") {
             const result = yield* compaction.process({
               messages: msgs,
-              parentID: lastUser.id,
+              parentID: initialUser.id,
               sessionID,
               auto: task.auto,
               overflow: task.overflow,
@@ -1163,15 +1203,15 @@ const layer = Layer.effect(
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
-            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+            yield* compaction.create({ sessionID, agent: initialUser.agent, model: initialUser.model, auto: true })
             continue
           }
 
-          const agent = yield* agents.get(lastUser.agent)
+          const agent = yield* agents.get(initialUser.agent)
           if (!agent) {
             const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
             const hint = available.length ? ` Available agents: ${available.join(", ")}` : ""
-            const error = new NamedError.Unknown({ message: `Agent not found: "${lastUser.agent}".${hint}` })
+            const error = new NamedError.Unknown({ message: `Agent not found: "${initialUser.agent}".${hint}` })
             yield* events.publish(Session.Event.Error, { sessionID, error: error.toObject() })
             throw error
           }
@@ -1185,11 +1225,11 @@ const layer = Layer.effect(
 
           const msg: SessionV1.Assistant = {
             id: MessageID.ascending(),
-            parentID: lastUser.id,
+            parentID: initialUser.id,
             role: "assistant",
             mode: agent.name,
             agent: agent.name,
-            variant: lastUser.model.variant,
+            variant: initialUser.model.variant,
             path: { cwd: ctx.directory, root: ctx.worktree },
             cost: 0,
             tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
@@ -1240,9 +1280,9 @@ const layer = Layer.effect(
               Effect.provideService(RuntimeFlags.Service, flags),
             )
 
-            if (lastUser.format?.type === "json_schema") {
+            if (initialUser.format?.type === "json_schema") {
               tools["StructuredOutput"] = createStructuredOutputTool({
-                schema: lastUser.format.schema,
+                schema: initialUser.format.schema,
                 onSuccess(output) {
                   structured = output
                 },
@@ -1250,7 +1290,7 @@ const layer = Layer.effect(
             }
 
             if (step === 1)
-              yield* summary.summarize({ sessionID, messageID: lastUser.id }).pipe(Effect.ignore, Effect.forkIn(scope))
+              yield* summary.summarize({ sessionID, messageID: initialUser.id }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
@@ -1267,10 +1307,10 @@ const layer = Layer.effect(
               ...(mcpInstructions ? [mcpInstructions] : []),
               ...(skills ? [skills] : []),
             ]
-            const format = lastUser.format ?? { type: "text" as const }
+            const format = initialUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({
-              user: lastUser,
+              user: initialUser,
               agent,
               permission: session.permission,
               sessionID,
@@ -1320,8 +1360,8 @@ const layer = Layer.effect(
             if (result === "compact") {
               yield* compaction.create({
                 sessionID,
-                agent: lastUser.agent,
-                model: lastUser.model,
+                agent: initialUser.agent,
+                model: initialUser.model,
                 auto: true,
                 overflow: !handle.message.finish,
               })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1453,6 +1453,276 @@ it.instance("assertNotBusy fails with BusyError when loop running", () =>
     yield* prompt.cancel(chat.id)
     yield* Fiber.await(fiber)
   }),
+  3_000,
+)
+
+it.instance(
+  "does not fan out assistant siblings when a new prompt arrives during a tool round-trip (#28202)",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const toolResultGate = yield* Deferred.make<void>()
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+
+      yield* llm.push(reply().tool("test", { input: "u1" }).toolCalls())
+      yield* llm.hold("continuation from U1", deferredAsPromise(toolResultGate))
+      yield* llm.text("U2 response")
+
+      const u1ID = MessageID.ascending()
+      const u2ID = MessageID.ascending()
+
+      const u1Fiber = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: u1ID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "U1" }],
+        })
+        .pipe(Effect.forkChild)
+
+      yield* llm.wait(1)
+
+      const u2Fiber = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: u2ID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "U2" }],
+        })
+        .pipe(Effect.forkChild)
+
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const msgs = yield* sessions.messages({ sessionID: chat.id })
+          return msgs.some((m) => m.info.role === "user" && m.info.id === u2ID) ? true : undefined
+        }),
+        "U2 user message did not persist before gate release",
+      )
+
+      yield* Deferred.succeed(toolResultGate, void 0)
+
+      const [eu1, eu2] = yield* Effect.all([Fiber.await(u1Fiber), Fiber.await(u2Fiber)])
+      expect(Exit.isSuccess(eu1)).toBe(true)
+      expect(Exit.isSuccess(eu2)).toBe(true)
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const assistants = msgs.filter((msg) => msg.info.role === "assistant")
+
+      const u1Assistants = assistants.filter(
+        (a): a is SessionV1.WithParts & { info: SessionV1.Assistant } =>
+          a.info.role === "assistant" && a.info.parentID === u1ID,
+      )
+      const u2Assistants = assistants.filter(
+        (a): a is SessionV1.WithParts & { info: SessionV1.Assistant } =>
+          a.info.role === "assistant" && a.info.parentID === u2ID,
+      )
+
+      // Exactly one tool-call assistant + one continuation under U1. The original
+      // #28202 bug fans out same-parent siblings and pushes this above 2.
+      expect(u1Assistants.length).toBe(2)
+      expect(u2Assistants.length).toBe(1)
+
+      const lastU1Assistant = u1Assistants[u1Assistants.length - 1]
+      expect(lastU1Assistant).toBeDefined()
+      if (!lastU1Assistant || lastU1Assistant.info.role !== "assistant") throw new Error("expected assistant")
+      expect(lastU1Assistant.info.finish).toBe("stop")
+      const u1TextPart = lastU1Assistant.parts.find((p: SessionV1.Part): p is SessionV1.TextPart => p.type === "text")
+      expect(u1TextPart).toBeDefined()
+
+      const firstU1Assistant = u1Assistants[0]
+      if (!firstU1Assistant || firstU1Assistant.info.role !== "assistant")
+        throw new Error("expected assistant")
+      expect(firstU1Assistant.info.finish).toBe("tool-calls")
+      const u1ToolPart = firstU1Assistant.parts.find(
+        (p: SessionV1.Part): p is CompletedToolPart => p.type === "tool" && p.state.status === "completed",
+      )
+      expect(u1ToolPart).toBeDefined()
+
+      const lastU2Assistant = u2Assistants[u2Assistants.length - 1]
+      expect(lastU2Assistant).toBeDefined()
+      if (!lastU2Assistant || lastU2Assistant.info.role !== "assistant")
+        throw new Error("expected assistant")
+      expect(lastU2Assistant.info.finish).toBe("stop")
+      const u2TextPart = lastU2Assistant.parts.find((p: SessionV1.Part): p is SessionV1.TextPart => p.type === "text")
+      expect(u2TextPart).toBeDefined()
+    }),
+  3_000,
+)
+
+it.instance(
+  "U1→U2→U3 chain produces exactly one terminal assistant per parent (#28202 regression 1)",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "U123Chain" })
+
+      yield* llm.text("R1")
+      yield* llm.text("R2")
+      yield* llm.text("R3")
+
+      const u1ID = MessageID.ascending()
+      const u2ID = MessageID.ascending()
+      const u3ID = MessageID.ascending()
+
+      const eu1 = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: u1ID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "U1" }],
+        })
+        .pipe(Effect.exit)
+      expect(Exit.isSuccess(eu1)).toBe(true)
+
+      const eu2 = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: u2ID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "U2" }],
+        })
+        .pipe(Effect.exit)
+      expect(Exit.isSuccess(eu2)).toBe(true)
+
+      const eu3 = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: u3ID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "U3" }],
+        })
+        .pipe(Effect.exit)
+      expect(Exit.isSuccess(eu3)).toBe(true)
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const assistants = msgs.filter(
+        (msg): msg is SessionV1.WithParts & { info: SessionV1.Assistant } => msg.info.role === "assistant",
+      )
+
+      const u1Assistants = assistants.filter((a) => a.info.parentID === u1ID)
+      const u2Assistants = assistants.filter((a) => a.info.parentID === u2ID)
+      const u3Assistants = assistants.filter((a) => a.info.parentID === u3ID)
+
+      expect(u1Assistants.length).toBe(1)
+      expect(u2Assistants.length).toBe(1)
+      expect(u3Assistants.length).toBe(1)
+
+      expect(u1Assistants[0].info.finish).toBe("stop")
+      expect(u2Assistants[0].info.finish).toBe("stop")
+      expect(u3Assistants[0].info.finish).toBe("stop")
+
+      const u1Text = u1Assistants[0].parts.find((p: SessionV1.Part): p is SessionV1.TextPart => p.type === "text")
+      const u2Text = u2Assistants[0].parts.find((p: SessionV1.Part): p is SessionV1.TextPart => p.type === "text")
+      const u3Text = u3Assistants[0].parts.find((p: SessionV1.Part): p is SessionV1.TextPart => p.type === "text")
+      expect(u1Text).toBeDefined()
+      expect(u2Text).toBeDefined()
+      expect(u3Text).toBeDefined()
+    }),
+  3_000,
+)
+
+it.instance(
+  "U2 with tool round-trip lands under U2, not U1 (#28202 regression 2)",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const toolResultGate = yield* Deferred.make<void>()
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "U2ToolRoundTrip" })
+
+      yield* llm.text("U1 response")
+      yield* llm.push(reply().tool("test", { input: "u2" }).toolCalls())
+      yield* llm.hold("continuation from U2", deferredAsPromise(toolResultGate))
+
+      const u1ID = MessageID.ascending()
+      const u2ID = MessageID.ascending()
+
+      const u1Fiber = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: u1ID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "U1" }],
+        })
+        .pipe(Effect.forkChild)
+
+      yield* llm.wait(1)
+
+      const u2Fiber = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: u2ID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "U2" }],
+        })
+        .pipe(Effect.forkChild)
+
+      yield* llm.wait(1)
+
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const msgs = yield* sessions.messages({ sessionID: chat.id })
+          const u2Assistants = msgs.filter(
+            (m) => m.info.role === "assistant" && m.info.parentID === u2ID,
+          )
+          return u2Assistants.length > 0 ? true : undefined
+        }),
+        "U2 tool assistant did not persist before gate release",
+      )
+
+      yield* Deferred.succeed(toolResultGate, void 0)
+
+      const [eu1, eu2] = yield* Effect.all([Fiber.await(u1Fiber), Fiber.await(u2Fiber)])
+      expect(Exit.isSuccess(eu1)).toBe(true)
+      expect(Exit.isSuccess(eu2)).toBe(true)
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const assistants = msgs.filter(
+        (msg): msg is SessionV1.WithParts & { info: SessionV1.Assistant } => msg.info.role === "assistant",
+      )
+
+      const u1Assistants = assistants.filter((a) => a.info.parentID === u1ID)
+      const u2Assistants = assistants.filter((a) => a.info.parentID === u2ID)
+
+      expect(u1Assistants.length).toBe(1)
+      expect(u1Assistants[0].info.finish).toBe("stop")
+      const u1Text = u1Assistants[0].parts.find((p: SessionV1.Part): p is SessionV1.TextPart => p.type === "text")
+      expect(u1Text).toBeDefined()
+
+      expect(u2Assistants.length).toBe(2)
+
+      const firstU2Assistant = u2Assistants[0]
+      expect(firstU2Assistant.info.finish).toBe("tool-calls")
+      const u2ToolPart = firstU2Assistant.parts.find(
+        (p: SessionV1.Part): p is CompletedToolPart => p.type === "tool" && p.state.status === "completed",
+      )
+      expect(u2ToolPart).toBeDefined()
+
+      const lastU2Assistant = u2Assistants[u2Assistants.length - 1]
+      expect(lastU2Assistant.info.finish).toBe("stop")
+      const u2ContinuationText = lastU2Assistant.parts.find(
+        (p: SessionV1.Part): p is SessionV1.TextPart => p.type === "text",
+      )
+      expect(u2ContinuationText).toBeDefined()
+
+      const otherAssistants = assistants.filter(
+        (a) => a.info.parentID !== u1ID && a.info.parentID !== u2ID,
+      )
+      expect(otherAssistants.length).toBe(0)
+    }),
+  3_000,
 )
 
 noLLMServer.instance("assertNotBusy succeeds when idle", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #28202
Closes #35399

### Type of change

- [x] Bug fix

### What does this PR do?

`runLoop` re-resolved the current user from `MessageV2.latest(msgs)` on every iteration. When another prompt arrived while U1 was still in a tool round-trip, U1's continuation could rebind to the newer user, orphan the original tool branch, and produce same-parent assistant siblings.

This change pins the turn's user (`initialUser`) once before the loop. All iteration sites that read `lastUser` now reference `initialUser`, so a mid-flight prompt cannot rebind the continuation's parentID.

The terminal-exit branch now requires `lastAssistant.parentID === initialUser.id` so a freshly transitioned turn does not exit on the prior turn's terminal assistant before calling the model for the new user.

Because `ensureRunning` single-flights concurrent `prompt.loop` calls for the same session, queued prompts must be drained inside the loop. The terminal-exit branch calls `nextUnansweredUser` to find the next user without a terminal assistant, re-pins `initialUser`, resets `step`/`structured`, and continues. This preserves dev's in-loop drain without the rebind that caused #28202.

Rebased onto the latest `dev` after the original base diverged. The fix approach changed from the original three-function restructure to a minimal pin-and-drain against dev's current `while(true)` loop, because dev accumulated 22 commits of features (mcpInstructions tuple, steering rewrite, StructuredOutputError) since the original base that would have required error-prone porting.

### How did you verify your code works?

- [x] `bun test --timeout 30000 test/session/prompt.test.ts` from `packages/opencode` — 59 pass, 1 skip, 0 fail, 256 expects
- [x] `bun run typecheck` from `packages/opencode`
- [x] `git diff --check origin/dev...HEAD`
- [x] Pre-push `bun turbo typecheck` — 30 successful, 30 total

Regression coverage in `test/session/prompt.test.ts`:

1. New prompt during a tool round-trip does not fan out assistant siblings.
2. U1→U2→U3 sequential turns with one terminal assistant per parent.
3. U2 tool round-trip lands under U2, not U1.

The pre-existing dev test `prompt submitted during an active run is included in the next LLM input` continues to pass, confirming the in-loop drain serves queued prompts correctly.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
