### PR TITLE
refactor(permission): drop redundant inner decode in Permission.ask

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -29,7 +29,11 @@ export type Rule = Schema.Schema.Type<typeof Rule>
 export const Ruleset = Schema.Array(Rule).annotate({ identifier: "PermissionRuleset" })
 export type Ruleset = Schema.Schema.Type<typeof Ruleset>
 
-export class Request extends Schema.Class<Request>("PermissionRequest")({
+// Pure data; nothing checks class identity. As `Schema.Struct` + type alias,
+// `Permission.ask` can trust its already-typed input and skip the inner
+// `decodeUnknownSync` that would otherwise throw uncaught on any structural
+// mismatch. Same pattern as `Question.Request` in PR #28570.
+export const Request = Schema.Struct({
   id: PermissionID,
   sessionID: SessionID,
   permission: Schema.String,
@@ -42,7 +46,8 @@ export class Request extends Schema.Class<Request>("PermissionRequest")({
       callID: Schema.String,
     }),
   ),
-}) {}
+}).annotate({ identifier: "PermissionRequest" })
+export type Request = Schema.Schema.Type<typeof Request>
 
 export const Reply = Schema.Literals(["once", "always", "reject"])
 export type Reply = Schema.Schema.Type<typeof Reply>
@@ -55,10 +60,11 @@ const reply = {
 export const ReplyBody = Schema.Struct(reply).annotate({ identifier: "PermissionReplyBody" })
 export type ReplyBody = Schema.Schema.Type<typeof ReplyBody>
 
-export class Approval extends Schema.Class<Approval>("PermissionApproval")({
+export const Approval = Schema.Struct({
   projectID: ProjectID,
   patterns: Schema.Array(Schema.String),
-}) {}
+}).annotate({ identifier: "PermissionApproval" })
+export type Approval = Schema.Schema.Type<typeof Approval>
 
 export const Event = {
   Asked: BusEvent.define("permission.asked", Request),
@@ -178,10 +184,15 @@ export const layer = Layer.effect(
       if (!needsAsk) return
 
       const id = request.id ?? PermissionID.ascending()
-      const info = Schema.decodeUnknownSync(Request)({
+      const info: Request = {
         id,
-        ...request,
-      })
+        sessionID: request.sessionID,
+        permission: request.permission,
+        patterns: request.patterns,
+        metadata: request.metadata,
+        always: request.always,
+        tool: request.tool,
+      }
       log.info("asking", { id, permission: info.permission, patterns: info.patterns })
 
       const deferred = yield* Deferred.make<void, RejectedError | CorrectedError>()


### PR DESCRIPTION
## Summary

Follow-up to #28570 applying the same architectural cleanup to Permission. The inner \`Schema.decodeUnknownSync(Request)\` in \`Permission.ask\` was the exact same anti-pattern as the original Question bug (#28438): re-decoding already-typed input via a synchronous throwing decoder. For any structural mismatch that slipped past the wrap-level validation, it would throw uncaught and crash the assistant turn.

This converts \`Permission.Request\` and \`Permission.Approval\` from \`Schema.Class\` to \`Schema.Struct\` + type alias, so \`Permission.ask\` can trust its already-typed \`AskInput\` and construct the request value directly. No re-decode, no friendly-error shim, no defect path — type-violating callers become loud developer bugs at the call site, which is the right failure mode.

Permission is called from the doom-loop check in the processor (\`session/processor.ts\`) and from the task tool's ask context (\`session/prompt.ts\`), so this hits a hot path. The risk profile mirrors #28570:

- Class identity: verified nothing uses \`instanceof Permission.{Request,Approval}\` anywhere.
- Construction: no \`new Permission.Request({...})\` or \`new Permission.Approval({...})\` calls in src or test.
- Errors stay \`Schema.TaggedErrorClass\` (\`RejectedError\`, \`CorrectedError\`, \`DeniedError\`) since they must be throwable.

## Test plan

- [x] Full opencode test suite: **2817 pass / 0 fail** across 253 files
- [x] \`bun run typecheck\` clean
- [x] \`./packages/sdk/js/script/build.ts\` produces **zero diff** (identifier annotations preserve the OpenAPI shape)