### PR TITLE
fix: override diff.mnemonicprefix in git config

### DIFF
--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -14,6 +14,8 @@ const cfg = [
   "core.symlinks=true",
   "-c",
   "core.quotepath=false",
+  "-c",
+  "diff.mnemonicprefix=false",
 ] as const
 
 const out = (result: { text(): string }) => result.text().trim()


### PR DESCRIPTION
### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/29203

Fixes #29203

this PR does not have issue yet

this fixes when you have this conf in git , the diff could not parse the diff showing empty diff, bc it was unable to parse it.

**2**

### Type of change

- [X] Bug fix

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._


<img width="2158" height="1314" alt="image" src="https://github.com/user-attachments/assets/b78e3714-db4d-4980-be0f-2f4947c9aab2" />

Using the following git config works
```
# This is Git's per-user configuration file.
[diff]
	mnemonicprefix = false

```

I have tested by changing the git config to `mnemonicprefix=false`, so opencode should override this value

