### PR TITLE
docs: add opencode-datadog-monitor to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -51,6 +51,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
+| [opencode-datadog-monitor](https://github.com/mormubis/opencode-datadog-monitor)                  | Trace OpenCode sessions with Datadog LLM Observability                                            |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                         |
 


### PR DESCRIPTION
Adds [opencode-datadog-monitor](https://github.com/mormubis/opencode-datadog-monitor) to the ecosystem plugins list.

An OpenCode plugin that sends session, tool, and LLM traces to Datadog LLM Observability via the HTTP API. No Datadog Agent or dd-trace dependency required.