### PR TITLE
fix(config): handle os.userInfo() failure in container/sandbox environments

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -762,7 +762,13 @@ export const layer = Layer.effect(
           result.permission = mergeDeep(perms, result.permission ?? {})
         }
 
-        if (!result.username) result.username = os.userInfo().username
+        if (!result.username) {
+          try {
+            result.username = os.userInfo().username
+          } catch {
+            result.username = "user"
+          }
+        }
 
         if (result.autoshare === true && !result.share) {
           result.share = "auto"

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, afterEach, beforeEach } from "bun:test"
+import { test, expect, describe, afterEach, beforeEach, beforeAll, afterAll, spyOn } from "bun:test"
 import { Effect, Exit, Layer, Option } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
@@ -26,6 +26,7 @@ import {
 import { InstanceRuntime } from "@/project/instance-runtime"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
+import os from "os"
 import path from "path"
 import fs from "fs/promises"
 import { pathToFileURL } from "url"
@@ -1970,4 +1971,25 @@ test("parseManagedPlist handles empty config", async () => {
     "test:mobileconfig",
   )
   expect(config.$schema).toBe("https://opencode.ai/config.json")
+})
+
+describe("os.userInfo fallback", () => {
+  let userInfoSpy: ReturnType<typeof spyOn>
+
+  beforeAll(() => {
+    userInfoSpy = spyOn(os, "userInfo").mockImplementation(() => {
+      throw new Error("ENOENT")
+    })
+  })
+
+  afterAll(() => {
+    userInfoSpy.mockRestore()
+  })
+
+  it.instance("falls back to 'user' when os.userInfo() fails", () =>
+    Effect.gen(function* () {
+      const config = yield* Config.use.get()
+      expect(config.username).toBe("user")
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #29292

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `loadInstanceState()` function in `config.ts` calls `os.userInfo().username` to set a default username when none is configured. In minimal Docker/OCI containers where the passwd entry is unavailable, `os.userInfo()` throws an error, causing config initialization failure. The fix wraps the call in try/catch with a "user" fallback.

### How did you verify your code works?

- Added a test that mocks `os.userInfo()` to throw ENOENT and verifies config loads with username = "user"
- Full config test suite passes (92/92)

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR