### PR TITLE
fix(cli): add newline to help output

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -59,12 +59,13 @@ const args = hideBin(process.argv)
 
 function show(out: string) {
   const text = out.trimStart()
+  const content = out.endsWith(EOL) ? out : out + EOL
   if (!text.startsWith("opencode ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text)
+    process.stderr.write(content.trimStart())
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(content)
 }
 
 const cli = yargs(args)


### PR DESCRIPTION
### Issue for this PR

Closes #28606 #24813 #26114

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode --help` does not print a new line at the end. The PR fixes the issue.

### How did you verify your code works?

Ran a locally built artifact (macOS + zsh) with `--help`, the trailing newline appeared.

### Screenshots / recordings

I am using `ghostty`, where a command output without a trailing `EOL` will be marked with `%` at the end.

<img width="75%" alt="image" src="https://github.com/user-attachments/assets/17ab8211-b275-4ed2-af5a-be2e2113bc68" />

The local build does not have a trailing `%` in its output.

<img width="75%" alt="image" src="https://github.com/user-attachments/assets/1553ccdd-4275-4881-9fce-79742332b4f2" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
