### PR TITLE
fix(acp): include shell command in permission request

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -205,7 +205,10 @@ export class Agent implements ACPAgent {
                 toolCall: {
                   toolCallId: permission.tool?.callID ?? permission.id,
                   status: "pending",
-                  title: permission.permission,
+                  title:
+                    typeof permission.metadata?.command === "string"
+                      ? permission.metadata.command
+                      : permission.permission,
                   rawInput: permission.metadata,
                   kind: toToolKind(permission.permission),
                   locations: toLocations(permission.permission, permission.metadata),

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -206,9 +206,11 @@ export class Agent implements ACPAgent {
                   toolCallId: permission.tool?.callID ?? permission.id,
                   status: "pending",
                   title:
-                    typeof permission.metadata?.command === "string"
-                      ? permission.metadata.command
-                      : permission.permission,
+                    typeof permission.metadata?.description === "string"
+                      ? permission.metadata.description
+                      : typeof permission.metadata?.command === "string"
+                        ? permission.metadata.command
+                        : permission.permission,
                   rawInput: permission.metadata,
                   kind: toToolKind(permission.permission),
                   locations: toLocations(permission.permission, permission.metadata),

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -263,7 +263,7 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
   return tree
 })
 
-const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan) {
+const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan, command: string) {
   if (scan.dirs.size > 0) {
     const globs = Array.from(scan.dirs).map((dir) => {
       if (process.platform === "win32") return AppFileSystem.normalizePathPattern(path.join(dir, "*"))
@@ -273,7 +273,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan)
       permission: "external_directory",
       patterns: globs,
       always: globs,
-      metadata: {},
+      metadata: { command },
     })
   }
 
@@ -282,7 +282,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan)
     permission: ShellID.ToolID,
     patterns: Array.from(scan.patterns),
     always: Array.from(scan.always),
-    metadata: {},
+    metadata: { command },
   })
 })
 
@@ -625,7 +625,7 @@ export const ShellTool = Tool.define(
                   )
                   const scan = yield* collect(tree.rootNode, cwd, ps, shell, instanceCtx)
                   if (!containsPath(cwd, instanceCtx)) scan.dirs.add(cwd)
-                  yield* ask(ctx, scan)
+                  yield* ask(ctx, scan, params.command)
                 }),
               )
 

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -263,7 +263,12 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
   return tree
 })
 
-const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan, command: string) {
+const ask = Effect.fn("ShellTool.ask")(function* (
+  ctx: Tool.Context,
+  scan: Scan,
+  command: string,
+  description: string | undefined,
+) {
   if (scan.dirs.size > 0) {
     const globs = Array.from(scan.dirs).map((dir) => {
       if (process.platform === "win32") return AppFileSystem.normalizePathPattern(path.join(dir, "*"))
@@ -273,7 +278,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
       permission: "external_directory",
       patterns: globs,
       always: globs,
-      metadata: { command },
+      metadata: { command, description },
     })
   }
 
@@ -282,7 +287,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
     permission: ShellID.ToolID,
     patterns: Array.from(scan.patterns),
     always: Array.from(scan.always),
-    metadata: { command },
+    metadata: { command, description },
   })
 })
 
@@ -625,7 +630,7 @@ export const ShellTool = Tool.define(
                   )
                   const scan = yield* collect(tree.rootNode, cwd, ps, shell, instanceCtx)
                   if (!containsPath(cwd, instanceCtx)) scan.dirs.add(cwd)
-                  yield* ask(ctx, scan, params.command)
+                  yield* ask(ctx, scan, params.command, params.description)
                 }),
               )
 


### PR DESCRIPTION
### Issue

Closes #4240 (partial — the `writeTextFile` gap is addressed separately in dev)

### Type of change

- [x] Bug fix

### What does this PR do?

When opencode asks for permission to run a shell command in ACP mode (e.g. inside Zed), the permission prompt showed only `bash` or nothing at all — giving no indication of what command would actually be executed.

Two fields were missing:

1. `tool/shell.ts`: `ask()` always passed `metadata: {}` — the command string was never included in the permission request
2. `acp/agent.ts`: `requestPermission` used the tool name (`bash`) as the `title` regardless; it now prefers `metadata.command` when present

With this fix, the Zed permission prompt shows the actual command (e.g. `git status`) as the title, and includes it in `rawInput` for the expanded detail view.

### How did you verify your code works?

Tested locally in Zed with `opencode-pr28734` custom agent. Permission prompts for bash commands now display the command string instead of just `bash`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR