### PR TITLE
fix(workspaces): surface real error messages on failed workspace operations

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -53,13 +53,22 @@ export function DialogSessionList() {
       const workspaceID = await (async () => {
         if (selection.type === "none") return null
         if (selection.type === "existing") return selection.workspaceID
-        const result = await sdk.client.experimental.workspace
-          .create({ type: selection.workspaceType, branch: null })
-          .catch(() => undefined)
+        let result
+        try {
+          result = await sdk.client.experimental.workspace.create({ type: selection.workspaceType, branch: null })
+        } catch (err) {
+          toast.show({
+            title: "Failed to create workspace",
+            message: errorMessage(err),
+            variant: "error",
+          })
+          return
+        }
         const workspace = result?.data
         if (!workspace) {
           toast.show({
-            message: `Failed to create workspace: ${errorMessage(result?.error ?? "no response")}`,
+            title: "Failed to create workspace",
+            message: errorMessage(result?.error ?? "no response"),
             variant: "error",
           })
           return

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-create.tsx
@@ -61,15 +61,17 @@ async function loadWorkspaceAdapters(input: {
   const dir = input.sync.path.directory || input.sdk.directory
   const url = new URL("/experimental/workspace/adapter", input.sdk.url)
   if (dir) url.searchParams.set("directory", dir)
-  const res = await input.sdk
-    .fetch(url)
-    .then((x) => x.json() as Promise<Adapter[]>)
-    .catch(() => undefined)
-  if (res) return res
-  input.toast.show({
-    message: "Failed to load workspace adapters",
-    variant: "error",
-  })
+  try {
+    const response = await input.sdk.fetch(url)
+    return (await response.json()) as Adapter[]
+  } catch (err) {
+    input.toast.show({
+      title: "Failed to load workspace adapters",
+      message: errorMessage(err),
+      variant: "error",
+    })
+    return undefined
+  }
 }
 
 export async function openWorkspaceSelect(input: {
@@ -100,13 +102,21 @@ export async function warpWorkspaceSession(input: {
   copyChanges: boolean
   done?: () => void
 }): Promise<boolean> {
-  const result = await input.sdk.client.experimental.workspace
-    .warp({
+  let result
+  try {
+    result = await input.sdk.client.experimental.workspace.warp({
       id: input.workspaceID,
       sessionID: input.sessionID,
       copyChanges: input.copyChanges,
     })
-    .catch(() => undefined)
+  } catch (err) {
+    input.toast.show({
+      title: "Failed to warp session",
+      message: errorMessage(err),
+      variant: "error",
+    })
+    return false
+  }
   if (!result?.data) {
     if (result?.error && "name" in result.error && result.error.name === "VcsApplyError") {
       await DialogAlert.show(
@@ -118,7 +128,8 @@ export async function warpWorkspaceSession(input: {
     }
 
     input.toast.show({
-      message: `Failed to warp session: ${errorMessage(result?.error ?? "no response")}`,
+      title: "Failed to warp session",
+      message: errorMessage(result?.error ?? "no response"),
       variant: "error",
     })
     return false

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -40,6 +40,7 @@ import type { AssistantMessage, FilePart, UserMessage } from "@opencode-ai/sdk/v
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util/locale"
+import { errorMessage } from "@/util/error"
 import { formatDuration } from "@/util/format"
 import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
@@ -216,14 +217,25 @@ export function Prompt(props: PromptProps) {
 
   async function createWorkspace(selection: Extract<WorkspaceSelection, { type: "new" }>) {
     setCreatingWorkspace(true)
-    const result = await sdk.client.experimental.workspace
-      .create({ type: selection.workspaceType, branch: null })
-      .catch(() => undefined)
-    if (result == undefined || result.error || !result.data) {
+    let result
+    try {
+      result = await sdk.client.experimental.workspace.create({ type: selection.workspaceType, branch: null })
+    } catch (err) {
       selectWorkspace(undefined)
       setCreatingWorkspace(false)
       toast.show({
-        message: "Creating workspace failed",
+        title: "Creating workspace failed",
+        message: errorMessage(err),
+        variant: "error",
+      })
+      return
+    }
+    if (result.error || !result.data) {
+      selectWorkspace(undefined)
+      setCreatingWorkspace(false)
+      toast.show({
+        title: "Creating workspace failed",
+        message: errorMessage(result.error ?? "no response"),
         variant: "error",
       })
       return

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/workspace.ts
@@ -27,6 +27,16 @@ export class ApiWorkspaceWarpError extends Schema.ErrorClass<ApiWorkspaceWarpErr
   { httpApiStatus: 400 },
 ) {}
 
+export class ApiWorkspaceCreateError extends Schema.ErrorClass<ApiWorkspaceCreateError>("WorkspaceCreateError")(
+  {
+    name: Schema.Literal("WorkspaceCreateError"),
+    data: Schema.Struct({
+      message: Schema.String,
+    }),
+  },
+  { httpApiStatus: 400 },
+) {}
+
 export const WorkspacePaths = {
   adapters: `${root}/adapter`,
   list: root,
@@ -64,7 +74,7 @@ export const WorkspaceApi = HttpApi.make("workspace")
           query: WorkspaceRoutingQuery,
           payload: CreatePayload,
           success: described(Workspace.Info, "Workspace created"),
-          error: HttpApiError.BadRequest,
+          error: [ApiWorkspaceCreateError, HttpApiError.BadRequest],
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "experimental.workspace.create",

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
@@ -2,12 +2,12 @@ import { listAdapters } from "@/control-plane/adapters"
 import { Workspace } from "@/control-plane/workspace"
 import * as InstanceState from "@/effect/instance-state"
 import { Vcs } from "@/project/vcs"
-import { Effect } from "effect"
-import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
+import { Cause, Effect } from "effect"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { notFound } from "../errors"
 import { ApiVcsApplyError } from "../groups/instance"
-import { ApiWorkspaceWarpError, CreatePayload, WarpPayload } from "../groups/workspace"
+import { ApiWorkspaceCreateError, ApiWorkspaceWarpError, CreatePayload, WarpPayload } from "../groups/workspace"
 
 export const workspaceHandlers = HttpApiBuilder.group(InstanceHttpApi, "workspace", (handlers) =>
   Effect.gen(function* () {
@@ -30,7 +30,22 @@ export const workspaceHandlers = HttpApiBuilder.group(InstanceHttpApi, "workspac
           extra: ctx.payload.extra ?? null,
           projectID: instance.project.id,
         })
-        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+        .pipe(
+          Effect.catchCause((cause) => {
+            // Plugin throws surface as defects (because EffectBridge.fromPromise uses Effect.promise),
+            // bypassing Effect.mapError. Walk the cause to surface the real error to the client.
+            const die = cause.reasons.find(Cause.isDieReason)
+            const fail = cause.reasons.find(Cause.isFailReason)
+            const reason: unknown = die?.defect ?? fail?.error
+            const message = reason instanceof Error ? reason.message : "Workspace creation failed"
+            return Effect.fail(
+              new ApiWorkspaceCreateError({
+                name: "WorkspaceCreateError",
+                data: { message },
+              }),
+            )
+          }),
+        )
     })
 
     const syncList = Effect.fn("WorkspaceHttpApi.syncList")(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #27284

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a workspace operation failed, the UI showed a generic message ("Creating workspace failed", "Failed to load workspace adapters", etc.) with no detail about the actual cause, so users had no idea why it failed.

There were two reasons the real error never reached the user:

1. **Server.** The `workspace.create` handler mapped every failure to a generic `BadRequest`, and plugin throws arrive as Effect defects (`EffectBridge` runs plugins via `Effect.promise`), so they bypassed `Effect.mapError` and surfaced generically. Now it catches the cause, extracts the original message, and returns a typed `ApiWorkspaceCreateError`.

2. **Client (TUI).** The create / warp / adapter-load flows used `.catch(() => undefined)` and detail-less toasts, discarding the error. Now they `try/catch` and show the real message via `errorMessage()` in a title + message toast. Warp keeps its existing `VcsApplyError` alert.

The server and client changes are complementary: the server makes the real message available in the response, and the client actually displays it. Success paths are unchanged.

### How did you verify your code works?

Manually, in the TUI, against a build of this branch. I registered a workspace adapter whose `create()` throws a recognizable error, then triggered a workspace creation so the adapter throws.

1. Create a plugin that registers a workspace adapter which always throws on create:

```ts
// fail-workspace-plugin.ts
export default async ({ experimental_workspace }) => {
  experimental_workspace.register("testfail", {
    name: "Test Fail",
    description: "Always throws on create",
    async configure(config) {
      return config
    },
    async create() {
      throw new Error("Daytona auth failed: invalid API key")
    },
    async remove() {},
    target(config) {
      return { type: "local", directory: config.directory ?? "" }
    },
  })
  return {}
}
```

2. Point a project's `opencode.json` at it (absolute path):

```json
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": ["file:///absolute/path/to/fail-workspace-plugin.ts"]
}
```

3. Launch opencode in that project with workspaces enabled:

```sh
OPENCODE_EXPERIMENTAL_WORKSPACES=1 opencode
```

4. In the TUI: `ctrl+p` → **Warp** → under **New workspace** pick **Test Fail**. The adapter's `create()` throws.

Result:

- **Before this change:** a generic "Creating workspace failed" toast with no detail (the plugin throw surfaced as a generic error server-side).
- **After:** the toast shows the adapter's actual message ("Daytona auth failed: invalid API key") under a "Failed to create workspace" title — confirming the real error now travels server (`ApiWorkspaceCreateError`) → client (`result.error`) → toast.

### Screenshots / recordings

https://github.com/user-attachments/assets/4f6d9f96-8c85-4365-9629-238a8737cea8

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._