### PR TITLE
fix(desktop): restore v2 controls

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1303,6 +1303,37 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return "Ask anything, / for commands, @ for context..."
   }
 
+  const agentControl = () => (
+    <Show when={!agentsLoading()}>
+      <div
+        data-component="prompt-agent-control"
+        style={agentsShouldFadeIn() ? { animation: "fade-in 0.3s" } : undefined}
+      >
+        <TooltipKeybind
+          placement="top"
+          gutter={4}
+          title={language.t("command.agent.cycle")}
+          keybind={command.keybind("agent.cycle")}
+        >
+          <Select
+            size="normal"
+            options={agentNames()}
+            current={local.agent.current()?.name ?? ""}
+            onSelect={(value) => {
+              local.agent.set(value)
+              restoreFocus()
+            }}
+            class="capitalize max-w-[150px] justify-start text-text-base [&_[data-component=icon]]:text-v2-icon-icon-muted"
+            valueClass="truncate text-[13px] font-[440] leading-4 text-v2-text-text-faint"
+            triggerStyle={control()}
+            triggerProps={{ "data-action": "prompt-agent" }}
+            variant="ghost"
+          />
+        </TooltipKeybind>
+      </div>
+    </Show>
+  )
+
   const modelControl = () => (
     <Show when={!providersLoading()}>
       <Show
@@ -1371,6 +1402,38 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           </ModelSelectorPopover>
         </TooltipKeybind>
       </Show>
+    </Show>
+  )
+
+  const modelVariantControl = () => (
+    <Show when={!providersLoading() && store.mode !== "shell" && variants().length > 2}>
+      <div
+        data-component="prompt-variant-control"
+        style={providersShouldFadeIn() ? { animation: "fade-in 0.3s" } : undefined}
+      >
+        <TooltipKeybind
+          placement="top"
+          gutter={4}
+          title={language.t("command.model.variant.cycle")}
+          keybind={command.keybind("model.variant.cycle")}
+        >
+          <Select
+            size="normal"
+            options={variants()}
+            current={local.model.variant.current() ?? "default"}
+            label={(x) => (x === "default" ? language.t("common.default") : x)}
+            onSelect={(value) => {
+              local.model.variant.set(value === "default" ? undefined : value)
+              restoreFocus()
+            }}
+            class="capitalize max-w-[150px] justify-start text-text-base [&_[data-component=icon]]:text-v2-icon-icon-muted"
+            valueClass="truncate text-[13px] font-[440] leading-4 text-v2-text-text-faint"
+            triggerStyle={control()}
+            triggerProps={{ "data-action": "prompt-model-variant" }}
+            variant="ghost"
+          />
+        </TooltipKeybind>
+      </div>
     </Show>
   )
 
@@ -1495,7 +1558,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               </div>
             </div>
             <div class="flex h-11 items-center px-2">
-              <div class="flex min-w-0 flex-1 items-center gap-0">
+              <div class="flex min-w-0 flex-1 items-center gap-1">
                 {fileAttachmentInput()}
                 <TooltipKeybind
                   placement="top"
@@ -1537,7 +1600,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     />
                   </div>
                 </Show>
-                {modelControl()}
+                {agentControl()}
+                <Show when={store.mode !== "shell"}>
+                  {modelControl()}
+                  {modelVariantControl()}
+                </Show>
               </div>
               <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
                 <IconButton

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -154,10 +154,11 @@ export function SessionHeader() {
   const hotkey = createMemo(() => command.keybind("file.open"))
   const os = createMemo(() => detectOS(platform))
   const isDesktopBeta = platform.platform === "desktop" && import.meta.env.VITE_OPENCODE_CHANNEL === "beta"
+  const useV2Titlebar = import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"
   const search = createMemo(() => !isDesktopBeta || settings.general.showSearch())
   const tree = createMemo(() => !isDesktopBeta || settings.general.showFileTree())
   const term = createMemo(() => !isDesktopBeta || settings.general.showTerminal())
-  const status = createMemo(() => !isDesktopBeta || settings.general.showStatus())
+  const status = createMemo(() => !useV2Titlebar && (!isDesktopBeta || settings.general.showStatus()))
 
   const [exists, setExists] = createStore<Partial<Record<OpenApp, boolean>>>({
     finder: true,

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -17,12 +17,15 @@ import { useSettings } from "@/context/settings"
 import { WindowsAppMenu } from "./windows-app-menu"
 import { applyPath, backPath, forwardPath } from "./titlebar-history"
 import { useGlobalSync } from "@/context/global-sync"
+import { SDKProvider } from "@/context/sdk"
+import { SyncProvider } from "@/context/sync"
 import { decodeDirectory } from "@/pages/directory-layout"
 import { iife } from "@opencode-ai/core/util/iife"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { Avatar as AvatarV2 } from "@opencode-ai/ui/v2/components/avatar-v2.jsx"
 import { displayName, getProjectAvatarSource, projectForSession } from "@/pages/layout/helpers"
 import { makeEventListener } from "@solid-primitives/event-listener"
+import { StatusPopover } from "./status-popover"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -222,6 +225,18 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
             const globalSync = useGlobalSync()
             const navigate = useNavigate()
             const homeMatch = useMatch(() => "/")
+            const status = createMemo(
+              () =>
+                !(platform.platform === "desktop" && import.meta.env.VITE_OPENCODE_CHANNEL === "beta") ||
+                settings.general.showStatus(),
+            )
+            const statusDirectory = createMemo(
+              () =>
+                (params.dir ? decodeDirectory(params.dir) : undefined) ||
+                layout.projects.list()[0]?.worktree ||
+                globalSync.data.path.home ||
+                undefined,
+            )
 
             const openNewSession = () => {
               if (params.dir) {
@@ -404,6 +419,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                   </Show>
                   <div class="min-w-0 flex-1" />
                 </div>
+                <TitlebarStatusPopover directory={statusDirectory} shown={status} />
                 <TitlebarUpdatePill update={props.update} />
                 <Show when={windows() && !electronWindows()}>
                   <div data-tauri-decorum-tb class="flex flex-row" />
@@ -568,6 +584,24 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
         </Match>
       </Switch>
     </header>
+  )
+}
+
+function TitlebarStatusPopover(props: { directory: () => string | undefined; shown: () => boolean }) {
+  const language = useLanguage()
+
+  return (
+    <Show when={props.shown() && props.directory()} keyed>
+      {(directory) => (
+        <SDKProvider directory={() => directory}>
+          <SyncProvider>
+            <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
+              <StatusPopover />
+            </Tooltip>
+          </SyncProvider>
+        </SDKProvider>
+      )}
+    </Show>
   )
 }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #28686

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores the missing Desktop V2 prompt controls: agent selection, model selection, and model variant/thinking-effort selection. It also moves the existing status popover into the V2 titlebar path so server/MCP/LSP/plugin status remains reachable, while hiding the legacy header status trigger in V2 to avoid duplicates.

These controls were still rendered through legacy UI paths after the V2 desktop layout moved the composer/titlebar.

### How did you verify your code works?

- `bun typecheck` from `packages/app`
- `bun typecheck` from `packages/desktop`
- `OPENCODE_CHANNEL=dev bun run build` from `packages/desktop`
- Push hook: `bun turbo typecheck`

### Screenshots / recordings

Verified locally in the Desktop dev build.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR