### PR TITLE
fix(opencode): prevent process.exit() from killing parent terminal on Windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -283,6 +283,12 @@ export const TuiThreadCommand = cmd({
         unguard?.()
       } catch {}
     }
+    // On Windows, process.exit() can send CTRL_CLOSE_EVENT to the console
+    // which kills the parent terminal process. Use exitCode instead.
+    if (process.platform === "win32") {
+      process.exitCode = 0
+      return
+    }
     process.exit(0)
   },
 })

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -134,6 +134,15 @@ try {
   }
   process.exitCode = 1
 } finally {
+  // On Windows, process.exit() can send CTRL_CLOSE_EVENT to the console
+  // which kills the parent terminal process (pwsh/cmd). This is a known
+  // regression since opentui 0.1.103.
+  // Set exitCode and let the process drain naturally. MCP subprocesses
+  // are cleaned up by Effect finalizers before this point.
+  if (process.platform === "win32") {
+    process.exitCode ||= 0
+    return
+  }
   // Some subprocesses don't react properly to SIGTERM and similar signals.
   // Most notably, some docker-container-based MCP servers don't handle such signals unless
   // run using `docker run --init`.


### PR DESCRIPTION
### Issue for this PR

Closes #28673

### Type of change

- [x] Bug fix

### What does this PR do?

On Windows, process.exit() calls ExitProcess() internally, which sends CTRL_CLOSE_EVENT to the console group. If the parent terminal (pwsh/cmd) shares the same console group, it gets killed too. This regression was introduced by the opentui dependency bump (0.1.99 ? 0.1.103) in v1.14.25, which changed how the TUI process terminates.

Root cause of the fix: On POSIX, process.exit() sends SIGTERM to the process only. On Windows, ExitProcess() tears down the entire console group. By avoiding process.exit() on Windows and using process.exitCode instead, the parent terminal is never signaled.

Changes:
- thread.ts: On Windows, use process.exitCode = 0; return instead of process.exit(0)
- index.ts: On Windows, set exitCode and return from the finally block instead of bare process.exit(). MCP subprocess trees are already cleaned up by Effect finalizers before this point.

### How did you verify your code works?

- bun run typecheck passes for the opencode package
- The @opencode-ai/enterprise typecheck failure is pre-existing (syntax error in custom-elements.d.ts)
- Logic verified: Windows guard wraps only the process.exit() call, leaving POSIX behavior unchanged

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR