### PR TITLE
feat(opencode): add project delete command with sync cleanup

### DIFF
--- a/packages/opencode/src/cli/cmd/project.ts
+++ b/packages/opencode/src/cli/cmd/project.ts
@@ -1,0 +1,116 @@
+import type { Argv } from "yargs"
+import { Cause, Effect } from "effect"
+import { cmd } from "./cmd"
+import { effectCmd, fail } from "../effect-cmd"
+import { Project } from "@/project/project"
+import { ProjectID } from "../../project/schema"
+import { UI } from "../ui"
+import { EOL } from "os"
+
+export const ProjectCommand = cmd({
+  command: "project",
+  describe: "manage projects",
+  builder: (yargs: Argv) => yargs.command(ProjectDeleteCommand).command(ProjectListCommand).demandCommand(),
+  async handler() {},
+})
+
+export const ProjectDeleteCommand = effectCmd({
+  command: "delete <projectID>",
+  describe: "delete a project and all its data",
+  instance: false,
+  builder: (yargs) =>
+    yargs
+      .positional("projectID", {
+        describe: "project ID to delete",
+        type: "string",
+        demandOption: true,
+      })
+      .option("force", {
+        alias: "f",
+        describe: "skip confirmation",
+        type: "boolean",
+        default: false,
+      }),
+  handler: Effect.fn("Cli.project.delete")(function* (args) {
+    const svc = yield* Project.Service
+    const projectID = ProjectID.make(args.projectID)
+
+    const project = yield* Effect.sync(() => Project.get(projectID))
+
+    if (!args.force) {
+      const name = project?.name ?? projectID
+      const input = yield* Effect.promise(() =>
+        UI.input(`Delete project '${name}' and ALL its data? Type '${projectID}' to confirm: `),
+      )
+      if (input !== projectID) {
+        UI.println("Confirmation failed. Aborting.")
+        return
+      }
+    }
+
+    yield* svc.remove(projectID).pipe(
+      Effect.catchCause((cause) => {
+        const error = Cause.squash(cause)
+        return fail(error instanceof Error ? error.message : String(error))
+      }),
+    )
+    UI.println(UI.Style.TEXT_SUCCESS_BOLD + `Project ${projectID} deleted` + UI.Style.TEXT_NORMAL)
+  }),
+})
+
+export const ProjectListCommand = effectCmd({
+  command: "list",
+  describe: "list projects",
+  instance: false,
+  builder: (yargs) =>
+    yargs.option("format", {
+      describe: "output format",
+      type: "string",
+      choices: ["table", "json"],
+      default: "table",
+    }),
+  handler: Effect.fn("Cli.project.list")(function* (args) {
+    const svc = yield* Project.Service
+    const projects = yield* svc.list()
+
+    if (projects.length === 0) return
+
+    const output = args.format === "json" ? formatProjectJSON(projects) : formatProjectTable(projects)
+    console.log(output)
+  }),
+})
+
+function formatProjectTable(projects: Project.Info[]): string {
+  const lines: string[] = []
+
+  const maxIdWidth = Math.max(20, ...projects.map((p) => p.id.length))
+  const maxNameWidth = Math.max(25, ...projects.map((p) => p.name?.length ?? 0))
+  const maxWorktreeWidth = Math.max(20, ...projects.map((p) => p.worktree.length))
+
+  const header = `Project ID${" ".repeat(Math.max(0, maxIdWidth - 10))}  Name${" ".repeat(Math.max(0, maxNameWidth - 4))}  Worktree${" ".repeat(Math.max(0, maxWorktreeWidth - 8))}  Updated`
+  lines.push(header)
+  lines.push("─".repeat(header.length))
+  for (const project of projects) {
+    const name = project.name ?? ""
+    const paddedId = project.id.padEnd(maxIdWidth)
+    const paddedName = name.padEnd(maxNameWidth)
+    const paddedWorktree = project.worktree.padEnd(maxWorktreeWidth)
+    const timeStr = new Date(project.time.updated).toISOString().slice(0, 19).replace("T", " ")
+    lines.push(`${paddedId}  ${paddedName}  ${paddedWorktree}  ${timeStr}`)
+  }
+
+  return lines.join(EOL)
+}
+
+function formatProjectJSON(projects: Project.Info[]): string {
+  const jsonData = projects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    worktree: project.worktree,
+    vcs: project.vcs,
+    updated: project.time.updated,
+    created: project.time.created,
+    sandboxes: project.sandboxes,
+  }))
+  return JSON.stringify(jsonData, null, 2)
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -29,6 +29,7 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
+import { ProjectCommand } from "./cli/cmd/project"
 import { DbCommand } from "./cli/cmd/db"
 import path from "path"
 import { Global } from "@opencode-ai/core/global"
@@ -176,6 +177,7 @@ const cli = yargs(args)
   .command(GithubCommand)
   .command(PrCommand)
   .command(SessionCommand)
