### PR TITLE
Gate prompt dismissal on reply ack

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -130,23 +130,64 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 
+    function groupRequestsBySession<T extends { sessionID: string; id: string }>(requests: readonly T[]) {
+      const grouped: Record<string, T[]> = {}
+      for (const request of requests) {
+        const sessionRequests = (grouped[request.sessionID] ??= [])
+        const match = Binary.search(sessionRequests, request.id, (item) => item.id)
+        if (match.found) sessionRequests[match.index] = request
+        if (!match.found) sessionRequests.splice(match.index, 0, request)
+      }
+      return grouped
+    }
+
+    async function refreshPermissions() {
+      const workspace = project.workspace.current()
+      const response = await sdk.client.permission.list({ workspace })
+      setStore("permission", reconcile(groupRequestsBySession(response.data ?? [])))
+    }
+
+    async function refreshQuestions() {
+      const workspace = project.workspace.current()
+      const response = await sdk.client.question.list({ workspace })
+      setStore("question", reconcile(groupRequestsBySession(response.data ?? [])))
+    }
+
+    function removePermissionRequest(sessionID: string, requestID: string) {
+      const requests = store.permission[sessionID]
+      if (!requests) return
+      const match = Binary.search(requests, requestID, (r) => r.id)
+      if (!match.found) return
+      setStore(
+        "permission",
+        sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 1)
+        }),
+      )
+    }
+
+    function removeQuestionRequest(sessionID: string, requestID: string) {
+      const requests = store.question[sessionID]
+      if (!requests) return
+      const match = Binary.search(requests, requestID, (r) => r.id)
+      if (!match.found) return
+      setStore(
+        "question",
+        sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 1)
+        }),
+      )
+    }
+
     event.subscribe((event, { workspace }) => {
       switch (event.type) {
         case "server.instance.disposed":
           void bootstrap()
           break
         case "permission.replied": {
-          const requests = store.permission[event.properties.sessionID]
-          if (!requests) break
-          const match = Binary.search(requests, event.properties.requestID, (r) => r.id)
-          if (!match.found) break
-          setStore(
-            "permission",
-            event.properties.sessionID,
-            produce((draft) => {
-              draft.splice(match.index, 1)
-            }),
-          )
+          removePermissionRequest(event.properties.sessionID, event.properties.requestID)
           break
         }
 
@@ -174,17 +215,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "question.replied":
         case "question.rejected": {
-          const requests = store.question[event.properties.sessionID]
-          if (!requests) break
-          const match = Binary.search(requests, event.properties.requestID, (r) => r.id)
-          if (!match.found) break
-          setStore(
-            "question",
-            event.properties.sessionID,
-            produce((draft) => {
-              draft.splice(match.index, 1)
-            }),
-          )
+          removeQuestionRequest(event.properties.sessionID, event.properties.requestID)
           break
         }
 
@@ -457,6 +488,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.session.status({ workspace }).then((x) => {
               setStore("session_status", reconcile(x.data ?? {}))
             }),
+            refreshPermissions(),
+            refreshQuestions(),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
             project.workspace.sync(),
@@ -545,6 +578,14 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         },
       },
       bootstrap,
+      permission: {
+        remove: removePermissionRequest,
+        refresh: refreshPermissions,
+      },
+      question: {
+        remove: removeQuestionRequest,
+        refresh: refreshQuestions,
+      },
     }
     return result
   },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -122,6 +122,28 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
 
   const session = createMemo(() => sync.data.session.find((s) => s.id === props.request.sessionID))
 
+  async function replyPermission(reply: "once" | "always" | "reject", message?: string) {
+    try {
+      const response = await sdk.client.permission.reply(
+        {
+          reply,
+          requestID: props.request.id,
+          message,
+          workspace: project.workspace.current(),
+        },
+        { throwOnError: true },
+      )
+      if (response.data === true) {
+        sync.permission.remove(props.request.sessionID, props.request.id)
+        return
+      }
+      await sync.permission.refresh()
+    } catch (error) {
+      await sync.permission.refresh().catch(() => {})
+      console.error("Failed to reply to permission request", error)
+    }
+  }
+
   const input = createMemo(() => {
     const tool = props.request.tool
     if (!tool) return {}
@@ -168,23 +190,14 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
           onSelect={(option) => {
             setStore("stage", "permission")
             if (option === "cancel") return
-            void sdk.client.permission.reply({
-              reply: "always",
-              requestID: props.request.id,
-              workspace: project.workspace.current(),
-            })
+            void replyPermission("always")
           }}
         />
       </Match>
       <Match when={store.stage === "reject"}>
         <RejectPrompt
           onConfirm={(message) => {
-            void sdk.client.permission.reply({
-              reply: "reject",
-              requestID: props.request.id,
-              message: message || undefined,
-              workspace: project.workspace.current(),
-            })
+            void replyPermission("reject", message || undefined)
           }}
           onCancel={() => {
             setStore("stage", "permission")
@@ -418,18 +431,10 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
                     setStore("stage", "reject")
                     return
                   }
-                  void sdk.client.permission.reply({
-                    reply: "reject",
-                    requestID: props.request.id,
-                    workspace: project.workspace.current(),
-                  })
+                  void replyPermission("reject")
                   return
                 }
-                void sdk.client.permission.reply({
-                  reply: "once",
-                  requestID: props.request.id,
-                  workspace: project.workspace.current(),
-                })
+                void replyPermission("once")
               }}
             />
           )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -5,6 +5,8 @@ import type { TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
+import { useProject } from "../../context/project"
+import { useSync } from "../../context/sync"
 import { SplitBorder } from "../../component/border"
 import { useTuiConfig } from "../../context/tui-config"
 import { useBindings, useOpencodeModeStack } from "../../keymap"
@@ -13,6 +15,8 @@ const QUESTION_MODE = "question"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
+  const project = useProject()
+  const sync = useSync()
   const { theme } = useTheme()
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
@@ -45,18 +49,54 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     return store.answers[store.tab]?.includes(value) ?? false
   })
 
+  async function replyQuestion(answers: QuestionAnswer[]) {
+    try {
+      const response = await sdk.client.question.reply(
+        {
+          requestID: props.request.id,
+          answers,
+          workspace: project.workspace.current(),
+        },
+        { throwOnError: true },
+      )
+      if (response.data === true) {
+        sync.question.remove(props.request.sessionID, props.request.id)
+        return
+      }
+      await sync.question.refresh()
+    } catch (error) {
+      await sync.question.refresh().catch(() => {})
+      console.error("Failed to reply to question request", error)
+    }
+  }
+
+  async function rejectQuestion() {
+    try {
+      const response = await sdk.client.question.reject(
+        {
+          requestID: props.request.id,
+          workspace: project.workspace.current(),
+        },
+        { throwOnError: true },
+      )
+      if (response.data === true) {
+        sync.question.remove(props.request.sessionID, props.request.id)
+        return
+      }
+      await sync.question.refresh()
+    } catch (error) {
+      await sync.question.refresh().catch(() => {})
+      console.error("Failed to reject question request", error)
+    }
+  }
+
   function submit() {
     const answers = questions().map((_, i) => store.answers[i] ?? [])
-    void sdk.client.question.reply({
-      requestID: props.request.id,
-      answers,
-    })
+    void replyQuestion(answers)
   }
 
   function reject() {
-    void sdk.client.question.reject({
-      requestID: props.request.id,
-    })
+    void rejectQuestion()
   }
 
   function pick(answer: string, custom: boolean = false) {
@@ -69,14 +109,10 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       setStore("custom", inputs)
     }
     if (single()) {
-      void sdk.client.question.reply({
-        requestID: props.request.id,
-        answers: [[answer]],
-      })
+      void replyQuestion([[answer]])
       return
     }
-    setStore("tab", store.tab + 1)
-    setStore("selected", 0)
+    selectTab(store.tab + 1)
   }
 
   function toggle(answer: string) {
@@ -97,6 +133,8 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
   function selectTab(index: number) {
     setStore("tab", index)
     setStore("selected", 0)
+    setStore("editing", false)
+    textarea = undefined
   }
 
   function selectOption() {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -215,33 +215,48 @@ export const layer = Layer.effect(
       const existing = pending.get(input.requestID)
       if (!existing) return yield* new NotFoundError({ requestID: input.requestID })
 
+      if (input.reply === "reject") {
+        pending.delete(input.requestID)
+        const completed = yield* Deferred.fail(
+          existing.deferred,
+          input.message ? new CorrectedError({ feedback: input.message }) : new RejectedError(),
+        )
+        if (!completed) {
+          log.warn("reply target was already resolved", { requestID: input.requestID })
+          return yield* new NotFoundError({ requestID: input.requestID })
+        }
+        yield* bus.publish(Event.Replied, {
+          sessionID: existing.info.sessionID,
+          requestID: existing.info.id,
+          reply: input.reply,
+        })
+
+        for (const [id, item] of pending.entries()) {
+          if (item.info.sessionID !== existing.info.sessionID) continue
+          pending.delete(id)
+          const rejected = yield* Deferred.fail(item.deferred, new RejectedError())
+          if (rejected) {
+            yield* bus.publish(Event.Replied, {
+              sessionID: item.info.sessionID,
+              requestID: item.info.id,
+              reply: "reject",
+            })
+          }
+        }
+        return
+      }
+
       pending.delete(input.requestID)
+      const completed = yield* Deferred.succeed(existing.deferred, undefined)
+      if (!completed) {
+        log.warn("reply target was already resolved", { requestID: input.requestID })
+        return yield* new NotFoundError({ requestID: input.requestID })
+      }
       yield* bus.publish(Event.Replied, {
         sessionID: existing.info.sessionID,
         requestID: existing.info.id,
         reply: input.reply,
       })
-
-      if (input.reply === "reject") {
-        yield* Deferred.fail(
-          existing.deferred,
-          input.message ? new CorrectedError({ feedback: input.message }) : new RejectedError(),
-        )
-
-        for (const [id, item] of pending.entries()) {
-          if (item.info.sessionID !== existing.info.sessionID) continue
-          pending.delete(id)
-          yield* bus.publish(Event.Replied, {
-            sessionID: item.info.sessionID,
-            requestID: item.info.id,
-            reply: "reject",
-          })
-          yield* Deferred.fail(item.deferred, new RejectedError())
-        }
-        return
-      }
-
-      yield* Deferred.succeed(existing.deferred, undefined)
       if (input.reply === "once") return
 
       for (const pattern of existing.info.always) {
@@ -259,12 +274,14 @@ export const layer = Layer.effect(
         )
         if (!ok) continue
         pending.delete(id)
-        yield* bus.publish(Event.Replied, {
-          sessionID: item.info.sessionID,
-          requestID: item.info.id,
-          reply: "always",
-        })
-        yield* Deferred.succeed(item.deferred, undefined)
+        const completed = yield* Deferred.succeed(item.deferred, undefined)
+        if (completed) {
+          yield* bus.publish(Event.Replied, {
+            sessionID: item.info.sessionID,
+            requestID: item.info.id,
+            reply: "always",
+          })
+        }
       }
     })
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -135,6 +135,11 @@ interface State {
   approved: Rule[]
 }
 
+interface StateContext {
+  state: State
+  cleanup: (id: PermissionID) => Effect.Effect<void>
+}
+
 export function evaluate(permission: string, pattern: string, ...rulesets: Ruleset[]): Rule {
   return PermissionV2.evaluate(permission, pattern, ...rulesets)
 }
@@ -145,7 +150,7 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
-    const state = yield* InstanceState.make<State>(
+    const state = yield* InstanceState.make<StateContext>(
       Effect.fn("Permission.state")(function* (ctx) {
         const row = Database.use((db) =>
           db.select().from(PermissionTable).where(eq(PermissionTable.project_id, ctx.project.id)).get(),
@@ -155,21 +160,34 @@ export const layer = Layer.effect(
           approved: [...(row?.data ?? [])],
         }
 
+        const cleanup = Effect.fn("Permission.cleanup")(function* (id: PermissionID) {
+          const existing = state.pending.get(id)
+          if (!existing) return
+          state.pending.delete(id)
+          yield* bus.publish(Event.Replied, {
+            sessionID: existing.info.sessionID,
+            requestID: existing.info.id,
+            reply: "reject",
+          })
+        })
+
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
-            for (const item of state.pending.values()) {
-              yield* Deferred.fail(item.deferred, new RejectedError())
+            for (const [id, item] of state.pending.entries()) {
+              const completed = yield* Deferred.fail(item.deferred, new RejectedError())
+              if (completed) yield* cleanup(id)
             }
             state.pending.clear()
           }),
         )
 
-        return state
+        return { state, cleanup }
       }),
     )
 
     const ask = Effect.fn("Permission.ask")(function* (input: AskInput) {
-      const { approved, pending } = yield* InstanceState.get(state)
+      const { state: data, cleanup } = yield* InstanceState.get(state)
+      const { approved, pending } = data
       const { ruleset, ...request } = input
       let needsAsk = false
 
@@ -204,14 +222,12 @@ export const layer = Layer.effect(
       yield* bus.publish(Event.Asked, info)
       return yield* Effect.ensuring(
         Deferred.await(deferred),
-        Effect.sync(() => {
-          pending.delete(id)
-        }),
+        cleanup(id),
       )
     })
 
     const reply = Effect.fn("Permission.reply")(function* (input: ReplyInput) {
-      const { approved, pending } = yield* InstanceState.get(state)
+      const { approved, pending } = (yield* InstanceState.get(state)).state
       const existing = pending.get(input.requestID)
       if (!existing) return yield* new NotFoundError({ requestID: input.requestID })
 
@@ -286,7 +302,7 @@ export const layer = Layer.effect(
     })
 
     const list = Effect.fn("Permission.list")(function* () {
-      const pending = (yield* InstanceState.get(state)).pending
+      const pending = (yield* InstanceState.get(state)).state.pending
       return Array.from(pending.values(), (item) => item.info)
     })
 

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -111,6 +111,11 @@ interface State {
   pending: Map<QuestionID, PendingEntry>
 }
 
+interface StateContext {
+  state: State
+  cleanup: (id: QuestionID) => Effect.Effect<void>
+}
+
 // Service
 
 export interface Interface {
@@ -133,22 +138,33 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
-    const state = yield* InstanceState.make<State>(
+    const state = yield* InstanceState.make<StateContext>(
       Effect.fn("Question.state")(function* () {
         const state = {
           pending: new Map<QuestionID, PendingEntry>(),
         }
 
+        const cleanup = Effect.fn("Question.cleanup")(function* (id: QuestionID) {
+          const existing = state.pending.get(id)
+          if (!existing) return
+          state.pending.delete(id)
+          yield* bus.publish(Event.Rejected, {
+            sessionID: existing.info.sessionID,
+            requestID: existing.info.id,
+          })
+        })
+
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
-            for (const item of state.pending.values()) {
-              yield* Deferred.fail(item.deferred, new RejectedError())
+            for (const [id, item] of state.pending.entries()) {
+              const completed = yield* Deferred.fail(item.deferred, new RejectedError())
+              if (completed) yield* cleanup(id)
             }
             state.pending.clear()
           }),
         )
 
-        return state
+        return { state, cleanup }
       }),
     )
 
@@ -157,7 +173,8 @@ export const layer = Layer.effect(
       questions: ReadonlyArray<Info>
       tool?: Tool
     }) {
-      const pending = (yield* InstanceState.get(state)).pending
+      const { state: data, cleanup } = yield* InstanceState.get(state)
+      const pending = data.pending
       const id = QuestionID.ascending()
       log.info("asking", { id, questions: input.questions.length })
 
@@ -173,9 +190,7 @@ export const layer = Layer.effect(
 
       return yield* Effect.ensuring(
         Deferred.await(deferred),
-        Effect.sync(() => {
-          pending.delete(id)
-        }),
+        cleanup(id),
       )
     })
 
@@ -183,7 +198,7 @@ export const layer = Layer.effect(
       requestID: QuestionID
       answers: ReadonlyArray<Answer>
     }) {
-      const pending = (yield* InstanceState.get(state)).pending
+      const pending = (yield* InstanceState.get(state)).state.pending
       const existing = pending.get(input.requestID)
       if (!existing) {
         log.warn("reply for unknown request", { requestID: input.requestID })
@@ -204,7 +219,7 @@ export const layer = Layer.effect(
     })
 
     const reject = Effect.fn("Question.reject")(function* (requestID: QuestionID) {
-      const pending = (yield* InstanceState.get(state)).pending
+      const pending = (yield* InstanceState.get(state)).state.pending
       const existing = pending.get(requestID)
       if (!existing) {
         log.warn("reject for unknown request", { requestID })
@@ -224,7 +239,7 @@ export const layer = Layer.effect(
     })
 
     const list = Effect.fn("Question.list")(function* () {
-      const pending = (yield* InstanceState.get(state)).pending
+      const pending = (yield* InstanceState.get(state)).state.pending
       return Array.from(pending.values(), (x) => x.info)
     })
 

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -191,12 +191,16 @@ export const layer = Layer.effect(
       }
       pending.delete(input.requestID)
       log.info("replied", { requestID: input.requestID, answers: input.answers })
+      const completed = yield* Deferred.succeed(existing.deferred, input.answers)
+      if (!completed) {
+        log.warn("reply target was already resolved", { requestID: input.requestID })
+        return yield* new NotFoundError({ requestID: input.requestID })
+      }
       yield* bus.publish(Event.Replied, {
         sessionID: existing.info.sessionID,
         requestID: existing.info.id,
         answers: input.answers.map((a) => [...a]),
       })
-      yield* Deferred.succeed(existing.deferred, input.answers)
     })
 
     const reject = Effect.fn("Question.reject")(function* (requestID: QuestionID) {
@@ -208,11 +212,15 @@ export const layer = Layer.effect(
       }
       pending.delete(requestID)
       log.info("rejected", { requestID })
+      const completed = yield* Deferred.fail(existing.deferred, new RejectedError())
+      if (!completed) {
+        log.warn("reject target was already resolved", { requestID })
+        return yield* new NotFoundError({ requestID })
+      }
       yield* bus.publish(Event.Rejected, {
         sessionID: existing.info.sessionID,
         requestID: existing.info.id,
       })
-      yield* Deferred.fail(existing.deferred, new RejectedError())
     })
 
     const list = Effect.fn("Question.list")(function* () {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
@@ -2,7 +2,6 @@ import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { PermissionNotFoundError } from "../errors"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
 import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
@@ -33,7 +32,7 @@ export const PermissionApi = HttpApi.make("permission")
           query: WorkspaceRoutingQuery,
           payload: ReplyPayload,
           success: described(Schema.Boolean, "Permission processed successfully"),
-          error: [HttpApiError.BadRequest, PermissionNotFoundError],
+          error: HttpApiError.BadRequest,
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "permission.reply",

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/question.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/question.ts
@@ -2,7 +2,6 @@ import { Question } from "@/question"
 import { QuestionID } from "@/question/schema"
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { QuestionNotFoundError } from "../errors"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
 import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
@@ -34,7 +33,7 @@ export const QuestionApi = HttpApi.make("question")
           query: WorkspaceRoutingQuery,
           payload: ReplyPayload,
           success: described(Schema.Boolean, "Question answered successfully"),
-          error: [HttpApiError.BadRequest, QuestionNotFoundError],
+          error: HttpApiError.BadRequest,
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "question.reply",
@@ -46,7 +45,7 @@ export const QuestionApi = HttpApi.make("question")
           params: { requestID: QuestionID },
           query: WorkspaceRoutingQuery,
           success: described(Schema.Boolean, "Question rejected successfully"),
-          error: [HttpApiError.BadRequest, QuestionNotFoundError],
+          error: HttpApiError.BadRequest,
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "question.reject",

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
@@ -3,7 +3,6 @@ import { PermissionID } from "@/permission/schema"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
-import { PermissionNotFoundError } from "../errors"
 
 export const permissionHandlers = HttpApiBuilder.group(InstanceHttpApi, "permission", (handlers) =>
   Effect.gen(function* () {
@@ -17,23 +16,16 @@ export const permissionHandlers = HttpApiBuilder.group(InstanceHttpApi, "permiss
       params: { requestID: PermissionID }
       payload: Permission.ReplyBody
     }) {
-      yield* svc
+      return yield* svc
         .reply({
           requestID: ctx.params.requestID,
           reply: ctx.payload.reply,
           message: ctx.payload.message,
         })
         .pipe(
-          Effect.catchTag("Permission.NotFoundError", (error) =>
-            Effect.fail(
-              new PermissionNotFoundError({
-                requestID: String(error.requestID),
-                message: `Permission request not found: ${error.requestID}`,
-              }),
-            ),
-          ),
+          Effect.as(true),
+          Effect.catchTag("Permission.NotFoundError", () => Effect.succeed(false)),
         )
-      return true
     })
 
     return handlers.handle("list", list).handle("reply", reply)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/question.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/question.ts
@@ -3,7 +3,6 @@ import { QuestionID } from "@/question/schema"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
-import { QuestionNotFoundError } from "../errors"
 
 export const questionHandlers = HttpApiBuilder.group(InstanceHttpApi, "question", (handlers) =>
   Effect.gen(function* () {
@@ -17,36 +16,22 @@ export const questionHandlers = HttpApiBuilder.group(InstanceHttpApi, "question"
       params: { requestID: QuestionID }
       payload: Question.Reply
     }) {
-      yield* svc
+      return yield* svc
         .reply({
           requestID: ctx.params.requestID,
           answers: ctx.payload.answers,
         })
         .pipe(
-          Effect.catchTag("Question.NotFoundError", (error) =>
-            Effect.fail(
-              new QuestionNotFoundError({
-                requestID: String(error.requestID),
-                message: `Question request not found: ${error.requestID}`,
-              }),
-            ),
-          ),
+          Effect.as(true),
+          Effect.catchTag("Question.NotFoundError", () => Effect.succeed(false)),
         )
-      return true
     })
 
     const reject = Effect.fn("QuestionHttpApi.reject")(function* (ctx: { params: { requestID: QuestionID } }) {
-      yield* svc.reject(ctx.params.requestID).pipe(
-        Effect.catchTag("Question.NotFoundError", (error) =>
-          Effect.fail(
-            new QuestionNotFoundError({
-              requestID: String(error.requestID),
-              message: `Question request not found: ${error.requestID}`,
-            }),
-          ),
-        ),
+      return yield* svc.reject(ctx.params.requestID).pipe(
+        Effect.as(true),
+        Effect.catchTag("Question.NotFoundError", () => Effect.succeed(false)),
       )
-      return true
     })
 
     return handlers.handle("list", list).handle("reply", reply).handle("reject", reject)

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -910,11 +910,12 @@ it.instance(
 )
 
 it.instance(
-  "reply - publishes replied event",
+  "reply - publishes one replied event",
   () =>
     Effect.gen(function* () {
       const bus = yield* Bus.Service
-      const seen = yield* Deferred.make<{ sessionID: SessionID; requestID: PermissionID; reply: Permission.Reply }>()
+      const seen: Array<{ sessionID: SessionID; requestID: PermissionID; reply: Permission.Reply }> = []
+      const first = yield* Deferred.make<void>()
 
       const fiber = yield* ask({
         id: PermissionID.make("per_test7"),
@@ -929,23 +930,65 @@ it.instance(
       yield* waitForPending(1)
 
       const unsub = yield* bus.subscribeCallback(Permission.Event.Replied, (event) => {
-        Deferred.doneUnsafe(seen, Effect.succeed(event.properties))
+        seen.push(event.properties)
+        Deferred.doneUnsafe(first, Effect.void)
       })
       yield* Effect.addFinalizer(() => Effect.sync(unsub))
 
       yield* reply({ requestID: PermissionID.make("per_test7"), reply: "once" })
       yield* Fiber.join(fiber)
+      yield* Deferred.await(first).pipe(
+        Effect.timeoutOrElse({
+          duration: "1 second",
+          orElse: () => Effect.fail(new Error("timed out waiting for permission replied event")),
+        }),
+      )
+      yield* Effect.sleep("50 millis")
+      expect(seen).toEqual([
+        {
+          sessionID: SessionID.make("session_test"),
+          requestID: PermissionID.make("per_test7"),
+          reply: "once",
+        },
+      ])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - publishes reject event when pending request is cleaned up",
+  () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const seen = yield* Deferred.make<{ sessionID: SessionID; requestID: PermissionID; reply: Permission.Reply }>()
+      const fiber = yield* ask({
+        id: PermissionID.make("per_cleanup"),
+        sessionID: SessionID.make("session_cleanup"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      yield* waitForPending(1)
+      const unsub = yield* bus.subscribeCallback(Permission.Event.Replied, (event) => {
+        Deferred.doneUnsafe(seen, Effect.succeed(event.properties))
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(unsub))
+
+      yield* Fiber.interrupt(fiber)
       expect(
         yield* Deferred.await(seen).pipe(
           Effect.timeoutOrElse({
             duration: "1 second",
-            orElse: () => Effect.fail(new Error("timed out waiting for permission replied event")),
+            orElse: () => Effect.fail(new Error("timed out waiting for permission cleanup event")),
           }),
         ),
       ).toEqual({
-        sessionID: SessionID.make("session_test"),
-        requestID: PermissionID.make("per_test7"),
-        reply: "once",
+        sessionID: SessionID.make("session_cleanup"),
+        requestID: PermissionID.make("per_cleanup"),
+        reply: "reject",
       })
     }),
   { git: true },

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect } from "bun:test"
-import { Cause, Effect, Exit, Fiber, Layer, Queue } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Queue } from "effect"
 import { Question } from "../../src/question"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { InstanceRuntime } from "../../src/project/instance-runtime"
@@ -184,6 +184,44 @@ it.instance(
 )
 
 it.instance(
+  "reply - does not publish rejected cleanup event",
+  () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      let rejected = false
+      const fiber = yield* askEffect({
+        sessionID: SessionID.make("ses_test"),
+        questions: [
+          {
+            question: "What would you like to do?",
+            header: "Action",
+            options: [
+              { label: "Option 1", description: "First option" },
+              { label: "Option 2", description: "Second option" },
+            ],
+          },
+        ],
+      }).pipe(Effect.forkScoped)
+
+      const pending = yield* waitForPending(1)
+      const unsub = yield* bus.subscribeCallback(Question.Event.Rejected, () => {
+        rejected = true
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(unsub))
+
+      yield* replyEffect({
+        requestID: pending[0].id,
+        answers: [["Option 1"]],
+      })
+      yield* Fiber.join(fiber)
+      yield* Effect.sleep("50 millis")
+
+      expect(rejected).toBe(false)
+    }),
+  { git: true },
+)
+
+it.instance(
   "reply - fails for unknown requestID",
   () =>
     Effect.gen(function* () {
@@ -268,6 +306,45 @@ it.instance(
       if (Exit.isFailure(exit)) {
         expect(Cause.squash(exit.cause)).toMatchObject({ _tag: "Question.NotFoundError", requestID: "que_unknown" })
       }
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - publishes rejected event when pending request is cleaned up",
+  () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const seen = yield* Deferred.make<{ sessionID: SessionID; requestID: QuestionID }>()
+      const fiber = yield* askEffect({
+        sessionID: SessionID.make("ses_cleanup"),
+        questions: [
+          {
+            question: "Cleanup me?",
+            header: "Cleanup",
+            options: [{ label: "Yes", description: "Yes" }],
+          },
+        ],
+      }).pipe(Effect.forkScoped)
+
+      const pending = yield* waitForPending(1)
+      const unsub = yield* bus.subscribeCallback(Question.Event.Rejected, (event) => {
+        Deferred.doneUnsafe(seen, Effect.succeed(event.properties))
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(unsub))
+
+      yield* Fiber.interrupt(fiber)
+      expect(
+        yield* Deferred.await(seen).pipe(
+          Effect.timeoutOrElse({
+            duration: "1 second",
+            orElse: () => Effect.fail(new Error("timed out waiting for question rejected event")),
+          }),
+        ),
+      ).toEqual({
+        sessionID: SessionID.make("ses_cleanup"),
+        requestID: pending[0].id,
+      })
     }),
   { git: true },
 )

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -233,7 +233,7 @@ const scenarios: Scenario[] = [
       headers: ctx.headers(),
       body: { reply: "once" },
     }))
-    .json(404, object, "status"),
+    .json(200, boolean, "status"),
   http.protected.get("/question", "question.list").json(200, array),
   http.protected
     .post("/question/{requestID}/reply", "question.reply.invalid")
@@ -250,14 +250,14 @@ const scenarios: Scenario[] = [
       headers: ctx.headers(),
       body: { answers: [["Yes"]] },
     }))
-    .json(404, object, "status"),
+    .json(200, boolean, "status"),
   http.protected
     .post("/question/{requestID}/reject", "question.reject")
     .at((ctx) => ({
       path: route("/question/{requestID}/reject", { requestID: "que_httpapi_reject" }),
       headers: ctx.headers(),
     }))
-    .json(404, object, "status"),
+    .json(200, boolean, "status"),
   http.protected
     .get("/file", "file.list")
     .seeded((ctx) => ctx.file("hello.txt", "hello\n"))

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -154,7 +154,7 @@ describe("instance HttpApi", () => {
     }),
   )
 
-  it.live("returns typed not found bodies for missing permission and question requests", () =>
+  it.live("returns false for stale permission and question requests", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })
       const request = (path: string, init?: RequestInit) =>
@@ -185,24 +185,12 @@ describe("instance HttpApi", () => {
         { concurrency: "unbounded" },
       )
 
-      expect(permission.status).toBe(404)
-      expect(yield* Effect.promise(() => permission.json())).toEqual({
-        _tag: "PermissionNotFoundError",
-        requestID: permissionID,
-        message: `Permission request not found: ${permissionID}`,
-      })
-      expect(questionReply.status).toBe(404)
-      expect(yield* Effect.promise(() => questionReply.json())).toEqual({
-        _tag: "QuestionNotFoundError",
-        requestID: questionReplyID,
-        message: `Question request not found: ${questionReplyID}`,
-      })
-      expect(questionReject.status).toBe(404)
-      expect(yield* Effect.promise(() => questionReject.json())).toEqual({
-        _tag: "QuestionNotFoundError",
-        requestID: questionRejectID,
-        message: `Question request not found: ${questionRejectID}`,
-      })
+      expect(permission.status).toBe(200)
+      expect(yield* Effect.promise(() => permission.json())).toBe(false)
+      expect(questionReply.status).toBe(200)
+      expect(yield* Effect.promise(() => questionReply.json())).toBe(false)
+      expect(questionReject.status).toBe(200)
+      expect(yield* Effect.promise(() => questionReject.json())).toBe(false)
     }),
   )
 

--- a/packages/opencode/test/server/httpapi-public-openapi.test.ts
+++ b/packages/opencode/test/server/httpapi-public-openapi.test.ts
@@ -158,19 +158,15 @@ describe("PublicApi OpenAPI v2 errors", () => {
     }
   })
 
-  test("documents permission and question not-found errors", () => {
+  test("documents permission and question missing requests as false replies", () => {
     const spec = OpenApi.fromApi(PublicApi) as OpenApiSpec
 
-    expect(
-      componentName(responseRef(spec.paths["/permission/{requestID}/reply"]?.post?.responses?.["404"]) ?? ""),
-    ).toBe("PermissionNotFoundError")
+    expect(spec.paths["/permission/{requestID}/reply"]?.post?.responses?.["404"]).toBeUndefined()
     for (const route of [
       ["post", "/question/{requestID}/reply"],
       ["post", "/question/{requestID}/reject"],
     ] as const) {
-      expect(componentName(responseRef(spec.paths[route[1]]?.[route[0]]?.responses?.["404"]) ?? "")).toBe(
-        "QuestionNotFoundError",
-      )
+      expect(spec.paths[route[1]]?.[route[0]]?.responses?.["404"]).toBeUndefined()
     }
   })
 


### PR DESCRIPTION
## Summary

Fix stale permission/question prompts by making prompt dismissal depend on an acknowledged server reply, resynchronizing pending prompt state from the server, and publishing prompt-removal events when server-side pending requests are cleaned up without a user reply.

## Root Cause

The TUI could get out of sync with the server-side pending permission/question state. A reply could be sent for a request that was already gone or routed to a stale local prompt. If the client treated the UI selection itself as success, the prompt could disappear while the server-side deferred request was not actually resolved, leaving the conversation blocked.

There was a second cleanup path: when a pending permission/question ask was interrupted by fiber cancellation, instance disposal, or reload, the service removed the pending entry silently. Because no reply/reject event was published, a TUI that had already rendered the prompt could keep showing a stale prompt even though `/permission` or `/question` no longer listed it.

## Changes

- Refresh pending permission and question lists during TUI bootstrap.
- Expose TUI sync helpers to refresh or remove individual permission/question requests.
- Make permission/question prompt actions wait for a successful reply acknowledgement before removing the local prompt.
- Refresh pending state on reply errors or unexpected response shapes.
- Return `false` for stale permission/question reply/reject requests so clients can refresh pending state without treating it as a typed not-found HTTP failure.
- Route question replies/rejections through the active workspace.
- Clear stale question edit state when switching tabs.
- Publish permission/question removal events when pending asks are cleaned up by interruption, disposal, or reload.
- Avoid duplicate cleanup events after normal permission/question replies.
- Publish permission/question reply events only after the deferred request is actually completed.

## Validation

- `bun run --cwd packages/opencode typecheck`
- `bun test ./packages/opencode/test/question/question.test.ts`
- `bun test ./packages/opencode/test/permission/next.test.ts`
- `bun test ./packages/opencode/test/server/httpapi-instance.test.ts -t 'returns false for stale permission and question requests'`
- `bun test ./packages/opencode/test/server/httpapi-public-openapi.test.ts`
- `git diff --check`
- pre-push `bun turbo typecheck` with Bun 1.3.14