### PR TITLE
feat(tool): add experimental rlm_repl tool

### DIFF
--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -48,6 +48,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   experimentalEventSystem: enabledByExperimental("OPENCODE_EXPERIMENTAL_EVENT_SYSTEM"),
   experimentalWorkspaces: enabledByExperimental("OPENCODE_EXPERIMENTAL_WORKSPACES"),
   experimentalIconDiscovery: enabledByExperimental("OPENCODE_EXPERIMENTAL_ICON_DISCOVERY"),
+  experimentalRlmRepl: enabledByExperimental("OPENCODE_EXPERIMENTAL_RLM_REPL"),
   outputTokenMax: positiveInteger("OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX"),
   bashDefaultTimeoutMs: positiveInteger("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS"),
   experimentalNativeLlm: enabledByExperimental("OPENCODE_EXPERIMENTAL_NATIVE_LLM"),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -55,6 +55,7 @@ import { Reference } from "@/reference/reference"
 import { BackgroundJob } from "@/background/job"
 import { SessionStatus } from "@/session/status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { RLMReplTool } from "./rlm-repl"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -136,6 +137,7 @@ export const layer: Layer.Layer<
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const rlmRepl = yield* RLMReplTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -246,6 +248,7 @@ export const layer: Layer.Layer<
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          rlm_repl: Tool.init(rlmRepl),
         })
 
         return {
@@ -269,6 +272,7 @@ export const layer: Layer.Layer<
             tool.patch,
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),
+            ...(flags.experimentalRlmRepl ? [tool.rlm_repl] : []),
           ],
           task: tool.task,
           read: tool.read,

--- a/packages/opencode/src/tool/rlm-repl.ts
+++ b/packages/opencode/src/tool/rlm-repl.ts
@@ -1,0 +1,271 @@
+import vm from "node:vm"
+import { Cause, Effect, Exit, Schema } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
+import * as Tool from "./tool"
+import { Agent } from "@/agent/agent"
+import { Session } from "@/session/session"
+import { MessageID } from "@/session/schema"
+import { MessageV2 } from "@/session/message-v2"
+import { EffectBridge } from "@/effect/bridge"
+import type { TaskPromptOps } from "./task"
+
+const log = Log.create({ service: "rlm-repl" })
+
+const DESCRIPTION = `Execute JavaScript code with access to sub-LLM calls for recursive processing.
+
+This experimental tool enables the Recursive Language Model (RLM) pattern: writing code that
+programmatically invokes sub-LLM calls in loops rather than requiring explicit tool calls for each invocation.
+
+Available functions:
+- sub_llm(prompt, agent?) - invoke a sub-LLM call and return its text result
+- sub_llm_parallel(prompts[], agent?) - invoke multiple sub-LLM calls in parallel
+- context.store(key, data) - store data outside the visible LLM context
+- context.load(key) - load stored data by key
+- context.chunk(key, chunkSize) - split stored data into chunks and return chunk keys
+- context.keys() - list stored keys
+
+Security and resource limits:
+- Code runs in a vm context with dynamic code generation disabled
+- Maximum 50 sub_llm calls per execution
+- 5 minute wall-clock timeout on total execution
+- Context store is limited to 10MB total
+- Sub-agent sessions cannot use task, rlm_repl, todowrite, or todoread
+`
+
+const Parameters = Schema.Struct({
+  code: Schema.String.annotate({ description: "JavaScript code to execute. Use a return statement for output." }),
+  agent: Schema.optional(Schema.String).annotate({
+    description: "Default agent for sub_llm calls. Defaults to build.",
+  }),
+})
+
+type Metadata = {
+  subLLMCalls: number
+  executionTimeMs: number
+  contextKeys: string[]
+  error?: string
+}
+
+class RLMContext {
+  private readonly values = new Map<string, string>()
+  private totalSize = 0
+  private readonly maxSize = 10 * 1024 * 1024
+
+  store(key: string, data: unknown) {
+    const text = typeof data === "string" ? data : JSON.stringify(data)
+    if (this.values.has(key)) this.totalSize -= this.values.get(key)?.length ?? 0
+    if (this.totalSize + text.length > this.maxSize) {
+      throw new Error(`Context store limit exceeded (max ${this.maxSize / 1024 / 1024}MB)`)
+    }
+    this.values.set(key, text)
+    this.totalSize += text.length
+    return key
+  }
+
+  load(key: string) {
+    return this.values.get(key)
+  }
+
+  chunk(key: string, chunkSize: number) {
+    if (!Number.isInteger(chunkSize) || chunkSize <= 0) throw new Error("chunkSize must be a positive integer")
+    const data = this.values.get(key)
+    if (data === undefined) throw new Error(`Key not found: ${key}`)
+    const keys: string[] = []
+    for (let index = 0; index < data.length; index += chunkSize) {
+      const chunkKey = `${key}_chunk_${keys.length}`
+      this.store(chunkKey, data.slice(index, index + chunkSize))
+      keys.push(chunkKey)
+    }
+    return keys
+  }
+
+  keys() {
+    return Array.from(this.values.keys())
+  }
+}
+
+function textOutput(value: unknown) {
+  if (typeof value === "string") return value
+  if (value === undefined) return "(no return value)"
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function timeoutPromise<T>(input: { promise: Promise<T>; timeoutMs: number; signal: AbortSignal }) {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("Execution timeout exceeded (5 minutes)")), input.timeoutMs)
+  })
+  const abort = new Promise<never>((_, reject) => {
+    if (input.signal.aborted) reject(new Error("Execution aborted"))
+    input.signal.addEventListener("abort", () => reject(new Error("Execution aborted")), { once: true })
+  })
+  return Promise.race([input.promise, timeout, abort]).finally(() => {
+    if (timer) clearTimeout(timer)
+  })
+}
+
+export const RLMReplTool = Tool.define(
+  "rlm_repl",
+  Effect.gen(function* () {
+    const agents = yield* Agent.Service
+    const sessions = yield* Session.Service
+    const bridge = yield* EffectBridge.make()
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: typeof Parameters.Type, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const defaultAgent = params.agent ?? "build"
+          const rlmContext = new RLMContext()
+          const start = Date.now()
+          const maxExecutionTime = 5 * 60 * 1000
+          const maxSubLLMCalls = 50
+          let subLLMCalls = 0
+
+          const metadata = (error?: string): Metadata => ({
+            ...(error ? { error } : {}),
+            subLLMCalls,
+            executionTimeMs: Date.now() - start,
+            contextKeys: rlmContext.keys(),
+          })
+
+          const checkTimeout = () => {
+            if (Date.now() - start > maxExecutionTime) throw new Error("Execution timeout exceeded (5 minutes)")
+          }
+
+          const subLLM = async (prompt: string, agent?: string): Promise<string> => {
+            checkTimeout()
+            subLLMCalls++
+            if (subLLMCalls > maxSubLLMCalls) throw new Error(`Maximum sub_llm calls exceeded (${maxSubLLMCalls})`)
+            const agentName = agent ?? defaultAgent
+            const info = await bridge.promise(agents.get(agentName))
+            if (!info) throw new Error(`Unknown agent: ${agentName}`)
+            const ops = ctx.extra?.promptOps as TaskPromptOps | undefined
+            if (!ops) throw new Error("rlm_repl requires promptOps in tool context for sub_llm calls")
+
+            log.info("sub_llm call", { callNumber: subLLMCalls, agent: agentName, promptLength: prompt.length })
+            const child = await bridge.promise(
+              sessions.create({
+                parentID: ctx.sessionID,
+                title: `RLM sub-call #${subLLMCalls}`,
+                agent: agentName,
+                permission: [
+                  { permission: "task", pattern: "*", action: "deny" as const },
+                  { permission: "rlm_repl", pattern: "*", action: "deny" as const },
+                  { permission: "todowrite", pattern: "*", action: "deny" as const },
+                  { permission: "todoread", pattern: "*", action: "deny" as const },
+                ],
+              }),
+            )
+            const result = await bridge.promise(
+              ops.prompt({
+                messageID: MessageID.ascending(),
+                sessionID: child.id,
+                agent: agentName,
+                parts: [{ type: "text", text: prompt }],
+              }),
+            )
+            return result.parts.findLast((part): part is MessageV2.TextPart => part.type === "text")?.text ?? ""
+          }
+
+          const subLLMParallel = async (prompts: string[], agent?: string): Promise<string[]> => {
+            checkTimeout()
+            if (subLLMCalls + prompts.length > maxSubLLMCalls) {
+              throw new Error(
+                `Would exceed maximum sub_llm calls (${maxSubLLMCalls}). Current: ${subLLMCalls}, Requested: ${prompts.length}`,
+              )
+            }
+            return Promise.all(prompts.map((prompt) => subLLM(prompt, agent)))
+          }
+
+          const sandbox = {
+            sub_llm: subLLM,
+            sub_llm_parallel: subLLMParallel,
+            context: {
+              store: (key: string, data: unknown) => rlmContext.store(key, data),
+              load: (key: string) => rlmContext.load(key),
+              chunk: (key: string, chunkSize: number) => rlmContext.chunk(key, chunkSize),
+              keys: () => rlmContext.keys(),
+            },
+            console: {
+              log: (...args: unknown[]) => log.info("rlm_repl console.log", { args }),
+              error: (...args: unknown[]) => log.error("rlm_repl console.error", { args }),
+              warn: (...args: unknown[]) => log.info("rlm_repl console.warn", { args }),
+            },
+            JSON,
+            Array,
+            Object,
+            String,
+            Number,
+            Boolean,
+            Date,
+            Math,
+            Promise,
+            Map,
+            Set,
+            RegExp,
+            Error,
+            parseInt,
+            parseFloat,
+            isNaN,
+            isFinite,
+            encodeURIComponent,
+            decodeURIComponent,
+            setTimeout: undefined,
+            setInterval: undefined,
+            fetch: undefined,
+            require: undefined,
+            eval: undefined,
+            Function: undefined,
+            process: undefined,
+          }
+
+          try {
+            const context = vm.createContext(sandbox, { codeGeneration: { strings: false, wasm: false } })
+            const wrapped = `"use strict"; (async () => {\n${params.code}\n})()`
+            const evaluated = vm.runInContext(wrapped, context, { timeout: 1_000 }) as unknown
+            const exit = yield* Effect.exit(
+              Effect.tryPromise({
+                try: () =>
+                  timeoutPromise({
+                    promise: Promise.resolve(evaluated),
+                    timeoutMs: maxExecutionTime,
+                    signal: ctx.abort,
+                  }),
+                catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+              }),
+            )
+            if (Exit.isFailure(exit)) throw Cause.squash(exit.cause)
+            const result = exit.value
+            const output = textOutput(result)
+            return {
+              title: `RLM execution (${subLLMCalls} sub-calls)`,
+              metadata: metadata(),
+              output: [
+                output,
+                "",
+                "<rlm_metadata>",
+                `sub_llm_calls: ${subLLMCalls}`,
+                `execution_time_ms: ${Date.now() - start}`,
+                `context_keys: ${rlmContext.keys().length}`,
+                "</rlm_metadata>",
+              ].join("\n"),
+            }
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            log.error("rlm_repl execution failed", { error: message })
+            return {
+              title: "RLM execution failed",
+              metadata: metadata(message),
+              output: `Error: ${message}\n\nSub-LLM calls made before error: ${subLLMCalls}`,
+            }
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -63,6 +63,7 @@ describe("RuntimeFlags", () => {
       expect(flags.experimentalWorkspaces).toBe(true)
       expect(flags.experimentalIconDiscovery).toBe(true)
       expect(flags.experimentalNativeLlm).toBe(true)
+      expect(flags.experimentalRlmRepl).toBe(true)
       expect(flags.client).toBe("desktop")
     }),
   )
@@ -91,6 +92,16 @@ describe("RuntimeFlags", () => {
     }),
   )
 
+  it.effect("enables RLM REPL via dedicated or umbrella flag", () =>
+    Effect.gen(function* () {
+      const explicit = yield* readFlags.pipe(Effect.provide(fromConfig({ OPENCODE_EXPERIMENTAL_RLM_REPL: "true" })))
+      const umbrella = yield* readFlags.pipe(Effect.provide(fromConfig({ OPENCODE_EXPERIMENTAL: "true" })))
+
+      expect(explicit.experimentalRlmRepl).toBe(true)
+      expect(umbrella.experimentalRlmRepl).toBe(true)
+    }),
+  )
+
   it.effect("layer accepts partial test overrides and fills defaults from Config definitions", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(
@@ -110,6 +121,7 @@ describe("RuntimeFlags", () => {
       expect(flags.enableExa).toBe(false)
       expect(flags.experimentalIconDiscovery).toBe(false)
       expect(flags.experimentalOxfmt).toBe(false)
+      expect(flags.experimentalRlmRepl).toBe(false)
       expect(flags.outputTokenMax).toBeUndefined()
       expect(flags.bashDefaultTimeoutMs).toBe(1_000)
       expect(flags.enableExperimentalModels).toBe(false)

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -102,6 +102,9 @@ const scout = testEffect(
 const background = testEffect(
   Layer.mergeAll(registryLayer({ flags: { experimentalBackgroundSubagents: true } }), node, Agent.defaultLayer),
 )
+const rlm = testEffect(
+  Layer.mergeAll(registryLayer({ flags: { experimentalRlmRepl: true } }), node, Agent.defaultLayer),
+)
 const withBrokenPlugin = testEffect(
   Layer.mergeAll(registryLayer({ plugin: brokenPluginLayer }), node, Agent.defaultLayer),
 )
@@ -163,6 +166,24 @@ describe("tool.registry", () => {
       const ids = yield* registry.ids()
 
       expect(ids).toContain("task_status")
+    }),
+  )
+
+  it.instance("hides rlm_repl unless experimental RLM REPL is enabled", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const ids = yield* registry.ids()
+
+      expect(ids).not.toContain("rlm_repl")
+    }),
+  )
+
+  rlm.instance("shows rlm_repl when experimental RLM REPL is enabled", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const ids = yield* registry.ids()
+
+      expect(ids).toContain("rlm_repl")
     }),
   )
 

--- a/packages/opencode/test/tool/rlm-repl.test.ts
+++ b/packages/opencode/test/tool/rlm-repl.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Agent } from "@/agent/agent"
+import { Session } from "@/session/session"
+import { RLMReplTool } from "@/tool/rlm-repl"
+import { Tool } from "@/tool/tool"
+import { MessageID, SessionID } from "@/session/schema"
+import * as Truncate from "@/tool/truncate"
+import { testEffect } from "../lib/effect"
+
+const layer = Layer.mergeAll(Truncate.defaultLayer, Agent.defaultLayer, Layer.mock(Session.Service)({}))
+
+const it = testEffect(layer)
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  agent: "build",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+} satisfies Tool.Context
+
+const runRlm = (code: string, agent?: string) =>
+  Effect.gen(function* () {
+    const info = yield* RLMReplTool
+    const tool = yield* Tool.init(info)
+    return yield* tool.execute({ code, agent }, ctx)
+  })
+
+describe("RLMReplTool", () => {
+  it.instance("executes JavaScript and returns metadata", () =>
+    Effect.gen(function* () {
+      const result = yield* runRlm("return ['alpha', 'beta'].join('-')")
+
+      expect(result.title).toBe("RLM execution (0 sub-calls)")
+      expect(result.output).toContain("alpha-beta")
+      expect(result.output).toContain("<rlm_metadata>")
+      expect(result.metadata.subLLMCalls).toBe(0)
+      expect(result.metadata.contextKeys).toEqual([])
+    }),
+  )
+
+  it.instance("stores, loads, and chunks context by pointer", () =>
+    Effect.gen(function* () {
+      const result = yield* runRlm(
+        [
+          'context.store("input", "abcdef")',
+          'const chunks = context.chunk("input", 2)',
+          "return chunks.map((key) => context.load(key)).join('|')",
+        ].join("\n"),
+      )
+
+      expect(result.output).toContain("ab|cd|ef")
+      expect(result.metadata.contextKeys).toEqual(["input", "input_chunk_0", "input_chunk_1", "input_chunk_2"])
+    }),
+  )
+
+  it.instance("blocks constructor-chain sandbox escape attempts", () =>
+    Effect.gen(function* () {
+      const result = yield* runRlm(
+        [
+          "try {",
+          "  return [].constructor.constructor('return process')().versions.node",
+          "} catch (_error) {",
+          "  return 'blocked'",
+          "}",
+        ].join("\n"),
+      )
+
+      expect(result.output).toContain("blocked")
+      expect(result.output).not.toContain(process.versions.node)
+    }),
+  )
+
+  it.instance("enforces context store size limit", () =>
+    Effect.gen(function* () {
+      const result = yield* runRlm('context.store("big", "x".repeat(10 * 1024 * 1024 + 1)); return "unreachable"')
+
+      expect(result.title).toBe("RLM execution failed")
+      expect(result.metadata.error).toContain("Context store limit exceeded")
+      expect(result.output).toContain("Sub-LLM calls made before error: 0")
+    }),
+  )
+
+  it.instance("rejects sub-LLM calls beyond the execution limit before spawning sessions", () =>
+    Effect.gen(function* () {
+      const result = yield* runRlm("return await sub_llm_parallel(Array.from({ length: 51 }, () => 'work'))")
+
+      expect(result.title).toBe("RLM execution failed")
+      expect(result.metadata.error).toContain("Would exceed maximum sub_llm calls")
+      expect(result.metadata.subLLMCalls).toBe(0)
+    }),
+  )
+
+  it.instance("reports unknown sub-LLM agents without spawning a prompt", () =>
+    Effect.gen(function* () {
+      const result = yield* runRlm("return await sub_llm('work', 'missing-agent')")
+
+      expect(result.title).toBe("RLM execution failed")
+      expect(result.metadata.error).toContain("Unknown agent: missing-agent")
+      expect(result.metadata.subLLMCalls).toBe(1)
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Related: #8555

This is a fresh port of the closed `rlm_repl` PR onto current `dev`.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an experimental `rlm_repl` tool for VM-backed JavaScript execution during tool calls. It includes pointer-based context storage, `sub_llm` / `sub_llm_parallel` helpers, sandbox guardrails, and resource limits.

The tool is opt-in only via `OPENCODE_EXPERIMENTAL_RLM_REPL` / `experimentalRlmRepl`, and registration is gated in the current Effect-based tool registry. This intentionally ports the idea from #8555 instead of rebasing it because the old flag module and registry wiring changed upstream.

Thanks @androolloyd, @mwalol, and @cloudpresser for the original direction and discussion.

### How did you verify your code works?

- `bun test test/effect/runtime-flags.test.ts test/tool/registry.test.ts test/tool/rlm-repl.test.ts` — 60 pass
- `bun run typecheck` — pass
- `bunx prettier --check packages/opencode/src/tool/rlm-repl.ts packages/opencode/src/tool/registry.ts packages/opencode/src/effect/runtime-flags.ts packages/opencode/test/tool/rlm-repl.test.ts packages/opencode/test/tool/registry.test.ts packages/opencode/test/effect/runtime-flags.test.ts` — pass
- `bun run build` — pass
- Full test suite earlier in this branch: 2906 pass, 0 fail
- Pre-push hook reran `bun turbo typecheck` successfully

### Screenshots / recordings

Not applicable; this is a non-UI tool/runtime change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR