### PR TITLE
fix(httpapi): model optional worktree payload as no content

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
@@ -166,6 +166,7 @@ export const ExperimentalApi = HttpApi.make("experimental")
           }),
         ),
         HttpApiEndpoint.post("worktreeCreate", ExperimentalPaths.worktree, {
+          disableCodecs: true,
           query: WorkspaceRoutingQuery,
           payload: [HttpApiSchema.NoContent, Worktree.CreateInput],
           success: described(Worktree.Info, "Worktree created"),

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
@@ -5,7 +5,7 @@ import { Session } from "@/session/session"
 import { Worktree } from "@/worktree"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
 import { Schema } from "effect"
-import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
 import {
@@ -166,9 +166,8 @@ export const ExperimentalApi = HttpApi.make("experimental")
           }),
         ),
         HttpApiEndpoint.post("worktreeCreate", ExperimentalPaths.worktree, {
-          disableCodecs: true,
           query: WorkspaceRoutingQuery,
-          payload: Schema.UndefinedOr(Worktree.CreateInput),
+          payload: [HttpApiSchema.NoContent, Worktree.CreateInput],
           success: described(Worktree.Info, "Worktree created"),
           error: WorktreeApiError,
         }).annotateMerge(

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
@@ -104,9 +104,9 @@ export const experimentalHandlers = HttpApiBuilder.group(InstanceHttpApi, "exper
     })
 
     const worktreeCreate = Effect.fn("ExperimentalHttpApi.worktreeCreate")(function* (ctx: {
-      payload: Worktree.CreateInput | undefined
+      payload: typeof Worktree.CreateInput.Type | void
     }) {
-      return yield* mapWorktreeError(worktreeSvc.create(ctx.payload))
+      return yield* mapWorktreeError(worktreeSvc.create(ctx.payload ?? undefined))
     })
 
     const worktreeRemove = Effect.fn("ExperimentalHttpApi.worktreeRemove")(function* (input: {

--- a/packages/opencode/test/server/worktree-endpoint-repro.test.ts
+++ b/packages/opencode/test/server/worktree-endpoint-repro.test.ts
@@ -229,6 +229,28 @@ describe("worktree endpoint reproduction", () => {
   )
 
   worktreeTest(
+    "direct HttpApi worktree create rejects explicit null payload",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const server = yield* serverScoped()
+
+        const response = yield* request(
+          server,
+          `${ExperimentalPaths.worktree}?directory=${encodeURIComponent(test.directory)}`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: "null",
+          },
+        )
+
+        expect(response.status).toBe(400)
+      }),
+    { git: true },
+  )
+
+  worktreeTest(
     "workspace worktree create does not hang",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- Model bodyless experimental worktree creation with `HttpApiSchema.NoContent` rather than `Schema.UndefinedOr`.
- Retain `disableCodecs: true` so explicit JSON `null` remains invalid while an absent body remains accepted.
- Add regression coverage for rejecting explicit `null`; existing tests cover missing bodies with and without `Content-Type`.

## Context
`HttpApiSchema.NoContent` is the intended HttpApi representation for an endpoint that accepts either a JSON payload or no request body. This follows the Effect maintainer guidance in https://github.com/Effect-TS/effect-smol/pull/2187#issuecomment-4472575265.

During review I verified that removing `disableCodecs` would widen behavior by turning an explicit JSON `null` request from `400` into successful worktree creation, so this PR keeps that codec boundary.

## Verification
- `bun prettier --write src/server/routes/instance/httpapi/groups/experimental.ts src/server/routes/instance/httpapi/handlers/experimental.ts test/server/worktree-endpoint-repro.test.ts`
- `bun oxlint packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts packages/opencode/test/server/worktree-endpoint-repro.test.ts` (passes with one existing warning in the regression test helper)
- `bun typecheck` from `packages/opencode`
- `bun run test -- test/server/worktree-endpoint-repro.test.ts test/server/httpapi-experimental.test.ts` from `packages/opencode`
- `./packages/sdk/js/script/build.ts` (no generated SDK changes)

## Note
- Initial push used `--no-verify` after confirmation because the repository pre-push hook failed in unchanged `packages/app/src/pages/session/message-timeline.tsx:584` (`VirtualizerHandle` has no `measure` property).
- The initial Linux unit CI failure was an unrelated timeout in `test/session/prompt.test.ts` (`shell rejects when another shell is already running`).