### PR TITLE
fix(core): restrict global directory permissions

### DIFF
--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -7,6 +7,7 @@ import { Flock } from "./util/flock"
 import { Flag } from "./flag/flag"
 
 const app = "opencode"
+const privateDirMode = 0o700
 const data = path.join(xdgData!, app)
 const cache = path.join(xdgCache!, app)
 const config = path.join(xdgConfig!, app)
@@ -31,15 +32,15 @@ export const Path = paths
 
 Flock.setGlobal({ state })
 
-await Promise.all([
-  fs.mkdir(Path.data, { recursive: true }),
-  fs.mkdir(Path.config, { recursive: true }),
-  fs.mkdir(Path.state, { recursive: true }),
-  fs.mkdir(Path.tmp, { recursive: true }),
-  fs.mkdir(Path.log, { recursive: true }),
-  fs.mkdir(Path.bin, { recursive: true }),
-  fs.mkdir(Path.repos, { recursive: true }),
-])
+async function ensurePrivateDir(dir: string) {
+  await fs.mkdir(dir, { recursive: true, mode: privateDirMode })
+  // mkdir mode is filtered by umask and does not change existing directories.
+  await fs.chmod(dir, privateDirMode)
+}
+
+await Promise.all(
+  [Path.data, Path.cache, Path.config, Path.state, Path.tmp, Path.log, Path.bin, Path.repos].map(ensurePrivateDir),
+)
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Global") {}
 

--- a/packages/core/test/global.test.ts
+++ b/packages/core/test/global.test.ts
@@ -13,4 +13,50 @@ describe("global paths", () => {
   test("tmp path is created on module load", async () => {
     expect((await fs.stat(Global.Path.tmp)).isDirectory()).toBe(true)
   })
+
+  test.skipIf(process.platform === "win32")("managed directories are private on module load", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-global-"))
+    const tmp = path.join(root, "tmp")
+
+    try {
+      await fs.mkdir(path.join(root, "data", "opencode"), { recursive: true })
+      await fs.chmod(path.join(root, "data", "opencode"), 0o755)
+      await fs.mkdir(tmp, { recursive: true })
+
+      const proc = Bun.spawn({
+        cmd: [process.execPath, "-e", "await import('./src/global.ts')"],
+        cwd: path.join(import.meta.dir, ".."),
+        env: {
+          ...process.env,
+          XDG_DATA_HOME: path.join(root, "data"),
+          XDG_CACHE_HOME: path.join(root, "cache"),
+          XDG_CONFIG_HOME: path.join(root, "config"),
+          XDG_STATE_HOME: path.join(root, "state"),
+          TMPDIR: tmp,
+        },
+        stderr: "pipe",
+      })
+
+      if ((await proc.exited) !== 0) {
+        throw new Error(await new Response(proc.stderr).text())
+      }
+
+      await Promise.all(
+        [
+          path.join(root, "data", "opencode"),
+          path.join(root, "cache", "opencode"),
+          path.join(root, "config", "opencode"),
+          path.join(root, "state", "opencode"),
+          path.join(root, "tmp", "opencode"),
+          path.join(root, "data", "opencode", "log"),
+          path.join(root, "cache", "opencode", "bin"),
+          path.join(root, "data", "opencode", "repos"),
+        ].map(async (dir) => {
+          expect((await fs.stat(dir)).mode & 0o777).toBe(0o700)
+        }),
+      )
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #28421

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode creates several managed directories under the user data, cache, config, state, and temp roots. On Unix-like systems those directories could be created with permissions widened by the process umask, or existing directories could remain at `0755`, making user-specific files readable by other local users.

This PR centralizes global directory creation through `ensurePrivateDir()`, creates each managed directory with mode `0700`, and then applies `chmod 0700` so existing directories are tightened as well. It also includes the cache root in the module-load initialization list, since `bin` lives under it.

The regression test imports `src/global.ts` in a fresh process with isolated XDG roots and verifies the data, cache, config, state, temp, log, bin, and repos directories are all `0700`, including an existing data directory that starts as `0755`.

### How did you verify your code works?

- `npx -y bun@1.3.14 test test/global.test.ts` from `packages/core`
- `npx -y bun@1.3.14 typecheck` from `packages/core`
- `git diff --check`
- `npx -y prettier@3.6.2 --check packages/core/src/global.ts packages/core/test/global.test.ts`

### Screenshots / recordings

N/A - filesystem permissions change with automated test coverage.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR