### PR TITLE
docs: add opencode-github-release to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -22,6 +22,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |
+| [opencode-github-release](https://github.com/amestsantim/opencode-github-release)                  | Create git tags and publish GitHub releases with semantic versioning                              |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                              |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |


### PR DESCRIPTION
Adds [opencode-github-release](https://github.com/amestsantim/opencode-github-release) to the Plugins section of the ecosystem page.

This plugin creates git tags and publishes GitHub releases with semantic versioning from OpenCode.