### PR TITLE
fix(opencode): replace fake .exe bin with Node.js launcher for Windows compat

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -26,7 +26,7 @@ const platform = platformMap[os.platform()] ?? os.platform()
 const arch = archMap[os.arch()] ?? os.arch()
 const base = `opencode-${platform}-${arch}`
 const sourceBinary = platform === "windows" ? "opencode.exe" : "opencode"
-const targetBinary = path.join(__dirname, "bin", "opencode.exe")
+const targetBinary = path.join(__dirname, "bin", sourceBinary)
 
 function supportsAvx2() {
   if (arch !== "x64") return false

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -35,28 +35,31 @@ await $`mkdir -p ./dist/${pkg.name}`
 await $`mkdir -p ./dist/${pkg.name}/bin`
 await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
 await Bun.file(`./dist/${pkg.name}/LICENSE`).write(await Bun.file("../../LICENSE").text())
-await Bun.file(`./dist/${pkg.name}/bin/${pkg.name}.exe`).write(
-  [
-    `echo "Error: ${pkg.name}-ai's postinstall script was not run." >&2`,
-    'echo "" >&2',
-    'echo "This occurs when using --ignore-scripts during installation, or when using a" >&2',
-    'echo "package manager like pnpm that does not run postinstall scripts by default." >&2',
-    'echo "" >&2',
-    'echo "To fix this, run the postinstall script manually:" >&2',
-    `echo "  cd node_modules/${pkg.name}-ai && node postinstall.mjs" >&2`,
-    'echo "" >&2',
-    `echo "Or reinstall ${pkg.name}-ai without the --ignore-scripts flag." >&2`,
-    "exit 1",
-    "",
-  ].join("\n"),
-)
+
+const binScript = [
+  "#!/usr/bin/env node",
+  "const cp = require('child_process'), fs = require('fs'), path = require('path')",
+  `const bin = path.join(__dirname, process.platform === 'win32' ? '${pkg.name}.exe' : '${pkg.name}')`,
+  "if (!fs.existsSync(bin)) {",
+  `  console.error('${pkg.name}-ai postinstall did not run. Try: cd node_modules/${pkg.name}-ai && node postinstall.mjs')`,
+  "  process.exit(1)",
+  "}",
+  "const child = cp.spawn(bin, process.argv.slice(2), { stdio: 'inherit' })",
+  "child.on('error', e => { console.error(e.message); process.exit(1) })",
+  "const sigs = ['SIGINT','SIGTERM','SIGHUP'], fw = {}",
+  "sigs.forEach(s => { fw[s] = () => { try { child.kill(s) } catch {} }; process.on(s, fw[s]) })",
+  "child.on('exit', (code, sig) => { sigs.forEach(s => process.removeListener(s, fw[s])); sig ? process.kill(process.pid, sig) : process.exit(code ?? 0) })",
+  "",
+].join("\n")
+
+await Bun.file(`./dist/${pkg.name}/bin/${pkg.name}.js`).write(binScript)
 
 await Bun.file(`./dist/${pkg.name}/package.json`).write(
   JSON.stringify(
     {
       name: pkg.name + "-ai",
       bin: {
-        [pkg.name]: `./bin/${pkg.name}.exe`,
+        [pkg.name]: `./bin/${pkg.name}.js`,
       },
       scripts: {
         postinstall: "node ./postinstall.mjs",


### PR DESCRIPTION
### Issue for this PR

Closes #29302

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The published `opencode-ai` package declares its bin as `./bin/opencode.exe`. That file is a shell script placeholder (bash `echo` commands), not a real Windows PE executable. The real native binary is meant to be copied there by `postinstall.mjs`. On Windows, `bun install` and `pnpm install` try to execute it as a native binary before postinstall replaces it, producing a Windows incompatibility error.

The fix replaces the fake `.exe` with a Node.js launcher script (`./bin/opencode.js`) that spawns the adjacent native binary placed by postinstall. This works across all package managers since they all support `.js` bin entries via Node.

Additionally, `postinstall.mjs` had the target path hardcoded to `opencode.exe` on all platforms. It now uses `sourceBinary` which is platform-aware (`opencode.exe` on Windows, `opencode` on macOS/Linux).

### How did you verify your code works?

- Reviewed the generated bin script logic against the existing `bin/opencode` launcher in the repo
- Confirmed `postinstall.mjs` target path is now correct for all platforms
- Pre-existing typecheck errors in `@opencode-ai/enterprise` (unrelated `custom-elements.d.ts` issue) block CI; changes are limited to `script/publish.ts` and `script/postinstall.mjs`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR