### PR TITLE
fix(desktop): correct user code extraction when URL contains colons

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -524,7 +524,7 @@ export function DialogConnectProvider(props: { provider: string }) {
     const code = createMemo(() => {
       const instructions = store.authorization?.instructions
       if (instructions?.includes(":")) {
-        return instructions.split(":")[1]?.trim()
+        return instructions.split(":").pop()?.trim()
       }
       return instructions
     })


### PR DESCRIPTION
### Issue for this PR

Closes #28834

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixed user code extraction in the desktop app's OAuth auto-view. The previous code used `instructions.split(":")[1]?.trim()`, which breaks when the instruction text contains multiple colons _(e.g., xAI's Open https://accounts.x.ai/oauth2/device on any device and enter code: ABCD-1234)_. This caused garbled text like "//accounts.x.ai/oauth2/device on any device and enter code" to display instead of the actual code.

Changed to `instructions.split(":").pop()?.trim()` to always grab the final segment (the real user code) regardless of how many colons appear in the URL or instruction text.

### How did you verify your code works?

- Verified the fix resolves the broken display for xAI device-code OAuth.
- Tested GitHub Copilot OAuth to confirm existing flows still work correctly and are not regressed.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR