### PR TITLE
fix(lsp): correct SourceKit extensions for Objective-C and Objective-C++ files

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -884,7 +884,7 @@ export const FSharp: Info = {
 
 export const SourceKit: Info = {
   id: "sourcekit-lsp",
-  extensions: [".swift", ".objc", "objcpp"],
+  extensions: [".swift", ".m", ".mm"],
   root: NearestRoot(["Package.swift", "*.xcodeproj", "*.xcworkspace"]),
   async spawn(root) {
     // Check if sourcekit-lsp is available in the PATH


### PR DESCRIPTION
### Issue for this PR

Closes #19092

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the file extensions for the SourceKit language server so it activates for Objective-C (`.m`) and Objective-C++ (`.mm`) files.

The previous values were `".objc"` and `"objcpp"` — these are VSCode language IDs, not file extensions. `"objcpp"` was also missing the leading dot entirely. The LSP dispatcher at `lsp/lsp.ts:261` matches via `path.parse(file).ext`, which returns `".m"` and `".mm"` respectively, so SourceKit never activated for any Objective-C or Objective-C++ file.

The one-line fix aligns the extensions with what is already in `language.ts`:
\`\`\`
".m":  "objective-c"
".mm": "objective-cpp"
\`\`\`

Users hitting this bug had to work around it by manually configuring `lsp.sourcekit-lsp.extensions` in `opencode.jsonc` (as documented in #19092). This removes the need for that workaround.

### How did you verify your code works?

- Traced the dispatch path in `lsp/lsp.ts`: `path.parse("MyClass.m").ext` → `".m"`, which now matches the updated extensions list
- Confirmed `language.ts` already maps `.m` → `"objective-c"` and `.mm` → `"objective-cpp"`, so the rest of the LSP pipeline expects these extensions
- All 15 packages pass `bun turbo typecheck`

### Screenshots / recordings

_N/A — LSP configuration change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR