### PR TITLE
refactor(server): rename Fence.waitEffect to Fence.wait

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -131,7 +131,7 @@ function proxyRemote(
     const response = yield* HttpApiProxy.http(client, proxyURL, target.headers, request)
     const sync = Fence.parse(new Headers(response.headers))
     if (sync) {
-      const syncFailure = yield* Fence.waitEffect(
+      const syncFailure = yield* Fence.wait(
         workspace.id,
         sync,
         request.source instanceof Request ? request.source.signal : undefined,

--- a/packages/opencode/src/server/shared/fence.ts
+++ b/packages/opencode/src/server/shared/fence.ts
@@ -53,7 +53,7 @@ export function parse(headers: Headers): State | undefined {
   )
 }
 
-export function waitEffect(workspaceID: WorkspaceID, state: State, signal?: AbortSignal) {
+export function wait(workspaceID: WorkspaceID, state: State, signal?: AbortSignal) {
   return Effect.gen(function* () {
     log.info("waiting for state", {
       workspaceID,


### PR DESCRIPTION
Follow-up to #28710. Now that the Promise-style \`Fence.wait\` wrapper is gone, the \`Effect\` suffix on \`waitEffect\` is redundant — there's only one \`wait\`.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun run test test/server/httpapi-workspace-routing.test.ts test/server/httpapi-instance.test.ts\` — 14/14 pass