### PR TITLE
feat(session): support forking to last assistant message

### DIFF
--- a/packages/app/src/components/dialog-fork.tsx
+++ b/packages/app/src/components/dialog-fork.tsx
@@ -14,8 +14,11 @@ import { useLanguage } from "@/context/language"
 
 interface ForkableMessage {
   id: string
+  // The messageID to pass to the fork API (exclusive cutoff = next message's id)
+  cutoffID: string | undefined
   text: string
   time: string
+  role: "user" | "assistant"
 }
 
 function formatTime(date: Date): string {
@@ -38,15 +41,23 @@ export const DialogFork: Component = () => {
     const msgs = sync.data.message[sessionID] ?? []
     const result: ForkableMessage[] = []
 
-    for (const message of msgs) {
-      if (message.role !== "user") continue
+    for (let i = 0; i < msgs.length; i++) {
+      const message = msgs[i]
+      if (message.role !== "user" && message.role !== "assistant") continue
 
       const parts = sync.data.part[message.id] ?? []
       const textPart = parts.find((x): x is SDKTextPart => x.type === "text" && !x.synthetic && !x.ignored)
       if (!textPart) continue
 
+      // For user messages: cutoff = user message id (exclusive, drops the user message itself — original behavior)
+      // For assistant messages: cutoff = the *next* message's id (exclusive), so the assistant message is included.
+      //   If there's no next message, cutoffID = undefined meaning fork everything (also correct).
+      const cutoffID = message.role === "user" ? message.id : msgs[i + 1]?.id
+
       result.push({
         id: message.id,
+        cutoffID,
+        role: message.role,
         text: textPart.text.replace(/\n/g, " ").slice(0, 200),
         time: formatTime(new Date(message.time.created)),
       })
@@ -61,22 +72,24 @@ export const DialogFork: Component = () => {
     const sessionID = params.id
     if (!sessionID) return
 
-    const parts = sync.data.part[item.id] ?? []
-    const restored = extractPromptFromParts(parts, {
-      directory: sdk.directory,
-      attachmentName: language.t("common.attachment"),
-    })
     const dir = base64Encode(sdk.directory)
 
     sdk.client.session
-      .fork({ sessionID, messageID: item.id })
+      .fork({ sessionID, messageID: item.cutoffID })
       .then((forked) => {
         if (!forked.data) {
           showToast({ title: language.t("common.requestFailed") })
           return
         }
         dialog.close()
-        prompt.set(restored, undefined, { dir, id: forked.data.id })
+        if (item.role === "user") {
+          const parts = sync.data.part[item.id] ?? []
+          const restored = extractPromptFromParts(parts, {
+            directory: sdk.directory,
+            attachmentName: language.t("common.attachment"),
+          })
+          prompt.set(restored, undefined, { dir, id: forked.data.id })
+        }
         navigate(`/${dir}/session/${forked.data.id}`)
       })
       .catch((err: unknown) => {
@@ -98,6 +111,9 @@ export const DialogFork: Component = () => {
       >
         {(item) => (
           <div class="w-full flex items-center gap-2">
+            {item.role === "assistant" && (
+              <span class="text-text-weak shrink-0 font-normal text-xs">[assistant]</span>
+            )}
             <span class="truncate flex-1 min-w-0 text-left font-normal">{item.text}</span>
             <span class="text-text-weak shrink-0 font-normal">{item.time}</span>
           </div>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
@@ -34,40 +34,66 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
       },
     } satisfies DialogSelectOption<string | undefined>
     const result = [] as DialogSelectOption<string | undefined>[]
-    for (const message of messages) {
-      if (message.role !== "user") continue
-      const part = (sync.data.part[message.id] ?? []).find(
-        (x) => x.type === "text" && !x.synthetic && !x.ignored,
-      ) as TextPart
-      if (!part) continue
-      result.push({
-        title: part.text.replace(/\n/g, " "),
-        value: message.id,
-        footer: Locale.time(message.time.created),
-        onSelect: async (dialog) => {
-          const forked = await sdk.client.session.fork({
-            sessionID: props.sessionID,
-            messageID: message.id,
-          })
-          const parts = sync.data.part[message.id] ?? []
-          const prompt = parts.reduce(
-            (agg, part) => {
-              if (part.type === "text") {
-                if (!part.synthetic) agg.input += part.text
-              }
-              if (part.type === "file") agg.parts.push(strip(part))
-              return agg
-            },
-            { input: "", parts: [] as PromptInfo["parts"] },
-          )
-          route.navigate({
-            sessionID: forked.data!.id,
-            type: "session",
-            prompt,
-          })
-          dialog.clear()
-        },
-      })
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i]
+      if (message.role === "user") {
+        const part = (sync.data.part[message.id] ?? []).find(
+          (x) => x.type === "text" && !x.synthetic && !x.ignored,
+        ) as TextPart
+        if (!part) continue
+        result.push({
+          title: part.text.replace(/\n/g, " "),
+          value: message.id,
+          footer: Locale.time(message.time.created),
+          onSelect: async (dialog) => {
+            const forked = await sdk.client.session.fork({
+              sessionID: props.sessionID,
+              messageID: message.id,
+            })
+            const parts = sync.data.part[message.id] ?? []
+            const prompt = parts.reduce(
+              (agg, part) => {
+                if (part.type === "text") {
+                  if (!part.synthetic) agg.input += part.text
+                }
+                if (part.type === "file") agg.parts.push(strip(part))
+                return agg
+              },
+              { input: "", parts: [] as PromptInfo["parts"] },
+            )
+            route.navigate({
+              sessionID: forked.data!.id,
+              type: "session",
+              prompt,
+            })
+            dialog.clear()
+          },
+        })
+      } else if (message.role === "assistant") {
+        const part = (sync.data.part[message.id] ?? []).find(
+          (x) => x.type === "text" && !x.synthetic && !x.ignored,
+        ) as TextPart
+        if (!part) continue
+        // Use the next message's id as exclusive cutoff so this assistant message is included.
+        // If there's no next message, cutoffID is undefined → fork entire session.
+        const cutoffID = messages[i + 1]?.id
+        result.push({
+          title: `[assistant] ${part.text.replace(/\n/g, " ")}`,
+          value: message.id,
+          footer: Locale.time(message.time.created),
+          onSelect: async (dialog) => {
+            const forked = await sdk.client.session.fork({
+              sessionID: props.sessionID,
+              messageID: cutoffID,
+            })
+            route.navigate({
+              sessionID: forked.data!.id,
+              type: "session",
+            })
+            dialog.clear()
+          },
+        })
+      }
     }
     return [fullSession, ...result.reverse()]
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -77,23 +77,30 @@ export function DialogMessage(props: {
           value: "session.fork",
           description: "create a new session",
           onSelect: async (dialog) => {
+            const msg = message()
+            const isAssistant = msg?.role === "assistant"
+            // For assistant messages, use the next message's id as the exclusive cutoff
+            // so the assistant message itself is included in the fork.
+            const messages = sync.data.message[props.sessionID] ?? []
+            const idx = messages.findIndex((m) => m.id === props.messageID)
+            const cutoffID = isAssistant ? messages[idx + 1]?.id : props.messageID
             const result = await sdk.client.session.fork({
               sessionID: props.sessionID,
-              messageID: props.messageID,
+              messageID: cutoffID,
             })
-            const msg = message()
-            const prompt = msg
-              ? sync.data.part[msg.id].reduce(
-                  (agg, part) => {
-                    if (part.type === "text") {
-                      if (!part.synthetic) agg.input += part.text
-                    }
-                    if (part.type === "file") agg.parts.push(part)
-                    return agg
-                  },
-                  { input: "", parts: [] as PromptInfo["parts"] },
-                )
-              : undefined
+            const prompt =
+              !isAssistant && msg
+                ? sync.data.part[msg.id].reduce(
+                    (agg, part) => {
+                      if (part.type === "text") {
+                        if (!part.synthetic) agg.input += part.text
+                      }
+                      if (part.type === "file") agg.parts.push(part)
+                      return agg
+                    },
+                    { input: "", parts: [] as PromptInfo["parts"] },
+                  )
+                : undefined
             route.navigate({
               sessionID: result.data!.id,
               type: "session",

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -256,6 +256,7 @@ export type CreateInput = Types.DeepMutable<Schema.Schema.Type<typeof CreateInpu
 export const ForkInput = Schema.Struct({
   sessionID: SessionID,
   messageID: Schema.optional(MessageID),
+  inclusive: Schema.optional(Schema.Boolean),
 })
 export const GetInput = SessionID
 export const ChildrenInput = SessionID
@@ -677,7 +678,11 @@ export const layer: Layer.Layer<
       })
     })
 
-    const fork = Effect.fn("Session.fork")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {
+    const fork = Effect.fn("Session.fork")(function* (input: {
+      sessionID: SessionID
+      messageID?: MessageID
+      inclusive?: boolean
+    }) {
       const ctx = yield* InstanceState.context
       const original = yield* get(input.sessionID)
       const title = getForkedTitle(original.title)
@@ -691,7 +696,7 @@ export const layer: Layer.Layer<
       const idMap = new Map<string, MessageID>()
 
       for (const msg of msgs) {
-        if (input.messageID && msg.info.id >= input.messageID) break
+        if (input.messageID && (input.inclusive ? msg.info.id > input.messageID : msg.info.id >= input.messageID)) break
         const newID = MessageID.ascending()
         idMap.set(msg.info.id, newID)
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3544,6 +3544,7 @@ export class Session2 extends HeyApiClient {
       directory?: string
       workspace?: string
       messageID?: string
+      inclusive?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3556,6 +3557,7 @@ export class Session2 extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
             { in: "body", key: "messageID" },
+            { in: "body", key: "inclusive" },
           ],
         },
       ],


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The fork dialog only showed user messages as fork points. This PR adds assistant messages to the list so you can fork a session at a completed agent reply, not just at a user prompt.

Changes:
- `Session.fork` accepts a new optional `inclusive` field — when true, the cutoff shifts from `>=` to `>` so the target message is included in the fork.
- The fork dialogs (TUI and web) now list assistant messages alongside user ones. For backward compatibility with older backends, forking to an assistant message passes the *next* message's id as the exclusive cutoff rather than relying on `inclusive`.
- Forking to an assistant message leaves the input box empty (no prompt is pre-filled).

### How did you verify your code works?

Ran the web app dev server against `opencode serve`. Opened the fork dialog, selected an assistant reply, and confirmed the new session contains both the user message and the full assistant reply with an empty input box.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
