### PR TITLE
fix(session): use server timestamps instead of IDs in runLoop exit condition

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1269,7 +1269,7 @@ export const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastUser.time.created <= lastAssistant.time.created
           ) {
             yield* slog.info("exiting loop")
             break


### PR DESCRIPTION
### Issue for this PR

Closes #28618

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The runLoop exit condition at `prompt.ts:1272` uses `lastUser.id < lastAssistant.id` to check whether the user message predates the assistant response. Message IDs encode `Date.now()` in their first 12 hex chars. When the web client sends a client-generated `messageID` (timestamped with the browser clock) and the browser is ahead of the server, the user ID sorts *after* the assistant ID — the exit check fails, the loop fires a second LLM call with a `<system-reminder>` wrap.

The fix replaces the ID comparison with `lastUser.time.created <= lastAssistant.time.created`. Both fields are set server-side via `Date.now()` when the message is created, so they are immune to client clock skew.

### How did you verify your code works?

- Traced the data flow: `User.time.created` is set at line 722 (`time: { created: Date.now() }`), always server-side regardless of whether `input.messageID` is client-provided
- `Assistant.time.created` is also set server-side
- Ran `bun test test/session/` — 39 pass, 16 fail (all pre-existing upstream failures, identical without this change)
- `bun test test/session/message-v2.test.ts` — 36/36 pass

### Screenshots / recordings

N/A — backend logic change, no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR