### PR TITLE
fix(ui): keep permission dock buttons in view on long requests

### DIFF
--- a/packages/app/src/pages/session/composer/session-permission-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-permission-dock.tsx
@@ -1,8 +1,10 @@
-import { For, Show } from "solid-js"
+import { For, Show, onCleanup, onMount } from "solid-js"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2"
 import { Button } from "@opencode-ai/ui/button"
 import { DockPrompt } from "@opencode-ai/ui/dock-prompt"
 import { Icon } from "@opencode-ai/ui/icon"
+import { makeEventListener } from "@solid-primitives/event-listener"
+import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLanguage } from "@/context/language"
 
 export function SessionPermissionDock(props: {
@@ -19,9 +21,57 @@ export function SessionPermissionDock(props: {
     return value
   }
 
+  let root: HTMLDivElement | undefined
+
+  const measure = () => {
+    if (!root) return
+
+    const scroller = document.querySelector(".scroll-view__viewport")
+    const head = scroller instanceof HTMLElement ? scroller.firstElementChild : undefined
+    const top =
+      head instanceof HTMLElement && head.classList.contains("sticky") ? head.getBoundingClientRect().bottom : 0
+    if (!top) {
+      root.style.removeProperty("--permission-prompt-max-height")
+      return
+    }
+
+    const dock = root.closest('[data-component="session-prompt-dock"]')
+    if (!(dock instanceof HTMLElement)) return
+
+    const dockBottom = dock.getBoundingClientRect().bottom
+    const below = Math.max(0, dockBottom - root.getBoundingClientRect().bottom)
+    const gap = 8
+    const max = Math.max(240, Math.floor(dockBottom - top - gap - below))
+    root.style.setProperty("--permission-prompt-max-height", `${max}px`)
+  }
+
+  onMount(() => {
+    let raf: number | undefined
+    const update = () => {
+      if (raf !== undefined) cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        raf = undefined
+        measure()
+      })
+    }
+
+    update()
+
+    makeEventListener(window, "resize", update)
+
+    const dock = root?.closest('[data-component="session-prompt-dock"]')
+    const scroller = document.querySelector(".scroll-view__viewport")
+    createResizeObserver([dock, scroller], update)
+
+    onCleanup(() => {
+      if (raf !== undefined) cancelAnimationFrame(raf)
+    })
+  })
+
   return (
     <DockPrompt
       kind="permission"
+      ref={(el) => (root = el)}
       header={
         <div data-slot="permission-row" data-variant="header">
           <span data-slot="permission-icon">

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -720,7 +720,7 @@
   flex-direction: column;
   gap: 0;
   min-height: 0;
-  max-height: 100dvh;
+  max-height: var(--permission-prompt-max-height, 100dvh);
 
   [data-slot="permission-body"] {
     display: flex;
@@ -744,6 +744,17 @@
 
   [data-slot="permission-row"][data-variant="header"] {
     align-items: center;
+  }
+
+  [data-slot="permission-row"]:has(> [data-slot="permission-patterns"]) {
+    flex: 1;
+    min-height: 0;
+    grid-template-rows: minmax(0, 1fr);
+    align-items: stretch;
+  }
+
+  [data-slot="permission-row"]:has(> [data-slot="permission-patterns"]) [data-slot="permission-spacer"] {
+    align-self: start;
   }
 
   [data-slot="permission-icon"] {
@@ -792,6 +803,11 @@
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    overscroll-behavior: contain;
+    mask: linear-gradient(to bottom, #ffff calc(100% - var(--bottom-fade)), #0000);
+    animation: scroll;
+    animation-timeline: --scroll;
+    scroll-timeline: --scroll y;
     scrollbar-width: none;
     -ms-overflow-style: none;
 


### PR DESCRIPTION
### Issue for this PR

Closes #28979

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A long `permission.patterns` could push the permission dock past its slot under the session header. The page's `overflow: hidden` then clipped the action buttons off-screen.

The fix:

1. **`max-height: min(40dvh, calc(100dvh - var(--sticky-accordion-top, 0px)))`** — caps the dock height to ~40% of the viewport while reserving the inherited sticky-header offset (`--sticky-accordion-top` is already set inline on the scroll container in `message-timeline.tsx` when the session title is shown).
2. **`:has(> permission-patterns) { flex: 1; min-height: 0; grid-template-rows: minmax(0, 1fr); align-items: stretch }`** — the load-bearing scroll fix. The intermediate `permission-row` (a grid) was missing `min-height: 0`, so it grew to fit its children and `overflow-y: auto` on `permission-patterns` never engaged. Forcing the grid track to `minmax(0, 1fr)` finally constrains the child.
3. **`overscroll-behavior: contain` + bottom-only `mask-image`** — scroll doesn't bubble to the page, and a 24px fade at the bottom edge signals more content below.

### How did you verify your code works?

Reproduced the bug with a Playwright fixture that injects a `PermissionV1.Request` with 40 long `bash` patterns into a mock-server-backed session (uses the `mockOpenCodeServer` pattern from `packages/app/e2e/utils/mock-server.ts`). See the verification script in the comment below.

### Screenshots / recordings

The content body is scrollable.

<img width="100%" alt="PixPin_2026-06-23_20-28-01" src="https://github.com/user-attachments/assets/2e03582d-da6b-4de5-a919-8423d606fd6d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
