### PR TITLE
fix(provider): expose reasoning effort variants for Kimi K2.6 and Qwen 3.6

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -628,9 +628,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("deepseek-v3") ||
     id.includes("minimax") ||
     id.includes("glm") ||
-    id.includes("kimi") ||
-    id.includes("k2p") ||
-    id.includes("qwen") ||
+    (id.includes("kimi") && !id.includes("k2.6") && !id.includes("k26") && !id.includes("k2p6")) ||
+    (id.includes("k2p") && !id.includes("k2p6")) ||
+    (id.includes("qwen") && !id.includes("3.6")) ||
     id.includes("big-pickle")
   )
     return {}


### PR DESCRIPTION
### Issue for this PR

Closes #28931

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `variants()` function in `transform.ts` has a blanket exclusion that catches all models with "kimi" or "qwen" in their ID, preventing reasoning effort variants from appearing. However, newer models like Kimi K2.6 and Qwen 3.6 Plus actually support the `reasoning_effort` parameter (accepting low/medium/high/none).

This narrows the exclusion to only block older models (kimi-k2.5, k2p5, qwen-plus) that don't support reasoning_effort. Newer models (kimi-k2.6, k2p6, k26, qwen3.6-\*) now fall through to the `@ai-sdk/openai-compatible` handler which offers low/medium/high — without `max` which these APIs reject.

### How did you verify your code works?

- All 224 provider transform tests pass (`bun test test/provider/transform.test.ts`)
- Manual verification with mock model objects confirms correct variant assignment for both old and new models

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---
🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop.