### PR TITLE
feat(provider): add NEAR AI Cloud support

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -54,6 +54,10 @@ function sdkKey(npm: string): string | undefined {
   return undefined
 }
 
+function isNearAI(model: Provider.Model) {
+  return model.providerID === "nearai"
+}
+
 // TODO: fix this stupid inefficient dogshit function
 function normalizeMessages(
   msgs: ModelMessage[],
@@ -618,6 +622,9 @@ function googleThinkingBudgetMax(apiId: string) {
 
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
+  // NEAR AI Cloud exposes OpenAI-compatible chat completions, but its gateway
+  // does not accept OpenAI-specific reasoning_effort controls.
+  if (isNearAI(model)) return {}
 
   const id = model.id.toLowerCase()
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
@@ -1130,7 +1137,7 @@ export function options(input: {
     return result
   }
 
-  if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
+  if (!isNearAI(input.model) && input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
     if (!input.model.api.id.includes("gpt-5-pro")) {
       result["reasoningEffort"] = "medium"
       result["reasoningSummary"] = "auto"

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -377,6 +377,27 @@ describe("ProviderTransform.options - gpt-5 reasoningEffort", () => {
 
     expect(result.reasoningEffort).toBeUndefined()
   })
+
+  test("nearai gpt-5 models do not set OpenAI-only reasoning controls", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...createModel("openai/gpt-5.4"),
+        id: "openai/gpt-5.4",
+        providerID: "nearai",
+        api: {
+          id: "openai/gpt-5.4",
+          url: "https://cloud-api.near.ai/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+      },
+      sessionID,
+      providerOptions: {},
+    })
+
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
+  })
 })
 
 describe("ProviderTransform.options - gateway", () => {
@@ -2403,6 +2424,20 @@ describe("ProviderTransform.variants", () => {
       api: {
         id: "deepseek-chat",
         url: "https://api.deepseek.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({})
+  })
+
+  test("nearai returns no OpenAI-only reasoning variants", () => {
+    const model = createMockModel({
+      id: "nearai/openai/gpt-5.4",
+      providerID: "nearai",
+      api: {
+        id: "openai/gpt-5.4",
+        url: "https://cloud-api.near.ai/v1",
         npm: "@ai-sdk/openai-compatible",
       },
     })

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1436,6 +1436,35 @@ To use Kimi K2 from Moonshot AI:
 
 ---
 
+### NEAR AI Cloud
+
+NEAR AI Cloud provides OpenAI-compatible access to TEE-backed private inference models through a single endpoint.
+
+1. Head over to the [NEAR AI Cloud console](https://cloud.near.ai), create an account, and generate an API key.
+
+2. Run the `/connect` command and search for **NEAR AI Cloud**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your NEAR AI Cloud API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _GLM-5.1 FP8_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### NVIDIA
 
 NVIDIA provides access to Nemotron models and many other open models through [build.nvidia.com](https://build.nvidia.com) for free.


### PR DESCRIPTION
### Issue for this PR

Closes #28667

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds NEAR AI Cloud to the provider docs now that it is available through the Models.dev catalog as `nearai` with `NEARAI_API_KEY` and the OpenAI-compatible Cloud API endpoint.

Also avoids generating OpenAI-only reasoning controls for NEAR AI Cloud models. The catalog can mark upstream models as reasoning-capable, but the NEAR AI Cloud gateway does not accept OpenAI `reasoning_effort` request options.

### How did you verify your code works?

- `bun test --timeout 30000 test/provider/transform.test.ts`
- `bun typecheck`
- `bun run --cwd packages/web build`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
