### PR TITLE
fix(opencode): follow symlinks in file scan and directory listing

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -249,7 +249,7 @@ export const layer = Layer.effect(
         )).flat()
       }
 
-      const files = Array.from(yield* ripgrep.files({ cwd: location.directory }).pipe(Stream.runCollect, Effect.orDie))
+      const files = Array.from(yield* ripgrep.files({ cwd: location.directory, follow: true }).pipe(Stream.runCollect, Effect.orDie))
       const dirs = new Set<string>()
       for (const file of files) {
         let current = file


### PR DESCRIPTION
### Issue for this PR

Closes #29080

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`@file` mentions cannot find files inside symlinked directories because `File.scan()` calls `rg.files()` without `--follow` — ripgrep skips symlinked directories by default.

this adds `follow: true` to the `rg.files()` call so ripgrep traverses symlinks when building the file search cache.

the other half of the issue (`readDirectoryEntries` classifying symlinked dirs as `"symlink"` instead of `"directory"`) is addressed by #28532 which fixes the root cause in `readDirectoryEntries` itself.

### How did you verify your code works?

- `bun typecheck` passes
- `bun test test/file/index.test.ts` — 52 tests pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR