### PR TITLE
refactor(opencode): drop AppRuntime from instance-runtime

### DIFF
--- a/packages/opencode/src/project/instance-runtime.ts
+++ b/packages/opencode/src/project/instance-runtime.ts
@@ -1,16 +1,21 @@
-import { AppRuntime } from "@/effect/app-runtime"
+import { Effect, ManagedRuntime } from "effect"
+import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { type InstanceContext } from "./instance-context"
+import { InstanceLayer } from "./instance-layer"
 import { InstanceStore, type LoadInput } from "./instance-store"
 
 // Bridge for Promise/ALS callers that cannot yet yield InstanceStore.Service.
 // Delete this module once those callers are migrated to Effect boundaries that
 // provide InstanceStore directly.
 
-export const load = (input: LoadInput) => AppRuntime.runPromise(InstanceStore.Service.use((store) => store.load(input)))
-export const disposeInstance = (ctx: InstanceContext) =>
-  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.dispose(ctx)))
-export const disposeAllInstances = () => AppRuntime.runPromise(InstanceStore.Service.use((store) => store.disposeAll()))
-export const reloadInstance = (input: LoadInput) =>
-  AppRuntime.runPromise(InstanceStore.Service.use((store) => store.reload(input)))
+const runtime = ManagedRuntime.make(InstanceLayer.layer, { memoMap })
+
+const run = <A, E>(fn: (store: InstanceStore.Interface) => Effect.Effect<A, E>) =>
+  runtime.runPromise(InstanceStore.Service.use(fn))
+
+export const load = (input: LoadInput) => run((store) => store.load(input))
+export const disposeInstance = (ctx: InstanceContext) => run((store) => store.dispose(ctx))
+export const disposeAllInstances = () => run((store) => store.disposeAll())
+export const reloadInstance = (input: LoadInput) => run((store) => store.reload(input))
 
 export * as InstanceRuntime from "./instance-runtime"


### PR DESCRIPTION
Stacked on top of #28528.

## Summary

Replaces `AppRuntime.runPromise(...)` inside `src/project/instance-runtime.ts` with a per-service `ManagedRuntime.make(InstanceLayer.layer, { memoMap })`. The four Promise helpers (`load`, `disposeInstance`, `disposeAllInstances`, `reloadInstance`) keep the same signatures, so every caller (`src/cli/bootstrap.ts`, `src/cli/cmd/tui/worker.ts`, `src/acp/runtime.ts`, the test fixtures) is unchanged.

## Why it's safe

- `InstanceStore.Interface` methods only need `Project.Service` + `InstanceBootstrap.Service` (`src/project/instance-store.ts:31`). Both are already inside `InstanceLayer.layer`.
- `InstanceBootstrap.run` requires Config/Plugin/LSP/Bus/etc. — all already provided internally by `InstanceBootstrap.defaultLayer` (`src/project/bootstrap.ts:58-73`).
- The shared process-wide `memoMap` (`@opencode-ai/core/effect/memo-map`) is passed to BOTH the existing `AppRuntime` and this new runtime, so any `defaultLayer` referenced in both resolves to the same Service instance. Service identity is preserved.
- `GlobalBus.emit(...)` calls inside `disposeContext` go through the process-global EventEmitter, not the layered Bus.Service — unchanged.

## Why this matters

One step toward removing `AppRuntime` entirely. `InstanceRuntime.load/dispose/disposeAll/reload` are called from `src/cli/bootstrap`, `src/cli/cmd/tui/worker`, `src/acp/runtime`, and the test fixtures. After this PR, none of those code paths import `AppRuntime` transitively through `InstanceRuntime` anymore.

## Test plan

- [x] `bun run test` across `test/project/worktree`, `test/question`, `test/config`, `test/control-plane/workspace`, plus the recent event tests — 155 pass, 0 fail.
- [x] `bun run typecheck` — clean for the changed file.
- [ ] CI green.

## Follow-up

The remaining 7 `AppRuntime` callers in `src/` can follow the same pattern, file by file. The hardest is `src/cli/effect-cmd.ts` (the CLI command runner) — that one's the right home for whatever cross-cutting runtime survives.