### PR TITLE
fix: exempt team members from compliance cleanup

### DIFF
--- a/.github/workflows/compliance-close.yml
+++ b/.github/workflows/compliance-close.yml
@@ -34,10 +34,30 @@ jobs:
 
             const now = Date.now();
             const twoHours = 2 * 60 * 60 * 1000;
+            const { data: teamFile } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/TEAM_MEMBERS',
+              ref: 'dev'
+            });
+            const teamMembers = Buffer.from(teamFile.content, 'base64').toString().split('\n').map(l => l.trim().toLowerCase()).filter(Boolean);
 
             for (const item of items) {
               const isPR = !!item.pull_request;
               const kind = isPR ? 'PR' : 'issue';
+
+              if (teamMembers.includes(item.user.login.toLowerCase())) {
+                core.info(`Skipping ${kind} #${item.number}: ${item.user.login} is a team member`);
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: item.number,
+                    name: 'needs:compliance',
+                  });
+                } catch (e) {}
+                continue;
+              }
 
               const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,

--- a/.github/workflows/compliance-close.yml
+++ b/.github/workflows/compliance-close.yml
@@ -11,14 +11,30 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  TEAM_MEMBERS: |
+    adamdotdevin
+    Brendonovich
+    fwang
+    Hona
+    iamdavidhill
+    jayair
+    jlongster
+    kitlangton
+    kommander
+    MrMushrooooom
+    nexxeln
+    R44VC0RP
+    rekram1-node
+    thdxr
+    simonklee
+    vimtor
+    starptech
+
 jobs:
   close-non-compliant:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: dev
-
       - name: Close non-compliant issues and PRs after 2 hours
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -38,8 +54,7 @@ jobs:
 
             const now = Date.now();
             const twoHours = 2 * 60 * 60 * 1000;
-            const teamMembers = require('fs')
-              .readFileSync('.github/TEAM_MEMBERS', 'utf8')
+            const teamMembers = process.env.TEAM_MEMBERS
               .split('\n')
               .map(l => l.trim().toLowerCase())
               .filter(Boolean);

--- a/.github/workflows/compliance-close.yml
+++ b/.github/workflows/compliance-close.yml
@@ -11,26 +11,6 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  TEAM_MEMBERS: |
-    adamdotdevin
-    Brendonovich
-    fwang
-    Hona
-    iamdavidhill
-    jayair
-    jlongster
-    kitlangton
-    kommander
-    MrMushrooooom
-    nexxeln
-    R44VC0RP
-    rekram1-node
-    thdxr
-    simonklee
-    vimtor
-    starptech
-
 jobs:
   close-non-compliant:
     runs-on: ubuntu-latest
@@ -54,17 +34,14 @@ jobs:
 
             const now = Date.now();
             const twoHours = 2 * 60 * 60 * 1000;
