### PR TITLE
fix(httpapi): model optional session payloads as no content

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -236,7 +236,7 @@ export const SessionApi = HttpApi.make("session")
         HttpApiEndpoint.post("fork", SessionPaths.fork, {
           params: { sessionID: SessionID },
           query: WorkspaceRoutingQuery,
-          payload: Schema.optional(ForkPayload),
+          payload: [HttpApiSchema.NoContent, ForkPayload],
           success: described(Session.Info, "200"),
           error: [HttpApiError.BadRequest, ApiNotFoundError],
         }).annotateMerge(

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -15,7 +15,7 @@ import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
-import { Cause, Effect, Option, Schema, Scope } from "effect"
+import { Cause, Effect, Option, Scope } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
@@ -36,12 +36,6 @@ import {
 } from "../groups/session"
 import { PermissionNotFoundError } from "../errors"
 import * as SessionError from "./session-errors"
-
-const tryParseJson = (text: string) =>
-  Effect.try({
-    try: () => JSON.parse(text) as unknown,
-    catch: () => new HttpApiError.BadRequest({}),
-  })
 
 export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", (handlers) =>
   Effect.gen(function* () {
@@ -149,27 +143,16 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       )
     })
 
-    const create = Effect.fn("SessionHttpApi.create")(function* (ctx: { payload?: Session.CreateInput }) {
-      return yield* shareSvc.create(ctx.payload)
-    })
-
-    const createRaw = Effect.fn("SessionHttpApi.createRaw")(function* (ctx: {
-      request: HttpServerRequest.HttpServerRequest
+    const create = Effect.fn("SessionHttpApi.create")(function* (ctx: {
+      payload: typeof Session.CreateInput.Type | void
     }) {
-      const body = yield* Effect.orDie(ctx.request.text)
-      if (body.trim().length === 0) return yield* create({})
-
-      const json = yield* tryParseJson(body)
-      const decoded = yield* Schema.decodeUnknownEffect(Session.CreateInput)(json).pipe(
-        Effect.mapError(() => new HttpApiError.BadRequest({})),
-      )
-      const payload = decoded
+      const payload = ctx.payload
         ? {
-            ...decoded,
-            permission: decoded.permission ? [...decoded.permission] : undefined,
+            ...ctx.payload,
+            permission: ctx.payload.permission ? [...ctx.payload.permission] : undefined,
           }
-        : decoded
-      return yield* create({ payload })
+        : undefined
+      return yield* shareSvc.create(payload)
     })
 
     const remove = Effect.fn("SessionHttpApi.remove")(function* (ctx: { params: { sessionID: SessionID } }) {
@@ -199,25 +182,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
 
     const fork = Effect.fn("SessionHttpApi.fork")(function* (ctx: {
       params: { sessionID: SessionID }
-      payload?: typeof ForkPayload.Type
+      payload: typeof ForkPayload.Type | void
     }) {
       return yield* SessionError.mapStorageNotFound(
         session.fork({ sessionID: ctx.params.sessionID, messageID: ctx.payload?.messageID }),
       )
-    })
-
-    const forkRaw = Effect.fn("SessionHttpApi.forkRaw")(function* (ctx: {
-      params: { sessionID: SessionID }
-      request: HttpServerRequest.HttpServerRequest
-    }) {
-      const body = yield* Effect.orDie(ctx.request.text)
-      if (body.trim().length === 0) return yield* fork({ params: ctx.params })
-
-      const json = yield* tryParseJson(body)
-      const payload = yield* Schema.decodeUnknownEffect(ForkPayload)(json).pipe(
-        Effect.mapError(() => new HttpApiError.BadRequest({})),
-      )
-      return yield* fork({ params: ctx.params, payload })
     })
 
     const abort = Effect.fn("SessionHttpApi.abort")(function* (ctx: { params: { sessionID: SessionID } }) {
@@ -412,10 +381,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("diff", diff)
       .handle("messages", messages)
       .handle("message", message)
-      .handleRaw("create", createRaw)
+      .handle("create", create)
       .handle("remove", remove)
       .handle("update", update)
-      .handleRaw("fork", forkRaw)
+      .handle("fork", fork)
       .handle("abort", abort)
       .handle("init", init)
       .handle("share", share)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -15,7 +15,7 @@ import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
-import { Cause, Effect, Option, Scope } from "effect"
+import { Cause, Effect, Option, Schema, Scope } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
@@ -36,6 +36,12 @@ import {
 } from "../groups/session"
 import { PermissionNotFoundError } from "../errors"
 import * as SessionError from "./session-errors"
+
+const tryParseJson = (text: string) =>
+  Effect.try({
+    try: () => JSON.parse(text) as unknown,
+    catch: () => new HttpApiError.BadRequest({}),
+  })
 
 export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", (handlers) =>
   Effect.gen(function* () {
@@ -143,16 +149,27 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       )
     })
 
-    const create = Effect.fn("SessionHttpApi.create")(function* (ctx: {
-      payload: typeof Session.CreateInput.Type | void
+    const create = Effect.fn("SessionHttpApi.create")(function* (ctx: { payload?: Session.CreateInput }) {
+      return yield* shareSvc.create(ctx.payload)
+    })
+
+    const createRaw = Effect.fn("SessionHttpApi.createRaw")(function* (ctx: {
+      request: HttpServerRequest.HttpServerRequest
     }) {
-      const payload = ctx.payload
+      const body = yield* Effect.orDie(ctx.request.text)
+      if (body.trim().length === 0) return yield* create({})
+
+      const json = yield* tryParseJson(body)
+      const decoded = yield* Schema.decodeUnknownEffect(Session.CreateInput)(json).pipe(
+        Effect.mapError(() => new HttpApiError.BadRequest({})),
+      )
+      const payload = decoded
         ? {
-            ...ctx.payload,
-            permission: ctx.payload.permission ? [...ctx.payload.permission] : undefined,
+            ...decoded,
+            permission: decoded.permission ? [...decoded.permission] : undefined,
           }
-        : undefined
-      return yield* shareSvc.create(payload)
+        : decoded
+      return yield* create({ payload })
     })
 
     const remove = Effect.fn("SessionHttpApi.remove")(function* (ctx: { params: { sessionID: SessionID } }) {
@@ -182,11 +199,25 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
 
     const fork = Effect.fn("SessionHttpApi.fork")(function* (ctx: {
       params: { sessionID: SessionID }
-      payload: typeof ForkPayload.Type | void
+      payload?: typeof ForkPayload.Type
     }) {
       return yield* SessionError.mapStorageNotFound(
         session.fork({ sessionID: ctx.params.sessionID, messageID: ctx.payload?.messageID }),
       )
+    })
+
+    const forkRaw = Effect.fn("SessionHttpApi.forkRaw")(function* (ctx: {
+      params: { sessionID: SessionID }
+      request: HttpServerRequest.HttpServerRequest
+    }) {
+      const body = yield* Effect.orDie(ctx.request.text)
+      if (body.trim().length === 0) return yield* fork({ params: ctx.params })
+
+      const json = yield* tryParseJson(body)
+      const payload = yield* Schema.decodeUnknownEffect(ForkPayload)(json).pipe(
+        Effect.mapError(() => new HttpApiError.BadRequest({})),
+      )
+      return yield* fork({ params: ctx.params, payload })
     })
 
     const abort = Effect.fn("SessionHttpApi.abort")(function* (ctx: { params: { sessionID: SessionID } }) {
@@ -381,10 +412,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("diff", diff)
       .handle("messages", messages)
       .handle("message", message)
-      .handle("create", create)
+      .handleRaw("create", createRaw)
       .handle("remove", remove)
       .handle("update", update)
-      .handle("fork", fork)
+      .handleRaw("fork", forkRaw)
       .handle("abort", abort)
       .handle("init", init)
       .handle("share", share)

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -582,26 +582,6 @@ describe("session HttpApi", () => {
         })
         expect(createdEmpty.id).toBeTruthy()
 
-        const createdWithoutContentType = yield* requestJson<Session.Info>(SessionPaths.create, {
-          method: "POST",
-          headers: { "x-opencode-directory": test.directory },
-        })
-        expect(createdWithoutContentType.id).toBeTruthy()
-
-        const invalidCreate = yield* request(SessionPaths.create, {
-          method: "POST",
-          headers,
-          body: "{",
-        })
-        expect(invalidCreate.status).toBe(400)
-
-        const createdWhitespace = yield* requestJson<Session.Info>(SessionPaths.create, {
-          method: "POST",
-          headers,
-          body: "  \n",
-        })
-        expect(createdWhitespace.id).toBeTruthy()
-
         const created = yield* requestJson<Session.Info>(SessionPaths.create, {
           method: "POST",
           headers,

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -582,6 +582,12 @@ describe("session HttpApi", () => {
         })
         expect(createdEmpty.id).toBeTruthy()
 
+        const createdWithoutContentType = yield* requestJson<Session.Info>(SessionPaths.create, {
+          method: "POST",
+          headers: { "x-opencode-directory": test.directory },
+        })
+        expect(createdWithoutContentType.id).toBeTruthy()
+
         const created = yield* requestJson<Session.Info>(SessionPaths.create, {
           method: "POST",
           headers,
@@ -601,6 +607,15 @@ describe("session HttpApi", () => {
           headers,
         })
         expect(forked.id).not.toBe(created.id)
+
+        const forkedWithoutContentType = yield* requestJson<Session.Info>(
+          pathFor(SessionPaths.fork, { sessionID: created.id }),
+          {
+            method: "POST",
+            headers: { "x-opencode-directory": test.directory },
+          },
+        )
+        expect(forkedWithoutContentType.id).not.toBe(created.id)
 
         expect(
           yield* requestJson<boolean>(pathFor(SessionPaths.abort, { sessionID: created.id }), {

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -588,6 +588,20 @@ describe("session HttpApi", () => {
         })
         expect(createdWithoutContentType.id).toBeTruthy()
 
+        const invalidCreate = yield* request(SessionPaths.create, {
+          method: "POST",
+          headers,
+          body: "{",
+        })
+        expect(invalidCreate.status).toBe(400)
+
+        const createdWhitespace = yield* requestJson<Session.Info>(SessionPaths.create, {
+          method: "POST",
+          headers,
+          body: "  \n",
+        })
+        expect(createdWhitespace.id).toBeTruthy()
+
         const created = yield* requestJson<Session.Info>(SessionPaths.create, {
           method: "POST",
           headers,
@@ -616,6 +630,23 @@ describe("session HttpApi", () => {
           },
         )
         expect(forkedWithoutContentType.id).not.toBe(created.id)
+
+        const invalidFork = yield* request(pathFor(SessionPaths.fork, { sessionID: created.id }), {
+          method: "POST",
+          headers,
+          body: "{",
+        })
+        expect(invalidFork.status).toBe(400)
+
+        const forkedWhitespace = yield* requestJson<Session.Info>(
+          pathFor(SessionPaths.fork, { sessionID: created.id }),
+          {
+            method: "POST",
+            headers,
+            body: "  \n",
+          },
+        )
+        expect(forkedWhitespace.id).not.toBe(created.id)
 
         expect(
           yield* requestJson<boolean>(pathFor(SessionPaths.abort, { sessionID: created.id }), {


### PR DESCRIPTION
## Summary
- Model bodyless session forks with `HttpApiSchema.NoContent` rather than a top-level `Schema.optional` payload.
- Keep the existing raw request parser in place because it preserves legacy handling for whitespace-only bodies and malformed JSON.
- Add regression coverage for bodyless forks without `Content-Type`, whitespace-only bodies, and malformed JSON returning `400`.

## Context
`HttpApiSchema.NoContent` is the intended HttpApi representation for an endpoint that accepts either a JSON payload or no request body. This follows the Effect maintainer guidance in https://github.com/Effect-TS/effect-smol/pull/2187#issuecomment-4472575265.

During review I verified that switching this route entirely to standard HttpApi decoding would change malformed JSON from `400` to `500`, so this PR deliberately updates the declaration without removing the compatibility parser.

## Verification
- `bun prettier --write test/server/httpapi-session.test.ts`
- `bun oxlint packages/opencode/src/server/routes/instance/httpapi/groups/session.ts packages/opencode/test/server/httpapi-session.test.ts` (passes with existing warnings in the test file)
- `bun typecheck` from `packages/opencode`
- `bun run test -- test/server/httpapi-session.test.ts` from `packages/opencode`
- `./packages/sdk/js/script/build.ts` (no generated SDK changes)

## Note
- Initial push used `--no-verify` after confirmation because the repository pre-push hook failed in unchanged `packages/app/src/pages/session/message-timeline.tsx:584` (`VirtualizerHandle` has no `measure` property). CI typecheck subsequently passed for the original PR revision.