### PR TITLE
fix(skill): use single-level glob to prevent recursive sub-skill discovery

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -20,9 +20,9 @@ import { isRecord } from "@/util/record"
 const log = Log.create({ service: "skill" })
 const CLAUDE_EXTERNAL_DIR = ".claude"
 const AGENTS_EXTERNAL_DIR = ".agents"
-const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
-const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"
-const SKILL_PATTERN = "**/SKILL.md"
+const EXTERNAL_SKILL_PATTERN = "skills/*/SKILL.md"
+const OPENCODE_SKILL_PATTERN = "{skill,skills}/*/SKILL.md"
+const SKILL_PATTERN = "*/SKILL.md"
 
 // Built-in skill that ships with opencode. The model's intuition for what an
 // opencode.json should look like is often wrong, and opencode hard-fails on


### PR DESCRIPTION
## Problem

The skill discovery patterns use `**/SKILL.md` which recursively scans all subdirectories. This causes sub-skills (e.g. `sub-skills/python/SKILL.md`, `sub-skills/security/SKILL.md`) to be loaded as independent top-level skills, flooding the agent context with hundreds of irrelevant skill descriptions.

For a harness with hierarchical skills (parent skill + sub-skills), this breaks the design where only the parent skill should be visible and sub-skills are referenced internally.

## Fix

Changed all three skill discovery patterns from recursive glob (`**`) to single-level glob (`*`):

```diff
-const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
+const EXTERNAL_SKILL_PATTERN = "skills/*/SKILL.md"
-const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"
+const OPENCODE_SKILL_PATTERN = "{skill,skills}/*/SKILL.md"
-const SKILL_PATTERN = "**/SKILL.md"
+const SKILL_PATTERN = "*/SKILL.md"
```

## Impact

- Only direct children of `skills/` directories are discovered as skills
- Sub-skills in `sub-skills/`, `domain-skills/`, etc. remain invisible to the global discovery
- Parent skills can still reference sub-skills internally via their content
- Reduces agent context bloat from hundreds of skills to the intended set
- No config changes required — works with existing `skills.paths` and walk-up discovery