### PR TITLE
fix(opencode): expose single session status endpoint

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -74,6 +74,7 @@ export const PermissionResponsePayload = Schema.Struct({
 export const SessionPaths = {
   list: root,
   status: `${root}/status`,
+  sessionStatus: `${root}/:sessionID/status`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
@@ -123,6 +124,19 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.status",
             summary: "Get session status",
             description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
+          }),
+        ),
+        HttpApiEndpoint.get("sessionStatus", SessionPaths.sessionStatus, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(SessionStatus.Info, "Get session status"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.sessionStatus",
+            summary: "Get single session status",
+            description:
+              "Retrieve the current status of a specific session, including active, idle, and completed states.",
           }),
         ),
         HttpApiEndpoint.get("get", SessionPaths.get, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -75,6 +75,13 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return Object.fromEntries(yield* statusSvc.list())
     })
 
+    const sessionStatus = Effect.fn("SessionHttpApi.sessionStatus")(function* (ctx: {
+      params: { sessionID: SessionID }
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* statusSvc.get(ctx.params.sessionID)
+    })
+
     const requireSession = Effect.fn("SessionHttpApi.requireSession")(function* (sessionID: SessionID) {
       return yield* SessionError.mapStorageNotFound(session.get(sessionID))
     })
@@ -406,6 +413,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     return handlers
       .handle("list", list)
       .handle("status", status)
+      .handle("sessionStatus", sessionStatus)
       .handle("get", get)
       .handle("children", children)
       .handle("todo", todo)


### PR DESCRIPTION
### Issue for this PR
Closes #29166

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
The session status service already had a `get(sessionID)` method for querying a single session's runtime status (idle/busy/retry), but it was only wired up to the bulk `/session/status` endpoint which returns all non-idle statuses as a record. If you needed just one session status you had to fetch the entire list and filter client-side.

This PR adds `GET /session/:sessionID/status` that calls that existing `get()` method directly. It follows the same pattern as other single-session endpoints like `GET /session/:sessionID/todo` — validate session existence with `requireSession()`, then delegate to the service.
Two files changed:
- `groups/session.ts` — added route path and endpoint definition
- `handlers/session.ts` — added handler + registered in chain

### How did you verify your code works?
Ran `opencode serve` locally and hit the endpoint against a known session ID. Returns `{ "type": "idle" }` for inactive sessions and the correct busy/retry state for active ones.

### Screenshots / recordings
N/A, backend-only change.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR