### PR TITLE
fix(task): respect subagent explicit edit:allow over inherited parent edit:deny

### DIFF
--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -23,8 +23,17 @@ export function deriveSubagentSessionPermission(input: {
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
   const parentAgentDenies =
     input.parentAgent?.permission.filter((rule) => rule.action === "deny" && rule.permission === "edit") ?? []
+
+  // If the subagent explicitly allows edit-class tools (e.g., write: allow,
+  // edit: allow), don't inherit the parent's edit denies. The subagent's
+  // explicit config represents user intent and overrides inherited restrictions.
+  const subagentHasExplicitEditAllow = input.subagent.permission.some(
+    (rule) => rule.permission === "edit" && rule.action === "allow",
+  )
+  const effectiveDenies = subagentHasExplicitEditAllow ? [] : parentAgentDenies
+
   return [
-    ...parentAgentDenies,
+    ...effectiveDenies,
     ...input.parentSessionPermission.filter(
       (rule) => rule.permission === "external_directory" || rule.action === "deny",
     ),

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -285,15 +285,18 @@ function expand(pattern: string): string {
   return pattern
 }
 
+const EDIT_CONFIG_KEYS = ["write", "apply_patch"]
+
 export function fromConfig(permission: ConfigPermission.Info) {
   const ruleset: Rule[] = []
   for (const [key, value] of Object.entries(permission)) {
+    const permissionKey = EDIT_CONFIG_KEYS.includes(key) ? "edit" : key
     if (typeof value === "string") {
-      ruleset.push({ permission: key, action: value, pattern: "*" })
+      ruleset.push({ permission: permissionKey, action: value, pattern: "*" })
       continue
     }
     ruleset.push(
-      ...Object.entries(value).map(([pattern, action]) => ({ permission: key, pattern: expand(pattern), action })),
+      ...Object.entries(value).map(([pattern, action]) => ({ permission: permissionKey, pattern: expand(pattern), action })),
     )
   }
   return ruleset

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1220,8 +1220,8 @@ export const layer = Layer.effect(
         permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
       }
       if (permissions.length > 0) {
-        session.permission = permissions
-        yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
+        session.permission = [...(session.permission ?? []), ...permissions]
+        yield* sessions.setPermission({ sessionID: session.id, permission: session.permission })
       }
 
       if (input.noReply === true) return message


### PR DESCRIPTION
### Issue for this PR

Closes #26514
Closes #26700

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes the interaction between #26514 (Plan Mode bypass) and #26700 (parent denies over-constrain subagents).
Subagents with an explicit `write: allow` (or `edit: allow`) configuration can now actually use edit-class tools, even when their parent agent has `edit: deny` (Plan Mode). Generic subagents without an explicit edit-class allow still inherit the parent's denies. Plan Mode security is preserved.
Three changes:

1. `fromConfig()` aliases `write`/`apply_patch` to the `edit` permission key (`packages/opencode/src/permission/index.ts`). The runtime already treats write, apply_patch, and edit as the same tool class via `EDIT_TOOLS`, but the config layer stored `write: allow` as `permission: "write"` which is invisible to the `"edit"` lookup. Aliasing makes config consistent with runtime.
2. `deriveSubagentSessionPermission()` skips parent `edit: deny` when the subagent has explicit `edit: allow` (`packages/opencode/src/agent/subagent-permissions.ts`). PR #26597 forwarded all parent edit denies to subagents. PR #27201 narrowed it to only edit denies. This extends the same principle: if the subagent explicitly allows edit tools, the inherited deny is suppressed. Generic subagents without explicit edit rules still inherit the parent deny so Plan Mode stays secure.
3. `prompt()` merges tool-level denies instead of overwriting session permission (`packages/opencode/src/session/prompt.ts`). The task tool calls `ops.prompt()` with tool-level denies for todowrite/task/primary_tools. `prompt()` was overwriting `session.permission`, destroying inherited rules including the Plan Mode `edit: deny` that `deriveSubagentSessionPermission()` just set up. This fix uses `[...session.permission, ...permissions]` instead of `session.permission = permissions`.

This is more complete than the similar PR #27654 which only covers fix 2.
The `fromConfig()` aliasing and `prompt.ts` merge are needed too.

This fix is also complementary to the approach in #24293 which propagated parent session permissions to subagents (enabling inheritance), while this PR adds the explicit allow check on top of that (allowing overrides when the subagent opts in).

### How did you verify your code works?

All upstream test scenarios pass:

- Plan Mode + generic subagent: `edit: deny` inherited, tools blocked
- Plan Mode + subagent with `write: allow`: `edit: allow` overrides, tools available
- Deny-by-default parent + capable subagent: subagent explicit allows work
- Controller/executor delegation (PR #27201 test): passes

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
