### PR TITLE
fix(app): open docs from help button

### DIFF
--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -180,7 +180,7 @@ function HomeDesign() {
         selectProject={selectProject}
         chooseProject={() => void chooseProject()}
         openSettings={openSettings}
-        openHelp={() => platform.openLink("https://opencode.ai/desktop-feedback")}
+        openHelp={() => platform.openLink("https://opencode.ai/docs")}
         language={language}
       />
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2356,7 +2356,7 @@ export default function Layout(props: ParentProps) {
       settingsKeybind={() => command.keybind("settings.open")}
       onOpenSettings={openSettings}
       helpLabel={() => language.t("sidebar.help")}
-      onOpenHelp={() => platform.openLink("https://opencode.ai/desktop-feedback")}
+      onOpenHelp={() => platform.openLink("https://opencode.ai/docs")}
       renderPanel={() =>
         mobile ? <SidebarPanel project={currentProject} mobile /> : <SidebarPanel project={currentProject} merged />
       }


### PR DESCRIPTION
Fixes #28703.

## Summary
- point the web/desktop help button at the documentation page instead of the feedback/Discord flow
- update both the home page and layout sidebar help handlers

## Testing
- Verified the updated help handlers reference `https://opencode.ai/docs`.
- `bun run typecheck` from `packages/app` could not run in this environment because `tsgo` is not installed on PATH.
