### PR TITLE
fix(opencode): ensure help output ends with newline

### DIFF
--- a/packages/opencode/src/control-plane/dev/README.md
+++ b/packages/opencode/src/control-plane/dev/README.md
@@ -16,4 +16,4 @@ How this works:
 
 - The workspace server needs to know the workspace id and port to run. It waits for this information to be written to a file and starts the server when the data is written.
 - The debug plugin writes this information in the `create` call to the workspace. So create a `debug` workspace will always kick off a new external server.
-- The server script watches for file changes, so whenver you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.
+- The server script watches for file changes, so whenever you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -61,10 +61,10 @@ function show(out: string) {
   const text = out.trimStart()
   if (!text.startsWith("opencode ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text)
+    process.stderr.write(text.endsWith("\n") ? text : text + EOL)
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(out.endsWith("\n") ? out : out + EOL)
 }
 
 const cli = yargs(args)

--- a/packages/opencode/test/cli/help/help-snapshots.test.ts
+++ b/packages/opencode/test/cli/help/help-snapshots.test.ts
@@ -91,6 +91,17 @@ const SUBCOMMANDS = [
 const SNAPSHOT_ENV = { COLUMNS: "120" }
 
 describe("opencode CLI help-text snapshots", () => {
+  cliIt.live(
+    "top-level help ends with a newline",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const result = yield* opencode.spawn(["--help"], { env: SNAPSHOT_ENV })
+        expect(result.exitCode).toBe(0)
+        expect(normalize(result.stderr).endsWith("\n")).toBe(true)
+      }),
+    60_000,
+  )
+
   // Single test, parallel spawns. Each command's help fires under
   // `concurrency: 8` — wall-clock stays under ~10s even for ~35 commands,
   // versus ~1 minute if we serialized.
@@ -121,7 +132,9 @@ describe("opencode CLI help-text snapshots", () => {
           // yargs writes --help to stderr, not stdout. Snapshotting stderr
           // means our test catches the help body; stdout for these commands
           // is expected to be empty.
-          expect(normalize(result.stderr)).toMatchSnapshot(`opencode ${argv.join(" ")} --help`)
+          const stderr = normalize(result.stderr)
+          expect(stderr.endsWith("\n")).toBe(true)
+          expect(stderr.slice(0, -1)).toMatchSnapshot(`opencode ${argv.join(" ")} --help`)
         }
         if (failures.length > 0) {
           throw new Error(`Help text failed for:\n  ${failures.join("\n  ")}`)


### PR DESCRIPTION
### Issue for this PR

Closes #28606
Closes #26114
Closes #27485

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`opencode --help` can print yargs help text without a trailing newline, which leaves the next shell prompt on the same line as the final help option. This updates the shared `show()` helper to append one platform newline only when the generated help text does not already end with `\n`.

The PR also adds regression coverage for top-level help and documented command help output so future CLI help paths keep the trailing newline while preserving the existing help snapshots. Separately, it fixes the `whenver` typo in the dev control-plane README.

### How did you verify your code works?

- `npx -y bun@1.3.14 test test/cli/help/help-snapshots.test.ts --timeout 180000`
- `npx -y bun@1.3.14 typecheck`

### Screenshots / recordings

N/A - terminal output and documentation-only changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR