### PR TITLE
fix(opencode): flush stdio before cli exit

### DIFF
--- a/packages/opencode/src/cli/stdout.ts
+++ b/packages/opencode/src/cli/stdout.ts
@@ -1,0 +1,12 @@
+export type FlushableWriteStream = {
+  destroyed?: boolean
+  writableEnded?: boolean
+  write(chunk: string, callback: () => void): boolean
+}
+
+export function flushWriteStream(stream: FlushableWriteStream) {
+  if (stream.destroyed || stream.writableEnded) return Promise.resolve()
+  return new Promise<void>((resolve) => {
+    stream.write("", () => resolve())
+  })
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -40,6 +40,7 @@ import { Heap } from "./cli/heap"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
 import { isRecord } from "@/util/record"
+import { flushWriteStream } from "@/cli/stdout"
 
 const processMetadata = ensureProcessMetadata("main")
 
@@ -247,5 +248,6 @@ try {
   // Most notably, some docker-container-based MCP servers don't handle such signals unless
   // run using `docker run --init`.
   // Explicitly exit to avoid any hanging subprocesses.
+  await Promise.all([flushWriteStream(process.stdout), flushWriteStream(process.stderr)])
   process.exit()
 }

--- a/packages/opencode/test/cli/stdout.test.ts
+++ b/packages/opencode/test/cli/stdout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { flushWriteStream } from "../../src/cli/stdout"
+
+describe("flushWriteStream", () => {
+  test("waits for the stream write callback", async () => {
+    let flush: (() => void) | undefined
+    let resolved = false
+
+    const pending = flushWriteStream({
+      write(_chunk, callback) {
+        flush = () => callback()
+        return false
+      },
+    }).then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    flush?.()
+    await pending
+
+    expect(resolved).toBe(true)
+  })
+
+  test("skips destroyed streams", async () => {
+    let wrote = false
+
+    await flushWriteStream({
+      destroyed: true,
+      write() {
+        wrote = true
+        return true
+      },
+    })
+
+    expect(wrote).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29330
Closes #26399

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The CLI explicitly calls `process.exit()` after command handling to avoid hanging subprocesses. Large stdout writes can still be buffered at that point when output is piped, so commands such as `opencode export <id> | jq` or `opencode debug skill | jq` can see truncated JSON.

This PR adds a small stdio flush helper and waits for stdout/stderr write callbacks before the final forced exit. The explicit exit behavior is preserved, but pending buffered CLI output gets a chance to drain first.

### How did you verify your code works?

- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/cli/stdout.test.ts`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`

### Screenshots / recordings

Not applicable; CLI stdout flushing only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR