### PR TITLE
fix(app): open selected file from file tree

### DIFF
--- a/packages/app/src/components/session/session-header-path.test.ts
+++ b/packages/app/src/components/session/session-header-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { resolveOpenPathTarget } from "./session-header-path"
+
+describe("resolveOpenPathTarget", () => {
+  test("opens the selected relative file inside the project directory", () => {
+    expect(resolveOpenPathTarget({ projectDirectory: "/repo", selectedFilePath: "src/app.ts" })).toBe(
+      "/repo/src/app.ts",
+    )
+  })
+
+  test("keeps absolute selected files unchanged", () => {
+    expect(resolveOpenPathTarget({ projectDirectory: "/repo", selectedFilePath: "/repo/src/app.ts" })).toBe(
+      "/repo/src/app.ts",
+    )
+  })
+
+  test("falls back to the project directory without a selected file", () => {
+    expect(resolveOpenPathTarget({ projectDirectory: "/repo" })).toBe("/repo")
+  })
+})

--- a/packages/app/src/components/session/session-header-path.ts
+++ b/packages/app/src/components/session/session-header-path.ts
@@ -1,0 +1,12 @@
+export function resolveOpenPathTarget(input: { projectDirectory: string; selectedFilePath?: string }) {
+  if (!input.projectDirectory) return ""
+
+  const selected = input.selectedFilePath?.trim()
+  if (!selected) return input.projectDirectory
+  if (selected.startsWith("/") || selected.startsWith("\\\\") || /^[A-Za-z]:[\\/]/.test(selected)) return selected
+
+  const root = input.projectDirectory.replace(/[\\/]+$/, "")
+  const child = selected.replace(/^[\\/]+/, "")
+  if (!root) return `/${child}`
+  return `${root}/${child}`
+}

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -25,6 +25,7 @@ import { messageAgentColor } from "@/utils/agent"
 import { decode64 } from "@/utils/base64"
 import { Persist, persisted } from "@/utils/persist"
 import { StatusPopover, StatusPopoverV2 } from "../status-popover"
+import { resolveOpenPathTarget } from "./session-header-path"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/components/icon-button-v2.jsx"
 import { Icon as IconV2 } from "@opencode-ai/ui/v2/components/icon.jsx"
 
@@ -133,7 +134,7 @@ const showRequestError = (language: ReturnType<typeof useLanguage>, err: unknown
   })
 }
 
