### PR TITLE
fix(mcp): trigger OAuth dance inside startAuth to get redirect URL

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -801,7 +801,25 @@ export const layer = Layer.effect(
           const client = new Client({ name: "opencode", version: InstallationVersion })
           return client
             .connect(transport)
-            .then(() => ({ authorizationUrl: "", oauthState, client }) satisfies AuthResult)
+            .then(async () => {
+              // connect() resolves before the SDK starts the OAuth dance,
+              // so force a real request to make it run and let onRedirect
+              // populate capturedUrl before we return.
+              try {
+                await client.listTools(undefined, { timeout: 15_000 })
+                return { authorizationUrl: "", oauthState, client } satisfies AuthResult
+              } catch (err) {
+                const start = Date.now()
+                while (!capturedUrl && Date.now() - start < 5_000) {
+                  await new Promise((r) => setTimeout(r, 50))
+                }
+                if (capturedUrl) {
+                  pendingOAuthTransports.set(mcpName, transport)
+                  return { authorizationUrl: capturedUrl.toString(), oauthState } satisfies AuthResult
+                }
+                throw err
+              }
+            })
         },
         catch: (error) => error,
       }).pipe(


### PR DESCRIPTION
### Issue for this PR

  Closes #28741

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  `opencode mcp auth <server>` against any OAuth-protected MCP server fails right away with `Failed to get tools`. The browser never opens, the callback server stays idle. Reproduced on `v1.15.6` with a Keycloak backend using dynamic client registration.

  The MCP SDK's `connect()` resolves before it actually starts the OAuth flow — that only kicks in on the first real request. So `startAuth()` thinks everything is fine and returns `authorizationUrl=""`, and `authenticate()` ends up calling `defs()` → `listTools()` on a client that isn't authenticated yet. By the time the SDK gets around to firing `onRedirect` and filling `capturedUrl`, it's too late: `defs()` has already swallowed the `UnauthorizedError` and reported failure.

  This PR makes `startAuth()` itself call `listTools()` right after `connect()`. That forces the SDK to do the OAuth dance there and then, so `capturedUrl` is ready by the time we return. `authenticate()` sees a real authorization URL, opens the browser, and waits for the callback like it's supposed to.

  ### How did you verify your code works?

  Ran the patched build end-to-end against my own Keycloak-backed MCP server:
  - `rm -f ~/.local/share/opencode/mcp-auth.json` to start clean
  - `bun run --conditions=browser ./src/index.ts --log-level DEBUG --print-logs mcp auth myserver`
  - Browser opens, I log in, Keycloak redirects to `http://127.0.0.1:19876/mcp/oauth/callback?code=...`, opencode picks up the code, exchanges it for tokens and stores them.

  Also confirmed `bun run typecheck` passes clean.

  ### Screenshots / recordings

  N/A (CLI flow, no UI changes).

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR