### PR TITLE
fix(session): use parent link for prompt loop exit

### DIFF
--- a/packages/opencode/src/session/prompt-loop.ts
+++ b/packages/opencode/src/session/prompt-loop.ts
@@ -1,0 +1,18 @@
+type AssistantLoopState = {
+  readonly id?: string
+  readonly finish?: string
+  readonly parentID?: string
+}
+
+export function shouldExitPromptLoop(input: {
+  readonly lastAssistant?: AssistantLoopState
+  readonly lastUserID: string
+  readonly hasToolCalls: boolean
+}) {
+  return (
+    input.lastAssistant?.finish !== undefined &&
+    !["tool-calls"].includes(input.lastAssistant.finish) &&
+    !input.hasToolCalls &&
+    input.lastAssistant.parentID === input.lastUserID
+  )
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -61,6 +61,7 @@ import { referencePromptMetadata, referenceTextPart } from "./prompt/reference"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { shouldExitPromptLoop } from "./prompt-loop"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1264,12 +1265,7 @@ export const layer = Layer.effect(
           const hasToolCalls =
             lastAssistantMsg?.parts.some((part) => part.type === "tool" && !part.metadata?.providerExecuted) ?? false
 
-          if (
-            lastAssistant?.finish &&
-            !["tool-calls"].includes(lastAssistant.finish) &&
-            !hasToolCalls &&
-            lastUser.id < lastAssistant.id
-          ) {
+          if (shouldExitPromptLoop({ lastAssistant, lastUserID: lastUser.id, hasToolCalls })) {
             yield* slog.info("exiting loop")
             break
           }

--- a/packages/opencode/test/session/prompt-loop.test.ts
+++ b/packages/opencode/test/session/prompt-loop.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import { shouldExitPromptLoop } from "../../src/session/prompt-loop"
+
+test("exits when the latest assistant finished as a reply to the latest user", () => {
+  expect(
+    shouldExitPromptLoop({
+      lastUserID: "msg_200",
+      lastAssistant: {
+        id: "msg_199",
+        parentID: "msg_200",
+        finish: "stop",
+      },
+      hasToolCalls: false,
+    }),
+  ).toBe(true)
+})
+
+test("does not exit when the latest assistant belongs to an older user message", () => {
+  expect(
+    shouldExitPromptLoop({
+      lastUserID: "msg_300",
+      lastAssistant: {
+        id: "msg_400",
+        parentID: "msg_200",
+        finish: "stop",
+      },
+      hasToolCalls: false,
+    }),
+  ).toBe(false)
+})
+
+test("does not exit when the assistant requested tool calls", () => {
+  expect(
+    shouldExitPromptLoop({
+      lastUserID: "msg_200",
+      lastAssistant: {
+        id: "msg_300",
+        parentID: "msg_200",
+        finish: "tool-calls",
+      },
+      hasToolCalls: false,
+    }),
+  ).toBe(false)
+})
+
+test("does not exit while non-provider-executed tool calls remain", () => {
+  expect(
+    shouldExitPromptLoop({
+      lastUserID: "msg_200",
+      lastAssistant: {
+        id: "msg_300",
+        parentID: "msg_200",
+        finish: "stop",
+      },
+      hasToolCalls: true,
+    }),
+  ).toBe(false)
+})
+
+test("does not exit before an assistant finish reason exists", () => {
+  expect(
+    shouldExitPromptLoop({
+      lastUserID: "msg_200",
+      lastAssistant: {
+        id: "msg_300",
+        parentID: "msg_200",
+      },
+      hasToolCalls: false,
+    }),
+  ).toBe(false)
+})
+
+test("does not exit when no assistant message exists yet", () => {
+  expect(
+    shouldExitPromptLoop({
+      lastUserID: "msg_200",
+      hasToolCalls: false,
+    }),
+  ).toBe(false)
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #26220

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The prompt loop exit check used `lastUser.id < lastAssistant.id` to decide whether the latest assistant response belonged to the latest user turn. That relies on message ID ordering.

This changes the check to use the actual message relationship instead:

```ts
lastAssistant.parentID === lastUser.id
```

Assistant messages already record the user message they reply to, so this is a more direct way to decide whether the loop can exit.

I also extracted the predicate into `shouldExitPromptLoop()` so the edge cases can be tested directly.

Prior related attempts include #21365, #24379, #24544, and #28637. This PR is closest to #21365: it keeps the `parentID` approach, but rebases it onto current `dev` where `prompt-effect.test.ts` no longer exists, and adds focused tests against the current code.

### How did you verify your code works?

- `bun test test/session/prompt-loop.test.ts`
  - 6 pass, 0 fail
- `bun run typecheck`
  - passed
- `PATH=/usr/bin:/bin bun test test/tool/write.test.ts --timeout 15000 -t "restores BOM after formatter strips it"`
  - 1 pass, 0 fail
- `git push git@github.com:BestSithInEU/opencode.git fix/session-prompt-loop-parent`
  - pre-push `bun turbo typecheck`: 15 successful, 15 total

I also attempted the full `bun test --timeout 30000`, but it did not complete in this environment because the unrelated write formatter test hung when `node` resolved through the local mise shim. Bypassing the shim made that isolated test pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
