### PR TITLE
fix(httpapi): encode event stream timestamps as epoch millis

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -5,18 +5,10 @@ import * as Stream from "effect/Stream"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
+import { eventData } from "@/server/shared/sse"
 import { EventApi } from "../groups/event"
 
 const log = Log.create({ service: "server" })
-
-function eventData(data: unknown): Sse.Event {
-  return {
-    _tag: "Event",
-    event: "message",
-    id: undefined,
-    data: JSON.stringify(data),
-  }
-}
 
 function eventResponse(bus: Bus.Interface) {
   return Effect.gen(function* () {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -11,19 +11,11 @@ import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
+import { eventData } from "@/server/shared/sse"
 import { RootHttpApi } from "../api"
 import { GlobalUpgradeInput } from "../groups/global"
 
 const log = Log.create({ service: "server" })
-
-function eventData(data: unknown): Sse.Event {
-  return {
-    _tag: "Event",
-    event: "message",
-    id: undefined,
-    data: JSON.stringify(data),
-  }
-}
 
 function parseBody(body: string) {
   try {

--- a/packages/opencode/src/server/shared/sse.ts
+++ b/packages/opencode/src/server/shared/sse.ts
@@ -1,0 +1,26 @@
+import { DateTime } from "effect"
+import * as Sse from "effect/unstable/encoding/Sse"
+
+// Serialize a bus/global event payload into an SSE frame for the `/event` and
+// `/global/event` streams.
+export function eventData(data: unknown): Sse.Event {
+  return {
+    _tag: "Event",
+    event: "message",
+    id: undefined,
+    data: JSON.stringify(encodeDateTimes(data)),
+  }
+}
+
+// `DateTime.toJSON()` emits ISO 8601 strings, but every event schema declares
+// timestamps as epoch-millis numbers (`V2Schema.DateTimeUtcFromMillis`). Encode
+// any `DateTime` to epoch millis so the wire form matches the OpenAPI spec.
+// See https://github.com/anomalyco/opencode/issues/28847.
+function encodeDateTimes(value: unknown): unknown {
+  if (DateTime.isDateTime(value)) return DateTime.toEpochMillis(value)
+  if (Array.isArray(value)) return value.map(encodeDateTimes)
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, encodeDateTimes(item)]))
+  }
+  return value
+}

--- a/packages/opencode/test/server/httpapi-event-diagnostics.test.ts
+++ b/packages/opencode/test/server/httpapi-event-diagnostics.test.ts
@@ -40,11 +40,24 @@ import { testEffectShared } from "../lib/effect"
 
 void Log.init({ print: false })
 
-const SseEvent = Schema.Struct({
-  id: Schema.optional(Schema.String),
-  type: Schema.String,
-  properties: Schema.Record(Schema.String, Schema.Any),
-})
+// Per-type wire schema for the events exercised below. The decode succeeds iff
+// the frame matches the Effect Schema that generates `openapi.json` for that
+// type, so any wire-form drift (e.g. issue #28847's ISO-string timestamp
+// regression) shows up as a decode error rather than slipping past loose
+// `Record<string, Any>` assertions. Add a variant when a new event type is
+// published below.
+const SseEvent = Schema.Union([
+  Schema.Struct({
+    id: Schema.optional(Schema.String),
+    type: Schema.Literal(ServerEvent.Connected.type),
+    properties: ServerEvent.Connected.properties,
+  }),
+  Schema.Struct({
+    id: Schema.optional(Schema.String),
+    type: Schema.Literal(MessageV2.Event.PartUpdated.type),
+    properties: MessageV2.Event.PartUpdated.properties,
+  }),
+])
 
 type SseEvent = Schema.Schema.Type<typeof SseEvent>
 type BusEvent = { type: string; properties: unknown }
@@ -121,7 +134,11 @@ const collectUntilEvent = (reader: ReadableStreamDefaultReader<Uint8Array>, pred
     }),
   )
 
-const isPartUpdated = (event: { type: string }) => event.type === MessageV2.Event.PartUpdated.type
+// Generic so the same predicate narrows both SSE frames (`SseEvent` → `PartUpdatedFrame`)
+// and the in-process Bus callback payloads (`BusEvent` → `BusEvent & {type: ...}`).
+const isPartUpdated = <E extends { type: string }>(
+  event: E,
+): event is E & { type: typeof MessageV2.Event.PartUpdated.type } => event.type === MessageV2.Event.PartUpdated.type
 
 describe("/event SSE delivery diagnostics", () => {
   // Sanity: baseline same as httpapi-event.test.ts test 3 (already known to pass)

--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -1,21 +1,39 @@
 import { afterEach, describe, expect } from "bun:test"
-import { Effect, Schema } from "effect"
+import { DateTime, Effect, Schema } from "effect"
 import * as Log from "@opencode-ai/core/util/log"
+import { SessionEvent } from "@opencode-ai/core/session-event"
 import { Bus } from "../../src/bus"
+import { GlobalBus } from "../../src/bus/global"
 import { Event as ServerEvent } from "../../src/server/event"
 import { Server } from "../../src/server/server"
 import { EventPaths } from "../../src/server/routes/instance/httpapi/groups/event"
+import { GlobalPaths } from "../../src/server/routes/instance/httpapi/groups/global"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffectShared } from "../lib/effect"
 
 void Log.init({ print: false })
 
-const EventData = Schema.Struct({
-  id: Schema.optional(Schema.String),
-  type: Schema.String,
-  properties: Schema.Record(Schema.String, Schema.Any),
-})
+// Per-type wire schema for every event this file exercises. Decoding a frame
+// through this union enforces both the `{id, type, properties}` envelope and
+// the per-type `properties` shape — the same Effect Schemas that generate the
+// OpenAPI spec, so a wire-form regression (issue #28847 was one) fails the
+// decode with a precise schema error. Add a variant when a new event type
+// appears in the tests below.
+const EventFrame = Schema.Union([
+  Schema.Struct({
+    id: Schema.optional(Schema.String),
+    type: Schema.Literal(ServerEvent.Connected.type),
+    properties: ServerEvent.Connected.properties,
+  }),
+  Schema.Struct({
+    id: Schema.optional(Schema.String),
+    type: Schema.Literal(SessionEvent.AgentSwitched.type),
+    properties: SessionEvent.AgentSwitched.data,
+  }),
+])
+
+const decodeEventFrame = Schema.decodeUnknownSync(EventFrame)
 
 const readEvent = (reader: ReadableStreamDefaultReader<Uint8Array>) =>
   Effect.gen(function* () {
@@ -26,9 +44,7 @@ const readEvent = (reader: ReadableStreamDefaultReader<Uint8Array>) =>
       }),
     )
     if (result.done || !result.value) return yield* Effect.fail(new Error("event stream closed"))
-    return Schema.decodeUnknownSync(EventData)(
-      JSON.parse(new TextDecoder().decode(result.value).replace(/^data: /, "")),
-    )
+    return decodeEventFrame(JSON.parse(new TextDecoder().decode(result.value).replace(/^data: /, "")))
   })
 
 const openEventStream = (directory: string) =>
@@ -40,6 +56,44 @@ const openEventStream = (directory: string) =>
     const reader = response.body.getReader()
     yield* Effect.addFinalizer(() => Effect.promise(() => reader.cancel().catch(() => undefined)))
     return { response, reader }
+  })
+
+const openGlobalStream = () =>
+  Effect.gen(function* () {
+    const response = yield* Effect.promise(async () => Server.Default().app.request(GlobalPaths.event))
+    if (!response.body) return yield* Effect.die("missing SSE response body")
+    const reader = response.body.getReader()
+    yield* Effect.addFinalizer(() => Effect.promise(() => reader.cancel().catch(() => undefined)))
+    return { response, reader }
+  })
+
+// /global/event wraps each emission as `{directory?, payload: <inner>}` where
+// `<inner>` is either a connected/heartbeat envelope or a sync event whose
+// `syncEvent.data` carries the EventV2 payload. We parse loosely here and
+// decode the inner `data` through its declared Effect Schema below — that is
+// the spec contract for the nested wire form.
+const readGlobalFrame = (reader: ReadableStreamDefaultReader<Uint8Array>) =>
+  Effect.gen(function* () {
+    const result = yield* Effect.promise(() => reader.read()).pipe(
+      Effect.timeoutOrElse({
+        duration: "5 seconds",
+        orElse: () => Effect.fail(new Error("timed out waiting for global event")),
+      }),
+    )
+    if (result.done || !result.value) return yield* Effect.fail(new Error("global event stream closed"))
+    return JSON.parse(new TextDecoder().decode(result.value).replace(/^data: /, "")) as {
+      directory?: string
+      payload: { id?: string; type: string; syncEvent?: { type: string; data: unknown } }
+    }
+  })
+
+const waitFor = (predicate: () => boolean) =>
+  Effect.gen(function* () {
+    const deadline = Date.now() + 2000
+    while (!predicate()) {
+      if (Date.now() > deadline) return yield* Effect.fail(new Error("timed out waiting for condition"))
+      yield* Effect.sleep("5 millis")
+    }
   })
 
 afterEach(async () => {
@@ -97,5 +151,86 @@ describe("event HttpApi", () => {
         expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
       }),
     { git: true, config: { formatter: false, lsp: false } },
+  )
+})
+
+// Regression coverage for https://github.com/anomalyco/opencode/issues/28847.
+// `session.next.*` events declare `timestamp` as the encoded form of
+// `V2Schema.DateTimeUtcFromMillis` — a finite number. Effect `DateTime` values
+// serialize through `toJSON()` as ISO 8601 strings, which would not satisfy
+// the schema. These tests publish on both event endpoints and rely on the
+// per-type schema decode above to fail loudly if the wire form drifts.
+describe("event timestamp serialization", () => {
+  it.instance(
+    "/event encodes session.next.* timestamps as epoch millis per the schema",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+        const { reader } = yield* openEventStream(directory)
+        expect((yield* readEvent(reader)).type).toBe(ServerEvent.Connected.type)
+
+        const now = Date.now()
+        yield* Bus.use.publish(
+          // `Bus.publish` wants `{type, properties: Schema}`; the EventV2-style
+          // `SessionEvent.AgentSwitched` exposes its payload schema as `.data`.
+          { type: SessionEvent.AgentSwitched.type, properties: SessionEvent.AgentSwitched.data },
+          {
+            sessionID: "ses_0000000000000000000000000000",
+            timestamp: DateTime.makeUnsafe(now),
+            agent: "build",
+          },
+        )
+
+        // readEvent decodes the frame through `SessionEvent.AgentSwitched.data`
+        // for this type — an ISO-string regression would throw with a precise
+        // "Expected number, got string at .properties.timestamp" error.
+        const event = yield* readEvent(reader)
+        if (event.type !== SessionEvent.AgentSwitched.type) {
+          return yield* Effect.fail(new Error(`unexpected event type ${event.type}`))
+        }
+        expect(DateTime.toEpochMillis(event.properties.timestamp)).toBe(now)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.live("/global/event encodes nested sync timestamps as epoch millis per the schema", () =>
+    Effect.gen(function* () {
+      const before = GlobalBus.listenerCount("event")
+      const { reader } = yield* openGlobalStream()
+      expect(yield* readGlobalFrame(reader)).toMatchObject({ payload: { type: "server.connected" } })
+
+      // The global handler registers its GlobalBus listener lazily, only once
+      // server.connected has drained. Wait for it before emitting so the
+      // event isn't dropped before anyone is listening.
+      yield* waitFor(() => GlobalBus.listenerCount("event") > before)
+
+      const now = Date.now()
+      yield* Effect.sync(() =>
+        GlobalBus.emit("event", {
+          directory: "/tmp/issue-28847",
+          payload: {
+            type: "sync",
+            syncEvent: {
+              type: "session.next.agent.switched.1",
+              id: "evt_0000000000000000000000000000",
+              seq: 0,
+              aggregateID: "ses_0000000000000000000000000000",
+              data: {
+                sessionID: "ses_0000000000000000000000000000",
+                timestamp: DateTime.makeUnsafe(now),
+                agent: "build",
+              },
+            },
+          },
+        }),
+      )
+
+      const frame = yield* readGlobalFrame(reader)
+      if (!frame.payload.syncEvent) return yield* Effect.fail(new Error("expected sync event in global frame"))
+      // Decode the inner `data` through the EventV2 schema; succeeds iff every
+      // declared field (including `timestamp` as a finite number) is on the wire.
+      const data = Schema.decodeUnknownSync(SessionEvent.AgentSwitched.data)(frame.payload.syncEvent.data)
+      expect(DateTime.toEpochMillis(data.timestamp)).toBe(now)
+    }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #28847

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The OpenAPI spec declares `session.next.*` event `timestamp` as a number (epoch millis), but the SSE streams sent it as an ISO 8601 string. Bus payloads carry Effect `DateTime` objects, and `JSON.stringify` serializes those via `DateTime.toJSON()` (ISO string) instead of the schema-encoded epoch millis. The shared `eventData` SSE serializer now walks the payload and converts any `DateTime` to epoch millis before stringifying, so `/event` and `/global/event`
match the spec.

The vast majority of this PR adds the tests. The first commit is the actual fix. We can merge only the fix if you think the tests add too much complexity.

### How did you verify your code works?

I ran a build of this branch locally and interacted with the API, making sure it now returns the unix epoch integer. I also added regression tests for `/event`, `/global/event` (nested sync events), and the `eventData` serializer. Also ran the full opencode test suite, typecheck, and the httpapi exerciser gates locally.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
