### PR TITLE
fix(llm): stabilize anthropic tool result typecheck

### DIFF
--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -335,7 +335,9 @@ const lowerToolResultContent = Effect.fn("AnthropicMessages.lowerToolResultConte
   // Text / json / error results stay as a string for backward compatibility
   // with existing cassettes and provider expectations.
   if (part.result.type !== "content") return ProviderShared.toolResultText(part)
-  return yield* Effect.forEach(part.result.value, lowerToolResultContentItem)
+  // Preserve the narrowed array element type when compiled through a consumer package.
+  const content: ReadonlyArray<ToolResultContentPart> = part.result.value
+  return yield* Effect.forEach(content, lowerToolResultContentItem)
 })
 
 const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (


### PR DESCRIPTION
## Summary
- preserve the narrowed Anthropic tool-result content array type before passing it to `Effect.forEach`
- avoid `tsgo` widening the mapper input/error type when `@opencode-ai/llm` is compiled through `packages/opencode`

## Reproduction
- clean `dev`: `bun run typecheck` from `packages/opencode` passes
- PR #28897 head without this fix: `bun run typecheck` from `packages/opencode` reproduces the three `anthropic-messages.ts` failures

## Validation
- `bun run typecheck` from `packages/opencode` on this branch
- `bun run typecheck` from `packages/opencode` in a PR #28897 sandbox with this same change applied
- `git diff --check`