### PR TITLE
feat(api): add single-session status HTTP endpoint

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -74,6 +74,7 @@ export const PermissionResponsePayload = Schema.Struct({
 export const SessionPaths = {
   list: root,
   status: `${root}/status`,
+  singleStatus: `${root}/:sessionID/status`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
@@ -123,6 +124,18 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.status",
             summary: "Get session status",
             description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
+          }),
+        ),
+        HttpApiEndpoint.get("singleStatus", SessionPaths.singleStatus, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(SessionStatus.Info, "Get single session status"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.singleStatus",
+            summary: "Get single session status",
+            description: "Retrieve the current status of a specific session.",
           }),
         ),
         HttpApiEndpoint.get("get", SessionPaths.get, {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -74,7 +74,7 @@ export const PermissionResponsePayload = Schema.Struct({
 export const SessionPaths = {
   list: root,
   status: `${root}/status`,
-  singleStatus: `${root}/:sessionID/status`,
+  getStatus: `${root}/:sessionID/status`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
@@ -126,7 +126,7 @@ export const SessionApi = HttpApi.make("session")
             description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
           }),
         ),
-        HttpApiEndpoint.get("getStatus", SessionPaths.singleStatus, {
+        HttpApiEndpoint.get("getStatus", SessionPaths.getStatus, {
           params: { sessionID: SessionID },
           query: WorkspaceRoutingQuery,
           success: described(SessionStatus.Info, "Get single session status"),

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -126,14 +126,14 @@ export const SessionApi = HttpApi.make("session")
             description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
           }),
         ),
-        HttpApiEndpoint.get("singleStatus", SessionPaths.singleStatus, {
+        HttpApiEndpoint.get("getStatus", SessionPaths.singleStatus, {
           params: { sessionID: SessionID },
           query: WorkspaceRoutingQuery,
           success: described(SessionStatus.Info, "Get single session status"),
           error: [HttpApiError.BadRequest, ApiNotFoundError],
         }).annotateMerge(
           OpenApi.annotations({
-            identifier: "session.singleStatus",
+            identifier: "session.getStatus",
             summary: "Get single session status",
             description: "Retrieve the current status of a specific session.",
           }),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -79,7 +79,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* SessionError.mapStorageNotFound(session.get(sessionID))
     })
 
-    const singleStatus = Effect.fn("SessionHttpApi.singleStatus")(function* (ctx: { params: { sessionID: SessionID } }) {
+    const getStatus = Effect.fn("SessionHttpApi.getStatus")(function* (ctx: { params: { sessionID: SessionID } }) {
       yield* requireSession(ctx.params.sessionID)
       return yield* statusSvc.get(ctx.params.sessionID)
     })
@@ -411,7 +411,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     return handlers
       .handle("list", list)
       .handle("status", status)
-      .handle("singleStatus", singleStatus)
+      .handle("getStatus", getStatus)
       .handle("get", get)
       .handle("children", children)
       .handle("todo", todo)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -75,13 +75,13 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return Object.fromEntries(yield* statusSvc.list())
     })
 
+    const requireSession = Effect.fn("SessionHttpApi.requireSession")(function* (sessionID: SessionID) {
+      return yield* SessionError.mapStorageNotFound(session.get(sessionID))
+    })
+
     const singleStatus = Effect.fn("SessionHttpApi.singleStatus")(function* (ctx: { params: { sessionID: SessionID } }) {
       yield* requireSession(ctx.params.sessionID)
       return yield* statusSvc.get(ctx.params.sessionID)
-    })
-
-    const requireSession = Effect.fn("SessionHttpApi.requireSession")(function* (sessionID: SessionID) {
-      return yield* SessionError.mapStorageNotFound(session.get(sessionID))
     })
 
     const get = Effect.fn("SessionHttpApi.get")(function* (ctx: { params: { sessionID: SessionID } }) {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -75,6 +75,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return Object.fromEntries(yield* statusSvc.list())
     })
 
+    const singleStatus = Effect.fn("SessionHttpApi.singleStatus")(function* (ctx: { params: { sessionID: SessionID } }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* statusSvc.get(ctx.params.sessionID)
+    })
+
     const requireSession = Effect.fn("SessionHttpApi.requireSession")(function* (sessionID: SessionID) {
       return yield* SessionError.mapStorageNotFound(session.get(sessionID))
     })
@@ -406,6 +411,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     return handlers
       .handle("list", list)
       .handle("status", status)
+      .handle("singleStatus", singleStatus)
       .handle("get", get)
       .handle("children", children)
       .handle("todo", todo)


### PR DESCRIPTION
### Issue for this PR

Closes #29166

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionStatus.Service` already had a `get(sessionID)` method but no dedicated HTTP endpoint. Only `GET /session/status` existed (returns all sessions). This adds `GET /session/:sessionID/status` that calls `get()` directly and returns 404 when the session doesn't exist.

### How did you verify your code works?

Built locally and confirmed the new route registers correctly in the HTTP API group alongside the other single-session endpoints.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
