### PR TITLE
docs(web): add openspec-superpowers-opencode to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -49,6 +49,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | 捆绑式多代理编排套件——16 个组件，一次安装                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode 的零摩擦 git worktree 管理                                    |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | 使用 Sentry AI Monitoring 追踪和调试您的 AI 代理                       |
+| [openspec-superpowers-opencode](https://github.com/moyaspace/openspec-superpowers-opencode)        | 将 Superpowers + OpenSpec 工作流桥接到 OpenCode 的 CLI 脚手架工具。    |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation only, no functional changes.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds openspec-superpowers-opencode (aka oso) to the Plugins table on the ecosystem page. It's a CLI scaffold that bridges Superpowers + OpenSpec workflows into OpenCode.

### How did you verify your code works?

Simple markdown change — manually reviewed the rendered table format. Verified the link is correct and the description renders properly in markdown.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
