### PR TITLE
refactor(server): drop dead Fence.wait + redundant casts

### DIFF
--- a/packages/opencode/src/server/shared/fence.ts
+++ b/packages/opencode/src/server/shared/fence.ts
@@ -4,7 +4,6 @@ import { EventSequenceTable } from "@/sync/event.sql"
 import { Workspace } from "@/control-plane/workspace"
 import type { WorkspaceID } from "@/control-plane/schema"
 import * as Log from "@opencode-ai/core/util/log"
-import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
 
 export const HEADER = "x-opencode-sync"
@@ -20,7 +19,7 @@ export function load(ids?: string[]) {
     return db.select().from(EventSequenceTable).where(inArray(EventSequenceTable.aggregate_id, ids)).all()
   })
 
-  return Object.fromEntries(rows.map((row) => [row.aggregate_id, row.seq])) as State
+  return Object.fromEntries(rows.map((row) => [row.aggregate_id, row.seq]))
 }
 
 export function diff(prev: State, next: State) {
@@ -31,15 +30,14 @@ export function diff(prev: State, next: State) {
       .filter(([id, seq]) => {
         return (prev[id] ?? -1) !== seq
       }),
-  ) as State
+  )
 }
 
-export function parse(headers: Headers) {
+export function parse(headers: Headers): State | undefined {
   const raw = headers.get(HEADER)
   if (!raw) return
 
   let data
-
   try {
     data = JSON.parse(raw)
   } catch {
@@ -49,10 +47,10 @@ export function parse(headers: Headers) {
   if (!data || typeof data !== "object") return
 
   return Object.fromEntries(
-    Object.entries(data).filter(([id, seq]) => {
-      return typeof id === "string" && Number.isInteger(seq)
+    Object.entries(data).filter((entry): entry is [string, number] => {
+      return typeof entry[0] === "string" && Number.isInteger(entry[1])
     }),
-  ) as State
+  )
 }
 
 export function waitEffect(workspaceID: WorkspaceID, state: State, signal?: AbortSignal) {
@@ -67,8 +65,4 @@ export function waitEffect(workspaceID: WorkspaceID, state: State, signal?: Abor
       state,
     })
   })
-}
-
-export async function wait(workspaceID: WorkspaceID, state: State, signal?: AbortSignal) {
-  await AppRuntime.runPromise(waitEffect(workspaceID, state, signal))
 }


### PR DESCRIPTION
## Summary
- \`Fence.wait\` (the Promise wrapper around \`Fence.waitEffect\`) has zero callers — \`grep -r Fence.wait\` across \`src/\` and \`test/\` returns nothing. Removing it also drops the last \`AppRuntime\` import from this module.
- The \`as State\` casts in \`parse\`, \`load\`, and \`diff\` were rescuing TS from an \`any\`-typed filter or just plain redundant. Typing the filter predicate in \`parse\` removes the need.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun run test test/server/httpapi-workspace-routing.test.ts test/server/httpapi-instance.test.ts\` — 14/14 pass
- [ ] CI green