### PR TITLE
fix(tui): open external editor in worktree cwd

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -509,7 +509,11 @@ export function Prompt(props: PromptProps) {
           const nonTextParts = store.prompt.parts.filter((p) => p.type !== "text")
 
           const value = text
-          const content = await Editor.open({ value, renderer })
+          const content = await Editor.open({
+            value,
+            renderer,
+            cwd: project.instance.path().worktree || project.instance.directory() || process.cwd(),
+          })
           if (!content) return
 
           input.setText(content)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -965,7 +965,11 @@ export function Session() {
 
           if (options.openWithoutSaving) {
             // Just open in editor without saving
-            await Editor.open({ value: transcript, renderer })
+            await Editor.open({
+              value: transcript,
+              renderer,
+              cwd: project.instance.path().worktree || project.instance.directory() || process.cwd(),
+            })
           } else {
             const exportDir = process.cwd()
             const filename = options.filename.trim()
@@ -974,7 +978,11 @@ export function Session() {
             await Filesystem.write(filepath, transcript)
 
             // Open with EDITOR if available
-            const result = await Editor.open({ value: transcript, renderer })
+            const result = await Editor.open({
+              value: transcript,
+              renderer,
+              cwd: project.instance.path().worktree || project.instance.directory() || process.cwd(),
+            })
             if (result !== undefined) {
               await Filesystem.write(filepath, result)
             }

--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -6,7 +6,7 @@ import { CliRenderer } from "@opentui/core"
 import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 
-export async function open(opts: { value: string; renderer: CliRenderer }): Promise<string | undefined> {
+export async function open(opts: { value: string; renderer: CliRenderer; cwd?: string }): Promise<string | undefined> {
   const editor = process.env["VISUAL"] || process.env["EDITOR"]
   if (!editor) return
 
@@ -19,6 +19,7 @@ export async function open(opts: { value: string; renderer: CliRenderer }): Prom
   try {
     const parts = editor.split(" ")
     const proc = Process.spawn([...parts, filepath], {
+      cwd: opts.cwd,
       stdin: "inherit",
       stdout: "inherit",
       stderr: "inherit",


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI `/editor` command launched the external editor without an explicit working directory, so the editor inherited the TUI process cwd. In worktree-backed sessions that can point at the original checkout instead of the active worktree.

This passes an explicit cwd into the external editor launcher and uses the active project worktree when available, falling back to the active instance directory and then `process.cwd()`. Session transcript editor opens use the same cwd selection.

### How did you verify your code works?

`git push` ran `bun turbo typecheck` successfully across the workspace.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR