### PR TITLE
feat(lsp): detect missing compile_commands.json and auto-configure clangd

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -962,12 +962,78 @@ export const RustAnalyzer: Info = {
   },
 }
 
+const clangdWarnedRoots = new Set<string>()
+
 export const Clangd: Info = {
   id: "clangd",
   root: NearestRoot(["compile_commands.json", "compile_flags.txt", ".clangd"]),
   extensions: [".c", ".cpp", ".cc", ".cxx", ".c++", ".h", ".hpp", ".hh", ".hxx", ".h++"],
   async spawn(root, _ctx, flags) {
-    const args = ["--background-index", "--clang-tidy"]
+    // Ensure compile_commands.json exists; if missing, suggest how to generate it
+    let compileCommandsDir: string | undefined
+    const hasCompileCommands = await pathExists(path.join(root, "compile_commands.json"))
+    const hasCompileFlags = await pathExists(path.join(root, "compile_flags.txt"))
+    const hasClangdConfig = await pathExists(path.join(root, ".clangd"))
+
+    if (!hasCompileCommands && !hasCompileFlags && !hasClangdConfig) {
+      // Check common build subdirectories
+      for (const dir of ["build", "out", "cmake-build-debug", "cmake-build-release"]) {
+        if (await pathExists(path.join(root, dir, "compile_commands.json"))) {
+          compileCommandsDir = dir
+          break
+        }
+      }
+
+      if (!compileCommandsDir && !clangdWarnedRoots.has(root)) {
+        clangdWarnedRoots.add(root)
+        const [hasCMake, hasMakefile, hasKbuild, hasWest, hasMeson, hasBazel] = await Promise.all([
+          pathExists(path.join(root, "CMakeLists.txt")),
+          pathExists(path.join(root, "Makefile")),
+          pathExists(path.join(root, "Kbuild")),
+          pathExists(path.join(root, "west.yml")),
+          pathExists(path.join(root, "meson.build")),
+          pathExists(path.join(root, "BUILD.bazel")),
+        ])
+        if (hasWest) {
+          log.info(
+            "Detected Zephyr RTOS project (west.yml) — generate compile_commands.json with:\n" +
+              "  west build -b <board>"
+          )
+        } else if (hasCMake) {
+          log.info(
+            "Detected CMakeLists.txt — generate compile_commands.json with:\n" +
+              "  cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+          )
+        } else if (hasKbuild) {
+          log.info(
+            "Detected Linux kernel (Kbuild) — generate compile_commands.json with:\n" +
+              "  make && ./scripts/clang-tools/gen_compile_commands.py"
+          )
+        } else if (hasMakefile) {
+          log.info(
+            "Detected Makefile — generate compile_commands.json with:\n" +
+              "  bear -- make   or   compiledb make"
+          )
+        } else if (hasMeson) {
+          log.info(
+            "Detected meson.build — generate compile_commands.json with:\n" +
+              "  meson setup build"
+          )
+        } else if (hasBazel) {
+          log.info(
+            "Detected Bazel project — generate compile_commands.json with:\n" +
+              "  bazel run @hedron_compile_commands//:refresh"
+          )
+        } else {
+          log.info(
+            "No compile_commands.json found. See clangd project setup:\n" +
+              "  https://clangd.llvm.org/installation#project-setup"
+          )
+        }
+      }
+    }
+
+    const args = ["--background-index", "--clang-tidy", ...(compileCommandsDir ? [`--compile-commands-dir=${compileCommandsDir}`] : [])]
     const fromPath = which("clangd")
     if (fromPath) {
       return {

--- a/packages/opencode/test/lsp/clangd-detection.test.ts
+++ b/packages/opencode/test/lsp/clangd-detection.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import * as LSPServer from "@/lsp/server"
+import { tmpdir } from "../fixture/fixture"
+
+async function touch(root: string, relPath: string, content = "") {
+  const full = path.join(root, relPath)
+  await fs.mkdir(path.dirname(full), { recursive: true })
+  await fs.writeFile(full, content)
+}
+
+async function setupFakeClangd(base: string) {
+  const fakeBinDir = path.join(base, "fake-bin")
+  await fs.mkdir(fakeBinDir, { recursive: true })
+  const argsFile = path.join(base, "clangd-args.txt")
+  // Simple POSIX-safe script: write one arg per line
+  await fs.writeFile(
+    path.join(fakeBinDir, "clangd"),
+    `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsFile}"\nexit 0\n`,
+  )
+  await fs.chmod(path.join(fakeBinDir, "clangd"), 0o755)
+  return { fakeBinDir, argsFile }
+}
+
+async function waitForArgs(argsFile: string, timeoutMs = 2000): Promise<string[]> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const content = await fs.readFile(argsFile, "utf-8")
+      return content.split("\n").filter(Boolean)
+    } catch {
+      // File not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  return []
+}
+
+function setPath(binDir: string): () => void {
+  const original = process.env["PATH"]
+  process.env["PATH"] = binDir + path.delimiter + (original ?? "")
+  return () => { process.env["PATH"] = original }
+}
+
+const flags = { disableLspDownload: true } as any
+
+describe("clangd compile_commands.json detection", () => {
+  // 1. compile_commands.json at root → no extra args
+  test("root-level compile_commands.json: no --compile-commands-dir", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir, argsFile } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, "compile_commands.json", "[]")
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+      const args = await waitForArgs(argsFile)
+      expect(args).toContain("--background-index")
+      expect(args).toContain("--clang-tidy")
+      expect(args.find((a) => a.startsWith("--compile-commands-dir"))).toBeUndefined()
+    } finally { restore() }
+  })
+
+  // 2. compile_flags.txt → skip detection
+  test("compile_flags.txt present: skip detection, no --compile-commands-dir", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir, argsFile } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, "compile_flags.txt", "-I/usr/include\n-std=c11")
+    await touch(root, "CMakeLists.txt", "") // would trigger warning if not skipped
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+      const args = await waitForArgs(argsFile)
+      expect(args.find((a) => a.startsWith("--compile-commands-dir"))).toBeUndefined()
+    } finally { restore() }
+  })
+
+  // 3. .clangd config → skip detection
+  test(".clangd config present: skip detection", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir, argsFile } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, ".clangd", "CompileCommands: build")
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+      const args = await waitForArgs(argsFile)
+      expect(args.find((a) => a.startsWith("--compile-commands-dir"))).toBeUndefined()
+    } finally { restore() }
+  })
+
+  // 4. compile_commands.json in build/ → auto --compile-commands-dir=build
+  test("build/compile_commands.json: pass --compile-commands-dir=build", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir, argsFile } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, "CMakeLists.txt", "")
+    await touch(root, "build/compile_commands.json", "[]")
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+      const args = await waitForArgs(argsFile)
+      expect(args).toContain("--compile-commands-dir=build")
+    } finally { restore() }
+  })
+
+  // 5. compile_commands.json in cmake-build-debug/ → auto-detect
+  test("cmake-build-debug/compile_commands.json: pass --compile-commands-dir", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir, argsFile } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, "CMakeLists.txt", "")
+    await touch(root, "cmake-build-debug/compile_commands.json", "[]")
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+      const args = await waitForArgs(argsFile)
+      expect(args).toContain("--compile-commands-dir=cmake-build-debug")
+    } finally { restore() }
+  })
+
+  // 6. Linux kernel (Kbuild + Makefile) → no crash, no --compile-commands-dir
+  test("kernel project (Kbuild + Makefile): spawn succeeds without error", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir, argsFile } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, "Kbuild", "")
+    await touch(root, "Makefile", "VERSION = 6")
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+      const args = await waitForArgs(argsFile)
+      expect(args.find((a) => a.startsWith("--compile-commands-dir"))).toBeUndefined()
+    } finally { restore() }
+  })
+
+  // 7. Bare project → no crash
+  test("bare project: spawn succeeds, no --compile-commands-dir", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir, argsFile } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, "main.c", "int main() { return 0; }")
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+      const args = await waitForArgs(argsFile)
+      expect(args.find((a) => a.startsWith("--compile-commands-dir"))).toBeUndefined()
+    } finally { restore() }
+  })
+
+  // 8. Zephyr RTOS → highest priority, no crash
+  test("Zephyr project (west.yml + CMakeLists.txt): spawn succeeds", async () => {
+    await using tmp = await tmpdir()
+    const { fakeBinDir } = await setupFakeClangd(tmp.path)
+    const root = path.join(tmp.path, "project")
+    await touch(root, "west.yml", "manifest:\n  projects: []")
+    await touch(root, "CMakeLists.txt", "")
+    const restore = setPath(fakeBinDir)
+    try {
+      const handle = await LSPServer.Clangd.spawn(root, {} as any, flags)
+      expect(handle).toBeDefined()
+    } finally { restore() }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #28976

### Type of change

- [x] New feature

### What does this PR do?

clangd LSP currently spawns without checking if `compile_commands.json` exists or where it lives. This PR adds pre-spawn detection logic:

- Skips detection if `compile_flags.txt` or `.clangd` config already present
- Scans `build/`, `out/`, `cmake-build-debug/`, `cmake-build-release/` and auto-passes `--compile-commands-dir` when found
- Falls back to build system detection (West, CMake, Kbuild, Makefile, Meson, Bazel) and logs a targeted hint
- Deduplicates warnings per project root

8 integration tests added covering all project layouts.

### How did you verify your code works?

Ran `bun test test/lsp/clangd-detection.test.ts` from `packages/opencode` — all 8 scenarios pass. Full turbo typecheck across all 20 packages also passes clean.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR