### PR TITLE
feat(provider): add Requesty model discovery from /v1/models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -562,6 +562,109 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    requesty: Effect.fnUntraced(function* (input: Info) {
+      const env = yield* dep.env()
+      const auth = yield* dep.auth(input.id)
+      const apiKey = iife(() => {
+        if (auth?.type === "api") return auth.key
+        const envKey = env["REQUESTY_API_KEY"]
+        if (envKey) return envKey
+        return undefined
+      })
+
+      return {
+        autoload: true,
+        async discoverModels(): Promise<Record<string, Model>> {
+          const baseURL = (input.options?.baseURL as string) || "https://router.requesty.ai/v1"
+          try {
+            const headers: Record<string, string> = {}
+            if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`
+
+            const res = await fetch(`${baseURL}/models`, {
+              headers,
+              signal: AbortSignal.timeout(5_000),
+            })
+            if (!res.ok) {
+              log.warn("requesty model discovery failed", { status: res.status })
+              return {}
+            }
+
+            const json = (await res.json()) as {
+              data?: Array<{
+                id?: string
+                input_price?: number
+                output_price?: number
+                cached_price?: number
+                context_window?: number
+                max_output_tokens?: number
+                supports_reasoning?: boolean
+                supports_vision?: boolean
+                supports_tool_calling?: boolean
+                supports_image_generation?: boolean
+              }>
+            }
+            if (!json?.data || !Array.isArray(json.data)) return {}
+
+            const models: Record<string, Model> = {}
+            for (const m of json.data) {
+              if (!m.id) continue
+              models[m.id] = {
+                id: ModelID.make(m.id),
+                providerID: ProviderID.make("requesty"),
+                name: m.id,
+                family: "",
+                api: {
+                  id: m.id,
+                  url: baseURL,
+                  npm: "@ai-sdk/openai-compatible",
+                },
+                status: "active",
+                headers: {},
+                options: {},
+                cost: {
+                  input: m.input_price ?? 0,
+                  output: m.output_price ?? 0,
+                  cache: { read: m.cached_price ?? 0, write: 0 },
+                },
+                limit: {
+                  context: m.context_window ?? 128000,
+                  output: m.max_output_tokens ?? 4096,
+                },
+                capabilities: {
+                  temperature: true,
+                  reasoning: m.supports_reasoning ?? false,
+                  attachment: m.supports_vision ?? false,
+                  toolcall: m.supports_tool_calling ?? false,
+                  input: {
+                    text: true,
+                    audio: false,
+                    image: m.supports_vision ?? false,
+                    video: false,
+                    pdf: false,
+                  },
+                  output: {
+                    text: true,
+                    audio: false,
+                    image: m.supports_image_generation ?? false,
+                    video: false,
+                    pdf: false,
+                  },
+                  interleaved: false,
+                },
+                release_date: "",
+                variants: {},
+              }
+            }
+
+            log.info("requesty model discovery complete", { count: Object.keys(models).length })
+            return models
+          } catch (e) {
+            log.warn("requesty model discovery failed", { error: e })
+            return {}
+          }
+        },
+      }
+    }),
     gitlab: Effect.fnUntraced(function* (input: Info) {
       const {
         VERSION: GITLAB_PROVIDER_VERSION,
@@ -1464,6 +1567,20 @@ export const layer = Layer.effect(
               }
             } catch (e) {
               log.warn("state discovery error", { id: "gitlab", error: e })
+            }
+          })
+        }
+
+        const requesty = ProviderID.make("requesty")
+        if (discoveryLoaders[requesty] && providers[requesty] && isProviderAllowed(requesty)) {
+          yield* Effect.promise(async () => {
+            try {
+              const discovered = await discoveryLoaders[requesty]()
+              if (Object.keys(discovered).length > 0) {
+                providers[requesty].models = discovered
+              }
+            } catch (e) {
+              log.warn("state discovery error", { id: "requesty", error: e })
             }
           })
         }


### PR DESCRIPTION
## Summary

Fixes #16344

Requesty users have approved models and routing policies configured in their account, but OpenCode only shows the static snapshot from models.dev. This means user specific policies (like `policy/opus-4-7`) never appear in the model selector.

This PR adds model discovery for the Requesty provider by fetching from `https://router.requesty.ai/v1/models` during provider initialization:

- When `REQUESTY_API_KEY` is set, fetches with auth and gets the user's approved models/policies
- When no key is set, fetches the public catalog so users still get up to date models without needing an API key
- Only adds models not already present from models.dev (no duplicates)
- 5 second timeout, graceful fallback on failure (logs warning, returns empty)

## Why not just update models.dev?

The models.dev catalog is a static snapshot. Requesty routing policies are user specific and dynamic. They can't be added to models.dev because every user has different policies configured in their Requesty dashboard. This is the same reason GitHub Copilot and GitLab already do their own model fetching.

## How I verified

- `tsgo --noEmit` passes (no type errors)
- All 88 existing provider tests pass
- Tested the endpoint directly: with API key returns 21 user policies, without key returns 451 public models
- Confirmed no duplicates with models already in the models.dev snapshot (checked via the `input.models[m.id]` guard)