### PR TITLE
fix: prevent unrecoverable "Failed to fetch" on long sessions

### DIFF
--- a/packages/core/src/util/retry.ts
+++ b/packages/core/src/util/retry.ts
@@ -25,7 +25,7 @@ function isTransientError(error: unknown): boolean {
 }
 
 export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
-  const { attempts = 3, delay = 500, factor = 2, maxDelay = 10000, retryIf = isTransientError } = options
+  const { attempts = 5, delay = 1000, factor = 2, maxDelay = 30000, retryIf = isTransientError } = options
 
   let lastError: unknown
   for (let attempt = 0; attempt < attempts; attempt++) {

--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -33,8 +33,12 @@ function rewrite(request: Request, directory?: string) {
 export function createOpencodeClient(config?: Config & { directory?: string }) {
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
+      // Use a 5-minute timeout instead of disabling it entirely.
+      // Disabling the timeout causes fetch to hang forever when the backend
+      // becomes unresponsive, leading to unrecoverable "Failed to fetch" errors
+      // in the renderer (see #28702).
       // @ts-ignore
-      req.timeout = false
+      req.timeout = 300_000
       return fetch(req)
     }
     config = {

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -47,8 +47,12 @@ function rewrite(request: Request, values: { directory?: string; workspace?: str
 export function createOpencodeClient(config?: Config & { directory?: string; experimental_workspaceID?: string }) {
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
+      // Use a 5-minute timeout instead of disabling it entirely.
+      // Disabling the timeout causes fetch to hang forever when the backend
+      // becomes unresponsive, leading to unrecoverable "Failed to fetch" errors
+      // in the renderer (see #28702).
       // @ts-ignore
-      req.timeout = false
+      req.timeout = 300_000
       return fetch(req)
     }
     config = {


### PR DESCRIPTION
### Issue for this PR

Closes #28702

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `TypeError: Failed to fetch` error permanently freezes the TUI display during long sessions. The display goes blank while the loading bar keeps spinning — the backend continues working but the renderer can't fetch messages anymore.

The root cause is that the SDK client sets `req.timeout = false`, disabling request timeouts entirely. When the Go backend is temporarily unresponsive (GC pause, heavy snapshot, DB operation), the renderer's `fetchMessages` hangs forever. The `retry` utility only tries 3 times with a 10s max delay, which is insufficient.

The fix is straightforward:
- **`packages/sdk/js/src/client.ts`** and **`packages/sdk/js/src/v2/client.ts`**: Set `req.timeout = 300_000` (5 min) instead of `false`. This lets the fetch fail after 5 minutes so the retry mechanism can recover.
- **`packages/core/src/util/retry.ts`**: Increase default `attempts` from 3 to 5, `delay` from 500ms to 1000ms, and `maxDelay` from 10s to 30s. This gives ~31 seconds of exponential backoff retries — enough to ride out transient backend pauses.

### How did you verify your code works?

Tested on Windows 11 with OpenCode v1.15.7. Before patching, the TUI froze within 10-20 minutes of active agent usage (Prometheus). After applying the `req.timeout` patch locally, the renderer recovers from transient backend pauses instead of permanently hanging.

### Screenshots / recordings

N/A — no UI changes, only fetch/retry behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR