### PR TITLE
feat: allow overriding system prompt date via OPENCODE_DATE env var

### DIFF
--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -52,6 +52,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   bashDefaultTimeoutMs: positiveInteger("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS"),
   experimentalNativeLlm: enabledByExperimental("OPENCODE_EXPERIMENTAL_NATIVE_LLM"),
   client: Config.string("OPENCODE_CLIENT").pipe(Config.withDefault("cli")),
+  dateOverride: Config.string("OPENCODE_DATE").pipe(Config.option),
 }) {}
 
 export type Info = Context.Service.Shape<typeof Service>

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -1,6 +1,7 @@
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Option } from "effect"
 
 import { InstanceState } from "@/effect/instance-state"
+import { RuntimeFlags } from "@/effect/runtime-flags"
 
 import PROMPT_ANTHROPIC from "./prompt/anthropic.txt"
 import PROMPT_DEFAULT from "./prompt/default.txt"
@@ -43,10 +44,12 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const skill = yield* Skill.Service
+    const flags = yield* RuntimeFlags.Service
 
     return Service.of({
       environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model) {
         const ctx = yield* InstanceState.context
+        const dateStr = Option.getOrElse(flags.dateOverride, () => new Date().toDateString())
         return [
           [
             `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
@@ -56,7 +59,7 @@ export const layer = Layer.effect(
             `  Workspace root folder: ${ctx.worktree}`,
             `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
-            `  Today's date: ${new Date().toDateString()}`,
+            `  Today's date: ${dateStr}`,
             `</env>`,
           ].join("\n"),
         ]
@@ -79,6 +82,9 @@ export const layer = Layer.effect(
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(Skill.defaultLayer))
+export const defaultLayer = layer.pipe(
+  Layer.provide(Skill.defaultLayer),
+  Layer.provide(RuntimeFlags.defaultLayer),
+)
 
 export * as SystemPrompt from "./system"

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import type { Agent } from "../../src/agent/agent"
 import { NamedError } from "@opencode-ai/core/util/error"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
 import { Skill } from "../../src/skill"
 import { Permission } from "../../src/permission"
 import { SystemPrompt } from "../../src/session/system"
@@ -53,6 +54,7 @@ const it = testEffect(
         }),
       ),
     ),
+    Layer.provide(RuntimeFlags.defaultLayer),
   ),
 )
 


### PR DESCRIPTION
Enables deterministic LLM request replay in CI integration tests by fixing the date string in the system prompt.

### Issue for this PR

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The system prompt in session/system.ts includes a dynamic Today's date: ${new Date().toDateString()} line. This makes it impossible to match recorded LLM requests when replaying them in CI integration tests, since the date changes every day.

This PR adds an OPENCODE_DATE environment variable that overrides the date string when set, falling back to the real date otherwise. It follows the established RuntimeFlags pattern used for other runtime overrides in the project.
```
Usage:
OPENCODE_DATE="Thu Jan 01 2025" opencode
```
### How did you verify your code works?

I built it locally, and ran:
```
OPENCODE_DATE="Yesterday" ./result/bin/opencode
```

Then I verified the system promt in the capture of llama-swap (see comment)


### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR