### PR TITLE
fix(tui): default new sessions always to local project

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -65,7 +65,6 @@ import { useTuiConfig } from "../../context/tui-config"
 
 export type PromptProps = {
   sessionID?: string
-  workspaceID?: string
   visible?: boolean
   disabled?: boolean
   onSubmit?: () => void
@@ -203,7 +202,6 @@ export function Prompt(props: PromptProps) {
   const [cursorVersion, setCursorVersion] = createSignal(0)
   const currentProviderLabel = createMemo(() => local.model.parsed().provider)
   const hasRightContent = createMemo(() => Boolean(props.right))
-  const defaultWorkspaceID = createMemo(() => props.workspaceID ?? project.workspace.current())
 
   function selectWorkspace(selection: WorkspaceSelection | undefined) {
     setWorkspaceSelection(selection)
@@ -1063,7 +1061,7 @@ export function Prompt(props: PromptProps) {
     if (sessionID == null) {
       const workspace = workspaceSelection()
       const workspaceID = iife(() => {
-        if (!workspace) return defaultWorkspaceID()
+        if (!workspace) return undefined
         if (workspace.type === "none") return undefined
         if (workspace.type === "existing") return workspace.workspaceID
         return undefined
@@ -1424,17 +1422,7 @@ export function Prompt(props: PromptProps) {
     | undefined
   >(() => {
     const selected = workspaceSelection()
-    if (!selected) {
-      const workspaceID = defaultWorkspaceID()
-      if (props.sessionID || !workspaceID) return
-      const workspace = project.workspace.get(workspaceID)
-      return {
-        type: "existing",
-        workspaceType: workspace?.type ?? "unknown",
-        workspaceName: workspace?.name ?? workspaceID,
-        status: project.workspace.status(workspaceID) ?? "error",
-      }
-    }
+    if (!selected) return
     if (selected.type === "none") return
     if (props.sessionID && !workspaceCreating()) return
     if (selected.type === "new") {

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -269,7 +269,6 @@ export function createTuiApi(input: Input): TuiPluginApi {
         return (
           <Prompt
             sessionID={props.sessionID}
-            workspaceID={props.workspaceID}
             visible={props.visible}
             disabled={props.disabled}
             onSubmit={props.onSubmit}

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,7 +1,6 @@
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import { createEffect, createSignal, onMount } from "solid-js"
 import { Logo } from "../component/logo"
-import { useProject } from "../context/project"
 import { useSync } from "../context/sync"
 import { Toast } from "../ui/toast"
 import { useArgs } from "../context/args"
@@ -19,7 +18,6 @@ const placeholder = {
 
 export function Home() {
   const sync = useSync()
-  const project = useProject()
   const route = useRouteData("home")
   const promptRef = usePromptRef()
   const [ref, setRef] = createSignal<PromptRef | undefined>()
@@ -73,13 +71,11 @@ export function Home() {
           <TuiPluginRuntime.Slot
             name="home_prompt"
             mode="replace"
-            workspace_id={project.workspace.current()}
             ref={bind}
           >
             <Prompt
               ref={bind}
-              workspaceID={project.workspace.current()}
-              right={<TuiPluginRuntime.Slot name="home_prompt_right" workspace_id={project.workspace.current()} />}
+              right={<TuiPluginRuntime.Slot name="home_prompt_right" />}
               placeholders={placeholder}
             />
           </TuiPluginRuntime.Slot>

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -205,7 +205,6 @@ export type TuiPromptRef = {
 
 export type TuiPromptProps = {
   sessionID?: string
-  workspaceID?: string
   visible?: boolean
   disabled?: boolean
   onSubmit?: () => void
@@ -453,12 +452,9 @@ export type TuiHostSlotMap = {
   app_bottom: {}
   home_logo: {}
   home_prompt: {
-    workspace_id?: string
     ref?: (ref: TuiPromptRef | undefined) => void
   }
-  home_prompt_right: {
-    workspace_id?: string
-  }
+  home_prompt_right: {}
   session_prompt: {
     session_id: string
     visible?: boolean


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

New TUI prompts no longer inherit the currently selected workspace by default. This keeps `/new` and the home prompt on the local project unless the user explicitly selects or warps to a workspace.

This removes the prompt-level workspace default, stops the home route from passing workspace context into prompt slots, and removes the unused workspace prompt API fields. Existing sessions still send prompts through their session ID, so their workspace association is preserved.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode`
- `bun typecheck` from `packages/plugin`
- full `bun turbo typecheck` ran successfully during push

### Screenshots / recordings

Not included; behavior-only TUI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR