### PR TITLE
feat: Add per-session plugin customization

### DIFF
--- a/packages/opencode/migration/20260523162000_add_session_plugin/migration.sql
+++ b/packages/opencode/migration/20260523162000_add_session_plugin/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `session` ADD `plugin` text;

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -663,6 +663,8 @@ export const layer = Layer.effect(
           yield* mergePluginOrigins(dir, list)
         }
 
+        yield* mergePluginOrigins(ctx.directory, ctx.plugin, "local")
+
         if (process.env.OPENCODE_CONFIG_CONTENT) {
           const source = "OPENCODE_CONFIG_CONTENT"
           const next = yield* loadConfig(process.env.OPENCODE_CONFIG_CONTENT, {

--- a/packages/opencode/src/config/plugin.ts
+++ b/packages/opencode/src/config/plugin.ts
@@ -1,16 +1,17 @@
 import { Glob } from "@opencode-ai/core/util/glob"
-import { Schema } from "effect"
+import { Schema, Types } from "effect"
 import { pathToFileURL } from "url"
 import { isPathPluginSpec, parsePluginSpecifier, resolvePathPluginTarget } from "@/plugin/shared"
 import path from "path"
 
-export const Options = Schema.Record(Schema.String, Schema.Unknown)
+export const Options = Schema.Record(Schema.String, Schema.Any)
 export type Options = Schema.Schema.Type<typeof Options>
 
 // Spec is the user-config value: either just a plugin identifier, or the identifier plus inline options.
 // It answers "what should we load?" but says nothing about where that value came from.
 export const Spec = Schema.Union([Schema.String, Schema.mutable(Schema.Tuple([Schema.String, Options]))])
 export type Spec = Schema.Schema.Type<typeof Spec>
+export type MutableSpec = Types.DeepMutable<Spec>
 
 export type Scope = "global" | "local"
 
@@ -61,6 +62,12 @@ export async function resolvePluginSpec(plugin: Spec, configFilepath: string): P
   const resolved = await resolvePathPluginTarget(file).catch(() => file)
 
   if (Array.isArray(plugin)) return [resolved, plugin[1]]
+  return resolved
+}
+
+export async function resolvePluginSpecFromDirectory(plugin: MutableSpec, directory: string): Promise<MutableSpec> {
+  const resolved = await resolvePluginSpec(plugin, path.join(directory, "opencode.json"))
+  if (Array.isArray(resolved)) return [resolved[0], resolved[1]]
   return resolved
 }
 

--- a/packages/opencode/src/effect/instance-state.ts
+++ b/packages/opencode/src/effect/instance-state.ts
@@ -24,20 +24,32 @@ export const workspaceID = Effect.gen(function* () {
 
 export const directory = Effect.map(context, (ctx) => ctx.directory)
 
+export const key = (ctx: InstanceContext) =>
+  ctx.plugin?.length ? `${ctx.directory}\0${JSON.stringify(ctx.plugin)}` : ctx.directory
+
 export const make = <A, E = never, R = never>(
   init: (ctx: InstanceContext) => Effect.Effect<A, E, R | Scope.Scope>,
 ): Effect.Effect<InstanceState<A, E, Exclude<R, Scope.Scope>>, never, R | Scope.Scope> =>
   Effect.gen(function* () {
+    const keys = new Set<string>()
     const cache = yield* ScopedCache.make<string, A, E, R>({
       capacity: Number.POSITIVE_INFINITY,
-      lookup: () =>
+      lookup: (cacheKey) =>
         Effect.gen(function* () {
+          keys.add(cacheKey)
           return yield* init(yield* context)
         }),
     })
 
     const off = registerDisposer((directory) =>
-      Effect.runPromise(ScopedCache.invalidate(cache, directory).pipe(Effect.provide(EffectLogger.layer))),
+      Effect.runPromise(
+        Effect.forEach(
+          [...keys].filter((cacheKey) => cacheKey === directory || cacheKey.startsWith(`${directory}\0`)),
+          (cacheKey) =>
+            ScopedCache.invalidate(cache, cacheKey).pipe(Effect.tap(() => Effect.sync(() => keys.delete(cacheKey)))),
+          { discard: true },
+        ).pipe(Effect.provide(EffectLogger.layer)),
+      ),
     )
     yield* Effect.addFinalizer(() => Effect.sync(off))
 
@@ -49,7 +61,7 @@ export const make = <A, E = never, R = never>(
 
 export const get = <A, E, R>(self: InstanceState<A, E, R>) =>
   Effect.gen(function* () {
-    return yield* ScopedCache.get(self.cache, yield* directory)
+    return yield* ScopedCache.get(self.cache, key(yield* context))
   })
 
 export const use = <A, E, R, B>(self: InstanceState<A, E, R>, select: (value: A) => B) => Effect.map(get(self), select)
@@ -61,12 +73,12 @@ export const useEffect = <A, E, R, B, E2, R2>(
 
 export const has = <A, E, R>(self: InstanceState<A, E, R>) =>
   Effect.gen(function* () {
-    return yield* ScopedCache.has(self.cache, yield* directory)
+    return yield* ScopedCache.has(self.cache, key(yield* context))
   })
 
 export const invalidate = <A, E, R>(self: InstanceState<A, E, R>) =>
   Effect.gen(function* () {
-    return yield* ScopedCache.invalidate(self.cache, yield* directory)
+    return yield* ScopedCache.invalidate(self.cache, key(yield* context))
   })
 
 export * as InstanceState from "./instance-state"

--- a/packages/opencode/src/project/instance-context.ts
+++ b/packages/opencode/src/project/instance-context.ts
@@ -1,11 +1,13 @@
 import { LocalContext } from "@/util/local-context"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import type { ConfigPlugin } from "@/config/plugin"
 import type * as Project from "./project"
 
 export interface InstanceContext {
   directory: string
   worktree: string
   project: Project.Info
+  plugin?: ConfigPlugin.MutableSpec[]
 }
 
 export const context = LocalContext.create<InstanceContext>("instance")

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -4,6 +4,7 @@ import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance as runDisposers } from "@/effect/instance-registry"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import type { ConfigPlugin } from "@/config/plugin"
 import { Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
 import { type InstanceContext } from "./instance-context"
 import { InstanceBootstrap } from "./bootstrap-service"
@@ -13,6 +14,7 @@ export interface LoadInput {
   directory: string
   worktree?: string
   project?: Project.Info
+  plugin?: ConfigPlugin.MutableSpec[]
 }
 
 export interface Interface {
@@ -47,12 +49,14 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
                 directory: input.directory,
                 worktree: input.worktree,
                 project: input.project,
+                plugin: input.plugin,
               }
             : yield* project.fromDirectory(input.directory).pipe(
                 Effect.map((result) => ({
                   directory: input.directory,
                   worktree: result.sandbox,
                   project: result.project,
+                  plugin: input.plugin,
                 })),
               )
         yield* bootstrap.run.pipe(Effect.provideService(InstanceRef, ctx))
@@ -102,18 +106,22 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
       return true
     })
 
+    const cacheKey = (directory: string, plugin?: ConfigPlugin.MutableSpec[]) =>
+      plugin?.length ? `${directory}\0${JSON.stringify(plugin)}` : directory
+
     const load = (input: LoadInput): Effect.Effect<InstanceContext> => {
       const directory = AppFileSystem.resolve(input.directory)
+      const key = cacheKey(directory, input.plugin)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const existing = cache.get(directory)
+          const existing = cache.get(key)
           if (existing) return yield* restore(Deferred.await(existing.deferred))
 
           const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>() }
-          cache.set(directory, entry)
+          cache.set(key, entry)
           yield* Effect.gen(function* () {
             yield* Effect.logInfo("creating instance").pipe(Effect.annotateLogs("directory", directory))
-            yield* completeLoad(directory, input, entry)
+            yield* completeLoad(key, { ...input, directory }, entry)
           }).pipe(Effect.forkIn(scope, { startImmediately: true }))
           return yield* restore(Deferred.await(entry.deferred))
         }),
@@ -122,11 +130,12 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
 
     const reload = (input: LoadInput): Effect.Effect<InstanceContext> => {
       const directory = AppFileSystem.resolve(input.directory)
+      const key = cacheKey(directory, input.plugin)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const previous = cache.get(directory)
+          const previous = cache.get(key)
           const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>() }
-          cache.set(directory, entry)
+          cache.set(key, entry)
           yield* Effect.gen(function* () {
             yield* Effect.logInfo("reloading instance").pipe(Effect.annotateLogs("directory", directory))
             if (previous) {
@@ -134,7 +143,7 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
               yield* Effect.promise(() => runDisposers(directory))
               yield* emitDisposed({ directory, project: input.project?.id })
             }
-            yield* completeLoad(directory, input, entry)
+            yield* completeLoad(key, { ...input, directory }, entry)
           }).pipe(Effect.forkIn(scope, { startImmediately: true }))
           return yield* restore(Deferred.await(entry.deferred))
         }),
@@ -142,13 +151,14 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
     }
 
     const dispose = Effect.fn("InstanceStore.dispose")(function* (ctx: InstanceContext) {
-      const entry = cache.get(ctx.directory)
+      const key = cacheKey(ctx.directory, ctx.plugin)
+      const entry = cache.get(key)
       if (!entry) return yield* disposeContext(ctx)
 
       const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
-      if (Exit.isFailure(exit)) return yield* removeEntry(ctx.directory, entry).pipe(Effect.asVoid)
+      if (Exit.isFailure(exit)) return yield* removeEntry(key, entry).pipe(Effect.asVoid)
       if (exit.value !== ctx) return
-      yield* disposeEntry(ctx.directory, entry, ctx).pipe(Effect.asVoid)
+      yield* disposeEntry(key, entry, ctx).pipe(Effect.asVoid)
     })
 
     const disposeAllOnce = Effect.fnUntraced(function* () {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -167,6 +167,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         ? {
             ...decoded,
             permission: decoded.permission ? [...decoded.permission] : undefined,
+            plugin: decoded.plugin ? [...decoded.plugin] : undefined,
           }
         : decoded
       return yield* create({ payload })

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -26,7 +26,7 @@ function provideInstanceContext<E>(
 ): Effect.Effect<HttpServerResponse.HttpServerResponse, E, WorkspaceRouteContext> {
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
-    const ctx = yield* store.load({ directory: decode(route.directory) })
+    const ctx = yield* store.load({ directory: decode(route.directory), plugin: route.plugin })
     return yield* effect.pipe(
       Effect.provideService(InstanceRef, ctx),
       Effect.provideService(WorkspaceRef, route.workspaceID),

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -1,4 +1,5 @@
 import { WorkspaceID } from "@/control-plane/schema"
+import type { ConfigPlugin } from "@/config/plugin"
 import type { Target } from "@/control-plane/types"
 import { Workspace } from "@/control-plane/workspace"
 import { WorkspaceAdapterRuntime } from "@/control-plane/workspace-adapter-runtime"
@@ -31,7 +32,11 @@ type RemoteTarget = Extract<Target, { type: "remote" }>
 type RequestPlan = Data.TaggedEnum<{
   InvalidWorkspace: {}
   MissingWorkspace: { readonly workspaceID: WorkspaceID }
-  Local: { readonly directory: string; readonly workspaceID?: WorkspaceID }
+  Local: {
+    readonly directory: string
+    readonly workspaceID?: WorkspaceID
+    readonly plugin?: ConfigPlugin.MutableSpec[]
+  }
   Remote: {
     readonly request: HttpServerRequest.HttpServerRequest
     readonly workspace: Workspace.Info
@@ -47,6 +52,7 @@ export class WorkspaceRouteContext extends Context.Service<
   {
     readonly directory: string
     readonly workspaceID?: WorkspaceID
+    readonly plugin?: ConfigPlugin.MutableSpec[]
   }
 >()("@opencode/ExperimentalHttpApiWorkspaceRouteContext") {}
 
@@ -159,14 +165,14 @@ function planWorkspaceRequest(
 
 function planRequest(
   request: HttpServerRequest.HttpServerRequest,
-  sessionWorkspaceID?: WorkspaceID,
+  session?: Session.Info,
 ): Effect.Effect<RequestPlan, never, Workspace.Service> {
   return Effect.gen(function* () {
     const url = requestURL(request)
     const envWorkspaceID = configuredWorkspaceID()
     const workspaceID = url.pathname.startsWith("/api/")
-      ? selectedV2WorkspaceID(url, sessionWorkspaceID)
-      : selectedWorkspaceID(url, sessionWorkspaceID)
+      ? selectedV2WorkspaceID(url, session?.workspaceID)
+      : selectedWorkspaceID(url, session?.workspaceID)
     if (workspaceID === InvalidWorkspaceID) return RequestPlan.InvalidWorkspace()
     const workspace = yield* resolveWorkspace(workspaceID, envWorkspaceID)
 
@@ -178,7 +184,11 @@ function planRequest(
       return yield* planWorkspaceRequest(request, url, workspace)
     }
 
-    return RequestPlan.Local({ directory: defaultDirectory(request, url), workspaceID: envWorkspaceID ?? workspaceID })
+    return RequestPlan.Local({
+      directory: defaultDirectory(request, url),
+      workspaceID: envWorkspaceID ?? workspaceID,
+      plugin: session?.plugin,
+    })
   })
 }
 
@@ -201,8 +211,10 @@ function routeWorkspace<E>(
       ),
     MissingWorkspace: ({ workspaceID }) => Effect.succeed(missingWorkspaceResponse(workspaceID)),
     Remote: ({ request, workspace, target, url }) => proxyRemote(client, request, workspace, target, url),
-    Local: ({ directory, workspaceID }) =>
-      effect.pipe(Effect.provideService(WorkspaceRouteContext, WorkspaceRouteContext.of({ directory, workspaceID }))),
+    Local: ({ directory, workspaceID, plugin }) =>
+      effect.pipe(
+        Effect.provideService(WorkspaceRouteContext, WorkspaceRouteContext.of({ directory, workspaceID, plugin })),
+      ),
   })
 }
 
@@ -223,7 +235,7 @@ function routeHttpApiWorkspace<E>(
           Effect.catchDefect(() => Effect.succeed(undefined)),
         )
       : undefined
-    const plan = yield* planRequest(request, session?.workspaceID)
+    const plan = yield* planRequest(request, session)
     return yield* routeWorkspace(client, effect, plan)
   })
 }

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -87,6 +87,7 @@ export function toPartialRow(info: DeepPartial<Session.Info>) {
     tokens_cache_write: grab(info, "tokens", (v) => grab(v, "cache", (cache) => grab(cache, "write"))),
     revert: grab(info, "revert"),
     permission: grab(info, "permission"),
+    plugin: grab(info, "plugin"),
     time_created: grab(info, "time", (v) => grab(v, "created")),
     time_updated: grab(info, "time", (v) => grab(v, "updated")),
     time_compacting: grab(info, "time", (v) => grab(v, "compacting")),

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -7,6 +7,7 @@ import type { Permission } from "../permission"
 import type { ProjectID } from "../project/schema"
 import type { SessionID, MessageID, PartID } from "./schema"
 import type { WorkspaceID } from "../control-plane/schema"
+import type { ConfigPlugin } from "../config/plugin"
 import { Timestamps } from "../storage/schema.sql"
 
 type PartData = Omit<MessageV2.Part, "id" | "sessionID" | "messageID">
@@ -47,6 +48,7 @@ export const SessionTable = sqliteTable(
       providerID: string
       variant?: string
     }>(),
+    plugin: text({ mode: "json" }).$type<ConfigPlugin.MutableSpec[]>(),
     ...Timestamps,
     time_compacting: integer(),
     time_archived: integer(),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -33,6 +33,7 @@ import { ProjectID } from "../project/schema"
 import { WorkspaceID } from "../control-plane/schema"
 import { SessionID, MessageID, PartID } from "./schema"
 import { ModelID, ProviderID } from "@/provider/schema"
+import { ConfigPlugin } from "@/config/plugin"
 
 import type { Provider } from "@/provider/provider"
 import { Permission } from "@/permission"
@@ -102,6 +103,7 @@ export function fromRow(row: SessionRow): Info {
     share,
     revert,
     permission: row.permission ? [...row.permission] : undefined,
+    plugin: row.plugin ? [...row.plugin] : undefined,
     time: {
       created: row.time_created,
       updated: row.time_updated,
@@ -137,6 +139,7 @@ export function toRow(info: Info) {
     tokens_cache_write: (info.tokens ?? EmptyTokens).cache.write,
     revert: info.revert ?? null,
     permission: info.permission,
+    plugin: info.plugin,
     time_created: info.time.created,
     time_updated: info.time.updated,
     time_compacting: info.time.compacting,
@@ -223,6 +226,7 @@ export const Info = Schema.Struct({
   version: Schema.String,
   time: Time,
   permission: optionalOmitUndefined(Permission.Ruleset),
+  plugin: optionalOmitUndefined(Schema.Array(ConfigPlugin.Spec)),
   revert: optionalOmitUndefined(Revert),
 }).annotate({ identifier: "Session" })
 export type Info = Types.DeepMutable<Schema.Schema.Type<typeof Info>>
@@ -247,6 +251,7 @@ export const CreateInput = Schema.optional(
     agent: Schema.optional(Schema.String),
     model: Schema.optional(Model),
     permission: Schema.optional(Permission.Ruleset),
+    plugin: Schema.optional(Schema.Array(ConfigPlugin.Spec)),
     workspaceID: Schema.optional(WorkspaceID),
   }),
 )
@@ -456,6 +461,7 @@ export interface Interface {
     agent?: string
     model?: Schema.Schema.Type<typeof Model>
     permission?: Permission.Ruleset
+    plugin?: ConfigPlugin.MutableSpec[]
     workspaceID?: WorkspaceID
   }) => Effect.Effect<Info>
   readonly fork: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Info, NotFound>
@@ -530,6 +536,7 @@ export const layer: Layer.Layer<
       directory: string
       path?: string
       permission?: Permission.Ruleset
+      plugin?: ConfigPlugin.MutableSpec[]
     }) {
       const ctx = yield* InstanceState.context
       const result: Info = {
@@ -545,6 +552,7 @@ export const layer: Layer.Layer<
         agent: input.agent,
         model: input.model,
         permission: input.permission ? [...input.permission] : undefined,
+        plugin: input.plugin ? [...input.plugin] : undefined,
         cost: 0,
         tokens: EmptyTokens,
         time: {
@@ -660,10 +668,17 @@ export const layer: Layer.Layer<
       agent?: string
       model?: Schema.Schema.Type<typeof Model>
       permission?: Permission.Ruleset
+      plugin?: ConfigPlugin.MutableSpec[]
       workspaceID?: WorkspaceID
     }) {
       const ctx = yield* InstanceState.context
       const workspace = yield* InstanceState.workspaceID
+      const inputPlugin = input?.plugin
+      const plugin = inputPlugin?.length
+        ? yield* Effect.promise(() =>
+            Promise.all(inputPlugin.map((item) => ConfigPlugin.resolvePluginSpecFromDirectory(item, ctx.directory))),
+          )
+        : undefined
       return yield* createNext({
         parentID: input?.parentID,
         directory: ctx.directory,
@@ -672,6 +687,7 @@ export const layer: Layer.Layer<
         agent: input?.agent,
         model: input?.model,
         permission: input?.permission,
+        plugin,
         workspaceID: input?.workspaceID ?? workspace,
       })
     })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3097,6 +3097,15 @@ export class Session2 extends HeyApiClient {
         variant?: string
       }
       permission?: PermissionRuleset
+      plugin?: Array<
+        | string
+        | [
+            string,
+            {
+              [key: string]: unknown
+            },
+          ]
+      >
       workspaceID?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -3113,6 +3122,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "agent" },
             { in: "body", key: "model" },
             { in: "body", key: "permission" },
+            { in: "body", key: "plugin" },
             { in: "body", key: "workspaceID" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -786,6 +786,15 @@ export type Session = {
     archived?: number
   }
   permission?: PermissionRuleset
+  plugin?: Array<
+    | string
+    | [
+        string,
+        {
+          [key: string]: unknown
+        },
+      ]
+  >
   revert?: {
     messageID: string
     partID?: string
@@ -6064,6 +6073,15 @@ export type SessionCreateData = {
       variant?: string
     }
     permission?: PermissionRuleset
+    plugin?: Array<
+      | string
+      | [
+          string,
+          {
+            [key: string]: unknown
+          },
+        ]
+    >
     workspaceID?: string
   }
   path?: never


### PR DESCRIPTION
### Issue for this PR

Closes #28985

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `plugin` array to session creation so API and SDK callers can attach extra plugins to a single session without mutating `.opencode` config for the project.

The implementation reuses the existing project plugin loader rather than adding session-scoped hook filtering. Session rows store resolved plugin specs, and local instance caches include the plugin list in their cache key. That lets two sessions in the same directory use different plugin sets while keeping hooks, tools, and config callbacks on the existing instance-scoped path.

Relative plugin paths passed to `session.create` resolve from the session directory.

### How did you verify your code works?

- `bun run --cwd packages/opencode typecheck`
- `bun run --cwd packages/sdk/js typecheck`
- `bun turbo typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR