### PR TITLE
fix(opencode): persist runtime config updates in .opencode overlay

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -346,6 +346,11 @@ function globalConfigFile() {
   return candidates[0]
 }
 
+function localRuntimeConfigFiles(ctx: InstanceContext) {
+  const root = ctx.project.vcs === "git" && ctx.worktree !== "/" ? ctx.worktree : ctx.directory
+  return [path.join(root, ".opencode", "opencode.jsonc"), path.join(root, ".opencode", "opencode.json")] as const
+}
+
 function patchJsonc(input: string, patch: unknown, path: string[] = []): string {
   if (!isRecord(patch)) {
     const edits = modify(input, path, patch, {
@@ -814,12 +819,21 @@ export const layer = Layer.effect(
     })
 
     const update = Effect.fn("Config.update")(function* (config: Info) {
-      const dir = yield* InstanceState.directory
-      const file = path.join(dir, "config.json")
-      const existing = yield* loadFile(file)
-      yield* fs
-        .writeFileString(file, JSON.stringify(mergeDeep(writable(existing), writable(config)), null, 2))
-        .pipe(Effect.orDie)
+      const ctx = yield* InstanceState.context
+      const [jsonc, json] = localRuntimeConfigFiles(ctx)
+      const file = (yield* fs.existsSafe(jsonc)) ? jsonc : (yield* fs.existsSafe(json)) ? json : jsonc
+      const before =
+        (yield* readConfigFile(file)) || JSON.stringify({ $schema: "https://opencode.ai/config.json" }, null, 2)
+      const patch = writable(config)
+
+      if (!file.endsWith(".jsonc")) {
+        const existing = ConfigParse.schema(Info, ConfigParse.jsonc(before, file), file)
+        const next = mergeDeep(writable(existing), patch)
+        yield* fs.writeWithDirs(file, JSON.stringify(next, null, 2)).pipe(Effect.orDie)
+        return
+      }
+
+      yield* fs.writeWithDirs(file, patchJsonc(before, patch)).pipe(Effect.orDie)
     })
 
     const invalidate = Effect.fn("Config.invalidate")(function* () {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -17,6 +17,7 @@ import { Env } from "../../src/env"
 import {
   provideTestInstance,
   provideTmpdirInstance,
+  reloadTestInstance,
   TestInstance,
   tmpdir,
   tmpdirScoped,
@@ -294,18 +295,111 @@ it.instance(
 it.instance("updates config and preserves empty shell sentinel", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance
-    yield* writeConfigEffect(
-      test.directory,
-      { $schema: "https://opencode.ai/config.json", shell: "bash" },
-      "config.json",
-    )
+    yield* mkdirEffect(path.join(test.directory, ".opencode"))
+    yield* writeConfigEffect(test.directory, { $schema: "https://opencode.ai/config.json", shell: "bash" }, ".opencode/opencode.jsonc")
 
     yield* Config.Service.use((svc) => svc.update(ConfigParse.schema(Config.Info, { shell: "" }, "test:config")))
 
     const writtenConfig = yield* Effect.promise(() =>
-      Filesystem.readJson<{ shell?: string }>(path.join(test.directory, "config.json")),
+      Filesystem.readJson<{ $schema?: string; shell?: string }>(path.join(test.directory, ".opencode", "opencode.jsonc")),
     )
-    expect(writtenConfig.shell).toBe("")
+    expect(writtenConfig).toMatchObject({
+      $schema: "https://opencode.ai/config.json",
+      shell: "",
+    })
+  }),
+)
+
+it.instance("writes runtime local config to .opencode overlay and survives reload", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+
+    yield* Config.Service.use((svc) =>
+      svc.update(
+        ConfigParse.schema(
+          Config.Info,
+          {
+            agent: {
+              orchestrator: {
+                description: "Runtime orchestrator",
+                mode: "primary",
+              },
+            },
+          },
+          "test:config",
+        ),
+      ),
+    )
+
+    expect(yield* Effect.promise(() => Filesystem.exists(path.join(test.directory, "config.json")))).toBe(false)
+    expect(yield* Effect.promise(() => Filesystem.exists(path.join(test.directory, ".opencode", "opencode.jsonc")))).toBe(true)
+
+    const before = yield* Effect.promise(() =>
+      provideTestInstance({
+        directory: test.directory,
+        fn: (ctx) => load(ctx),
+      }),
+    )
+    expect(before.agent?.orchestrator?.description).toBe("Runtime orchestrator")
+
+    const reloaded = yield* Effect.promise(() =>
+      provideTestInstance({
+        directory: test.directory,
+        fn: (ctx) => load(ctx),
+      }),
+    )
+    expect(reloaded.agent?.orchestrator?.description).toBe("Runtime orchestrator")
+  }),
+)
+
+it.instance("runtime-added agent survives explicit instance reload", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+
+    yield* Config.Service.use((svc) =>
+      svc.update(
+        ConfigParse.schema(
+          Config.Info,
+          {
+            agent: {
+              orchestrator: {
+                description: "Runtime orchestrator",
+                mode: "primary",
+              },
+            },
+          },
+          "test:config",
+        ),
+      ),
+    )
+
+    yield* Effect.promise(() => reloadTestInstance({ directory: test.directory }))
+
+    const reloaded = yield* Effect.promise(() =>
+      provideTestInstance({
+        directory: test.directory,
+        fn: (ctx) => load(ctx),
+      }),
+    )
+    expect(reloaded.agent?.orchestrator?.description).toBe("Runtime orchestrator")
+  }),
+)
+
+it.instance("updates existing .opencode json overlay without creating jsonc", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* mkdirEffect(path.join(test.directory, ".opencode"))
+    yield* writeConfigEffect(test.directory, { $schema: "https://opencode.ai/config.json", model: "seed/model" }, ".opencode/opencode.json")
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(Config.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    expect(yield* Effect.promise(() => Filesystem.exists(path.join(test.directory, ".opencode", "opencode.jsonc")))).toBe(false)
+    const writtenConfig = yield* Effect.promise(() =>
+      Filesystem.readJson<{ model: string }>(path.join(test.directory, ".opencode", "opencode.json")),
+    )
+    expect(writtenConfig.model).toBe("updated/model")
   }),
 )
 
@@ -875,7 +969,7 @@ it.instance("updates config and writes to file", () =>
     )
 
     const writtenConfig = yield* Effect.promise(() =>
-      Filesystem.readJson<{ model: string }>(path.join(test.directory, "config.json")),
+      Filesystem.readJson<{ model: string }>(path.join(test.directory, ".opencode", "opencode.jsonc")),
     )
     expect(writtenConfig.model).toBe("updated/model")
   }),

--- a/packages/opencode/test/server/httpapi-config.test.ts
+++ b/packages/opencode/test/server/httpapi-config.test.ts
@@ -59,7 +59,7 @@ describe("config HttpApi", () => {
         lsp: false,
       })
       yield* Fiber.join(disposed)
-      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "config.json")).json())).toMatchObject({
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, ".opencode", "opencode.jsonc")).json())).toMatchObject({
         username: "patched-user",
         formatter: false,
         lsp: false,

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect } from "bun:test"
 import { mkdir } from "node:fs/promises"
+import fs from "node:fs/promises"
 import path from "node:path"
 import { Cause, Effect, Exit, Layer } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -229,6 +230,50 @@ describe("session HttpApi", () => {
           message: `Session is busy: ${sessionID}`,
         })
       }
+    }),
+  )
+
+  it.instance("prompt still resolves runtime-added agent after config update disposal", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const headers = { "x-opencode-directory": test.directory, "content-type": "application/json" }
+      const create = yield* requestJson<Session.Info>(SessionPaths.create, { method: "POST", headers })
+
+      const update = yield* request("/config", {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({
+          agent: {
+            orchestrator: {
+              description: "Runtime orchestrator",
+              mode: "primary",
+            },
+          },
+        }),
+      })
+      expect(update.status).toBe(200)
+
+      const file = path.join(test.directory, ".opencode", "opencode.jsonc")
+      expect(yield* Effect.promise(() => fs.access(file).then(() => true).catch(() => false))).toBe(true)
+
+      const prompt = yield* request(pathFor(SessionPaths.prompt, { sessionID: String(create.id) }), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          agent: "orchestrator",
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        }),
+      })
+
+      expect(prompt.status).toBe(200)
+      const body = yield* responseJson(prompt)
+      expect(body).toMatchObject({
+        info: {
+          role: "user",
+          agent: "orchestrator",
+        },
+      })
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Fixes #28966

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Config.update()` was writing runtime local updates to project-root `config.json`, but fresh instance config loading does not read that file.

This change writes runtime local updates to the managed local overlay instead:
- prefer existing `.opencode/opencode.jsonc`
- else existing `.opencode/opencode.json`
- else create `.opencode/opencode.jsonc`

This keeps runtime config changes in the local config path that reload already reads, so runtime-added agents survive disposal/reload.

It also preserves JSONC when updating an existing `.jsonc` overlay.

### How did you verify your code works?

Ran focused package-scoped regressions from `packages/opencode`:

- `bun test test/config/config.test.ts -t 'updates config and preserves empty shell sentinel|writes runtime local config to .opencode overlay and survives reload|runtime-added agent survives explicit instance reload|updates existing .opencode json overlay without creating jsonc|updates config and writes to file'`
- `bun test test/server/httpapi-config.test.ts`
- `bun test test/server/httpapi-session.test.ts -t 'prompt still resolves runtime-added agent after config update disposal'`

These cover:
- writing to `.opencode/opencode.jsonc` instead of ignored project-root `config.json`
- preserving existing `.opencode/opencode.json`
- runtime-added agent visibility after explicit reload
- runtime-added agent visibility after HTTP config update + disposal

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
