### PR TITLE
fix(sdk): unbreak typecheck on dev after v2 error widening

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
@@ -108,7 +108,7 @@ export async function warpWorkspaceSession(input: {
     })
     .catch(() => undefined)
   if (!result?.data) {
-    if (result?.error?.name === "VcsApplyError") {
+    if (result?.error && "name" in result.error && result.error.name === "VcsApplyError") {
       await DialogAlert.show(
         input.dialog,
         "Unable to Warp Session",

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -40,6 +40,24 @@ await createClient({
   ],
 })
 
+// Patch a @hey-api/openapi-ts codegen bug: SseFn incorrectly passes the
+// endpoint's TError into the second generic of ServerSentEventsResult, which
+// is the AsyncGenerator's TReturn slot. Iterator return values have nothing
+// to do with HTTP errors, and any consumer that calls `.return()` or returns
+// from a mock generator gets type-checked against the wrong shape. Drop the
+// arg so TReturn defaults to void.
+const sseTypesPath = "./src/v2/gen/client/types.gen.ts"
+const sseTypesFile = Bun.file(sseTypesPath)
+const sseTypesSource = await sseTypesFile.text()
+const sseTypesPatched = sseTypesSource.replace(
+  "=> Promise<ServerSentEventsResult<TData, TError>>",
+  "=> Promise<ServerSentEventsResult<TData>>",
+)
+if (sseTypesPatched === sseTypesSource) {
+  throw new Error(`SseFn patch did not apply; @hey-api/openapi-ts output may have changed (${sseTypesPath})`)
+}
+await Bun.write(sseTypesPath, sseTypesPatched)
+
 await $`bun prettier --write src/gen`
 await $`bun prettier --write src/v2`
 await $`rm -rf dist`

--- a/packages/sdk/js/src/v2/gen/client/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/client/types.gen.ts
@@ -144,7 +144,7 @@ type SseFn = <
   TResponseStyle extends ResponseStyle = "fields",
 >(
   options: Omit<RequestOptions<TData, TResponseStyle, ThrowOnError>, "method">,
-) => Promise<ServerSentEventsResult<TData, TError>>
+) => Promise<ServerSentEventsResult<TData>>
 
 type RequestFn = <
   TData = unknown,


### PR DESCRIPTION
## Summary

`dev` has been red since commit `0e118d1961` (`chore: generate` following #28495). Two distinct issues:

### 1. `@hey-api/openapi-ts` `SseFn` miswiring (latent for ~9 months)

In every generated client bundle, the SDK declares:

```ts
type SseFn = <TData, TError, ...>(options) => Promise<ServerSentEventsResult<TData, TError>>
//                                                                                  ^^^^^^
```

But `ServerSentEventsResult<TData, TReturn = void, TNext = unknown>` — that second slot is the underlying `AsyncGenerator`'s **return value type**, not an error channel. HTTP errors are thrown from the initial promise or surfaced via `onSseError`; an async generator's `.return()` value has nothing to do with them.

Confirming this is the SDK's own bug, not intentional:

- The SSE implementation itself declares `ServerSentEventsResult<TData>` (no `TError`) — see [`client-core/bundle/serverSentEvents.ts:80-92`](https://github.com/hey-api/openapi-ts/blob/main/packages/openapi-ts/src/plugins/%40hey-api/client-core/bundle/serverSentEvents.ts).
- The inner generator is `async function*` with no explicit return → real `TReturn` is `void`.
- Same bug in all six generated clients (fetch / axios / ky / next / ofetch / angular). Introduced by `d43ef3f3b` ("feat(client): add support for server-sent events", Aug 2025).

While the v2 `GlobalEventErrors` union was effectively empty/unknown this was harmless. PR #28495 widened error responses to concrete types, and now every `.return(undefined)` call and every mock async generator violates the iterator's `TReturn` contract:

```
src/cli/cmd/run/stream.transport.ts(421,43): TS2345: Argument of type 'undefined' is not assignable to parameter of type 'GlobalEventErrors | PromiseLike<GlobalEventErrors>'.
src/cli/cmd/run/stream.transport.ts(426,37): TS2345: ...
test/cli/run/stream.transport.test.ts(169,3): TS2322: Type 'AsyncGenerator<GlobalEvent, void>' is not assignable to type 'AsyncGenerator<GlobalEvent, GlobalEventErrors>'.
test/cli/run/stream.transport.test.ts(1095,9): TS2322: ...
test/cli/run/stream.transport.test.ts(1196,9): TS2322: ...
```

**Fix:** drop `TError` from the `ServerSentEventsResult<>` generics in our generated `packages/sdk/js/src/v2/gen/client/types.gen.ts` so `TReturn` defaults to `void`. Because `@hey-api/openapi-ts` runs with `clean: true` and would overwrite that file on every regen, add a post-gen patch step to `packages/sdk/js/script/build.ts` that reapplies the fix automatically (and throws if the upstream output shape ever changes, so we'll notice). The phantom `TError` parameter on `SseFn` is preserved to keep call-site type-argument arity intact.

I'll open an upstream PR to `hey-api/openapi-ts` separately so we can drop this workaround when it ships.

### 2. `workspace.warp` 400 union widened to include `InvalidRequestError`

Real consumer bug, separate from #1. `ExperimentalWorkspaceWarpErrors` is now `WorkspaceWarpError | VcsApplyError | InvalidRequestError`. The first two discriminate via `name`, but `InvalidRequestError` uses `_tag` (mixed conventions in the SDK). The dialog narrowed via `result.error.name === "VcsApplyError"` and now hits:

```
src/cli/cmd/tui/component/dialog-workspace-create.tsx(111,24): TS2339: Property 'name' does not exist on type 'InvalidRequestError | VcsApplyError | WorkspaceWarpError'.
```

**Fix:** narrow with `"name" in result.error && result.error.name === "VcsApplyError"` before reading. Behavior unchanged — `InvalidRequestError` continues to fall through to the toast path, same as any other non-`VcsApplyError`.

## Test plan

- [x] `bun run typecheck` (full monorepo) — green
- [x] `bun run build` in `packages/sdk/js` after reverting the patched line to the buggy upstream form — confirms post-gen patch reapplies after a real `createClient` wipe + regen
- [x] `bun run test test/cli/run/stream.transport.test.ts` — 21/21 pass
