### PR TITLE
feat(opencode): add categories for agents & pipe through to agent-dialog

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -29,6 +29,7 @@ import { type DeepMutable } from "@opencode-ai/core/schema"
 export const Info = Schema.Struct({
   name: Schema.String,
   description: Schema.optional(Schema.String),
+  category: Schema.optional(Schema.String),
   mode: Schema.Literals(["subagent", "primary", "all"]),
   native: Schema.optional(Schema.Boolean),
   hidden: Schema.optional(Schema.Boolean),
@@ -129,6 +130,7 @@ export const layer = Layer.effect(
         const agents: Record<string, Info> = {
           build: {
             name: "build",
+            category: "build",
             description: "The default agent. Executes tools based on configured permissions.",
             options: {},
             permission: Permission.merge(
@@ -144,6 +146,7 @@ export const layer = Layer.effect(
           },
           plan: {
             name: "plan",
+            category: "plan",
             description: "Plan mode. Disallows all edit tools.",
             options: {},
             permission: Permission.merge(
@@ -167,6 +170,7 @@ export const layer = Layer.effect(
           },
           general: {
             name: "general",
+            category: "general",
             description: `General-purpose agent for researching complex questions and executing multi-step tasks. Use this agent to execute multiple units of work in parallel.`,
             permission: Permission.merge(
               defaults,
@@ -181,6 +185,7 @@ export const layer = Layer.effect(
           },
           explore: {
             name: "explore",
+            category: "explore",
             permission: Permission.merge(
               defaults,
               Permission.fromConfig({
@@ -204,8 +209,9 @@ export const layer = Layer.effect(
           },
           ...(flags.experimentalScout
             ? {
-                scout: {
-                  name: "scout",
+                  scout: {
+                    name: "scout",
+                    category: "explore",
                   permission: Permission.merge(
                     defaults,
                     Permission.fromConfig({
@@ -234,6 +240,7 @@ export const layer = Layer.effect(
             : {}),
           compaction: {
             name: "compaction",
+            category: "general",
             mode: "primary",
             native: true,
             hidden: true,
@@ -249,6 +256,7 @@ export const layer = Layer.effect(
           },
           title: {
             name: "title",
+            category: "general",
             mode: "primary",
             options: {},
             native: true,
@@ -265,6 +273,7 @@ export const layer = Layer.effect(
           },
           summary: {
             name: "summary",
+            category: "explore",
             mode: "primary",
             options: {},
             native: true,
@@ -295,6 +304,7 @@ export const layer = Layer.effect(
               native: false,
             }
           if (value.model) item.model = Provider.parseModel(value.model)
+          item.category = value.category ?? item.category
           item.variant = value.variant ?? item.variant
           item.prompt = value.prompt ?? item.prompt
           item.description = value.description ?? item.description

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -1,20 +1,48 @@
 import { createMemo } from "solid-js"
 import { useLocal } from "@tui/context/local"
-import { DialogSelect } from "@tui/ui/dialog-select"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
+import type { Agent } from "@opencode-ai/sdk/v2"
+
+/**
+ * Sort comparator for agents by category.
+ *
+ * Ordering:
+ * 1. Categorized agents, ordered alphabetically by category
+ * 2. Uncategorized agents last
+ */
+function sortAgentByCategory(a: Agent, b: Agent) {
+  const aCat = a.category ?? ""
+  const bCat = b.category ?? ""
+
+  // Uncategorized agents sink to the bottom.
+  if (!a.category && b.category) return 1
+  if (a.category && !b.category) return -1
+  if (!a.category && !b.category) return 0
+
+  // Alphabetical by category. Each built-in agent is its own
+  // category group (build, explore, general, plan, etc.).
+  return aCat.localeCompare(bCat)
+}
+
+/** Maps an agent to a dialog-select option with a display category. */
+function mapAgentToDialogOptions(agent: Agent): DialogSelectOption<string> {
+  return {
+    value: agent.name,
+    title: agent.name,
+    category: agent.category
+      ? agent.category[0].toUpperCase() + agent.category.slice(1)
+      : "Uncategorized",
+    description: agent.description ?? "native",
+  }
+}
 
 export function DialogAgent() {
   const local = useLocal()
   const dialog = useDialog()
 
   const options = createMemo(() =>
-    local.agent.list().map((item) => {
-      return {
-        value: item.name,
-        title: item.name,
-        description: item.native ? "native" : item.description,
-      }
-    }),
+    local.agent.list().slice().sort(sortAgentByCategory).map(mapAgentToDialogOptions),
   )
 
   return (

--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -20,6 +20,7 @@ const Color = Schema.Union([
 
 const AgentSchema = Schema.StructWithRest(
   Schema.Struct({
+    category: Schema.optional(Schema.String).annotate({ description: "Category for grouping agents together" }),
     model: Schema.optional(ConfigModelID),
     variant: Schema.optional(Schema.String).annotate({
       description: "Default model variant for this agent (applies only when using the agent's configured model).",
@@ -51,6 +52,7 @@ const AgentSchema = Schema.StructWithRest(
 
 const KNOWN_KEYS = new Set([
   "name",
+  "category",
   "model",
   "variant",
   "prompt",

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1627,6 +1627,7 @@ export type Command = {
 
 export type Agent = {
   name: string
+  category?: string
   description?: string
   mode: "subagent" | "primary" | "all"
   native?: boolean

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -631,6 +631,34 @@ Users can always invoke any subagent directly via the `@` autocomplete menu, eve
 
 ---
 
+### Category
+
+Group agents together in the UI with the `category` option. This affects how agents are organized, such as in the command palette.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "code-reviewer": {
+      "description": "Reviews code for best practices",
+      "category": "review"
+    }
+  }
+}
+```
+
+Categories are free-form strings. Built-in agents use categories like `build`, `plan`, `general`, and `explore`.
+
+You can also set it in Markdown agents:
+
+```markdown title="~/.config/opencode/agents/review.md"
+---
+description: Code review agent
+category: review
+---
+```
+
+---
+
 ### Color
 
 Customize the agent's visual appearance in the UI with the `color` option. This affects how the agent appears in the interface.


### PR DESCRIPTION
### Issue for this PR

Closes #28663 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds a new `category` prop on the agents schema and types + pipes it through to the Agent Dialog. This way users can categorize their Agents accordingly when having a lot of agents. I also added categories to the default agents so they can be listed with custom agents by context. (First I thought about putting them together into a "core" category but that would make no sense imho).

### How did you verify your code works?

I tested this locally on my own repos, checked if agents are loaded and categorized correctly, I checked if the search picks up the categories correctly and also the core agents I could directly run (since the other agents are hidden by default).

I wrote the code by hand and used AI to do a review & fix findings it encountered. The documentation was written by my documentation agent.

### Screenshots / recordings

<img width="549" height="500" alt="grafik" src="https://github.com/user-attachments/assets/5fad8115-db01-4324-a62c-41823c807606" />

<img width="597" height="502" alt="grafik" src="https://github.com/user-attachments/assets/c7c5c680-37c2-4eea-9661-1435432a1783" />

<img width="545" height="483" alt="grafik" src="https://github.com/user-attachments/assets/6c789463-ea77-43d9-8151-a445d860f6fe" />

<img width="548" height="466" alt="grafik" src="https://github.com/user-attachments/assets/0232af89-8e83-4f72-9f57-656c95b4aa4a" />



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
