### PR TITLE
fix(question): surface schema failures as friendly tool errors

### DIFF
--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -146,12 +146,26 @@ export const layer = Layer.effect(
       log.info("asking", { id, questions: input.questions.length })
 
       const deferred = yield* Deferred.make<ReadonlyArray<Answer>, RejectedError>()
-      const info = Schema.decodeUnknownSync(Request)({
+      // Use the Effect-returning decode so a schema failure surfaces as a
+      // typed error the tool wrap can turn into a "rewrite the input" tool
+      // result. The previous `decodeUnknownSync` would throw uncaught, which
+      // crashed the assistant turn for any payload that slipped past the
+      // wrap-level validation (#28438).
+      const info = yield* Schema.decodeUnknownEffect(Request)({
         id,
         sessionID: input.sessionID,
         questions: input.questions,
         tool: input.tool,
-      })
+      }).pipe(
+        Effect.mapError(
+          (error) =>
+            new Error(
+              `The question tool was called with invalid arguments: ${error}.\nPlease rewrite the input so it satisfies the expected schema.`,
+              { cause: error },
+            ),
+        ),
+        Effect.orDie,
+      )
       pending.set(id, { info, deferred })
       yield* bus.publish(Event.Asked, info)
 

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -416,6 +416,46 @@ it.live("pending question rejects on instance dispose", () =>
   }),
 )
 
+// Regression for #28438: when an invalid payload reaches `Question.ask`
+// (one that's missing a required field like `question`), the previous
+// `Schema.decodeUnknownSync` would throw uncaught and crash the whole
+// assistant turn. The fix routes the failure through `Effect.orDie` with a
+// "rewrite the input" Error so the surrounding tool wrap can hand it back to
+// the model as a tool-call error rather than killing the session.
+it.instance(
+  "ask - invalid payload surfaces as a friendly defect, not a thrown SchemaError",
+  () =>
+    Effect.gen(function* () {
+      const exit = yield* askEffect({
+        sessionID: SessionID.make("ses_invalid"),
+        // Cast: bypassing the public type to simulate an upstream caller
+        // (or a future schema divergence) that lets a missing required
+        // field reach the decode boundary.
+        questions: [
+          {
+            header: "Pick mode",
+            options: [
+              { label: "A", description: "x" },
+              { label: "B", description: "y" },
+            ],
+          } as unknown as Question.Info,
+        ],
+      }).pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const message = exit.cause.toString()
+        // Friendly preamble the AI SDK feeds back to the model so it can retry.
+        expect(message).toContain("invalid arguments")
+        expect(message).toContain("Please rewrite the input")
+        // The exact JSON path pinpointing the missing field, so the model
+        // knows which question and which field to fix.
+        expect(message).toContain(`["questions"][0]["question"]`)
+      }
+    }),
+  { git: true },
+)
+
 it.live("pending question rejects on instance reload", () =>
   Effect.gen(function* () {
     const dir = yield* tmpdirScoped({ git: true })


### PR DESCRIPTION
## Summary

When the model emits a `question` tool call with a payload that's missing a required field (eg. just `header` + `options` with no `question`), the inner `Schema.decodeUnknownSync` at `question/index.ts:149` throws uncaught and the whole assistant turn dies.

This switches the inner decode to the Effect-returning form and maps any failure to the same "rewrite the input" error shape that the wrap-level decode already uses at `tool/tool.ts:90`. The defect still propagates, but with an actionable message the AI SDK feeds back to the model as a tool-call error, so the session continues and the model can self-correct on the next turn.

Same pattern as the existing tool-arg validation path. Verified end-to-end earlier with the `edit` tool: an invalid payload produces

```
Error: The edit tool was called with invalid arguments: SchemaError(Missing key
  at ["oldString"]).
Please rewrite the input so it satisfies the expected schema.
```

and the model recovers.

Closes #28438. Supersedes #28452 (which relaxed the schema rather than hardening the decode boundary; thanks @21pounder for surfacing the issue).

## Test plan

- [x] New regression test in `test/question/question.test.ts` simulating an invalid payload reaching `Question.ask`. Confirms the failure carries the friendly text and the underlying schema detail, not an uncaught throw.
- [x] All 15 `test/question/question.test.ts` tests pass.
- [x] All 2 `test/tool/question.test.ts` tests pass.
- [x] `bun run typecheck` clean.