### PR TITLE
fix: convert display-width offsets to char indices when expanding paste extmarks

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1092,6 +1092,21 @@ export function Prompt(props: PromptProps) {
     const messageID = MessageID.ascending()
     let inputText = store.prompt.input
 
+    // Extmark start/end are display-width offsets, NOT JS string indices.
+    // Convert them to char indices before slicing.
+    function visualOffsetToCharIndex(text: string, visualOffset: number): number {
+      let seen = 0
+      let idx = 0
+      while (idx < text.length) {
+        if (seen >= visualOffset) return idx
+        const cp = text.codePointAt(idx)!
+        const char = String.fromCodePoint(cp)
+        seen += char === "\n" ? 1 : Bun.stringWidth(char)
+        idx += char.length
+      }
+      return idx
+    }
+
     // Expand pasted text inline before submitting
     const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
     const sortedExtmarks = allExtmarks.sort((a: { start: number }, b: { start: number }) => b.start - a.start)
@@ -1101,8 +1116,10 @@ export function Prompt(props: PromptProps) {
       if (partIndex !== undefined) {
         const part = store.prompt.parts[partIndex]
         if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
+          const charStart = visualOffsetToCharIndex(inputText, extmark.start)
+          const charEnd = visualOffsetToCharIndex(inputText, extmark.end)
+          const before = inputText.slice(0, charStart)
+          const after = inputText.slice(charEnd)
           inputText = before + part.text + after
         }
       }


### PR DESCRIPTION
## Problem

When submitting a prompt with pasted content after typing CJK characters (Korean, Chinese, Japanese), the submitted message shows literal \[Pasted\ text instead of the actual pasted content.

## Root Cause

In \submitInner()\, the code expands pasted text from extmarks using:

\\\	s
const before = inputText.slice(0, extmark.start)
const after = inputText.slice(extmark.end)
\\\

However, extmark \start\/\end\ are **display-width offsets** (visual columns), not JS string indices. \slice()\ expects character indices. For CJK characters (visual width 2, string length 1), these diverge, causing \slice()\ to cut at wrong positions.

## Fix

Add \isualOffsetToCharIndex()\ that walks the string accumulating visual width until reaching the target offset, then returns the corresponding character index. Use it to convert extmark positions before slicing.

## Related

- Depends on opentui fix: https://github.com/anomalyco/opentui/pull/1102 (extmark shift using \stringWidth\ instead of \	ext.length\)