### PR TITLE
feat(tui): focus first file in file tree

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
@@ -127,7 +127,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     const next =
       lastHighlighted !== undefined && fileRows().some((row) => row.id === lastHighlighted)
         ? lastHighlighted
-        : fileRows()[0]?.id
+        : fileRows().find((row) => row.fileIndex !== undefined)?.id
     setHighlightedFileNode(next)
   }
 


### PR DESCRIPTION
## Summary
- Focus the first patch-backed file row when switching focus into the diff viewer file tree without an existing selection.
- Preserve the previous behavior of restoring an existing or last highlighted row when it is still visible.

## Verification
- `bun test test/cli/tui/diff-viewer-file-tree-utils.test.ts test/cli/tui/diff-viewer-file-tree.test.tsx` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- Pre-push `bun turbo typecheck`