### PR TITLE
fix(desktop): add conflicts/replaces for old open-code deb package

### DIFF
--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -76,6 +76,9 @@ const getBase = (): Configuration => ({
     category: "Development",
     target: ["AppImage", "deb", "rpm"],
   },
+  deb: {
+    fpm: ["--conflicts", "open-code", "--replaces", "open-code"],
+  },
 })
 
 function getConfig() {


### PR DESCRIPTION
### Issue for this PR

Closes #28953

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop deb package was renamed from `open-code` to `opencode` but the new package never declared `Conflicts` or `Replaces` for the old name. On Linux, `dpkg` treats them as unrelated packages and installs both. The old binary at `/usr/bin/OpenCode` keeps getting launched by its desktop entry, so users see a perpetual "Update available (1.15.10)" notification that never resolves.

This adds `--conflicts open-code` and `--replaces open-code` fpm flags to the deb section of the electron-builder config. When `dpkg` processes the new `opencode` package, it will automatically remove the old `open-code` package first.

### How did you verify your code works?

Confirmed the issue on a real system running Ubuntu 22.04 where both packages coexisted:

```
$ dpkg -l opencode open-code
ii  open-code      1.14.20      amd64        The open source AI coding agent
ii  opencode       1.15.10      amd64
$ ps aux | grep OpenCode
/usr/bin/OpenCode --disable-gpu   # old binary still launching
```

Manually removing `open-code` (`sudo dpkg -r open-code`) resolved the issue, confirming the conflict is the root cause. The fpm `--conflicts` and `--replaces` flags are the standard debian mechanism for handling package renames and will produce the correct `Conflicts:` and `Replaces:` fields in the `.deb` control file.

### Screenshots / recordings

_N/A (packaging change, no UI impact)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR