### PR TITLE
fix(xai): use chat completions instead of responses API

### DIFF
--- a/packages/llm/src/providers/xai.ts
+++ b/packages/llm/src/providers/xai.ts
@@ -3,7 +3,6 @@ import type { RouteDefaultsInput } from "../route/client"
 import { ProviderID, type ModelID } from "../schema"
 import * as OpenAICompatibleProfiles from "./openai-compatible-profile"
 import * as OpenAICompatibleChat from "../protocols/openai-compatible-chat"
-import * as OpenAIResponses from "../protocols/openai-responses"
 
 export const id = ProviderID.make("xai")
 
@@ -12,19 +11,9 @@ export type ModelOptions = RouteDefaultsInput &
     readonly baseURL?: string
   }
 
-export const routes = [OpenAIResponses.route, OpenAICompatibleChat.route]
+export const routes = [OpenAICompatibleChat.route]
 
 const auth = (options: ProviderAuthOption<"optional">) => AuthOptions.bearer(options, "XAI_API_KEY")
-
-const configuredResponsesRoute = (input: ModelOptions) => {
-  const { apiKey: _, auth: _auth, baseURL, ...rest } = input
-  return OpenAIResponses.route.with({
-    ...rest,
-    provider: id,
-    endpoint: { baseURL: baseURL ?? OpenAICompatibleProfiles.profiles.xai.baseURL },
-    auth: auth(input),
-  })
-}
 
 const configuredChatRoute = (input: ModelOptions) => {
   const { apiKey: _, auth: _auth, baseURL, ...rest } = input
@@ -37,14 +26,11 @@ const configuredChatRoute = (input: ModelOptions) => {
 }
 
 export const configure = (input: ModelOptions = {}) => {
-  const responsesRoute = configuredResponsesRoute(input)
   const chatRoute = configuredChatRoute(input)
-  const responses = (modelID: string | ModelID) => responsesRoute.model({ id: modelID })
   const chat = (modelID: string | ModelID) => chatRoute.model({ id: modelID })
   return {
     id,
-    model: responses,
-    responses,
+    model: chat,
     chat,
     configure,
   }
@@ -52,5 +38,4 @@ export const configure = (input: ModelOptions = {}) => {
 
 export const provider = configure()
 export const model = provider.model
-export const responses = provider.responses
 export const chat = provider.chat


### PR DESCRIPTION
## Summary

xAI does not implement the OpenAI Responses API (`/v1/responses`). The xAI provider currently defaults to `OpenAIResponses.route`, causing:

```
TypeError: sdk.responses is not a function. (In 'sdk.responses(Q)', 'sdk.responses' is undefined)
```

## Fix

Remove the responses route from the xAI provider and default to `OpenAICompatibleChat.route` (`/v1/chat/completions`) which xAI supports.

## Related Issues

- #16049 — TypeError: sdk.responses is not a function when switching models
- #8622 — gpt-5.2-codex TypeError: sdk.responses is not a function
- vercel/ai#11999 — xAI completely broken

## Tested

- Built patched binary from source
- Verified xAI OAuth + Grok 4.3 works in TUI with the fix