### PR TITLE
feat(opencode): allow vscode-webview:// origins in cors allowlist

### DIFF
--- a/packages/opencode/src/server/cors.ts
+++ b/packages/opencode/src/server/cors.ts
@@ -15,6 +15,7 @@ export function isAllowedCorsOrigin(input: string | undefined, opts?: CorsOption
   if (input.startsWith("oc://renderer")) return true
   if (input === "tauri://localhost" || input === "http://tauri.localhost" || input === "https://tauri.localhost")
     return true
+  if (input.startsWith("vscode-webview://")) return true
   if (opencodeOrigin.test(input)) return true
   return opts?.cors?.includes(input) ?? false
 }

--- a/packages/opencode/test/server/httpapi-cors.test.ts
+++ b/packages/opencode/test/server/httpapi-cors.test.ts
@@ -119,4 +119,27 @@ describe("HttpApi CORS", () => {
       expect(rejected.headers.get("access-control-allow-origin")).not.toBe("https://evil.example")
     }),
   )
+
+  it.live("allows vscode-webview:// origins without an explicit --cors entry", () =>
+    Effect.gen(function* () {
+      // VS Code assigns each WebviewPanel a fresh `vscode-webview://<random-guid>`
+      // origin. Without this allowance, extensions that embed opencode would
+      // have to restart the process on every new panel to refresh the --cors
+      // allowlist (killing any in-flight turn). Mirrors the existing tauri
+      // allowance for the same reason.
+      const response = yield* HttpClientRequest.options(InstancePaths.path).pipe(
+        HttpClientRequest.setHeaders({
+          origin: "vscode-webview://0abc1234-5678-90de-fghi-jklmnopqrstu",
+          "access-control-request-method": "GET",
+          "access-control-request-headers": "authorization",
+        }),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(204)
+      expect(response.headers["access-control-allow-origin"]).toBe(
+        "vscode-webview://0abc1234-5678-90de-fghi-jklmnopqrstu",
+      )
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

None — improves out-of-the-box behavior for VS Code webview integrations.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `vscode-webview://*` to `isAllowedCorsOrigin`'s built-in allowlist in `packages/opencode/src/server/cors.ts`, mirroring the existing `tauri://localhost` allowance.

**Why this matters in practice.** VS Code assigns every `WebviewPanel` a fresh `vscode-webview://<random-guid>` origin — the suffix is unguessable per-panel by design. An extension that embeds opencode and hosts UI in a webview has to:

1. Pass each panel's origin via repeated `--cors` flags at spawn time, and
2. **Restart opencode every time the user opens a new panel** — the allowlist is exact-match (`opts?.cors?.includes(input)`, no wildcards), and there's no way to extend it without a respawn.

That restart kills any in-flight turn. Opening a new editor tab interrupts generation in the existing tab. We're shipping a VS Code extension that wraps opencode and hit this every time. With this patch, our extension stops needing `--cors` plumbing at all for the webview case.

`vscode-webview://` is the same shape as the already-allowed `tauri://localhost`:
- Both wrap a local IDE host, not a remote site.
- Both talk to the loopback opencode server, which is bearer-token-auth'd separately.
- The CORS allowance is ceremony for what is architecturally same-origin traffic.

**Relation to #28743.** That PR adds explicit `cors: ["*"]` wildcard support — opt-in for users who want everything allowed. This PR is complementary: a hardcoded allowance for a specific safe scheme, so the common case of "wrap opencode in a VS Code webview" works without any `--cors` configuration. Both can land independently.

### How did you verify your code works?

Added a regression test in `packages/opencode/test/server/httpapi-cors.test.ts` alongside the existing tauri / custom-cors cases, asserting a `vscode-webview://<guid>` preflight passes without any `--cors` argument.

```
$ bun test test/server/httpapi-cors.test.ts
 4 pass
 0 fail
```

Built `v1.15.7 + this patch` from source and verified end-to-end in our VS Code extension: opening multiple webview panels no longer requires restarting opencode, and no longer interrupts in-flight turns in sibling panels.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR