### PR TITLE
fix(tui): stop writing kv.json on every theme preview keystroke

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
@@ -17,7 +17,7 @@ export function DialogThemeList() {
   const initial = theme.selected
 
   onCleanup(() => {
-    if (!confirmed) theme.set(initial)
+    if (!confirmed) theme.preview(initial)
   })
 
   return (
@@ -26,7 +26,7 @@ export function DialogThemeList() {
       options={options}
       current={initial}
       onMove={(opt) => {
-        theme.set(opt.value)
+        theme.preview(opt.value)
       }}
       onSelect={(opt) => {
         theme.set(opt.value)
@@ -38,12 +38,12 @@ export function DialogThemeList() {
       }}
       onFilter={(query) => {
         if (query.length === 0) {
-          theme.set(initial)
+          theme.preview(initial)
           return
         }
 
         const first = ref.filtered[0]
-        if (first) theme.set(first.value)
+        if (first) theme.preview(first.value)
       }}
     />
   )

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -478,6 +478,11 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         kv.set("theme", theme)
         return true
       },
+      preview(theme: string) {
+        if (!hasTheme(theme)) return false
+        setStore("active", theme)
+        return true
+      },
       get ready() {
         return store.ready
       },

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -109,6 +109,7 @@ type Opts = {
     selected?: string
     has?: HostPluginApi["theme"]["has"]
     set?: HostPluginApi["theme"]["set"]
+    preview?: HostPluginApi["theme"]["preview"]
     install?: HostPluginApi["theme"]["install"]
     mode?: HostPluginApi["theme"]["mode"]
     ready?: boolean
@@ -144,6 +145,13 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
   let selected = opts.theme?.selected ?? "opencode"
   const set =
     opts.theme?.set ??
+    ((name: string) => {
+      if (!has(name)) return false
+      selected = name
+      return true
+    })
+  const preview =
+    opts.theme?.preview ??
     ((name: string) => {
       if (!has(name)) return false
       selected = name
@@ -338,6 +346,9 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       },
       set(name) {
         return set(name)
+      },
+      preview(name) {
+        return preview(name)
       },
       async install(file) {
         if (opts.theme?.install) return opts.theme.install(file)

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -361,6 +361,7 @@ export type TuiTheme = {
   readonly selected: string
   has: (name: string) => boolean
   set: (name: string) => boolean
+  preview: (name: string) => boolean
   install: (jsonPath: string) => Promise<void>
   mode: () => "dark" | "light"
   readonly ready: boolean


### PR DESCRIPTION
### Issue for this PR

Closes #28893

### Type of change

- [x] Bug fix

### What does this PR do?

The `/themes` dialog calls `theme.set(value)` on every cursor move and filter change, which unconditionally writes to `kv.json`. This causes theme thrashing during preview and potential corruption on abrupt exits.

Added `theme.preview(name)` which changes the active theme without writing to kv. The dialog uses `preview` for cursor navigation, filter changes, and cancel-restore, and `set` only when the user confirms. Also added `preview` to the `TuiTheme` plugin interface.

### How did you verify your code works?

- Existing 5 theme-store tests pass
- Existing 15 plugin-loader tests pass (fixture updated with `preview`)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR