### PR TITLE
fix(opencode): dedupe event openapi refs

### DIFF
--- a/packages/opencode/src/bus/bus-event.ts
+++ b/packages/opencode/src/bus/bus-event.ts
@@ -18,6 +18,7 @@ export function define<Type extends string, Properties extends Schema.Top>(
 }
 
 export function effectPayloads() {
+  const registered = new Set(registry.keys())
   return [
     ...registry
       .entries()
@@ -31,6 +32,7 @@ export function effectPayloads() {
       .toArray(),
     ...EventV2.registry
       .values()
+      .filter((definition) => !registered.has(definition.type))
       .map((definition) =>
         Schema.Struct({
           id: Schema.String,

--- a/packages/opencode/test/server/httpapi-public-openapi.test.ts
+++ b/packages/opencode/test/server/httpapi-public-openapi.test.ts
@@ -3,7 +3,11 @@ import { OpenApi } from "effect/unstable/httpapi"
 import { PublicApi } from "../../src/server/routes/instance/httpapi/public"
 
 type Method = "get" | "post" | "put" | "delete" | "patch"
-type OpenApiSchema = { readonly $ref?: string }
+type OpenApiSchema = {
+  readonly $ref?: string
+  readonly anyOf?: readonly OpenApiSchema[]
+  readonly properties?: Record<string, OpenApiSchema>
+}
 type OpenApiResponse = {
   readonly description?: string
   readonly content?: Record<string, { readonly schema?: OpenApiSchema }>
@@ -13,7 +17,10 @@ type OpenApiOperation = {
   readonly security?: unknown
 }
 type OpenApiPathItem = Partial<Record<Method, OpenApiOperation>>
-type OpenApiSpec = { readonly paths: Record<string, OpenApiPathItem> }
+type OpenApiSpec = {
+  readonly components?: { readonly schemas?: Record<string, OpenApiSchema> }
+  readonly paths: Record<string, OpenApiPathItem>
+}
 
 const methods = ["get", "post", "put", "delete", "patch"] as const
 
@@ -40,6 +47,16 @@ function componentName(ref: string) {
 
 function isBuiltInEndpointError(name: string) {
   return name.startsWith("EffectHttpApiError") || name.startsWith("effect_HttpApiError_")
+}
+
+function component(spec: OpenApiSpec, name: string) {
+  const schema = spec.components?.schemas?.[name]
+  expect(schema, name).toBeDefined()
+  return schema!
+}
+
+function uniqueRefs(schema: OpenApiSchema) {
+  return (schema.anyOf ?? []).flatMap((entry) => entry.$ref ?? [])
 }
 
 describe("PublicApi OpenAPI v2 errors", () => {
@@ -215,5 +232,17 @@ describe("PublicApi OpenAPI v2 errors", () => {
     expect(componentName(responseRef(spec.paths["/project/{projectID}"]?.patch?.responses?.["404"]) ?? "")).toBe(
       "ProjectNotFoundError",
     )
+  })
+
+  test("does not duplicate event union refs", () => {
+    const spec = OpenApi.fromApi(PublicApi) as OpenApiSpec
+
+    for (const refs of [
+      uniqueRefs(component(spec, "Event")),
+      uniqueRefs(component(spec, "GlobalEvent").properties?.payload ?? {}),
+    ]) {
+      expect(refs.length).toBeGreaterThan(0)
+      expect(refs).toEqual([...new Set(refs)])
+    }
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #28826

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The OpenAPI generator was adding some event payload schemas through both the bus event list and the core EventV2 list. This dedupes those schema refs before writing the `Event` and `GlobalEvent.payload` unions, so generated OpenAPI output no longer lists the same `EventSessionNext*` schemas twice.

The regression test checks both affected OpenAPI unions for duplicate refs.

### How did you verify your code works?

- `bun test test/server/httpapi-public-openapi.test.ts`: pass
- `bun typecheck` from `packages/opencode`: pass
- pre-push `bun turbo typecheck`: pass

### Screenshots / recordings

N/A, API schema output only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

AI-assisted; human-reviewed, locally tested, and I can explain/iterate on the change.