### PR TITLE
fix(tui): avoid placeholder session route on continue

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -4,7 +4,7 @@ import * as Clipboard from "@tui/util/clipboard"
 import * as Selection from "@tui/util/selection"
 import * as TuiAudio from "@tui/util/audio"
 import { createCliRenderer, MouseButton, type CliRendererConfig } from "@opentui/core"
-import { RouteProvider, useRoute } from "@tui/context/route"
+import { RouteProvider, useRoute, type Route } from "@tui/context/route"
 import {
   Switch,
   Match,
@@ -146,6 +146,11 @@ function rendererConfig(_config: TuiConfig.Resolved): CliRendererConfig {
   }
 }
 
+export function initialRouteForArgs(args: Args): Route | undefined {
+  if (args.sessionID && !args.fork) return { type: "session", sessionID: args.sessionID }
+  return undefined
+}
+
 function errorMessage(error: unknown) {
   const formatted = FormatError(error)
   if (formatted !== undefined) return formatted
@@ -210,14 +215,7 @@ export function tui(input: {
                 <KVProvider>
                   <ToastProvider>
                     <RouteProvider
-                      initialRoute={
-                        input.args.continue
-                          ? {
-                              type: "session",
-                              sessionID: "dummy",
-                            }
-                          : undefined
-                      }
+                      initialRoute={initialRouteForArgs(input.args)}
                     >
                       <TuiConfigProvider config={input.config}>
                         <SDKProvider

--- a/packages/opencode/test/cli/tui/app.test.ts
+++ b/packages/opencode/test/cli/tui/app.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { initialRouteForArgs } from "../../../src/cli/cmd/tui/app"
+
+describe("tui app", () => {
+  test("does not use a placeholder session route while resolving --continue", () => {
+    expect(initialRouteForArgs({ continue: true })).toBeUndefined()
+  })
+
+  test("does not use a placeholder session route while resolving --continue --fork", () => {
+    expect(initialRouteForArgs({ continue: true, fork: true })).toBeUndefined()
+  })
+
+  test("uses explicit session route when not forking", () => {
+    expect(initialRouteForArgs({ sessionID: "ses_existing" })).toEqual({
+      type: "session",
+      sessionID: "ses_existing",
+    })
+  })
+
+  test("waits for fork result before routing an explicit session fork", () => {
+    expect(initialRouteForArgs({ sessionID: "ses_existing", fork: true })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29262

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI used `sessionID: "dummy"` as the initial route whenever `--continue` was passed. While the real previous session or fork target is resolved asynchronously, the session route can issue startup requests for `/session/dummy`, which fails server-side validation and shows an `Unexpected server error` toast.

This removes the placeholder session route. `--continue` and `--continue --fork` now start on the home route until the real session id is known. Explicit `--session` without `--fork` still starts directly on that real session id.

### How did you verify your code works?

- `bun test test/cli/tui/app.test.ts` from `packages/opencode`
- `bun test test/cli/tui/thread.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun turbo typecheck` from repo root
- `.husky/pre-push` from repo root

Note: after syncing latest `dev`, the new stats packages required refreshing local dependencies with `bun install` so `@tsconfig/node22` was available. The generated lockfile rewrite was not included in this PR.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
