### PR TITLE
fix(config): support ${env:VAR} syntax in addition to {env:VAR} for env substitution

### DIFF
--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -30,10 +30,11 @@ function dir(input: ParseSource) {
   return input.type === "path" ? path.dirname(input.path) : input.dir
 }
 
-/** Apply {env:VAR} and {file:path} substitutions to config text. */
+/** Apply {env:VAR}, ${env:VAR}, and {file:path} substitutions to config text. */
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
-  let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
+  let text = input.text.replace(/\$\{env:([^}]+)\}|\{env:([^}]+)\}/g, (_, dollarVar, braceVar) => {
+    const varName = dollarVar ?? braceVar
     return (input.env?.[varName] ?? process.env[varName]) || ""
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #27853

### Type of change

- [x] Bug fix

### What does this PR do?

The config substitution regex in ConfigVariable.substitute() only matched {env:VAR} syntax (curly braces, no dollar prefix). However, users naturally use ${env:VAR} syntax because:
1. It is the standard shell environment variable convention
2. The shell tool (shell.ts) already supports ${env:VAR} syntax
3. Documentation and examples often show the ${env:VAR} format

This caused the literal string ${env:VAR} to be passed through as the API key instead of resolving the environment variable.

Root cause: The regex /\{env:([^}]+)\}/g in packages/opencode/src/config/variable.ts only matched {env:VAR}, not ${env:VAR}.

Fix: Updated the regex to match both formats: /\$\{env:([^}]+)\}|\{env:([^}]+)\}/g. The dollar-prefixed variant is tried first, falling back to the bare curly-brace variant. Backward compatible — all existing {env:VAR} usages continue to work unchanged.

### How did you verify your code works?

- bun run typecheck passes (exit code 0)
- All 202 config tests pass (0 failures)
- Existing {env:VAR} format continues to work (covered by existing tests)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR