### PR TITLE
fix(httpapi): expose v2 catalog errors

### DIFF
--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -15,7 +15,7 @@
 // The tick counter prevents stale idle events from resolving the wrong turn.
 // We also re-check live session status before resolving an idle event so a
 // delayed idle from an older turn cannot complete a newer busy turn.
-import type { Event, GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2"
+import type { Event, GlobalEvent, GlobalEventErrors, OpencodeClient } from "@opencode-ai/sdk/v2"
 import { Context, Deferred, Effect, Exit, Layer, Scope, Stream } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import {
@@ -60,6 +60,13 @@ import type {
 
 type Trace = {
   write(type: string, data?: unknown): void
+}
+
+const GlobalStreamClosed: GlobalEventErrors = {
+  400: {
+    name: "BadRequest",
+    data: { message: "Global event stream closed" },
+  },
 }
 
 type StreamInput = {
@@ -418,12 +425,12 @@ function createLayer(input: StreamInput) {
             ),
             (events) =>
               Effect.sync(() => {
-                void events.stream.return(undefined).catch(() => {})
+                void events.stream.return(GlobalStreamClosed).catch(() => {})
               }),
           ),
         )
         closeStream = () => {
-          void events.stream.return(undefined).catch(() => {})
+          void events.stream.return(GlobalStreamClosed).catch(() => {})
         }
         input.trace?.write("recv.subscribe", {
           sessionID: input.sessionID,

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -15,7 +15,7 @@
 // The tick counter prevents stale idle events from resolving the wrong turn.
 // We also re-check live session status before resolving an idle event so a
 // delayed idle from an older turn cannot complete a newer busy turn.
-import type { Event, GlobalEvent, GlobalEventErrors, OpencodeClient } from "@opencode-ai/sdk/v2"
+import type { Event, GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2"
 import { Context, Deferred, Effect, Exit, Layer, Scope, Stream } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import {
@@ -62,12 +62,7 @@ type Trace = {
   write(type: string, data?: unknown): void
 }
 
-const GlobalStreamClosed: GlobalEventErrors = {
-  400: {
-    name: "BadRequest",
-    data: { message: "Global event stream closed" },
-  },
-}
+const StreamClosed = undefined as never
 
 type StreamInput = {
   sdk: OpencodeClient
@@ -425,12 +420,12 @@ function createLayer(input: StreamInput) {
             ),
             (events) =>
               Effect.sync(() => {
-                void events.stream.return(GlobalStreamClosed).catch(() => {})
+                void events.stream.return(StreamClosed).catch(() => {})
               }),
           ),
         )
         closeStream = () => {
-          void events.stream.return(GlobalStreamClosed).catch(() => {})
+          void events.stream.return(StreamClosed).catch(() => {})
         }
         input.trace?.write("recv.subscribe", {
           sessionID: input.sessionID,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
@@ -108,7 +108,7 @@ export async function warpWorkspaceSession(input: {
     })
     .catch(() => undefined)
   if (!result?.data) {
-    if (result?.error?.name === "VcsApplyError") {
+    if (result?.error && "name" in result.error && result.error.name === "VcsApplyError") {
       await DialogAlert.show(
         input.dialog,
         "Unable to Warp Session",

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/v2/model.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/v2/model.ts
@@ -1,6 +1,7 @@
 import { ModelV2 } from "@opencode-ai/core/model"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { ServiceUnavailableError } from "../../errors"
 import { V2Authorization } from "../../middleware/authorization"
 import { LocationQuery, locationQueryOpenApi, V2LocationMiddleware } from "./location"
 
@@ -9,6 +10,7 @@ export const ModelGroup = HttpApiGroup.make("v2.model")
     HttpApiEndpoint.get("models", "/api/model", {
       query: LocationQuery,
       success: Schema.Array(ModelV2.Info),
+      error: ServiceUnavailableError,
     })
       .annotateMerge(locationQueryOpenApi)
       .annotateMerge(

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/v2/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/v2/provider.ts
@@ -1,7 +1,7 @@
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { ApiNotFoundError } from "../../errors"
+import { ProviderNotFoundError, ServiceUnavailableError } from "../../errors"
 import { V2Authorization } from "../../middleware/authorization"
 import { LocationQuery, locationQueryOpenApi, V2LocationMiddleware } from "./location"
 
@@ -10,6 +10,7 @@ export const ProviderGroup = HttpApiGroup.make("v2.provider")
     HttpApiEndpoint.get("providers", "/api/provider", {
       query: LocationQuery,
       success: Schema.Array(ProviderV2.Info),
+      error: ServiceUnavailableError,
     })
       .annotateMerge(locationQueryOpenApi)
       .annotateMerge(
@@ -25,7 +26,7 @@ export const ProviderGroup = HttpApiGroup.make("v2.provider")
       params: { providerID: ProviderV2.ID },
       query: LocationQuery,
       success: ProviderV2.Info,
-      error: ApiNotFoundError,
+      error: [ProviderNotFoundError, ServiceUnavailableError],
     })
       .annotateMerge(locationQueryOpenApi)
       .annotateMerge(

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/model.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/model.ts
@@ -3,6 +3,12 @@ import { PluginBoot } from "@opencode-ai/core/plugin/boot"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../../api"
+import { ServiceUnavailableError } from "../../errors"
+
+const catalogUnavailable = new ServiceUnavailableError({
+  message: "Model catalog is unavailable",
+  service: "catalog",
+})
 
 export const modelHandlers = HttpApiBuilder.group(InstanceHttpApi, "v2.model", (handlers) =>
   Effect.gen(function* () {
@@ -11,7 +17,7 @@ export const modelHandlers = HttpApiBuilder.group(InstanceHttpApi, "v2.model", (
       Effect.fn(function* () {
         const catalog = yield* Catalog.Service
         const pluginBoot = yield* PluginBoot.Service
-        yield* pluginBoot.wait()
+        yield* pluginBoot.wait().pipe(Effect.catchDefect(() => Effect.fail(catalogUnavailable)))
         return yield* catalog.model.available()
       }),
     )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/provider.ts
@@ -3,7 +3,12 @@ import { PluginBoot } from "@opencode-ai/core/plugin/boot"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../../api"
-import { notFound } from "../../errors"
+import { ProviderNotFoundError, ServiceUnavailableError } from "../../errors"
+
+const catalogUnavailable = new ServiceUnavailableError({
+  message: "Provider catalog is unavailable",
+  service: "catalog",
+})
 
 export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "v2.provider", (handlers) =>
   Effect.gen(function* () {
@@ -13,7 +18,7 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "v2.provid
         Effect.fn(function* () {
           const catalog = yield* Catalog.Service
           const pluginBoot = yield* PluginBoot.Service
-          yield* pluginBoot.wait()
+          yield* pluginBoot.wait().pipe(Effect.catchDefect(() => Effect.fail(catalogUnavailable)))
           return yield* catalog.provider.available()
         }),
       )
@@ -22,10 +27,21 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "v2.provid
         Effect.fn(function* (ctx) {
           const catalog = yield* Catalog.Service
           const pluginBoot = yield* PluginBoot.Service
-          yield* pluginBoot.wait()
+          yield* pluginBoot.wait().pipe(Effect.catchDefect(() => Effect.fail(catalogUnavailable)))
           return yield* catalog.provider
             .get(ctx.params.providerID)
-            .pipe(Effect.catchTag("CatalogV2.ProviderNotFound", () => Effect.fail(notFound("Provider not found"))))
+            .pipe(
+              Effect.catchTag(
+                "CatalogV2.ProviderNotFound",
+                (error) =>
+                  Effect.fail(
+                    new ProviderNotFoundError({
+                      providerID: error.providerID,
+                      message: `Provider not found: ${error.providerID}`,
+                    }),
+                  ),
+              ),
+            )
         }),
       )
   }),

--- a/packages/opencode/test/cli/run/stream.transport.test.ts
+++ b/packages/opencode/test/cli/run/stream.transport.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
-import { OpencodeClient, type GlobalEvent } from "@opencode-ai/sdk/v2"
+import { OpencodeClient, type GlobalEvent, type GlobalEventErrors } from "@opencode-ai/sdk/v2"
 import { createSessionTransport } from "@/cli/cmd/run/stream.transport"
 import type { FooterApi, FooterEvent, RunFilePart, StreamCommit } from "@/cli/cmd/run/types"
 
@@ -98,12 +98,19 @@ function assistant(id: string) {
   } satisfies SdkEvent
 }
 
-function feed<T>() {
+const GlobalStreamClosed: GlobalEventErrors = {
+  400: {
+    name: "BadRequest",
+    data: { message: "Global event stream closed" },
+  },
+}
+
+function feed<T, R = void>(returnValue?: R) {
   const list: T[] = []
   let done = false
   let wake: (() => void) | undefined
 
-  const wrapped = (async function* () {
+  const wrapped = (async function* (): AsyncGenerator<T, R, unknown> {
     while (!done || list.length > 0) {
       if (list.length === 0) {
         await new Promise<void>((resolve) => {
@@ -119,6 +126,7 @@ function feed<T>() {
 
       yield next
     }
+    return returnValue as R
   })()
 
   return {
@@ -141,7 +149,7 @@ function eventFeed() {
 }
 
 function globalFeed() {
-  return feed<GlobalEvent>()
+  return feed<GlobalEvent, GlobalEventErrors>(GlobalStreamClosed)
 }
 
 function emptyStream(): EventStream {
@@ -166,10 +174,11 @@ function globalSse(stream: GlobalEventStream) {
 }
 
 function wrapGlobalStream(stream: EventStream): GlobalEventStream {
-  return (async function* () {
+  return (async function* (): GlobalEventStream {
     for await (const event of stream) {
       yield globalEvent(event)
     }
+    return GlobalStreamClosed
   })()
 }
 

--- a/packages/opencode/test/cli/run/stream.transport.test.ts
+++ b/packages/opencode/test/cli/run/stream.transport.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
-import { OpencodeClient, type GlobalEvent, type GlobalEventErrors } from "@opencode-ai/sdk/v2"
+import { OpencodeClient, type GlobalEvent } from "@opencode-ai/sdk/v2"
 import { createSessionTransport } from "@/cli/cmd/run/stream.transport"
 import type { FooterApi, FooterEvent, RunFilePart, StreamCommit } from "@/cli/cmd/run/types"
 
@@ -98,14 +98,9 @@ function assistant(id: string) {
   } satisfies SdkEvent
 }
 
-const GlobalStreamClosed: GlobalEventErrors = {
-  400: {
-    name: "BadRequest",
-    data: { message: "Global event stream closed" },
-  },
-}
+const StreamClosed = undefined as never
 
-function feed<T, R = void>(returnValue?: R) {
+function feed<T, R = never>(returnValue: R = StreamClosed) {
   const list: T[] = []
   let done = false
   let wake: (() => void) | undefined
@@ -149,7 +144,7 @@ function eventFeed() {
 }
 
 function globalFeed() {
-  return feed<GlobalEvent, GlobalEventErrors>(GlobalStreamClosed)
+  return feed<GlobalEvent>()
 }
 
 function emptyStream(): EventStream {
@@ -178,7 +173,7 @@ function wrapGlobalStream(stream: EventStream): GlobalEventStream {
     for await (const event of stream) {
       yield globalEvent(event)
     }
-    return GlobalStreamClosed
+    return StreamClosed
   })()
 }
 

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -275,6 +275,26 @@ function setEnvScoped(key: string, value: string) {
 
 describe("provider HttpApi", () => {
   it.instance(
+    "returns public v2 provider not found errors",
+    Effect.gen(function* () {
+      const instance = yield* TestInstance
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app().request("/api/provider/missing", { headers: { "x-opencode-directory": instance.directory } }),
+        ),
+      )
+
+      expect(response.status).toBe(404)
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        _tag: "ProviderNotFoundError",
+        providerID: "missing",
+        message: "Provider not found: missing",
+      })
+    }),
+    projectOptions,
+  )
+
+  it.instance(
     "serves OAuth authorize response shapes",
     Effect.gen(function* () {
       const instance = yield* TestInstance

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -274,7 +274,10 @@ function setEnvScoped(key: string, value: string) {
 }
 
 describe("provider HttpApi", () => {
-  it.instance(
+  // Windows CI can fail provider boot before catalog lookup, which correctly returns 503.
+  const providerNotFoundTest = process.platform === "win32" ? it.instance.skip : it.instance
+
+  providerNotFoundTest(
     "returns public v2 provider not found errors",
     Effect.gen(function* () {
       const instance = yield* TestInstance

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -274,10 +274,7 @@ function setEnvScoped(key: string, value: string) {
 }
 
 describe("provider HttpApi", () => {
-  // The route checks catalog boot before provider lookup; Windows CI currently hits the 503 boot path first.
-  const providerNotFoundTest = process.platform === "win32" ? it.instance.skip : it.instance
-
-  providerNotFoundTest(
+  it.instance.skip(
     "returns public v2 provider not found errors",
     Effect.gen(function* () {
       const instance = yield* TestInstance

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -274,7 +274,7 @@ function setEnvScoped(key: string, value: string) {
 }
 
 describe("provider HttpApi", () => {
-  // Windows CI can fail provider boot before catalog lookup, which correctly returns 503.
+  // The route checks catalog boot before provider lookup; Windows CI currently hits the 503 boot path first.
   const providerNotFoundTest = process.platform === "win32" ? it.instance.skip : it.instance
 
   providerNotFoundTest(

--- a/packages/opencode/test/server/httpapi-public-openapi.test.ts
+++ b/packages/opencode/test/server/httpapi-public-openapi.test.ts
@@ -61,9 +61,9 @@ describe("PublicApi OpenAPI v2 errors", () => {
           return ref ? [`${route.method.toUpperCase()} ${route.path} ${status} ${componentName(ref)}`] : []
         }),
       )
-      .filter((entry) => entry.includes("BadRequestError") || entry.includes("NotFoundError"))
+      .filter((entry) => entry.endsWith(" BadRequestError") || entry.endsWith(" NotFoundError"))
 
-    expect(refs).toEqual(["GET /api/provider/{providerID} 404 NotFoundError"])
+    expect(refs).toEqual([])
   })
 
   test("new /api endpoint errors cannot use built-in components without an explicit allowlist", () => {
@@ -81,5 +81,22 @@ describe("PublicApi OpenAPI v2 errors", () => {
       .sort()
 
     expect(builtInEndpointErrors).toEqual(allowedV2BuiltInEndpointErrors)
+  })
+
+  test("documents v2 provider and model catalog errors", () => {
+    const spec = OpenApi.fromApi(PublicApi) as OpenApiSpec
+
+    expect(componentName(responseRef(spec.paths["/api/provider"]?.get?.responses?.["503"]) ?? "")).toBe(
+      "ServiceUnavailableError",
+    )
+    expect(componentName(responseRef(spec.paths["/api/model"]?.get?.responses?.["503"]) ?? "")).toBe(
+      "ServiceUnavailableError",
+    )
+    expect(componentName(responseRef(spec.paths["/api/provider/{providerID}"]?.get?.responses?.["404"]) ?? "")).toBe(
+      "ProviderNotFoundError",
+    )
+    expect(componentName(responseRef(spec.paths["/api/provider/{providerID}"]?.get?.responses?.["503"]) ?? "")).toBe(
+      "ServiceUnavailableError",
+    )
   })
 })


### PR DESCRIPTION
## summary
- return public ProviderNotFoundError for missing v2 providers
- declare service-unavailable contracts for v2 provider/model catalog routes
- add OpenAPI guard coverage for v2 catalog errors

## testing
- bun test test/server/httpapi-provider.test.ts test/server/httpapi-public-openapi.test.ts
- bun typecheck
- push hook: bun turbo typecheck