### PR TITLE
feat(provider): discriminate provider behaviour by npm where unique

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -6,6 +6,7 @@ import { generateObject, streamObject, type ModelMessage } from "ai"
 import { Truncate } from "@/tool/truncate"
 import { Auth } from "../auth"
 import { ProviderTransform } from "@/provider/transform"
+import { NPM } from "@/provider/npm"
 
 import PROMPT_GENERATE from "./generate.txt"
 import PROMPT_COMPACTION from "./prompt/compaction.txt"
@@ -399,7 +400,7 @@ export const layer = Layer.effect(
 
         // TODO: clean this up so provider specific logic doesnt bleed over
         const authInfo = yield* auth.get(model.providerID).pipe(Effect.orDie)
-        const isOpenaiOauth = model.providerID === "openai" && authInfo?.type === "oauth"
+        const isOpenaiOauth = resolved.api.npm === NPM.OPENAI && authInfo?.type === "oauth"
 
         const params = {
           experimental_telemetry: {

--- a/packages/opencode/src/provider/npm.ts
+++ b/packages/opencode/src/provider/npm.ts
@@ -1,0 +1,32 @@
+// Centralised npm package identifiers for the AI SDK providers we discriminate
+// behaviour on. Use these constants in `model.api.npm === NPM.X` checks and as
+// keys in `BUNDLED_PROVIDERS` so the canonical strings live in one place.
+//
+// A given npm value may map to more than one canonical loader ID (the
+// `@ai-sdk/openai-compatible` family and the azure pair). Behaviour that
+// genuinely needs to discriminate within those groups must key off the
+// provider ID, not the npm value.
+
+export const NPM = {
+  GOOGLE_VERTEX: "@ai-sdk/google-vertex",
+  GOOGLE_VERTEX_ANTHROPIC: "@ai-sdk/google-vertex/anthropic",
+  AMAZON_BEDROCK: "@ai-sdk/amazon-bedrock",
+  ANTHROPIC: "@ai-sdk/anthropic",
+  OPENAI: "@ai-sdk/openai",
+  OPENAI_COMPATIBLE: "@ai-sdk/openai-compatible",
+  XAI: "@ai-sdk/xai",
+  CEREBRAS: "@ai-sdk/cerebras",
+  VERCEL_GATEWAY: "@ai-sdk/gateway",
+  GOOGLE: "@ai-sdk/google",
+  AZURE: "@ai-sdk/azure",
+  MISTRAL: "@ai-sdk/mistral",
+  ALIBABA: "@ai-sdk/alibaba",
+  GITHUB_COPILOT_SHIM: "@ai-sdk/github-copilot",
+  OPENROUTER: "@openrouter/ai-sdk-provider",
+  SAP_AI: "@jerome-benoit/sap-ai-provider-v2",
+  GITLAB: "gitlab-ai-provider",
+  CLOUDFLARE_AI_GATEWAY: "ai-gateway-provider",
+  VENICE: "venice-ai-sdk-provider",
+} as const
+
+export type NpmValue = (typeof NPM)[keyof typeof NPM]

--- a/packages/opencode/src/provider/npm.ts
+++ b/packages/opencode/src/provider/npm.ts
@@ -1,12 +1,3 @@
-// Centralised npm package identifiers for the AI SDK providers we discriminate
-// behaviour on. Use these constants in `model.api.npm === NPM.X` checks and as
-// keys in `BUNDLED_PROVIDERS` so the canonical strings live in one place.
-//
-// A given npm value may map to more than one canonical loader ID (the
-// `@ai-sdk/openai-compatible` family and the azure pair). Behaviour that
-// genuinely needs to discriminate within those groups must key off the
-// provider ID, not the npm value.
-
 export const NPM = {
   GOOGLE_VERTEX: "@ai-sdk/google-vertex",
   GOOGLE_VERTEX_ANTHROPIC: "@ai-sdk/google-vertex/anthropic",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1405,7 +1405,7 @@ export const layer = Layer.effect(
 
         const loaders = custom(dep)
         const resolveLoader = (entryID: string, data: Info): CustomLoader | undefined => {
-          // Canonical loaders match by exact ID. Same path as before.
+          // Canonical loaders match by exact ID.
           if (loaders[entryID]) return loaders[entryID]
           // Otherwise read the entry's npm from its first model and accept a
           // canonical loader whose models.dev npm uniquely matches. Where the

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -27,6 +27,7 @@ import { optionalOmitUndefined } from "@opencode-ai/core/schema"
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
 import { ModelStatus } from "./model-status"
+import { NPM } from "./npm"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 
 const log = Log.create({ service: "provider" })
@@ -501,10 +502,13 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         },
       }
     }),
-    "google-vertex-anthropic": Effect.fnUntraced(function* () {
+    "google-vertex-anthropic": Effect.fnUntraced(function* (provider: Info) {
       const env = yield* dep.env()
-      const project = env["GOOGLE_CLOUD_PROJECT"] ?? env["GCP_PROJECT"] ?? env["GCLOUD_PROJECT"]
-      const location = env["GOOGLE_CLOUD_LOCATION"] ?? env["VERTEX_LOCATION"] ?? "global"
+      const project =
+        provider.options?.project ?? env["GOOGLE_CLOUD_PROJECT"] ?? env["GCP_PROJECT"] ?? env["GCLOUD_PROJECT"]
+      const location = String(
+        provider.options?.location ?? env["GOOGLE_CLOUD_LOCATION"] ?? env["VERTEX_LOCATION"] ?? "global",
+      )
       const autoload = Boolean(project)
       if (!autoload) return { autoload: false }
       return {
@@ -1399,15 +1403,26 @@ export const layer = Layer.effect(
           mergeProvider(providerID, patch)
         }
 
-        for (const [id, fn] of Object.entries(custom(dep))) {
+        const loaders = custom(dep)
+        const resolveLoader = (entryID: string, data: Info): CustomLoader | undefined => {
+          // Exact match: canonical loader entry. Preserves prior behaviour.
+          if (loaders[entryID]) return loaders[entryID]
+          // Alias: look at the entry's npm (from any model) and accept a unique
+          // canonical loader whose models.dev npm matches. Ambiguous npm values
+          // (e.g. shared by the @ai-sdk/openai-compatible family) fall through
+          // and the entry is handled by the generic SDK resolver.
+          const firstModel = Object.values(data.models)[0]
+          const entryNpm = firstModel?.api?.npm
+          if (!entryNpm) return undefined
+          const candidates = Object.keys(loaders).filter((id) => modelsDev[id]?.npm === entryNpm)
+          return candidates.length === 1 ? loaders[candidates[0]] : undefined
+        }
+        for (const [id, data] of Object.entries(database)) {
           const providerID = ProviderID.make(id)
           if (disabled.has(providerID)) continue
-          const data = database[providerID]
-          if (!data) {
-            log.error("Provider does not exist in model list " + providerID)
-            continue
-          }
-          const result = yield* fn(data)
+          const loader = resolveLoader(id, data)
+          if (!loader) continue
+          const result = yield* loader(data)
           if (result && (result.autoload || providers[providerID])) {
             if (result.getModel) modelLoaders[providerID] = result.getModel
             if (result.vars) varsLoaders[providerID] = result.vars
@@ -1516,7 +1531,7 @@ export const layer = Layer.effect(
         const provider = s.providers[model.providerID]
         const options = { ...provider.options }
 
-        if (model.providerID === "google-vertex" && !model.api.npm.includes("@ai-sdk/openai-compatible")) {
+        if (model.api.npm === NPM.GOOGLE_VERTEX) {
           delete options.fetch
         }
 
@@ -1746,8 +1761,9 @@ export const layer = Layer.effect(
       if (providerID.startsWith("github-copilot")) {
         priority = ["gpt-5-mini", "claude-haiku-4.5", ...priority]
       }
+      const firstModelNpm = Object.values(provider.models)[0]?.api?.npm
       for (const item of priority) {
-        if (providerID === ProviderID.amazonBedrock) {
+        if (firstModelNpm === NPM.AMAZON_BEDROCK) {
           const crossRegionPrefixes = ["global.", "us.", "eu."]
           const candidates = Object.keys(provider.models).filter((m) => m.includes(item))
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1405,12 +1405,12 @@ export const layer = Layer.effect(
 
         const loaders = custom(dep)
         const resolveLoader = (entryID: string, data: Info): CustomLoader | undefined => {
-          // Exact match: canonical loader entry. Preserves prior behaviour.
+          // Canonical loaders match by exact ID. Same path as before.
           if (loaders[entryID]) return loaders[entryID]
-          // Alias: look at the entry's npm (from any model) and accept a unique
-          // canonical loader whose models.dev npm matches. Ambiguous npm values
-          // (e.g. shared by the @ai-sdk/openai-compatible family) fall through
-          // and the entry is handled by the generic SDK resolver.
+          // Otherwise read the entry's npm from its first model and accept a
+          // canonical loader whose models.dev npm uniquely matches. Where the
+          // npm is shared (the @ai-sdk/openai-compatible family, plus the
+          // @ai-sdk/azure pair), the entry falls through to the generic loader.
           const firstModel = Object.values(data.models)[0]
           const entryNpm = firstModel?.api?.npm
           if (!entryNpm) return undefined

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -208,7 +208,7 @@ function normalizeMessages(
       return msg
     })
   }
-  if (model.api.npm === NPM.ANTHROPIC || model.api.npm === NPM.GOOGLE_VERTEX_ANTHROPIC) {
+  if (([NPM.ANTHROPIC, NPM.GOOGLE_VERTEX_ANTHROPIC] as string[]).includes(model.api.npm)) {
     // Anthropic rejects assistant turns where tool_use blocks are followed by non-tool
     // content, e.g. [tool_use, tool_use, text], with:
     // `tool_use` ids were found without `tool_result` blocks immediately after...
@@ -1229,9 +1229,7 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   // Other SDKs (xai, mistral, groq, cohere, etc.) use hardcoded keys
   // like "xai" or "cohere" - applying .split(".")[0] would break those.
   const usesDotSplitOptions =
-    model.api.npm === NPM.OPENAI_COMPATIBLE ||
-    model.api.npm === NPM.OPENAI ||
-    model.api.npm === NPM.ANTHROPIC
+    model.api.npm === NPM.OPENAI_COMPATIBLE || model.api.npm === NPM.OPENAI || model.api.npm === NPM.ANTHROPIC
   const key = sdkKey(model.api.npm) ?? (usesDotSplitOptions ? model.providerID.split(".")[0] : model.providerID)
   // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
   // providerOptions["openai"], but OpenAIResponsesLanguageModel checks

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -4,6 +4,7 @@ import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@opencode-ai/core/models-dev"
 import { iife } from "@/util/iife"
+import { NPM } from "./npm"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
@@ -24,24 +25,24 @@ export function sanitizeSurrogates(content: string) {
 // Maps npm package to the key the AI SDK expects for providerOptions
 function sdkKey(npm: string): string | undefined {
   switch (npm) {
-    case "@ai-sdk/github-copilot":
+    case NPM.GITHUB_COPILOT_SHIM:
       return "copilot"
-    case "@ai-sdk/azure":
+    case NPM.AZURE:
       return "azure"
-    case "@ai-sdk/openai":
+    case NPM.OPENAI:
       return "openai"
-    case "@ai-sdk/amazon-bedrock":
+    case NPM.AMAZON_BEDROCK:
       return "bedrock"
-    case "@ai-sdk/anthropic":
-    case "@ai-sdk/google-vertex/anthropic":
+    case NPM.ANTHROPIC:
+    case NPM.GOOGLE_VERTEX_ANTHROPIC:
       return "anthropic"
-    case "@ai-sdk/google-vertex":
+    case NPM.GOOGLE_VERTEX:
       return "vertex"
-    case "@ai-sdk/google":
+    case NPM.GOOGLE:
       return "google"
-    case "@ai-sdk/gateway":
+    case NPM.VERCEL_GATEWAY:
       return "gateway"
-    case "@openrouter/ai-sdk-provider":
+    case NPM.OPENROUTER:
       return "openrouter"
     case "ai-gateway-provider":
       // ai-gateway-provider/unified wraps createOpenAICompatible({ name: "Unified" }),
@@ -124,7 +125,7 @@ function normalizeMessages(
 
   // Anthropic rejects messages with empty content - filter out empty string messages
   // and remove empty text/reasoning parts from array content
-  if (model.api.npm === "@ai-sdk/anthropic") {
+  if (model.api.npm === NPM.ANTHROPIC) {
     msgs = msgs
       .map((msg) => {
         if (typeof msg.content === "string") {
@@ -152,7 +153,7 @@ function normalizeMessages(
   }
 
   // Bedrock specific transforms
-  if (model.api.npm === "@ai-sdk/amazon-bedrock") {
+  if (model.api.npm === NPM.AMAZON_BEDROCK) {
     msgs = msgs
       .map((msg) => {
         if (typeof msg.content === "string") {
@@ -207,7 +208,7 @@ function normalizeMessages(
       return msg
     })
   }
-  if (["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
+  if (model.api.npm === NPM.ANTHROPIC || model.api.npm === NPM.GOOGLE_VERTEX_ANTHROPIC) {
     // Anthropic rejects assistant turns where tool_use blocks are followed by non-tool
     // content, e.g. [tool_use, tool_use, text], with:
     // `tool_use` ids were found without `tool_result` blocks immediately after...
@@ -233,7 +234,7 @@ function normalizeMessages(
     })
   }
   if (
-    model.providerID === "mistral" ||
+    model.api.npm === NPM.MISTRAL ||
     model.api.id.toLowerCase().includes("mistral") ||
     model.api.id.toLocaleLowerCase().includes("devstral")
   ) {
@@ -303,7 +304,7 @@ function normalizeMessages(
   if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
-    model.api.npm !== "@openrouter/ai-sdk-provider"
+    model.api.npm !== NPM.OPENROUTER
   ) {
     const field = model.capabilities.interleaved.field
     return msgs.map((msg) => {
@@ -364,9 +365,9 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
 
   for (const msg of unique([...system, ...final])) {
     const useMessageLevelOptions =
-      model.providerID === "anthropic" ||
-      model.providerID.includes("bedrock") ||
-      model.api.npm === "@ai-sdk/amazon-bedrock"
+      model.api.npm === NPM.ANTHROPIC ||
+      model.api.npm === NPM.GOOGLE_VERTEX_ANTHROPIC ||
+      model.api.npm === NPM.AMAZON_BEDROCK
     const shouldUseContentOptions = !useMessageLevelOptions && Array.isArray(msg.content) && msg.content.length > 0
 
     if (shouldUseContentOptions) {
@@ -430,15 +431,14 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
   if (
-    (model.providerID === "anthropic" ||
-      model.providerID === "google-vertex-anthropic" ||
+    (model.api.npm === NPM.ANTHROPIC ||
+      model.api.npm === NPM.GOOGLE_VERTEX_ANTHROPIC ||
       model.api.id.includes("anthropic") ||
       model.api.id.includes("claude") ||
       model.id.includes("anthropic") ||
       model.id.includes("claude") ||
-      model.api.npm === "@ai-sdk/anthropic" ||
-      model.api.npm === "@ai-sdk/alibaba") &&
-    model.api.npm !== "@ai-sdk/gateway"
+      model.api.npm === NPM.ALIBABA) &&
+    model.api.npm !== NPM.VERCEL_GATEWAY
   ) {
     msgs = applyCaching(msgs, model)
   }
@@ -637,7 +637,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
   // see: https://docs.x.ai/docs/guides/reasoning#control-how-hard-the-model-thinks
   if (id.includes("grok") && id.includes("grok-3-mini")) {
-    if (model.api.npm === "@openrouter/ai-sdk-provider") {
+    if (model.api.npm === NPM.OPENROUTER) {
       return {
         low: { reasoning: { effort: "low" } },
         high: { reasoning: { effort: "high" } },
@@ -651,7 +651,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (id.includes("grok")) return {}
 
   switch (model.api.npm) {
-    case "@openrouter/ai-sdk-provider":
+    case NPM.OPENROUTER:
       if (!id.includes("gpt") && !id.includes("gemini-3") && !id.includes("claude")) return {}
       return Object.fromEntries(
         (id.includes("gpt") ? openaiCompatibleReasoningEfforts(id) : OPENAI_EFFORTS).map((effort) => [
@@ -674,7 +674,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
     }
 
-    case "@ai-sdk/gateway":
+    case NPM.VERCEL_GATEWAY:
       if (model.id.includes("anthropic")) {
         if (adaptiveEfforts) {
           return Object.fromEntries(
@@ -735,7 +735,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         openaiCompatibleReasoningEfforts(model.api.id).map((effort) => [effort, { reasoningEffort: effort }]),
       )
 
-    case "@ai-sdk/github-copilot":
+    case NPM.GITHUB_COPILOT_SHIM:
       if (model.id.includes("gemini")) {
         // currently github copilot only returns thinking
         return {}
@@ -769,16 +769,16 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     // https://v5.ai-sdk.dev/providers/ai-sdk-providers/xai
     case "@ai-sdk/deepinfra":
     // https://v5.ai-sdk.dev/providers/ai-sdk-providers/deepinfra
-    case "venice-ai-sdk-provider":
+    case NPM.VENICE:
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
-    case "@ai-sdk/openai-compatible":
+    case NPM.OPENAI_COMPATIBLE:
       const efforts = [...WIDELY_SUPPORTED_EFFORTS]
       if (model.api.id.toLowerCase().includes("deepseek-v4")) {
         efforts.push("max")
       }
       return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
 
-    case "@ai-sdk/azure":
+    case NPM.AZURE:
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
       return Object.fromEntries(
@@ -794,7 +794,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           },
         ]),
       )
-    case "@ai-sdk/openai": {
+    case NPM.OPENAI: {
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
       const efforts = openaiReasoningEfforts(model.api.id, model.release_date)
       return Object.fromEntries(
@@ -809,9 +809,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       )
     }
 
-    case "@ai-sdk/anthropic":
+    case NPM.ANTHROPIC:
     // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
-    case "@ai-sdk/google-vertex/anthropic":
+    case NPM.GOOGLE_VERTEX_ANTHROPIC:
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
       if (adaptiveEfforts) {
         let efforts = [...adaptiveEfforts]
@@ -857,7 +857,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         },
       }
 
-    case "@ai-sdk/amazon-bedrock":
+    case NPM.AMAZON_BEDROCK:
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
       if (adaptiveEfforts) {
         return Object.fromEntries(
@@ -906,9 +906,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         ]),
       )
 
-    case "@ai-sdk/google-vertex":
+    case NPM.GOOGLE_VERTEX:
     // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex
-    case "@ai-sdk/google":
+    case NPM.GOOGLE:
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
       if (id.includes("2.5")) {
         return {
@@ -939,7 +939,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         ]),
       )
 
-    case "@ai-sdk/mistral":
+    case NPM.MISTRAL:
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
       // https://docs.mistral.ai/capabilities/reasoning/adjustable
       if (!model.capabilities.reasoning) return {}
@@ -1038,27 +1038,23 @@ export function options(input: {
   const result: Record<string, any> = {}
 
   if (
-    input.model.api.npm === "@ai-sdk/google-vertex/anthropic" ||
-    (!input.model.api.id.includes("claude") && input.model.api.npm === "@ai-sdk/anthropic")
+    input.model.api.npm === NPM.GOOGLE_VERTEX_ANTHROPIC ||
+    (!input.model.api.id.includes("claude") && input.model.api.npm === NPM.ANTHROPIC)
   ) {
     result["toolStreaming"] = false
   }
 
   // openai and providers using openai package should set store to false by default.
-  if (
-    input.model.providerID === "openai" ||
-    input.model.api.npm === "@ai-sdk/openai" ||
-    input.model.api.npm === "@ai-sdk/github-copilot"
-  ) {
+  if (input.model.api.npm === NPM.OPENAI || input.model.api.npm === NPM.GITHUB_COPILOT_SHIM) {
     result["store"] = false
   }
 
-  if (input.model.api.npm === "@ai-sdk/azure") {
+  if (input.model.api.npm === NPM.AZURE) {
     result["store"] = false
     result["promptCacheKey"] = input.sessionID
   }
 
-  if (input.model.api.npm === "@openrouter/ai-sdk-provider" || input.model.api.npm === "@llmgateway/ai-sdk-provider") {
+  if (input.model.api.npm === NPM.OPENROUTER || input.model.api.npm === "@llmgateway/ai-sdk-provider") {
     result["usage"] = {
       include: true,
     }
@@ -1076,7 +1072,7 @@ export function options(input: {
 
   if (
     ["zai", "zhipuai"].some((id) => input.model.providerID.includes(id)) &&
-    input.model.api.npm === "@ai-sdk/openai-compatible"
+    input.model.api.npm === NPM.OPENAI_COMPATIBLE
   ) {
     result["thinking"] = {
       type: "enabled",
@@ -1084,11 +1080,11 @@ export function options(input: {
     }
   }
 
-  if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {
+  if (input.model.api.npm === NPM.OPENAI || input.providerOptions?.setCacheKey) {
     result["promptCacheKey"] = input.sessionID
   }
 
-  if (input.model.api.npm === "@ai-sdk/google" || input.model.api.npm === "@ai-sdk/google-vertex") {
+  if (input.model.api.npm === NPM.GOOGLE || input.model.api.npm === NPM.GOOGLE_VERTEX) {
     if (input.model.capabilities.reasoning) {
       result["thinkingConfig"] = {
         includeThoughts: true,
@@ -1102,7 +1098,7 @@ export function options(input: {
   // Enable thinking by default for kimi models using anthropic SDK
   const modelId = input.model.api.id.toLowerCase()
   if (
-    (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
+    (input.model.api.npm === NPM.ANTHROPIC || input.model.api.npm === NPM.GOOGLE_VERTEX_ANTHROPIC) &&
     (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))
   ) {
     result["thinking"] = {
@@ -1119,13 +1115,13 @@ export function options(input: {
   if (
     input.model.providerID === "alibaba-cn" &&
     input.model.capabilities.reasoning &&
-    input.model.api.npm === "@ai-sdk/openai-compatible" &&
+    input.model.api.npm === NPM.OPENAI_COMPATIBLE &&
     !modelId.includes("kimi-k2-thinking")
   ) {
     result["enable_thinking"] = true
   }
 
-  if (input.model.api.npm === "@ai-sdk/azure" && input.model.api.id.includes("gpt-5.5")) {
+  if (input.model.api.npm === NPM.AZURE && input.model.api.id.includes("gpt-5.5")) {
     result["reasoningSummary"] = "auto"
     return result
   }
@@ -1142,7 +1138,7 @@ export function options(input: {
       input.model.api.id.includes("gpt-5.") &&
       !input.model.api.id.includes("codex") &&
       !input.model.api.id.includes("-chat") &&
-      input.model.providerID !== "azure"
+      input.model.api.npm !== NPM.AZURE
     ) {
       result["textVerbosity"] = "low"
     }
@@ -1154,14 +1150,14 @@ export function options(input: {
     }
   }
 
-  if (input.model.providerID === "venice") {
+  if (input.model.api.npm === NPM.VENICE) {
     result["promptCacheKey"] = input.sessionID
   }
 
-  if (input.model.providerID === "openrouter") {
+  if (input.model.api.npm === NPM.OPENROUTER) {
     result["prompt_cache_key"] = input.sessionID
   }
-  if (input.model.api.npm === "@ai-sdk/gateway") {
+  if (input.model.api.npm === NPM.VERCEL_GATEWAY) {
     result["gateway"] = {
       caching: "auto",
     }
@@ -1172,21 +1168,17 @@ export function options(input: {
 
 export function smallOptions(model: Provider.Model) {
   const small = Object.values(model.variants ?? {})[0] ?? {}
-  if (
-    model.providerID === "openai" ||
-    model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/github-copilot"
-  ) {
+  if (model.api.npm === NPM.OPENAI || model.api.npm === NPM.GITHUB_COPILOT_SHIM) {
     const base = { store: false }
     return mergeDeep(base, small)
   }
-  if (model.providerID === "openrouter" || model.providerID === "llmgateway") {
+  if (model.api.npm === NPM.OPENROUTER || model.providerID === "llmgateway") {
     if (Object.keys(small).length === 0 && model.api.id.includes("google")) {
       return { reasoning: { enabled: false } }
     }
   }
 
-  if (model.providerID === "venice") {
+  if (model.api.npm === NPM.VENICE) {
     if (Object.keys(small).length > 0) return small
     return { veniceParameters: { disableThinking: true } }
   }
@@ -1201,7 +1193,7 @@ const SLUG_OVERRIDES: Record<string, string> = {
 }
 
 export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
-  if (model.api.npm === "@ai-sdk/gateway") {
+  if (model.api.npm === NPM.VERCEL_GATEWAY) {
     // Gateway providerOptions are split across two namespaces:
     // - `gateway`: gateway-native routing/caching controls (order, only, byok, etc.)
     // - `<upstream slug>`: provider-specific model options (anthropic/openai/...)
@@ -1237,14 +1229,14 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   // Other SDKs (xai, mistral, groq, cohere, etc.) use hardcoded keys
   // like "xai" or "cohere" - applying .split(".")[0] would break those.
   const usesDotSplitOptions =
-    model.api.npm === "@ai-sdk/openai-compatible" ||
-    model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/anthropic"
+    model.api.npm === NPM.OPENAI_COMPATIBLE ||
+    model.api.npm === NPM.OPENAI ||
+    model.api.npm === NPM.ANTHROPIC
   const key = sdkKey(model.api.npm) ?? (usesDotSplitOptions ? model.providerID.split(".")[0] : model.providerID)
   // @ai-sdk/azure delegates to OpenAIChatLanguageModel which reads from
   // providerOptions["openai"], but OpenAIResponsesLanguageModel checks
   // "azure" first. Pass both so model options work on either code path.
-  if (model.api.npm === "@ai-sdk/azure") {
+  if (model.api.npm === NPM.AZURE) {
     return { openai: options, azure: options }
   }
   return { [key]: options }
@@ -1292,7 +1284,7 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
   }
 
   // Convert integer enums to string enums for Google/Gemini
-  if (model.providerID === "google" || model.api.id.includes("gemini")) {
+  if (model.api.npm === NPM.GOOGLE || model.api.id.includes("gemini")) {
     const isPlainObject = (node: unknown): node is Record<string, any> =>
       typeof node === "object" && node !== null && !Array.isArray(node)
     const hasCombiner = (node: unknown) =>

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1725,252 +1725,174 @@ it.effect("opencode loader keeps paid models when auth exists", () =>
   }).pipe(provideMultiInstance),
 )
 
-test("Google Vertex Anthropic: honours project/location from config options", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            "google-vertex-anthropic": {
-              options: { project: "config-project", location: "europe-west1" },
-            },
+it.instance(
+  "Google Vertex Anthropic: honours project/location from config options",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const va = providers[ProviderID.make("google-vertex-anthropic")]
+    expect(va).toBeDefined()
+    expect(va.options.project).toBe("config-project")
+    expect(va.options.location).toBe("europe-west1")
+  }),
+  {
+    config: {
+      provider: {
+        "google-vertex-anthropic": {
+          options: { project: "config-project", location: "europe-west1" },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "Bedrock: aliased entry receives cross-region small-model selection",
+  Effect.gen(function* () {
+    yield* set("AWS_ACCESS_KEY_ID", "test")
+    yield* set("AWS_SECRET_ACCESS_KEY", "test")
+    const small = yield* Provider.use.getSmallModel(ProviderID.make("bedrock-eu"))
+    expect(small).toBeDefined()
+    expect(small!.id.startsWith("eu.")).toBe(true)
+  }),
+  {
+    config: {
+      provider: {
+        "bedrock-eu": {
+          name: "Bedrock EU",
+          npm: "@ai-sdk/amazon-bedrock",
+          models: {
+            "us.anthropic.claude-haiku-4-5-20251022-v1:0": { name: "Claude Haiku 4.5 (US)" },
+            "eu.anthropic.claude-haiku-4-5-20251022-v1:0": { name: "Claude Haiku 4.5 (EU)" },
           },
-        }),
-      )
+          options: { region: "eu-west-1" },
+        },
+      },
     },
-  })
-  await withTestInstance({
-    directory: tmp.path,
-    fn: async (ctx) => {
-      const providers = await list(ctx)
-      const va = providers[ProviderID.make("google-vertex-anthropic")]
-      expect(va).toBeDefined()
-      expect(va.options.project).toBe("config-project")
-      expect(va.options.location).toBe("europe-west1")
-    },
-  })
-})
+  },
+)
 
-test("Bedrock: aliased entry receives cross-region small-model selection", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            "bedrock-eu": {
-              name: "Bedrock EU",
-              npm: "@ai-sdk/amazon-bedrock",
-              models: {
-                "us.anthropic.claude-haiku-4-5-20251022-v1:0": {
-                  name: "Claude Haiku 4.5 (US)",
-                },
-                "eu.anthropic.claude-haiku-4-5-20251022-v1:0": {
-                  name: "Claude Haiku 4.5 (EU)",
-                },
-              },
-              options: { region: "eu-west-1" },
-            },
-          },
-        }),
-      )
+it.instance(
+  "ambiguous npm: openai-compatible alias does not inherit canonical loader behaviour",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const proxy = providers[ProviderID.make("my-llm-proxy")]
+    expect(proxy).toBeDefined()
+    // No canonical loader fires for the ambiguous-npm alias, so the user's
+    // own options are the only ones present (`apiKey` here). Specifically not
+    // the `apiKey: "public"` the opencode loader would inject.
+    expect(proxy.options.apiKey).toBe("proxy-key")
+    expect(proxy.options.apiKey).not.toBe("public")
+    expect(proxy.options.fetch).toBeUndefined()
+  }),
+  {
+    config: {
+      provider: {
+        "my-llm-proxy": {
+          name: "Generic Proxy",
+          npm: "@ai-sdk/openai-compatible",
+          api: "https://example.com/v1",
+          models: { small: { name: "Small" } },
+          options: { apiKey: "proxy-key" },
+        },
+      },
     },
-  })
+  },
+)
 
-  await withTestInstance({
-    directory: tmp.path,
-    fn: async (ctx) => {
-      await set(ctx, "AWS_ACCESS_KEY_ID", "test")
-      await set(ctx, "AWS_SECRET_ACCESS_KEY", "test")
-      const small = await getSmallModel(ProviderID.make("bedrock-eu"), ctx)
-      expect(small).toBeDefined()
-      expect(small!.id.startsWith("eu.")).toBe(true)
+it.instance(
+  "ambiguous npm: azure-style alias does not inherit azure loader behaviour",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const fork = providers[ProviderID.make("my-azure-fork")]
+    expect(fork).toBeDefined()
+    // `@ai-sdk/azure` matches both `azure` and `azure-cognitive-services`,
+    // so the resolver finds no unique base and falls through. The user's
+    // resourceName survives but the azure-cognitive-services baseURL does not.
+    expect(fork.options.apiKey).toBe("azure-key")
+    expect(fork.options.resourceName).toBe("custom-resource")
+    expect(fork.options.baseURL).toBeUndefined()
+  }),
+  {
+    config: {
+      provider: {
+        "my-azure-fork": {
+          name: "Custom Azure Fork",
+          npm: "@ai-sdk/azure",
+          api: "https://example.openai.azure.com/openai",
+          models: { "gpt-4o": { name: "GPT-4o" } },
+          options: { apiKey: "azure-key", resourceName: "custom-resource" },
+        },
+      },
     },
-  })
-})
+  },
+)
 
-test("ambiguous npm: openai-compatible alias does not inherit canonical loader behaviour", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            "my-llm-proxy": {
-              name: "Generic Proxy",
-              npm: "@ai-sdk/openai-compatible",
-              api: "https://example.com/v1",
-              models: {
-                small: { name: "Small" },
-              },
-              options: { apiKey: "proxy-key" },
-            },
-          },
-        }),
-      )
-    },
-  })
+it.instance("Google Vertex: canonical entry loaded from env still receives ADC fetch", () =>
+  Effect.gen(function* () {
+    yield* setProcessEnv("GOOGLE_CLOUD_PROJECT", "env-project")
+    yield* setProcessEnv("GOOGLE_VERTEX_LOCATION", "us-central1")
+    const providers = yield* list
+    const vertex = providers[ProviderID.make("google-vertex")]
+    expect(vertex).toBeDefined()
+    expect(vertex.options.project).toBe("env-project")
+    expect(vertex.options.location).toBe("us-central1")
+    expect(typeof vertex.options.fetch).toBe("function")
+  }),
+)
 
-  await withTestInstance({
-    directory: tmp.path,
-    fn: async (ctx) => {
-      const providers = await list(ctx)
-      const proxy = providers[ProviderID.make("my-llm-proxy")]
-      expect(proxy).toBeDefined()
-      // No canonical loader fires for the ambiguous-npm alias. So no extras
-      // appear on options (apiKey is the only value the user supplied).
-      expect(proxy.options.apiKey).toBe("proxy-key")
-      // Specific tells from canonical openai-compat loaders that share this npm
-      // (opencode injects apiKey:"public", github-copilot/nvidia/etc. would
-      // inject their own options).
-      expect(proxy.options.apiKey).not.toBe("public")
-      expect(proxy.options.fetch).toBeUndefined()
+it.instance(
+  "Google Vertex: canonical and aliased entries coexist with distinct options",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const canonical = providers[ProviderID.make("google-vertex")]
+    const alias = providers[ProviderID.make("google-vertex-eu")]
+    expect(canonical).toBeDefined()
+    expect(alias).toBeDefined()
+    expect(canonical.options.location).toBe("europe-west4")
+    expect(alias.options.location).toBe("eu")
+    expect(canonical.options.project).toBe("test-canonical")
+    expect(alias.options.project).toBe("test-alias")
+    expect(typeof canonical.options.fetch).toBe("function")
+    expect(typeof alias.options.fetch).toBe("function")
+    expect(canonical.options.fetch).not.toBe(alias.options.fetch)
+  }),
+  {
+    config: {
+      provider: {
+        "google-vertex": {
+          options: { project: "test-canonical", location: "europe-west4" },
+        },
+        "google-vertex-eu": {
+          name: "Vertex EU",
+          npm: "@ai-sdk/google-vertex",
+          models: { "gemini-2.5-pro": { name: "Gemini 2.5 Pro", tool_call: true } },
+          options: { project: "test-alias", location: "eu" },
+        },
+      },
     },
-  })
-})
+  },
+)
 
-test("ambiguous npm: azure-style alias does not inherit azure loader behaviour", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            "my-azure-fork": {
-              name: "Custom Azure Fork",
-              npm: "@ai-sdk/azure",
-              api: "https://example.openai.azure.com/openai",
-              models: {
-                "gpt-4o": { name: "GPT-4o" },
-              },
-              options: { apiKey: "azure-key", resourceName: "custom-resource" },
-            },
-          },
-        }),
-      )
+it.instance(
+  "Google Vertex: aliased entry inherits ADC fetch from canonical loader",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const alias = providers[ProviderID.make("google-vertex-eu")]
+    expect(alias).toBeDefined()
+    expect(alias.options.project).toBe("test-project-eu")
+    expect(alias.options.location).toBe("eu")
+    expect(typeof alias.options.fetch).toBe("function")
+  }),
+  {
+    config: {
+      provider: {
+        "google-vertex-eu": {
+          name: "Vertex EU",
+          npm: "@ai-sdk/google-vertex",
+          models: { "gemini-2.5-pro": { name: "Gemini 2.5 Pro", tool_call: true } },
+          options: { project: "test-project-eu", location: "eu" },
+        },
+      },
     },
-  })
-
-  await withTestInstance({
-    directory: tmp.path,
-    fn: async (ctx) => {
-      const providers = await list(ctx)
-      const fork = providers[ProviderID.make("my-azure-fork")]
-      expect(fork).toBeDefined()
-      // Both `azure` and `azure-cognitive-services` canonical loaders match
-      // @ai-sdk/azure, so the resolver finds no unique base and falls through.
-      // The user-supplied resourceName is preserved but no loader-injected
-      // baseURL appears (azure-cognitive-services would set one).
-      expect(fork.options.apiKey).toBe("azure-key")
-      expect(fork.options.resourceName).toBe("custom-resource")
-      expect(fork.options.baseURL).toBeUndefined()
-    },
-  })
-})
-
-test("Google Vertex: canonical entry loaded from env still receives ADC fetch", async () => {
-  await using tmp = await tmpdir({})
-  await withTestInstance({
-    directory: tmp.path,
-    fn: async (ctx) => {
-      await set(ctx, "GOOGLE_CLOUD_PROJECT", "env-project")
-      await set(ctx, "GOOGLE_VERTEX_LOCATION", "us-central1")
-      const providers = await list(ctx)
-      const vertex = providers[ProviderID.make("google-vertex")]
-      expect(vertex).toBeDefined()
-      expect(vertex.options.project).toBe("env-project")
-      expect(vertex.options.location).toBe("us-central1")
-      expect(typeof vertex.options.fetch).toBe("function")
-    },
-  })
-})
-
-test("Google Vertex: canonical and aliased entries coexist with distinct options", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            "google-vertex": {
-              options: { project: "test-canonical", location: "europe-west4" },
-            },
-            "google-vertex-eu": {
-              name: "Vertex EU",
-              npm: "@ai-sdk/google-vertex",
-              models: {
-                "gemini-2.5-pro": { name: "Gemini 2.5 Pro", tool_call: true },
-              },
-              options: { project: "test-alias", location: "eu" },
-            },
-          },
-        }),
-      )
-    },
-  })
-
-  await withTestInstance({
-    directory: tmp.path,
-    fn: async (ctx) => {
-      const providers = await list(ctx)
-      const canonical = providers[ProviderID.make("google-vertex")]
-      const alias = providers[ProviderID.make("google-vertex-eu")]
-      expect(canonical).toBeDefined()
-      expect(alias).toBeDefined()
-      expect(canonical.options.location).toBe("europe-west4")
-      expect(alias.options.location).toBe("eu")
-      expect(canonical.options.project).toBe("test-canonical")
-      expect(alias.options.project).toBe("test-alias")
-      expect(typeof canonical.options.fetch).toBe("function")
-      expect(typeof alias.options.fetch).toBe("function")
-      expect(canonical.options.fetch).not.toBe(alias.options.fetch)
-    },
-  })
-})
-
-test("Google Vertex: aliased entry inherits ADC fetch from canonical loader", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            "google-vertex-eu": {
-              name: "Vertex EU",
-              npm: "@ai-sdk/google-vertex",
-              models: {
-                "gemini-2.5-pro": {
-                  name: "Gemini 2.5 Pro",
-                  tool_call: true,
-                },
-              },
-              options: {
-                project: "test-project-eu",
-                location: "eu",
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-
-  await withTestInstance({
-    directory: tmp.path,
-    fn: async (ctx) => {
-      const providers = await list(ctx)
-      const alias = providers[ProviderID.make("google-vertex-eu")]
-      expect(alias).toBeDefined()
-      expect(alias.options.project).toBe("test-project-eu")
-      expect(alias.options.location).toBe("eu")
-      expect(typeof alias.options.fetch).toBe("function")
-    },
-  })
-})
+  },
+)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1724,3 +1724,253 @@ it.effect("opencode loader keeps paid models when auth exists", () =>
     expect(keyedCount).toBeGreaterThan(0)
   }).pipe(provideMultiInstance),
 )
+
+test("Google Vertex Anthropic: honours project/location from config options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: { project: "config-project", location: "europe-west1" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const providers = await list(ctx)
+      const va = providers[ProviderID.make("google-vertex-anthropic")]
+      expect(va).toBeDefined()
+      expect(va.options.project).toBe("config-project")
+      expect(va.options.location).toBe("europe-west1")
+    },
+  })
+})
+
+test("Bedrock: aliased entry receives cross-region small-model selection", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "bedrock-eu": {
+              name: "Bedrock EU",
+              npm: "@ai-sdk/amazon-bedrock",
+              models: {
+                "us.anthropic.claude-haiku-4-5-20251022-v1:0": {
+                  name: "Claude Haiku 4.5 (US)",
+                },
+                "eu.anthropic.claude-haiku-4-5-20251022-v1:0": {
+                  name: "Claude Haiku 4.5 (EU)",
+                },
+              },
+              options: { region: "eu-west-1" },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      await set(ctx, "AWS_ACCESS_KEY_ID", "test")
+      await set(ctx, "AWS_SECRET_ACCESS_KEY", "test")
+      const small = await getSmallModel(ProviderID.make("bedrock-eu"), ctx)
+      expect(small).toBeDefined()
+      expect(small!.id.startsWith("eu.")).toBe(true)
+    },
+  })
+})
+
+test("ambiguous npm: openai-compatible alias does not inherit canonical loader behaviour", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "my-llm-proxy": {
+              name: "Generic Proxy",
+              npm: "@ai-sdk/openai-compatible",
+              api: "https://example.com/v1",
+              models: {
+                "small": { name: "Small" },
+              },
+              options: { apiKey: "proxy-key" },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const providers = await list(ctx)
+      const proxy = providers[ProviderID.make("my-llm-proxy")]
+      expect(proxy).toBeDefined()
+      // No canonical loader fires for the ambiguous-npm alias. So no extras
+      // appear on options (apiKey is the only value the user supplied).
+      expect(proxy.options.apiKey).toBe("proxy-key")
+      // Specific tells from canonical openai-compat loaders that share this npm
+      // (opencode injects apiKey:"public", github-copilot/nvidia/etc. would
+      // inject their own options).
+      expect(proxy.options.apiKey).not.toBe("public")
+      expect(proxy.options.fetch).toBeUndefined()
+    },
+  })
+})
+
+test("ambiguous npm: azure-style alias does not inherit azure loader behaviour", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "my-azure-fork": {
+              name: "Custom Azure Fork",
+              npm: "@ai-sdk/azure",
+              api: "https://example.openai.azure.com/openai",
+              models: {
+                "gpt-4o": { name: "GPT-4o" },
+              },
+              options: { apiKey: "azure-key", resourceName: "custom-resource" },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const providers = await list(ctx)
+      const fork = providers[ProviderID.make("my-azure-fork")]
+      expect(fork).toBeDefined()
+      // Both `azure` and `azure-cognitive-services` canonical loaders match
+      // @ai-sdk/azure, so the resolver finds no unique base and falls through.
+      // The user-supplied resourceName is preserved but no loader-injected
+      // baseURL appears (azure-cognitive-services would set one).
+      expect(fork.options.apiKey).toBe("azure-key")
+      expect(fork.options.resourceName).toBe("custom-resource")
+      expect(fork.options.baseURL).toBeUndefined()
+    },
+  })
+})
+
+test("Google Vertex: canonical entry loaded from env still receives ADC fetch", async () => {
+  await using tmp = await tmpdir({})
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      await set(ctx, "GOOGLE_CLOUD_PROJECT", "env-project")
+      await set(ctx, "GOOGLE_VERTEX_LOCATION", "us-central1")
+      const providers = await list(ctx)
+      const vertex = providers[ProviderID.make("google-vertex")]
+      expect(vertex).toBeDefined()
+      expect(vertex.options.project).toBe("env-project")
+      expect(vertex.options.location).toBe("us-central1")
+      expect(typeof vertex.options.fetch).toBe("function")
+    },
+  })
+})
+
+test("Google Vertex: canonical and aliased entries coexist with distinct options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex": {
+              options: { project: "test-canonical", location: "europe-west4" },
+            },
+            "google-vertex-eu": {
+              name: "Vertex EU",
+              npm: "@ai-sdk/google-vertex",
+              models: {
+                "gemini-2.5-pro": { name: "Gemini 2.5 Pro", tool_call: true },
+              },
+              options: { project: "test-alias", location: "eu" },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const providers = await list(ctx)
+      const canonical = providers[ProviderID.make("google-vertex")]
+      const alias = providers[ProviderID.make("google-vertex-eu")]
+      expect(canonical).toBeDefined()
+      expect(alias).toBeDefined()
+      expect(canonical.options.location).toBe("europe-west4")
+      expect(alias.options.location).toBe("eu")
+      expect(canonical.options.project).toBe("test-canonical")
+      expect(alias.options.project).toBe("test-alias")
+      expect(typeof canonical.options.fetch).toBe("function")
+      expect(typeof alias.options.fetch).toBe("function")
+      expect(canonical.options.fetch).not.toBe(alias.options.fetch)
+    },
+  })
+})
+
+test("Google Vertex: aliased entry inherits ADC fetch from canonical loader", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-eu": {
+              name: "Vertex EU",
+              npm: "@ai-sdk/google-vertex",
+              models: {
+                "gemini-2.5-pro": {
+                  name: "Gemini 2.5 Pro",
+                  tool_call: true,
+                },
+              },
+              options: {
+                project: "test-project-eu",
+                location: "eu",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const providers = await list(ctx)
+      const alias = providers[ProviderID.make("google-vertex-eu")]
+      expect(alias).toBeDefined()
+      expect(alias.options.project).toBe("test-project-eu")
+      expect(alias.options.location).toBe("eu")
+      expect(typeof alias.options.fetch).toBe("function")
+    },
+  })
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1805,7 +1805,7 @@ test("ambiguous npm: openai-compatible alias does not inherit canonical loader b
               npm: "@ai-sdk/openai-compatible",
               api: "https://example.com/v1",
               models: {
-                "small": { name: "Small" },
+                small: { name: "Small" },
               },
               options: { apiKey: "proxy-key" },
             },


### PR DESCRIPTION
### Issue for this PR

Closes #28524

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Declaring a second Vertex AI provider entry under a custom ID (say `google-vertex-eu` for the `eu` multi-region) silently skips the Vertex loader today. The resulting SDK has no ADC credentials and requests fail with `Model not found`. The custom-loader iteration in `packages/opencode/src/provider/provider.ts` walks `Object.entries(custom(dep))`, keyed by exact provider ID, so anything that isn't a canonical loader name is dropped.

This PR walks the merged provider database instead. Each entry resolves to a loader by exact-ID match (canonical behaviour, untouched) or by unique-`npm` match. When the `npm` is shared (the `@ai-sdk/openai-compatible` family of seven loaders, plus the `@ai-sdk/azure` pair), the resolver returns `undefined` and the entry falls through to the generic SDK path. That keeps the change narrow. Explicit aliasing inside those shared-npm groups is a separate problem; #28489 attacks one slice of it with an `auth_provider` config field.

I also moved the literal `model.providerID === "X"` discriminations in `provider.ts`, `transform.ts`, and `agent.ts` to `model.api.npm === NPM.X` wherever the canonical loader uniquely owns its npm. Sites inside the openai-compatible family stay ID-keyed; npm can't discriminate among them. A new `packages/opencode/src/provider/npm.ts` holds the npm constants so a typo at a call site is a compile error.

Drive-by: the `google-vertex-anthropic` loader was reading `project` and `location` from env vars only and silently ignoring `provider.options`. Fixed to mirror `google-vertex` (config first, env fallback). Regression test included.

### How did you verify your code works?

Seven new tests in `packages/opencode/test/provider/provider.test.ts` cover the alias path, canonical-entry regression, ambiguous-npm fallthrough for the azure pair and the openai-compatible family, the `google-vertex-anthropic` config gap, and the migrated Bedrock cross-region small-model picker.

```
bun test test/provider/ test/agent/   # 390 pass, 0 fail
bun run typecheck                     # clean
```

Manual, with the config below in `opencode.json` and Google ADC set up (`gcloud auth application-default login`):

```
opencode run --model google-vertex/gemini-2.5-pro --log-level DEBUG "ping"
opencode run --model google-vertex-eu/gemini-3.5-flash --log-level DEBUG "ping"
```

Both succeed. Debug logs show each request hitting its configured regional endpoint with an `Authorization: Bearer …` header from ADC.

#### Example

```jsonc
{
  "provider": {
    "google-vertex": {
      "options": { "project": "P", "location": "europe-west4" },
      "models": { "gemini-2.5-pro": {} }
    },
    "google-vertex-eu": {
      "npm": "@ai-sdk/google-vertex",
      "options": { "project": "P", "location": "eu" },
      "models": { "gemini-3.5-flash": {} }
    }
  }
}
```

### Screenshots / recordings

N/A — backend/provider logic change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
