### PR TITLE
fix(filesystem): resolve symlink/junction targets to directory type in readDirectoryEntries

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -71,10 +71,24 @@ export namespace FSUtil {
         return yield* Effect.tryPromise({
           try: async () => {
             const entries = await NFS.readdir(dirPath, { withFileTypes: true })
-            return entries.map(
-              (e): DirEntry => ({
-                name: e.name,
-                type: e.isDirectory() ? "directory" : e.isSymbolicLink() ? "symlink" : e.isFile() ? "file" : "other",
+            return await Promise.all(
+              entries.map(async (e): Promise<DirEntry> => {
+                let type: DirEntry["type"]
+                if (e.isDirectory()) {
+                  type = "directory"
+                } else if (e.isSymbolicLink()) {
+                  try {
+                    const target = await NFS.stat(join(dirPath, e.name))
+                    type = target.isDirectory() ? "directory" : "symlink"
+                  } catch {
+                    type = "symlink"
+                  }
+                } else if (e.isFile()) {
+                  type = "file"
+                } else {
+                  type = "other"
+                }
+                return { name: e.name, type }
               }),
             )
           },


### PR DESCRIPTION
### Issue for this PR

Closes #28526

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Symlinked directories (Linux `ln -s`) and Windows junction points (e.g., OneDrive Desktop) are invisible in the directory picker, @file picker, and file listing because `readDirectoryEntries` classifies them as `"symlink"` and downstream filters skip non-directory types.

This fixes the root cause in `packages/core/src/filesystem.ts:readDirectoryEntries`: when `isSymbolicLink()` is true, stat() the target and return `"directory"` if the target is a directory. This fixes ALL consumers at once — no downstream filter changes needed.

Also resolves long-standing open issues:
- #10365 — Linux symlink directories in project picker (auto-closed, never fixed)
- #16342 — Windows symlinks not recognized in @file

### How did you verify your code works?

`bun test test/file/` — 87 pass, 1 skip, 0 fail. No regressions.

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
