### PR TITLE
fix(config): fallback when user info is unavailable

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -2,7 +2,6 @@ import * as Log from "@opencode-ai/core/util/log"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import path from "path"
 import { pathToFileURL } from "url"
-import os from "os"
 import { mergeDeep } from "remeda"
 import { Global } from "@opencode-ai/core/global"
 import fsNode from "fs/promises"
@@ -41,6 +40,7 @@ import { ConfigReference } from "./reference"
 import { ConfigServer } from "./server"
 import { ConfigSkills } from "./skills"
 import { ConfigVariable } from "./variable"
+import { ConfigUsername } from "./username"
 import { Npm } from "@opencode-ai/core/npm"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 
@@ -762,7 +762,7 @@ export const layer = Layer.effect(
           result.permission = mergeDeep(perms, result.permission ?? {})
         }
 
-        if (!result.username) result.username = os.userInfo().username
+        if (!result.username) result.username = ConfigUsername.get()
 
         if (result.autoshare === true && !result.share) {
           result.share = "auto"

--- a/packages/opencode/src/config/managed.ts
+++ b/packages/opencode/src/config/managed.ts
@@ -1,10 +1,10 @@
 export * as ConfigManaged from "./managed"
 
 import { existsSync } from "fs"
-import os from "os"
 import path from "path"
 import * as Log from "@opencode-ai/core/util/log"
 import { Process } from "@/util/process"
+import { ConfigUsername } from "./username"
 
 const log = Log.create({ service: "config" })
 
@@ -46,7 +46,7 @@ export function parseManagedPlist(json: string): string {
 export async function readManagedPreferences() {
   if (process.platform !== "darwin") return
 
-  const user = os.userInfo().username
+  const user = ConfigUsername.get()
   const paths = [
     path.join("/Library/Managed Preferences", user, `${MANAGED_PLIST_DOMAIN}.plist`),
     path.join("/Library/Managed Preferences", `${MANAGED_PLIST_DOMAIN}.plist`),

--- a/packages/opencode/src/config/username.ts
+++ b/packages/opencode/src/config/username.ts
@@ -1,0 +1,15 @@
+export * as ConfigUsername from "./username"
+
+import os from "os"
+import * as Log from "@opencode-ai/core/util/log"
+
+const log = Log.create({ service: "config" })
+
+export function get() {
+  try {
+    return os.userInfo().username || "user"
+  } catch (err) {
+    log.warn("failed to read system username, using fallback", { err })
+    return "user"
+  }
+}

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, afterEach, beforeEach } from "bun:test"
+import { test, expect, describe, afterEach, beforeEach, spyOn } from "bun:test"
 import { Effect, Exit, Layer, Option } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
@@ -28,6 +28,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
 import path from "path"
 import fs from "fs/promises"
+import os from "os"
 import { pathToFileURL } from "url"
 import { Global } from "@opencode-ai/core/global"
 import { ProjectID } from "../../src/project/schema"
@@ -288,6 +289,20 @@ it.instance("loads config with defaults when no files exist", () =>
   Effect.gen(function* () {
     const config = yield* Config.use.get()
     expect(config.username).toBeDefined()
+  }),
+)
+
+it.instance("falls back to a generic username when system user info is unavailable", () =>
+  Effect.gen(function* () {
+    const userInfo = spyOn(os, "userInfo").mockImplementation(() => {
+      throw Object.assign(new Error("missing passwd entry"), { code: "ENOENT" })
+    })
+    try {
+      const config = yield* Config.use.get()
+      expect(config.username).toBe("user")
+    } finally {
+      userInfo.mockRestore()
+    }
   }),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #29292

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Config startup currently assumes `os.userInfo().username` is always available. In minimal containers or sandboxed environments without a passwd entry, that call can throw and prevent config initialization from completing.

This PR adds a small config username helper that falls back to `"user"` when system user lookup fails or returns an empty username. It is used for both the default config username and macOS managed preference lookup, so the same failure mode does not crash either path.

### How did you verify your code works?

- `bun test test/config/config.test.ts -t "falls back to a generic username"`
- `bun test test/config/config.test.ts`
- `bun typecheck`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`

### Screenshots / recordings

Not applicable; config startup behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
