### PR TITLE
feat(server): add wildcard CORS origin support

### DIFF
--- a/packages/opencode/src/server/cors.ts
+++ b/packages/opencode/src/server/cors.ts
@@ -16,6 +16,7 @@ export function isAllowedCorsOrigin(input: string | undefined, opts?: CorsOption
   if (input === "tauri://localhost" || input === "http://tauri.localhost" || input === "https://tauri.localhost")
     return true
   if (opencodeOrigin.test(input)) return true
+  if (opts?.cors?.includes("*")) return true
   return opts?.cors?.includes(input) ?? false
 }
 

--- a/packages/opencode/test/server/httpapi-cors.test.ts
+++ b/packages/opencode/test/server/httpapi-cors.test.ts
@@ -119,4 +119,28 @@ describe("HttpApi CORS", () => {
       expect(rejected.headers.get("access-control-allow-origin")).not.toBe("https://evil.example")
     }),
   )
+
+  it.live("allows any origin when cors contains wildcard *", () =>
+    Effect.gen(function* () {
+      const listener = yield* Effect.acquireRelease(
+        Effect.promise(() => Server.listen({ hostname: "127.0.0.1", port: 0, cors: ["*"] })),
+        (listener) => Effect.promise(() => listener.stop(true)),
+      )
+
+      const response = yield* Effect.promise(() =>
+        fetch(new URL(InstancePaths.path, listener.url), {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://any.origin.example",
+            "access-control-request-method": "GET",
+            "access-control-request-headers": "authorization",
+          },
+        }),
+      )
+
+      expect(response.status).toBe(204)
+      expect(response.headers.get("access-control-allow-origin")).toBe("https://any.origin.example")
+      expect(response.headers.get("access-control-allow-headers")).toBe("authorization")
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #28927

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds wildcard (`*`) origin support to `isAllowedCorsOrigin` in `src/server/cors.ts`. When the server is configured with `cors: ["*"]`, any incoming `Origin` header is now accepted and reflected back in `Access-Control-Allow-Origin`.

### How did you verify your code works?

I ran an opencode server with and without cors, then fetch from my website (has a different origin) to verify the request went through with `Access-Control-Allow-Origin` set.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
