### PR TITLE
fix(opencode): wait for shell output drain

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -481,7 +481,7 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -553,6 +553,9 @@ export const ShellTool = Tool.define(
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
+
+          // Process close can win before the stream fiber has processed buffered output.
+          yield* Fiber.join(output).pipe(Effect.ignore)
 
           return exit.kind === "exit" ? exit.code : null
         }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Effect, Exit, Layer, Stream } from "effect"
+import * as Sink from "effect/Sink"
 import type * as Scope from "effect/Scope"
 import os from "os"
 import path from "path"
@@ -14,20 +15,46 @@ import { Truncate } from "@/tool/truncate"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { ChildProcessSpawner } from "effect/unstable/process"
 import { Plugin } from "../../src/plugin"
 import { testEffect } from "../lib/effect"
 import { Tool } from "@/tool/tool"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 
-const shellLayer = Layer.mergeAll(
-  CrossSpawnSpawner.defaultLayer,
-  AppFileSystem.defaultLayer,
-  Plugin.defaultLayer,
-  Truncate.defaultLayer,
-  Config.defaultLayer,
-  Agent.defaultLayer,
-  RuntimeFlags.defaultLayer,
+const makeShellLayer = (spawner: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner, never, never>) =>
+  Layer.mergeAll(
+    spawner,
+    AppFileSystem.defaultLayer,
+    Plugin.defaultLayer,
+    Truncate.defaultLayer,
+    Config.defaultLayer,
+    Agent.defaultLayer,
+    RuntimeFlags.defaultLayer,
+  )
+
+const shellLayer = makeShellLayer(CrossSpawnSpawner.defaultLayer)
+const encoder = new TextEncoder()
+const delayedOutputLayer = Layer.succeed(
+  ChildProcessSpawner.ChildProcessSpawner,
+  ChildProcessSpawner.make(() =>
+    Effect.succeed(
+      ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(0),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: Sink.drain,
+        stdout: Stream.empty,
+        stderr: Stream.empty,
+        all: Stream.fromEffect(Effect.sleep("50 millis").pipe(Effect.as(encoder.encode("delayed output\n")))),
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      }),
+    ),
+  ),
 )
+const delayedOutputIt = testEffect(makeShellLayer(delayedOutputLayer))
 const it = testEffect(shellLayer)
 type ShellTestServices =
   | (typeof shellLayer extends Layer.Layer<infer ROut, infer _E, infer _RIn> ? ROut : never)
@@ -206,6 +233,28 @@ describe("tool.shell", () => {
           )
           expect(result.metadata.exit).toBe(0)
           expect(result.output).toContain("fallback")
+        }),
+      )
+    }),
+  )
+
+  delayedOutputIt.live("waits for shell output after process exit", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const bash = yield* initBash()
+          const result = yield* bash.execute(
+            {
+              command: "echo delayed",
+              description: "Echo delayed output",
+            },
+            ctx,
+          )
+          expect(result.metadata.exit).toBe(0)
+          expect(result.output).toContain("delayed output")
+          expect(result.metadata.output).toContain("delayed output")
         }),
       )
     }),


### PR DESCRIPTION
### Issue for this PR

Closes #29214

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ShellTool.run` was returning as soon as the child process exit code resolved. The output reader runs in a scoped fiber, so the scope could close before buffered stdout/stderr chunks were processed. That made short shell commands occasionally return `(no output)` even though the process printed text.

This PR keeps the output reader fiber and waits for it to drain before building the final shell result. It also adds a deterministic regression test where the process exit resolves before the output stream emits.

### How did you verify your code works?

- `bun test test/tool/shell.test.ts` from `packages/opencode`
- 20 repeated runs of `bun test test/tool/shell.test.ts -t "falls back from terminal-only configured shell"` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun turbo typecheck` from the repo root
- `.husky/pre-push`

### Screenshots / recordings

No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
