### PR TITLE
fix(ui): preserve target attribute in DOMPurify config for markdown links

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -34,7 +34,7 @@ const config = {
   FORBID_TAGS: ["style"],
   FORBID_CONTENTS: ["style", "script"],
   ADD_TAGS: ["svg", "path"],
-  ADD_ATTR: ["d", "viewBox", "preserveAspectRatio", "xmlns"],
+  ADD_ATTR: ["d", "viewBox", "preserveAspectRatio", "xmlns", "target"],
 }
 
 const iconPaths = {


### PR DESCRIPTION
### Issue for this PR

Closes #28587

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

DOMPurify 3.x does not include `target` in its default HTML attribute allowlist. The `marked` renderer correctly outputs `target="_blank" rel="noopener noreferrer"` on external links, but DOMPurify strips `target` during sanitization.

The existing `afterSanitizeAttributes` hook (lines 19-28) is designed to enforce `rel="noopener noreferrer"` on `target="_blank"` links, but it never fires because `target` is already gone by the time the hook runs.

The fix adds `"target"` to the `ADD_ATTR` config array so DOMPurify preserves it. The hook then correctly enforces the security policy.

### How did you verify your code works?

1. Verified DOMPurify 3.3.1 source: `target` is not in the default HTML attribute list (`node_modules/.bun/dompurify@3.3.1/node_modules/dompurify/dist/purify.cjs.js` line 202)
2. Confirmed the `afterSanitizeAttributes` hook depends on `target` surviving sanitization
3. `rel` is already in DOMPurify's default allowlist, so no change needed there

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.