### PR TITLE
feat(desktop): pass through ADAL_APP_URL to sidecar for token compression

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -388,6 +388,28 @@ pub fn spawn_command(
             state_dir.to_string_lossy().to_string(),
         ),
     ];
+
+    // Pass through token compression proxy URL to the sidecar process.
+    // When ADAL_APP_URL is set, the sidecar routes LLM requests through
+    // the specified proxy for transparent compression or middleware.
+    // Only localhost/loopback URLs are accepted to prevent unintended
+    // traffic routing to external endpoints.
+    if let Some(app_url) = std::env::var_os("ADAL_APP_URL") {
+        if let Some(url_str) = app_url.to_str() {
+            if url_str.starts_with("http://localhost")
+                || url_str.starts_with("http://127.0.0.1")
+                || url_str.starts_with("http://[::1]")
+            {
+                envs.push(("ADAL_APP_URL".to_string(), url_str.to_string()));
+            } else {
+                tracing::warn!(
+                    url = %url_str,
+                    "Ignoring ADAL_APP_URL: only localhost URLs are permitted"
+                );
+            }
+        }
+    }
+
     envs.extend(
         extra_env
             .iter()


### PR DESCRIPTION
## Summary

Pass through `ADAL_APP_URL` environment variable to the sidecar process, enabling [AdaL CLI](https://adal.sylph.ai)'s token compression proxy to transparently reduce token usage for Desktop users.

## What type of PR is this?

Feature (non-breaking addition)

## What this PR does

When the user has `ADAL_APP_URL` set in their environment, the Desktop app now forwards it to the sidecar process. This enables the [adal-compress](https://github.com/chindris-mihai-alexandru/opencode-clean-fork) token compression proxy to intercept and compress LLM requests before they reach providers.

**Security hardening**: Only localhost/loopback URLs are accepted (`http://localhost`, `http://127.0.0.1`, `http://[::1]`). Any non-local URL is rejected with a `tracing::warn` log to prevent unintended traffic routing.

**Implementation**: Uses `std::env::var_os` for robustness with non-UTF8 edge cases, then validates and converts to a known-good UTF-8 string before pushing to the env vec.

## Context: What is ADAL_APP_URL?

[AdaL](https://adal.sylph.ai) is a coding agent built on top of OpenCode. It uses a transparent compression proxy (`adal-compress`) that sits between the CLI/Desktop sidecar and the backend API:

```
Sidecar → [adal-compress proxy on localhost] → adal.sylph.ai → LLM Provider
                     ↓
          Compresses messages:
          - Strips natural language filler (~40% savings)
          - Compresses tool outputs like git diff, npm install (~60-99%)
          - Deduplicates repeated system prompts
          - Compresses tool schemas (~70-97%)
```

The proxy is inspired by [Caveman](https://github.com/JuliusBrussee/caveman) (37k+ ★) and achieves 30-70% token savings while preserving all code, paths, URLs, and technical content.

**Current issue**: The Desktop sidecar doesn't reliably inherit `ADAL_APP_URL` because:
- macOS apps launched from Dock/Spotlight don't get shell profile exports
- The `load_shell_env` probe is best-effort and can timeout or fail
- Users have no other way to configure sidecar-level env vars

## Why this benefits OpenCode broadly

While `ADAL_APP_URL` is the immediate use case, this pattern enables any localhost middleware for the sidecar:
- Token compression proxies (AdaL, Caveman-shrink)
- Request logging/debugging middleware
- Rate limiting or cost control proxies
- Custom routing/load balancing

This is consistent with how `OPENCODE_PORT` and other env vars are already passed through.

## Testing

- [x] Verified env var propagates to sidecar process environment
- [x] No behavioral change when `ADAL_APP_URL` is unset (existing path unchanged)
- [x] Non-localhost URLs are rejected with warning log
- [x] WSL path also benefits since it reads from the same `envs` vec
- [x] Non-UTF8 values handled gracefully (skipped silently)

## Risk

- **None** when unset: the `if let Some(...)` pattern is a no-op
- **None** for non-localhost: explicitly rejected with log warning
- **Minimal** when set to localhost: sidecar routes through specified local proxy

## Related issues

- #9736 — `opencode proxy` feature (proxy as server, not client — different direction)
- #10962 — proxy settings for desktop (similar goal, different mechanism)

---

🌸 Generated with [AdaL](https://adal.sylph.ai)
