### PR TITLE
fix(llm): prevent empty parts array in Gemini requests

### DIFF
--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -196,6 +196,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
           return yield* ProviderShared.unsupportedContent("Gemini", "user", ["text", "media"])
         parts.push(lowerUserPart(part))
       }
+      if (parts.length === 0) parts.push({ text: "" })
       contents.push({ role: "user", parts })
       continue
     }
@@ -218,6 +219,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
           continue
         }
       }
+      if (parts.length === 0) parts.push({ text: "" })
       contents.push({ role: "model", parts })
       continue
     }
@@ -236,6 +238,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
         },
       })
     }
+    if (parts.length === 0) parts.push({ text: "" })
     contents.push({ role: "user", parts })
   }
 

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -110,6 +110,42 @@ describe("Gemini route", () => {
       })
     }),
   )
+  it.effect("pads completely empty messages with an empty string text part", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare(
+        LLM.request({
+          id: "req_empty_parts",
+          model,
+          messages: [
+            // Simulates a message that was completely truncated by compaction
+            Message.user([]),
+            Message.assistant([]),
+            Message.tool({ id: "call_1", name: "lookup", result: "" }),
+          ],
+        }),
+      )
+
+      expect(prepared.body).toEqual({
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "" }],
+          },
+          {
+            role: "model",
+            parts: [{ text: "" }],
+          },
+          {
+            role: "user",
+            parts: [
+              { functionResponse: { name: "lookup", response: { name: "lookup", content: '""' } } },
+            ],
+          },
+        ],
+      })
+    }),
+  )
+
 
   it.effect("sanitizes integer enums, dangling required, untyped arrays, and scalar object keys", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
### Description
This PR fixes an issue where using Gemini models causes a 400 Bad Request error: `Unable to submit request because it must include at least one parts field, which describes the prompt input.`
This typically surfaces during long sessions (around the limit of context compaction) when OpenCode's history compaction results in empty messages. The Gemini API strictly requires at least one element in the `parts` array for every message in the conversation history. Sending `parts: []` causes the API to reject the entire request. See: https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/Content
> A Content message must have at least one Part.

### Changes
- Updated the Gemini protocol adapter (`packages/llm/src/protocols/gemini.ts`) to intercept serialized messages where `parts.length === 0`.
- Added a fallback to inject an empty string text part (`[{ text: "" }]`) for these empty messages to satisfy the API schema without leaking extra tokens or context to the model.
- Added test coverage in `packages/llm/test/provider/gemini.test.ts` to guarantee empty messages (from users, assistants, or tools) are padded properly and prevent future regressions.
- 
### Issue for this PR

Closes #17519

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes an issue where using Gemini models causes a 400 Bad Request error: `Unable to submit request because it must include at least one parts field, which describes the prompt input.`
This typically surfaces during long sessions (around the limit of context compaction) when OpenCode's history compaction results in empty messages. The Gemini API strictly requires at least one element in the `parts` array for every message in the conversation history. Sending `parts: []` causes the API to reject the entire request. See: https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/Content
> A Content message must have at least one Part.

### How did you verify your code works?

By executing calls with and without parts before & after.
Before:
```
Request:
curl -s -X POST -H "Authorization: Bearer <TOKEN>" -H "Content-Type: application/json" \
  -d '{
    "contents": [
      {"role": "user", "parts": [{"text": "Hello!"}]},
      {"role": "model", "parts": []}, 
      {"role": "user", "parts": [{"text": "How are you?"}]}
    ]
  }' \
  "https://us-central1-aiplatform.googleapis.com/v1/projects/<redacted>/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
Response (400 Bad Request):
{
  "error": {
    "code": 400,
    "message": "Unable to submit request because it must include at least one parts field, which describes the prompt input. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini",
    "status": "INVALID_ARGUMENT"
  }
}
```

after:
```
Request:
curl -s -X POST -H "Authorization: Bearer <TOKEN>" -H "Content-Type: application/json" \
  -d '{
    "contents": [
      {"role": "user", "parts": [{"text": "Hello!"}]},
      {"role": "model", "parts": [{"text": ""}]}, 
      {"role": "user", "parts": [{"text": "How are you?"}]}
    ]
  }' \
  "https://us-central1-aiplatform.googleapis.com/v1/projects/<redacted>/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
Response (200 OK):
{
  "candidates": [
    {
      "content": {
        "role": "model",
        "parts": [
          {
            "text": "Hello! I'm doing well, thank you for asking! How are you doing today?"
          }
        ]
      },
      "finishReason": "STOP"
    }
  ]
}
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
