### PR TITLE
fix(opencode): preserve reasoning_content for Kimi K2.5/K2.6 multi-turn tool calls

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -282,8 +282,24 @@ function normalizeMessages(
     return result
   }
 
-  // Deepseek requires all assistant messages to have reasoning on them
-  if (model.api.id.toLowerCase().includes("deepseek")) {
+  // DeepSeek requires all assistant messages to have reasoning on them.
+  // Kimi K2.5/K2.6 have the same requirement when thinking is enabled (the
+  // default on Moonshot, Cloudflare Workers AI, Cerebras, etc. via the
+  // openai-compatible SDK): the API rejects multi-turn tool-calling
+  // requests with "thinking is enabled but reasoning_content is missing
+  // in assistant tool call message". Kimi K2-Thinking is excluded — it
+  // returns reasoning_content by default and the SDK path differs.
+  const lowerId = model.api.id.toLowerCase()
+  const isKimiK2RequiringReasoning =
+    lowerId.includes("kimi-k2") &&
+    !lowerId.includes("k2-thinking") &&
+    (lowerId.includes("k2.5") ||
+      lowerId.includes("k2.6") ||
+      lowerId.includes("k2p5") ||
+      lowerId.includes("k2p6") ||
+      lowerId.includes("k2-5") ||
+      lowerId.includes("k2-6"))
+  if (lowerId.includes("deepseek") || isKimiK2RequiringReasoning) {
     msgs = msgs.map((msg) => {
       if (msg.role !== "assistant") return msg
       if (Array.isArray(msg.content)) {
@@ -297,6 +313,36 @@ function normalizeMessages(
           { type: "reasoning" as const, text: "" },
         ],
       }
+    })
+  }
+
+  // Ensure Kimi K2.5/K2.6 always get reasoning_content placed into
+  // providerOptions for downstream openai-compatible SDK serialization,
+  // even when models.dev does not yet declare interleaved={field:"reasoning_content"}
+  // for these models. Mirrors how DeepSeek is configured.
+  if (
+    isKimiK2RequiringReasoning &&
+    model.api.npm === "@ai-sdk/openai-compatible" &&
+    !(typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field)
+  ) {
+    return msgs.map((msg) => {
+      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+        const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
+        const reasoningText = reasoningParts.map((part: any) => part.text).join("")
+        const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
+        return {
+          ...msg,
+          content: filteredContent,
+          providerOptions: {
+            ...msg.providerOptions,
+            openaiCompatible: {
+              ...msg.providerOptions?.openaiCompatible,
+              reasoning_content: reasoningText,
+            },
+          },
+        }
+      }
+      return msg
     })
   }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1192,6 +1192,102 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   })
 })
 
