### PR TITLE
fix(shell): truncate metadata preview by bytes

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -220,7 +220,7 @@ function pathArgs(list: Part[], ps: boolean, cmd = false) {
   return out
 }
 
-function preview(text: string) {
+export function previewMetadata(text: string) {
   if (Buffer.byteLength(text, "utf-8") <= MAX_METADATA_LENGTH) return text
   return "...\n\n" + tailBytes(text, MAX_METADATA_LENGTH)
 }
@@ -497,7 +497,7 @@ export const ShellTool = Tool.define(
                 cut = true
               }
 
-              last = preview(last + chunk)
+              last = previewMetadata(last + chunk)
 
               if (file) {
                 sink?.write(chunk)
@@ -589,7 +589,7 @@ export const ShellTool = Tool.define(
       return {
         title: input.description,
         metadata: {
-          output: last || preview(output),
+          output: last || previewMetadata(output),
           exit: code,
           description: input.description,
           truncated: cut,

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -221,8 +221,16 @@ function pathArgs(list: Part[], ps: boolean, cmd = false) {
 }
 
 function preview(text: string) {
-  if (text.length <= MAX_METADATA_LENGTH) return text
-  return "...\n\n" + text.slice(-MAX_METADATA_LENGTH)
+  if (Buffer.byteLength(text, "utf-8") <= MAX_METADATA_LENGTH) return text
+  return "...\n\n" + tailBytes(text, MAX_METADATA_LENGTH)
+}
+
+function tailBytes(text: string, maxBytes: number) {
+  const buf = Buffer.from(text, "utf-8")
+  if (buf.length <= maxBytes) return text
+  let start = buf.length - maxBytes
+  while (start < buf.length && (buf[start] & 0xc0) === 0x80) start++
+  return buf.subarray(start).toString("utf-8")
 }
 
 function tail(text: string, maxLines: number, maxBytes: number) {
@@ -240,11 +248,7 @@ function tail(text: string, maxLines: number, maxBytes: number) {
     const size = Buffer.byteLength(lines[i], "utf-8") + (out.length > 0 ? 1 : 0)
     if (bytes + size > maxBytes) {
       if (out.length === 0) {
-        const buf = Buffer.from(lines[i], "utf-8")
-        let start = buf.length - maxBytes
-        if (start < 0) start = 0
-        while (start < buf.length && (buf[start] & 0xc0) === 0x80) start++
-        out.unshift(buf.subarray(start).toString("utf-8"))
+        out.unshift(tailBytes(lines[i], maxBytes))
       }
       break
     }

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1205,6 +1205,43 @@ describe("tool.shell truncation", () => {
     ),
   )
 
+  it.live("truncates metadata output by utf8 byte length", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const result = yield* run({
+          command: `${bin} -e ${evalarg("process.stdout.write(String.fromCodePoint(0x4e00).repeat(10001))")}`,
+          description: "Generate CJK output exceeding metadata byte limit",
+        })
+        const output = result.metadata.output
+        if (typeof output !== "string") throw new Error("expected metadata output")
+
+        expect(output.startsWith("...\n\n")).toBe(true)
+        expect(Buffer.byteLength(output.slice("...\n\n".length), "utf-8")).toBeLessThanOrEqual(30_000)
+      }),
+    ),
+  )
+
+  it.live("does not split surrogate pairs when truncating metadata output", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const result = yield* run({
+          command: `${bin} -e ${evalarg(
+            "process.stdout.write(String.fromCharCode(97)+String.fromCodePoint(0x1f642).repeat(15000)+String.fromCharCode(98))",
+          )}`,
+          description: "Generate emoji output exceeding metadata byte limit",
+        })
+        const output = result.metadata.output
+        if (typeof output !== "string") throw new Error("expected metadata output")
+
+        const first = output.charCodeAt("...\n\n".length)
+        expect(output.startsWith("...\n\n")).toBe(true)
+        expect(first < 0xdc00 || first > 0xdfff).toBe(true)
+      }),
+    ),
+  )
+
   it.live("full output is saved to file when truncated", () =>
     runIn(
       projectRoot,

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { Cause, Effect, Exit, Layer } from "effect"
 import type * as Scope from "effect/Scope"
 import os from "os"
 import path from "path"
 import { Config } from "@/config/config"
 import { Shell } from "../../src/shell/shell"
-import { ShellTool } from "../../src/tool/shell"
+import { ShellTool, previewMetadata } from "../../src/tool/shell"
 import { Filesystem } from "@/util/filesystem"
 import { provideInstance, tmpdirScoped } from "../fixture/fixture"
 import type { Permission } from "../../src/permission"
@@ -1205,42 +1205,22 @@ describe("tool.shell truncation", () => {
     ),
   )
 
-  it.live("truncates metadata output by utf8 byte length", () =>
-    runIn(
-      projectRoot,
-      Effect.gen(function* () {
-        const result = yield* run({
-          command: `${bin} -e ${evalarg("process.stdout.write(String.fromCodePoint(0x4e00).repeat(10001))")}`,
-          description: "Generate CJK output exceeding metadata byte limit",
-        })
-        const output = result.metadata.output
-        if (typeof output !== "string") throw new Error("expected metadata output")
+  test("truncates metadata output by utf8 byte length", () => {
+    const output = previewMetadata(String.fromCodePoint(0x4e00).repeat(10001))
 
-        expect(output.startsWith("...\n\n")).toBe(true)
-        expect(Buffer.byteLength(output.slice("...\n\n".length), "utf-8")).toBeLessThanOrEqual(30_000)
-      }),
-    ),
-  )
+    expect(output.startsWith("...\n\n")).toBe(true)
+    expect(Buffer.byteLength(output.slice("...\n\n".length), "utf-8")).toBeLessThanOrEqual(30_000)
+  })
 
-  it.live("does not split surrogate pairs when truncating metadata output", () =>
-    runIn(
-      projectRoot,
-      Effect.gen(function* () {
-        const result = yield* run({
-          command: `${bin} -e ${evalarg(
-            "process.stdout.write(String.fromCharCode(97)+String.fromCodePoint(0x1f642).repeat(15000)+String.fromCharCode(98))",
-          )}`,
-          description: "Generate emoji output exceeding metadata byte limit",
-        })
-        const output = result.metadata.output
-        if (typeof output !== "string") throw new Error("expected metadata output")
+  test("does not split surrogate pairs when truncating metadata output", () => {
+    const output = previewMetadata(
+      String.fromCharCode(97) + String.fromCodePoint(0x1f642).repeat(15000) + String.fromCharCode(98),
+    )
+    const first = output.charCodeAt("...\n\n".length)
 
-        const first = output.charCodeAt("...\n\n".length)
-        expect(output.startsWith("...\n\n")).toBe(true)
-        expect(first < 0xdc00 || first > 0xdfff).toBe(true)
-      }),
-    ),
-  )
+    expect(output.startsWith("...\n\n")).toBe(true)
+    expect(first < 0xdc00 || first > 0xdfff).toBe(true)
+  })
 
   it.live("full output is saved to file when truncated", () =>
     runIn(


### PR DESCRIPTION
### Issue for this PR

Closes #29291

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shell tool metadata previews were checking `text.length`, which counts UTF-16 code units rather than UTF-8 bytes. Multi-byte output could exceed the metadata byte limit without being preview-truncated, and slicing by code units could start on an invalid surrogate boundary.

This PR makes metadata preview truncation use UTF-8 byte length, trims from a valid byte boundary, and reuses the same byte-tail helper in the existing shell output tail path.

### How did you verify your code works?

- `bun test test/tool/shell.test.ts -t "metadata output"`
- `bun test test/tool/shell.test.ts`
- `bun typecheck`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`

### Screenshots / recordings

Not applicable; shell metadata behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
