### PR TITLE
fix(provider): close OpenAI response streams on terminal events

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -84,6 +84,71 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
     statusText: res.statusText,
   })
 }
+function isTerminalSSEData(data: string) {
+  const trimmed = data.trim()
+  if (trimmed === "[DONE]") return true
+  try {
+    const parsed = JSON.parse(trimmed) as { type?: unknown }
+    return (
+      parsed.type === "response.completed" || parsed.type === "response.incomplete" || parsed.type === "response.failed"
+    )
+  } catch {
+    return false
+  }
+}
+function isTerminalSSELine(line: string) {
+  if (!line.startsWith("data:")) return false
+  return isTerminalSSEData(line.slice(5).trimStart())
+}
+
+function wrapTerminalSSE(res: Response) {
+  if (!res.body) return res
+  if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let pending = ""
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(ctrl) {
+      const part = await reader.read()
+      if (part.done) {
+        ctrl.close()
+        return
+      }
+
+      ctrl.enqueue(part.value)
+      pending += decoder.decode(part.value, { stream: true }).replaceAll("\r\n", "\n")
+
+      let offset = 0
+      while (true) {
+        const index = pending.indexOf("\n", offset)
+        if (index === -1) break
+        if (isTerminalSSELine(pending.slice(offset, index))) {
+          ctrl.close()
+          void reader.cancel("terminal SSE event received")
+          return
+        }
+        offset = index + 1
+      }
+      pending = pending.slice(offset)
+      if (isTerminalSSELine(pending)) {
+        ctrl.close()
+        void reader.cancel("terminal SSE event received")
+        return
+      }
+    },
+    cancel(reason) {
+      void reader.cancel(reason)
+    },
+  })
+
+  return new Response(body, {
+    headers: new Headers(res.headers),
+    status: res.status,
+    statusText: res.statusText,
+  })
+}
 
 function googleVertexAnthropicBaseURL(project: string | undefined, location: string | undefined) {
   if (!project) return
@@ -1641,8 +1706,7 @@ export const layer = Layer.effect(
             timeout: false,
           })
 
-          if (!chunkAbortCtl) return res
-          return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+          return wrapTerminalSSE(chunkAbortCtl ? wrapSSE(res, chunkTimeout, chunkAbortCtl) : res)
         }
 
         const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -695,6 +695,28 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
     headers: { "Content-Type": "text/event-stream" },
   })
 }
+function createUnclosedEventResponse(chunks: unknown[], includeDone = false, hangOnCancel = false, closeLastEvent = true) {
+  const lines = chunks.map((chunk) => `data: ${typeof chunk === "string" ? chunk : JSON.stringify(chunk)}`)
+  if (includeDone) {
+    lines.push("data: [DONE]")
+  }
+  const payload = lines.join("\n\n") + (closeLastEvent ? "\n\n" : "")
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(payload))
+      },
+      cancel() {
+        if (hangOnCancel) return new Promise(() => {})
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    },
+  )
+}
 
 describe("session.llm.stream", () => {
   const vivgridFixture = { providerID: "vivgrid", modelID: "gemini-3.1-pro-preview" }
@@ -1000,6 +1022,72 @@ describe("session.llm.stream", () => {
       }),
     { config: () => openAIConfig(loadFixture("openai", "gpt-5.2").model, `${state.server!.url.origin}/v1`) },
   )
+  it.instance(
+    "finishes OpenAI Responses streams when terminal event remains open without a final frame delimiter",
+    () =>
+      Effect.gen(function* () {
+        const model = loadFixture("openai", "gpt-5.2").model
+        const request = waitRequest(
+          "/responses",
+          createUnclosedEventResponse([
+            {
+              type: "response.created",
+              response: {
+                id: "resp-terminal-open",
+                created_at: Math.floor(Date.now() / 1000),
+                model: model.id,
+                service_tier: null,
+              },
+            },
+            {
+              type: "response.completed",
+              response: {
+                incomplete_details: null,
+                usage: {
+                  input_tokens: 1,
+                  input_tokens_details: null,
+                  output_tokens: 0,
+                  output_tokens_details: null,
+                },
+                service_tier: null,
+              },
+            },
+          ], false, true, false),
+        )
+
+        const resolved = yield* Provider.use.getModel(ProviderID.openai, ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-openai-terminal-open")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("msg_user-openai-terminal-open"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("openai"), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const exit = yield* drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        }).pipe(Effect.timeout("1 second"), Effect.exit)
+
+        yield* Effect.promise(() => request)
+        expect(Exit.isSuccess(exit)).toBe(true)
+      }),
+    { config: () => openAIConfig(loadFixture("openai", "gpt-5.2").model, `${state.server!.url.origin}/v1`) },
+  )
+
 
   it.instance(
     "keeps supported OpenAI models on AI SDK path when native flag is off",


### PR DESCRIPTION
## Summary

- close SSE responses locally when OpenAI Responses emits a terminal `response.completed`, `response.incomplete`, or `response.failed` event
- also close on `[DONE]` so callers do not wait for a proxy/provider socket close that may never arrive
- keep the existing chunk watchdog behavior, but do not use timeouts as the primary fix

## Test

- `bun test test/session/llm.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run build`
- push hook: `bun turbo typecheck`