+describe("ProviderTransform.message - Kimi K2.5/K2.6 reasoning content", () => {
+  const buildKimiModel = (apiId: string) =>
+    ({
+      id: ModelID.make(`moonshotai/${apiId}`),
+      providerID: ProviderID.make("moonshotai"),
+      api: {
+        id: apiId,
+        url: "https://api.moonshot.ai",
+        npm: "@ai-sdk/openai-compatible" as const,
+      },
+      name: apiId,
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+      limit: { context: 256000, output: 16384 },
+      status: "active" as const,
+      options: {},
+      headers: {},
+      release_date: "2026-04-20",
+    }) as any
+
+  test("Kimi K2.6 injects empty reasoning placeholder on assistant tool-call without reasoning", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "test",
+            toolName: "bash",
+            input: { command: "echo hi" },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, buildKimiModel("kimi-k2.6"), {})
+    expect(result).toHaveLength(1)
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("")
+    expect((result[0].content as any[]).some((p) => p.type === "tool-call")).toBe(true)
+  })
+
+  test("Kimi K2.5 preserves existing reasoning content in providerOptions", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "I need to call bash" },
+          {
+            type: "tool-call",
+            toolCallId: "test",
+            toolName: "bash",
+            input: { command: "ls" },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, buildKimiModel("kimi-k2.5"), {})
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("I need to call bash")
+    expect((result[0].content as any[]).every((p) => p.type !== "reasoning")).toBe(true)
+  })
+
+  test("Kimi K2-Thinking is NOT touched (returns reasoning_content natively)", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, buildKimiModel("kimi-k2-thinking"), {})
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+    expect((result[0].content as any[]).every((p) => p.type !== "reasoning")).toBe(true)
+  })
+
+  test("Kimi K2 base (non-K2.5/K2.6) is not affected", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, buildKimiModel("kimi-k2"), {})
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.message - surrogate sanitization", () => {
   const model = {
     id: "test/test-model",


### PR DESCRIPTION
## Summary

Kimi K2.5 and K2.6 (Moonshot AI) reject subsequent requests in multi-turn tool-calling conversations with:

```
thinking is enabled but reasoning_content is missing in assistant
tool call message at index [N]
```

The model returns `reasoning_content` alongside `tool_calls` in the first turn, but opencode strips it before building the next request's message history. Kimi requires `reasoning_content` to be preserved on every assistant message (even empty) when thinking mode is active — which is the **default** on Moonshot's API, Cloudflare Workers AI, Cerebras, and any other openai-compatible Kimi K2.5/K2.6 hosting.

This is the same class of bug already fixed for DeepSeek in `transform.ts`.

## Symptom in the wild

Observed empirically with `cloudflare/@cf/moonshotai/kimi-k2.6` via the openai-compatible SDK:

- Sisyphus/orchestrator agent says "I should call Oracle now" as text
- No structured `tool_call` is emitted in the response
- `finish_reason: stop`
- Session hangs until user manually re-prompts

Multiple matching reports:
- #10996 — Kimi K2.5/K2p5 fails with thinking-enabled tool calls (the issue this PR fixes)
- #24722 — DeepSeek thinking mode tool call 400 (same root cause, already fixed for DeepSeek)
- #24190 — DeepSeek V4 reasoning_content not round-tripped

## Fix

Two changes in `packages/opencode/src/provider/transform.ts`:

1. **Extend the reasoning-placeholder injection guard** (`isKimiK2RequiringReasoning`) to match Kimi K2.5/K2.6 model IDs alongside DeepSeek. Matches: `kimi-k2.5`, `kimi-k2.6`, `kimi-k2p5`, `kimi-k2p6`, `kimi-k2-5`, `kimi-k2-6`. Kimi K2-Thinking is excluded — it returns `reasoning_content` natively and uses a different SDK path.

2. **Add an explicit interleaved-style serialization block** that places `reasoning_content` into `providerOptions.openaiCompatible` for Kimi K2.5/K2.6 on `@ai-sdk/openai-compatible`, even when the models.dev catalog has not yet declared `interleaved: { field: "reasoning_content" }` for these models. This avoids depending on a separate models.dev change to fix the bug.

## Tests

Added 4 test cases following the existing DeepSeek test pattern:

- `Kimi K2.6 injects empty reasoning placeholder on assistant tool-call without reasoning`
- `Kimi K2.5 preserves existing reasoning content in providerOptions`
- `Kimi K2-Thinking is NOT touched (returns reasoning_content natively)`
- `Kimi K2 base (non-K2.5/K2.6) is not affected`

All 228 existing + new transform tests pass. All 340 tests under `test/provider/` pass with no regressions.

## Test plan

- [x] `bun test packages/opencode/test/provider/transform.test.ts` — 228 pass, 0 fail
- [x] `bun test packages/opencode/test/provider/` — 340 pass, 0 fail
- [ ] Manual: route `kimi-k2.6` (via Cloudflare Workers AI or Cerebras openai-compatible endpoint) through a multi-turn tool-calling session

Fixes #10996
Related: #24722, #24190