### PR TITLE
fix(tui): prevent scroll snap when reading history during LLM response

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -225,6 +225,7 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const [userScrolledUp, setUserScrolledUp] = createSignal(false)
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -270,7 +271,10 @@ export function Session() {
       }
       editor.reconnect(result.data.directory)
       await sync.session.sync(sessionID)
-      if (route.sessionID === sessionID && scroll) scroll.scrollBy(100_000)
+      if (route.sessionID === sessionID && scroll) {
+        scroll.scrollBy(100_000)
+        setUserScrolledUp(false)
+      }
     })().catch((error) => {
       if (route.sessionID !== sessionID) return
       toast.show({
@@ -404,6 +408,7 @@ export function Session() {
     setTimeout(() => {
       if (!scroll || scroll.isDestroyed) return
       scroll.scrollTo(scroll.scrollHeight)
+      setUserScrolledUp(false)
     }, 50)
   }
 
@@ -736,6 +741,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(-scroll.height / 2)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -756,6 +762,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(-1)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -776,6 +783,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(-scroll.height / 4)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -796,6 +804,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollTo(0)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -806,6 +815,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollTo(scroll.scrollHeight)
+        setUserScrolledUp(false)
         dialog.clear()
       },
     },
@@ -1120,7 +1130,7 @@ export function Session() {
                     foregroundColor: theme.border,
                   },
                 }}
-                stickyScroll={true}
+                stickyScroll={!userScrolledUp()}
                 stickyStart="bottom"
                 flexGrow={1}
                 scrollAcceleration={scrollAcceleration()}


### PR DESCRIPTION
### Issue for this PR

Closes #29094 (re-open of #4196)

### Type of change

- [x] Bug fix

### What does this PR do?

The session message scrollbox is hard-coded to \`stickyScroll={true}\`, so every streamed token pulls the viewport back to the bottom. Users can't read older messages while an LLM response is in flight.

Track when the user has scrolled away from the bottom in a \`userScrolledUp\` signal and make \`stickyScroll\` reactive on \`!userScrolledUp()\`. Upward commands (Page Up, Line Up, Half Page Up, First message) set the flag; commands that return to bottom (Last message, \`toBottom()\`, session sync) clear it.

Mirrors the pattern already used in the web client's \`packages/ui/src/hooks/create-auto-scroll.tsx\`.

### How did you verify your code works?

Manual test against the steps in the linked issue: scroll up mid-response, viewport stays put; press Last Message or scroll to bottom, sticky resumes. Diff is contained to \`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx\`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

This supersedes my earlier PR #21343, which was auto-closed by cleanup. Rebased onto current \`dev\`.