### PR TITLE
test(app): restore timeline e2e server health mock

### DIFF
--- a/packages/app/e2e/regression/session-timeline-collapse-state.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-collapse-state.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test, type Locator, type Page, type Route } from "@playwright/test"
+import { expect, test, type Locator, type Page } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
 
 const directory = "C:/OpenCode/TimelineStateRegression"
 const projectID = "proj_timeline_state_regression"
@@ -299,39 +300,13 @@ function readExpanded(element: Element) {
 }
 
 async function mockServer(page: Page, events: EventPayload[]) {
-  await page.route("**/*", async (route) => {
-    const url = new URL(route.request().url())
-    const targetPort = process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"
-    if (url.port !== targetPort) return route.fallback()
-
-    const path = url.pathname
-    if (path === "/global/event") return sse(route, events.splice(0))
-    if (
-      path === "/global/config" ||
-      path === "/config" ||
-      path === "/provider/auth" ||
-      path === "/mcp" ||
-      path === "/session/status"
-    )
-      return json(route, {})
-    if (
-      ["/skill", "/command", "/lsp", "/formatter", "/permission", "/question", "/vcs/status", "/vcs/diff"].includes(
-        path,
-      )
-    )
-      return json(route, [])
-    if (path === "/provider") return json(route, provider())
-    if (path === "/path")
-      return json(route, { state: directory, config: directory, worktree: directory, directory, home: "C:/OpenCode" })
-    if (path === "/project") return json(route, [project()])
-    if (path === "/project/current") return json(route, project())
-    if (path === "/agent") return json(route, [{ name: "build", mode: "primary" }])
-    if (path === "/vcs") return json(route, { branch: "main", default_branch: "main" })
-    if (path === "/session") return json(route, [session()])
-    if (path === `/session/${sessionID}`) return json(route, session())
-    if (/^\/session\/[^/]+\/(children|todo|diff)$/.test(path)) return json(route, [])
-    if (path === `/session/${sessionID}/message`) return json(route, [userMessage, assistantMessage])
-    return json(route, {})
+  await mockOpenCodeServer(page, {
+    directory,
+    project: project(),
+    provider: provider(),
+    sessions: [session()],
+    pageMessages: () => ({ items: [userMessage, assistantMessage] }),
+    events: () => events.splice(0),
   })
 }
 
@@ -370,24 +345,6 @@ function provider() {
     connected: ["opencode"],
     default: { providerID: "opencode", modelID: "claude-opus-4-6" },
   }
-}
-
-function json(route: Route, body: unknown, headers?: Record<string, string>) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    headers: { "access-control-allow-origin": "*", "access-control-expose-headers": "x-next-cursor", ...headers },
-    body: JSON.stringify(body ?? null),
-  })
-}
-
-function sse(route: Route, events: EventPayload[]) {
-  return route.fulfill({
-    status: 200,
-    contentType: "text/event-stream",
-    headers: { "access-control-allow-origin": "*" },
-    body: events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
-  })
 }
 
 function base64Encode(value: string) {

--- a/packages/app/e2e/regression/session-timeline-context-resize.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-context-resize.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test, type Page, type Route } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
 
 const directory = "C:/OpenCode/ContextResizeRegression"
 const projectID = "proj_context_resize_regression"
@@ -207,33 +208,12 @@ function contextTool(partID: string, messageID: string, tool: string, input: Rec
 }
 
 async function mockServer(page: Page) {
-  await page.route("**/*", async (route) => {
-    const url = new URL(route.request().url())
-    const targetPort = process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"
-    if (url.port !== targetPort) return route.fallback()
-
-    const path = url.pathname
-    if (path === "/global/event" || path === "/event") return sse(route)
-    if (["/global/config", "/config", "/provider/auth", "/mcp", "/session/status"].includes(path))
-      return json(route, {})
-    if (
-      ["/skill", "/command", "/lsp", "/formatter", "/permission", "/question", "/vcs/status", "/vcs/diff"].includes(
-        path,
-      )
-    )
-      return json(route, [])
-    if (path === "/provider") return json(route, provider())
-    if (path === "/path")
-      return json(route, { state: directory, config: directory, worktree: directory, directory, home: "C:/OpenCode" })
-    if (path === "/project") return json(route, [project()])
-    if (path === "/project/current") return json(route, project())
-    if (path === "/agent") return json(route, [{ name: "build", mode: "primary" }])
-    if (path === "/vcs") return json(route, { branch: "main", default_branch: "main" })
-    if (path === "/session") return json(route, [session()])
-    if (path === `/session/${sessionID}`) return json(route, session())
-    if (/^\/session\/[^/]+\/(children|todo|diff)$/.test(path)) return json(route, [])
-    if (path === `/session/${sessionID}/message`) return json(route, messages)
-    return json(route, {})
+  await mockOpenCodeServer(page, {
+    directory,
+    project: project(),
+    provider: provider(),
+    sessions: [session()],
+    pageMessages: () => ({ items: messages }),
   })
 }
 
@@ -280,19 +260,6 @@ function provider() {
     connected: ["opencode"],
     default: { providerID: "opencode", modelID: "claude-opus-4-6" },
   }
-}
-
-function json(route: Route, body: unknown, headers?: Record<string, string>) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    headers: { "access-control-allow-origin": "*", "access-control-expose-headers": "x-next-cursor", ...headers },
-    body: JSON.stringify(body ?? null),
-  })
-}
-
-function sse(route: Route) {
-  return route.fulfill({ status: 200, contentType: "text/event-stream", body: ": ok\n\n" })
 }
 
 function base64Encode(value: string) {

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -18,6 +18,7 @@ export interface MockServerConfig {
   project: unknown
   sessions: ({ id: string } & Record<string, unknown>)[]
   pageMessages: (sessionId: string, limit: number, before?: string) => { items: unknown[]; cursor?: string }
+  events?: () => unknown[]
 }
 
 export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
@@ -43,7 +44,8 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     if (url.port !== targetPort) return route.fallback()
 
     const path = url.pathname
-    if (path === "/global/event" || path === "/event") return sse(route)
+    if (path === "/global/event" || path === "/event") return sse(route, config.events?.())
+    if (path === "/global/health") return json(route, { healthy: true })
     if (emptyObject.has(path)) return json(route, {})
     if (emptyList.has(path)) return json(route, [])
     if (path in staticRoutes) return json(route, staticRoutes[path])
@@ -81,6 +83,10 @@ function json(route: Route, body: unknown, headers?: Record<string, string>) {
   })
 }
 
-function sse(route: Route) {
-  return route.fulfill({ status: 200, contentType: "text/event-stream", body: ": ok\n\n" })
+function sse(route: Route, events?: unknown[]) {
+  return route.fulfill({
+    status: 200,
+    contentType: "text/event-stream",
+    body: events?.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") || ": ok\n\n",
+  })
 }


### PR DESCRIPTION
## Summary
- make the shared Playwright mock server respond to the required global health endpoint
- reuse that mock in the two timeline regression specs instead of maintaining duplicate route tables
- allow the streamed timeline regression to provide its queued SSE events through the shared mock

## Cause
After global server health moved into app startup state, these timeline tests still returned an empty object for `/global/health`. The app correctly treated the mocked server as unhealthy and stayed on the reconnect screen before reaching any timeline assertion.

## Validation
- `bunx playwright test e2e/smoke/session-timeline.spec.ts e2e/regression/session-timeline-collapse-state.spec.ts e2e/regression/session-timeline-context-resize.spec.ts` — 4 passed
- `bun typecheck` in `packages/app`
- push hook: `bun turbo typecheck` — 18 successful
