### PR TITLE
fix(httpapi): remove config error middleware special case

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
@@ -1,6 +1,5 @@
 import { NamedError } from "@opencode-ai/core/util/error"
 import * as Log from "@opencode-ai/core/util/log"
-import { ConfigError } from "@/config/error"
 import { Cause, Effect } from "effect"
 import { HttpRouter, HttpServerError, HttpServerRespondable, HttpServerResponse } from "effect/unstable/http"
 
@@ -19,13 +18,6 @@ export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect)
       if (!defect) return Effect.failCause(cause)
 
       const error = defect.defect
-      if (
-        error instanceof NamedError &&
-        (ConfigError.InvalidError.isInstance(error) || ConfigError.JsonError.isInstance(error))
-      ) {
-        return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 400 }))
-      }
-
       const ref = `err_${crypto.randomUUID().slice(0, 8)}`
 
       log.error("failed", { ref, error, cause: Cause.pretty(cause) })

--- a/packages/opencode/test/server/httpapi-error-middleware.test.ts
+++ b/packages/opencode/test/server/httpapi-error-middleware.test.ts
@@ -53,7 +53,7 @@ describe("HttpApi error middleware", () => {
     }),
   )
 
-  it.live("preserves config defects as client-visible bad requests", () =>
+  it.live("does not expose config defects from generic middleware", () =>
     Effect.gen(function* () {
       const configError = new ConfigError.InvalidError({
         path: "/tmp/opencode.json",
@@ -68,9 +68,13 @@ describe("HttpApi error middleware", () => {
 
       const response = yield* HttpClientRequest.get("/config-error").pipe(HttpClient.execute)
       const body = yield* response.json
+      const serialized = JSON.stringify(body)
 
-      expect(response.status).toBe(400)
-      expect(JSON.stringify(body)).toBe(JSON.stringify(configError.toObject()))
+      expect(response.status).toBe(500)
+      expectUnknownErrorBody(body)
+      expect(serialized).not.toContain("/tmp/opencode.json")
+      expect(serialized).not.toContain("provider")
+      expect(serialized).not.toContain("anthropic")
     }),
   )
 


### PR DESCRIPTION
## summary
- remove config-domain handling from generic HttpApi error middleware
- keep config defects masked as safe UnknownError responses with refs
- update middleware tests to assert config paths/details are not exposed

## testing
- bun test test/server/httpapi-error-middleware.test.ts
- bun typecheck
- bun turbo typecheck