### PR TITLE
refactor(tui): clarify sequential shortcut labels

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/keymap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/keymap.tsx
@@ -183,6 +183,12 @@ function formatOptions(config: TuiConfig.Resolved) {
 }
 
 export function formatKeySequence(parts: Parameters<typeof formatKeySequenceExtra>[0], config: TuiConfig.Resolved) {
+  if (parts && parts.length > 1 && parts[0]?.tokenName === LEADER_TOKEN) {
+    return parts
+      .map((part) => formatKeySequenceExtra([part], formatOptions(config)))
+      .filter(Boolean)
+      .join(" then ")
+  }
   return formatKeySequenceExtra(parts, formatOptions(config))
 }
 
@@ -190,7 +196,19 @@ export function formatKeyBindings(
   bindings: Parameters<typeof formatCommandBindingsExtra>[0],
   config: TuiConfig.Resolved,
 ) {
-  return formatCommandBindingsExtra(bindings, formatOptions(config))
+  if (!bindings?.length) return
+  const seen = new Set<string>()
+  let formatted = ""
+  let itemCount = 0
+  for (const binding of bindings) {
+    const item = formatKeySequence(binding.sequence, config)
+    if (!item) continue
+    if (seen.has(item)) continue
+    seen.add(item)
+    formatted = itemCount === 0 ? item : `${formatted}, ${item}`
+    itemCount += 1
+  }
+  return formatted
 }
 
 export function registerOpencodeKeymap(

--- a/packages/opencode/src/cli/cmd/tui/keymap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/keymap.tsx
@@ -183,20 +183,21 @@ function formatOptions(config: TuiConfig.Resolved) {
 }
 
 export function formatKeySequence(parts: Parameters<typeof formatKeySequenceExtra>[0], config: TuiConfig.Resolved) {
+  const options = formatOptions(config)
   if (parts && parts.length > 1 && parts[0]?.tokenName === LEADER_TOKEN) {
     return parts
-      .map((part) => formatKeySequenceExtra([part], formatOptions(config)))
+      .map((part) => formatKeySequenceExtra([part], options))
       .filter(Boolean)
       .join(" then ")
   }
-  return formatKeySequenceExtra(parts, formatOptions(config))
+  return formatKeySequenceExtra(parts, options)
 }
 
 export function formatKeyBindings(
   bindings: Parameters<typeof formatCommandBindingsExtra>[0],
   config: TuiConfig.Resolved,
 ) {
-  if (!bindings?.length) return
+  if (!bindings?.length) return ""
   const seen = new Set<string>()
   let formatted = ""
   let itemCount = 0

--- a/packages/opencode/test/cli/tui/keymap.test.tsx
+++ b/packages/opencode/test/cli/tui/keymap.test.tsx
@@ -4,7 +4,7 @@ import { testRender, useRenderer } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { onCleanup } from "solid-js"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
-import { OpencodeKeymapProvider, registerOpencodeKeymap } from "@/cli/cmd/tui/keymap"
+import { formatKeyBindings, formatKeySequence, OpencodeKeymapProvider, registerOpencodeKeymap } from "@/cli/cmd/tui/keymap"
 
 test("legacy page key aliases compile as page keys", async () => {
   const sequences: Record<string, string[][]> = {}
@@ -48,6 +48,157 @@ test("legacy page key aliases compile as page keys", async () => {
       up: [["pageup"]],
       down: [["pagedown"]],
     })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("sequential leader shortcut displays with 'then'", async () => {
+  const results: Record<string, string> = {}
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offLayer = keymap.registerLayer({
+      bindings: config.keybinds.gather("session", ["session.child.first"]),
+    })
+    const bindings = keymap.getCommandBindings({
+      visibility: "registered",
+      commands: ["session.child.first"],
+    })
+    const sequence = bindings.get("session.child.first")?.[0]?.sequence
+    results.defaultLeader = formatKeySequence(sequence, config)
+    onCleanup(() => {
+      offLayer()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    expect(results.defaultLeader).toBe("ctrl+x then down")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("custom leader shortcut displays with 'then' using custom leader", async () => {
+  const results: Record<string, string> = {}
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig({
+      keybinds: {
+        leader: "ctrl+j",
+      },
+    })
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offLayer = keymap.registerLayer({
+      bindings: config.keybinds.gather("session", ["session.child.first"]),
+    })
+    const bindings = keymap.getCommandBindings({
+      visibility: "registered",
+      commands: ["session.child.first"],
+    })
+    const sequence = bindings.get("session.child.first")?.[0]?.sequence
+    results.customLeader = formatKeySequence(sequence, config)
+    onCleanup(() => {
+      offLayer()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    expect(results.customLeader).toBe("ctrl+j then down")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("single-part chord shortcut stays unchanged", async () => {
+  const results: Record<string, string> = {}
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offLayer = keymap.registerLayer({
+      bindings: config.keybinds.gather("command", ["command.palette.show"]),
+    })
+    const bindings = keymap.getCommandBindings({
+      visibility: "registered",
+      commands: ["command.palette.show"],
+    })
+    const sequence = bindings.get("command.palette.show")?.[0]?.sequence
+    results.singlePart = formatKeySequence(sequence, config)
+    onCleanup(() => {
+      offLayer()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    expect(results.singlePart).toBe("ctrl+p")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("alternative bindings remain comma-separated without 'then' between alternatives", async () => {
+  const results: Record<string, string | undefined> = {}
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offLayer = keymap.registerLayer({
+      bindings: config.keybinds.gather("app", ["app.exit"]),
+    })
+    const bindings = keymap.getCommandBindings({
+      visibility: "registered",
+      commands: ["app.exit"],
+    })
+    results.alternatives = formatKeyBindings(bindings.get("app.exit") ?? [], config)
+    onCleanup(() => {
+      offLayer()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    expect(results.alternatives).toBe("ctrl+c, ctrl+d, ctrl+x then q")
   } finally {
     app.renderer.destroy()
   }

--- a/packages/opencode/test/cli/tui/keymap.test.tsx
+++ b/packages/opencode/test/cli/tui/keymap.test.tsx
@@ -6,6 +6,35 @@ import { onCleanup } from "solid-js"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 import { formatKeyBindings, formatKeySequence, OpencodeKeymapProvider, registerOpencodeKeymap } from "@/cli/cmd/tui/keymap"
 
+async function renderKeymap<T>(
+  fn: (
+    keymap: ReturnType<typeof createDefaultOpenTuiKeymap>,
+    config: ReturnType<typeof createTuiResolvedConfig>,
+  ) => T,
+  configOverrides?: Parameters<typeof createTuiResolvedConfig>[0],
+): Promise<T> {
+  let result!: T
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig(configOverrides)
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    result = fn(keymap, config)
+    onCleanup(() => offKeymap())
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+  const app = await testRender(() => <Harness />)
+  try {
+    return result
+  } finally {
+    app.renderer.destroy()
+  }
+}
+
 test("legacy page key aliases compile as page keys", async () => {
   const sequences: Record<string, string[][]> = {}
 
@@ -54,13 +83,7 @@ test("legacy page key aliases compile as page keys", async () => {
 })
 
 test("sequential leader shortcut displays with 'then'", async () => {
-  const results: Record<string, string> = {}
-
-  function Harness() {
-    const renderer = useRenderer()
-    const keymap = createDefaultOpenTuiKeymap(renderer)
-    const config = createTuiResolvedConfig()
-    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+  const result = await renderKeymap((keymap, config) => {
     const offLayer = keymap.registerLayer({
       bindings: config.keybinds.gather("session", ["session.child.first"]),
     })
@@ -69,76 +92,33 @@ test("sequential leader shortcut displays with 'then'", async () => {
       commands: ["session.child.first"],
     })
     const sequence = bindings.get("session.child.first")?.[0]?.sequence
-    results.defaultLeader = formatKeySequence(sequence, config)
-    onCleanup(() => {
-      offLayer()
-      offKeymap()
-    })
-
-    return (
-      <OpencodeKeymapProvider keymap={keymap}>
-        <box />
-      </OpencodeKeymapProvider>
-    )
-  }
-
-  const app = await testRender(() => <Harness />)
-  try {
-    expect(results.defaultLeader).toBe("ctrl+x then down")
-  } finally {
-    app.renderer.destroy()
-  }
+    onCleanup(() => offLayer())
+    return formatKeySequence(sequence, config)
+  })
+  expect(result).toBe("ctrl+x then down")
 })
 
 test("custom leader shortcut displays with 'then' using custom leader", async () => {
-  const results: Record<string, string> = {}
-
-  function Harness() {
-    const renderer = useRenderer()
-    const keymap = createDefaultOpenTuiKeymap(renderer)
-    const config = createTuiResolvedConfig({
-      keybinds: {
-        leader: "ctrl+j",
-      },
-    })
-    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
-    const offLayer = keymap.registerLayer({
-      bindings: config.keybinds.gather("session", ["session.child.first"]),
-    })
-    const bindings = keymap.getCommandBindings({
-      visibility: "registered",
-      commands: ["session.child.first"],
-    })
-    const sequence = bindings.get("session.child.first")?.[0]?.sequence
-    results.customLeader = formatKeySequence(sequence, config)
-    onCleanup(() => {
-      offLayer()
-      offKeymap()
-    })
-
-    return (
-      <OpencodeKeymapProvider keymap={keymap}>
-        <box />
-      </OpencodeKeymapProvider>
-    )
-  }
-
-  const app = await testRender(() => <Harness />)
-  try {
-    expect(results.customLeader).toBe("ctrl+j then down")
-  } finally {
-    app.renderer.destroy()
-  }
+  const result = await renderKeymap(
+    (keymap, config) => {
+      const offLayer = keymap.registerLayer({
+        bindings: config.keybinds.gather("session", ["session.child.first"]),
+      })
+      const bindings = keymap.getCommandBindings({
+        visibility: "registered",
+        commands: ["session.child.first"],
+      })
+      const sequence = bindings.get("session.child.first")?.[0]?.sequence
+      onCleanup(() => offLayer())
+      return formatKeySequence(sequence, config)
+    },
+    { keybinds: { leader: "ctrl+j" } },
+  )
+  expect(result).toBe("ctrl+j then down")
 })
 
 test("single-part chord shortcut stays unchanged", async () => {
-  const results: Record<string, string> = {}
-
-  function Harness() {
-    const renderer = useRenderer()
-    const keymap = createDefaultOpenTuiKeymap(renderer)
-    const config = createTuiResolvedConfig()
-    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+  const result = await renderKeymap((keymap, config) => {
     const offLayer = keymap.registerLayer({
       bindings: config.keybinds.gather("command", ["command.palette.show"]),
     })
@@ -147,35 +127,14 @@ test("single-part chord shortcut stays unchanged", async () => {
       commands: ["command.palette.show"],
     })
     const sequence = bindings.get("command.palette.show")?.[0]?.sequence
-    results.singlePart = formatKeySequence(sequence, config)
-    onCleanup(() => {
-      offLayer()
-      offKeymap()
-    })
-
-    return (
-      <OpencodeKeymapProvider keymap={keymap}>
-        <box />
-      </OpencodeKeymapProvider>
-    )
-  }
-
-  const app = await testRender(() => <Harness />)
-  try {
-    expect(results.singlePart).toBe("ctrl+p")
-  } finally {
-    app.renderer.destroy()
-  }
+    onCleanup(() => offLayer())
+    return formatKeySequence(sequence, config)
+  })
+  expect(result).toBe("ctrl+p")
 })
 
 test("alternative bindings remain comma-separated without 'then' between alternatives", async () => {
-  const results: Record<string, string | undefined> = {}
-
-  function Harness() {
-    const renderer = useRenderer()
-    const keymap = createDefaultOpenTuiKeymap(renderer)
-    const config = createTuiResolvedConfig()
-    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+  const result = await renderKeymap((keymap, config) => {
     const offLayer = keymap.registerLayer({
       bindings: config.keybinds.gather("app", ["app.exit"]),
     })
@@ -183,23 +142,8 @@ test("alternative bindings remain comma-separated without 'then' between alterna
       visibility: "registered",
       commands: ["app.exit"],
     })
-    results.alternatives = formatKeyBindings(bindings.get("app.exit") ?? [], config)
-    onCleanup(() => {
-      offLayer()
-      offKeymap()
-    })
-
-    return (
-      <OpencodeKeymapProvider keymap={keymap}>
-        <box />
-      </OpencodeKeymapProvider>
-    )
-  }
-
-  const app = await testRender(() => <Harness />)
-  try {
-    expect(results.alternatives).toBe("ctrl+c, ctrl+d, ctrl+x then q")
-  } finally {
-    app.renderer.destroy()
-  }
+    onCleanup(() => offLayer())
+    return formatKeyBindings(bindings.get("app.exit") ?? [], config)
+  })
+  expect(result).toBe("ctrl+c, ctrl+d, ctrl+x then q")
 })


### PR DESCRIPTION
Closes #28700

### Type of change

- [x] Refactor / code improvement

### What does this PR do?

Improves the `formatKeySequence` and `formatKeyBindings` helpers in `keymap.tsx` so that leader-key-based sequential shortcuts display with an explicit `" then "` separator instead of a space. This removes the user-visible ambiguity between sequential and chord-style shortcuts.

**Changes:**
- **`formatKeySequence`** — detects leader-sequence patterns (where `parts[0].tokenName === LEADER_TOKEN` and `parts.length > 1`) and joins them with `" then "`.
- **`formatKeyBindings`** — reimplemented to iterate bindings manually and call the local `formatKeySequence` wrapper so that alternative bindings containing leader sequences also display correctly.

| Before | After |
|---|---|
| `ctrl+x down` | `ctrl+x then down` |
| `ctrl+c, ctrl+d, <leader>q` | `ctrl+c, ctrl+d, ctrl+x then q` |

This is purely a display-text change — no keybinding registration, parsing, or dispatch logic was touched. The formatter outputs lowercase modifier names.

### How did you verify your code works?

- `bun test --timeout 30000 test/cli/tui/keymap.test.tsx` → 5 pass, 0 fail (4 new + 1 existing)
- `bun run typecheck` from `packages/opencode` → clean
- 4 new tests cover: default leader sequence, custom leader, single-part chord unchanged, and alternative bindings with leader

### Screenshots / recordings

<table>
<tr>
<td align="center"><strong>Before</strong></td>
<td align="center"><strong>After</strong></td>
</tr>
<tr>
<td><img width="400" alt="before" src="https://github.com/user-attachments/assets/9a2f2256-60a5-48c3-9646-b6fdce146740" /></td>
<td><img width="400" alt="after" src="https://github.com/user-attachments/assets/8776cacf-9d14-4c9e-bf39-15864c7ce0ab2" /></td>
</tr>
</table>

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR