### PR TITLE
fix(app): respect custom opencode project icons

### DIFF
--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -12,8 +12,10 @@ import {
   displayName,
   effectiveWorkspaceOrder,
   errorMessage,
+  getProjectAvatarSource,
   hasProjectPermissions,
   latestRootSession,
+  OPENCODE_PROJECT_ID,
 } from "./helpers"
 import { pathKey } from "@/utils/path-key"
 
@@ -215,6 +217,20 @@ describe("layout workspace helpers", () => {
   test("formats fallback project display name", () => {
     expect(displayName({ worktree: "/tmp/app" })).toBe("app")
     expect(displayName({ worktree: "/tmp/app", name: "My App" })).toBe("My App")
+  })
+
+  test("uses the opencode favicon as the default project icon", () => {
+    expect(getProjectAvatarSource(OPENCODE_PROJECT_ID)).toBe("https://opencode.ai/favicon.svg")
+  })
+
+  test("allows custom project icons to override the opencode favicon", () => {
+    expect(getProjectAvatarSource(OPENCODE_PROJECT_ID, { override: "data:image/png;base64,abc" })).toBe(
+      "data:image/png;base64,abc",
+    )
+  })
+
+  test("allows color avatars to override the opencode favicon", () => {
+    expect(getProjectAvatarSource(OPENCODE_PROJECT_ID, { color: "pink" })).toBeUndefined()
   })
 
   test("extracts api error message and fallback", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -55,12 +55,12 @@ export const childSessionOnPath = (sessions: Session[] | undefined, rootID: stri
 export const displayName = (project: { name?: string; worktree: string }) =>
   project.name || getFilename(project.worktree)
 
-const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
+export const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
 export function getProjectAvatarSource(id?: string, icon?: { color?: string; url?: string; override?: string }) {
-  if (id === OPENCODE_PROJECT_ID) return "https://opencode.ai/favicon.svg"
   if (icon?.override) return icon.override
   if (icon?.color) return undefined
+  if (id === OPENCODE_PROJECT_ID) return "https://opencode.ai/favicon.svg"
   return icon?.url
 }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #27882
Fixes #26888
Fixes #24744
Fixes #24197

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The opencode project has a default hard-coded favicon. That default was returned before checking user-provided icon overrides, so an uploaded project icon could be saved but still not display for that project.

This changes the avatar-source precedence to prefer uploaded overrides first, then color avatars, then the opencode favicon fallback. It also adds regression coverage for that precedence.

### How did you verify your code works?

<details>
<summary>Verification</summary>

- `bun test src/pages/layout/helpers.test.ts`
- `bun typecheck`

</details>

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR