### PR TITLE
fix(session): use parent link for loop exit

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1268,7 +1268,7 @@ export const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastAssistant.parentID === lastUser.id
           ) {
             yield* slog.info("exiting loop")
             break


### PR DESCRIPTION
## Summary

- Use the assistant message parent link to determine whether the latest assistant response belongs to the latest user message.
- Avoid relying on lexicographic/time-sortable message ID ordering for the session loop exit condition.

## Motivation

The current loop exit guard compares message IDs:

```ts
lastUser.id < lastAssistant.id
```

That can be fragile when user and assistant messages are created in different contexts or clocks, and can prevent the prompt loop from exiting even after a final assistant response.

Assistant messages are created with:

```ts
parentID: lastUser.id
```

So checking that relationship is the direct condition.

This is related to reports of repeated `session.prompt step=N loop` after tool/assistant completion.

## Validation

- Built a local single-platform binary with this patch:
  `bun run build -- --single --skip-install --skip-embed-web-ui`
- Build smoke test passed: `opencode --version`
- `bun turbo typecheck` passed during branch push hook
- Local patched session exited to idle after previously looping: observed `session.prompt ... exiting loop` and `session.idle publishing`
