### PR TITLE
fix(opencode): add F# code fence alias

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -310,6 +310,7 @@ export default {
     },
     {
       filetype: "fsharp",
+      aliases: ["f#"],
       wasm: "https://github.com/ionide/tree-sitter-fsharp/releases/download/0.3.0/tree-sitter-fsharp.wasm",
       queries: {
         highlights: [


### PR DESCRIPTION
### Issue for this PR

Closes #28965

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

F# syntax highlighting already had a parser and WASM configured, but Markdown code blocks labelled `F#`/`f#` did not resolve to the existing `fsharp` parser. This adds `f#` as an alias on the existing F# parser config so OpenTUI can resolve the Markdown fence label to `fsharp` and use the existing parser.

### How did you verify your code works?

Ran the test suite and a local build to confirm `F#` Markdown code-fence highlighting works (see screenshots).

### Screenshots / recordings

Before:

<img width="254" height="453" alt="F# Markdown fence before fix" src="https://github.com/user-attachments/assets/43d6970d-8170-4752-ba27-ebbde4f0593b" />

After:

<img width="756" height="375" alt="F# Markdown fence after fix" src="https://github.com/user-attachments/assets/d87350b0-feaa-46ee-aac8-3d3b1384b122" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
