### PR TITLE
feat(plugin): expose logging API to plugins

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -1,6 +1,7 @@
 import type {
   Hooks,
   PluginInput,
+  PluginLogger,
   Plugin as PluginInstance,
   PluginModule,
   WorkspaceAdapter as PluginWorkspaceAdapter,
@@ -96,6 +97,28 @@ function getLegacyPlugins(mod: Record<string, unknown>) {
   return result
 }
 
+/**
+ * Creates a namespaced logger for a plugin that writes to OpenCode's log system.
+ * @param pluginId - Identifier for the plugin (function name for internal, package name or file basename for external)
+ */
+function createPluginLogger(pluginId: string): PluginLogger {
+  return Log.create({ service: `plugin.${pluginId}` })
+}
+
+function pluginIdFromLoad(load: PluginLoader.Loaded): string {
+  if (load.pkg?.pkg) return load.pkg.pkg
+  if (!load.spec.startsWith("file://")) return load.spec
+  try {
+    const url = new URL(load.spec)
+    let path = url.pathname.replace(/\.[jt]sx?$/i, "")
+    if (path.endsWith("/index")) path = path.slice(0, -"/index".length)
+    const last = path.split("/").filter(Boolean).pop()
+    return last ?? load.spec
+  } catch {
+    return load.spec
+  }
+}
+
 async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[]) {
   const plugin = readV1Plugin(load.mod, load.spec, "server", "detect")
   if (plugin) {
@@ -134,7 +157,9 @@ export const layer = Layer.effect(
           fetch: async (...args) => Server.Default().app.fetch(...args),
         })
         const cfg = yield* config.get()
-        const input: PluginInput = {
+
+        // Base input without logger - logger is added per-plugin
+        const baseInput = {
           client,
           project: ctx.project,
           worktree: ctx.worktree,
@@ -147,14 +172,23 @@ export const layer = Layer.effect(
           get serverUrl(): URL {
             return Server.url ?? new URL("http://localhost:4096")
           },
-          // @ts-expect-error
           $: typeof Bun === "undefined" ? undefined : Bun.$,
         }
 
+        // Helper to create plugin input with namespaced logger
+        function createPluginInput(pluginId: string): PluginInput {
+          return {
+            ...baseInput,
+            log: createPluginLogger(pluginId),
+          } as PluginInput
+        }
+
         for (const plugin of flags.disableDefaultPlugins ? [] : INTERNAL_PLUGINS) {
+          const pluginId = plugin.name || "internal"
+          const pluginInput = createPluginInput(pluginId)
           log.info("loading internal plugin", { name: plugin.name })
           const init = yield* Effect.tryPromise({
-            try: () => plugin(input),
+            try: () => plugin(pluginInput),
             catch: (err) => {
               log.error("failed to load internal plugin", { name: plugin.name, error: err })
             },
@@ -212,10 +246,13 @@ export const layer = Layer.effect(
         for (const load of loaded) {
           if (!load) continue
 
+          // Create plugin-specific input with namespaced logger
+          const pluginInput = createPluginInput(pluginIdFromLoad(load))
+
           // Keep plugin execution sequential so hook registration and execution
           // order remains deterministic across plugin runs.
           yield* Effect.tryPromise({
-            try: () => applyPlugin(load, input, hooks),
+            try: () => applyPlugin(load, pluginInput, hooks),
             catch: (err) => {
               const message = errorMessage(err)
               log.error("failed to load plugin", { path: load.spec, error: message })

--- a/packages/opencode/test/plugin/cloudflare.test.ts
+++ b/packages/opencode/test/plugin/cloudflare.test.ts
@@ -11,6 +11,7 @@ const pluginInput = {
   },
   serverUrl: new URL("https://example.com"),
   $: {} as never,
+  log: { debug() {}, info() {}, warn() {}, error() {} },
 }
 
 function makeHookInput(overrides: { providerID?: string; apiId?: string; reasoning?: boolean }) {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -191,6 +191,7 @@ describe("plugin.codex", () => {
         },
         serverUrl: new URL("https://example.com"),
         $: {} as never,
+        log: { debug() {}, info() {}, warn() {}, error() {} },
       },
       {
         issuer: server.url.origin,

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -228,6 +228,7 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
     },
     serverUrl: new URL("https://example.com"),
     $: {} as never,
+    log: { debug() {}, info() {}, warn() {}, error() {} },
   })
 
   const models = await hooks.provider!.models!(

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -53,6 +53,17 @@ export type WorkspaceAdapter = {
   target(config: WorkspaceInfo): WorkspaceTarget | Promise<WorkspaceTarget>
 }
 
+/**
+ * Structured logger for plugins to write to OpenCode's log system.
+ * Messages are persisted to OpenCode's log files with proper namespace tagging.
+ */
+export type PluginLogger = {
+  debug(message?: any, extra?: Record<string, any>): void
+  info(message?: any, extra?: Record<string, any>): void
+  warn(message?: any, extra?: Record<string, any>): void
+  error(message?: any, extra?: Record<string, any>): void
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -63,6 +74,11 @@ export type PluginInput = {
   }
   serverUrl: URL
   $: BunShell
+  /**
+   * Structured logger for writing to OpenCode's log system.
+   * Use this instead of console.log to ensure logs are captured in log files.
+   */
+  log: PluginLogger
 }
 
 export type PluginOptions = Record<string, unknown>


### PR DESCRIPTION
### Issue for this PR

Closes #27285

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins currently have no way to write to OpenCode's log files — they can only use `console.log`, which isn't captured anywhere useful.

This adds a `log` object to the `PluginInput` that every plugin receives, with `debug`, `info`, `warn`, and `error` methods. Each plugin gets its own logger namespaced as `plugin.<id>`, so its output is written to OpenCode's normal log files and is attributable to the specific plugin.

How it works:
- `packages/plugin/src/index.ts` — adds the public `PluginLogger` type and a `log: PluginLogger` field on `PluginInput`.
- `packages/opencode/src/plugin/index.ts` — builds a per-plugin logger via `Log.create({ service: "plugin.<id>" })` and injects it when each plugin loads. The `<id>` is the package name for installed plugins, or the file basename for `file://` plugins (e.g. `…/my-plugin/index.ts` → `my-plugin`, `…/my-plugin.ts` → `my-plugin`).

Since `log` is now a required field on `PluginInput`, the existing plugin auth-test fixtures are updated to supply it.

### How did you verify your code works?

Manually, by running the real CLI with a plugin and confirming its log output appears, correctly namespaced. Minimal repro:

1. Create `myplugin.ts` anywhere:

   ```ts
   export default async ({ log }) => {
     log.debug("debug line", { ok: true })
     log.info("info line")
     log.warn("warn line")
     log.error("error line")
     return {}
   }
   ```

2. In any project, point `opencode.json` at it (use the absolute path):

   ```json
   {
     "$schema": "https://opencode.ai/config.json",
     "plugin": ["file:///absolute/path/to/myplugin.ts"]
   }
   ```

3. Run any command that boots the project, with logs printed to the terminal:

   ```
   opencode models --print-logs --log-level DEBUG
   ```

4. Confirm the output contains the plugin's lines, namespaced `service=plugin.myplugin`:

   ```
   DEBUG … service=plugin.myplugin ok=true debug line
   INFO  … service=plugin.myplugin info line
   WARN  … service=plugin.myplugin warn line
   ERROR … service=plugin.myplugin error line
   ```

This confirms the `log` object is injected, all four levels are written, and the `plugin.<basename>` namespace is derived correctly. Re-running with `--log-level INFO` drops the DEBUG line, confirming level filtering flows through the plugin logger.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR