### PR TITLE
opencode: provide channel to web build

### DIFF
--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -5,6 +5,13 @@ import { fileURLToPath } from "url"
 
 const theme = fileURLToPath(new URL("./public/oc-theme-preload.js", import.meta.url))
 
+const channel = (() => {
+  const raw = process.env.OPENCODE_CHANNEL
+  if (raw === "dev" || raw === "beta" || raw === "prod") return raw
+  if (process.env.OPENCODE_CHANNEL === "latest") return "prod"
+  return "dev"
+})()
+
 /**
  * @type {import("vite").PluginOption}
  */
@@ -17,6 +24,9 @@ export default [
           alias: {
             "@": fileURLToPath(new URL("./src", import.meta.url)),
           },
+        },
+        define: {
+          "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
         },
         worker: {
           format: "es",

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -3,13 +3,14 @@ import { defineConfig } from "electron-vite"
 import appPlugin from "@opencode-ai/app/vite"
 import * as fs from "node:fs/promises"
 
+const OPENCODE_SERVER_DIST = "../opencode/dist/node"
+
 const channel = (() => {
   const raw = process.env.OPENCODE_CHANNEL
   if (raw === "dev" || raw === "beta" || raw === "prod") return raw
+  if (process.env.OPENCODE_CHANNEL === "latest") return "prod"
   return "dev"
 })()
-
-const OPENCODE_SERVER_DIST = "../opencode/dist/node"
 
 const nodePtyPkg = `@lydell/node-pty-${process.platform}-${process.arch}`
 
@@ -82,9 +83,6 @@ export default defineConfig({
     plugins: [appPlugin, sentry],
     publicDir: "../../../app/public",
     root: "src/renderer",
-    define: {
-      "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
-    },
     build: {
       sourcemap: true,
       rollupOptions: {

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -58,7 +58,7 @@ const createEmbeddedWebUIBundle = async () => {
   console.log(`Building Web UI to embed in the binary`)
   const appDir = path.join(import.meta.dirname, "../../app")
   const dist = path.join(appDir, "dist")
-  await $`bun run --cwd ${appDir} build`
+  await $`OPENCODE_CHANNEL=${Script.channel} bun run --cwd ${appDir} build`
   const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: dist })))
     .map((file) => file.replaceAll("\\", "/"))
     .filter((file) => !file.endsWith(".map"))


### PR DESCRIPTION
Makes the cli build script pass through OPENCODE_CHANNEL (usually 'latest') to the web build, which is converted to 'prod', so that beta features don't leak through to the web build.