### PR TITLE
fix(session): preserve time_updated on project_id migration

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -315,7 +315,7 @@ export const layer = Layer.effect(
         yield* db((d) =>
           d
             .update(SessionTable)
-            .set({ project_id: projectID })
+            .set({ project_id: projectID, time_updated: sql`${SessionTable.time_updated}` })
             .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.directory)))
             .run(),
         )

--- a/packages/opencode/test/project/migrate-global.test.ts
+++ b/packages/opencode/test/project/migrate-global.test.ts
@@ -104,6 +104,14 @@ describe("migrateFromGlobal", () => {
       const id = legacySessionID()
       yield* Effect.sync(() => seed({ id, dir: tmp, project: ProjectID.global }))
 
+      // Capture the original time_updated so we can verify migration
+      // does not corrupt it. Regression test for #25392 — without the
+      // preserve clause, Drizzle's $onUpdate hook bumps time_updated to
+      // Date.now() on every startup, scrambling the /sessions timeline.
+      const before = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
+      expect(before).toBeDefined()
+      const originalTimeUpdated = before!.time_updated
+
       // 4. Call fromDirectory again — project row already exists,
       //    so the current code skips migration entirely. This is the bug.
       yield* projects.fromDirectory(tmp)
@@ -111,6 +119,8 @@ describe("migrateFromGlobal", () => {
       const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
       expect(row).toBeDefined()
       expect(row!.project_id).toBe(project.id)
+      // time_updated must be preserved across the project_id rewrite.
+      expect(row!.time_updated).toBe(originalTimeUpdated)
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #25392

### Type of change

- [x] Bug fix

### What does this PR do?

Two bulk `UPDATE` statements in `project.ts` rewrite `session.project_id` without touching `time_updated`:

1. `Project.fromDirectory` — moves sessions from the `global` project into a real project when their `directory` matches (runs every time you open a project).
2. `Project.migrateProjectId` — moves sessions when a project's ID changes (e.g. directory rename).

Because `time_updated` has Drizzle's `.$onUpdate(() => Date.now())` hook, every row touched by those `UPDATE`s gets its `time_updated` stamped to the current time. Net effect for users with any legacy `global`-scoped sessions: `/sessions` shows every old session with today's date on every startup.

Fix: pass the column through unchanged via `sql\`${SessionTable.time_updated}\``, which makes Drizzle skip the auto-update. Same pattern that `projectors.ts` (PR #27094) and `data-migration.ts` already use elsewhere in the file.

### How did you verify your code works?

Extended the existing regression test in `test/project/migrate-global.test.ts` — captures `time_updated` before calling `fromDirectory`, then asserts it is identical after. Confirmed the test fails without the fix (the column drifts by tens of ms) and passes with it.

```
$ bun test test/project/migrate-global.test.ts
 4 pass
 0 fail
```

Also verified directly against a local DB:

```
sqlite3 ~/.local/share/opencode/opencode.db \
  "SELECT id, datetime(time_updated/1000, 'unixepoch') FROM session ORDER BY time_updated DESC LIMIT 10"
```

Before the fix: every recently-opened project's sessions cluster on the launch timestamp. After: the historical timeline is preserved.

`bun turbo typecheck --filter opencode` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR