### PR TITLE
fix(provider): strip Nvidia Kimi tool schemas

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1273,6 +1273,10 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
   }
   */
 
+  if (model.providerID === "nvidia" && model.api.id.toLowerCase().includes("kimi")) {
+    return { type: "object" }
+  }
+
   if (model.providerID === "moonshotai" || model.api.id.toLowerCase().includes("kimi")) {
     const sanitizeMoonshot = (obj: unknown): unknown => {
       if (obj === null || typeof obj !== "object") return obj

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1068,6 +1068,31 @@ describe("ProviderTransform.schema - moonshot $ref siblings", () => {
   })
 })
 
+describe("ProviderTransform.schema - Nvidia Kimi K2.6 tool parameters", () => {
+  const nvidiaKimiModel = {
+    providerID: "nvidia",
+    api: {
+      id: "moonshotai/kimi-k2.6",
+    },
+  } as any
+
+  test("strips nested tool parameter schemas that Nvidia NIM rejects", () => {
+    const result = ProviderTransform.schema(nvidiaKimiModel, {
+      type: "object",
+      properties: {
+        repo_path: {
+          type: "string",
+          description: "Path to repository",
+        },
+      },
+      required: ["repo_path"],
+      additionalProperties: false,
+    } as any)
+
+    expect(result).toEqual({ type: "object" })
+  })
+})
+
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   test("DeepSeek with tool calls includes reasoning_content in providerOptions", () => {
     const msgs = [


### PR DESCRIPTION
### Issue for this PR

Closes #26662

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Nvidia-hosted Kimi K2.6 rejects normal tool parameter schemas with an internal server error: unhashable type: dict.

This keeps the existing Moonshot/Kimi handling, and adds the same practical fallback for Nvidia Kimi: send a minimal object schema for tool parameters. That avoids the provider-side schema hashing crash while still allowing tools to be offered.

### How did you verify your code works?

From packages/opencode:

- bun test test/provider/transform.test.ts -t "Nvidia Kimi"
- bun typecheck

From the repo root:

- git diff --check

I also checked the related open PR #25492. That PR is about Moonshot schema depth, while this one is scoped to the Nvidia-hosted Kimi provider error.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
