### PR TITLE
fix(tui): handle non-git project paths when opening editor

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -512,7 +512,12 @@ export function Prompt(props: PromptProps) {
           const content = await Editor.open({
             value,
             renderer,
-            cwd: project.instance.path().worktree || project.instance.directory() || process.cwd(),
+            cwd:
+              (project.instance.path().worktree === "/"
+                ? undefined
+                : project.instance.path().worktree) ||
+              project.instance.directory() ||
+              process.cwd(),
           })
           if (!content) return
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -968,7 +968,12 @@ export function Session() {
             await Editor.open({
               value: transcript,
               renderer,
-              cwd: project.instance.path().worktree || project.instance.directory() || process.cwd(),
+              cwd:
+                (project.instance.path().worktree === "/"
+                  ? undefined
+                  : project.instance.path().worktree) ||
+                project.instance.directory() ||
+                process.cwd(),
             })
           } else {
             const exportDir = process.cwd()
@@ -981,7 +986,12 @@ export function Session() {
             const result = await Editor.open({
               value: transcript,
               renderer,
-              cwd: project.instance.path().worktree || project.instance.directory() || process.cwd(),
+              cwd:
+                (project.instance.path().worktree === "/"
+                  ? undefined
+                  : project.instance.path().worktree) ||
+                project.instance.directory() ||
+                process.cwd(),
             })
             if (result !== undefined) {
               await Filesystem.write(filepath, result)


### PR DESCRIPTION
### Issue for this PR

Closes #16071

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opening the external editor from the TUI prompt or session export, the cwd was resolved as:
`project.instance.path().worktree || project.instance.directory() || process.cwd()`

For non-git projects, worktree is intentionally set to "/" (see `src/project/project.ts`). Because "/" is truthy, it was selected as the working directory, causing the editor to open at the filesystem root instead of the actual project directory.

**Fix**

Treat "/" as an invalid worktree at the three Editor.open() call sites so the fallback chain correctly resolves to `project.instance.directory()`.

### How did you verify your code works?

- Tests Run Successful

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR