### PR TITLE
docs(ecosystem): add vibeOS plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -53,7 +53,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                         |
-| [vibeOS](https://github.com/DrunkkToys/vibeOS)                                                    | Trinity model-tiers plugin: cost-aware delegation enforcement, live savings footer, flow/TDD enforcers, blackbox decision engine, and stress-aware routing |
+| vibeOS                                                    | Trinity model-tiers plugin: cost-aware delegation enforcement, live savings footer, flow/TDD enforcers, blackbox decision engine, and stress-aware routing |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -53,6 +53,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                         |
+| [vibeOS](https://github.com/DrunkkToys/vibeOS)                                                    | Trinity model-tiers plugin: cost-aware delegation enforcement, live savings footer, flow/TDD enforcers, blackbox decision engine, and stress-aware routing |
 
 ---
 


### PR DESCRIPTION
Adds vibeOS to the Plugins table — a Trinity model-tiers plugin with cost-aware delegation enforcement, live savings tracking, flow/TDD enforcers, blackbox decision engine, and stress-aware routing. (Repo currently private, link omitted.)