### PR TITLE
fix(tui): avoid question taking over open dialog

### DIFF
--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -16,6 +16,7 @@ import { getScrollAcceleration } from "../../util/scroll"
 import { useTuiConfig } from "../../config"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut } from "../../keymap"
 import { usePathFormatter } from "../../context/path-format"
+import { useDialog } from "../../ui/dialog"
 
 type PermissionStage = "permission" | "always" | "reject"
 
@@ -448,8 +449,10 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
   const tuiConfig = useTuiConfig()
   const dimensions = useTerminalDimensions()
   const narrow = createMemo(() => dimensions().width < 80)
+  const dialog = useDialog()
   useBindings(() => ({
     mode: OPENCODE_BASE_MODE,
+    enabled: !dialog.active,
     commands: [
       {
         name: "app.exit",
@@ -542,9 +545,11 @@ function Prompt<const T extends Record<string, string>>(props: {
   })
   const narrow = createMemo(() => dimensions().width < 80)
   const fullscreenHint = useCommandShortcut("permission.prompt.fullscreen")
+  const dialog = useDialog()
 
   useBindings(() => ({
     mode: OPENCODE_BASE_MODE,
+    enabled: !dialog.active,
     commands: [
       {
         name: "app.exit",

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -8,6 +8,7 @@ import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../ui/border"
 import { useTuiConfig } from "../../config"
 import { useBindings, useOpencodeModeStack } from "../../keymap"
+import { useDialog } from "../../ui/dialog"
 
 const QUESTION_MODE = "question"
 
@@ -17,6 +18,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
   const modeStack = useOpencodeModeStack()
+  const dialog = useDialog()
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -132,7 +134,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
 
   useBindings(() => ({
     mode: QUESTION_MODE,
-    enabled: store.editing && !confirm(),
+    enabled: store.editing && !confirm() && !dialog.active,
     commands: [
       {
         name: "prompt.clear",
@@ -213,7 +215,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
 
     return {
       mode: QUESTION_MODE,
-      enabled: !store.editing,
+      enabled: !store.editing && !dialog.active,
       commands: [
         {
           name: "app.exit",

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -163,6 +163,9 @@ function init() {
     get stack() {
       return store.stack
     },
+    get active() {
+      return store.stack.length > 0
+    },
     get size() {
       return store.size
     },


### PR DESCRIPTION
### Issue for this PR

Closes #28935 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I dont have a lot of experience on the stack, but following react-ish principles regarding hooks i just added a method to check if the dialog was open checking the size of the stack. Then if the stack is open, it doesnt allow the question or permission prompt (not sure how to call that binding) to take focus

### How did you verify your code works?

Following the reproduction steps of the issue 

### Screenshots / recordings

#### Before fix:

https://github.com/user-attachments/assets/8bc70e09-9307-4309-abfa-2c9bae4f9508

#### After:

https://github.com/user-attachments/assets/d34a6813-856d-4d82-96d8-07685025c31c




### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