-            const teamMembers = process.env.TEAM_MEMBERS
-              .split('\n')
-              .map(l => l.trim().toLowerCase())
-              .filter(Boolean);
+            const teamAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
 
             for (const item of items) {
               const isPR = !!item.pull_request;
               const kind = isPR ? 'PR' : 'issue';
 
-              if (teamMembers.includes(item.user.login.toLowerCase())) {
-                core.info(`Skipping ${kind} #${item.number}: ${item.user.login} is a team member`);
+              if (teamAssociations.includes(item.author_association)) {
+                core.info(`Skipping ${kind} #${item.number}: author association is ${item.author_association}`);
                 try {
                   await github.rest.issues.removeLabel({
                     owner: context.repo.owner,

--- a/.github/workflows/compliance-close.yml
+++ b/.github/workflows/compliance-close.yml
@@ -15,6 +15,10 @@ jobs:
   close-non-compliant:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+
       - name: Close non-compliant issues and PRs after 2 hours
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -34,13 +38,11 @@ jobs:
 
             const now = Date.now();
             const twoHours = 2 * 60 * 60 * 1000;
-            const { data: teamFile } = await github.rest.repos.getContent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              path: '.github/TEAM_MEMBERS',
-              ref: 'dev'
-            });
-            const teamMembers = Buffer.from(teamFile.content, 'base64').toString().split('\n').map(l => l.trim().toLowerCase()).filter(Boolean);
+            const teamMembers = require('fs')
+              .readFileSync('.github/TEAM_MEMBERS', 'utf8')
+              .split('\n')
+              .map(l => l.trim().toLowerCase())
+              .filter(Boolean);
 
             for (const item of items) {
               const isPR = !!item.pull_request;

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -17,12 +17,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check team membership
+        id: team-check
+        run: |
+          LOGIN="${{ github.event.issue.user.login }}"
+          if grep -qxiF "$LOGIN" .github/TEAM_MEMBERS; then
+            echo "is_team=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping: $LOGIN is a team member"
+          else
+            echo "is_team=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: ./.github/actions/setup-bun
+        if: steps.team-check.outputs.is_team != 'true'
 
       - name: Install opencode
+        if: steps.team-check.outputs.is_team != 'true'
         run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Check duplicates and compliance
+        if: steps.team-check.outputs.is_team != 'true'
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -129,12 +143,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check team membership
+        id: team-check
+        run: |
+          LOGIN="${{ github.event.issue.user.login }}"
+          if grep -qxiF "$LOGIN" .github/TEAM_MEMBERS; then
+            echo "is_team=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping: $LOGIN is a team member"
+          else
+            echo "is_team=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: ./.github/actions/setup-bun
+        if: steps.team-check.outputs.is_team != 'true'
 
       - name: Install opencode
+        if: steps.team-check.outputs.is_team != 'true'
         run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Recheck compliance
+        if: steps.team-check.outputs.is_team != 'true'
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-duplicates:
-    if: github.event.action == 'opened'
+    if: github.event.action == 'opened' && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -17,26 +17,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Check team membership
-        id: team-check
-        run: |
-          LOGIN="${{ github.event.issue.user.login }}"
-          if grep -qxiF "$LOGIN" .github/TEAM_MEMBERS; then
-            echo "is_team=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping: $LOGIN is a team member"
-          else
-            echo "is_team=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: ./.github/actions/setup-bun
-        if: steps.team-check.outputs.is_team != 'true'
 
       - name: Install opencode
-        if: steps.team-check.outputs.is_team != 'true'
         run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Check duplicates and compliance
-        if: steps.team-check.outputs.is_team != 'true'
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,7 +118,7 @@ jobs:
           Remember: post at most ONE comment combining all findings. If everything is fine, post nothing."
 
   recheck-compliance:
-    if: github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance')
+    if: github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance') && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -143,26 +129,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Check team membership
-        id: team-check
-        run: |
-          LOGIN="${{ github.event.issue.user.login }}"
-          if grep -qxiF "$LOGIN" .github/TEAM_MEMBERS; then
-            echo "is_team=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping: $LOGIN is a team member"
-          else
-            echo "is_team=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: ./.github/actions/setup-bun
-        if: steps.team-check.outputs.is_team != 'true'
 
       - name: Install opencode
-        if: steps.team-check.outputs.is_team != 'true'
         run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Recheck compliance
-        if: steps.team-check.outputs.is_team != 'true'
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -20,7 +20,7 @@ jobs:
         id: team-check
         run: |
           LOGIN="${{ github.event.pull_request.user.login }}"
-          if [ "$LOGIN" = "opencode-agent[bot]" ] || grep -qxF "$LOGIN" .github/TEAM_MEMBERS; then
+          if [ "$LOGIN" = "opencode-agent[bot]" ] || grep -qxiF "$LOGIN" .github/TEAM_MEMBERS; then
             echo "is_team=true" >> "$GITHUB_OUTPUT"
             echo "Skipping: $LOGIN is a team member or bot"
           else

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -11,21 +11,24 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 1
-
       - name: Check team membership
         id: team-check
         run: |
           LOGIN="${{ github.event.pull_request.user.login }}"
-          if [ "$LOGIN" = "opencode-agent[bot]" ] || grep -qxiF "$LOGIN" .github/TEAM_MEMBERS; then
+          ASSOCIATION="${{ github.event.pull_request.author_association }}"
+          if [ "$LOGIN" = "opencode-agent[bot]" ] || [ "$ASSOCIATION" = "OWNER" ] || [ "$ASSOCIATION" = "MEMBER" ] || [ "$ASSOCIATION" = "COLLABORATOR" ]; then
             echo "is_team=true" >> "$GITHUB_OUTPUT"
             echo "Skipping: $LOGIN is a team member or bot"
           else
             echo "is_team=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Checkout repository
+        if: steps.team-check.outputs.is_team != 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Setup Bun
         if: steps.team-check.outputs.is_team != 'true'

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -4,26 +4,6 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
-env:
-  TEAM_MEMBERS: |
-    adamdotdevin
-    Brendonovich
-    fwang
-    Hona
-    iamdavidhill
-    jayair
-    jlongster
-    kitlangton
-    kommander
-    MrMushrooooom
-    nexxeln
-    R44VC0RP
-    rekram1-node
-    thdxr
-    simonklee
-    vimtor
-    starptech
-
 jobs:
   check-standards:
     runs-on: ubuntu-latest
@@ -48,12 +28,9 @@ jobs:
 
             // Check if author is a team member or bot
             if (login === 'opencode-agent[bot]') return;
-            const members = process.env.TEAM_MEMBERS
-              .split('\n')
-              .map(l => l.trim().toLowerCase())
-              .filter(Boolean);
-            if (members.includes(login.toLowerCase())) {
-              console.log(`Skipping: ${login} is a team member`);
+            const teamAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (teamAssociations.includes(pr.author_association)) {
+              console.log(`Skipping: ${login} has author association ${pr.author_association}`);
               return;
             }
 
@@ -192,12 +169,9 @@ jobs:
 
             // Check if author is a team member or bot
             if (login === 'opencode-agent[bot]') return;
-            const members = process.env.TEAM_MEMBERS
-              .split('\n')
-              .map(l => l.trim().toLowerCase())
-              .filter(Boolean);
-            if (members.includes(login.toLowerCase())) {
-              console.log(`Skipping: ${login} is a team member`);
+            const teamAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (teamAssociations.includes(pr.author_association)) {
+              console.log(`Skipping: ${login} has author association ${pr.author_association}`);
               return;
             }
 

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -34,8 +34,8 @@ jobs:
               path: '.github/TEAM_MEMBERS',
               ref: 'dev'
             });
-            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim()).filter(Boolean);
-            if (members.includes(login)) {
+            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim().toLowerCase()).filter(Boolean);
+            if (members.includes(login.toLowerCase())) {
               console.log(`Skipping: ${login} is a team member`);
               return;
             }
@@ -181,8 +181,8 @@ jobs:
               path: '.github/TEAM_MEMBERS',
               ref: 'dev'
             });
-            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim()).filter(Boolean);
-            if (members.includes(login)) {
+            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim().toLowerCase()).filter(Boolean);
+            if (members.includes(login.toLowerCase())) {
               console.log(`Skipping: ${login} is a team member`);
               return;
             }

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -11,6 +11,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+
       - name: Check PR standards
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -28,13 +32,11 @@ jobs:
 
             // Check if author is a team member or bot
             if (login === 'opencode-agent[bot]') return;
-            const { data: file } = await github.rest.repos.getContent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              path: '.github/TEAM_MEMBERS',
-              ref: 'dev'
-            });
-            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim().toLowerCase()).filter(Boolean);
+            const members = require('fs')
+              .readFileSync('.github/TEAM_MEMBERS', 'utf8')
+              .split('\n')
+              .map(l => l.trim().toLowerCase())
+              .filter(Boolean);
             if (members.includes(login.toLowerCase())) {
               console.log(`Skipping: ${login} is a team member`);
               return;
@@ -158,6 +160,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: dev
+
       - name: Check PR template compliance
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -175,13 +181,11 @@ jobs:
 
             // Check if author is a team member or bot
             if (login === 'opencode-agent[bot]') return;
-            const { data: file } = await github.rest.repos.getContent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              path: '.github/TEAM_MEMBERS',
-              ref: 'dev'
-            });
-            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim().toLowerCase()).filter(Boolean);
+            const members = require('fs')
+              .readFileSync('.github/TEAM_MEMBERS', 'utf8')
+              .split('\n')
+              .map(l => l.trim().toLowerCase())
+              .filter(Boolean);
             if (members.includes(login.toLowerCase())) {
               console.log(`Skipping: ${login} is a team member`);
               return;

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -4,6 +4,26 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
+env:
+  TEAM_MEMBERS: |
+    adamdotdevin
+    Brendonovich
+    fwang
+    Hona
+    iamdavidhill
+    jayair
+    jlongster
+    kitlangton
+    kommander
+    MrMushrooooom
+    nexxeln
+    R44VC0RP
+    rekram1-node
+    thdxr
+    simonklee
+    vimtor
+    starptech
+
 jobs:
   check-standards:
     runs-on: ubuntu-latest
@@ -11,10 +31,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: dev
-
       - name: Check PR standards
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -32,8 +48,7 @@ jobs:
 
             // Check if author is a team member or bot
             if (login === 'opencode-agent[bot]') return;
-            const members = require('fs')
-              .readFileSync('.github/TEAM_MEMBERS', 'utf8')
+            const members = process.env.TEAM_MEMBERS
               .split('\n')
               .map(l => l.trim().toLowerCase())
               .filter(Boolean);
@@ -160,10 +175,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: dev
-
       - name: Check PR template compliance
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -181,8 +192,7 @@ jobs:
 
             // Check if author is a team member or bot
             if (login === 'opencode-agent[bot]') return;
-            const members = require('fs')
-              .readFileSync('.github/TEAM_MEMBERS', 'utf8')
+            const members = process.env.TEAM_MEMBERS
               .split('\n')
               .map(l => l.trim().toLowerCase())
               .filter(Boolean);

--- a/script/github/close-issues.ts
+++ b/script/github/close-issues.ts
@@ -15,7 +15,17 @@ const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
 type Issue = {
   number: number
   updated_at: string
+  user: {
+    login: string
+  }
 }
+
+const teamMembers = new Set(
+  (await Bun.file(new URL("../../.github/TEAM_MEMBERS", import.meta.url)).text())
+    .split("\n")
+    .map((login) => login.trim().toLowerCase())
+    .filter(Boolean),
+)
 
 const headers = {
   Authorization: `Bearer ${token}`,
@@ -63,6 +73,10 @@ async function main() {
     for (const i of all) {
       const updated = new Date(i.updated_at)
       if (updated < cutoff) {
+        if (teamMembers.has(i.user.login.toLowerCase())) {
+          console.log(`Skipping #${i.number}: ${i.user.login} is a team member`)
+          continue
+        }
         stale.push(i.number)
       } else {
         console.log(`\nFound fresh issue #${i.number}, stopping`)

--- a/script/github/close-issues.ts
+++ b/script/github/close-issues.ts
@@ -15,17 +15,10 @@ const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
 type Issue = {
   number: number
   updated_at: string
-  user: {
-    login: string
-  }
+  author_association: string
 }
 
-const teamMembers = new Set(
-  (await Bun.file(new URL("../../.github/TEAM_MEMBERS", import.meta.url)).text())
-    .split("\n")
-    .map((login) => login.trim().toLowerCase())
-    .filter(Boolean),
-)
+const teamAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"])
 
 const headers = {
   Authorization: `Bearer ${token}`,
@@ -73,8 +66,8 @@ async function main() {
     for (const i of all) {
       const updated = new Date(i.updated_at)
       if (updated < cutoff) {
-        if (teamMembers.has(i.user.login.toLowerCase())) {
-          console.log(`Skipping #${i.number}: ${i.user.login} is a team member`)
+        if (teamAssociations.has(i.author_association)) {
+          console.log(`Skipping #${i.number}: author association is ${i.author_association}`)
           continue
         }
         stale.push(i.number)

--- a/script/github/close-prs.ts
+++ b/script/github/close-prs.ts
@@ -69,12 +69,7 @@ const maxClose =
 const sleepMs = requireNonNegativeInteger("sleep-ms", values["sleep-ms"])
 const printLimit = requireNonNegativeInteger("print-limit", values["print-limit"])
 const cutoff = subtractMonths(new Date(), ageMonths)
-const teamMembers = new Set(
-  (await Bun.file(new URL("../../.github/TEAM_MEMBERS", import.meta.url)).text())
-    .split("\n")
-    .map((login) => login.trim().toLowerCase())
-    .filter(Boolean),
-)
+const teamAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"])
 
 const headers = {
   Authorization: `Bearer ${token}`,
@@ -88,9 +83,7 @@ type PullRequest = {
   title: string
   url: string
   createdAt: string
-  author: {
-    login: string
-  }
+  authorAssociation: string
   reactionGroups: Array<{
     content: string
     users: {
@@ -220,9 +213,7 @@ async function fetchOpenPullRequests() {
               title
               url
               createdAt
-              author {
-                login
-              }
+              authorAssociation
               reactionGroups {
                 content
                 users {
@@ -354,7 +345,7 @@ function hasPriorCleanup(pr: PullRequest) {
 }
 
 function isTeamMember(pr: PullRequest) {
-  return teamMembers.has(pr.author.login.toLowerCase())
+  return teamAssociations.has(pr.authorAssociation)
 }
 
 function requireRepo(value: string | undefined) {

--- a/script/github/close-prs.ts
+++ b/script/github/close-prs.ts
@@ -69,6 +69,12 @@ const maxClose =
 const sleepMs = requireNonNegativeInteger("sleep-ms", values["sleep-ms"])
 const printLimit = requireNonNegativeInteger("print-limit", values["print-limit"])
 const cutoff = subtractMonths(new Date(), ageMonths)
+const teamMembers = new Set(
+  (await Bun.file(new URL("../../.github/TEAM_MEMBERS", import.meta.url)).text())
+    .split("\n")
+    .map((login) => login.trim().toLowerCase())
+    .filter(Boolean),
+)
 
 const headers = {
   Authorization: `Bearer ${token}`,
@@ -82,6 +88,9 @@ type PullRequest = {
   title: string
   url: string
   createdAt: string
+  author: {
+    login: string
+  }
   reactionGroups: Array<{
     content: string
     users: {
@@ -145,19 +154,25 @@ async function main() {
   console.log(`Threshold: fewer than ${threshold} positive reactions`)
 
   const prs = await fetchOpenPullRequests()
-  const recentCount = prs.filter((pr) => new Date(pr.createdAt) >= cutoff).length
-  const matching = prs
-    .map((pr) => ({ ...pr, positiveReactions: positiveReactionCount(pr) }))
-    .filter((pr) => new Date(pr.createdAt) < cutoff && pr.positiveReactions < threshold)
+  const scored = prs.map((pr) => ({ ...pr, positiveReactions: positiveReactionCount(pr) }))
+  const recentCount = scored.filter((pr) => new Date(pr.createdAt) >= cutoff).length
+  const teamCount = scored.filter((pr) => isTeamMember(pr)).length
+  const matching = scored.filter(
+    (pr) => !isTeamMember(pr) && new Date(pr.createdAt) < cutoff && pr.positiveReactions < threshold,
+  )
   const candidates = matching.filter((pr) => !hasPriorCleanup(pr))
   const selected = maxClose === undefined ? candidates : candidates.slice(0, maxClose)
 
   console.log(`Fetched ${prs.length} open PRs`)
   console.log(`Matching cleanup criteria: ${matching.length}`)
   console.log(`Skipped previously cleaned PRs: ${matching.length - candidates.length}`)
+  console.log(`Team member PRs untouched: ${teamCount}`)
   console.log(`Recent PRs untouched: ${recentCount}`)
   console.log(
-    `Older PRs with at least ${threshold} positive reactions untouched: ${prs.length - matching.length - recentCount}`,
+    `Older PRs with at least ${threshold} positive reactions untouched: ${
+      scored.filter((pr) => !isTeamMember(pr) && new Date(pr.createdAt) < cutoff && pr.positiveReactions >= threshold)
+        .length
+    }`,
   )
 
   if (selected.length === 0) return
@@ -205,6 +220,9 @@ async function fetchOpenPullRequests() {
               title
               url
               createdAt
+              author {
+                login
+              }
               reactionGroups {
                 content
                 users {
@@ -333,6 +351,10 @@ function positiveReactionCount(pr: PullRequest) {
 
 function hasPriorCleanup(pr: PullRequest) {
   return pr.labels.nodes.some((label) => label.name === cleanupLabel)
+}
+
+function isTeamMember(pr: PullRequest) {
+  return teamMembers.has(pr.author.login.toLowerCase())
 }
 
 function requireRepo(value: string | undefined) {


### PR DESCRIPTION
## Summary
- Use GitHub's built-in author_association as the single source of truth for team exemptions
- Skip compliance checks and auto-close cleanup for OWNER, MEMBER, and COLLABORATOR authors
- Avoid checkout/API/file reads for membership checks in pull_request_target workflows
- Keep PR duplicate-management checkout behind the team check and pin it to the base SHA

## Testing
- bun build script/github/close-issues.ts script/github/close-prs.ts --target bun --outdir /var/folders/wp/p9bq_z410fl2zmv767k8w0zw0000gn/T/opencode/compliance-build
- bun x prettier --check .github/workflows/compliance-close.yml .github/workflows/duplicate-issues.yml .github/workflows/pr-management.yml .github/workflows/pr-standards.yml script/github/close-issues.ts script/github/close-prs.ts
- git diff --check -- .github/workflows/compliance-close.yml .github/workflows/duplicate-issues.yml .github/workflows/pr-management.yml .github/workflows/pr-standards.yml script/github/close-issues.ts script/github/close-prs.ts