### PR TITLE
docs: add OrgX OpenCode plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -50,6 +50,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
+| [orgx-opencode-plugin](https://github.com/useorgx/orgx-opencode-plugin)                            | Task dispatch, execution receipts, deviations, and passive Work Graph reconciliation events        |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                         |


### PR DESCRIPTION
### Issue for this PR

Closes #28749

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the OrgX OpenCode plugin to the ecosystem Plugins table. The plugin repo is public at https://github.com/useorgx/orgx-opencode-plugin and provides task dispatch, execution receipts, deviations, and passive Work Graph reconciliation events for OpenCode sessions.

### How did you verify your code works?

- `git diff --check`
- `/opt/homebrew/bin/npm exec --yes bun@1.3.14 -- install --frozen-lockfile`
- `/opt/homebrew/bin/npm exec --yes bun@1.3.14 -- --cwd packages/web build`

The web build completed successfully and generated the Astro/Starlight docs output.

### Screenshots / recordings

Not applicable; documentation table row only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR