### PR TITLE
feat(opencode): add /goal plugin for autonomous task completion

### DIFF
--- a/packages/opencode/src/plugin/goal/goal.ts
+++ b/packages/opencode/src/plugin/goal/goal.ts
@@ -1,0 +1,270 @@
+import type { Hooks, Plugin, PluginInput } from "@opencode-ai/plugin"
+import { tool, type ToolContext } from "@opencode-ai/plugin"
+import fs from "node:fs"
+import path from "node:path"
+import crypto from "node:crypto"
+import z from "zod"
+
+type GoalStatus = "active" | "paused" | "blocked" | "usage_limited" | "complete"
+
+interface Goal {
+  threadID: string
+  goalID: string
+  objective: string
+  status: GoalStatus
+  timeUsedSeconds: number
+  iterationCount: number
+  timeCreated: number
+  timeUpdated: number
+}
+
+// ── Single-file storage ──
+
+function storagePath(directory: string): string {
+  return path.join(directory, ".opencode", "goals.json")
+}
+
+function readAllGoals(directory: string): Record<string, Goal> {
+  const p = storagePath(directory)
+  if (!fs.existsSync(p)) return {}
+  try { return JSON.parse(fs.readFileSync(p, "utf-8")) } catch { return {} }
+}
+
+function writeAllGoals(directory: string, goals: Record<string, Goal>): void {
+  const dir = path.dirname(storagePath(directory))
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  const tmp = storagePath(directory) + ".tmp"
+  fs.writeFileSync(tmp, JSON.stringify(goals, null, 2))
+  fs.renameSync(tmp, storagePath(directory))
+}
+
+function readGoal(directory: string, threadID: string): Goal | undefined {
+  return readAllGoals(directory)[threadID]
+}
+
+function writeGoal(directory: string, goal: Goal): void {
+  const goals = readAllGoals(directory)
+  goals[goal.threadID] = goal
+  writeAllGoals(directory, goals)
+}
+
+function deleteGoal(directory: string, threadID: string): void {
+  const goals = readAllGoals(directory)
+  delete goals[threadID]
+  writeAllGoals(directory, goals)
+}
+
+// ── Continuation logic (no token budget — simple and honest) ──
+
+function isGoalContinueNeeded(g: Goal): boolean {
+  return g.status === "active"
+}
+
+function continuationPrompt(g: Goal): string {
+  return [
+    "<system-reminder>",
+    "Continue working toward your goal. Do not acknowledge this reminder.",
+    "",
+    `<objective>${g.objective}</objective>`,
+    "",
+    `Status: ${g.status}`,
+    `Time used: ${fmtDuration(g.timeUsedSeconds)}`,
+    `Iterations: ${g.iterationCount}`,
+    "",
+    "Before deciding the goal is achieved, verify every requirement.",
+    'Update the goal to "complete" only when you are certain.',
+    "</system-reminder>",
+  ].join("\n")
+}
+
+function fmtDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  return `${h}h ${m}m`
+}
+
+// ── Promise timeout helper ──
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timeout")), ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+// ── Plugin ──
+
+export const GoalPlugin: Plugin = async (input: PluginInput): Promise<Hooks> => {
+  const { client, directory } = input
+
+  const inFlight = new Set<string>()
+  const lastIdle = new Map<string, number>()
+
+  return {
+    event: async ({ event }) => {
+      if (event.type !== "session.status") return
+      if (event.properties.status.type !== "idle") return
+
+      const sessionID = (event.properties as any).sessionID as string | undefined
+      if (!sessionID) return
+
+      const goal = readGoal(directory, sessionID)
+      if (!goal || !isGoalContinueNeeded(goal)) return
+
+      // Prevent duplicate continuation
+      if (inFlight.has(sessionID)) return
+      inFlight.add(sessionID)
+
+      try {
+        const now = Date.now()
+        const prev = lastIdle.get(sessionID)
+        if (prev) goal.timeUsedSeconds += Math.round((now - prev) / 1000)
+        lastIdle.set(sessionID, now)
+        goal.iterationCount++
+        goal.timeUpdated = now
+        writeGoal(directory, goal)
+
+        // Use promptAsync to avoid blocking other sessions' event handlers
+        await withTimeout(
+          (client as any).promptAsync?.({
+            path: { id: sessionID },
+            body: { parts: [{ type: "text", text: continuationPrompt(goal) }] },
+          }) ?? (client as any).prompt({
+            path: { id: sessionID },
+            body: { parts: [{ type: "text", text: continuationPrompt(goal) }] },
+          }),
+          30_000,
+        )
+      } catch {
+        // Ignore errors
+      } finally {
+        inFlight.delete(sessionID)
+      }
+    },
+
+    tool: {
+      create_goal: tool({
+        description:
+          "Set a goal for the current session. The session will work autonomously across multiple turns to achieve it.",
+        args: {
+          objective: z.string().describe("The goal to achieve in this session"),
+        },
+        execute: async (args, ctx: ToolContext) => {
+          const now = Date.now()
+          const dir = ctx.directory || directory
+          const existing = readGoal(dir, ctx.sessionID)
+          if (existing) {
+            existing.objective = args.objective
+            existing.status = "active"
+            existing.timeUsedSeconds = 0
+            existing.iterationCount = 0
+            existing.timeUpdated = now
+            writeGoal(dir, existing)
+            return { title: `Goal set: ${args.objective}`, output: `Goal has been set: ${args.objective}` }
+          }
+          const goal: Goal = {
+            threadID: ctx.sessionID,
+            goalID: crypto.randomUUID(),
+            objective: args.objective,
+            status: "active",
+            timeUsedSeconds: 0,
+            iterationCount: 0,
+            timeCreated: now,
+            timeUpdated: now,
+          }
+          writeGoal(dir, goal)
+          return { title: `Goal set: ${args.objective}`, output: `Goal has been set: ${args.objective}` }
+        },
+      }),
+
+      update_goal: tool({
+        description:
+          'Update the status of the current active goal. Use "complete" only after verifying every requirement. Use "blocked" if the same blocking condition repeats for 3 consecutive turns.',
+        args: {
+          status: z
+            .union([z.literal("complete"), z.literal("blocked")])
+            .describe("New status: complete (goal achieved), blocked (cannot proceed)"),
+        },
+        execute: async (args, ctx: ToolContext) => {
+          const dir = ctx.directory || directory
+          const goal = readGoal(dir, ctx.sessionID)
+          if (!goal) return { title: "No active goal", output: "No active goal found for this session." }
+          goal.status = args.status
+          goal.timeUpdated = Date.now()
+          writeGoal(dir, goal)
+          return { title: `Goal status: ${args.status}`, output: `Goal status updated to: ${args.status}` }
+        },
+      }),
+
+      get_goal: tool({
+        description: "Get the current goal for this session, or null if none is set.",
+        args: {},
+        execute: async (_args, ctx: ToolContext) => {
+          const goal = readGoal(ctx.directory || directory, ctx.sessionID)
+          if (!goal) return { title: "No goal", output: "No active goal for this session." }
+          return {
+            title: `Goal: ${goal.objective}`,
+            output: [
+              `Objective: ${goal.objective}`,
+              `Status: ${goal.status}`,
+              `Iterations: ${goal.iterationCount}`,
+              `Time used: ${fmtDuration(goal.timeUsedSeconds)}`,
+            ].join("\n"),
+          }
+        },
+      }),
+    },
+
+    "command.execute.before": async (cmd, output) => {
+      if (cmd.command !== "goal") return
+      const trimmed = cmd.arguments.trim()
+
+      if (trimmed === "pause" || trimmed === "resume" || trimmed === "clear") {
+        const goal = readGoal(directory, cmd.sessionID)
+
+        if (trimmed === "pause") {
+          if (goal) {
+            goal.status = "paused"
+            goal.timeUpdated = Date.now()
+            writeGoal(directory, goal)
+            output.parts = [{ type: "text", text: `Goal paused: ${goal.objective}` }] as any
+          } else {
+            output.parts = [{ type: "text", text: "No active goal to pause." }] as any
+          }
+          return
+        }
+
+        if (trimmed === "resume") {
+          if (goal) {
+            goal.status = "active"
+            goal.timeUpdated = Date.now()
+            writeGoal(directory, goal)
+            output.parts = [{ type: "text", text: `Goal resumed: ${goal.objective}` }] as any
+          } else {
+            output.parts = [{ type: "text", text: "No paused goal to resume." }] as any
+          }
+          return
+        }
+
+        if (trimmed === "clear") {
+          if (goal) deleteGoal(directory, cmd.sessionID)
+          output.parts = [{ type: "text", text: "Goal cleared." }] as any
+          return
+        }
+      }
+
+      // Default: inject goal template
+      output.parts = [
+        {
+          type: "text",
+          text: `I want you to achieve this goal: ${trimmed}\n\nYou have get_goal, create_goal and update_goal tools available. Work autonomously across multiple turns.\n\nIf a goal is already set for this session, use get_goal to check it and continue working.`,
+        },
+      ] as any
+    },
+  }
+}
+
+export default GoalPlugin

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -20,6 +20,7 @@ import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cl
 import { AzureAuthPlugin } from "./azure"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
 import { XaiAuthPlugin } from "./xai"
+import { GoalPlugin } from "./goal/goal"
 import { Effect, Layer, Context, Stream } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
@@ -78,6 +79,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     AzureAuthPlugin,
     DigitalOceanAuthPlugin,
     XaiAuthPlugin,
+    GoalPlugin,
   ]
 }
 

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -15,6 +15,7 @@ import { Glob } from "@opencode-ai/core/util/glob"
 import * as Log from "@opencode-ai/core/util/log"
 import { Discovery } from "./discovery"
 import CUSTOMIZE_OPENCODE_SKILL_BODY from "./prompt/customize-opencode.md" with { type: "text" }
+import GOAL_SKILL_BODY from "./prompt/goal.md" with { type: "text" }
 import { isRecord } from "@/util/record"
 
 const log = Log.create({ service: "skill" })
@@ -32,6 +33,10 @@ const SKILL_PATTERN = "**/SKILL.md"
 const CUSTOMIZE_OPENCODE_SKILL_NAME = "customize-opencode"
 const CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION =
   "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself."
+
+const GOAL_SKILL_NAME = "goal"
+const GOAL_SKILL_DESCRIPTION =
+  "Set a goal with create_goal — main conversation manages state, subagents only for parallel data fetches."
 
 export const Info = Schema.Struct({
   name: Schema.String,
@@ -276,6 +281,12 @@ export const layer = Layer.effect(
           description: CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION,
           location: "<built-in>",
           content: CUSTOMIZE_OPENCODE_SKILL_BODY,
+        }
+        s.skills[GOAL_SKILL_NAME] = {
+          name: GOAL_SKILL_NAME,
+          description: GOAL_SKILL_DESCRIPTION,
+          location: "<built-in>",
+          content: GOAL_SKILL_BODY,
         }
         yield* loadSkills(s, yield* InstanceState.get(discovered), bus)
         return s

--- a/packages/opencode/src/skill/prompt/goal.md
+++ b/packages/opencode/src/skill/prompt/goal.md
@@ -1,0 +1,94 @@
+<!--
+  Built-in skill. Name and description are registered in code at
+  packages/opencode/src/skill/index.ts (see GOAL_SKILL_NAME
+  and GOAL_SKILL_DESCRIPTION). The body below becomes the
+  skill's content.
+-->
+
+**CRITICAL: create_goal / update_goal / get_goal must be called in the main conversation. Subagents (task) write to their own session — goal state is invisible to them. Never delegate goal state management to a subagent.**
+
+---
+
+# Goal — State-Tracked Iteration
+
+## Architecture Rule
+
+```
+┌─────────────────────────────────────────────────┐
+│  Main Conversation (owns goal state)            │
+│  - create_goal() / update_goal() / get_goal()   │
+│  - Decide next step                             │
+│  - Aggregate results, judge completion           │
+│  - CAN launch task() for data gathering          │
+├─────────────────────────────────────────────────┤
+│  Subagent (task) — stateless worker             │
+│  - Search, scrape, fetch data in parallel        │
+│  - Return raw results to main conversation       │
+│  - MUST NOT call create_goal / update_goal       │
+└─────────────────────────────────────────────────┘
+```
+
+## Tools
+
+| Tool | Where | Purpose |
+|------|-------|---------|
+| create_goal(objective) | Main only | Set the goal at start |
+| get_goal() | Main only | Check state before each step |
+| update_goal(status) | Main only | Mark complete / blocked |
+| task(...) | Main only | Parallel data gathering (not state mgmt) |
+
+## Workflow
+
+### Iteration-based tasks (compile -> fix -> compile)
+
+AI does everything directly, no subagents needed:
+
+```
+create_goal("Fix all TypeScript errors")
+-> run typecheck -> see 5 errors
+-> fix error 1 -> fix error 2 -> ...
+-> run typecheck -> 0 errors
+-> update_goal("complete")
+```
+
+### Data-gathering tasks (search 50 sources)
+
+Main conversation manages state, subagents do parallel searches:
+
+```
+Step 1: create_goal("Collect E260 prices from 50 sources")
+
+Step 2: Launch parallel tasks
+  task("Search E260 price on site A, B, C")
+  task("Search E260 price on site D, E, F")
+  // ... more parallel tasks
+
+Step 3: Collect results, merge, deduplicate
+  -> Main conversation aggregates all task outputs
+
+Step 4: Judge completion
+  -> 50 sources covered? -> update_goal("complete")
+  -> Not enough? -> launch more tasks, repeat from Step 2
+```
+
+### Mixed pattern (common)
+
+Main conversation does the thinking/summarizing; tasks only fetch raw data.
+
+## Completion Criteria
+
+Clear criteria make auto-evaluation possible:
+
+| Type | Example |
+|------|---------|
+| Tests passing | All tests passing |
+| Code change | Complete form validation on registration page |
+| Bug fix | Fix all TypeScript type errors |
+| File operations | Migrate 5 files from src/old/ to src/new/ |
+
+## Notes
+
+- Cross-turn: call get_goal() at the start of the next conversation to check and continue
+- Cancel anytime with /goal clear
+- If blocked, call update_goal(status: "blocked") with an explanation
+- Subagents CANNOT see or modify goal state — their session ID differs from the main conversation

--- a/packages/opencode/test/plugin/goal.integration.test.ts
+++ b/packages/opencode/test/plugin/goal.integration.test.ts
@@ -1,0 +1,294 @@
+import { afterAll, expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import os from "node:os"
+import crypto from "node:crypto"
+
+// Import the actual plugin
+import { GoalPlugin } from "../../src/plugin/goal/goal"
+
+// ── Test setup ──
+
+let tmpDir: string
+
+function setup() {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "goal-int-"))
+}
+
+function teardown() {
+  if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true })
+}
+
+function readGoalsFile(): Record<string, any> {
+  const p = path.join(tmpDir, ".opencode", "goals.json")
+  try { return JSON.parse(fs.readFileSync(p, "utf-8")) } catch { return {} }
+}
+
+function createMockClient() {
+  const calls: Array<{ method: string; args: any }> = []
+  return {
+    calls,
+    client: {
+      promptAsync: async (opts: any) => {
+        calls.push({ method: "promptAsync", args: opts })
+      },
+      prompt: async (opts: any) => {
+        calls.push({ method: "prompt", args: opts })
+      },
+      messages: async () => ({ data: [] }),
+    },
+  }
+}
+
+// Helper: ToolResult is string | object, narrow to object for assertions
+function r<T>(result: T): T & Record<string, any> {
+  return result as any
+}
+
+// ── Integration tests ──
+
+setup()
+
+test("plugin returns hooks with all expected keys", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  expect(hooks).toHaveProperty("event")
+  expect(hooks).toHaveProperty("tool")
+  expect(hooks["command.execute.before"]).toBeDefined()
+  expect(hooks.tool).toHaveProperty("create_goal")
+  expect(hooks.tool).toHaveProperty("update_goal")
+  expect(hooks.tool).toHaveProperty("get_goal")
+})
+
+test("create_goal tool writes to goals.json", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const result = await hooks.tool!.create_goal.execute({ objective: "fix the login" }, {
+    sessionID: "s1",
+    messageID: "m1",
+    agent: "build",
+    directory: tmpDir,
+    worktree: tmpDir,
+    abort: new AbortController().signal,
+    metadata: () => {},
+    ask: async () => {},
+  })
+
+  expect(r(result).title).toContain("fix the login")
+  const goals = readGoalsFile()
+  expect(goals["s1"].objective).toBe("fix the login")
+  expect(goals["s1"].status).toBe("active")
+  expect(goals["s1"].goalID).toBeTruthy()
+  expect(goals["s1"].iterationCount).toBe(0)
+})
+
+test("create_goal idempotent on same objective", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const ctx = { sessionID: "s2", messageID: "m2", agent: "build", directory: tmpDir, worktree: tmpDir, abort: new AbortController().signal, metadata: () => {}, ask: async () => {} }
+
+  await hooks.tool!.create_goal.execute({ objective: "same task" }, ctx)
+  await hooks.tool!.create_goal.execute({ objective: "same task" }, ctx)
+
+  const goals = readGoalsFile()
+  expect(Object.keys(goals)).toHaveLength(2) // s1 from previous + s2
+  expect(goals["s2"].iterationCount).toBe(0) // reset
+})
+
+test("get_goal returns info for active goal", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  // Pre-populate via create
+  await hooks.tool!.create_goal.execute({ objective: "refactor" }, {
+    sessionID: "s3", messageID: "m3", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+
+  const result = await hooks.tool!.get_goal.execute({}, {
+    sessionID: "s3", messageID: "m4", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+  expect(r(result).title).toContain("refactor")
+  expect(r(result).output).toContain("Status: active")
+})
+
+test("get_goal returns no-goal for unknown session", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const result = await hooks.tool!.get_goal.execute({}, {
+    sessionID: "nonexistent", messageID: "mx", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+  expect(r(result).title).toBe("No goal")
+})
+
+test("update_goal changes status to complete", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  await hooks.tool!.create_goal.execute({ objective: "done task" }, {
+    sessionID: "s4", messageID: "m4", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+
+  const result = await hooks.tool!.update_goal.execute({ status: "complete" }, {
+    sessionID: "s4", messageID: "m5", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+  expect(r(result).title).toBe("Goal status: complete")
+  expect(readGoalsFile()["s4"].status).toBe("complete")
+})
+
+test("update_goal on non-existent goal returns no active", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const result = await hooks.tool!.update_goal.execute({ status: "blocked" }, {
+    sessionID: "nx", messageID: "mx", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+  expect(r(result).title).toBe("No active goal")
+})
+
+test("command.execute.before handles /goal pause", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  // Pre-populate goal
+  await hooks.tool!.create_goal.execute({ objective: "pausable" }, {
+    sessionID: "s5", messageID: "m5", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+
+  const output: any = { parts: [] }
+  await hooks["command.execute.before"]!(
+    { command: "goal", sessionID: "s5", arguments: "pause" } as any,
+    output,
+  )
+  expect(output.parts[0].text).toContain("Goal paused")
+  expect(readGoalsFile()["s5"].status).toBe("paused")
+})
+
+test("command.execute.before handles /goal resume", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  // s5 is paused from previous test
+  const output: any = { parts: [] }
+  await hooks["command.execute.before"]!(
+    { command: "goal", sessionID: "s5", arguments: "resume" } as any,
+    output,
+  )
+  expect(output.parts[0].text).toContain("Goal resumed")
+  expect(readGoalsFile()["s5"].status).toBe("active")
+})
+
+test("command.execute.before handles /goal clear", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  await hooks.tool!.create_goal.execute({ objective: "temporary" }, {
+    sessionID: "s6", messageID: "m6", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+
+  const output: any = { parts: [] }
+  await hooks["command.execute.before"]!(
+    { command: "goal", sessionID: "s6", arguments: "clear" } as any,
+    output,
+  )
+  expect(output.parts[0].text).toBe("Goal cleared.")
+  expect(readGoalsFile()).not.toHaveProperty("s6")
+})
+
+test("command.execute.before handles /goal with template", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const output: any = { parts: [] }
+  await hooks["command.execute.before"]!(
+    { command: "goal", sessionID: "s7", arguments: "fix the login button" } as any,
+    output,
+  )
+  expect(output.parts[0].type).toBe("text")
+  expect(output.parts[0].text).toContain("fix the login button")
+  expect(output.parts[0].text).toContain("get_goal")
+})
+
+test("command.execute.before ignores non-goal commands", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const output: any = { parts: [{ type: "text", text: "original" }] }
+  await hooks["command.execute.before"]!(
+    { command: "review", sessionID: "s8", arguments: "HEAD" } as any,
+    output,
+  )
+  expect(output.parts[0].text).toBe("original") // unchanged
+})
+
+test("event hook triggers continuation for active goal", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  // Pre-populate goal
+  await hooks.tool!.create_goal.execute({ objective: "auto task" }, {
+    sessionID: "s9", messageID: "m9", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+
+  // Simulate idle event
+  await hooks.event!({
+    event: {
+      type: "session.status",
+      properties: { status: { type: "idle" }, sessionID: "s9" },
+    },
+  } as any)
+
+  // Should have called promptAsync
+  expect(mock.calls.length).toBeGreaterThanOrEqual(1)
+  expect(mock.calls[0].method).toMatch(/prompt/)
+  expect(mock.calls[0].args.path.id).toBe("s9")
+
+  // Check iteration count incremented
+  expect(readGoalsFile()["s9"].iterationCount).toBeGreaterThanOrEqual(1)
+})
+
+test("event hook skips when goal is complete", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  await hooks.tool!.create_goal.execute({ objective: "done" }, {
+    sessionID: "s10", messageID: "m10", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+  await hooks.tool!.update_goal.execute({ status: "complete" }, {
+    sessionID: "s10", messageID: "m11", agent: "build", directory: tmpDir, worktree: tmpDir,
+    abort: new AbortController().signal, metadata: () => {}, ask: async () => {},
+  })
+
+  const before = mock.calls.length
+  await hooks.event!({
+    event: {
+      type: "session.status",
+      properties: { status: { type: "idle" }, sessionID: "s10" },
+    },
+  } as any)
+  expect(mock.calls.length).toBe(before) // No new calls
+})
+
+test("event hook skips non-idle status", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const before = mock.calls.length
+  await hooks.event!({
+    event: {
+      type: "session.status",
+      properties: { status: { type: "busy" }, sessionID: "s9" },
+    },
+  } as any)
+  expect(mock.calls.length).toBe(before)
+})
+
+test("event hook skips non-status events", async () => {
+  const mock = createMockClient()
+  const hooks = await GoalPlugin({ client: mock.client as any, directory: tmpDir } as any)
+  const before = mock.calls.length
+  await hooks.event!({
+    event: { type: "session.error", properties: { error: "test" } },
+  } as any)
+  expect(mock.calls.length).toBe(before)
+})
+
+afterAll(teardown)

--- a/packages/opencode/test/plugin/goal.test.ts
+++ b/packages/opencode/test/plugin/goal.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, expect, test } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import os from "node:os"
+import crypto from "node:crypto"
+
+// ── Replicated types and logic from the plugin (same as goal.ts) ──
+
+type GoalStatus = "active" | "paused" | "blocked" | "usage_limited" | "complete"
+
+interface Goal {
+  threadID: string
+  goalID: string
+  objective: string
+  status: GoalStatus
+  timeUsedSeconds: number
+  iterationCount: number
+  timeCreated: number
+  timeUpdated: number
+}
+
+function storagePath(base: string): string {
+  return path.join(base, "goals.json")
+}
+
+function readAllGoals(base: string): Record<string, Goal> {
+  const p = storagePath(base)
+  try { return JSON.parse(fs.readFileSync(p, "utf-8")) } catch { return {} }
+}
+
+function writeAllGoals(base: string, goals: Record<string, Goal>): void {
+  const tmp = storagePath(base) + ".tmp"
+  fs.writeFileSync(tmp, JSON.stringify(goals, null, 2))
+  fs.renameSync(tmp, storagePath(base))
+}
+
+function readGoal(base: string, id: string): Goal | undefined {
+  return readAllGoals(base)[id]
+}
+
+function writeGoal(base: string, goal: Goal): void {
+  const goals = readAllGoals(base)
+  goals[goal.threadID] = goal
+  writeAllGoals(base, goals)
+}
+
+function deleteGoal(base: string, id: string): void {
+  const goals = readAllGoals(base)
+  delete goals[id]
+  writeAllGoals(base, goals)
+}
+
+function isGoalContinueNeeded(g: Goal): boolean {
+  return g.status === "active"
+}
+
+function continuationPrompt(g: Goal): string {
+  return [
+    "<system-reminder>",
+    "Continue working toward your goal. Do not acknowledge this reminder.",
+    "",
+    `<objective>${g.objective}</objective>`,
+    "",
+    `Status: ${g.status}`,
+    `Time used: ${fmtDuration(g.timeUsedSeconds)}`,
+    `Iterations: ${g.iterationCount}`,
+    "",
+    "Before deciding the goal is achieved, verify every requirement.",
+    'Update the goal to "complete" only when you are certain.',
+    "</system-reminder>",
+  ].join("\n")
+}
+
+function fmtDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  return `${h}h ${m}m`
+}
+
+// ── Test setup ──
+
+let tmpDir: string
+
+function setup() {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "goal-test-"))
+}
+
+function teardown() {
+  if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true })
+}
+
+function resetStorage() {
+  writeAllGoals(tmpDir, {})
+}
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    threadID: "s1",
+    goalID: crypto.randomUUID(),
+    objective: "fix the bug",
+    status: "active",
+    timeUsedSeconds: 0,
+    iterationCount: 0,
+    timeCreated: Date.now(),
+    timeUpdated: Date.now(),
+    ...overrides,
+  }
+}
+
+setup()
+resetStorage()
+
+// ── Storage tests ──
+
+test("writeGoal creates goals.json with single entry", () => {
+  resetStorage()
+  writeGoal(tmpDir, makeGoal())
+  const all = readAllGoals(tmpDir)
+  expect(all).toHaveProperty("s1")
+  expect(all["s1"].objective).toBe("fix the bug")
+})
+
+test("writeGoal persists goalID and all fields", () => {
+  resetStorage()
+  writeGoal(tmpDir, makeGoal({ goalID: "u-123", iterationCount: 3, timeUsedSeconds: 60 }))
+  const r = readGoal(tmpDir, "s1")!
+  expect(r.goalID).toBe("u-123")
+  expect(r.status).toBe("active")
+  expect(r.iterationCount).toBe(3)
+  expect(r.timeUsedSeconds).toBe(60)
+})
+
+test("writeGoal updates existing goal", () => {
+  resetStorage()
+  writeGoal(tmpDir, makeGoal({ objective: "first" }))
+  writeGoal(tmpDir, makeGoal({ objective: "second", iterationCount: 5 }))
+  const r = readGoal(tmpDir, "s1")!
+  expect(r.objective).toBe("second")
+  expect(r.iterationCount).toBe(5)
+})
+
+test("writeGoal handles multiple sessions", () => {
+  resetStorage()
+  writeGoal(tmpDir, makeGoal({ threadID: "a", objective: "task-a" }))
+  writeGoal(tmpDir, makeGoal({ threadID: "b", objective: "task-b" }))
+  const all = readAllGoals(tmpDir)
+  expect(Object.keys(all)).toHaveLength(2)
+})
+
+test("deleteGoal removes entry", () => {
+  resetStorage()
+  writeGoal(tmpDir, makeGoal({ threadID: "a" }))
+  writeGoal(tmpDir, makeGoal({ threadID: "b" }))
+  deleteGoal(tmpDir, "a")
+  const all = readAllGoals(tmpDir)
+  expect(all).not.toHaveProperty("a")
+  expect(all).toHaveProperty("b")
+})
+
+test("readGoal returns undefined for missing", () => {
+  resetStorage()
+  expect(readGoal(tmpDir, "nonexistent")).toBeUndefined()
+})
+
+test("atomic write via tmp file", () => {
+  resetStorage()
+  writeGoal(tmpDir, makeGoal())
+  expect(fs.existsSync(storagePath(tmpDir))).toBe(true)
+  expect(fs.existsSync(storagePath(tmpDir) + ".tmp")).toBe(false)
+})
+
+// ── isGoalContinueNeeded tests ──
+
+test("isGoalContinueNeeded true for active", () => {
+  expect(isGoalContinueNeeded(makeGoal({ status: "active" }))).toBe(true)
+})
+
+test("isGoalContinueNeeded false for complete", () => {
+  expect(isGoalContinueNeeded(makeGoal({ status: "complete" }))).toBe(false)
+})
+
+test("isGoalContinueNeeded false for paused", () => {
+  expect(isGoalContinueNeeded(makeGoal({ status: "paused" }))).toBe(false)
+})
+
+test("isGoalContinueNeeded false for blocked", () => {
+  expect(isGoalContinueNeeded(makeGoal({ status: "blocked" }))).toBe(false)
+})
+
+test("isGoalContinueNeeded false for usage_limited", () => {
+  expect(isGoalContinueNeeded(makeGoal({ status: "usage_limited" }))).toBe(false)
+})
+
+// ── continuationPrompt tests ──
+
+test("continuationPrompt wraps in system-reminder tags", () => {
+  const p = continuationPrompt(makeGoal())
+  expect(p).toContain("<system-reminder>")
+  expect(p).toContain("</system-reminder>")
+  expect(p).toContain("Do not acknowledge this reminder")
+})
+
+test("continuationPrompt includes objective and status", () => {
+  const p = continuationPrompt(makeGoal({ objective: "refactor module" }))
+  expect(p).toContain("refactor module")
+  expect(p).toContain("Status: active")
+})
+
+test("continuationPrompt includes time and iterations", () => {
+  const p = continuationPrompt(makeGoal({ timeUsedSeconds: 125, iterationCount: 3 }))
+  expect(p).toContain("2m 5s")
+  expect(p).toContain("Iterations: 3")
+})
+
+// ── fmtDuration tests ──
+
+test("fmtDuration seconds", () => {
+  expect(fmtDuration(0)).toBe("0s")
+  expect(fmtDuration(59)).toBe("59s")
+})
+
+test("fmtDuration minutes", () => {
+  expect(fmtDuration(60)).toBe("1m 0s")
+  expect(fmtDuration(3599)).toBe("59m 59s")
+})
+
+test("fmtDuration hours", () => {
+  expect(fmtDuration(3600)).toBe("1h 0m")
+  expect(fmtDuration(7200)).toBe("2h 0m")
+})
+
+// ── Cleanup ──
+
+afterAll(teardown)


### PR DESCRIPTION
## Summary

A built-in plugin that enables multi-turn autonomous goal execution via `/goal` command. Zero core changes — all business logic in the plugin, command registration via existing skill system.

- `create_goal` / `update_goal` / `get_goal` tools via `Hooks.tool`
- `/goal pause` / `resume` / `clear` via `command.execute.before`
- Idle-event continuation loop via `client.promptAsync()`
- Storage: `.opencode/goals.json` per directory (atomic write)

Closes #27167

## Testing

- `bun test test/plugin/goal.test.ts`: 18/18 pass (storage, logic, formatting)
- `bun test test/plugin/goal.integration.test.ts`: 16/16 pass (all hooks via mock PluginInput)
- `bun typecheck`: 0 errors
- No regression in existing tests