+  .command(ProjectCommand)
   .command(PluginCommand)
   .command(DbCommand)
   .fail((msg, err) => {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -22,6 +22,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { AbsolutePath, NonNegativeInt, optionalOmitUndefined } from "@opencode-ai/core/schema"
 import { serviceUse } from "@/effect/service-use"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { SyncEvent } from "../sync"
 
 const log = Log.create({ service: "project" })
 
@@ -59,6 +60,7 @@ export type Info = Types.DeepMutable<Schema.Schema.Type<typeof Info>>
 
 export const Event = {
   Updated: BusEvent.define("project.updated", Info),
+  Deleted: BusEvent.define("project.deleted", Info),
 }
 
 type Row = typeof ProjectTable.$inferSelect
@@ -132,6 +134,7 @@ export interface Interface {
   readonly sandboxes: (id: ProjectID) => Effect.Effect<string[]>
   readonly addSandbox: (id: ProjectID, directory: string) => Effect.Effect<void>
   readonly removeSandbox: (id: ProjectID, directory: string) => Effect.Effect<void>
+  readonly remove: (id: ProjectID) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Project") {}
@@ -147,6 +150,7 @@ export const layer = Layer.effect(
     const projectV2 = yield* ProjectV2.Service
     const bus = yield* Bus.Service
     const flags = yield* RuntimeFlags.Service
+    const sync = yield* SyncEvent.Service
 
     const git = Effect.fnUntraced(
       function* (args: string[], opts?: { cwd?: string }) {
@@ -173,6 +177,15 @@ export const layer = Layer.effect(
           directory: "global",
           project: data.id,
           payload: { type: Event.Updated.type, properties: data },
+        }),
+      )
+
+    const emitDeleted = (data: Info) =>
+      Effect.sync(() =>
+        GlobalBus.emit("event", {
+          directory: "global",
+          project: data.id,
+          payload: { type: Event.Deleted.type, properties: data },
         }),
       )
 
@@ -461,6 +474,27 @@ export const layer = Layer.effect(
       yield* emitUpdated(fromRow(result))
     })
 
+    const remove: Interface["remove"] = Effect.fn("Project.remove")(function* (id: ProjectID) {
+      if (id === ProjectID.global) throw new Error("Cannot delete the default project")
+      const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
+      if (!row) throw new Error(`Project not found: ${id}`)
+
+      const data = fromRow(row)
+
+      const sessions = yield* db((d) =>
+        d.select({ id: SessionTable.id }).from(SessionTable).where(eq(SessionTable.project_id, id)).all(),
+      )
+      yield* Effect.forEach(
+        sessions,
+        (session) => sync.remove(session.id),
+        { concurrency: "unbounded" },
+      )
+
+      yield* db((d) => d.delete(ProjectTable).where(eq(ProjectTable.id, id)).run())
+
+      yield* emitDeleted(data)
+    })
+
     return Service.of({
       init,
       fromDirectory,
@@ -473,6 +507,7 @@ export const layer = Layer.effect(
       sandboxes,
       addSandbox,
       removeSandbox,
+      remove,
     })
   }),
 )
@@ -484,6 +519,7 @@ export const defaultLayer = layer.pipe(
   Layer.provide(CrossSpawnSpawner.defaultLayer),
   Layer.provide(AppFileSystem.defaultLayer),
   Layer.provide(RuntimeFlags.defaultLayer),
+  Layer.provide(SyncEvent.defaultLayer),
 )
 
 export const use = serviceUse(Service)

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -25,6 +25,7 @@ import { Project as ProjectV2 } from "@opencode-ai/core/project"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { SyncEvent } from "../../src/sync"
 
 void Log.init({ print: false })
 
@@ -88,6 +89,7 @@ function projectLayerWithFailure(failArg: string) {
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
     Layer.provide(RuntimeFlags.defaultLayer),
+    Layer.provide(SyncEvent.defaultLayer),
   )
 }
 
@@ -99,6 +101,7 @@ function projectLayerWithRuntimeFlags(flags: Parameters<typeof RuntimeFlags.laye
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
     Layer.provide(RuntimeFlags.layer(flags)),
+    Layer.provide(SyncEvent.defaultLayer),
   )
 }
 
@@ -809,6 +812,36 @@ describe("Project.fromDirectory with bare repos", () => {
 
       const correctCache = path.join(barePath, "opencode")
       expect(yield* Effect.promise(() => Bun.file(correctCache).exists())).toBe(true)
+    }),
+  )
+})
+
+describe("Project.remove", () => {
+  it.live("throws error for non-existent project", () =>
+    Effect.gen(function* () {
+      const exit = yield* run((svc) => svc.remove(ProjectID.make("nonexistent-project"))).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+    }),
+  )
+
+  it.live("throws error when deleting global project", () =>
+    Effect.gen(function* () {
+      const exit = yield* run((svc) => svc.remove(ProjectID.global)).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+    }),
+  )
+
+  it.live("removes existing project and cleans up data", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const { project } = yield* run((svc) => svc.fromDirectory(tmp))
+
+      expect(Project.get(project.id)).toBeDefined()
+
+      yield* run((svc) => svc.remove(project.id))
+
+      const afterRemove = Project.get(project.id)
+      expect(afterRemove).toBeUndefined()
     }),
   )
 })


### PR DESCRIPTION
## Issue for this PR
Closes #28946

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
## What does this PR do?
feat(opencode): add project delete command with sync cleanup
- Add `Project.remove()` with `Event.Deleted` and sync event cleanup
- Create CLI `cmd/project.ts` with `delete` and `list` subcommands
- Prevent deletion of default project (global)
- Add unit tests for `remove()` including global protection
## How did you verify your code works?
Unit tests added in `packages/opencode/test/project/project.test.ts` covering:
- Successful project deletion
- Global project deletion protection
## Screenshots / recordings
_None (CLI command)_
## Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR