### PR TITLE
feat(opencode): add ACP client backend support

### DIFF
--- a/packages/opencode/src/acp/client.ts
+++ b/packages/opencode/src/acp/client.ts
@@ -92,7 +92,7 @@ type RemoteSessionState = {
   server: string
   ctx: InstanceContext
   localSession: Session.Info
-  assistant: MessageV2.Assistant
+  assistant?: MessageV2.Assistant
   ruleset: Permission.Ruleset
   textPartID?: PartID
   textMessageID?: string
@@ -138,9 +138,19 @@ export interface RunInput {
   assistant: MessageV2.Assistant
 }
 
+export interface PrepareInput {
+  server: string
+  agent: {
+    name: string
+    permission: Permission.Ruleset
+  }
+  session: Session.Info
+}
+
 export interface Interface {
   readonly run: (input: RunInput) => Effect.Effect<MessageV2.Assistant>
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+  readonly prepare: (input: PrepareInput) => Effect.Effect<ACPStatePayload, Error>
   readonly setConfigOption: (input: {
     sessionID: SessionID
     configID: string
@@ -485,20 +495,27 @@ export const layer = Layer.effect(
       return entry
     })
 
-    const ensureRemoteSession = Effect.fn("ACPClient.ensureRemoteSession")(function* (input: RunInput) {
+    const ensureRemoteSession = Effect.fn("ACPClient.ensureRemoteSession")(function* (input: {
+      server: string
+      agent: { name: string; permission: Permission.Ruleset }
+      session: Session.Info
+      assistant?: MessageV2.Assistant
+    }) {
       const runtime = yield* InstanceState.get(state)
       const existing = runtime.sessions.get(input.session.id)
       if (existing && existing.server === input.server) {
-        existing.assistant = input.assistant
+        if (input.assistant) {
+          existing.assistant = input.assistant
+          existing.activeAssistantID = input.assistant.id
+          existing.textPartID = undefined
+          existing.textMessageID = undefined
+          existing.reasoningPartID = undefined
+          existing.reasoningMessageID = undefined
+          existing.planPartID = undefined
+          existing.tools = new Map()
+        }
         existing.localSession = input.session
         existing.ruleset = Permission.merge(input.agent.permission, input.session.permission ?? [])
-        existing.textPartID = undefined
-        existing.textMessageID = undefined
-        existing.reasoningPartID = undefined
-        existing.reasoningMessageID = undefined
-        existing.planPartID = undefined
-        existing.tools = new Map()
-        existing.activeAssistantID = input.assistant.id
         return existing
       }
 
@@ -532,7 +549,7 @@ export const layer = Layer.effect(
         tools: new Map(),
         terminals: new Map(),
         pendingPermissions: new Set(),
-        activeAssistantID: input.assistant.id,
+        activeAssistantID: input.assistant?.id,
         configOptions: Array.isArray((created as any).configOptions) ? (created as any).configOptions : undefined,
         modes: (created as any).modes,
         models: (created as any).models,
@@ -541,6 +558,23 @@ export const layer = Layer.effect(
       runtime.remoteToLocal.set(created.sessionId, input.session.id)
       yield* publishACPState(bus, remote)
       return remote
+    })
+
+    const prepare = Effect.fn("ACPClient.prepare")(function* (input: PrepareInput) {
+      const remote = yield* ensureRemoteSession({
+        server: input.server,
+        agent: input.agent,
+        session: input.session,
+      })
+      return {
+        sessionID: remote.localSessionID,
+        configOptions: remote.configOptions,
+        modes: remote.modes,
+        models: remote.models,
+        availableCommands: remote.availableCommands,
+        usage: remote.usage,
+        info: remote.info,
+      }
     })
 
     const run = Effect.fn("ACPClient.run")(function* (input: RunInput) {
@@ -558,7 +592,12 @@ export const layer = Layer.effect(
 
       return yield* Effect.gen(function* () {
         const connection = yield* connect(input.server)
-        const remote = yield* ensureRemoteSession(input)
+        const remote = yield* ensureRemoteSession({
+          server: input.server,
+          agent: input.agent,
+          session: input.session,
+          assistant: input.assistant,
+        })
         const startSnapshot = yield* snapshot.track()
         yield* session.updatePart({
           id: PartID.ascending(),
@@ -627,7 +666,7 @@ export const layer = Layer.effect(
       remote.pendingPermissions.clear()
       yield* finishOpenParts(session, remote)
       yield* failOpenTools(session, remote, "ACP prompt cancelled")
-      clearActiveTurn(remote, remote.assistant.id)
+      if (remote.assistant) clearActiveTurn(remote, remote.assistant.id)
       const connection = runtime.connections.get(remote.server)
       if (!connection) return
       yield* Effect.promise(() => connection.agent.cancel({ sessionId: remote.remoteSessionID })).pipe(Effect.ignore)
@@ -689,6 +728,7 @@ export const layer = Layer.effect(
     return Service.of({
       run: (input) => run(input).pipe(Effect.onInterrupt(() => cancel(input.session.id))),
       cancel,
+      prepare,
       setConfigOption,
     })
   }),
@@ -735,7 +775,7 @@ function handleSessionUpdate(runtime: State, params: SessionNotification) {
         yield* publishACPState(bus, remote)
         return
     }
-    if (!remote.activeAssistantID || remote.activeAssistantID !== remote.assistant.id) return
+    if (!remote.assistant || !remote.activeAssistantID || remote.activeAssistantID !== remote.assistant.id) return
     switch (update.sessionUpdate) {
       case "agent_message_chunk":
         yield* appendContent(
@@ -809,11 +849,13 @@ function recordACPFailurePatch(
 ) {
   return Effect.gen(function* () {
     if (!startSnapshot) return
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const patch = yield* snapshot.patch(startSnapshot)
     if (!patch.files.length) return
     yield* svc.updatePart({
       id: PartID.ascending(),
-      messageID: remote.assistant.id,
+      messageID: assistant.id,
       sessionID: remote.localSessionID,
       type: "patch",
       hash: patch.hash,
@@ -832,12 +874,14 @@ function recordACPStepFinish(input: {
   userMessageID: MessageV2.User["id"]
 }) {
   return Effect.gen(function* () {
+    if (!input.remote.assistant) return
+    const assistant = input.remote.assistant
     const completedSnapshot = yield* input.snapshot.track()
     yield* input.session.updatePart({
       id: PartID.ascending(),
       reason: input.reason,
       snapshot: completedSnapshot,
-      messageID: input.remote.assistant.id,
+      messageID: assistant.id,
       sessionID: input.remote.localSessionID,
       type: "step-finish",
       tokens: {
@@ -853,7 +897,7 @@ function recordACPStepFinish(input: {
       if (patch.files.length) {
         yield* input.session.updatePart({
           id: PartID.ascending(),
-          messageID: input.remote.assistant.id,
+          messageID: assistant.id,
           sessionID: input.remote.localSessionID,
           type: "patch",
           hash: patch.hash,
@@ -869,24 +913,26 @@ function recordACPStepFinish(input: {
 
 function finishOpenParts(svc: Session.Interface, remote: RemoteSessionState) {
   return Effect.gen(function* () {
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const now = Date.now()
     if (remote.textPartID) {
       const current = yield* svc.getPart({
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
         partID: remote.textPartID,
       })
       if (current?.type === "text" && current.time?.end === undefined) {
         yield* svc.updatePart({
           ...current,
-          time: { start: current.time?.start ?? remote.assistant.time.created, end: now },
+          time: { start: current.time?.start ?? assistant.time.created, end: now },
         })
       }
     }
     if (remote.reasoningPartID) {
       const current = yield* svc.getPart({
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
         partID: remote.reasoningPartID,
       })
       if (current?.type === "reasoning" && current.time.end === undefined) {
@@ -901,11 +947,13 @@ function finishOpenParts(svc: Session.Interface, remote: RemoteSessionState) {
 
 function failOpenTools(svc: Session.Interface, remote: RemoteSessionState, message: string) {
   return Effect.gen(function* () {
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const now = Date.now()
     for (const partID of remote.tools.values()) {
       const current = yield* svc.getPart({
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
         partID,
       })
       if (!current || current.type !== "tool") continue
@@ -927,8 +975,10 @@ function failOpenTools(svc: Session.Interface, remote: RemoteSessionState, messa
 
 function ensureVisibleResponse(svc: Session.Interface, remote: RemoteSessionState) {
   return Effect.gen(function* () {
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const messages = yield* svc.messages({ sessionID: remote.localSessionID, limit: 1 }).pipe(Effect.orDie)
-    const current = messages.find((message) => message.info.id === remote.assistant.id)
+    const current = messages.find((message) => message.info.id === assistant.id)
     const visible = current?.parts.some((part) => {
       if (part.type === "text") return !part.synthetic && !part.ignored && part.text.trim().length > 0
       if (part.type === "reasoning") return part.text.trim().length > 0
@@ -941,7 +991,7 @@ function ensureVisibleResponse(svc: Session.Interface, remote: RemoteSessionStat
     yield* svc.updatePart({
       id: PartID.ascending(),
       sessionID: remote.localSessionID,
-      messageID: remote.assistant.id,
+      messageID: assistant.id,
       type: "text",
       text: "Done.",
       metadata: { acp: { fallback: true } },
@@ -957,6 +1007,8 @@ function closeStreamingText(remote: RemoteSessionState) {
 
 function appendContent(remote: RemoteSessionState, content: unknown, messageID?: string) {
   return Effect.gen(function* () {
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const file = contentBlockFilePart(remote, content)
     if (file) {
       const svc = yield* Session.Service
@@ -964,7 +1016,7 @@ function appendContent(remote: RemoteSessionState, content: unknown, messageID?:
         ...file,
         id: PartID.ascending(),
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
       })
       return
     }
@@ -976,7 +1028,7 @@ function appendContent(remote: RemoteSessionState, content: unknown, messageID?:
       const part = yield* svc.updatePart({
         id: PartID.ascending(),
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
         type: "text",
         text,
         time: { start: Date.now() },
@@ -987,7 +1039,7 @@ function appendContent(remote: RemoteSessionState, content: unknown, messageID?:
     }
     const current = yield* svc.getPart({
       sessionID: remote.localSessionID,
-      messageID: remote.assistant.id,
+      messageID: assistant.id,
       partID: remote.textPartID,
     })
     if (!current || current.type !== "text") return
@@ -997,6 +1049,8 @@ function appendContent(remote: RemoteSessionState, content: unknown, messageID?:
 
 function appendReasoning(remote: RemoteSessionState, content: unknown, messageID?: string) {
   return Effect.gen(function* () {
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const text = contentBlockText(content)
     if (!text) return
     const svc = yield* Session.Service
@@ -1008,7 +1062,7 @@ function appendReasoning(remote: RemoteSessionState, content: unknown, messageID
       const part = yield* svc.updatePart({
         id: PartID.ascending(),
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
         type: "reasoning",
         text,
         time: { start: Date.now() },
@@ -1019,7 +1073,7 @@ function appendReasoning(remote: RemoteSessionState, content: unknown, messageID
     }
     const current = yield* svc.getPart({
       sessionID: remote.localSessionID,
-      messageID: remote.assistant.id,
+      messageID: assistant.id,
       partID: remote.reasoningPartID,
     })
     if (!current || current.type !== "reasoning") return
@@ -1029,6 +1083,8 @@ function appendReasoning(remote: RemoteSessionState, content: unknown, messageID
 
 function upsertPlan(remote: RemoteSessionState, entries: Array<Record<string, unknown>>) {
   return Effect.gen(function* () {
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const text = entries
       .map((entry) => {
         const status = typeof entry.status === "string" ? ` [${entry.status}]` : ""
@@ -1042,7 +1098,7 @@ function upsertPlan(remote: RemoteSessionState, entries: Array<Record<string, un
       const part = yield* svc.updatePart({
         id: PartID.ascending(),
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
         type: "text",
         text: value,
         synthetic: true,
@@ -1054,7 +1110,7 @@ function upsertPlan(remote: RemoteSessionState, entries: Array<Record<string, un
     }
     const current = yield* svc.getPart({
       sessionID: remote.localSessionID,
-      messageID: remote.assistant.id,
+      messageID: assistant.id,
       partID: remote.planPartID,
     })
     if (!current || current.type !== "text") return
@@ -1064,6 +1120,8 @@ function upsertPlan(remote: RemoteSessionState, entries: Array<Record<string, un
 
 function upsertTool(remote: RemoteSessionState, update: Record<string, any>) {
   return Effect.gen(function* () {
+    if (!remote.assistant) return
+    const assistant = remote.assistant
     const toolCallID = String(update.toolCallId)
     const svc = yield* Session.Service
     const existingID = remote.tools.get(toolCallID)
@@ -1074,7 +1132,7 @@ function upsertTool(remote: RemoteSessionState, update: Record<string, any>) {
       const part = yield* svc.updatePart({
         id: PartID.ascending(),
         sessionID: remote.localSessionID,
-        messageID: remote.assistant.id,
+        messageID: assistant.id,
         type: "tool",
         callID: toolCallID,
         tool: `acp:${update.kind ?? "tool"}`,

--- a/packages/opencode/src/acp/client.ts
+++ b/packages/opencode/src/acp/client.ts
@@ -1,0 +1,1362 @@
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { Config } from "@/config/config"
+import { ConfigACP } from "@/config/acp"
+import { InstanceRef } from "@/effect/instance-ref"
+import { InstanceState } from "@/effect/instance-state"
+import { Permission } from "@/permission"
+import * as Session from "@/session/session"
+import { SessionSummary } from "@/session/summary"
+import { MessageV2 } from "@/session/message-v2"
+import { PartID, SessionID } from "@/session/schema"
+import { Shell } from "@/shell/shell"
+import { Snapshot } from "@/snapshot"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import * as Log from "@opencode-ai/core/util/log"
+import type { InstanceContext } from "@/project/instance-context"
+import {
+  ClientSideConnection,
+  RequestError,
+  ndJsonStream,
+  type Agent as ACPAgent,
+  type Client as ACPClientHandler,
+  type ContentBlock,
+  type CreateTerminalRequest,
+  type CreateTerminalResponse,
+  type KillTerminalRequest,
+  type KillTerminalResponse,
+  type InitializeResponse,
+  type ReadTextFileRequest,
+  type ReadTextFileResponse,
+  type ReleaseTerminalRequest,
+  type ReleaseTerminalResponse,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+  type TerminalOutputRequest,
+  type TerminalOutputResponse,
+  type WaitForTerminalExitRequest,
+  type WaitForTerminalExitResponse,
+  type WriteTextFileRequest,
+  type WriteTextFileResponse,
+} from "@agentclientprotocol/sdk"
+import { Context, Effect, Layer, Scope, Schema } from "effect"
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import path from "node:path"
+import { Readable, Writable } from "node:stream"
+
+const log = Log.create({ service: "acp-client" })
+const DEFAULT_TIMEOUT = 30_000
+
+const ACPStatePayload = Schema.Struct({
+  sessionID: SessionID,
+  configOptions: Schema.optional(Schema.Array(Schema.Any)),
+  modes: Schema.optional(Schema.Any),
+  models: Schema.optional(Schema.Any),
+  availableCommands: Schema.optional(Schema.Array(Schema.Any)),
+  usage: Schema.optional(Schema.Any),
+  info: Schema.optional(Schema.Any),
+})
+export type ACPStatePayload = Schema.Schema.Type<typeof ACPStatePayload>
+
+export const Event = {
+  StateUpdated: BusEvent.define("acp.session.updated", ACPStatePayload),
+}
+
+type ConfiguredACP = NonNullable<Config.Info["acp"]>[string]
+
+function isConfiguredACP(entry: ConfiguredACP | undefined): entry is ConfigACP.Info {
+  return typeof entry === "object" && entry !== null && "type" in entry
+}
+
+type TerminalState = {
+  process: ChildProcessWithoutNullStreams
+  output: string
+  truncated: boolean
+  outputByteLimit: number
+  exitStatus?: {
+    exitCode: number | null
+    signal: string | null
+  }
+  wait: Promise<void>
+}
+
+type PendingPermission = {
+  resolve: (value: RequestPermissionResponse) => void
+}
+
+type RemoteSessionState = {
+  localSessionID: SessionID
+  remoteSessionID: string
+  server: string
+  ctx: InstanceContext
+  localSession: Session.Info
+  assistant: MessageV2.Assistant
+  ruleset: Permission.Ruleset
+  textPartID?: PartID
+  textMessageID?: string
+  reasoningPartID?: PartID
+  reasoningMessageID?: string
+  planPartID?: PartID
+  tools: Map<string, PartID>
+  terminals: Map<string, TerminalState>
+  pendingPermissions: Set<PendingPermission>
+  activeAssistantID?: MessageV2.Assistant["id"]
+  configOptions?: unknown[]
+  modes?: unknown
+  models?: unknown
+  availableCommands?: unknown[]
+  usage?: unknown
+  info?: unknown
+}
+
+type ConnectionState = {
+  server: string
+  config: ConfigACP.Info
+  agent: ACPAgent
+  process: ChildProcessWithoutNullStreams
+  initialized: boolean
+  init: InitializeResponse
+}
+
+type State = {
+  connections: Map<string, ConnectionState>
+  sessions: Map<SessionID, RemoteSessionState>
+  remoteToLocal: Map<string, SessionID>
+  terminalCounter: number
+}
+
+export interface RunInput {
+  server: string
+  agent: {
+    name: string
+    permission: Permission.Ruleset
+  }
+  session: Session.Info
+  user: MessageV2.WithParts & { info: MessageV2.User }
+  assistant: MessageV2.Assistant
+}
+
+export interface Interface {
+  readonly run: (input: RunInput) => Effect.Effect<MessageV2.Assistant>
+  readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+  readonly setConfigOption: (input: {
+    sessionID: SessionID
+    configID: string
+    value: string
+  }) => Effect.Effect<ACPStatePayload, Error>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/ACPClient") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const config = yield* Config.Service
+    const session = yield* Session.Service
+    const permission = yield* Permission.Service
+    const fs = yield* AppFileSystem.Service
+    const bus = yield* Bus.Service
+    const snapshot = yield* Snapshot.Service
+    const summary = yield* SessionSummary.Service
+    const scope = yield* Scope.Scope
+
+    const state = yield* InstanceState.make<State>(
+      Effect.fn("ACPClient.state")(function* (_ctx) {
+        const result: State = {
+          connections: new Map(),
+          sessions: new Map(),
+          remoteToLocal: new Map(),
+          terminalCounter: 0,
+        }
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(async () => {
+            for (const remote of result.sessions.values()) {
+              for (const terminal of remote.terminals.values()) {
+                await Shell.killTree(terminal.process).catch(() => {})
+              }
+            }
+            for (const connection of result.connections.values()) {
+              await Shell.killTree(connection.process).catch(() => {})
+            }
+            result.sessions.clear()
+            result.remoteToLocal.clear()
+            result.connections.clear()
+          }),
+        )
+        return result
+      }),
+    )
+
+    const createClientHandler = (runtime: State, ctx: InstanceContext): ACPClientHandler => {
+      const runWithInstance = (effect: Effect.Effect<any, any, any>) =>
+        Effect.runPromise(
+          effect.pipe(
+            Effect.provideService(Session.Service, session),
+            Effect.provideService(Bus.Service, bus),
+            Effect.provideService(InstanceRef, ctx),
+          ) as Effect.Effect<any, any, never>,
+        )
+
+      const resolveSession = (remoteSessionID: string) => {
+        const local = runtime.remoteToLocal.get(remoteSessionID)
+        return local ? runtime.sessions.get(local) : undefined
+      }
+
+      const requestPermission = async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
+        const remote = resolveSession(params.sessionId)
+        if (!remote) {
+          return { outcome: { outcome: "cancelled" } }
+        }
+        const patterns = permissionPatterns(params.toolCall)
+        const allowOnce = params.options.find((option) => option.kind === "allow_once")
+        const allowAlways = params.options.find((option) => option.kind === "allow_always")
+        const reject = params.options.find((option) => option.kind === "reject_once" || option.kind === "reject_always")
+        const selected = allowOnce ?? allowAlways ?? params.options.find((option) => !option.kind.startsWith("reject"))
+        if (!selected) return { outcome: { outcome: "cancelled" } }
+
+        return new Promise<RequestPermissionResponse>((resolve) => {
+          const pending = { resolve }
+          remote.pendingPermissions.add(pending)
+          const effect = permission
+            .ask({
+              sessionID: remote.localSessionID,
+              permission: `acp:${params.toolCall.kind ?? "other"}`,
+              patterns,
+              always: patterns,
+              metadata: {
+                server: remote.server,
+                toolCall: params.toolCall,
+                options: params.options,
+              },
+              ruleset: remote.ruleset,
+            })
+            .pipe(
+              Effect.match({
+                onFailure: () => ({
+                  outcome: reject
+                    ? { outcome: "selected" as const, optionId: reject.optionId }
+                    : { outcome: "cancelled" as const },
+                }),
+                onSuccess: () => ({ outcome: { outcome: "selected" as const, optionId: selected.optionId } }),
+              }),
+            )
+
+          Effect.runPromise(effect.pipe(Effect.provideService(InstanceRef, remote.ctx))).then(
+            (response) => {
+              remote.pendingPermissions.delete(pending)
+              resolve(response)
+            },
+            () => {
+              remote.pendingPermissions.delete(pending)
+              resolve({ outcome: { outcome: "cancelled" } })
+            },
+          )
+        })
+      }
+
+      const readTextFile = async (params: ReadTextFileRequest): Promise<ReadTextFileResponse> => {
+        const remote = resolveSession(params.sessionId)
+        if (!remote) throw RequestError.invalidParams(`Unknown session: ${params.sessionId}`)
+        await assertExternalDirectory(permission, remote, params.path)
+        const relative = relativeToWorktree(remote.ctx, params.path)
+        await Effect.runPromise(
+          permission
+            .ask({
+              sessionID: remote.localSessionID,
+              permission: "read",
+              patterns: [relative],
+              always: ["*"],
+              metadata: { path: params.path, server: remote.server },
+              ruleset: remote.ruleset,
+            })
+            .pipe(Effect.provideService(InstanceRef, remote.ctx)),
+        )
+        const content = await Effect.runPromise(
+          fs.readFileStringSafe(params.path).pipe(Effect.provideService(InstanceRef, remote.ctx)),
+        )
+        if (content === undefined) throw RequestError.resourceNotFound(params.path)
+        return { content: sliceLines(content, params.line ?? undefined, params.limit ?? undefined) }
+      }
+
+      const writeTextFile = async (params: WriteTextFileRequest): Promise<WriteTextFileResponse> => {
+        const remote = resolveSession(params.sessionId)
+        if (!remote) throw RequestError.invalidParams(`Unknown session: ${params.sessionId}`)
+        await assertExternalDirectory(permission, remote, params.path)
+        const relative = relativeToWorktree(remote.ctx, params.path)
+        await Effect.runPromise(
+          permission
+            .ask({
+              sessionID: remote.localSessionID,
+              permission: "edit",
+              patterns: [relative],
+              always: ["*"],
+              metadata: { path: params.path, server: remote.server },
+              ruleset: remote.ruleset,
+            })
+            .pipe(Effect.provideService(InstanceRef, remote.ctx)),
+        )
+        await Effect.runPromise(
+          fs.writeWithDirs(params.path, params.content).pipe(Effect.provideService(InstanceRef, remote.ctx)),
+        )
+        return {}
+      }
+
+      const createTerminal = async (params: CreateTerminalRequest): Promise<CreateTerminalResponse> => {
+        const remote = resolveSession(params.sessionId)
+        if (!remote) throw RequestError.invalidParams(`Unknown session: ${params.sessionId}`)
+        await assertExternalDirectory(permission, remote, params.cwd ?? remote.ctx.directory)
+        const commandText = [params.command, ...(params.args ?? [])].join(" ")
+        await Effect.runPromise(
+          permission
+            .ask({
+              sessionID: remote.localSessionID,
+              permission: "bash",
+              patterns: [commandText],
+              always: [params.command + " *"],
+              metadata: { cwd: params.cwd, command: params.command, args: params.args, server: remote.server },
+              ruleset: remote.ruleset,
+            })
+            .pipe(Effect.provideService(InstanceRef, remote.ctx)),
+        )
+        const terminalID = `acp_${++runtime.terminalCounter}`
+        const child = spawn(params.command, params.args ?? [], {
+          cwd: params.cwd ?? remote.ctx.directory,
+          env: {
+            ...process.env,
+            ...Object.fromEntries((params.env ?? []).map((entry) => [entry.name, entry.value])),
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+          detached: process.platform !== "win32",
+        }) as unknown as ChildProcessWithoutNullStreams
+        const terminal: TerminalState = {
+          process: child,
+          output: "",
+          truncated: false,
+          outputByteLimit: params.outputByteLimit ?? 1024 * 1024,
+          wait: Promise.resolve(),
+        }
+        const append = (chunk: Buffer) => {
+          terminal.output += chunk.toString("utf8")
+          if (Buffer.byteLength(terminal.output, "utf8") > terminal.outputByteLimit) {
+            terminal.truncated = true
+            terminal.output = trimUtf8Start(terminal.output, terminal.outputByteLimit)
+          }
+        }
+        child.stdout.on("data", append)
+        child.stderr.on("data", append)
+        terminal.wait = new Promise<void>((resolve) => {
+          child.once("exit", (exitCode: number | null, signal: NodeJS.Signals | null) => {
+            terminal.exitStatus = { exitCode, signal }
+            resolve()
+          })
+          child.once("error", (error: Error) => {
+            terminal.output += String(error)
+            terminal.exitStatus = { exitCode: 1, signal: null }
+            resolve()
+          })
+        })
+        remote.terminals.set(terminalID, terminal)
+        return { terminalId: terminalID }
+      }
+
+      const getTerminal = (params: { sessionId: string; terminalId: string }) => {
+        const remote = resolveSession(params.sessionId)
+        const terminal = remote?.terminals.get(params.terminalId)
+        if (!remote || !terminal) throw RequestError.invalidParams(`Unknown terminal: ${params.terminalId}`)
+        return { remote, terminal }
+      }
+
+      return {
+        requestPermission,
+        sessionUpdate: (params) => runWithInstance(handleSessionUpdate(runtime, params)),
+        readTextFile,
+        writeTextFile,
+        createTerminal,
+        terminalOutput: async (params: TerminalOutputRequest): Promise<TerminalOutputResponse> => {
+          const { terminal } = getTerminal(params)
+          return {
+            output: terminal.output,
+            truncated: terminal.truncated,
+            ...(terminal.exitStatus ? { exitStatus: terminal.exitStatus } : {}),
+          }
+        },
+        waitForTerminalExit: async (params: WaitForTerminalExitRequest): Promise<WaitForTerminalExitResponse> => {
+          const { terminal } = getTerminal(params)
+          await terminal.wait
+          return terminal.exitStatus ?? { exitCode: null, signal: null }
+        },
+        killTerminal: async (params: KillTerminalRequest): Promise<KillTerminalResponse> => {
+          const { terminal } = getTerminal(params)
+          await Shell.killTree(terminal.process)
+          await terminal.wait
+          return {}
+        },
+        releaseTerminal: async (params: ReleaseTerminalRequest): Promise<ReleaseTerminalResponse> => {
+          const { remote, terminal } = getTerminal(params)
+          await Shell.killTree(terminal.process).catch(() => {})
+          remote.terminals.delete(params.terminalId)
+          return {}
+        },
+      }
+    }
+
+    const connect = Effect.fn("ACPClient.connect")(function* (server: string) {
+      const runtime = yield* InstanceState.get(state)
+      const existing = runtime.connections.get(server)
+      if (existing && existing.initialized && !existing.process.killed && existing.process.exitCode === null)
+        return existing
+      if (existing) runtime.connections.delete(server)
+
+      const cfg = yield* config.get()
+      const serverConfig = cfg.acp?.[server]
+      if (!isConfiguredACP(serverConfig) || serverConfig.enabled === false) {
+        throw new Error(`ACP server not configured or disabled: ${server}`)
+      }
+      if (serverConfig.command.length === 0) throw new Error(`ACP server ${server} has an empty command`)
+
+      const [command, ...args] = serverConfig.command
+      const ctx = yield* InstanceState.context
+      const child = spawn(command!, args, {
+        cwd: ctx.directory,
+        env: { ...process.env, ...serverConfig.environment },
+        stdio: ["pipe", "pipe", "pipe"],
+        detached: process.platform !== "win32",
+      }) as unknown as ChildProcessWithoutNullStreams
+      child.stderr.on("data", (chunk) => log.info("server stderr", { server, text: chunk.toString("utf8") }))
+
+      const input = Writable.toWeb(child.stdin) as WritableStream<Uint8Array>
+      const output = Readable.toWeb(child.stdout) as unknown as ReadableStream<Uint8Array>
+      const stream = ndJsonStream(input, output)
+      const connection = new ClientSideConnection(() => createClientHandler(runtime, ctx), stream)
+      const entry: ConnectionState = {
+        server,
+        config: serverConfig,
+        agent: connection,
+        process: child,
+        initialized: false,
+        init: {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          authMethods: [],
+        },
+      }
+      child.once("exit", () => {
+        if (runtime.connections.get(server) === entry) runtime.connections.delete(server)
+      })
+
+      yield* Effect.tryPromise({
+        try: async () => {
+          try {
+            const init = await withTimeout(
+              connection.initialize({
+                protocolVersion: 1,
+                clientCapabilities: {
+                  fs: { readTextFile: true, writeTextFile: true },
+                  terminal: true,
+                },
+                clientInfo: {
+                  name: "opencode",
+                  title: "opencode",
+                  version: InstallationVersion,
+                },
+              }),
+              serverConfig.timeout ?? DEFAULT_TIMEOUT,
+            )
+            if (init.protocolVersion !== 1) {
+              throw new Error(`Unsupported ACP protocol version: ${init.protocolVersion}`)
+            }
+            entry.init = init
+          } catch (error) {
+            runtime.connections.delete(server)
+            await Shell.killTree(child).catch(() => {})
+            throw error
+          }
+        },
+        catch: (error) => new Error(`Failed to initialize ACP server ${server}: ${errorMessage(error)}`),
+      })
+      entry.initialized = true
+      runtime.connections.set(server, entry)
+      return entry
+    })
+
+    const ensureRemoteSession = Effect.fn("ACPClient.ensureRemoteSession")(function* (input: RunInput) {
+      const runtime = yield* InstanceState.get(state)
+      const existing = runtime.sessions.get(input.session.id)
+      if (existing && existing.server === input.server) {
+        existing.assistant = input.assistant
+        existing.localSession = input.session
+        existing.ruleset = Permission.merge(input.agent.permission, input.session.permission ?? [])
+        existing.textPartID = undefined
+        existing.textMessageID = undefined
+        existing.reasoningPartID = undefined
+        existing.reasoningMessageID = undefined
+        existing.planPartID = undefined
+        existing.tools = new Map()
+        existing.activeAssistantID = input.assistant.id
+        return existing
+      }
+
+      if (existing) {
+        yield* Effect.promise(() => cleanupRemoteSession(runtime, existing))
+        runtime.sessions.delete(input.session.id)
+      }
+
+      const connection = yield* connect(input.server)
+      const ctx = yield* InstanceState.context
+      const created = yield* Effect.tryPromise({
+        try: () =>
+          withTimeout(
+            connection.agent.newSession({
+              cwd: ctx.directory,
+              mcpServers: [],
+            }),
+            connection.config.timeout ?? DEFAULT_TIMEOUT,
+          ),
+        catch: (error) => new Error(`Failed to create ACP session on ${input.server}: ${errorMessage(error)}`),
+      })
+      const remote: RemoteSessionState = {
+        localSessionID: input.session.id,
+        remoteSessionID: created.sessionId,
+        server: input.server,
+        ctx,
+        localSession: input.session,
+        assistant: input.assistant,
+        ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
+        tools: new Map(),
+        terminals: new Map(),
+        pendingPermissions: new Set(),
+        activeAssistantID: input.assistant.id,
+        configOptions: Array.isArray((created as any).configOptions) ? (created as any).configOptions : undefined,
+        modes: (created as any).modes,
+        models: (created as any).models,
+      }
+      runtime.sessions.set(input.session.id, remote)
+      runtime.remoteToLocal.set(created.sessionId, input.session.id)
+      yield* publishACPState(bus, remote)
+      return remote
+    })
+
+    const run = Effect.fn("ACPClient.run")(function* (input: RunInput) {
+      const failAssistant = (error: unknown) =>
+        Effect.gen(function* () {
+          input.assistant.error = MessageV2.fromError(error, {
+            providerID: input.assistant.providerID,
+            aborted: isAbortError(error),
+          })
+          input.assistant.finish = isAbortError(error) ? "cancelled" : "error"
+          input.assistant.time.completed = Date.now()
+          yield* session.updateMessage(input.assistant)
+          return input.assistant
+        })
+
+      return yield* Effect.gen(function* () {
+        const connection = yield* connect(input.server)
+        const remote = yield* ensureRemoteSession(input)
+        const startSnapshot = yield* snapshot.track()
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          messageID: input.assistant.id,
+          sessionID: input.session.id,
+          snapshot: startSnapshot,
+          type: "step-start",
+        })
+        return yield* Effect.tryPromise({
+          try: () =>
+            connection.agent.prompt({
+              sessionId: remote.remoteSessionID,
+              prompt: promptParts(input.user.parts, connection.init),
+            }),
+          catch: (error) => error,
+        }).pipe(
+          Effect.matchEffect({
+            onFailure: (error) =>
+              Effect.gen(function* () {
+                yield* finishOpenParts(session, remote)
+                yield* failOpenTools(session, remote, "ACP prompt failed")
+                yield* recordACPFailurePatch(session, snapshot, remote, startSnapshot)
+                clearActiveTurn(remote, input.assistant.id)
+                return yield* failAssistant(error)
+              }),
+            onSuccess: (result) =>
+              Effect.gen(function* () {
+                yield* finishOpenParts(session, remote)
+                yield* ensureVisibleResponse(session, remote)
+                yield* recordACPStepFinish({
+                  session,
+                  snapshot,
+                  summary,
+                  remote,
+                  startSnapshot,
+                  reason: finishReason(result.stopReason),
+                  userMessageID: input.user.info.id,
+                })
+                clearActiveTurn(remote, input.assistant.id)
+                input.assistant.finish = finishReason(result.stopReason)
+                input.assistant.time.completed = Date.now()
+                yield* session.updateMessage(input.assistant)
+                return input.assistant
+              }),
+          }),
+        )
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.gen(function* () {
+            if (!input.assistant.time.completed) {
+              return yield* failAssistant(error)
+            }
+            return input.assistant
+          }),
+        ),
+      )
+    })
+
+    const cancel = Effect.fn("ACPClient.cancel")(function* (sessionID: SessionID) {
+      const runtime = yield* InstanceState.get(state)
+      const remote = runtime.sessions.get(sessionID)
+      if (!remote) return
+      for (const pending of remote.pendingPermissions) {
+        pending.resolve({ outcome: { outcome: "cancelled" } })
+      }
+      remote.pendingPermissions.clear()
+      yield* finishOpenParts(session, remote)
+      yield* failOpenTools(session, remote, "ACP prompt cancelled")
+      clearActiveTurn(remote, remote.assistant.id)
+      const connection = runtime.connections.get(remote.server)
+      if (!connection) return
+      yield* Effect.promise(() => connection.agent.cancel({ sessionId: remote.remoteSessionID })).pipe(Effect.ignore)
+    })
+
+    const setConfigOption = Effect.fn("ACPClient.setConfigOption")(function* (input: {
+      sessionID: SessionID
+      configID: string
+      value: string
+    }) {
+      const runtime = yield* InstanceState.get(state)
+      const remote = runtime.sessions.get(input.sessionID)
+      if (!remote) throw new Error(`ACP session not found: ${input.sessionID}`)
+      const connection = yield* connect(remote.server)
+      if (!connection.agent.setSessionConfigOption) {
+        throw new Error(`ACP server does not support session/set_config_option: ${remote.server}`)
+      }
+      const response = yield* Effect.tryPromise({
+        try: () =>
+          connection.agent.setSessionConfigOption!({
+            sessionId: remote.remoteSessionID,
+            configId: input.configID,
+            value: input.value,
+          }),
+        catch: (error) => new Error(`Failed to set ACP config option: ${errorMessage(error)}`),
+      })
+      remote.configOptions = response.configOptions
+      yield* publishACPState(bus, remote)
+      return {
+        sessionID: remote.localSessionID,
+        configOptions: remote.configOptions,
+        modes: remote.modes,
+        models: remote.models,
+        availableCommands: remote.availableCommands,
+        usage: remote.usage,
+        info: remote.info,
+      }
+    })
+
+    return Service.of({
+      run: (input) => run(input).pipe(Effect.onInterrupt(() => cancel(input.session.id))),
+      cancel,
+      setConfigOption,
+    })
+  }),
+)
+
+function handleSessionUpdate(runtime: State, params: SessionNotification) {
+  return Effect.gen(function* () {
+    const local = runtime.remoteToLocal.get(params.sessionId)
+    if (!local) return
+    const remote = runtime.sessions.get(local)
+    if (!remote) return
+    if (remote.remoteSessionID !== params.sessionId) return
+    const bus = yield* Bus.Service
+    const update = params.update as Record<string, any>
+    switch (update.sessionUpdate) {
+      case "available_commands_update":
+        remote.availableCommands = Array.isArray(update.availableCommands) ? update.availableCommands : []
+        yield* publishACPState(bus, remote)
+        return
+      case "config_option_update":
+        remote.configOptions = Array.isArray(update.configOptions) ? update.configOptions : []
+        yield* publishACPState(bus, remote)
+        return
+      case "current_mode_update":
+        remote.modes = {
+          ...(asRecord(remote.modes) ?? {}),
+          currentModeId: update.modeId,
+        }
+        yield* publishACPState(bus, remote)
+        return
+      case "session_info_update":
+        remote.info = {
+          ...(asRecord(remote.info) ?? {}),
+          ...update,
+        }
+        if (typeof update.title === "string") {
+          const svc = yield* Session.Service
+          yield* svc.setTitle({ sessionID: remote.localSessionID, title: update.title })
+        }
+        yield* publishACPState(bus, remote)
+        return
+      case "usage_update":
+        remote.usage = update
+        yield* publishACPState(bus, remote)
+        return
+    }
+    if (!remote.activeAssistantID || remote.activeAssistantID !== remote.assistant.id) return
+    switch (update.sessionUpdate) {
+      case "agent_message_chunk":
+        yield* appendContent(
+          remote,
+          update.content,
+          typeof update.messageId === "string" ? update.messageId : undefined,
+        )
+        return
+      case "agent_thought_chunk":
+        yield* appendReasoning(
+          remote,
+          update.content,
+          typeof update.messageId === "string" ? update.messageId : undefined,
+        )
+        return
+      case "tool_call":
+        closeStreamingText(remote)
+        yield* upsertTool(remote, update)
+        return
+      case "tool_call_update":
+        closeStreamingText(remote)
+        yield* upsertTool(remote, update)
+        return
+      case "plan":
+        closeStreamingText(remote)
+        yield* upsertPlan(remote, update.entries ?? [])
+        return
+      default:
+        return
+    }
+  })
+}
+
+async function cleanupRemoteSession(runtime: State, remote: RemoteSessionState) {
+  runtime.remoteToLocal.delete(remote.remoteSessionID)
+  for (const pending of remote.pendingPermissions) {
+    pending.resolve({ outcome: { outcome: "cancelled" } })
+  }
+  remote.pendingPermissions.clear()
+  for (const terminal of remote.terminals.values()) {
+    await Shell.killTree(terminal.process).catch(() => {})
+  }
+  remote.terminals.clear()
+  const connection = runtime.connections.get(remote.server)
+  if (connection?.agent.closeSession) {
+    await connection.agent.closeSession({ sessionId: remote.remoteSessionID }).catch(() => {})
+  }
+}
+
+function clearActiveTurn(remote: RemoteSessionState, assistantID: MessageV2.Assistant["id"]) {
+  if (remote.activeAssistantID === assistantID) remote.activeAssistantID = undefined
+}
+
+function publishACPState(bus: Bus.Interface, remote: RemoteSessionState) {
+  return bus.publish(Event.StateUpdated, {
+    sessionID: remote.localSessionID,
+    configOptions: remote.configOptions,
+    modes: remote.modes,
+    models: remote.models,
+    availableCommands: remote.availableCommands,
+    usage: remote.usage,
+    info: remote.info,
+  })
+}
+
+function recordACPFailurePatch(
+  svc: Session.Interface,
+  snapshot: Snapshot.Interface,
+  remote: RemoteSessionState,
+  startSnapshot: string | undefined,
+) {
+  return Effect.gen(function* () {
+    if (!startSnapshot) return
+    const patch = yield* snapshot.patch(startSnapshot)
+    if (!patch.files.length) return
+    yield* svc.updatePart({
+      id: PartID.ascending(),
+      messageID: remote.assistant.id,
+      sessionID: remote.localSessionID,
+      type: "patch",
+      hash: patch.hash,
+      files: patch.files,
+    })
+  })
+}
+
+function recordACPStepFinish(input: {
+  session: Session.Interface
+  snapshot: Snapshot.Interface
+  summary: SessionSummary.Interface
+  remote: RemoteSessionState
+  startSnapshot: string | undefined
+  reason: string
+  userMessageID: MessageV2.User["id"]
+}) {
+  return Effect.gen(function* () {
+    const completedSnapshot = yield* input.snapshot.track()
+    yield* input.session.updatePart({
+      id: PartID.ascending(),
+      reason: input.reason,
+      snapshot: completedSnapshot,
+      messageID: input.remote.assistant.id,
+      sessionID: input.remote.localSessionID,
+      type: "step-finish",
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      cost: 0,
+    })
+    if (input.startSnapshot) {
+      const patch = yield* input.snapshot.patch(input.startSnapshot)
+      if (patch.files.length) {
+        yield* input.session.updatePart({
+          id: PartID.ascending(),
+          messageID: input.remote.assistant.id,
+          sessionID: input.remote.localSessionID,
+          type: "patch",
+          hash: patch.hash,
+          files: patch.files,
+        })
+      }
+    }
+    yield* input.summary
+      .summarize({ sessionID: input.remote.localSessionID, messageID: input.userMessageID })
+      .pipe(Effect.ignore)
+  })
+}
+
+function finishOpenParts(svc: Session.Interface, remote: RemoteSessionState) {
+  return Effect.gen(function* () {
+    const now = Date.now()
+    if (remote.textPartID) {
+      const current = yield* svc.getPart({
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+        partID: remote.textPartID,
+      })
+      if (current?.type === "text" && current.time?.end === undefined) {
+        yield* svc.updatePart({
+          ...current,
+          time: { start: current.time?.start ?? remote.assistant.time.created, end: now },
+        })
+      }
+    }
+    if (remote.reasoningPartID) {
+      const current = yield* svc.getPart({
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+        partID: remote.reasoningPartID,
+      })
+      if (current?.type === "reasoning" && current.time.end === undefined) {
+        yield* svc.updatePart({
+          ...current,
+          time: { start: current.time.start, end: now },
+        })
+      }
+    }
+  })
+}
+
+function failOpenTools(svc: Session.Interface, remote: RemoteSessionState, message: string) {
+  return Effect.gen(function* () {
+    const now = Date.now()
+    for (const partID of remote.tools.values()) {
+      const current = yield* svc.getPart({
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+        partID,
+      })
+      if (!current || current.type !== "tool") continue
+      if (current.state.status !== "pending" && current.state.status !== "running") continue
+      const start = "time" in current.state ? current.state.time.start : now
+      yield* svc.updatePart({
+        ...current,
+        state: {
+          status: "error",
+          input: current.state.input,
+          error: message,
+          metadata: "metadata" in current.state ? current.state.metadata : undefined,
+          time: { start, end: now },
+        },
+      })
+    }
+  })
+}
+
+function ensureVisibleResponse(svc: Session.Interface, remote: RemoteSessionState) {
+  return Effect.gen(function* () {
+    const messages = yield* svc.messages({ sessionID: remote.localSessionID, limit: 1 }).pipe(Effect.orDie)
+    const current = messages.find((message) => message.info.id === remote.assistant.id)
+    const visible = current?.parts.some((part) => {
+      if (part.type === "text") return !part.synthetic && !part.ignored && part.text.trim().length > 0
+      if (part.type === "reasoning") return part.text.trim().length > 0
+      if (part.type === "tool") return true
+      if (part.type === "file") return true
+      return false
+    })
+    if (visible) return
+    const now = Date.now()
+    yield* svc.updatePart({
+      id: PartID.ascending(),
+      sessionID: remote.localSessionID,
+      messageID: remote.assistant.id,
+      type: "text",
+      text: "Done.",
+      metadata: { acp: { fallback: true } },
+      time: { start: now, end: now },
+    })
+  })
+}
+
+function closeStreamingText(remote: RemoteSessionState) {
+  remote.textPartID = undefined
+  remote.textMessageID = undefined
+}
+
+function appendContent(remote: RemoteSessionState, content: unknown, messageID?: string) {
+  return Effect.gen(function* () {
+    const file = contentBlockFilePart(remote, content)
+    if (file) {
+      const svc = yield* Session.Service
+      yield* svc.updatePart({
+        ...file,
+        id: PartID.ascending(),
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+      })
+      return
+    }
+    const text = contentBlockText(content)
+    if (!text) return
+    const svc = yield* Session.Service
+    if (messageID && remote.textMessageID && remote.textMessageID !== messageID) closeStreamingText(remote)
+    if (!remote.textPartID) {
+      const part = yield* svc.updatePart({
+        id: PartID.ascending(),
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+        type: "text",
+        text,
+        time: { start: Date.now() },
+      })
+      remote.textPartID = part.id
+      remote.textMessageID = messageID
+      return
+    }
+    const current = yield* svc.getPart({
+      sessionID: remote.localSessionID,
+      messageID: remote.assistant.id,
+      partID: remote.textPartID,
+    })
+    if (!current || current.type !== "text") return
+    yield* svc.updatePart({ ...current, text: current.text + text })
+  })
+}
+
+function appendReasoning(remote: RemoteSessionState, content: unknown, messageID?: string) {
+  return Effect.gen(function* () {
+    const text = contentBlockText(content)
+    if (!text) return
+    const svc = yield* Session.Service
+    if (messageID && remote.reasoningMessageID && remote.reasoningMessageID !== messageID) {
+      remote.reasoningPartID = undefined
+      remote.reasoningMessageID = undefined
+    }
+    if (!remote.reasoningPartID) {
+      const part = yield* svc.updatePart({
+        id: PartID.ascending(),
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+        type: "reasoning",
+        text,
+        time: { start: Date.now() },
+      })
+      remote.reasoningPartID = part.id
+      remote.reasoningMessageID = messageID
+      return
+    }
+    const current = yield* svc.getPart({
+      sessionID: remote.localSessionID,
+      messageID: remote.assistant.id,
+      partID: remote.reasoningPartID,
+    })
+    if (!current || current.type !== "reasoning") return
+    yield* svc.updatePart({ ...current, text: current.text + text })
+  })
+}
+
+function upsertPlan(remote: RemoteSessionState, entries: Array<Record<string, unknown>>) {
+  return Effect.gen(function* () {
+    const text = entries
+      .map((entry) => {
+        const status = typeof entry.status === "string" ? ` [${entry.status}]` : ""
+        return `- ${String(entry.content ?? "")}${status}`
+      })
+      .join("\n")
+    if (!text) return
+    const svc = yield* Session.Service
+    const value = `Plan:\n${text}`
+    if (!remote.planPartID) {
+      const part = yield* svc.updatePart({
+        id: PartID.ascending(),
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+        type: "text",
+        text: value,
+        synthetic: true,
+        metadata: { acp: { kind: "plan" } },
+        time: { start: Date.now(), end: Date.now() },
+      })
+      remote.planPartID = part.id
+      return
+    }
+    const current = yield* svc.getPart({
+      sessionID: remote.localSessionID,
+      messageID: remote.assistant.id,
+      partID: remote.planPartID,
+    })
+    if (!current || current.type !== "text") return
+    yield* svc.updatePart({ ...current, text: value })
+  })
+}
+
+function upsertTool(remote: RemoteSessionState, update: Record<string, any>) {
+  return Effect.gen(function* () {
+    const toolCallID = String(update.toolCallId)
+    const svc = yield* Session.Service
+    const existingID = remote.tools.get(toolCallID)
+    const now = Date.now()
+    if (!existingID) {
+      const status = toolStatus(update.status)
+      const input = asRecord(update.rawInput)
+      const part = yield* svc.updatePart({
+        id: PartID.ascending(),
+        sessionID: remote.localSessionID,
+        messageID: remote.assistant.id,
+        type: "tool",
+        callID: toolCallID,
+        tool: `acp:${update.kind ?? "tool"}`,
+        state:
+          status === "pending"
+            ? { status: "pending", input, raw: JSON.stringify(update.rawInput ?? {}) }
+            : {
+                status: status === "running" ? "running" : status === "completed" ? "completed" : "error",
+                input,
+                ...(status === "running"
+                  ? { title: update.title, metadata: asRecord(update.rawInput), time: { start: now } }
+                  : status === "completed"
+                    ? {
+                        title: update.title ?? "ACP tool",
+                        output: toolOutput(update, remote),
+                        metadata: asRecord(update.rawOutput),
+                        time: { start: now, end: now },
+                      }
+                    : {
+                        error: toolOutput(update, remote) || "ACP tool failed",
+                        metadata: asRecord(update.rawOutput),
+                        time: { start: now, end: now },
+                      }),
+              },
+        metadata: {
+          providerExecuted: true,
+          acp: {
+            server: remote.server,
+            kind: update.kind,
+            title: update.title,
+            locations: update.locations,
+            content: update.content,
+            rawInput: update.rawInput,
+            rawOutput: update.rawOutput,
+          },
+        },
+      } as MessageV2.ToolPart)
+      remote.tools.set(toolCallID, part.id)
+      return
+    }
+    const current = yield* svc.getPart({
+      sessionID: remote.localSessionID,
+      messageID: remote.assistant.id,
+      partID: existingID,
+    })
+    if (!current || current.type !== "tool") return
+    const status = toolStatus(update.status, current.state.status)
+    const input = update.rawInput === undefined ? current.state.input : asRecord(update.rawInput)
+    const start = "time" in current.state ? current.state.time.start : now
+    yield* svc.updatePart({
+      ...current,
+      state:
+        status === "pending"
+          ? { status: "pending", input, raw: JSON.stringify(update.rawInput ?? current.state.input ?? {}) }
+          : status === "running"
+            ? { status: "running", input, title: update.title, metadata: asRecord(update.rawInput), time: { start } }
+            : status === "completed"
+              ? {
+                  status: "completed",
+                  input,
+                  title: update.title ?? current.tool,
+                  output: toolOutput(update, remote) || ("output" in current.state ? current.state.output : ""),
+                  metadata:
+                    update.rawOutput === undefined && "metadata" in current.state
+                      ? (current.state.metadata ?? {})
+                      : asRecord(update.rawOutput),
+                  time: { start, end: now },
+                }
+              : {
+                  status: "error",
+                  input,
+                  error:
+                    toolOutput(update, remote) || ("error" in current.state ? current.state.error : "ACP tool failed"),
+                  metadata:
+                    update.rawOutput === undefined && "metadata" in current.state
+                      ? current.state.metadata
+                      : asRecord(update.rawOutput),
+                  time: { start, end: now },
+                },
+    })
+  })
+}
+
+function promptParts(parts: MessageV2.Part[], init: InitializeResponse): ContentBlock[] {
+  const result: ContentBlock[] = []
+  const capabilities = init.agentCapabilities?.promptCapabilities
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.ignored) continue
+      result.push({
+        type: "text",
+        text: part.text,
+        ...((part.synthetic || part.ignored) && {
+          annotations: { audience: part.synthetic ? ["assistant"] : ["user"] },
+        }),
+      } as ContentBlock)
+      continue
+    }
+    if (part.type !== "file") continue
+    if (part.url.startsWith("file://")) {
+      result.push({
+        type: "resource_link",
+        uri: part.url,
+        name: part.filename ?? path.basename(part.url),
+        mimeType: part.mime,
+      } as ContentBlock)
+      continue
+    }
+    if (part.url.startsWith("data:")) {
+      const match = part.url.match(/^data:([^;]+);base64,(.*)$/)
+      const mimeType = match?.[1] ?? part.mime
+      const data = match?.[2] ?? ""
+      if (mimeType.startsWith("image/")) {
+        if (!capabilities?.image) continue
+        result.push({ type: "image", mimeType, data } as ContentBlock)
+      } else {
+        if (!capabilities?.embeddedContext) continue
+        result.push({
+          type: "resource",
+          resource: { uri: part.filename ?? "file", mimeType, blob: data },
+        } as ContentBlock)
+      }
+    }
+  }
+  return result
+}
+
+function contentBlockText(content: unknown): string {
+  if (!content || typeof content !== "object") return ""
+  const block = content as Record<string, any>
+  if (block.type === "text") return String(block.text ?? "")
+  if (block.type === "resource" && block.resource && typeof block.resource.text === "string") return block.resource.text
+  return ""
+}
+
+function contentBlockFilePart(
+  remote: RemoteSessionState,
+  content: unknown,
+): Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID"> | undefined {
+  if (!content || typeof content !== "object") return
+  const block = content as Record<string, any>
+  if (block.type === "resource_link" && typeof block.uri === "string") {
+    return {
+      type: "file",
+      url: block.uri,
+      filename: typeof block.name === "string" ? block.name : block.uri,
+      mime: typeof block.mimeType === "string" ? block.mimeType : "application/octet-stream",
+      source: {
+        type: "resource",
+        text: { value: "", start: 0, end: 0 },
+        clientName: remote.server,
+        uri: block.uri,
+      },
+    }
+  }
+  if (block.type === "image" && typeof block.mimeType === "string" && typeof block.data === "string") {
+    return {
+      type: "file",
+      url: `data:${block.mimeType};base64,${block.data}`,
+      filename: typeof block.uri === "string" ? path.basename(block.uri) : "image",
+      mime: block.mimeType,
+    }
+  }
+  if (block.type === "resource" && block.resource && typeof block.resource === "object") {
+    const resource = block.resource as Record<string, any>
+    if (typeof resource.blob !== "string") return
+    const mime = typeof resource.mimeType === "string" ? resource.mimeType : "application/octet-stream"
+    const uri = typeof resource.uri === "string" ? resource.uri : "resource"
+    return {
+      type: "file",
+      url: `data:${mime};base64,${resource.blob}`,
+      filename: path.basename(uri),
+      mime,
+      source: {
+        type: "resource",
+        text: { value: "", start: 0, end: 0 },
+        clientName: remote.server,
+        uri,
+      },
+    }
+  }
+}
+
+function toolOutput(update: Record<string, any>, remote?: RemoteSessionState) {
+  if (typeof update.rawOutput === "string") return update.rawOutput
+  if (update.rawOutput !== undefined) return JSON.stringify(update.rawOutput)
+  if (Array.isArray(update.content))
+    return update.content
+      .map((item) => toolContentText(item, remote))
+      .filter(Boolean)
+      .join("\n")
+  return ""
+}
+
+function toolContentText(value: unknown, remote?: RemoteSessionState): string {
+  if (!value || typeof value !== "object") return ""
+  const item = value as Record<string, any>
+  if (item.type === "content") return contentBlockText(item.content)
+  if (item.type === "diff") return `Diff: ${item.path ?? ""}`
+  if (item.type === "terminal") {
+    const terminalID = typeof item.terminalId === "string" ? item.terminalId : ""
+    const terminal = terminalID ? remote?.terminals.get(terminalID) : undefined
+    const output = terminal?.output.trim()
+    return output ? `Terminal ${terminalID}:\n${output}` : `Terminal: ${terminalID}`
+  }
+  return ""
+}
+
+function permissionPatterns(toolCall: RequestPermissionRequest["toolCall"]) {
+  const locations = Array.isArray(toolCall.locations) ? toolCall.locations : []
+  const paths = locations.map((location) => location.path).filter((item): item is string => typeof item === "string")
+  return paths.length ? paths : [toolCall.title ?? toolCall.toolCallId ?? "*"]
+}
+
+async function assertExternalDirectory(
+  permission: Permission.Interface,
+  remote: RemoteSessionState,
+  targetPath: string,
+) {
+  const resolved = path.resolve(targetPath)
+  if (AppFileSystem.contains(remote.ctx.worktree, resolved)) return
+  const pattern = path.join(path.dirname(resolved), "*").replaceAll("\\", "/")
+  await Effect.runPromise(
+    permission
+      .ask({
+        sessionID: remote.localSessionID,
+        permission: "external_directory",
+        patterns: [pattern],
+        always: [pattern],
+        metadata: { path: resolved, server: remote.server },
+        ruleset: remote.ruleset,
+      })
+      .pipe(Effect.provideService(InstanceRef, remote.ctx)),
+  )
+}
+
+function toolStatus(status: unknown, fallback: "pending" | "running" | "completed" | "error" = "pending") {
+  if (status === undefined) return fallback
+  if (status === "in_progress") return "running"
+  if (status === "completed") return "completed"
+  if (status === "failed" || status === "error") return "error"
+  return "pending"
+}
+
+function asRecord(value: unknown): Record<string, any> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, any>) : {}
+}
+
+function finishReason(reason: string) {
+  if (reason === "end_turn") return "stop"
+  if (reason === "cancelled") return "cancelled"
+  return reason
+}
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === "AbortError"
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function sliceLines(content: string, line?: number, limit?: number) {
+  if (!line && !limit) return content
+  const lines = content.split("\n")
+  const start = Math.max((line ?? 1) - 1, 0)
+  const end = limit && limit > 0 ? start + limit : undefined
+  return lines.slice(start, end).join("\n")
+}
+
+function trimUtf8Start(value: string, maxBytes: number) {
+  let output = value
+  while (Buffer.byteLength(output, "utf8") > maxBytes && output.length > 0) {
+    output = output.slice(Math.max(1, output.length - maxBytes))
+  }
+  return output
+}
+
+function relativeToWorktree(ctx: InstanceContext, filepath: string) {
+  return path.relative(ctx.worktree, filepath).replaceAll("\\", "/")
+}
+
+function withTimeout<T>(promise: Promise<T>, timeout: number) {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timed out after ${timeout}ms`)), timeout)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+export const defaultLayer = layer.pipe(
+  Layer.provide(Config.defaultLayer),
+  Layer.provide(Session.defaultLayer),
+  Layer.provide(Permission.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(Snapshot.defaultLayer),
+  Layer.provide(SessionSummary.defaultLayer),
+  Layer.provide(Bus.layer),
+)
+
+export * as ACPClient from "./client"

--- a/packages/opencode/src/acp/client.ts
+++ b/packages/opencode/src/acp/client.ts
@@ -307,7 +307,10 @@ export const layer = Layer.effect(
         const remote = resolveSession(params.sessionId)
         if (!remote) throw RequestError.invalidParams(`Unknown session: ${params.sessionId}`)
         await assertExternalDirectory(permission, remote, params.cwd ?? remote.ctx.directory)
-        const commandText = [params.command, ...(params.args ?? [])].join(" ")
+        const commandText =
+          params.args && params.args.length > 0
+            ? [shellQuote(params.command), ...params.args.map(shellQuote)].join(" ")
+            : params.command
         await Effect.runPromise(
           permission
             .ask({
@@ -321,7 +324,8 @@ export const layer = Layer.effect(
             .pipe(Effect.provideService(InstanceRef, remote.ctx)),
         )
         const terminalID = `acp_${++runtime.terminalCounter}`
-        const child = spawn(params.command, params.args ?? [], {
+        const shell = Shell.preferred()
+        const child = spawn(shell, Shell.args(shell, commandText, params.cwd ?? remote.ctx.directory), {
           cwd: params.cwd ?? remote.ctx.directory,
           env: {
             ...process.env,
@@ -1328,6 +1332,11 @@ function trimUtf8Start(value: string, maxBytes: number) {
     output = output.slice(Math.max(1, output.length - maxBytes))
   }
   return output
+}
+
+function shellQuote(value: string) {
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value
+  return `'${value.replaceAll("'", "'\\''")}'`
 }
 
 function relativeToWorktree(ctx: InstanceContext, filepath: string) {

--- a/packages/opencode/src/acp/client.ts
+++ b/packages/opencode/src/acp/client.ts
@@ -642,19 +642,36 @@ export const layer = Layer.effect(
       const remote = runtime.sessions.get(input.sessionID)
       if (!remote) throw new Error(`ACP session not found: ${input.sessionID}`)
       const connection = yield* connect(remote.server)
-      if (!connection.agent.setSessionConfigOption) {
-        throw new Error(`ACP server does not support session/set_config_option: ${remote.server}`)
+      const hasConfigOption = remote.configOptions?.some((option: any) => option?.id === input.configID) === true
+      if (hasConfigOption) {
+        if (!connection.agent.setSessionConfigOption) throw new Error(`ACP server does not support session/set_config_option: ${remote.server}`)
+        const response = yield* Effect.tryPromise({
+          try: () =>
+            connection.agent.setSessionConfigOption!({
+              sessionId: remote.remoteSessionID,
+              configId: input.configID,
+              value: input.value,
+            }),
+          catch: (error) => new Error(`Failed to set ACP config option: ${errorMessage(error)}`),
+        })
+        remote.configOptions = response.configOptions
+      } else if (input.configID === "mode") {
+        if (!connection.agent.setSessionMode) throw new Error(`ACP server does not support session/set_mode: ${remote.server}`)
+        yield* Effect.tryPromise({
+          try: () => connection.agent.setSessionMode!({ sessionId: remote.remoteSessionID, modeId: input.value }),
+          catch: (error) => new Error(`Failed to set ACP mode: ${errorMessage(error)}`),
+        })
+        remote.modes = { ...asRecord(remote.modes), currentModeId: input.value }
+      } else if (input.configID === "model") {
+        if (!connection.agent.unstable_setSessionModel) throw new Error(`ACP server does not support session/set_model: ${remote.server}`)
+        yield* Effect.tryPromise({
+          try: () => connection.agent.unstable_setSessionModel!({ sessionId: remote.remoteSessionID, modelId: input.value }),
+          catch: (error) => new Error(`Failed to set ACP model: ${errorMessage(error)}`),
+        })
+        remote.models = { ...asRecord(remote.models), currentModelId: input.value }
+      } else {
+        throw new Error(`ACP server does not support config option: ${input.configID}`)
       }
-      const response = yield* Effect.tryPromise({
-        try: () =>
-          connection.agent.setSessionConfigOption!({
-            sessionId: remote.remoteSessionID,
-            configId: input.configID,
-            value: input.value,
-          }),
-        catch: (error) => new Error(`Failed to set ACP config option: ${errorMessage(error)}`),
-      })
-      remote.configOptions = response.configOptions
       yield* publishACPState(bus, remote)
       return {
         sessionID: remote.localSessionID,

--- a/packages/opencode/src/acp/client.ts
+++ b/packages/opencode/src/acp/client.ts
@@ -655,6 +655,8 @@ export const layer = Layer.effect(
           catch: (error) => new Error(`Failed to set ACP config option: ${errorMessage(error)}`),
         })
         remote.configOptions = response.configOptions
+        if (input.configID === "mode") remote.modes = { ...asRecord(remote.modes), currentModeId: input.value }
+        if (input.configID === "model") remote.models = { ...asRecord(remote.models), currentModelId: input.value }
       } else if (input.configID === "mode") {
         if (!connection.agent.setSessionMode) throw new Error(`ACP server does not support session/set_mode: ${remote.server}`)
         yield* Effect.tryPromise({

--- a/packages/opencode/src/acp/client.ts
+++ b/packages/opencode/src/acp/client.ts
@@ -507,11 +507,12 @@ export const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const created = yield* Effect.tryPromise({
         try: () =>
-          withTimeout(
-            connection.agent.newSession({
-              cwd: ctx.directory,
-              mcpServers: [],
-            }),
+          retryACPRequest(
+            () =>
+              connection.agent.newSession({
+                cwd: ctx.directory,
+                mcpServers: [],
+              }),
             connection.config.timeout ?? DEFAULT_TIMEOUT,
           ),
         catch: (error) => new Error(`Failed to create ACP session on ${input.server}: ${errorMessage(error)}`),
@@ -1347,6 +1348,26 @@ function withTimeout<T>(promise: Promise<T>, timeout: number) {
       },
     )
   })
+}
+
+async function retryACPRequest<T>(request: () => Promise<T>, timeout: number) {
+  const delays = [0, 250, 1000, 2000]
+  let lastError: unknown
+  for (const delay of delays) {
+    if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay))
+    try {
+      return await withTimeout(request(), timeout)
+    } catch (error) {
+      lastError = error
+      if (!isRetryableACPError(error)) break
+    }
+  }
+  throw lastError
+}
+
+function isRetryableACPError(error: unknown) {
+  const message = errorMessage(error).toLowerCase()
+  return message.includes("internal error") || message.includes("-32603")
 }
 
 export const defaultLayer = layer.pipe(

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -1,4 +1,5 @@
 import { Config } from "@/config/config"
+import { ConfigAgent } from "@/config/agent"
 import { serviceUse } from "@/effect/service-use"
 import { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
@@ -42,6 +43,7 @@ export const Info = Schema.Struct({
       providerID: ProviderID,
     }),
   ),
+  backend: Schema.optional(ConfigAgent.Backend),
   variant: Schema.optional(Schema.String),
   prompt: Schema.optional(Schema.String),
   options: Schema.Record(Schema.String, Schema.Unknown),
@@ -295,6 +297,7 @@ export const layer = Layer.effect(
               native: false,
             }
           if (value.model) item.model = Provider.parseModel(value.model)
+          item.backend = value.backend ?? item.backend
           item.variant = value.variant ?? item.variant
           item.prompt = value.prompt ?? item.prompt
           item.description = value.description ?? item.description

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -612,8 +612,38 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         title: "ACP options",
         category: "Agent",
         slashName: "acp-options",
-        hidden: route.data.type !== "session",
-        run: () => {
+        hidden: local.agent.current()?.backend?.type !== "acp",
+        run: async () => {
+          if (route.data.type === "session") {
+            dialog.replace(() => <DialogAcpConfig />)
+            return
+          }
+          const agent = local.agent.current()
+          if (!agent || agent.backend?.type !== "acp") return
+          const selectedModel = local.model.current()
+          if (!selectedModel) {
+            toast.show({ message: "Connect a provider to use ACP options", variant: "warning" })
+            return
+          }
+          const res = await sdk.client.session.create({
+            agent: agent.name,
+            model: {
+              providerID: selectedModel.providerID,
+              id: selectedModel.modelID,
+              variant: local.model.variant.current(),
+            },
+          })
+          if (res.error || !res.data) {
+            toast.show({ message: "Failed to create session for ACP options", variant: "error" })
+            return
+          }
+          route.navigate({ type: "session", sessionID: res.data.id })
+          const url = new URL(`/session/${res.data.id}/acp/prepare`, sdk.url)
+          const prepareResponse = await sdk.fetch(url, { method: "POST" })
+          if (prepareResponse.ok) {
+            const state = await prepareResponse.json().catch(() => undefined)
+            if (state && typeof state === "object") sync.acp.update(state)
+          }
           dialog.replace(() => <DialogAcpConfig />)
         },
       },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -613,7 +613,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         category: "Agent",
         slashName: "acp-options",
         hidden:
-          route.data.type !== "session" || (sync.data.acp[route.data.sessionID]?.configOptions?.length ?? 0) === 0,
+          route.data.type !== "session" ||
+          ((sync.data.acp[route.data.sessionID]?.configOptions?.length ?? 0) === 0 &&
+            !sync.data.acp[route.data.sessionID]?.modes &&
+            !sync.data.acp[route.data.sessionID]?.models),
         run: () => {
           dialog.replace(() => <DialogAcpConfig />)
         },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -612,11 +612,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         title: "ACP options",
         category: "Agent",
         slashName: "acp-options",
-        hidden:
-          route.data.type !== "session" ||
-          ((sync.data.acp[route.data.sessionID]?.configOptions?.length ?? 0) === 0 &&
-            !sync.data.acp[route.data.sessionID]?.modes &&
-            !sync.data.acp[route.data.sessionID]?.models),
+        hidden: route.data.type !== "session",
         run: () => {
           dialog.replace(() => <DialogAcpConfig />)
         },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -78,6 +78,7 @@ import {
 
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
+import { DialogAcpConfig } from "./component/dialog-acp-config"
 
 const appBindingCommands = [
   "command.palette.show",
@@ -103,6 +104,7 @@ const appBindingCommands = [
   "agent.cycle.reverse",
   "variant.cycle",
   "variant.list",
+  "acp.config",
   "provider.connect",
   "console.org.switch",
   "opencode.status",
@@ -603,6 +605,17 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         slashName: "variants",
         run: () => {
           dialog.replace(() => <DialogVariant />)
+        },
+      },
+      {
+        name: "acp.config",
+        title: "ACP options",
+        category: "Agent",
+        slashName: "acp-options",
+        hidden:
+          route.data.type !== "session" || (sync.data.acp[route.data.sessionID]?.configOptions?.length ?? 0) === 0,
+        run: () => {
+          dialog.replace(() => <DialogAcpConfig />)
         },
       },
       {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-acp-config.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-acp-config.tsx
@@ -23,9 +23,45 @@ export function DialogAcpConfig() {
   const dialog = useDialog()
   const toast = useToast()
   const sessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
-  const options = createMemo(() => {
+  const configOptions = createMemo(() => {
     const state = sessionID() ? sync.data.acp[sessionID()!] : undefined
-    return (state?.configOptions ?? [])
+    if (state?.configOptions?.length) return state.configOptions
+    const modes = state?.modes
+    const models = state?.models
+    return [
+      ...(modes?.availableModes
+        ? [
+            {
+              id: "mode",
+              name: "Mode",
+              type: "select",
+              currentValue: modes.currentModeId,
+              options: modes.availableModes.map((mode: any) => ({
+                value: mode.id,
+                name: mode.name,
+                description: mode.description,
+              })),
+            },
+          ]
+        : []),
+      ...(models?.availableModels
+        ? [
+            {
+              id: "model",
+              name: "Model",
+              type: "select",
+              currentValue: models.currentModelId,
+              options: models.availableModels.map((model: any) => ({
+                value: model.modelId,
+                name: model.name,
+              })),
+            },
+          ]
+        : []),
+    ]
+  })
+  const options = createMemo(() => {
+    return configOptions()
       .filter((item): item is ConfigOption => item?.type === "select" && Array.isArray(item.options))
       .flatMap((item) =>
         item.options.map((option) => ({

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-acp-config.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-acp-config.tsx
@@ -1,0 +1,57 @@
+import { createMemo } from "solid-js"
+import { DialogSelect } from "@tui/ui/dialog-select"
+import { useDialog } from "@tui/ui/dialog"
+import { useRoute } from "@tui/context/route"
+import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
+import { useToast } from "@tui/ui/toast"
+
+type ConfigOption = {
+  id: string
+  name: string
+  description?: string
+  currentValue: string
+  type: string
+  category?: string
+  options: Array<{ value: string; name: string; description?: string }>
+}
+
+export function DialogAcpConfig() {
+  const route = useRoute()
+  const sync = useSync()
+  const sdk = useSDK()
+  const dialog = useDialog()
+  const toast = useToast()
+  const sessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
+  const options = createMemo(() => {
+    const state = sessionID() ? sync.data.acp[sessionID()!] : undefined
+    return (state?.configOptions ?? [])
+      .filter((item): item is ConfigOption => item?.type === "select" && Array.isArray(item.options))
+      .flatMap((item) =>
+        item.options.map((option) => ({
+          value: { configID: item.id, value: option.value },
+          title: option.name,
+          description: option.description ?? item.description,
+          category: item.name,
+          footer: item.currentValue === option.value ? "Current" : undefined,
+          onSelect: async () => {
+            const id = sessionID()
+            if (!id) return
+            const url = new URL(`/session/${id}/acp/config`, sdk.url)
+            const response = await sdk.fetch(url, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ configID: item.id, value: option.value }),
+            })
+            if (!response.ok) {
+              toast.show({ variant: "error", message: "Failed to set ACP option", duration: 3000 })
+              return
+            }
+            dialog.clear()
+          },
+        })),
+      )
+  })
+
+  return <DialogSelect options={options()} title="ACP options" flat={true} />
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-acp-config.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-acp-config.tsx
@@ -83,6 +83,8 @@ export function DialogAcpConfig() {
               toast.show({ variant: "error", message: "Failed to set ACP option", duration: 3000 })
               return
             }
+            const state = await response.json().catch(() => undefined)
+            if (state && typeof state === "object") sync.acp.update(state)
             dialog.clear()
           },
         })),

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -6,6 +6,7 @@ import { firstBy } from "remeda"
 import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Show, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useEditorContext } from "@tui/context/editor"
+import { useLocal } from "@tui/context/local"
 import { useProject } from "@tui/context/project"
 import { useSDK } from "@tui/context/sdk"
 import { useSync } from "@tui/context/sync"
@@ -85,6 +86,7 @@ export function Autocomplete(props: {
   const editor = useEditorContext()
   const sdk = useSDK()
   const sync = useSync()
+  const local = useLocal()
   const project = useProject()
   const slashes = useCommandSlashes()
   const keymap = useOpencodeKeymap()
@@ -547,8 +549,12 @@ export function Autocomplete(props: {
   const commands = createMemo((): AutocompleteOption[] => {
     const results: AutocompleteOption[] = [...slashes()]
     const acpState = sync.data.acp[props.sessionID ?? ""]
+    const currentAgentBackend = local.agent.current()?.backend?.type
 
-    if (props.sessionID && !slashes().some((item) => item.display === "/acp-options")) {
+    if (
+      (props.sessionID || currentAgentBackend === "acp") &&
+      !slashes().some((item) => item.display === "/acp-options")
+    ) {
       results.push({
         display: "/acp-options",
         description: "ACP options",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -17,7 +17,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { Locale } from "@/util/locale"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
-import { useBindings, useCommandSlashes, useOpencodeModeStack } from "../../keymap"
+import { useBindings, useCommandSlashes, useOpencodeKeymap, useOpencodeModeStack } from "../../keymap"
 import { Reference } from "@/reference/reference"
 import { ConfigReference } from "@/config/reference"
 import { displayCharAt, mentionTriggerIndex } from "@/cli/cmd/prompt-display"
@@ -87,6 +87,7 @@ export function Autocomplete(props: {
   const sync = useSync()
   const project = useProject()
   const slashes = useCommandSlashes()
+  const keymap = useOpencodeKeymap()
   const modeStack = useOpencodeModeStack()
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
@@ -553,11 +554,7 @@ export function Autocomplete(props: {
         display: "/acp-options",
         description: "ACP options",
         onSelect: () => {
-          const newText = "/acp-options "
-          const cursor = props.input().logicalCursor
-          props.input().deleteRange(0, 0, cursor.row, cursor.col)
-          props.input().insertText(newText)
-          props.input().cursorOffset = Bun.stringWidth(newText)
+          keymap.dispatchCommand("acp.config")
         },
       })
     }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -562,6 +562,21 @@ export function Autocomplete(props: {
       })
     }
 
+    for (const command of sync.data.acp[props.sessionID ?? ""]?.availableCommands ?? []) {
+      if (!command || typeof command.name !== "string") continue
+      results.push({
+        display: "/" + command.name + ":acp",
+        description: typeof command.description === "string" ? command.description : undefined,
+        onSelect: () => {
+          const newText = "/" + command.name + " "
+          const cursor = props.input().logicalCursor
+          props.input().deleteRange(0, 0, cursor.row, cursor.col)
+          props.input().insertText(newText)
+          props.input().cursorOffset = Bun.stringWidth(newText)
+        },
+      })
+    }
+
     results.sort((a, b) => a.display.localeCompare(b.display))
 
     const max = firstBy(results, [(x) => x.display.length, "desc"])?.display.length

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -546,10 +546,9 @@ export function Autocomplete(props: {
 
   const commands = createMemo((): AutocompleteOption[] => {
     const results: AutocompleteOption[] = [...slashes()]
-    const currentAgent = sync.data.agent.find((agent) => agent.name === sync.session.get(props.sessionID ?? "")?.agent)
     const acpState = sync.data.acp[props.sessionID ?? ""]
 
-    if (currentAgent?.backend?.type === "acp" && !slashes().some((item) => item.display === "/acp-options")) {
+    if (props.sessionID && !slashes().some((item) => item.display === "/acp-options")) {
       results.push({
         display: "/acp-options",
         description: "ACP options",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -545,6 +545,22 @@ export function Autocomplete(props: {
 
   const commands = createMemo((): AutocompleteOption[] => {
     const results: AutocompleteOption[] = [...slashes()]
+    const currentAgent = sync.data.agent.find((agent) => agent.name === sync.session.get(props.sessionID ?? "")?.agent)
+    const acpState = sync.data.acp[props.sessionID ?? ""]
+
+    if (currentAgent?.backend?.type === "acp" && !slashes().some((item) => item.display === "/acp-options")) {
+      results.push({
+        display: "/acp-options",
+        description: "ACP options",
+        onSelect: () => {
+          const newText = "/acp-options "
+          const cursor = props.input().logicalCursor
+          props.input().deleteRange(0, 0, cursor.row, cursor.col)
+          props.input().insertText(newText)
+          props.input().cursorOffset = Bun.stringWidth(newText)
+        },
+      })
+    }
 
     for (const serverCommand of sync.data.command) {
       if (serverCommand.source === "skill") continue
@@ -562,7 +578,7 @@ export function Autocomplete(props: {
       })
     }
 
-    for (const command of sync.data.acp[props.sessionID ?? ""]?.availableCommands ?? []) {
+    for (const command of acpState?.availableCommands ?? []) {
       if (!command || typeof command.name !== "string") continue
       results.push({
         display: "/" + command.name + ":acp",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -198,7 +198,18 @@ export function Prompt(props: PromptProps) {
   const [workspaceCreatingDots, setWorkspaceCreatingDots] = createSignal(3)
   const [warpNotice, setWarpNotice] = createSignal<string>()
   const [cursorVersion, setCursorVersion] = createSignal(0)
-  const currentProviderLabel = createMemo(() => local.model.parsed().provider)
+  const acpModel = createMemo(() => {
+    const state = props.sessionID ? sync.data.acp[props.sessionID] : undefined
+    const current = state?.models?.currentModelId
+    if (typeof current !== "string") return
+    const match = state?.models?.availableModels?.find((model: any) => model?.modelId === current)
+    return {
+      model: typeof match?.name === "string" ? match.name : current,
+      provider: "ACP",
+    }
+  })
+  const currentModelLabel = createMemo(() => acpModel()?.model ?? local.model.parsed().model)
+  const currentProviderLabel = createMemo(() => acpModel()?.provider ?? local.model.parsed().provider)
   const hasRightContent = createMemo(() => Boolean(props.right))
 
   function selectWorkspace(selection: WorkspaceSelection | undefined) {
@@ -1567,7 +1578,7 @@ export function Prompt(props: PromptProps) {
                             flexShrink={0}
                             fg={fadeColor(leader() ? theme.textMuted : theme.text, modelMetaAlpha())}
                           >
-                            {local.model.parsed().model}
+                            {currentModelLabel()}
                           </text>
                           <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>{currentProviderLabel()}</text>
                           <Show when={showVariant()}>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -200,11 +200,14 @@ export function Prompt(props: PromptProps) {
   const [cursorVersion, setCursorVersion] = createSignal(0)
   const acpModel = createMemo(() => {
     const state = props.sessionID ? sync.data.acp[props.sessionID] : undefined
-    const current = state?.models?.currentModelId
+    const modelOption = state?.configOptions?.find((option: any) => option?.id === "model" || option?.category === "model")
+    const current = typeof modelOption?.currentValue === "string" ? modelOption.currentValue : state?.models?.currentModelId
     if (typeof current !== "string") return
-    const match = state?.models?.availableModels?.find((model: any) => model?.modelId === current)
+    const match =
+      modelOption?.options?.find((option: any) => option?.value === current) ??
+      state?.models?.availableModels?.find((model: any) => model?.modelId === current)
     return {
-      model: typeof match?.name === "string" ? match.name : current,
+      model: typeof match?.name === "string" ? match.name : typeof match?.modelId === "string" ? match.modelId : current,
       provider: "ACP",
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -565,15 +565,27 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       },
       acp: {
         update(state: AcpSessionState & { sessionID: string }) {
-          setStore("acp", state.sessionID, (prev = {}) => ({
-            ...prev,
-            ...(state.configOptions !== undefined ? { configOptions: state.configOptions } : {}),
-            ...(state.modes !== undefined ? { modes: state.modes } : {}),
-            ...(state.models !== undefined ? { models: state.models } : {}),
-            ...(state.availableCommands !== undefined ? { availableCommands: state.availableCommands } : {}),
-            ...(state.usage !== undefined ? { usage: state.usage } : {}),
-            ...(state.info !== undefined ? { info: state.info } : {}),
-          }))
+          const sessionID = state.sessionID
+          if (!store.acp[sessionID]) {
+            setStore("acp", sessionID, {
+              configOptions: state.configOptions,
+              modes: state.modes,
+              models: state.models,
+              availableCommands: state.availableCommands,
+              usage: state.usage,
+              info: state.info,
+            })
+            return
+          }
+          batch(() => {
+            if (state.configOptions !== undefined) setStore("acp", sessionID, "configOptions", state.configOptions)
+            if (state.modes !== undefined) setStore("acp", sessionID, "modes", state.modes)
+            if (state.models !== undefined) setStore("acp", sessionID, "models", state.models)
+            if (state.availableCommands !== undefined)
+              setStore("acp", sessionID, "availableCommands", state.availableCommands)
+            if (state.usage !== undefined) setStore("acp", sessionID, "usage", state.usage)
+            if (state.info !== undefined) setStore("acp", sessionID, "info", state.info)
+          })
         },
       },
       bootstrap,

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -34,6 +34,15 @@ import path from "path"
 import { useKV } from "./kv"
 import { aggregateFailures } from "./aggregate-failures"
 
+type AcpSessionState = {
+  configOptions?: any[]
+  modes?: any
+  models?: any
+  availableCommands?: any[]
+  usage?: any
+  info?: any
+}
+
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
   init: () => {
@@ -76,6 +85,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       mcp_resource: {
         [key: string]: McpResource
       }
+      acp: {
+        [sessionID: string]: AcpSessionState
+      }
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
     }>({
@@ -103,6 +115,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       lsp: [],
       mcp: {},
       mcp_resource: {},
+      acp: {},
       formatter: [],
       vcs: undefined,
     })
@@ -131,6 +144,20 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     }
 
     event.subscribe((event, { workspace }) => {
+      const anyEvent = event as any
+      if (anyEvent.type === "acp.session.updated") {
+        const state = anyEvent.properties as AcpSessionState & { sessionID: string }
+        setStore("acp", state.sessionID, (prev = {}) => ({
+          ...prev,
+          ...(state.configOptions !== undefined ? { configOptions: state.configOptions } : {}),
+          ...(state.modes !== undefined ? { modes: state.modes } : {}),
+          ...(state.models !== undefined ? { models: state.models } : {}),
+          ...(state.availableCommands !== undefined ? { availableCommands: state.availableCommands } : {}),
+          ...(state.usage !== undefined ? { usage: state.usage } : {}),
+          ...(state.info !== undefined ? { info: state.info } : {}),
+        }))
+        return
+      }
       switch (event.type) {
         case "server.instance.disposed":
           void bootstrap()

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -147,15 +147,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       const anyEvent = event as any
       if (anyEvent.type === "acp.session.updated") {
         const state = anyEvent.properties as AcpSessionState & { sessionID: string }
-        setStore("acp", state.sessionID, (prev = {}) => ({
-          ...prev,
-          ...(state.configOptions !== undefined ? { configOptions: state.configOptions } : {}),
-          ...(state.modes !== undefined ? { modes: state.modes } : {}),
-          ...(state.models !== undefined ? { models: state.models } : {}),
-          ...(state.availableCommands !== undefined ? { availableCommands: state.availableCommands } : {}),
-          ...(state.usage !== undefined ? { usage: state.usage } : {}),
-          ...(state.info !== undefined ? { info: state.info } : {}),
-        }))
+        result.acp.update(state)
         return
       }
       switch (event.type) {
@@ -569,6 +561,19 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             }),
           )
           fullSyncedSessions.add(sessionID)
+        },
+      },
+      acp: {
+        update(state: AcpSessionState & { sessionID: string }) {
+          setStore("acp", state.sessionID, (prev = {}) => ({
+            ...prev,
+            ...(state.configOptions !== undefined ? { configOptions: state.configOptions } : {}),
+            ...(state.modes !== undefined ? { modes: state.modes } : {}),
+            ...(state.models !== undefined ? { models: state.models } : {}),
+            ...(state.availableCommands !== undefined ? { availableCommands: state.availableCommands } : {}),
+            ...(state.usage !== undefined ? { usage: state.usage } : {}),
+            ...(state.info !== undefined ? { info: state.info } : {}),
+          }))
         },
       },
       bootstrap,

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -1,6 +1,7 @@
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { InternalTuiPlugin } from "../../plugin/internal"
 import { useSyncV2 } from "@tui/context/sync-v2"
+import { useSync } from "@tui/context/sync"
 import { SplitBorder } from "@tui/component/border"
 import { Spinner } from "@tui/component/spinner"
 import { useTheme } from "@tui/context/theme"
@@ -302,11 +303,31 @@ function AssistantMessage(props: {
 }) {
   const { theme } = useTheme()
   const local = useLocal()
+  const sync = useSync()
   const duration = createMemo(() => {
     if (!props.message.time.completed) return 0
     return props.message.time.completed - (props.start ?? props.message.time.created)
   })
+  const acpModelLabel = createMemo(() => {
+    const agent = sync.data.agent.find((a) => a.name === props.message.agent)
+    if (agent?.backend?.type !== "acp") return undefined
+    const acpState = sync.data.acp[props.sessionID] as
+      | {
+          configOptions?: Array<{ id?: string; category?: string; currentValue?: string; options?: Array<{ value?: string; name?: string }> }>
+          models?: { currentModelId?: string; availableModels?: Array<{ modelId?: string; name?: string }> }
+        }
+      | undefined
+    const modelOption = acpState?.configOptions?.find((opt) => opt?.id === "model" || opt?.category === "model")
+    const current = typeof modelOption?.currentValue === "string" ? modelOption.currentValue : acpState?.models?.currentModelId
+    if (typeof current !== "string") return undefined
+    const match =
+      modelOption?.options?.find((opt) => opt?.value === current) ??
+      acpState?.models?.availableModels?.find((m) => m?.modelId === current)
+    return typeof match?.name === "string" ? match.name : current
+  })
   const model = createMemo(() => {
+    const overridden = acpModelLabel()
+    if (overridden) return `${overridden} ACP`
     const variant = props.message.model.variant ? `/${props.message.model.variant}` : ""
     return `${props.message.model.providerID}/${props.message.model.id}${variant}`
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -271,6 +271,20 @@ export function Session() {
       editor.reconnect(result.data.directory)
       await sync.session.sync(sessionID)
       if (route.sessionID === sessionID && scroll) scroll.scrollBy(100_000)
+      const agentName = result.data.agent
+      if (agentName && !sync.data.acp[sessionID]?.configOptions?.length) {
+        const agent = sync.data.agent.find((a) => a.name === agentName)
+        if (agent?.backend?.type === "acp") {
+          try {
+            const prepareUrl = new URL(`/session/${sessionID}/acp/prepare`, sdk.url)
+            const prepareResponse = await sdk.fetch(prepareUrl, { method: "POST" })
+            if (prepareResponse.ok) {
+              const state = await prepareResponse.json().catch(() => undefined)
+              if (state && typeof state === "object") sync.acp.update(state)
+            }
+          } catch {}
+        }
+      }
     })().catch((error) => {
       if (route.sessionID !== sessionID) return
       toast.show({

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1692,6 +1692,12 @@ type ToolProps<T> = {
 function GenericTool(props: ToolProps<any>) {
   const { theme } = useTheme()
   const ctx = use()
+  const acp = createMemo(() =>
+    props.part.metadata?.acp && typeof props.part.metadata.acp === "object"
+      ? (props.part.metadata.acp as Record<string, any>)
+      : undefined,
+  )
+  const title = createMemo(() => String(acp()?.title ?? props.tool))
   const output = createMemo(() => props.output?.trim() ?? "")
   const [expanded, setExpanded] = createSignal(false)
   const maxLines = 3
@@ -1706,14 +1712,21 @@ function GenericTool(props: ToolProps<any>) {
     <Show
       when={props.output && ctx.showGenericToolOutput()}
       fallback={
-        <InlineTool icon="⚙" pending="Writing command..." complete={true} part={props.part}>
-          {props.tool} {input(props.input)}
+        <InlineTool
+          icon="⚙"
+          pending={title()}
+          complete={props.part.state.status === "completed" || props.part.state.status === "error"}
+          spinner={props.part.state.status === "pending" || props.part.state.status === "running"}
+          part={props.part}
+        >
+          {title()} {input(props.input)}
         </InlineTool>
       }
     >
       <BlockTool
-        title={`# ${props.tool} ${input(props.input)}`}
+        title={`# ${title()} ${input(props.input)}`}
         part={props.part}
+        spinner={props.part.state.status === "pending" || props.part.state.status === "running"}
         onClick={collapsed().overflow ? () => setExpanded((prev) => !prev) : undefined}
       >
         <box gap={1}>

--- a/packages/opencode/src/config/acp.ts
+++ b/packages/opencode/src/config/acp.ts
@@ -1,0 +1,24 @@
+import { Schema } from "effect"
+import { PositiveInt } from "@opencode-ai/core/schema"
+
+export const Local = Schema.Struct({
+  type: Schema.Literal("local").annotate({ description: "Type of ACP server connection" }),
+  command: Schema.mutable(Schema.Array(Schema.String)).annotate({
+    description: "Command and arguments to run the ACP server over stdio",
+  }),
+  environment: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({
+    description: "Environment variables to set when running the ACP server",
+  }),
+  enabled: Schema.optional(Schema.Boolean).annotate({
+    description: "Enable or disable the ACP server",
+  }),
+  timeout: Schema.optional(PositiveInt).annotate({
+    description: "Timeout in ms for ACP server requests. Defaults to 30000 (30 seconds) if not specified.",
+  }),
+}).annotate({ identifier: "AcpLocalConfig" })
+export type Local = Schema.Schema.Type<typeof Local>
+
+export const Info = Local.annotate({ discriminator: "type" })
+export type Info = Schema.Schema.Type<typeof Info>
+
+export * as ConfigACP from "./acp"

--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -18,9 +18,20 @@ const Color = Schema.Union([
   Schema.Literals(["primary", "secondary", "accent", "success", "warning", "error", "info"]),
 ])
 
+export const Backend = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("acp"),
+    server: Schema.String.annotate({
+      description: "Name of the configured ACP server to use for this agent",
+    }),
+  }),
+]).annotate({ discriminator: "type", identifier: "AgentBackendConfig" })
+export type Backend = Schema.Schema.Type<typeof Backend>
+
 const AgentSchema = Schema.StructWithRest(
   Schema.Struct({
     model: Schema.optional(ConfigModelID),
+    backend: Schema.optional(Backend),
     variant: Schema.optional(Schema.String).annotate({
       description: "Default model variant for this agent (applies only when using the agent's configured model).",
     }),
@@ -52,6 +63,7 @@ const AgentSchema = Schema.StructWithRest(
 const KNOWN_KEYS = new Set([
   "name",
   "model",
+  "backend",
   "variant",
   "prompt",
   "description",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -31,6 +31,7 @@ import { ConfigLayout } from "./layout"
 import { ConfigLSP } from "./lsp"
 import { ConfigManaged } from "./managed"
 import { ConfigMCP } from "./mcp"
+import { ConfigACP } from "./acp"
 import { ConfigModelID } from "./model-id"
 import { ConfigParse } from "./parse"
 import { ConfigPaths } from "./paths"
@@ -220,6 +221,16 @@ export const Info = Schema.Struct({
   provider: Schema.optional(Schema.Record(Schema.String, ConfigProvider.Info)).annotate({
     description: "Custom provider configurations and model overrides",
   }),
+  acp: Schema.optional(
+    Schema.Record(
+      Schema.String,
+      Schema.Union([
+        ConfigACP.Info,
+        // Matches the `{ enabled: false }` form used to disable a server.
+        Schema.Struct({ enabled: Schema.Boolean }),
+      ]),
+    ),
+  ).annotate({ description: "ACP (Agent Client Protocol) server configurations" }),
   mcp: Schema.optional(
     Schema.Record(
       Schema.String,

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -103,6 +103,7 @@ export const SessionPaths = {
   deletePart: `${root}/:sessionID/message/:messageID/part/:partID`,
   updatePart: `${root}/:sessionID/message/:messageID/part/:partID`,
   acpConfigOption: `${root}/:sessionID/acp/config`,
+  acpPrepare: `${root}/:sessionID/acp/prepare`,
 } as const
 
 export const SessionApi = HttpApi.make("session")
@@ -249,6 +250,19 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.acp.config",
             summary: "Set ACP session config option",
             description: "Set a configuration option on the ACP backend for this session.",
+          }),
+        ),
+        HttpApiEndpoint.post("acpPrepare", SessionPaths.acpPrepare, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Any, "Prepared ACP session"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.acp.prepare",
+            summary: "Prepare ACP session",
+            description:
+              "Connect to the ACP backend and create the remote session so its config options and modes are available.",
           }),
         ),
         HttpApiEndpoint.post("fork", SessionPaths.fork, {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -70,6 +70,10 @@ export const RevertPayload = Schema.Struct(Struct.omit(SessionRevert.RevertInput
 export const PermissionResponsePayload = Schema.Struct({
   response: Permission.Reply,
 })
+export const AcpConfigOptionPayload = Schema.Struct({
+  configID: Schema.String,
+  value: Schema.String,
+})
 
 export const SessionPaths = {
   list: root,
@@ -98,6 +102,7 @@ export const SessionPaths = {
   deleteMessage: `${root}/:sessionID/message/:messageID`,
   deletePart: `${root}/:sessionID/message/:messageID/part/:partID`,
   updatePart: `${root}/:sessionID/message/:messageID/part/:partID`,
+  acpConfigOption: `${root}/:sessionID/acp/config`,
 } as const
 
 export const SessionApi = HttpApi.make("session")
@@ -231,6 +236,19 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.update",
             summary: "Update session",
             description: "Update properties of an existing session, such as title or other metadata.",
+          }),
+        ),
+        HttpApiEndpoint.post("acpConfigOption", SessionPaths.acpConfigOption, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          payload: AcpConfigOptionPayload,
+          success: described(Schema.Any, "Updated ACP config options"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.acp.config",
+            summary: "Set ACP session config option",
+            description: "Set a configuration option on the ACP backend for this session.",
           }),
         ),
         HttpApiEndpoint.post("fork", SessionPaths.fork, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -214,6 +214,22 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
     })
 
+    const acpPrepare = Effect.fn("SessionHttpApi.acpPrepare")(function* (ctx: { params: { sessionID: SessionID } }) {
+      const current = yield* requireSession(ctx.params.sessionID)
+      const messages = yield* SessionError.mapStorageNotFound(session.messages({ sessionID: ctx.params.sessionID }))
+      const defaultAgent = yield* agentSvc.defaultAgent()
+      const agentName = messages.findLast((message) => message.info.role === "user")?.info.agent ?? current.agent ?? defaultAgent
+      const agent = yield* agentSvc.get(agentName).pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+      if (agent.backend?.type !== "acp") return new HttpApiError.BadRequest({})
+      return yield* acp
+        .prepare({
+          server: agent.backend.server,
+          agent: { name: agent.name, permission: agent.permission },
+          session: current,
+        })
+        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+    })
+
     const fork = Effect.fn("SessionHttpApi.fork")(function* (ctx: {
       params: { sessionID: SessionID }
       payload?: typeof ForkPayload.Type
@@ -433,6 +449,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("remove", remove)
       .handle("update", update)
       .handle("acpConfigOption", acpConfigOption)
+      .handle("acpPrepare", acpPrepare)
       .handleRaw("fork", forkRaw)
       .handle("abort", abort)
       .handle("init", init)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -1,4 +1,5 @@
 import { Agent } from "@/agent/agent"
+import { ACPClient } from "@/acp/client"
 import { Bus } from "@/bus"
 import { Command } from "@/command"
 import { Permission } from "@/permission"
@@ -21,6 +22,7 @@ import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import {
+  AcpConfigOptionPayload,
   CommandPayload,
   DiffQuery,
   ForkPayload,
@@ -57,6 +59,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const todoSvc = yield* Todo.Service
     const summary = yield* SessionSummary.Service
     const bus = yield* Bus.Service
+    const acp = yield* ACPClient.Service
     const scope = yield* Scope.Scope
 
     const list = Effect.fn("SessionHttpApi.list")(function* (ctx: { query: typeof ListQuery.Type }) {
@@ -195,6 +198,20 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         yield* session.setArchived({ sessionID: ctx.params.sessionID, time: ctx.payload.time.archived })
       }
       return yield* requireSession(ctx.params.sessionID)
+    })
+
+    const acpConfigOption = Effect.fn("SessionHttpApi.acpConfigOption")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof AcpConfigOptionPayload.Type
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* acp
+        .setConfigOption({
+          sessionID: ctx.params.sessionID,
+          configID: ctx.payload.configID,
+          value: ctx.payload.value,
+        })
+        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
     })
 
     const fork = Effect.fn("SessionHttpApi.fork")(function* (ctx: {
@@ -415,6 +432,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handleRaw("create", createRaw)
       .handle("remove", remove)
       .handle("update", update)
+      .handle("acpConfigOption", acpConfigOption)
       .handleRaw("fork", forkRaw)
       .handle("abort", abort)
       .handle("init", init)

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -11,6 +11,7 @@ import {
 import * as Socket from "effect/unstable/socket/Socket"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Account } from "@/account/account"
+import { ACPClient } from "@/acp/client"
 import { Agent } from "@/agent/agent"
 import { Auth } from "@/auth"
 import { Bus } from "@/bus"
@@ -192,6 +193,7 @@ export function createRoutes(
       fenceLayer,
       cors(corsOptions),
       Account.defaultLayer,
+      ACPClient.defaultLayer,
       Agent.defaultLayer,
       Auth.defaultLayer,
       Command.defaultLayer,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -61,6 +61,7 @@ import { referencePromptMetadata, referenceTextPart } from "./prompt/reference"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { ACPClient } from "@/acp/client"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -120,6 +121,7 @@ export const layer = Layer.effect(
     const summary = yield* SessionSummary.Service
     const sys = yield* SystemPrompt.Service
     const llm = yield* LLM.Service
+    const acp = yield* ACPClient.Service
     const references = yield* Reference.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
@@ -1355,6 +1357,23 @@ export const layer = Layer.effect(
             yield* sessions.updateMessage(msg)
           })
 
+          if (agent.backend?.type === "acp") {
+            const lastUserMsg = msgs.findLast(
+              (m): m is MessageV2.WithParts & { info: MessageV2.User } => m.info.role === "user",
+            )
+            if (!lastUserMsg) throw new Error("No user message found for ACP prompt")
+            yield* acp
+              .run({
+                server: agent.backend.server,
+                agent,
+                session,
+                user: lastUserMsg,
+                assistant: msg,
+              })
+              .pipe(Effect.onInterrupt(() => finalizeInterruptedAssistant))
+            break
+          }
+
           const handle = yield* processor
             .create({
               assistantMessage: msg,
@@ -1646,6 +1665,7 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(
       Layer.mergeAll(
         EventV2Bridge.defaultLayer,
+        ACPClient.defaultLayer,
         Agent.defaultLayer,
         SystemPrompt.defaultLayer,
         LLM.defaultLayer,

--- a/packages/opencode/test/acp/client.test.ts
+++ b/packages/opencode/test/acp/client.test.ts
@@ -3,6 +3,7 @@ import { Effect, Layer } from "effect"
 import fs from "node:fs/promises"
 import path from "node:path"
 import { ACPClient } from "@/acp/client"
+import { Bus } from "@/bus"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { MessageV2 } from "@/session/message-v2"
 import { MessageID, PartID } from "@/session/schema"
@@ -17,6 +18,7 @@ const layer = Layer.mergeAll(
   SessionRevert.defaultLayer,
   SessionSummary.defaultLayer,
   ACPClient.defaultLayer,
+  Bus.defaultLayer,
 )
 
 const it = testEffect(layer)
@@ -408,6 +410,173 @@ it.instance("runs ACP terminal commands through a shell", () =>
   }),
 )
 
+it.instance("prepare creates remote ACP session and exposes config options without running a prompt", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const server = path.join(test.directory, "prepare-acp-server.js")
+    yield* Effect.promise(() => fs.writeFile(server, configOptionServerSource))
+    yield* Effect.promise(() =>
+      fs.writeFile(
+        path.join(test.directory, "opencode.json"),
+        JSON.stringify({
+          acp: {
+            prepare: {
+              type: "local",
+              command: [process.execPath, server],
+              timeout: 5000,
+            },
+          },
+        }),
+      ),
+    )
+
+    const sessions = yield* Session.Service
+    const acp = yield* ACPClient.Service
+    const bus = yield* Bus.Service
+    const events: ACPClient.ACPStatePayload[] = []
+    yield* bus.subscribeCallback(ACPClient.Event.StateUpdated, (event) => {
+      events.push(event.properties)
+    })
+
+    const info = yield* sessions.create({
+      title: "prepare test",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      agent: "prepare-acp",
+      model: { id: model.modelID, providerID: model.providerID },
+    })
+
+    const result = yield* acp.prepare({
+      server: "prepare",
+      agent: {
+        name: "prepare-acp",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
+      session: info,
+    })
+
+    expect(result.sessionID).toBe(info.id)
+    const modelOption = (result.configOptions as Array<{ id: string; currentValue: string }> | undefined)?.find(
+      (option) => option.id === "model",
+    )
+    expect(modelOption?.currentValue).toBe("alpha[]")
+
+    yield* Effect.promise(async () => {
+      const deadline = Date.now() + 2000
+      while (events.length === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+    })
+    expect(events.length).toBeGreaterThan(0)
+    expect(events[events.length - 1]?.sessionID).toBe(info.id)
+  }),
+)
+
+it.instance("updates ACP config option current value and publishes state event", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const server = path.join(test.directory, "config-acp-server.js")
+    yield* Effect.promise(() => fs.writeFile(server, configOptionServerSource))
+    yield* Effect.promise(() =>
+      fs.writeFile(
+        path.join(test.directory, "opencode.json"),
+        JSON.stringify({
+          acp: {
+            config: {
+              type: "local",
+              command: [process.execPath, server],
+              timeout: 5000,
+            },
+          },
+        }),
+      ),
+    )
+
+    const sessions = yield* Session.Service
+    const acp = yield* ACPClient.Service
+    const bus = yield* Bus.Service
+    const events: ACPClient.ACPStatePayload[] = []
+    yield* bus.subscribeCallback(ACPClient.Event.StateUpdated, (event) => {
+      events.push(event.properties)
+    })
+
+    const info = yield* sessions.create({
+      title: "config option test",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      agent: "config-acp",
+      model: { id: model.modelID, providerID: model.providerID },
+    })
+    const user: MessageV2.User = {
+      id: MessageID.ascending(),
+      sessionID: info.id,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "config-acp",
+      model,
+    }
+    yield* sessions.updateMessage(user)
+    const userPart = yield* sessions.updatePart({
+      id: PartID.ascending(),
+      sessionID: info.id,
+      messageID: user.id,
+      type: "text",
+      text: "hello",
+    })
+    const assistant: MessageV2.Assistant = {
+      id: MessageID.ascending(),
+      parentID: user.id,
+      role: "assistant",
+      mode: "config-acp",
+      agent: "config-acp",
+      path: { cwd: test.directory, root: test.directory },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: model.modelID,
+      providerID: model.providerID,
+      time: { created: Date.now() },
+      sessionID: info.id,
+    }
+    yield* sessions.updateMessage(assistant)
+
+    yield* acp.run({
+      server: "config",
+      agent: {
+        name: "config-acp",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
+      session: info,
+      user: { info: user, parts: [userPart] },
+      assistant,
+    })
+
+    const eventsBefore = events.length
+    const response = yield* acp.setConfigOption({
+      sessionID: info.id,
+      configID: "model",
+      value: "beta[]",
+    })
+
+    expect(response.configOptions).toBeDefined()
+    const modelOption = (response.configOptions as Array<{ id: string; currentValue: string }>).find(
+      (option) => option.id === "model",
+    )
+    expect(modelOption?.currentValue).toBe("beta[]")
+
+    yield* Effect.promise(async () => {
+      const deadline = Date.now() + 2000
+      while (events.length <= eventsBefore && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+    })
+    expect(events.length).toBeGreaterThan(eventsBefore)
+    const lastEvent = events[events.length - 1]
+    expect(lastEvent?.sessionID).toBe(info.id)
+    const eventModel = (lastEvent?.configOptions as Array<{ id: string; currentValue: string }> | undefined)?.find(
+      (option) => option.id === "model",
+    )
+    expect(eventModel?.currentValue).toBe("beta[]")
+  }),
+)
+
 const fakeServerSource = `
 const write = (message) => process.stdout.write(JSON.stringify(message) + "\\n")
 let buffer = ""
@@ -634,6 +803,76 @@ process.stdin.on("data", (chunk) => {
       })
       write({ jsonrpc: "2.0", id: pendingPromptId, result: { stopReason: "end_turn" } })
       pendingPromptId = undefined
+    }
+  }
+})
+`
+
+const configOptionServerSource = `
+const write = (message) => process.stdout.write(JSON.stringify(message) + "\\n")
+let buffer = ""
+let configOptions = [
+  {
+    id: "model",
+    name: "Model",
+    type: "select",
+    category: "model",
+    currentValue: "alpha[]",
+    options: [
+      { value: "alpha[]", name: "Alpha" },
+      { value: "beta[]", name: "Beta" },
+    ],
+  },
+]
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", (chunk) => {
+  buffer += chunk
+  const lines = buffer.split("\\n")
+  buffer = lines.pop() ?? ""
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const message = JSON.parse(line)
+    if (message.method === "initialize") {
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          agentInfo: { name: "config-acp", title: "Config ACP", version: "1.0.0" },
+          authMethods: [],
+        },
+      })
+      continue
+    }
+    if (message.method === "session/new") {
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: { sessionId: "remote_config", configOptions },
+      })
+      continue
+    }
+    if (message.method === "session/prompt") {
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "ack" },
+          },
+        },
+      })
+      write({ jsonrpc: "2.0", id: message.id, result: { stopReason: "end_turn" } })
+      continue
+    }
+    if (message.method === "session/set_config_option") {
+      const target = configOptions.find((option) => option.id === message.params.configId)
+      if (target) target.currentValue = message.params.value
+      write({ jsonrpc: "2.0", id: message.id, result: { configOptions } })
+      continue
     }
   }
 })

--- a/packages/opencode/test/acp/client.test.ts
+++ b/packages/opencode/test/acp/client.test.ts
@@ -331,6 +331,83 @@ it.instance(
   { git: true },
 )
 
+it.instance("runs ACP terminal commands through a shell", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const server = path.join(test.directory, "terminal-acp-server.js")
+    yield* Effect.promise(() => fs.writeFile(server, terminalServerSource))
+    yield* Effect.promise(() =>
+      fs.writeFile(
+        path.join(test.directory, "opencode.json"),
+        JSON.stringify({
+          acp: {
+            terminal: {
+              type: "local",
+              command: [process.execPath, server],
+              timeout: 5000,
+            },
+          },
+        }),
+      ),
+    )
+
+    const sessions = yield* Session.Service
+    const acp = yield* ACPClient.Service
+    const info = yield* sessions.create({
+      title: "terminal ACP client test",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      agent: "terminal-acp",
+      model: { id: model.modelID, providerID: model.providerID },
+    })
+    const user: MessageV2.User = {
+      id: MessageID.ascending(),
+      sessionID: info.id,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "terminal-acp",
+      model,
+    }
+    yield* sessions.updateMessage(user)
+    const userPart = yield* sessions.updatePart({
+      id: PartID.ascending(),
+      sessionID: info.id,
+      messageID: user.id,
+      type: "text",
+      text: "run shell",
+    })
+    const assistant: MessageV2.Assistant = {
+      id: MessageID.ascending(),
+      parentID: user.id,
+      role: "assistant",
+      mode: "terminal-acp",
+      agent: "terminal-acp",
+      path: { cwd: test.directory, root: test.directory },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: model.modelID,
+      providerID: model.providerID,
+      time: { created: Date.now() },
+      sessionID: info.id,
+    }
+    yield* sessions.updateMessage(assistant)
+
+    yield* acp.run({
+      server: "terminal",
+      agent: {
+        name: "terminal-acp",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
+      session: info,
+      user: { info: user, parts: [userPart] },
+      assistant,
+    })
+
+    const messages = yield* sessions.messages({ sessionID: info.id })
+    const stored = messages.find((message) => message.info.id === assistant.id)
+    expect(stored?.parts.some((part) => part.type === "text" && part.text.includes("shell-ok"))).toBe(true)
+  }),
+)
+
 const fakeServerSource = `
 const write = (message) => process.stdout.write(JSON.stringify(message) + "\\n")
 let buffer = ""
@@ -557,6 +634,75 @@ process.stdin.on("data", (chunk) => {
       })
       write({ jsonrpc: "2.0", id: pendingPromptId, result: { stopReason: "end_turn" } })
       pendingPromptId = undefined
+    }
+  }
+})
+`
+
+const terminalServerSource = `
+const write = (message) => process.stdout.write(JSON.stringify(message) + "\\n")
+let buffer = ""
+let promptId
+let sessionId
+let terminalId
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", (chunk) => {
+  buffer += chunk
+  const lines = buffer.split("\\n")
+  buffer = lines.pop() ?? ""
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const message = JSON.parse(line)
+    if (message.method === "initialize") {
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          agentInfo: { name: "terminal-acp", title: "Terminal ACP", version: "1.0.0" },
+          authMethods: [],
+        },
+      })
+      continue
+    }
+    if (message.method === "session/new") {
+      write({ jsonrpc: "2.0", id: message.id, result: { sessionId: "remote_terminal" } })
+      continue
+    }
+    if (message.method === "session/prompt") {
+      promptId = message.id
+      sessionId = message.params.sessionId
+      write({
+        jsonrpc: "2.0",
+        id: 200,
+        method: "terminal/create",
+        params: { sessionId, command: "echo shell-ok | cat", cwd: process.cwd(), outputByteLimit: 10000 },
+      })
+      continue
+    }
+    if (message.id === 200) {
+      terminalId = message.result.terminalId
+      write({ jsonrpc: "2.0", id: 201, method: "terminal/wait_for_exit", params: { sessionId, terminalId } })
+      continue
+    }
+    if (message.id === 201) {
+      write({ jsonrpc: "2.0", id: 202, method: "terminal/output", params: { sessionId, terminalId } })
+      continue
+    }
+    if (message.id === 202) {
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: message.result.output },
+          },
+        },
+      })
+      write({ jsonrpc: "2.0", id: promptId, result: { stopReason: "end_turn" } })
     }
   }
 })

--- a/packages/opencode/test/acp/client.test.ts
+++ b/packages/opencode/test/acp/client.test.ts
@@ -1,0 +1,563 @@
+import { expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { ACPClient } from "@/acp/client"
+import { ModelID, ProviderID } from "@/provider/schema"
+import { MessageV2 } from "@/session/message-v2"
+import { MessageID, PartID } from "@/session/schema"
+import { Session } from "@/session/session"
+import { SessionRevert } from "@/session/revert"
+import { SessionSummary } from "@/session/summary"
+import { testEffect } from "../lib/effect"
+import { TestInstance } from "../fixture/fixture"
+
+const layer = Layer.mergeAll(
+  Session.defaultLayer,
+  SessionRevert.defaultLayer,
+  SessionSummary.defaultLayer,
+  ACPClient.defaultLayer,
+)
+
+const it = testEffect(layer)
+
+const model = {
+  providerID: ProviderID.make("acp"),
+  modelID: ModelID.make("remote"),
+}
+
+it.instance("runs a prompt against a stdio ACP server and stores streamed parts", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const server = path.join(test.directory, "fake-acp-server.js")
+    yield* Effect.promise(() => fs.writeFile(server, fakeServerSource))
+    yield* Effect.promise(() =>
+      fs.writeFile(
+        path.join(test.directory, "opencode.json"),
+        JSON.stringify({
+          acp: {
+            fake: {
+              type: "local",
+              command: [process.execPath, server],
+              timeout: 5000,
+            },
+          },
+        }),
+      ),
+    )
+
+    const sessions = yield* Session.Service
+    const acp = yield* ACPClient.Service
+    const info = yield* sessions.create({
+      title: "ACP client test",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      agent: "fake-acp",
+      model: { id: model.modelID, providerID: model.providerID },
+    })
+
+    const user: MessageV2.User = {
+      id: MessageID.ascending(),
+      sessionID: info.id,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "fake-acp",
+      model,
+    }
+    yield* sessions.updateMessage(user)
+    const userPart = yield* sessions.updatePart({
+      id: PartID.ascending(),
+      sessionID: info.id,
+      messageID: user.id,
+      type: "text",
+      text: "hello",
+    })
+
+    const assistant: MessageV2.Assistant = {
+      id: MessageID.ascending(),
+      parentID: user.id,
+      role: "assistant",
+      mode: "fake-acp",
+      agent: "fake-acp",
+      path: { cwd: test.directory, root: test.directory },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: model.modelID,
+      providerID: model.providerID,
+      time: { created: Date.now() },
+      sessionID: info.id,
+    }
+    yield* sessions.updateMessage(assistant)
+
+    const result = yield* acp.run({
+      server: "fake",
+      agent: {
+        name: "fake-acp",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
+      session: info,
+      user: { info: user, parts: [userPart] },
+      assistant,
+    })
+
+    expect(result.finish).toBe("stop")
+    const messages = yield* sessions.messages({ sessionID: info.id })
+    const stored = messages.find((message) => message.info.id === assistant.id)
+    expect(stored?.parts.some((part) => part.type === "text" && part.text === "hello from acp")).toBe(true)
+    expect(stored?.parts.some((part) => part.type === "file" && part.mime === "image/png")).toBe(true)
+    expect(stored?.parts.some((part) => part.type === "step-start")).toBe(true)
+    expect(stored?.parts.some((part) => part.type === "step-finish")).toBe(true)
+    expect(
+      stored?.parts.some(
+        (part) => part.type === "reasoning" && part.text === "thinking" && part.time.end !== undefined,
+      ),
+    ).toBe(true)
+    expect(
+      stored?.parts.some(
+        (part) => part.type === "tool" && part.callID === "call_1" && part.state.status === "completed",
+      ),
+    ).toBe(true)
+    const toolIndex = stored?.parts.findIndex((part) => part.type === "tool" && part.callID === "call_1") ?? -1
+    const finalTextIndex =
+      stored?.parts.findIndex((part) => part.type === "text" && part.text === "final from acp") ?? -1
+    expect(finalTextIndex).toBeGreaterThan(toolIndex)
+
+    const secondUser: MessageV2.User = {
+      id: MessageID.ascending(),
+      sessionID: info.id,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "fake-acp",
+      model,
+    }
+    yield* sessions.updateMessage(secondUser)
+    const secondUserPart = yield* sessions.updatePart({
+      id: PartID.ascending(),
+      sessionID: info.id,
+      messageID: secondUser.id,
+      type: "text",
+      text: "second turn",
+    })
+    const secondAssistant: MessageV2.Assistant = {
+      ...assistant,
+      id: MessageID.ascending(),
+      parentID: secondUser.id,
+      time: { created: Date.now() },
+    }
+    yield* sessions.updateMessage(secondAssistant)
+    yield* acp.run({
+      server: "fake",
+      agent: {
+        name: "fake-acp",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
+      session: info,
+      user: { info: secondUser, parts: [secondUserPart] },
+      assistant: secondAssistant,
+    })
+    const afterSecond = yield* sessions.messages({ sessionID: info.id })
+    const storedSecond = afterSecond.find((message) => message.info.id === secondAssistant.id)
+    expect(storedSecond?.parts.some((part) => part.type === "text" && part.text === "hello from acp")).toBe(true)
+  }),
+)
+
+it.instance("stores a visible fallback when ACP completes without message chunks", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const server = path.join(test.directory, "silent-acp-server.js")
+    yield* Effect.promise(() => fs.writeFile(server, silentServerSource))
+    yield* Effect.promise(() =>
+      fs.writeFile(
+        path.join(test.directory, "opencode.json"),
+        JSON.stringify({
+          acp: {
+            silent: {
+              type: "local",
+              command: [process.execPath, server],
+              timeout: 5000,
+            },
+          },
+        }),
+      ),
+    )
+
+    const sessions = yield* Session.Service
+    const acp = yield* ACPClient.Service
+    const info = yield* sessions.create({
+      title: "silent ACP client test",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      agent: "silent-acp",
+      model: { id: model.modelID, providerID: model.providerID },
+    })
+    const user: MessageV2.User = {
+      id: MessageID.ascending(),
+      sessionID: info.id,
+      role: "user",
+      time: { created: Date.now() },
+      agent: "silent-acp",
+      model,
+    }
+    yield* sessions.updateMessage(user)
+    const userPart = yield* sessions.updatePart({
+      id: PartID.ascending(),
+      sessionID: info.id,
+      messageID: user.id,
+      type: "text",
+      text: "ok",
+    })
+    const assistant: MessageV2.Assistant = {
+      id: MessageID.ascending(),
+      parentID: user.id,
+      role: "assistant",
+      mode: "silent-acp",
+      agent: "silent-acp",
+      path: { cwd: test.directory, root: test.directory },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: model.modelID,
+      providerID: model.providerID,
+      time: { created: Date.now() },
+      sessionID: info.id,
+    }
+    yield* sessions.updateMessage(assistant)
+
+    yield* acp.run({
+      server: "silent",
+      agent: {
+        name: "silent-acp",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
+      session: info,
+      user: { info: user, parts: [userPart] },
+      assistant,
+    })
+
+    const messages = yield* sessions.messages({ sessionID: info.id })
+    const stored = messages.find((message) => message.info.id === assistant.id)
+    expect(stored?.parts.some((part) => part.type === "text" && part.text === "Done.")).toBe(true)
+  }),
+)
+
+it.instance(
+  "captures and reverts ACP client file writes",
+  () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const server = path.join(test.directory, "write-acp-server.js")
+      const target = path.join(test.directory, "acp-write.txt")
+      yield* Effect.promise(() => fs.writeFile(server, writeServerSource))
+      yield* Effect.promise(() =>
+        fs.writeFile(
+          path.join(test.directory, "opencode.json"),
+          JSON.stringify({
+            acp: {
+              writer: {
+                type: "local",
+                command: [process.execPath, server],
+                environment: { TARGET_FILE: target },
+                timeout: 5000,
+              },
+            },
+          }),
+        ),
+      )
+
+      const sessions = yield* Session.Service
+      const revert = yield* SessionRevert.Service
+      const acp = yield* ACPClient.Service
+      const info = yield* sessions.create({
+        title: "ACP writer test",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        agent: "writer-acp",
+        model: { id: model.modelID, providerID: model.providerID },
+      })
+      const user: MessageV2.User = {
+        id: MessageID.ascending(),
+        sessionID: info.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "writer-acp",
+        model,
+      }
+      yield* sessions.updateMessage(user)
+      const userPart = yield* sessions.updatePart({
+        id: PartID.ascending(),
+        sessionID: info.id,
+        messageID: user.id,
+        type: "text",
+        text: "write a file",
+      })
+      const assistant: MessageV2.Assistant = {
+        id: MessageID.ascending(),
+        parentID: user.id,
+        role: "assistant",
+        mode: "writer-acp",
+        agent: "writer-acp",
+        path: { cwd: test.directory, root: test.directory },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: model.modelID,
+        providerID: model.providerID,
+        time: { created: Date.now() },
+        sessionID: info.id,
+      }
+      yield* sessions.updateMessage(assistant)
+
+      yield* acp.run({
+        server: "writer",
+        agent: {
+          name: "writer-acp",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
+        session: info,
+        user: { info: user, parts: [userPart] },
+        assistant,
+      })
+
+      const content = yield* Effect.promise(() => fs.readFile(target, "utf8"))
+      expect(content).toBe("written by acp")
+      const messages = yield* sessions.messages({ sessionID: info.id })
+      const stored = messages.find((message) => message.info.id === assistant.id)
+      expect(stored?.parts.some((part) => part.type === "patch" && part.files.includes(target))).toBe(true)
+
+      yield* revert.revert({ sessionID: info.id, messageID: user.id })
+      const exists = yield* Effect.promise(() =>
+        fs
+          .access(target)
+          .then(() => true)
+          .catch(() => false),
+      )
+      expect(exists).toBe(false)
+    }),
+  { git: true },
+)
+
+const fakeServerSource = `
+const write = (message) => process.stdout.write(JSON.stringify(message) + "\\n")
+let buffer = ""
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", (chunk) => {
+  buffer += chunk
+  const lines = buffer.split("\\n")
+  buffer = lines.pop() ?? ""
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const message = JSON.parse(line)
+    if (message.method === "initialize") {
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          agentInfo: { name: "fake-acp", title: "Fake ACP", version: "1.0.0" },
+          authMethods: [],
+        },
+      })
+      continue
+    }
+    if (message.method === "session/new") {
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          sessionId: "remote_1",
+          configOptions: [
+            {
+              id: "mode",
+              name: "Mode",
+              type: "select",
+              currentValue: "ask",
+              options: [{ value: "ask", name: "Ask" }],
+            },
+          ],
+        },
+      })
+      continue
+    }
+    if (message.method === "session/prompt") {
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "hello from acp" },
+          },
+        },
+      })
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "thinking" },
+          },
+        },
+      })
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "available_commands_update",
+            availableCommands: [{ name: "joke", description: "Tell a joke" }],
+          },
+        },
+      })
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "image", mimeType: "image/png", data: "iVBORw0KGgo=" },
+          },
+        },
+      })
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: "call_1",
+            title: "Fake tool",
+            kind: "read",
+            status: "pending",
+            rawInput: { path: "README.md" },
+          },
+        },
+      })
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "call_1",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "done" } }],
+            rawOutput: { ok: true },
+          },
+        },
+      })
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: message.params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "final from acp" },
+          },
+        },
+      })
+      setTimeout(() => {
+        write({ jsonrpc: "2.0", id: message.id, result: { stopReason: "end_turn" } })
+      }, 50)
+    }
+  }
+})
+`
+
+const silentServerSource = `
+const write = (message) => process.stdout.write(JSON.stringify(message) + "\\n")
+let buffer = ""
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", (chunk) => {
+  buffer += chunk
+  const lines = buffer.split("\\n")
+  buffer = lines.pop() ?? ""
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const message = JSON.parse(line)
+    if (message.method === "initialize") {
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          agentInfo: { name: "silent-acp", title: "Silent ACP", version: "1.0.0" },
+          authMethods: [],
+        },
+      })
+      continue
+    }
+    if (message.method === "session/new") {
+      write({ jsonrpc: "2.0", id: message.id, result: { sessionId: "remote_silent" } })
+      continue
+    }
+    if (message.method === "session/prompt") {
+      write({ jsonrpc: "2.0", id: message.id, result: { stopReason: "end_turn" } })
+    }
+  }
+})
+`
+
+const writeServerSource = `
+const write = (message) => process.stdout.write(JSON.stringify(message) + "\\n")
+let buffer = ""
+let pendingPromptId
+let pendingSessionId
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", (chunk) => {
+  buffer += chunk
+  const lines = buffer.split("\\n")
+  buffer = lines.pop() ?? ""
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const message = JSON.parse(line)
+    if (message.method === "initialize") {
+      write({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: 1,
+          agentCapabilities: {},
+          agentInfo: { name: "writer-acp", title: "Writer ACP", version: "1.0.0" },
+          authMethods: [],
+        },
+      })
+      continue
+    }
+    if (message.method === "session/new") {
+      write({ jsonrpc: "2.0", id: message.id, result: { sessionId: "remote_writer" } })
+      continue
+    }
+    if (message.method === "session/prompt") {
+      pendingPromptId = message.id
+      pendingSessionId = message.params.sessionId
+      write({
+        jsonrpc: "2.0",
+        id: 100,
+        method: "fs/write_text_file",
+        params: { sessionId: pendingSessionId, path: process.env.TARGET_FILE, content: "written by acp" },
+      })
+      continue
+    }
+    if (message.id === 100 && pendingPromptId !== undefined) {
+      write({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: pendingSessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "wrote file" },
+          },
+        },
+      })
+      write({ jsonrpc: "2.0", id: pendingPromptId, result: { stopReason: "end_turn" } })
+      pendingPromptId = undefined
+    }
+  }
+})
+`

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -634,6 +634,41 @@ it.instance("handles agent configuration", () =>
   }),
 )
 
+it.instance("handles ACP server and agent backend configuration", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      acp: {
+        cursor: {
+          type: "local",
+          command: ["cursor", "acp"],
+          environment: { CURSOR_CHANNEL: "stable" },
+          enabled: true,
+          timeout: 30000,
+        },
+      },
+      agent: {
+        cursor: {
+          mode: "primary",
+          description: "Use Cursor through ACP",
+          backend: { type: "acp", server: "cursor" },
+        },
+      },
+    })
+
+    const config = yield* Config.use.get()
+    expect(config.acp?.cursor).toEqual({
+      type: "local",
+      command: ["cursor", "acp"],
+      environment: { CURSOR_CHANNEL: "stable" },
+      enabled: true,
+      timeout: 30000,
+    })
+    expect(config.agent?.cursor?.backend).toEqual({ type: "acp", server: "cursor" })
+  }),
+)
+
 it.instance("treats agent variant as model-scoped setting (not provider option)", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -138,6 +138,7 @@ const acp = Layer.succeed(
   ACPClient.Service.of({
     run: () => Effect.die("unexpected ACP client run in prompt tests"),
     cancel: () => Effect.void,
+    prepare: () => Effect.die("unexpected ACP prepare in prompt tests"),
     setConfigOption: () => Effect.die("unexpected ACP config option in prompt tests"),
   }),
 )

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -55,6 +55,7 @@ import { reply, TestLLMServer } from "../lib/llm-server"
 import { SyncEvent } from "@/sync"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { ACPClient } from "@/acp/client"
 
 void Log.init({ print: false })
 
@@ -132,6 +133,15 @@ const mcp = Layer.succeed(
   }),
 )
 
+const acp = Layer.succeed(
+  ACPClient.Service,
+  ACPClient.Service.of({
+    run: () => Effect.die("unexpected ACP client run in prompt tests"),
+    cancel: () => Effect.void,
+    setConfigOption: () => Effect.die("unexpected ACP config option in prompt tests"),
+  }),
+)
+
 const lsp = Layer.succeed(
   LSP.Service,
   LSP.Service.of({
@@ -178,6 +188,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     ProviderSvc.defaultLayer,
     lsp,
     mcp,
+    acp,
     AppFileSystem.defaultLayer,
     BackgroundJob.defaultLayer,
     status,

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -95,6 +95,7 @@ const acp = Layer.succeed(
   ACPClient.Service.of({
     run: () => Effect.die("unexpected ACP client run in snapshot race test"),
     cancel: () => Effect.void,
+    prepare: () => Effect.die("unexpected ACP prepare in snapshot race test"),
     setConfigOption: () => Effect.die("unexpected ACP config option in snapshot race test"),
   }),
 )

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -63,6 +63,7 @@ import { RepositoryCache } from "../../src/reference/repository-cache"
 import { SyncEvent } from "@/sync"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { ACPClient } from "@/acp/client"
 
 void Log.init({ print: false })
 
@@ -86,6 +87,15 @@ const mcp = Layer.succeed(
     supportsOAuth: () => Effect.succeed(false),
     hasStoredTokens: () => Effect.succeed(false),
     getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const acp = Layer.succeed(
+  ACPClient.Service,
+  ACPClient.Service.of({
+    run: () => Effect.die("unexpected ACP client run in snapshot race test"),
+    cancel: () => Effect.void,
+    setConfigOption: () => Effect.die("unexpected ACP config option in snapshot race test"),
   }),
 )
 
@@ -127,6 +137,7 @@ function makeHttp() {
     ProviderSvc.defaultLayer,
     lsp,
     mcp,
+    acp,
     AppFileSystem.defaultLayer,
     BackgroundJob.defaultLayer,
     status,

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -159,6 +159,8 @@ import type {
   QuestionReplyResponses,
   SessionAbortErrors,
   SessionAbortResponses,
+  SessionAcpConfigErrors,
+  SessionAcpConfigResponses,
   SessionChildrenErrors,
   SessionChildrenResponses,
   SessionCommandErrors,
@@ -3036,6 +3038,49 @@ export class Provider extends HeyApiClient {
   }
 }
 
+export class Acp extends HeyApiClient {
+  /**
+   * Set ACP session config option
+   *
+   * Set a configuration option on the ACP backend for this session.
+   */
+  public config<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      configID?: string
+      value?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "configID" },
+            { in: "body", key: "value" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionAcpConfigResponses, SessionAcpConfigErrors, ThrowOnError>({
+      url: "/session/{sessionID}/acp/config",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class Session2 extends HeyApiClient {
   /**
    * List sessions
@@ -3993,6 +4038,11 @@ export class Session2 extends HeyApiClient {
       ...options,
       ...params,
     })
+  }
+
+  private _acp?: Acp
+  get acp(): Acp {
+    return (this._acp ??= new Acp({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5,12 +5,6 @@ export type ClientOptions = {
 }
 
 export type Event =
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow1
-  | EventTuiSessionSelect
-  | EventServerConnected
-  | EventGlobalDisposed
   | EventServerInstanceDisposed
   | EventFileEdited
   | EventFileWatcherUpdated
@@ -27,11 +21,16 @@ export type Event =
   | EventTodoUpdated
   | EventSessionStatus
   | EventSessionIdle
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow1
+  | EventTuiSessionSelect
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventCommandExecuted
   | EventProjectUpdated
   | EventSessionCompacted
+  | EventAcpSessionUpdated
   | EventVcsBranchUpdated
   | EventWorkspaceReady
   | EventWorkspaceFailed
@@ -77,11 +76,13 @@ export type Event =
   | EventSessionNextCompactionStarted
   | EventSessionNextCompactionDelta
   | EventSessionNextCompactionEnded
-  | EventCatalogModelUpdated
+  | EventServerConnected
+  | EventGlobalDisposed
   | EventModelsDevRefreshed
   | EventAccountAdded
   | EventAccountRemoved
   | EventAccountSwitched
+  | EventCatalogModelUpdated
 
 export type OAuth = {
   type: "oauth"
@@ -117,61 +118,6 @@ export type InvalidRequestError = {
   message: string
   kind?: string
   field?: string
-}
-
-export type EventTuiPromptAppend = {
-  id: string
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  id: string
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.line.up"
-      | "session.line.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  id: string
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    duration?: number
-  }
-}
-
-export type EventTuiSessionSelect = {
-  id: string
-  type: "tui.session.select"
-  properties: {
-    /**
-     * Session ID to navigate to
-     */
-    sessionID: string
-  }
 }
 
 export type PermissionRequest = {
@@ -351,6 +297,61 @@ export type SessionStatus =
   | {
       type: "busy"
     }
+
+export type EventTuiPromptAppend = {
+  id: string
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  id: string
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.line.up"
+      | "session.line.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  id: string
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    duration?: number
+  }
+}
+
+export type EventTuiSessionSelect = {
+  id: string
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
+}
 
 export type Project = {
   id: string
@@ -806,12 +807,6 @@ export type GlobalEvent = {
   project?: string
   workspace?: string
   payload:
-    | EventTuiPromptAppend
-    | EventTuiCommandExecute
-    | EventTuiToastShow
-    | EventTuiSessionSelect
-    | EventServerConnected
-    | EventGlobalDisposed
     | EventServerInstanceDisposed
     | EventFileEdited
     | EventFileWatcherUpdated
@@ -828,11 +823,16 @@ export type GlobalEvent = {
     | EventTodoUpdated
     | EventSessionStatus
     | EventSessionIdle
+    | EventTuiPromptAppend
+    | EventTuiCommandExecute
+    | EventTuiToastShow
+    | EventTuiSessionSelect
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
     | EventCommandExecuted
     | EventProjectUpdated
     | EventSessionCompacted
+    | EventAcpSessionUpdated
     | EventVcsBranchUpdated
     | EventWorkspaceReady
     | EventWorkspaceFailed
@@ -878,11 +878,13 @@ export type GlobalEvent = {
     | EventSessionNextCompactionStarted
     | EventSessionNextCompactionDelta
     | EventSessionNextCompactionEnded
-    | EventCatalogModelUpdated
+    | EventServerConnected
+    | EventGlobalDisposed
     | EventModelsDevRefreshed
     | EventAccountAdded
     | EventAccountRemoved
     | EventAccountSwitched
+    | EventCatalogModelUpdated
     | SyncEventMessageUpdated
     | SyncEventMessageRemoved
     | SyncEventMessagePartUpdated
@@ -954,6 +956,14 @@ export type ReferenceConfig = {
   [key: string]: ReferenceConfigEntry
 }
 
+export type AgentBackendConfig = {
+  type: "acp"
+  /**
+   * Name of the configured ACP server to use for this agent
+   */
+  server: string
+}
+
 export type PermissionActionConfig = "ask" | "allow" | "deny"
 
 export type PermissionObjectConfig = {
@@ -987,6 +997,7 @@ export type PermissionConfig =
 
 export type AgentConfig = {
   model?: string
+  backend?: AgentBackendConfig
   variant?: string
   temperature?: number
   top_p?: number
@@ -1011,6 +1022,7 @@ export type AgentConfig = {
   [key: string]:
     | unknown
     | string
+    | AgentBackendConfig
     | number
     | {
         [key: string]: boolean
@@ -1114,6 +1126,22 @@ export type ProviderConfig = {
       }
     }
   }
+}
+
+export type AcpLocalConfig = {
+  /**
+   * Type of ACP server connection
+   */
+  type: "local"
+  /**
+   * Command and arguments to run the ACP server over stdio
+   */
+  command: Array<string>
+  environment?: {
+    [key: string]: string
+  }
+  enabled?: boolean
+  timeout?: number
 }
 
 export type McpLocalConfig = {
@@ -1238,6 +1266,13 @@ export type Config = {
   }
   provider?: {
     [key: string]: ProviderConfig
+  }
+  acp?: {
+    [key: string]:
+      | AcpLocalConfig
+      | {
+          enabled: boolean
+        }
   }
   mcp?: {
     [key: string]:
@@ -1640,6 +1675,7 @@ export type Agent = {
     modelID: string
     providerID: string
   }
+  backend?: AgentBackendConfig
   variant?: string
   prompt?: string
   options: {
@@ -2499,22 +2535,6 @@ export type SyncEventSessionNextCompactionEnded = {
   }
 }
 
-export type EventServerConnected = {
-  id: string
-  type: "server.connected"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
-export type EventGlobalDisposed = {
-  id: string
-  type: "global.disposed"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
 export type EventServerInstanceDisposed = {
   id: string
   type: "server.instance.disposed"
@@ -2693,6 +2713,20 @@ export type EventSessionCompacted = {
   type: "session.compacted"
   properties: {
     sessionID: string
+  }
+}
+
+export type EventAcpSessionUpdated = {
+  id: string
+  type: "acp.session.updated"
+  properties: {
+    sessionID: string
+    configOptions?: Array<unknown>
+    modes?: unknown
+    models?: unknown
+    availableCommands?: Array<unknown>
+    usage?: unknown
+    info?: unknown
   }
 }
 
@@ -3241,6 +3275,80 @@ export type EventSessionNextCompactionEnded = {
   }
 }
 
+export type EventServerConnected = {
+  id: string
+  type: "server.connected"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type EventGlobalDisposed = {
+  id: string
+  type: "global.disposed"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type EventModelsDevRefreshed = {
+  id: string
+  type: "models-dev.refreshed"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type AccountV2oAuthCredential = {
+  type: "oauth"
+  refresh: string
+  access: string
+  expires: number
+}
+
+export type AccountV2ApiKeyCredential = {
+  type: "api"
+  key: string
+  metadata?: {
+    [key: string]: string
+  }
+}
+
+export type AccountV2Credential = AccountV2oAuthCredential | AccountV2ApiKeyCredential
+
+export type AccountV2Info = {
+  id: string
+  serviceID: string
+  description: string
+  credential: AccountV2Credential
+}
+
+export type EventAccountAdded = {
+  id: string
+  type: "account.added"
+  properties: {
+    account: AccountV2Info
+  }
+}
+
+export type EventAccountRemoved = {
+  id: string
+  type: "account.removed"
+  properties: {
+    account: AccountV2Info
+  }
+}
+
+export type EventAccountSwitched = {
+  id: string
+  type: "account.switched"
+  properties: {
+    serviceID: string
+    from?: string
+    to?: string
+  }
+}
+
 export type ModelV2Info = {
   id: string
   apiID: string
@@ -3344,64 +3452,6 @@ export type EventCatalogModelUpdated = {
   type: "catalog.model.updated"
   properties: {
     model: ModelV2Info
-  }
-}
-
-export type EventModelsDevRefreshed = {
-  id: string
-  type: "models-dev.refreshed"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
-export type AccountV2oAuthCredential = {
-  type: "oauth"
-  refresh: string
-  access: string
-  expires: number
-}
-
-export type AccountV2ApiKeyCredential = {
-  type: "api"
-  key: string
-  metadata?: {
-    [key: string]: string
-  }
-}
-
-export type AccountV2Credential = AccountV2oAuthCredential | AccountV2ApiKeyCredential
-
-export type AccountV2Info = {
-  id: string
-  serviceID: string
-  description: string
-  credential: AccountV2Credential
-}
-
-export type EventAccountAdded = {
-  id: string
-  type: "account.added"
-  properties: {
-    account: AccountV2Info
-  }
-}
-
-export type EventAccountRemoved = {
-  id: string
-  type: "account.removed"
-  properties: {
-    account: AccountV2Info
-  }
-}
-
-export type EventAccountSwitched = {
-  id: string
-  type: "account.switched"
-  properties: {
-    serviceID: string
-    from?: string
-    to?: string
   }
 }
 
@@ -6496,6 +6546,41 @@ export type SessionMessageResponses = {
 }
 
 export type SessionMessageResponse = SessionMessageResponses[keyof SessionMessageResponses]
+
+export type SessionAcpConfigData = {
+  body?: {
+    configID: string
+    value: string
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/acp/config"
+}
+
+export type SessionAcpConfigErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionAcpConfigError = SessionAcpConfigErrors[keyof SessionAcpConfigErrors]
+
+export type SessionAcpConfigResponses = {
+  /**
+   * Updated ACP config options
+   */
+  200: unknown
+}
 
 export type SessionForkData = {
   body?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -6255,6 +6255,105 @@
         ]
       }
     },
+    "/session/{sessionID}/acp/config": {
+      "post": {
+        "tags": ["session"],
+        "operationId": "session.acp.config",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated ACP config options",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Updated ACP config options"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Set a configuration option on the ACP backend for this session.",
+        "summary": "Set ACP session config option",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "configID": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["configID", "value"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.acp.config({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/fork": {
       "post": {
         "tags": ["session"],
@@ -10468,24 +10567,6 @@
       "Event": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/Event.tui.prompt.append"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.command.execute"
-          },
-          {
-            "$ref": "#/components/schemas/EventTuiToastShow1"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.session.select"
-          },
-          {
-            "$ref": "#/components/schemas/EventServerConnected"
-          },
-          {
-            "$ref": "#/components/schemas/EventGlobalDisposed"
-          },
-          {
             "$ref": "#/components/schemas/EventServerInstanceDisposed"
           },
           {
@@ -10534,6 +10615,18 @@
             "$ref": "#/components/schemas/EventSessionIdle"
           },
           {
+            "$ref": "#/components/schemas/Event.tui.prompt.append"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.command.execute"
+          },
+          {
+            "$ref": "#/components/schemas/EventTuiToastShow1"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.session.select"
+          },
+          {
             "$ref": "#/components/schemas/EventMcpToolsChanged"
           },
           {
@@ -10547,6 +10640,9 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionCompacted"
+          },
+          {
+            "$ref": "#/components/schemas/EventAcpSessionUpdated"
           },
           {
             "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -10684,6 +10780,24 @@
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
           },
           {
+            "$ref": "#/components/schemas/EventServerConnected"
+          },
+          {
+            "$ref": "#/components/schemas/EventGlobalDisposed"
+          },
+          {
+            "$ref": "#/components/schemas/EventModels-devRefreshed"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountAdded"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountRemoved"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountSwitched"
+          },
+          {
             "$ref": "#/components/schemas/EventCatalogModelUpdated"
           },
           {
@@ -10763,18 +10877,6 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-          },
-          {
-            "$ref": "#/components/schemas/EventModels-devRefreshed"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountAdded"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountRemoved"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountSwitched"
           }
         ]
       },
@@ -10884,140 +10986,6 @@
           }
         },
         "required": ["_tag", "message"],
-        "additionalProperties": false
-      },
-      "Event.tui.prompt.append": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.prompt.append"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "text": {
-                "type": "string"
-              }
-            },
-            "required": ["text"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.command.execute": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.command.execute"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "command": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "enum": [
-                      "session.list",
-                      "session.new",
-                      "session.share",
-                      "session.interrupt",
-                      "session.compact",
-                      "session.page.up",
-                      "session.page.down",
-                      "session.line.up",
-                      "session.line.down",
-                      "session.half.page.up",
-                      "session.half.page.down",
-                      "session.first",
-                      "session.last",
-                      "prompt.clear",
-                      "prompt.submit",
-                      "agent.cycle"
-                    ]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "required": ["command"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.toast.show": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.toast.show"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              },
-              "variant": {
-                "type": "string",
-                "enum": ["info", "success", "warning", "error"]
-              },
-              "duration": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              }
-            },
-            "required": ["message", "variant"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.session.select": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.session.select"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses",
-                "description": "Session ID to navigate to"
-              }
-            },
-            "required": ["sessionID"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
       "PermissionRequest": {
@@ -11481,6 +11449,140 @@
             "additionalProperties": false
           }
         ]
+      },
+      "Event.tui.prompt.append": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.prompt.append"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              }
+            },
+            "required": ["text"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.command.execute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.command.execute"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "command": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "session.list",
+                      "session.new",
+                      "session.share",
+                      "session.interrupt",
+                      "session.compact",
+                      "session.page.up",
+                      "session.page.down",
+                      "session.line.up",
+                      "session.line.down",
+                      "session.half.page.up",
+                      "session.half.page.down",
+                      "session.first",
+                      "session.last",
+                      "prompt.clear",
+                      "prompt.submit",
+                      "agent.cycle"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.toast.show": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.toast.show"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "variant": {
+                "type": "string",
+                "enum": ["info", "success", "warning", "error"]
+              },
+              "duration": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["message", "variant"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.session.select": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.session.select"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses",
+                "description": "Session ID to navigate to"
+              }
+            },
+            "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
       },
       "Project": {
         "type": "object",
@@ -12894,24 +12996,6 @@
           "payload": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Event.tui.prompt.append"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.command.execute"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.toast.show"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.session.select"
-              },
-              {
-                "$ref": "#/components/schemas/EventServerConnected"
-              },
-              {
-                "$ref": "#/components/schemas/EventGlobalDisposed"
-              },
-              {
                 "$ref": "#/components/schemas/EventServerInstanceDisposed"
               },
               {
@@ -12960,6 +13044,18 @@
                 "$ref": "#/components/schemas/EventSessionIdle"
               },
               {
+                "$ref": "#/components/schemas/Event.tui.prompt.append"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.command.execute"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.toast.show"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.session.select"
+              },
+              {
                 "$ref": "#/components/schemas/EventMcpToolsChanged"
               },
               {
@@ -12973,6 +13069,9 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionCompacted"
+              },
+              {
+                "$ref": "#/components/schemas/EventAcpSessionUpdated"
               },
               {
                 "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -13110,6 +13209,24 @@
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
               },
               {
+                "$ref": "#/components/schemas/EventServerConnected"
+              },
+              {
+                "$ref": "#/components/schemas/EventGlobalDisposed"
+              },
+              {
+                "$ref": "#/components/schemas/EventModels-devRefreshed"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountAdded"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountRemoved"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountSwitched"
+              },
+              {
                 "$ref": "#/components/schemas/EventCatalogModelUpdated"
               },
               {
@@ -13189,18 +13306,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-              },
-              {
-                "$ref": "#/components/schemas/EventModels-devRefreshed"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountAdded"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountRemoved"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountSwitched"
               },
               {
                 "$ref": "#/components/schemas/SyncEventMessageUpdated"
@@ -13376,6 +13481,21 @@
           "$ref": "#/components/schemas/ReferenceConfigEntry"
         }
       },
+      "AgentBackendConfig": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["acp"]
+          },
+          "server": {
+            "type": "string",
+            "description": "Name of the configured ACP server to use for this agent"
+          }
+        },
+        "required": ["type", "server"],
+        "additionalProperties": false
+      },
       "PermissionActionConfig": {
         "type": "string",
         "enum": ["ask", "allow", "deny"]
@@ -13467,6 +13587,9 @@
         "properties": {
           "model": {
             "type": "string"
+          },
+          "backend": {
+            "$ref": "#/components/schemas/AgentBackendConfig"
           },
           "variant": {
             "type": "string"
@@ -13766,6 +13889,38 @@
             }
           }
         },
+        "additionalProperties": false
+      },
+      "AcpLocalConfig": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["local"],
+            "description": "Type of ACP server connection"
+          },
+          "command": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Command and arguments to run the ACP server over stdio"
+          },
+          "environment": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "timeout": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          }
+        },
+        "required": ["type", "command"],
         "additionalProperties": false
       },
       "McpLocalConfig": {
@@ -14091,6 +14246,26 @@
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ProviderConfig"
+            }
+          },
+          "acp": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/AcpLocalConfig"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["enabled"],
+                  "additionalProperties": false
+                }
+              ]
             }
           },
           "mcp": {
@@ -15285,6 +15460,9 @@
             },
             "required": ["modelID", "providerID"],
             "additionalProperties": false
+          },
+          "backend": {
+            "$ref": "#/components/schemas/AgentBackendConfig"
           },
           "variant": {
             "type": "string"
@@ -18099,42 +18277,6 @@
         "required": ["type", "name", "id", "seq", "aggregateID", "data"],
         "additionalProperties": false
       },
-      "EventServerConnected": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["server.connected"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventGlobalDisposed": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["global.disposed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
       "EventServerInstanceDisposed": {
         "type": "object",
         "properties": {
@@ -18680,6 +18822,41 @@
                 "type": "string",
                 "pattern": "^ses"
               }
+            },
+            "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventAcpSessionUpdated": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["acp.session.updated"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "configOptions": {
+                "type": "array"
+              },
+              "modes": {},
+              "models": {},
+              "availableCommands": {
+                "type": "array"
+              },
+              "usage": {},
+              "info": {}
             },
             "required": ["sessionID"],
             "additionalProperties": false
@@ -20338,6 +20515,208 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
+      "EventServerConnected": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["server.connected"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventGlobalDisposed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["global.disposed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventModels-devRefreshed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["models-dev.refreshed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "AccountV2OAuthCredential": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["oauth"]
+          },
+          "refresh": {
+            "type": "string"
+          },
+          "access": {
+            "type": "string"
+          },
+          "expires": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": ["type", "refresh", "access", "expires"],
+        "additionalProperties": false
+      },
+      "AccountV2ApiKeyCredential": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["api"]
+          },
+          "key": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["type", "key"],
+        "additionalProperties": false
+      },
+      "AccountV2Credential": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/AccountV2OAuthCredential"
+          },
+          {
+            "$ref": "#/components/schemas/AccountV2ApiKeyCredential"
+          }
+        ]
+      },
+      "AccountV2Info": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "serviceID": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "credential": {
+            "$ref": "#/components/schemas/AccountV2Credential"
+          }
+        },
+        "required": ["id", "serviceID", "description", "credential"],
+        "additionalProperties": false
+      },
+      "EventAccountAdded": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["account.added"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "account": {
+                "$ref": "#/components/schemas/AccountV2Info"
+              }
+            },
+            "required": ["account"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventAccountRemoved": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["account.removed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "account": {
+                "$ref": "#/components/schemas/AccountV2Info"
+              }
+            },
+            "required": ["account"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventAccountSwitched": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["account.switched"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "serviceID": {
+                "type": "string"
+              },
+              "from": {
+                "type": "string"
+              },
+              "to": {
+                "type": "string"
+              }
+            },
+            "required": ["serviceID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "ModelV2Info": {
         "type": "object",
         "properties": {
@@ -20680,172 +21059,6 @@
               }
             },
             "required": ["model"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventModels-devRefreshed": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["models-dev.refreshed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "AccountV2OAuthCredential": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["oauth"]
-          },
-          "refresh": {
-            "type": "string"
-          },
-          "access": {
-            "type": "string"
-          },
-          "expires": {
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "required": ["type", "refresh", "access", "expires"],
-        "additionalProperties": false
-      },
-      "AccountV2ApiKeyCredential": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["api"]
-          },
-          "key": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        },
-        "required": ["type", "key"],
-        "additionalProperties": false
-      },
-      "AccountV2Credential": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/AccountV2OAuthCredential"
-          },
-          {
-            "$ref": "#/components/schemas/AccountV2ApiKeyCredential"
-          }
-        ]
-      },
-      "AccountV2Info": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "serviceID": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "credential": {
-            "$ref": "#/components/schemas/AccountV2Credential"
-          }
-        },
-        "required": ["id", "serviceID", "description", "credential"],
-        "additionalProperties": false
-      },
-      "EventAccountAdded": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["account.added"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "account": {
-                "$ref": "#/components/schemas/AccountV2Info"
-              }
-            },
-            "required": ["account"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventAccountRemoved": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["account.removed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "account": {
-                "$ref": "#/components/schemas/AccountV2Info"
-              }
-            },
-            "required": ["account"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventAccountSwitched": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["account.switched"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "serviceID": {
-                "type": "string"
-              },
-              "from": {
-                "type": "string"
-              },
-              "to": {
-                "type": "string"
-              }
-            },
-            "required": ["serviceID"],
             "additionalProperties": false
           }
         },


### PR DESCRIPTION
### Issue for this PR

Closes #28991

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds ACP client-backed agents to opencode. This lets an agent config point at a local ACP server, then routes prompt turns through that server while storing the output in opencode sessions.

The implementation adds ACP server config, an agent `backend` field, an ACP client runtime, TUI state for ACP options/commands, snapshot/revert integration, and tests for streaming, multi-turn output, file writes, terminal commands, and fallback responses.

### How did you verify your code works?

- `bun run typecheck`
- `bun test test/acp test/config/config.test.ts test/session/prompt.test.ts test/session/snapshot-tool-race.test.ts`
- pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

I tested locally in the TUI with Cursor ACP. I can add screenshots if helpful.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR