### PR TITLE
fix(opencode): map .v files to coq

### DIFF
--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -1,4 +1,5 @@
 export const LANGUAGE_EXTENSIONS: Record<string, string> = {
+  ".v": "coq",
   ".abap": "abap",
   ".bat": "bat",
   ".bib": "bibtex",


### PR DESCRIPTION
## Summary

Map `.v` files to the `coq` language id for LSP clients.

This fixes `rocq-lsp` / `coq-lsp` setups where OpenCode was opening `.v` files as `plaintext`, which causes document conversion failures like `unknown format: plaintext`.

## Verification

- `bun typecheck` in `packages/opencode`
- repo pre-push hook also ran `bun turbo typecheck` successfully during push