### PR TITLE
fix: CLI --help trailing newline & headless run in non-git directories

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -61,10 +61,10 @@ function show(out: string) {
   const text = out.trimStart()
   if (!text.startsWith("opencode ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text)
+    process.stderr.write(text.endsWith(EOL) ? text : text + EOL)
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(out.endsWith(EOL) ? out : out + EOL)
 }
 
 const cli = yargs(args)

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -203,8 +203,8 @@ export const layer: Layer.Layer<
         if (!dotgit) {
           return {
             id: ProjectID.global,
-            worktree: "/",
-            sandbox: "/",
+            worktree: directory,
+            sandbox: directory,
             vcs: fakeVcs,
           }
         }


### PR DESCRIPTION
## Summary

Two bug fixes:

1. **#28606** — `--help` output lacks trailing newline, causing the next shell prompt to appear on the same line. Fixed by ensuring `show()` always appends `EOL` when the output doesn't already end with one.

2. **#28605** — `opencode run` exits silently with no output in a non-git directory. Root cause: `Project.fromDirectory` returns `{worktree: "/", sandbox: "/"}` when no `.git` directory is found. This makes `containsPath()` treat all files outside `ctx.directory` as external, triggering `external_directory` permission requests that are auto-rejected in headless mode. Fixed by using `directory` (the actual working directory) instead of `"/"` as the project root boundary.

## Changes

- `packages/opencode/src/index.ts`: `show()` now ensures trailing newline via `endsWith(EOL)` check.
- `packages/opencode/src/project/project.ts`: `fromDirectory` returns `{worktree: directory, sandbox: directory}` instead of `{worktree: "/", sandbox: "/"}` when no `.git` is present.

Closes #28606, closes #28605