-export function SessionHeader() {
+export function SessionHeader(props: { selectedFilePath?: string } = {}) {
   const layout = useLayout()
   const command = useCommand()
   const server = useServer()
@@ -235,6 +236,12 @@ export function SessionHeader() {
   const tint = createMemo(() =>
     messageAgentColor(params.id ? sync.data.message[params.id] : undefined, sync.data.agent),
   )
+  const openPathTarget = createMemo(() =>
+    resolveOpenPathTarget({
+      projectDirectory: projectDirectory(),
+      selectedFilePath: props.selectedFilePath,
+    }),
+  )
   const v2ActionsState = createMemo<SessionHeaderV2ActionsState>(() => ({
     statusVisible: status(),
     statusLabel: language.t("status.popover.trigger"),
@@ -251,14 +258,14 @@ export function SessionHeader() {
 
   const openDir = (app: OpenApp) => {
     if (opening() || !canOpen() || !platform.openPath) return
-    const directory = projectDirectory()
-    if (!directory) return
+    const target = openPathTarget()
+    if (!target) return
 
     const item = options().find((o) => o.id === app)
     const openWith = item && "openWith" in item ? item.openWith : undefined
     setOpenRequest("app", app)
     platform
-      .openPath(directory, openWith)
+      .openPath(target, openWith)
       .catch((err: unknown) => showRequestError(language, err))
       .finally(() => {
         setOpenRequest("app", undefined)
@@ -266,16 +273,16 @@ export function SessionHeader() {
   }
 
   const copyPath = () => {
-    const directory = projectDirectory()
-    if (!directory) return
+    const target = openPathTarget()
+    if (!target) return
     navigator.clipboard
-      .writeText(directory)
+      .writeText(target)
       .then(() => {
         showToast({
           variant: "success",
           icon: "circle-check",
           title: language.t("session.share.copy.copied"),
-          description: directory,
+          description: target,
         })
       })
       .catch((err: unknown) => showRequestError(language, err))

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,4 +1,4 @@
-import type { Project, UserMessage } from "@opencode-ai/sdk/v2"
+import type { FileNode, Project, UserMessage } from "@opencode-ai/sdk/v2"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createQuery, skipToken, useMutation, useQueryClient } from "@tanstack/solid-query"
 import {
@@ -873,6 +873,7 @@ export default function Page() {
     reviewScroll: undefined as HTMLDivElement | undefined,
     pendingDiff: undefined as string | undefined,
     activeDiff: undefined as string | undefined,
+    selectedFilePath: undefined as string | undefined,
   })
 
   createEffect(
@@ -883,7 +884,25 @@ export default function Page() {
           reviewScroll: undefined,
           pendingDiff: undefined,
           activeDiff: undefined,
+          selectedFilePath: undefined,
         })
+      },
+      { defer: true },
+    ),
+  )
+
+  const selectFileOpenTarget = (node: FileNode) => {
+    setTree("selectedFilePath", node.absolute || node.path)
+  }
+
+  createEffect(
+    on(
+      activeFileTab,
+      (tab) => {
+        if (!tab) return
+        const path = file.pathFromTab(tab)
+        if (!path) return
+        setTree("selectedFilePath", path)
       },
       { defer: true },
     ),
@@ -1709,7 +1728,7 @@ export default function Page() {
   return (
     <div class="relative bg-background-base size-full overflow-hidden flex flex-col">
       {sessionSync() ?? ""}
-      <SessionHeader />
+      <SessionHeader selectedFilePath={tree.selectedFilePath} />
       <div class="flex-1 min-h-0 flex flex-col md:flex-row">
         <Show when={!isDesktop() && !!params.id}>
           <Tabs value={store.mobileTab} class="h-auto">
@@ -1833,6 +1852,7 @@ export default function Page() {
           reviewPanel={reviewPanel}
           activeDiff={tree.activeDiff}
           focusReviewDiff={focusReviewDiff}
+          onFileSelect={selectFileOpenTarget}
           reviewSnap={ui.reviewSnap}
           size={size}
         />

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -8,7 +8,7 @@ import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { Mark } from "@opencode-ai/ui/logo"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
-import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
+import type { FileNode, SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
 import { ConstrainDragYAxis, getDraggableId } from "@/utils/solid-dnd"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 
@@ -46,6 +46,7 @@ export function SessionSidePanel(props: {
   reviewPanel: () => JSX.Element
   activeDiff?: string
   focusReviewDiff: (path: string) => void
+  onFileSelect?: (node: FileNode) => void
   reviewSnap: boolean
   size: Sizing
 }) {
@@ -413,7 +414,10 @@ export function SessionSidePanel(props: {
                               kinds={kinds()}
                               draggable={false}
                               active={props.activeDiff}
-                              onFileClick={(node) => props.focusReviewDiff(node.path)}
+                              onFileClick={(node) => {
+                                props.onFileSelect?.(node)
+                                props.focusReviewDiff(node.path)
+                              }}
                             />
                           </Show>
                         </Match>
@@ -428,7 +432,10 @@ export function SessionSidePanel(props: {
                             class="pt-3"
                             modified={diffFiles()}
                             kinds={kinds()}
-                            onFileClick={(node) => openTab(file.tab(node.path))}
+                            onFileClick={(node) => {
+                              props.onFileSelect?.(node)
+                              openTab(file.tab(node.path))
+                            }}
                           />
                         </Match>
                       </Switch>


### PR DESCRIPTION
### Issue for this PR

Closes #29299

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop header open button always used the project directory as its target. After selecting a file in the right file tree, clicking the open button still opened the project root instead of the selected file.

This PR tracks the most recently selected file from the side-panel file tree, keeps that selection in sync when an active file tab changes, and resolves the header open/copy target to that file path. Without a selected file, the button still falls back to the project directory.

### How did you verify your code works?

- `cd packages/app && PATH="$HOME/.bun/bin:$PATH" bun test src/components/session/session-header-path.test.ts src/pages/session/helpers.test.ts src/components/file-tree.test.ts`
- `cd packages/app && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`
- `cd packages/app && PATH="$HOME/.bun/bin:$PATH" bun test --preload ./happydom.ts ./src`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`

### Screenshots / recordings

Not included; this changes the open target behavior without changing visible layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR