### PR TITLE
fix: await event loop in non-interactive `opencode run`

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -767,10 +767,7 @@ export const RunCommand = effectCmd({
 
         if (!args.interactive) {
           const events = await client.event.subscribe()
-          loop(client, events).catch((e) => {
-            console.error(e)
-            process.exit(1)
-          })
+          const loopDone = loop(client, events)
 
           if (args.command) {
             const result = await client.session.command({
@@ -785,19 +782,26 @@ export const RunCommand = effectCmd({
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
               process.exitCode = 1
             }
-            return
+          } else {
+            const model = pick(args.model)
+            const result = await client.session.prompt({
+              sessionID,
+              agent,
+              model,
+              variant: args.variant,
+              parts: [...files, { type: "text", text: message }],
+            })
+            if (result.error) {
+              if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+              process.exitCode = 1
+            }
           }
 
-          const model = pick(args.model)
-          const result = await client.session.prompt({
-            sessionID,
-            agent,
-            model,
-            variant: args.variant,
-            parts: [...files, { type: "text", text: message }],
-          })
-          if (result.error) {
-            if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+          try {
+            const loopError = await loopDone
+            if (loopError) process.exitCode = 1
+          } catch (e) {
+            console.error(e)
             process.exitCode = 1
           }
           return


### PR DESCRIPTION
## Bug

In non-interactive mode (`opencode run "..." --format json`), the event processing loop was started with fire-and-forget:

```typescript
loop(client, events).catch((e) => { console.error(e); process.exit(1) })
```

When `prompt()` returns its HTTP acknowledgment, `execute()` returns immediately. The Effect framework's cleanup then disposes the in-process server, killing the SSE stream before the model finishes generating.

**Only `step_start` was emitted** (it arrives before `prompt()` returns). All `text`, `tool_use`, and `step_finish` events were lost because the stream was torn down mid-generation.

## Fix

Store the loop promise and await it after the prompt/command call completes:

```typescript
const loopDone = loop(client, events)

// ... prompt or command call ...

try {
  const loopError = await loopDone
  if (loopError) process.exitCode = 1
} catch (e) {
  console.error(e)
  process.exitCode = 1
}
```

This keeps the process alive until the session reaches `idle` and all events have been processed.

## Testing

Before fix — only `step_start`:
```
$ opencode run "what is 2+2?" --format json --dangerously-skip-permissions
{"type":"step_start",...}
```

After fix — all three events:
```
{"type":"step_start",...}
{"type":"text","part":{"type":"text","text":"4",...}}
{"type":"step_finish","part":{"reason":"stop","tokens":{...},...}}
```

Full typecheck passes across all 15 workspace packages.