### PR TITLE
fix(cli): add trailing newline to --help output

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -197,7 +197,7 @@ try {
     await cli.parse(args, (err: Error | undefined, _argv: unknown, out: string) => {
       if (err) throw err
       if (!out) return
-      show(out)
+      show(out + EOL)
     })
   } else {
     await cli.parse()


### PR DESCRIPTION
### Issue for this PR

Closes #28606

### Type of change

- [x] Bug fix

### What does this PR do?

Yargs `--help` output does not end with a trailing newline, causing the next shell prompt to appear immediately after the last line of help text on the same line. This is a cosmetic issue.

**Fix:** Append `EOL` to the help output string in the `--help` parse callback before passing it to the `show()` function.

### How did you verify your code works?

- `bun run typecheck` passes (exit code 0)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR