### PR TITLE
fix(session): inline @agent mention uses agent's configured model

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -680,7 +680,7 @@ export const layer = Layer.effect(
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
-      const agentName = input.agent ?? input.parts.find((p): p is MessageV2.AgentPartInput => p.type === "agent")?.name
+      const agentName = input.agent ?? input.parts.find((p): p is SessionV1.AgentPartInput => p.type === "agent")?.name
       const ag = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()
       if (!ag) {
         const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -680,7 +680,7 @@ export const layer = Layer.effect(
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
-      const agentName = input.agent
+      const agentName = input.agent ?? input.parts.find((p): p is MessageV2.AgentPartInput => p.type === "agent")?.name
       const ag = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()
       if (!ag) {
         const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2229,6 +2229,57 @@ noLLMServer.instance(
   },
 )
 
+// Inline agent mention uses agent's configured model
+
+it.instance(
+  "inline @agent mention uses the agent's configured model instead of default",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        noReply: true,
+        parts: [
+          { type: "agent", name: "other" },
+          { type: "text", text: "hello from other agent" },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+      expect(msg.info.model.providerID).toBe(ProviderID.make("test"))
+      expect(msg.info.model.modelID).toBe(ModelID.make("test-model-2"))
+
+      yield* sessions.remove(session.id)
+    }),
+  {
+    config: {
+      ...cfg,
+      provider: {
+        ...cfg.provider,
+        test: {
+          ...cfg.provider.test,
+          models: {
+            ...cfg.provider.test.models,
+            "test-model-2": {
+              ...cfg.provider.test.models["test-model"],
+              id: "test-model-2",
+              name: "Test Model 2",
+            },
+          },
+        },
+      },
+      agent: {
+        other: {
+          model: "test/test-model-2",
+        },
+      },
+    },
+  },
+)
+
 // Agent / command resolution errors
 
 noLLMServer.instance(

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2249,8 +2249,8 @@ it.instance(
       })
 
       if (msg.info.role !== "user") throw new Error("expected user message")
-      expect(msg.info.model.providerID).toBe(ProviderID.make("test"))
-      expect(msg.info.model.modelID).toBe(ModelID.make("test-model-2"))
+      expect(msg.info.model.providerID).toBe(ProviderV2.ID.make("test"))
+      expect(msg.info.model.modelID).toBe(ModelV2.ID.make("test-model-2"))
 
       yield* sessions.remove(session.id)
     }),


### PR DESCRIPTION
### Issue for this PR

Closes #28809

### Type of change

- [x] Bug fix

### What does this PR do?

Single-line fix in `packages/opencode/src/session/prompt.ts`:

```diff
- const agentName = input.agent
+ const agentName = input.agent ?? input.parts.find((p): p is SessionV1.AgentPartInput => p.type === \"agent\")?.name
```

`createUserMessage` was only reading `input.agent` (top-level field set by the UI agent switch). When mentioning an agent inline like `@other hello`, the agent name lives in `input.parts` as `AgentPartInput`, so `input.agent` remains undefined. This caused the code to fall back to the default agent's model instead of using the mentioned agent's configured model.

### How did you verify your code works?

- Added test in `test/session/prompt.test.ts`: inline `@agent` mention uses the agent's configured model
- `bun typecheck` passes (all packages)
- `bun test ./test/session/prompt.test.ts --test-name-pattern \"inline.*agent.*mention\"` passes
- Full prompt test suite: all relevant tests pass

### Screenshots / recordings

_N/A — logic fix, no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR