### PR TITLE
fix(tui): wire prompt.skills keybinding to gather call

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -630,6 +630,7 @@ export function Prompt(props: PromptProps) {
       "prompt.submit",
       "prompt.editor",
       "prompt.editor_context.clear",
+      "prompt.skills",
       "prompt.stash",
       "prompt.stash.pop",
       "prompt.stash.list",


### PR DESCRIPTION
### Issue for this PR

Fixes #29148

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`prompt_skills` keybinding in tui.json had no effect. The command handler was defined in promptCommands() but "prompt.skills" was missing from the gather() call. Added "prompt.skills" to that list.

### How did you verify your code works?

Run `bun dev` and check if keybind assigned to `prompt_skills` in `tui.json` make popup skills window. Works same way as clicking `ctrl+p` and selecting `Skills`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR