### PR TITLE
fix(shell): case-insensitive env var lookup for pwsh on non-Windows

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -139,7 +139,6 @@ function home(text: string) {
 }
 
 function envValue(key: string) {
-  if (process.platform !== "win32") return process.env[key]
   const name = Object.keys(process.env).find((item) => item.toLowerCase() === key.toLowerCase())
   return name ? process.env[name] : undefined
 }

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1236,3 +1236,42 @@ describe("tool.shell truncation", () => {
     ),
   )
 })
+
+for (const item of ps) {
+  it.live(`resolves $env: references case-insensitively [${item.label}]`, () =>
+    withShell(
+      item,
+      runIn(
+        projectRoot,
+        Effect.acquireUseRelease(
+          Effect.sync(() => {
+            const prev = process.env.TestEnvVarMixedCase
+            process.env.TestEnvVarMixedCase = os.tmpdir()
+            return prev
+          }),
+          () =>
+            Effect.gen(function* () {
+              const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+              const err = new Error("stop after permission")
+              expect(
+                yield* fail(
+                  {
+                    command: `Get-Content $env:TESTENVVARMIXEDCASE/file.txt`,
+                    description: "Test case-insensitive env var in path",
+                  },
+                  capture(requests, err),
+                ),
+              ).toMatchObject({ message: err.message })
+              const extDirReq = requests.find((r) => r.permission === "external_directory")
+              expect(extDirReq).toBeDefined()
+            }),
+          (prev) =>
+            Effect.sync(() => {
+              if (prev === undefined) delete process.env.TestEnvVarMixedCase
+              else process.env.TestEnvVarMixedCase = prev
+            }),
+        ),
+      ),
+    ),
+  )
+}


### PR DESCRIPTION
### Issue for this PR

Closes #29290

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The envValue() function in shell.ts used case-sensitive process.env lookup on non-Windows platforms, but the $env: expansion regex is case-insensitive. This caused mixed-case env var references like $env:Path to fail on Linux/macOS when using pwsh. On Windows this worked because the platform's env API is case-insensitive.

The fix removes the platform check so the case-insensitive lookup via Object.keys(process.env).find() is always used.

### How did you verify your code works?

- Added a dedicated test that sets a mixed-case env var (TestEnvVarMixedCase) and references it in ALL CAPS ($env:TESTENVVARMIXEDCASE), verifying the permission system resolves the path correctly
- Full shell test suite passes (64/66, 2 pre-existing failures unrelated to this change)

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR