### PR TITLE
fix(session): stop auto-compaction infinite loop when assistant ended its turn

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -474,6 +474,29 @@ export const layer = Layer.effect(
         })
       }
 
+      // Detect whether the assistant that triggered this auto-compaction ended
+      // its turn naturally (finish set, not "tool-calls"/"unknown", no pending
+      // tool calls). If so, the synthetic "Continue if you have next steps..."
+      // follow-up below would push the model into another turn, which itself
+      // overflows, triggers another compaction, injects another Continue —
+      // infinite loop. See https://github.com/anomalyco/opencode/issues/15533
+      let lastRealAssistant: { info: MessageV2.Assistant; parts: MessageV2.Part[] } | undefined
+      for (let i = input.messages.length - 1; i >= 0; i--) {
+        const m = input.messages[i]!
+        if (m.info.role !== "assistant") continue
+        if (m.info.summary || !m.info.finish) continue
+        lastRealAssistant = m as { info: MessageV2.Assistant; parts: MessageV2.Part[] }
+        break
+      }
+      const hasPendingToolCalls =
+        lastRealAssistant?.parts.some(
+          (part) => part.type === "tool" && !part.metadata?.providerExecuted,
+        ) ?? false
+      const assistantEndedNaturally =
+        lastRealAssistant !== undefined &&
+        !["tool-calls", "unknown"].includes(lastRealAssistant.info.finish ?? "") &&
+        !hasPendingToolCalls
+
       if (result === "continue" && input.auto) {
         if (replay) {
           const original = replay.info
@@ -503,7 +526,7 @@ export const layer = Layer.effect(
           }
         }
 
-        if (!replay) {
+        if (!replay && !assistantEndedNaturally) {
           const info = yield* provider.getProvider(userMessage.model.providerID)
           if (
             (yield* plugin.trigger(
@@ -578,6 +601,13 @@ export const layer = Layer.effect(
         }
         yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
       }
+      // When the previous assistant turn ended naturally and there is no user
+      // message to replay, exit the prompt loop. Without this, the loop would
+      // re-iterate, hit the natural break condition only to find that the
+      // compaction user message is newer than the last assistant, and re-enter
+      // the model call — re-triggering #15533. Returning "stop" lets the user
+      // resume with their next prompt instead.
+      if (result === "continue" && input.auto && !replay && assistantEndedNaturally) return "stop"
       return result
     })
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -907,6 +907,43 @@ describe("session.compaction.process", () => {
     }),
   )
 
+  // Regression test for https://github.com/anomalyco/opencode/issues/15533:
+  // when the assistant message that triggered auto-compaction already
+  // finished naturally (finish != tool-calls, no pending tool calls), the
+  // synthetic Continue must NOT be injected and process() must return "stop"
+  // so the prompt loop exits instead of looping forever.
+  it.instance(
+    "skips synthetic continue and stops when prior assistant ended naturally",
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const ssn = yield* SessionNs.Service
+      const session = yield* ssn.create({})
+      const user = yield* createUserMessage(session.id, "hello")
+      yield* createAssistantMessage(session.id, user.id, test.directory)
+      yield* createCompactionMarker(session.id)
+      const msgs = yield* ssn.messages({ sessionID: session.id })
+      const parent = msgs.at(-1)?.info.id
+      expect(parent).toBeTruthy()
+
+      const result = yield* SessionCompaction.use.process({
+        parentID: parent!,
+        messages: msgs,
+        sessionID: session.id,
+        auto: true,
+      })
+
+      const all = yield* ssn.messages({ sessionID: session.id })
+      const synthetic = all.find((m) =>
+        m.parts.some(
+          (p) => p.type === "text" && p.metadata?.compaction_continue === true,
+        ),
+      )
+
+      expect(result).toBe("stop")
+      expect(synthetic).toBeUndefined()
+    }),
+  )
+
   itCompaction.instance(
     "persists tail_start_id for retained recent turns",
     Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Fixes #15533.

Auto-compaction triggers after an assistant turn whose token usage overflows the model's context window. Before this change, `SessionCompaction.process()` unconditionally injected a synthetic `Continue if you have next steps...` user message whenever `auto: true` and no replay was needed.

When the assistant had **already ended its turn naturally** (`finish` ≠ `"tool-calls"` / `"unknown"` and no pending tool calls), that synthetic Continue pushed the model into yet another turn — which overflowed again, triggered another compaction, injected another Continue, and so on. Sessions got stuck in the `Build → Compaction → Build → Compaction → …` loop reported repeatedly in #15533, including reproductions with Claude Opus via Copilot, OpenAI GPT 5.5, local llama.cpp, mlx, and others.

## What this PR changes

`packages/opencode/src/session/compaction.ts`:

1. Before deciding whether to inject the synthetic Continue, walk `input.messages` backwards and find the most recent **non-summary assistant message that has `finish` set** — i.e. the message whose overflow caused this auto-compaction.
2. Classify it as "ended naturally" iff:
   - `finish` is **not** `"tool-calls"` or `"unknown"`, and
   - it has no non-providerExecuted `tool` parts pending.
   This matches the finish-reason set the prompt loop itself uses at `prompt.ts:1267-1275` to decide it can break out of the run loop.
3. If the assistant ended naturally:
   - Skip the synthetic Continue injection.
   - Return `"stop"` from `process()` so `runLoop` in `prompt.ts` exits cleanly instead of re-entering with a synthetic user message that is now newer than `lastAssistant`.

## What this PR does *not* change

- Manual compaction (`auto: false`) — never injected Continue, untouched.
- The overflow-with-replay path (`input.overflow === true` with a recoverable prior user message) — still replays the original user turn.
- Mid-tool-call compactions (`finish === "tool-calls"` or pending tool calls) — still inject Continue so the model can finish its in-flight work.
- The `experimental.compaction.autocontinue` plugin hook — still consulted exactly as before for the (now narrower) cases where we *do* want to autocontinue.

## Test plan

- [x] `bun test test/session/compaction.test.ts` — 52/52 pass.
- [x] Existing "adds synthetic continue prompt when auto is enabled" test still passes (assistant with no prior `finish` ⇒ `assistantEndedNaturally` stays false ⇒ Continue still injected).
- [x] New regression test added: `skips synthetic continue and stops when prior assistant ended naturally` — sets up `user → assistant(finish=end_turn) → compaction-marker user`, calls `process({ auto: true })`, asserts (a) no `compaction_continue`-marked synthetic user is produced, and (b) `process` returns `"stop"`.
- [x] `bun run typecheck` clean (full monorepo, 15/15 packages).

## Why "stop" instead of "continue" at the end

If we only skipped the Continue injection but still returned `"continue"`, the prompt loop in `prompt.ts:1294-1304` would `continue` back to the top. There it would find the just-created compaction user message as `lastUser`, with `lastUser.id > lastAssistant.id`, so the `lastUser.id < lastAssistant.id` natural break condition (`prompt.ts:1271`) would be false, and the loop would call the model again with the compacted summary in context — re-triggering #15533 by a slightly different path. Returning `"stop"` ends the loop the moment we know the assistant had nothing more to do. The user can pick up the conversation with their next prompt; the compacted summary is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)