### PR TITLE
feat(opencode): add trigger words for inline image attachments

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -714,6 +714,18 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               text: `[Attached ${part.mime}: ${part.filename ?? "file"}]`,
             })
           } else {
+            if (isMedia(part.mime)) {
+              const filename = part.filename ?? ""
+              const lower = filename.toLowerCase()
+              let trigger = "image"
+              if (lower.includes("screenshot")) trigger = "screenshot"
+              else if (lower.includes("clipboard")) trigger = "clipboard"
+              else if (lower.includes("photo")) trigger = "photo"
+              userMessage.parts.push({
+                type: "text",
+                text: `[${trigger}]`,
+              })
+            }
             userMessage.parts.push({
               type: "file",
               url: part.url,

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -303,6 +303,7 @@ describe("session.message-v2.toModelMessage", () => {
         role: "user",
         content: [
           { type: "text", text: "hello" },
+          { type: "text", text: "[image]" },
           {
             type: "file",
             mediaType: "image/png",


### PR DESCRIPTION
### Issue for this PR

Closes #21585

### Type of change

- [x] New feature

### What does this PR do?

Skills like \`vision-analysis\` auto-activate based on trigger words in the user's text. Inline image attachments only send a \`file\` part to the model — no surrounding text — so those skills never see anything to match against and the agent ends up giving a confused fallback reply.

In \`packages/opencode/src/session/message-v2.ts\`, when pushing a media file part for the model, also push a small text part containing a trigger word derived from the filename:

- \`Screenshot 2026-…\` → \`[screenshot]\`
- \`clipboard-…\` → \`[clipboard]\`
- \`photo*\` → \`[photo]\`
- other images → \`[image]\`

Mirrors how the existing \`stripMedia\` branch already injects an \`[Attached <mime>: <filename>]\` text part.

### How did you verify your code works?

\`packages/opencode/test/session/message-v2.test.ts\` was updated to expect the new \`[image]\` text part alongside the file part in the inline-image test case. Logic-checked against the existing branch immediately above (\`stripMedia\`) which already follows the same shape.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Supersedes #21586 (auto-closed by cleanup). Rebased onto current \`dev\`.