### PR TITLE
tweak (config): make modalities input/output fields optional so that u can specify one without both being required 

### DIFF
--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -44,8 +44,8 @@ export const Model = Schema.Struct({
   ),
   modalities: Schema.optional(
     Schema.Struct({
-      input: Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"]))),
-      output: Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"]))),
+      input: Schema.optional(Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"])))),
+      output: Schema.optional(Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"])))),
     }),
   ),
   experimental: Schema.optional(Schema.Boolean),


### PR DESCRIPTION
Fixes #29269

## Problem

When configuring a custom model with only `modalities.input` (the common case — e.g. enabling image support on a local LM Studio model), opencode crashes on startup:

```
ConfigInvalidError: Missing key
  at ["provider"]["lmstudio"]["models"]["google/gemma-4-e4b"]["modalities"]["output"]
```

The entire `modalities` block is `Schema.optional`, but once provided, both `input` and `output` are required fields inside the struct. The error gives no hint that `output` is required or what values it accepts. Workaround is to add `"output": ["text"]` — but users have no way to discover this.

## Fix

Wrap each field in `Schema.optional` so users can specify just the fields relevant to them:

```jsonc
"modalities": { "input": ["image"] }  // now valid
```

## Why this is safe

All consuming code in `provider.ts` already accesses both fields via optional chaining (`?.`) with explicit fallback defaults.