### PR TITLE
fix(opencode): scope rtk permission patterns

### DIFF
--- a/packages/opencode/src/permission/arity.ts
+++ b/packages/opencode/src/permission/arity.ts
@@ -136,6 +136,26 @@ const ARITY: Record<string, number> = {
   rake: 2, // rake db:migrate
   rbenv: 2, // rbenv install 3.2.0
   "redis-cli": 2, // redis-cli ping
+  rtk: 2, // rtk env PATH
+  "rtk aws": 3, // rtk aws s3 ls
+  "rtk cargo": 3, // rtk cargo test
+  "rtk docker": 3, // rtk docker logs api
+  "rtk docker compose": 4, // rtk docker compose logs api
+  "rtk dotnet": 3, // rtk dotnet test
+  "rtk gh": 3, // rtk gh pr list
+  "rtk git": 3, // rtk git status
+  "rtk glab": 3, // rtk glab mr list
+  "rtk go": 3, // rtk go test
+  "rtk gt": 3, // rtk gt submit
+  "rtk hook": 3, // rtk hook check git status
+  "rtk kubectl": 3, // rtk kubectl get pods
+  "rtk npm": 3, // rtk npm test
+  "rtk npx": 3, // rtk npx prisma generate
+  "rtk pip": 3, // rtk pip install requests
+  "rtk pnpm": 3, // rtk pnpm list
+  "rtk prisma": 3, // rtk prisma generate
+  "rtk prisma migrate": 4, // rtk prisma migrate status
+  "rtk telemetry": 3, // rtk telemetry status
   rustup: 2, // rustup update
   serverless: 2, // serverless invoke
   sfdx: 3, // sfdx force:org:list

--- a/packages/opencode/test/permission/arity.test.ts
+++ b/packages/opencode/test/permission/arity.test.ts
@@ -21,6 +21,22 @@ test("longest match wins - nested prefixes", () => {
   expect(BashArity.prefix(["consul", "kv", "get", "config"])).toEqual(["consul", "kv", "get"])
 })
 
+test("rtk commands scope always-allow patterns to the wrapped subcommand", () => {
+  expect(BashArity.prefix(["rtk", "env", "PATH"])).toEqual(["rtk", "env"])
+  expect(BashArity.prefix(["rtk", "git", "clone", "https://github.com/example/repo"])).toEqual([
+    "rtk",
+    "git",
+    "clone",
+  ])
+  expect(BashArity.prefix(["rtk", "docker", "compose", "logs", "api"])).toEqual([
+    "rtk",
+    "docker",
+    "compose",
+    "logs",
+  ])
+  expect(BashArity.prefix(["rtk", "telemetry", "status"])).toEqual(["rtk", "telemetry", "status"])
+})
+
 test("exact length matches", () => {
   expect(BashArity.prefix(["git", "checkout"])).toEqual(["git", "checkout"])
   expect(BashArity.prefix(["npm", "run", "dev"])).toEqual(["npm", "run", "dev"])


### PR DESCRIPTION
### Issue for this PR

Closes #29311

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The bash permission arity dictionary did not know about `rtk`, so an always-allow decision for commands such as `rtk env PATH` or `rtk git clone ...` collapsed to `rtk *`. That pattern is broader than the command the user approved.

This PR adds `rtk` arity entries for the wrapper's top-level and nested subcommands, including git, docker compose, telemetry, hook, package manager, and language/tool wrappers. The added regression test confirms `rtk env *`, `rtk git clone *`, `rtk docker compose logs *`, and `rtk telemetry status *` style prefixes are produced.

### How did you verify your code works?

- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/permission/arity.test.ts`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`

### Screenshots / recordings

Not applicable; permission pattern generation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR