### PR TITLE
fix(tui): use colon for collapsed thinking labels

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -416,7 +416,7 @@ function AssistantReasoning(props: {
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={props.subtleSyntax}
-              content={(inMinimal() ? "- " : "") + "_Thinking:_ " + content()}
+              content={(inMinimal() ? "- " : "") + (isDone() ? "_Thought:_ " : "_Thinking:_ ") + content()}
               conceal={true}
               fg={theme.textMuted}
             />
@@ -443,7 +443,7 @@ function CollapsedReasoningText(props: { title: string | null }) {
   return (
     <text fg={theme.warning} wrapMode="none">
       <span style={{ fg: theme.warning, italic: true }}>
-        {props.title ? "+ Thought · " + props.title : "+ Thought"}
+        {props.title ? "+ Thought: " + props.title : "+ Thought"}
       </span>
     </text>
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1565,7 +1565,7 @@ function CollapsedReasoningText(props: { title: string | null; duration: number 
   return (
     <text fg={theme.warning} wrapMode="none">
       <span style={{ fg: theme.warning, italic: true }}>
-        {props.title ? "+ Thought · " + props.title + " · " + duration() : "+ Thought · " + duration()}
+        {props.title ? "+ Thought: " + props.title + " · " + duration() : "+ Thought: " + duration()}
       </span>
     </text>
   )


### PR DESCRIPTION
Makes the collapsed (minimal/hide) thinking state use a colon for the label, matching the expanded state:

- Expanded: `_Thought:_` / `_Thinking:_`
- Collapsed: `+ Thought: <title> · <time>` (or `+ Thought: <time>`)

Also synced the v2 session path to switch to "Thought:" once the block is complete (was always "Thinking:").

Files:
- packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
- packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx