### PR TITLE
feat: avoid forced tool choice for structured output when unsupported

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -49,6 +49,7 @@ export const Model = Schema.Struct({
   reasoning: Schema.Boolean,
   temperature: Schema.Boolean,
   tool_call: Schema.Boolean,
+  tool_choice_required: Schema.optional(Schema.Boolean),
   interleaved: Schema.optional(
     Schema.Union([
       Schema.Literal(true),

--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -11,6 +11,7 @@ export const Model = Schema.Struct({
   reasoning: Schema.optional(Schema.Boolean),
   temperature: Schema.optional(Schema.Boolean),
   tool_call: Schema.optional(Schema.Boolean),
+  tool_choice_required: Schema.optional(Schema.Boolean),
   interleaved: Schema.optional(
     Schema.Union([
       Schema.Literal(true),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -867,6 +867,7 @@ const ProviderCapabilities = Schema.Struct({
   reasoning: Schema.Boolean,
   attachment: Schema.Boolean,
   toolcall: Schema.Boolean,
+  toolChoiceRequired: Schema.optional(Schema.Boolean),
   input: ProviderModalities,
   output: ProviderModalities,
   interleaved: ProviderInterleaved,
@@ -1068,6 +1069,7 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
       reasoning: model.reasoning ?? false,
       attachment: model.attachment ?? false,
       toolcall: model.tool_call ?? true,
+      toolChoiceRequired: model.tool_choice_required ?? true,
       input: {
         text: model.modalities?.input?.includes("text") ?? false,
         audio: model.modalities?.input?.includes("audio") ?? false,
@@ -1296,6 +1298,7 @@ export const layer = Layer.effect(
                 reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
                 attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
                 toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
+                toolChoiceRequired: model.tool_choice_required ?? existingModel?.capabilities.toolChoiceRequired ?? true,
                 input: {
                   text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
                   audio: model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1436,7 +1436,12 @@ export const layer = Layer.effect(
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
               tools,
               model,
-              toolChoice: format.type === "json_schema" ? "required" : undefined,
+              toolChoice:
+                format.type === "json_schema"
+                  ? model.capabilities.toolChoiceRequired === false
+                    ? "auto"
+                    : "required"
+                  : undefined,
             })
 
             if (structured !== undefined) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -757,6 +757,7 @@ test("model inherits properties from existing database model", async () => {
       const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
       expect(model.name).toBe("Custom Name for Sonnet")
       expect(model.capabilities.toolcall).toBe(true)
+      expect(model.capabilities.toolChoiceRequired).toBe(true)
       expect(model.capabilities.attachment).toBe(true)
       expect(model.limit.context).toBeGreaterThan(0)
     },
@@ -1372,6 +1373,44 @@ test("model defaults tool_call to true when not specified", async () => {
     fn: async (ctx) => {
       const providers = await list(ctx)
       expect(providers[ProviderID.make("default-tools")].models["model"].capabilities.toolcall).toBe(true)
+    },
+  })
+})
+
+test("model can disable required tool_choice separately from tool_call", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "tool-choice": {
+              name: "Tool Choice Provider",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                model: {
+                  name: "Model",
+                  tool_call: true,
+                  tool_choice_required: false,
+                  limit: { context: 4000, output: 1000 },
+                },
+              },
+              options: { apiKey: "test" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const providers = await list(ctx)
+      const model = providers[ProviderID.make("tool-choice")].models.model
+      expect(model.capabilities.toolcall).toBe(true)
+      expect(model.capabilities.toolChoiceRequired).toBe(false)
     },
   })
 })
@@ -2018,6 +2057,7 @@ test("models.dev normalization fills required response fields", () => {
   expect(model.capabilities.reasoning).toBe(false)
   expect(model.capabilities.attachment).toBe(false)
   expect(model.capabilities.toolcall).toBe(true)
+  expect(model.capabilities.toolChoiceRequired).toBe(true)
   expect(model.release_date).toBe("")
 })
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2048,16 +2048,32 @@ test("models.dev normalization fills required response fields", () => {
           output: 128_000,
         },
       },
+      "deepseek-reasoner": {
+        id: "deepseek-reasoner",
+        name: "DeepSeek Reasoner",
+        family: "deepseek",
+        tool_choice_required: false,
+        cost: {
+          input: 0.5,
+          output: 2,
+        },
+        limit: {
+          context: 64_000,
+          output: 8_000,
+        },
+      },
     },
   } as unknown as ModelsDev.Provider
 
   const model = Provider.fromModelsDevProvider(provider).models["gpt-5.4"]
+  const reasoner = Provider.fromModelsDevProvider(provider).models["deepseek-reasoner"]
   expect(model.api.url).toBe("")
   expect(model.capabilities.temperature).toBe(false)
   expect(model.capabilities.reasoning).toBe(false)
   expect(model.capabilities.attachment).toBe(false)
   expect(model.capabilities.toolcall).toBe(true)
   expect(model.capabilities.toolChoiceRequired).toBe(true)
+  expect(reasoner.capabilities.toolChoiceRequired).toBe(false)
   expect(model.release_date).toBe("")
 })
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -294,6 +294,30 @@ function providerCfg(url: string) {
   }
 }
 
+function toolChoiceRequiredDisabledProviderCfg(url: string) {
+  return {
+    ...providerCfg(url),
+    provider: {
+      test: {
+        ...cfg.provider.test,
+        models: {
+          ...cfg.provider.test.models,
+          "tool-choice-disabled": {
+            ...cfg.provider.test.models["test-model"],
+            id: "tool-choice-disabled",
+            name: "Tool Choice Disabled",
+            tool_choice_required: false,
+          },
+        },
+        options: {
+          ...cfg.provider.test.options,
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
 const writeText = Effect.fn("test.writeText")(function* (file: string, text: string) {
   const fs = yield* AppFileSystem.Service
   yield* fs.writeWithDirs(file, text)
@@ -479,6 +503,43 @@ it.instance("loop calls LLM and returns assistant message", () =>
     const parts = result.parts.filter((p) => p.type === "text")
     expect(parts.some((p) => p.type === "text" && p.text === "world")).toBe(true)
     expect(yield* llm.hits).toHaveLength(1)
+  }),
+)
+
+it.instance("structured output uses auto tool choice when model disables required tool choice", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(toolChoiceRequiredDisabledProviderCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "Pinned",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* llm.text("plain text")
+
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      model: { providerID: ProviderID.make("test"), modelID: ModelID.make("tool-choice-disabled") },
+      parts: [{ type: "text", text: "say hello" }],
+      format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { answer: { type: "string" } },
+          required: ["answer"],
+        },
+      },
+    })
+
+    const inputs = yield* llm.inputs
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0].tool_choice).toBe("auto")
+    expect(inputs[0].tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ function: expect.objectContaining({ name: "StructuredOutput" }) }),
+      ]),
+    )
   }),
 )
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -506,7 +506,7 @@ it.instance("loop calls LLM and returns assistant message", () =>
   }),
 )
 
-it.instance("structured output uses auto tool choice when model disables required tool choice", () =>
+it.instance("structured output uses auto tool choice and errors when the model ignores the tool", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfgWithoutRequiredToolChoice)
     const prompt = yield* SessionPrompt.Service
@@ -517,7 +517,7 @@ it.instance("structured output uses auto tool choice when model disables require
     })
     yield* llm.text("plain text")
 
-    yield* prompt.prompt({
+    const result = yield* prompt.prompt({
       sessionID: chat.id,
       agent: "build",
       model: { providerID: ProviderID.make("test"), modelID: ModelID.make("tool-choice-disabled") },
@@ -540,6 +540,11 @@ it.instance("structured output uses auto tool choice when model disables require
         expect.objectContaining({ function: expect.objectContaining({ name: "StructuredOutput" }) }),
       ]),
     )
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role === "assistant") {
+      expect(result.info.error?.name).toBe("StructuredOutputError")
+      expect(result.info.structured).toBeUndefined()
+    }
   }),
 )
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -548,6 +548,38 @@ it.instance("structured output uses auto tool choice and errors when the model i
   }),
 )
 
+it.instance("structured output uses required tool choice by default", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "Pinned",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* llm.text("plain text")
+
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+      parts: [{ type: "text", text: "say hello" }],
+      format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { answer: { type: "string" } },
+          required: ["answer"],
+        },
+      },
+    })
+
+    const inputs = yield* llm.inputs
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0].tool_choice).toBe("required")
+  }),
+)
+
 noLLMServer.instance(
   "prompt emits v2 prompted and synthetic events",
   () =>

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -294,7 +294,7 @@ function providerCfg(url: string) {
   }
 }
 
-function toolChoiceRequiredDisabledProviderCfg(url: string) {
+function providerCfgWithoutRequiredToolChoice(url: string) {
   return {
     ...providerCfg(url),
     provider: {
@@ -508,7 +508,7 @@ it.instance("loop calls LLM and returns assistant message", () =>
 
 it.instance("structured output uses auto tool choice when model disables required tool choice", () =>
   Effect.gen(function* () {
-    const { llm } = yield* useServerConfig(toolChoiceRequiredDisabledProviderCfg)
+    const { llm } = yield* useServerConfig(providerCfgWithoutRequiredToolChoice)
     const prompt = yield* SessionPrompt.Service
     const sessions = yield* Session.Service
     const chat = yield* sessions.create({

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -58320,6 +58320,7 @@
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "tool_choice_required": false,
         "interleaved": {
           "field": "reasoning_content"
         },

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1044,6 +1044,7 @@ export type ProviderConfig = {
       reasoning?: boolean
       temperature?: boolean
       tool_call?: boolean
+      tool_choice_required?: boolean
       cost?: {
         input: number
         output: number

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1049,6 +1049,7 @@ export type ProviderConfig = {
       reasoning?: boolean
       temperature?: boolean
       tool_call?: boolean
+      tool_choice_required?: boolean
       interleaved?:
         | true
         | {
@@ -1313,6 +1314,7 @@ export type Model = {
     reasoning: boolean
     attachment: boolean
     toolcall: boolean
+    toolChoiceRequired?: boolean
     input: {
       text: boolean
       audio: boolean


### PR DESCRIPTION
### Issue for this PR

None

### What does this PR do?

This fixes SDK structured response support for DeepSeek v4 reasoning models. Those models do not support forcing tool calls with `tool_choice: "required"`.

Previously, OpenCode always used forced tool calling for JSON schema output. That worked for many models, but DeepSeek reasoning models [reject this parameter](https://github.com/deepseek-ai/DeepSeek-R1/issues/836) with an error like:

`deepseek-reasoner does not support this tool_choice`

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### Open Question

Since we changed the semantics from `required` to `auto,` should we detect and return an error when a structured response wasn't generated?

**UPDATE**: We already do https://github.com/anomalyco/opencode/blob/7d5e91b8015f70588697e39f1ad7f983b1525ee4/packages/opencode/src/session/prompt.ts#L1451

Naming `tool_choice_required` might be a bit confusing, however, if you read it as "capability" like `tool_call,` it could be fine. 

### What Changed

- Added a new model capability: tool_choice_required.
- Kept tool_call separate from forced tool choice support.
- Updated structured output logic:
  - Use toolChoice: "required" when the model supports forced tool choice.
  - Use toolChoice: "auto" when tool_choice_required: false.
  - Added config support so users can override model metadata.
  - Added models.dev schema support for tool_choice_required.
  - Added SDK types for tool_choice_required.
  - Added tests proving tools are still sent while forced tool choice is avoided.

## Why
Some models have this capability shape:
```
{
  "tool_call": true,
  "tool_choice_required": false
}
```

That means:
- The model supports tools.
- The model can choose to call a tool.
- The model does not support being forced to call a tool.

Structured output uses a StructuredOutput tool. For these models, we now send the tool but use tool_choice: "auto" instead of tool_choice: "required".

## Example

This SDK script proves the fix by using DeepSeek V4 Flash Free / Pro with JSON schema output:

```ts
import { createOpencode } from "@opencode-ai/sdk"
const { client } = await createOpencode({
  port: 14096,
  config: {
    model: "opencode/deepseek-v4-flash-free",
    provider: {
      opencode: {
        models: {
          "deepseek-v4-flash-free": {
            tool_call: true,
            tool_choice_required: false, // Toggle to make it fail
          },
        },
      },
    },
  },
})
const session = await client.session.create({
  body: { title: "Test 1" },
})
const result = await client.session.prompt({
  path: { id: session.data.id },
  body: {
    parts: [{ type: "text", text: "Say hello in one sentence." }],
    format: {
      type: "json_schema",
      schema: {
        type: "object",
        properties: {
          answer: { type: "string" },
        },
        required: ["answer"],
      },
    },
  },
})
console.log(JSON.stringify(result.data, null, 2))
```


Before this fix, the request could fail because OpenCode forced:
`tool_choice: "required"`

After this fix, the request uses:
`tool_choice: "auto"`

while still sending the StructuredOutput tool.

## Before release

The models.dev metadata must be updated for affected DeepSeek reasoning models:
```json
{
  "tool_call": true,
  "tool_choice_required": false
}
```

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
