### PR TITLE
feat(opencode): add project delete command with sync cleanup

### DIFF
--- a/packages/opencode/src/cli/cmd/project.ts
+++ b/packages/opencode/src/cli/cmd/project.ts
@@ -1,0 +1,116 @@
+import type { Argv } from "yargs"
+import { Cause, Effect } from "effect"
+import { cmd } from "./cmd"
+import { effectCmd, fail } from "../effect-cmd"
+import { Project } from "@/project/project"
+import { ProjectID } from "../../project/schema"
+import { UI } from "../ui"
+import { EOL } from "os"
+
+export const ProjectCommand = cmd({
+  command: "project",
+  describe: "manage projects",
+  builder: (yargs: Argv) => yargs.command(ProjectDeleteCommand).command(ProjectListCommand).demandCommand(),
+  async handler() {},
+})
+
+export const ProjectDeleteCommand = effectCmd({
+  command: "delete <projectID>",
+  describe: "delete a project and all its data",
+  instance: false,
+  builder: (yargs) =>
+    yargs
+      .positional("projectID", {
+        describe: "project ID to delete",
+        type: "string",
+        demandOption: true,
+      })
+      .option("force", {
+        alias: "f",
+        describe: "skip confirmation",
+        type: "boolean",
+        default: false,
+      }),
+  handler: Effect.fn("Cli.project.delete")(function* (args) {
+    const svc = yield* Project.Service
+    const projectID = ProjectID.make(args.projectID)
+
+    const project = yield* Effect.sync(() => Project.get(projectID))
+
+    if (!args.force) {
+      const name = project?.name ?? projectID
+      const input = yield* Effect.promise(() =>
+        UI.input(`Delete project '${name}' and ALL its data? Type '${projectID}' to confirm: `),
+      )
+      if (input !== projectID) {
+        UI.println("Confirmation failed. Aborting.")
+        return
+      }
+    }
+
+    yield* svc.remove(projectID).pipe(
+      Effect.catchCause((cause) => {
+        const error = Cause.squash(cause)
+        return fail(error instanceof Error ? error.message : String(error))
+      }),
+    )
+    UI.println(UI.Style.TEXT_SUCCESS_BOLD + `Project ${projectID} deleted` + UI.Style.TEXT_NORMAL)
+  }),
+})
+
+export const ProjectListCommand = effectCmd({
+  command: "list",
+  describe: "list projects",
+  instance: false,
+  builder: (yargs) =>
+    yargs.option("format", {
+      describe: "output format",
+      type: "string",
+      choices: ["table", "json"],
+      default: "table",
+    }),
+  handler: Effect.fn("Cli.project.list")(function* (args) {
+    const svc = yield* Project.Service
+    const projects = yield* svc.list()
+
+    if (projects.length === 0) return
+
+    const output = args.format === "json" ? formatProjectJSON(projects) : formatProjectTable(projects)
+    console.log(output)
+  }),
+})
+
+function formatProjectTable(projects: Project.Info[]): string {
+  const lines: string[] = []
+
+  const maxIdWidth = Math.max(20, ...projects.map((p) => p.id.length))
+  const maxNameWidth = Math.max(25, ...projects.map((p) => p.name?.length ?? 0))
+  const maxWorktreeWidth = Math.max(20, ...projects.map((p) => p.worktree.length))
+
+  const header = `Project ID${" ".repeat(Math.max(0, maxIdWidth - 10))}  Name${" ".repeat(Math.max(0, maxNameWidth - 4))}  Worktree${" ".repeat(Math.max(0, maxWorktreeWidth - 8))}  Updated`
+  lines.push(header)
+  lines.push("─".repeat(header.length))
+  for (const project of projects) {
+    const name = project.name ?? ""
+    const paddedId = project.id.padEnd(maxIdWidth)
+    const paddedName = name.padEnd(maxNameWidth)
+    const paddedWorktree = project.worktree.padEnd(maxWorktreeWidth)
+    const timeStr = new Date(project.time.updated).toISOString().slice(0, 19).replace("T", " ")
+    lines.push(`${paddedId}  ${paddedName}  ${paddedWorktree}  ${timeStr}`)
+  }
+
+  return lines.join(EOL)
+}
+
+function formatProjectJSON(projects: Project.Info[]): string {
+  const jsonData = projects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    worktree: project.worktree,
+    vcs: project.vcs,
+    updated: project.time.updated,
+    created: project.time.created,
+    sandboxes: project.sandboxes,
+  }))
+  return JSON.stringify(jsonData, null, 2)
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -29,6 +29,7 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
+import { ProjectCommand } from "./cli/cmd/project"
 import { DbCommand } from "./cli/cmd/db"
 import path from "path"
 import { Global } from "@opencode-ai/core/global"
@@ -176,6 +177,7 @@ const cli = yargs(args)
   .command(GithubCommand)
   .command(PrCommand)
   .command(SessionCommand)
+  .command(ProjectCommand)
   .command(PluginCommand)
   .command(DbCommand)
   .fail((msg, err) => {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -20,6 +20,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { NonNegativeInt, optionalOmitUndefined } from "@opencode-ai/core/schema"
 import { serviceUse } from "@/effect/service-use"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { SyncEvent } from "../sync"
 
 const log = Log.create({ service: "project" })
 
@@ -57,6 +58,7 @@ export type Info = Types.DeepMutable<Schema.Schema.Type<typeof Info>>
 
 export const Event = {
   Updated: BusEvent.define("project.updated", Info),
+  Deleted: BusEvent.define("project.deleted", Info),
 }
 
 type Row = typeof ProjectTable.$inferSelect
@@ -122,6 +124,7 @@ export interface Interface {
   readonly sandboxes: (id: ProjectID) => Effect.Effect<string[]>
   readonly addSandbox: (id: ProjectID, directory: string) => Effect.Effect<void>
   readonly removeSandbox: (id: ProjectID, directory: string) => Effect.Effect<void>
+  readonly remove: (id: ProjectID) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Project") {}
@@ -131,7 +134,7 @@ type GitResult = { code: number; text: string; stderr: string }
 export const layer: Layer.Layer<
   Service,
   never,
-  AppFileSystem.Service | Path.Path | ChildProcessSpawner.ChildProcessSpawner | Bus.Service | RuntimeFlags.Service
+  AppFileSystem.Service | Path.Path | ChildProcessSpawner.ChildProcessSpawner | Bus.Service | RuntimeFlags.Service | SyncEvent.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -140,6 +143,7 @@ export const layer: Layer.Layer<
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const bus = yield* Bus.Service
     const flags = yield* RuntimeFlags.Service
+    const sync = yield* SyncEvent.Service
 
     const git = Effect.fnUntraced(
       function* (args: string[], opts?: { cwd?: string }) {
@@ -166,6 +170,15 @@ export const layer: Layer.Layer<
           directory: "global",
           project: data.id,
           payload: { type: Event.Updated.type, properties: data },
+        }),
+      )
+
+    const emitDeleted = (data: Info) =>
+      Effect.sync(() =>
+        GlobalBus.emit("event", {
+          directory: "global",
+          project: data.id,
+          payload: { type: Event.Deleted.type, properties: data },
         }),
       )
 
@@ -486,6 +499,27 @@ export const layer: Layer.Layer<
       yield* emitUpdated(fromRow(result))
     })
 
+    const remove: Interface["remove"] = Effect.fn("Project.remove")(function* (id: ProjectID) {
+      if (id === ProjectID.global) throw new Error("Cannot delete the default project")
+      const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
+      if (!row) throw new Error(`Project not found: ${id}`)
+
+      const data = fromRow(row)
+
+      const sessions = yield* db((d) =>
+        d.select({ id: SessionTable.id }).from(SessionTable).where(eq(SessionTable.project_id, id)).all(),
+      )
+      yield* Effect.forEach(
+        sessions,
+        (session) => sync.remove(session.id),
+        { concurrency: "unbounded" },
+      )
+
+      yield* db((d) => d.delete(ProjectTable).where(eq(ProjectTable.id, id)).run())
+
+      yield* emitDeleted(data)
+    })
+
     return Service.of({
       init,
       fromDirectory,
@@ -498,6 +532,7 @@ export const layer: Layer.Layer<
       sandboxes,
       addSandbox,
       removeSandbox,
+      remove,
     })
   }),
 )
@@ -508,6 +543,7 @@ export const defaultLayer = layer.pipe(
   Layer.provide(AppFileSystem.defaultLayer),
   Layer.provide(NodePath.layer),
   Layer.provide(RuntimeFlags.defaultLayer),
+  Layer.provide(SyncEvent.defaultLayer),
 )
 
 export const use = serviceUse(Service)

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -14,6 +14,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { SyncEvent } from "../../src/sync"
 
 void Log.init({ print: false })
 
@@ -71,6 +72,7 @@ function projectLayerWithFailure(failArg: string) {
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
     Layer.provide(RuntimeFlags.defaultLayer),
+    Layer.provide(SyncEvent.defaultLayer),
   )
 }
 
@@ -80,6 +82,7 @@ function projectLayerWithRuntimeFlags(flags: Parameters<typeof RuntimeFlags.laye
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
     Layer.provide(RuntimeFlags.layer(flags)),
+    Layer.provide(SyncEvent.defaultLayer),
   )
 }
 
@@ -709,6 +712,36 @@ describe("Project.fromDirectory with bare repos", () => {
 
       const correctCache = path.join(barePath, "opencode")
       expect(yield* Effect.promise(() => Bun.file(correctCache).exists())).toBe(true)
+    }),
+  )
+})
+
+describe("Project.remove", () => {
+  it.live("throws error for non-existent project", () =>
+    Effect.gen(function* () {
+      const exit = yield* run((svc) => svc.remove(ProjectID.make("nonexistent-project"))).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+    }),
+  )
+
+  it.live("throws error when deleting global project", () =>
+    Effect.gen(function* () {
+      const exit = yield* run((svc) => svc.remove(ProjectID.global)).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+    }),
+  )
+
+  it.live("removes existing project and cleans up data", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
+
+      expect(Project.get(project.id)).toBeDefined()
+
+      yield* run((svc) => svc.remove(project.id))
+
+      const afterRemove = Project.get(project.id)
+      expect(afterRemove).toBeUndefined()
     }),
   )
 })


### PR DESCRIPTION
- Add Project.remove() with Event.Deleted and sync event cleanup
- Create CLI cmd/project.ts with delete and list subcommands
- Prevent deletion of default project (global)
- Add unit tests for remove() including global protection
