### PR TITLE
fix(skill): ensure plugin config hooks run before skill discovery

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -14,6 +14,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Glob } from "@opencode-ai/core/util/glob"
 import * as Log from "@opencode-ai/core/util/log"
 import { Discovery } from "./discovery"
+import { Plugin } from "@/plugin"
 import CUSTOMIZE_OPENCODE_SKILL_BODY from "./prompt/customize-opencode.md" with { type: "text" }
 import { isRecord } from "@/util/record"
 
@@ -242,8 +243,12 @@ export const layer = Layer.effect(
     const fsys = yield* AppFileSystem.Service
     const global = yield* Global.Service
     const flags = yield* RuntimeFlags.Service
+    const plugin = yield* Plugin.Service
     const discovered = yield* InstanceState.make(
       Effect.fn("Skill.discovery")(function* (ctx) {
+        // Plugin config() hooks may mutate config.skills.paths (e.g. superpowers).
+        // Initialize plugins first so those mutations are visible during discovery.
+        yield* plugin.init()
         return yield* discoverSkills(
           config,
           discovery,
@@ -304,6 +309,10 @@ export const defaultLayer = layer.pipe(
   Layer.provide(AppFileSystem.defaultLayer),
   Layer.provide(Global.layer),
   Layer.provide(RuntimeFlags.defaultLayer),
+  // Plugin must initialize before skill discovery so plugin config() hooks
+  // that mutate config.skills.paths (e.g. superpowers) are visible when
+  // discoverSkills() reads the config at startup.
+  Layer.provide(Plugin.defaultLayer),
 )
 
 export function fmt(list: Info[], opts: { verbose: boolean }) {


### PR DESCRIPTION
### Issue for this PR

Closes #28646
Refs #20940

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugin `config()` hooks (e.g. superpowers) may mutate `config.skills.paths` to register additional skill directories. However, the Skill service runs its discovery independently during initialization, before plugin hooks have executed. By the time plugins mutate the config object, `discoverSkills()` has already cached its result and never re-reads `config.skills.paths`.

This fix ensures that plugin config hooks run **before** skill discovery completes, by:

1. Adding `Plugin.Service` as a dependency in the Skill layer
2. Calling `yield* plugin.init()` inside the `discoverSkills` InstanceState init, so plugins are loaded and their config hooks execute before the config is read for skill path discovery

The change is minimal (9 lines added) and the ordering is safe because:
- Plugin has no circular dependency on Skill
- `plugin.init()` is idempotent (cached via ScopedCache)
- In pure mode, plugin.init() is a no-op

### How did you verify your code works?

- [x] TypeScript compilation: `lsp_diagnostics` reports 0 errors on the changed file
- [x] No circular dependency: verified Plugin module does not import from Skill
- [x] Import path `@/plugin` resolves correctly via tsconfig paths (`./src/*`)
- [x] All existing callers of `plugin.init()` are unaffected (it is already idempotent)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
