### PR TITLE
fix(shell): preview Unicode truncation uses byte length instead of char length

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -218,8 +218,11 @@ function pathArgs(list: Part[], ps: boolean, cmd = false) {
 }
 
 function preview(text: string) {
-  if (text.length <= MAX_METADATA_LENGTH) return text
-  return "...\n\n" + text.slice(-MAX_METADATA_LENGTH)
+  if (Buffer.byteLength(text, "utf-8") <= MAX_METADATA_LENGTH) return text
+  let buf = Buffer.from(text, "utf-8")
+  buf = buf.subarray(-MAX_METADATA_LENGTH)
+  while (buf.length > 0 && (buf[0] & 0xc0) === 0x80) buf = buf.subarray(1)
+  return "...\n\n" + buf.toString("utf-8")
 }
 
 function tail(text: string, maxLines: number, maxBytes: number) {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1235,4 +1235,21 @@ describe("tool.shell truncation", () => {
       }),
     ),
   )
+
+  it.live("preview keeps valid UTF-8 for multi-byte output", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const n = 12000
+        const result = yield* run({
+          command: `${bin} -e ${evalarg(`process.stdout.write('\\u4e2d'.repeat(${n}))`)} ${n}`,
+          description: "Generate Unicode output",
+        })
+        const meta = result.metadata as { output?: string }
+        if (meta.output) {
+          expect(meta.output.includes("\uFFFD")).toBe(false)
+        }
+      }),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #29291

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `preview()` function in `shell.ts` used `text.length` (UTF-16 code units) to check if output exceeds the 30,000-byte metadata limit. Multi-byte characters like CJK (3 bytes each) or emoji (4 bytes) were incorrectly counted. The fix uses `Buffer.byteLength()` for byte-accurate checking and ensures truncated output doesn't split a multi-byte character.

### How did you verify your code works?

- Added a test that generates 12,000 CJK characters (36,000 bytes) and verifies the metadata output contains no Unicode replacement characters
- Full shell test suite passes (64/66, 2 pre-existing failures unrelated to this change)

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR