### PR TITLE
fix(task): surface non-text subagent results

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -100,6 +100,30 @@ function errorText(error: unknown) {
   return String(error)
 }
 
+function taskResultError(error: MessageV2.Assistant["error"]) {
+  if (!error) return "none"
+  return JSON.stringify(error) ?? String(error)
+}
+
+function taskResultText(result: MessageV2.WithParts) {
+  const textPart = result.parts.findLast((item) => item.type === "text")
+  if (textPart) return textPart.text
+
+  const partTypes = result.parts.map((item) => item.type).join(", ") || "none"
+  if (result.info.role !== "assistant") {
+    return ["Subagent completed without an assistant response.", `role: ${result.info.role}`, `parts: ${partTypes}`].join(
+      "\n",
+    )
+  }
+
+  return [
+    "Subagent completed without a text response.",
+    `finish: ${result.info.finish ?? "unknown"}`,
+    `error: ${taskResultError(result.info.error)}`,
+    `parts: ${partTypes}`,
+  ].join("\n")
+}
+
 export const TaskTool = Tool.define(
   id,
   Effect.gen(function* () {
@@ -208,7 +232,7 @@ export const TaskTool = Tool.define(
           },
           parts,
         })
-        return result.parts.findLast((item) => item.type === "text")?.text ?? ""
+        return taskResultText(result)
       })
 
       const resumeWhenIdle: (input: { userID: MessageID; state: "completed" | "error" }) => Effect.Effect<void> =

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -126,6 +126,44 @@ function reply(input: SessionPrompt.PromptInput, text: string): MessageV2.WithPa
   }
 }
 
+type PartDraft = MessageV2.Part extends infer Part
+  ? Part extends MessageV2.Part
+    ? Omit<Part, "id" | "messageID" | "sessionID">
+    : never
+  : never
+
+function replyWithParts(
+  input: SessionPrompt.PromptInput,
+  parts: PartDraft[],
+  info?: Partial<MessageV2.Assistant>,
+): MessageV2.WithParts {
+  const id = MessageID.ascending()
+  return {
+    info: {
+      id,
+      role: "assistant",
+      parentID: input.messageID ?? MessageID.ascending(),
+      sessionID: input.sessionID,
+      mode: input.agent ?? "general",
+      agent: input.agent ?? "general",
+      cost: 0,
+      path: { cwd: "/tmp", root: "/tmp" },
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: input.model?.modelID ?? ref.modelID,
+      providerID: input.model?.providerID ?? ref.providerID,
+      time: { created: Date.now() },
+      finish: "stop",
+      ...info,
+    },
+    parts: parts.map((part) => ({
+      ...part,
+      id: PartID.ascending(),
+      messageID: id,
+      sessionID: input.sessionID,
+    })) as MessageV2.Part[],
+  }
+}
+
 describe("tool.task", () => {
   it.instance(
     "description sorts subagents by name and is stable across calls",
@@ -239,6 +277,93 @@ describe("tool.task", () => {
       expect(result.metadata.sessionId).toBe(child.id)
       expect(result.output).toContain(`task_id: ${child.id}`)
       expect(seen?.sessionID).toBe(child.id)
+    }),
+  )
+
+  it.instance("execute returns child text output when present", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps: stubOps({ text: "done" }) },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("<task_result>\ndone\n</task_result>")
+    }),
+  )
+
+  it.instance("execute returns diagnostic output when child finishes without a text part", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const promptOps: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+        prompt: (input) =>
+          Effect.succeed(
+            replyWithParts(
+              input,
+              [
+                {
+                  type: "step-start",
+                },
+                {
+                  type: "reasoning",
+                  text: "thinking",
+                  time: { start: Date.now() },
+                },
+                {
+                  type: "step-finish",
+                  reason: "stop",
+                  cost: 0,
+                  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                },
+              ],
+              { finish: "stop" },
+            ),
+          ),
+        loop: (input) => Effect.succeed(reply({ sessionID: input.sessionID, parts: [] }, "done")),
+      }
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("Subagent completed without a text response.")
+      expect(result.output).toContain("finish: stop")
+      expect(result.output).toContain("error: none")
+      expect(result.output).toContain("parts: step-start, reasoning, step-finish")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #24447

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the `task` tool returning an empty `<task_result>` when a subagent completes without a final `text` part.

Before this change, `TaskTool` only looked for the last `text` part and fell back to `""` if none existed. That made reasoning-only or non-text child completions look like blank results in the parent session.

This change keeps the existing behavior when a child returns text, and otherwise returns a short diagnostic summary with the finish reason, error, and emitted part types.

### How did you verify your code works?

- Ran `bun run typecheck` in `packages/opencode`
- Ran `bun test test/tool/task.test.ts --test-name-pattern "execute returns child text output when present|execute returns diagnostic output when child finishes without a text part"`
- Ran `bun test test/cli/run/entry.body.test.ts test/cli/run/scrollback.surface.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
