### PR TITLE
fix(opencode): stabilize git diff patch prefixes

### DIFF
--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -15,6 +15,7 @@ const cfg = [
   "-c",
   "core.quotepath=false",
 ] as const
+const patchPrefixArgs = ["--src-prefix=a/", "--dst-prefix=b/"] as const
 
 const out = (result: { text(): string }) => result.text().trim()
 const nuls = (text: string) => text.split("\0").filter(Boolean)
@@ -261,7 +262,17 @@ export const layer = Layer.effect(
 
     const patch = Effect.fn("Git.patch")(function* (cwd: string, ref: string, file: string, options?: PatchOptions) {
       const result = yield* run(
-        ["diff", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", file],
+        [
+          "diff",
+          "--patch",
+          "--no-ext-diff",
+          "--no-renames",
+          ...patchPrefixArgs,
+          `--unified=${options?.context ?? 3}`,
+          ref,
+          "--",
+          file,
+        ],
         { cwd, maxOutputBytes: options?.maxOutputBytes },
       )
       return { text: result.truncated ? "" : result.text(), truncated: result.truncated } satisfies Patch
@@ -269,7 +280,17 @@ export const layer = Layer.effect(
 
     const patchAll = Effect.fn("Git.patchAll")(function* (cwd: string, ref: string, options?: PatchOptions) {
       const result = yield* run(
-        ["diff", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", "."],
+        [
+          "diff",
+          "--patch",
+          "--no-ext-diff",
+          "--no-renames",
+          ...patchPrefixArgs,
+          `--unified=${options?.context ?? 3}`,
+          ref,
+          "--",
+          ".",
+        ],
         { cwd, maxOutputBytes: options?.maxOutputBytes },
       )
       return { text: result.text(), truncated: result.truncated } satisfies Patch
@@ -287,6 +308,7 @@ export const layer = Layer.effect(
           "--patch",
           "--no-ext-diff",
           "--no-renames",
+          ...patchPrefixArgs,
           `--unified=${options?.context ?? 3}`,
           "--",
           "/dev/null",

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -300,6 +300,31 @@ describe("Vcs diff", () => {
   )
 
   it.instance(
+    "diff('git') ignores mnemonic prefix config when rendering patches",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* write(path.join(test.directory, "file.txt"), "original\n")
+        yield* git(test.directory, ["add", "."])
+        yield* git(test.directory, ["commit", "--no-gpg-sign", "-m", "add file"])
+        yield* git(test.directory, ["config", "diff.mnemonicprefix", "true"])
+        yield* write(path.join(test.directory, "file.txt"), "changed\n")
+
+        const vcs = yield* init()
+        const diff = yield* vcs.diff("git")
+        const file = diff.find((item) => item.file === "file.txt")
+
+        expect(file?.patch).toContain("diff --git a/file.txt b/file.txt")
+        expect(file?.patch).toContain("--- a/file.txt")
+        expect(file?.patch).toContain("+++ b/file.txt")
+        expect(file?.patch).not.toContain("i/file.txt")
+        expect(file?.patch).not.toContain("w/file.txt")
+        expect(() => parsePatch(file?.patch ?? "")).not.toThrow()
+      }),
+    { git: true },
+  )
+
+  it.instance(
     "diff('branch') returns changes against default branch",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #29203

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Git's `diff.mnemonicprefix=true` changes patch headers from the usual `a/` and `b/` prefixes to contextual prefixes such as `c/` and `w/`. Those patches can fail downstream diff rendering even though the file list is correct.

This PR forces the git patch commands used by OpenCode to emit stable `a/` and `b/` prefixes without changing the user's repository config. It covers single-file, batched, and untracked patch generation paths.

### How did you verify your code works?

- `bun test test/project/vcs.test.ts -t "ignores mnemonic prefix"` from `packages/opencode`
- `bun test test/project/vcs.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun turbo typecheck` from the repo root
- `.husky/pre-push`

### Screenshots / recordings

No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
