### PR TITLE
feat: pass lastUserMessage to experimental.chat.system.transform hook

### DIFF
--- a/.github/workflows/build-patched.yml
+++ b/.github/workflows/build-patched.yml
@@ -1,0 +1,94 @@
+name: Build Patched Binary
+
+on:
+  push:
+    branches:
+      - feat/system-transform-lastUserMessage
+  workflow_dispatch:
+
+concurrency: build-patched-${{ github.ref }}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: macos-latest
+            target: macos-arm64
+          - os: macos-13
+            target: macos-x64
+          - os: windows-latest
+            target: windows-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Build
+        run: |
+          ./packages/opencode/script/build.ts
+        env:
+          OPENCODE_VERSION: "0.0.0-patched"
+          OPENCODE_RELEASE: "false"
+
+      - name: Rename binary
+        shell: bash
+        run: |
+          cd packages/opencode/dist
+          if [ "${{ matrix.target }}" = "windows-x64" ]; then
+            cp opencode-windows-x64/bin/opencode.exe opencode-windows-x64.exe
+          elif [ "${{ matrix.target }}" = "linux-x64" ]; then
+            cp opencode-linux-x64/bin/opencode opencode-linux-x64
+            chmod +x opencode-linux-x64
+          elif [ "${{ matrix.target }}" = "macos-arm64" ]; then
+            cp opencode-darwin-arm64/bin/opencode opencode-macos-arm64
+            chmod +x opencode-macos-arm64
+          elif [ "${{ matrix.target }}" = "macos-x64" ]; then
+            cp opencode-darwin-x64/bin/opencode opencode-macos-x64
+            chmod +x opencode-macos-x64
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: opencode-${{ matrix.target }}
+          path: |
+            packages/opencode/dist/opencode-${{ matrix.target }}*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/feat/system-transform-lastUserMessage'
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+
+      - name: Create release
+        uses: softprops/action-gh-release@62c30c1b3e8493c9b3cfa4e4a4e8c6c6fcd42e18 # v2.3.0
+        with:
+          tag_name: patched-latest
+          name: Patched OpenCode (lastUserMessage)
+          body: |
+            Patched OpenCode build with `lastUserMessage` support in `experimental.chat.system.transform` hook.
+
+            **What's changed:**
+            - `packages/plugin/src/index.ts`: Added `lastUserMessage?: string` to hook input type
+            - `packages/opencode/src/session/llm/request.ts`: Extract and pass lastUserMessage from `input.messages`
+
+            **Upstream PR:** https://github.com/anomalyco/opencode/pull/28993
+
+            **Usage with PEtFiSh:**
+            ```bash
+            uv run scripts/patch_opencode.py
+            ```
+          files: |
+            opencode-linux-x64/opencode-linux-x64
+            opencode-macos-arm64/opencode-macos-arm64
+            opencode-macos-x64/opencode-macos-x64
+            opencode-windows-x64/opencode-windows-x64.exe

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -64,9 +64,20 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
   ]
 
   const header = system[0]
+  // Extract last user message text for plugin hooks (e.g. topic detection)
+  const lastUserMsg = input.messages.findLast((m) => m.role === "user")
+  const lastUserMessage =
+    typeof lastUserMsg?.content === "string"
+      ? lastUserMsg.content
+      : Array.isArray(lastUserMsg?.content)
+        ? (lastUserMsg!.content as Array<{ type: string; text?: string }>)
+            .filter((p) => p.type === "text" && typeof p.text === "string")
+            .map((p) => p.text!)
+            .join(" ")
+        : undefined
   yield* input.plugin.trigger(
     "experimental.chat.system.transform",
-    { sessionID: input.sessionID, model: input.model },
+    { sessionID: input.sessionID, model: input.model, lastUserMessage },
     { system },
   )
   if (system.length > 2 && system[0] === header) {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -288,7 +288,7 @@ export interface Hooks {
     },
   ) => Promise<void>
   "experimental.chat.system.transform"?: (
-    input: { sessionID?: string; model: Model },
+    input: { sessionID?: string; model: Model; lastUserMessage?: string },
     output: {
       system: string[]
     },


### PR DESCRIPTION
## Summary

Adds optional lastUserMessage string to the xperimental.chat.system.transform hook input, enabling plugins to perform real-time detection (topic switches, intent classification) without additional MCP calls.

## Changes

- packages/plugin/src/index.ts: add lastUserMessage?: string to hook input type
- packages/opencode/src/session/llm/request.ts: extract last user message text from input.messages and pass it to the hook

## Backward Compatibility

lastUserMessage is optional. Existing plugins are completely unaffected.

## Use Case

Plugin developers (e.g., PEtFiSh topic governance) need to detect topic switches in real-time within the system prompt transform hook. Currently the hook only receives {sessionID, model} making this impossible. The user message text is already available in input.messages at the call site.

## Related Issue

Closes #28992