### PR TITLE
refactor(app): simplify session routing and tab close handling

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -48,21 +48,16 @@ import { ErrorPage } from "./pages/error"
 import { useCheckServerHealth } from "./utils/server-health"
 
 const HomeRoute = lazy(() => import("@/pages/home"))
-const loadSession = () => import("@/pages/session")
-const Session = lazy(loadSession)
-const Loading = () => <div class="size-full" />
+const Session = lazy(() => import("@/pages/session"))
 
-if (typeof location === "object" && /\/session(?:\/|$)/.test(location.pathname)) {
-  void loadSession()
-}
-
-const SessionRoute = () => (
-  <SessionProviders>
-    <Session />
-  </SessionProviders>
+const SessionRoute = Object.assign(
+  () => (
+    <SessionProviders>
+      <Session />
+    </SessionProviders>
+  ),
+  { preload: Session.preload },
 )
-
-const SessionIndexRoute = () => <Navigate href="session" />
 
 function UiI18nBridge(props: ParentProps) {
   const language = useLanguage()
@@ -317,7 +312,7 @@ export function AppInterface(props: {
                 >
                   <Route path="/" component={HomeRoute} />
                   <Route path="/:dir" component={DirectoryLayout}>
-                    <Route path="/" component={SessionIndexRoute} />
+                    <Route path="/" component={() => <Navigate href="session" />} />
                     <Route path="/session/:id?" component={SessionRoute} />
                   </Route>
                 </Dynamic>

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -223,19 +223,13 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
             const navigate = useNavigate()
             const homeMatch = useMatch(() => "/")
 
-            const openNewSession = () => {
-              if (params.dir) {
-                navigate(`/${params.dir}/session`)
-                return
-              }
+            const newSessionHref = () => {
+              if (params.dir) return `/${params.dir}/session`
 
               const project = layout.projects.list()[0]
-              if (!project) {
-                navigate("/")
-                return
-              }
+              if (!project) return "/"
 
-              navigate(`/${base64Encode(project.worktree)}/session`)
+              return `/${base64Encode(project.worktree)}/session`
             }
 
             type Tab = { dir: string; sessionId: string; href: string }
@@ -313,13 +307,21 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
               return true
             }
 
+            const closeNewSessionTab = () => {
+              if (!(params.dir && !params.id)) return false
+              const last = tabsStore[tabsStore.length - 1]
+              if (last) navigate(last.href)
+              else navigate("/")
+              return true
+            }
+
             makeEventListener(
               document,
               "keydown",
               (event) => {
                 if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
                 if (event.key.toLowerCase() !== "w") return
-                if (!closeCurrentSessionTab()) return
+                if (!(closeCurrentSessionTab() || closeNewSessionTab())) return
 
                 event.preventDefault()
                 event.stopPropagation()
@@ -391,7 +393,8 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                         size="large"
                         class="shrink-0"
                         icon={<IconV2 name="plus" />}
-                        onClick={openNewSession}
+                        as="a"
+                        href={newSessionHref()}
                         aria-label={language.t("command.session.new")}
                       />
                     }


### PR DESCRIPTION
- Simplifies lazy loading of Session component and removes manual preloading
- Refactors new session navigation to return href instead of navigating directly
- Adds support for closing new session tabs with Cmd+W