### PR TITLE
fix: use local time instead of UTC in session title and logs

### DIFF
--- a/packages/core/src/util/log.ts
+++ b/packages/core/src/util/log.ts
@@ -19,6 +19,11 @@ const levelPriority: Record<Level, number> = {
   WARN: 2,
   ERROR: 3,
 }
+function localISOString(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+}
+
 const keep = 10
 const initializedRunID = "OPENCODE_LOG_INITIALIZED_RUN_ID"
 
@@ -69,7 +74,7 @@ export async function init(options: Options) {
   if (options.print) return
   logpath = path.join(
     Global.Path.log,
-    options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
+    options.dev ? "dev.log" : localISOString(new Date()).replace(/:/g, "") + ".log",
   )
   const runID = process.env.OPENCODE_RUN_ID
   const shouldTruncate = !options.dev || !runID || process.env[initializedRunID] !== runID
@@ -137,7 +142,7 @@ export function create(tags?: Record<string, any>) {
     const next = new Date()
     const diff = next.getTime() - last
     last = next.getTime()
-    return [next.toISOString().split(".")[0], "+" + diff + "ms", prefix, message].filter(Boolean).join(" ") + "\n"
+    return [localISOString(next), "+" + diff + "ms", prefix, message].filter(Boolean).join(" ") + "\n"
   }
   const result: Logger = {
     debug(message?: any, extra?: Record<string, any>) {

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -46,13 +46,18 @@ const log = Log.create({ service: "session" })
 const parentTitlePrefix = "New session - "
 const childTitlePrefix = "Child session - "
 
+function localTimestamp(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${date.getMilliseconds().toString().padStart(3, '0')}`
+}
+
 function createDefaultTitle(isChild = false) {
-  return (isChild ? childTitlePrefix : parentTitlePrefix) + new Date().toISOString()
+  return (isChild ? childTitlePrefix : parentTitlePrefix) + localTimestamp(new Date())
 }
 
 export function isDefaultTitle(title: string) {
   return new RegExp(
-    `^(${parentTitlePrefix}|${childTitlePrefix})\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$`,
+    `^(${parentTitlePrefix}|${childTitlePrefix})\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}$`,
   ).test(title)
 }
 


### PR DESCRIPTION
## Summary

Replaces \	oISOString()\ (always UTC) with local time formatters in:

- **Session title** (\packages/opencode/src/session/session.ts\): \createDefaultTitle()\ and \isDefaultTitle()\ regex no longer expect \Z\ suffix
- **Log filename** (\packages/core/src/util/log.ts\): file naming uses local time
- **Log entry timestamp** (\packages/core/src/util/log.ts\): each log line uses local time

Fixes #21330, #22781

## Changes

### \packages/opencode/src/session/session.ts\
- Added \localTimestamp()\ helper using \getFullYear()/getMonth()/...\
- Updated regex to match new format (no \.000Z\ suffix)

### \packages/core/src/util/log.ts\
- Added \localISOString()\ helper
- Log filename uses local time instead of UTC
- Log entry timestamps use local time instead of UTC