### PR TITLE
fix(app): recover deleted session sync races

### DIFF
--- a/packages/app/src/context/directory-sync-error.test.ts
+++ b/packages/app/src/context/directory-sync-error.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test"
+import { isSessionNotFoundError, recoverSessionNotFound } from "./directory-sync-error"
+
+describe("isSessionNotFoundError", () => {
+  test("matches SDK-wrapped session not found errors", () => {
+    const error = new Error("Session not found: ses_1", {
+      cause: {
+        body: {
+          name: "NotFoundError",
+          data: {
+            message: "Session not found: ses_1",
+          },
+        },
+        status: 404,
+      },
+    })
+
+    expect(isSessionNotFoundError(error)).toBe(true)
+  })
+
+  test("matches tagged session not found errors", () => {
+    const error = new Error("Session not found", {
+      cause: {
+        body: {
+          name: "SessionNotFoundError",
+        },
+        status: 404,
+      },
+    })
+
+    expect(isSessionNotFoundError(error)).toBe(true)
+  })
+
+  test("does not match unrelated not found errors", () => {
+    const error = new Error("Provider not found", {
+      cause: {
+        body: {
+          name: "NotFoundError",
+          data: {
+            message: "Provider not found: openai",
+          },
+        },
+        status: 404,
+      },
+    })
+
+    expect(isSessionNotFoundError(error)).toBe(false)
+  })
+
+  test("does not match non-404 session errors", () => {
+    const error = new Error("Session not found: ses_1", {
+      cause: {
+        body: {
+          name: "NotFoundError",
+          data: {
+            message: "Session not found: ses_1",
+          },
+        },
+        status: 500,
+      },
+    })
+
+    expect(isSessionNotFoundError(error)).toBe(false)
+  })
+
+  test("recovers session not found rejections", async () => {
+    let recovered = false
+
+    await recoverSessionNotFound(
+      Promise.reject(
+        new Error("Session not found: ses_1", {
+          cause: {
+            body: {
+              name: "NotFoundError",
+              data: {
+                message: "Session not found: ses_1",
+              },
+            },
+            status: 404,
+          },
+        }),
+      ),
+      () => {
+        recovered = true
+      },
+    )
+
+    expect(recovered).toBe(true)
+  })
+
+  test("rethrows unrelated rejections", async () => {
+    const error = new Error("Provider not found", {
+      cause: {
+        body: {
+          name: "NotFoundError",
+          data: {
+            message: "Provider not found: openai",
+          },
+        },
+        status: 404,
+      },
+    })
+    let result: unknown
+
+    try {
+      await recoverSessionNotFound(Promise.reject(error), () => {
+        result = "recovered"
+      })
+    } catch (caught) {
+      result = caught
+    }
+
+    expect(result).toBe(error)
+  })
+})

--- a/packages/app/src/context/directory-sync-error.ts
+++ b/packages/app/src/context/directory-sync-error.ts
@@ -1,0 +1,26 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function isSessionNotFoundError(error: unknown) {
+  if (!(error instanceof Error)) return false
+  if (!isRecord(error.cause)) return false
+  if (error.cause.status !== 404) return false
+  if (!isRecord(error.cause.body)) return false
+
+  if (error.cause.body.name === "SessionNotFoundError") return true
+  if (error.cause.body._tag === "SessionNotFoundError") return true
+  if (error.cause.body.name !== "NotFoundError") return false
+
+  const data = isRecord(error.cause.body.data) ? error.cause.body.data : undefined
+  return typeof data?.message === "string" && data.message.startsWith("Session not found:")
+}
+
+export async function recoverSessionNotFound<T>(promise: Promise<T>, recover: () => void) {
+  try {
+    return await promise
+  } catch (error) {
+    if (!isSessionNotFoundError(error)) throw error
+    recover()
+  }
+}

--- a/packages/app/src/context/directory-sync.ts
+++ b/packages/app/src/context/directory-sync.ts
@@ -13,6 +13,7 @@ import type { Message, OpencodeClient, Part } from "@opencode-ai/sdk/v2/client"
 import { SESSION_CACHE_LIMIT, dropSessionCaches, pickSessionCacheEvictions } from "./global-sync/session-cache"
 import { diffs as list, message as clean } from "@/utils/diffs"
 import { useServerSDK } from "./server-sdk"
+import { recoverSessionNotFound } from "./directory-sync-error"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -279,6 +280,18 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
     clearMeta(directory, sessionIDs)
   }
 
+  const forgetMissingSession = (directory: string, setStore: Setter, sessionID: string) => {
+    seenFor(directory).delete(sessionID)
+    evict(directory, setStore, [sessionID])
+    setStore(
+      "session",
+      produce((draft) => {
+        const match = Binary.search(draft, sessionID, (s) => s.id)
+        if (match.found) draft.splice(match.index, 1)
+      }),
+    )
+  }
+
   const touch = (directory: string, setStore: Setter, sessionID: string) => {
     const stale = pickSessionCacheEvictions({
       seen: seenFor(directory),
@@ -435,59 +448,62 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
           })
         }
 
-        return runInflight(inflight, key, async () => {
-          const pending = getSessionPrefetchPromise(directory, sessionID)
-          if (pending) {
-            await pending
-            const seeded = getSessionPrefetch(directory, sessionID)
-            if (seeded && store.message[sessionID] !== undefined && meta.limit[key] === undefined) {
-              batch(() => {
-                setMeta("limit", key, seeded.limit)
-                setMeta("cursor", key, seeded.cursor)
-                setMeta("complete", key, seeded.complete)
-                setMeta("loading", key, false)
-              })
+        return recoverSessionNotFound(
+          runInflight(inflight, key, async () => {
+            const pending = getSessionPrefetchPromise(directory, sessionID)
+            if (pending) {
+              await pending
+              const seeded = getSessionPrefetch(directory, sessionID)
+              if (seeded && store.message[sessionID] !== undefined && meta.limit[key] === undefined) {
+                batch(() => {
+                  setMeta("limit", key, seeded.limit)
+                  setMeta("cursor", key, seeded.cursor)
+                  setMeta("complete", key, seeded.complete)
+                  setMeta("loading", key, false)
+                })
+              }
             }
-          }
 
-          const hasSession = Binary.search(store.session, sessionID, (s) => s.id).found
-          const cached = store.message[sessionID] !== undefined && meta.limit[key] !== undefined
-          if (cached && hasSession && !opts?.force) return
+            const hasSession = Binary.search(store.session, sessionID, (s) => s.id).found
+            const cached = store.message[sessionID] !== undefined && meta.limit[key] !== undefined
+            if (cached && hasSession && !opts?.force) return
 
-          const limit = meta.limit[key] ?? initialMessagePageSize
-          const sessionReq =
-            hasSession && !opts?.force
-              ? Promise.resolve()
-              : retry(() => client.session.get({ sessionID })).then((session) => {
-                  if (!tracked(directory, sessionID)) return
-                  const data = session.data
-                  if (!data) return
-                  setStore(
-                    "session",
-                    produce((draft) => {
-                      const match = Binary.search(draft, sessionID, (s) => s.id)
-                      if (match.found) {
-                        draft[match.index] = data
-                        return
-                      }
-                      draft.splice(match.index, 0, data)
-                    }),
-                  )
-                })
+            const limit = meta.limit[key] ?? initialMessagePageSize
+            const sessionReq =
+              hasSession && !opts?.force
+                ? Promise.resolve()
+                : retry(() => client.session.get({ sessionID })).then((session) => {
+                    if (!tracked(directory, sessionID)) return
+                    const data = session.data
+                    if (!data) return
+                    setStore(
+                      "session",
+                      produce((draft) => {
+                        const match = Binary.search(draft, sessionID, (s) => s.id)
+                        if (match.found) {
+                          draft[match.index] = data
+                          return
+                        }
+                        draft.splice(match.index, 0, data)
+                      }),
+                    )
+                  })
 
-          const messagesReq =
-            cached && !opts?.force
-              ? Promise.resolve()
-              : loadMessages({
-                  directory,
-                  client,
-                  setStore,
-                  sessionID,
-                  limit,
-                })
+            const messagesReq =
+              cached && !opts?.force
+                ? Promise.resolve()
+                : loadMessages({
+                    directory,
+                    client,
+                    setStore,
+                    sessionID,
+                    limit,
+                  })
 
-          await Promise.all([sessionReq, messagesReq])
-        })
+            await Promise.all([sessionReq, messagesReq])
+          }),
+          () => forgetMissingSession(directory, setStore, sessionID),
+        )
       },
       async diff(sessionID: string, opts?: { force?: boolean }) {
         const [store, setStore] = serverSync.child(directory)
@@ -495,11 +511,14 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
         if (store.session_diff[sessionID] !== undefined && !opts?.force) return
 
         const key = keyFor(directory, sessionID)
-        return runInflight(inflightDiff, key, () =>
-          retry(() => client.session.diff({ sessionID })).then((diff) => {
-            if (!tracked(directory, sessionID)) return
-            setStore("session_diff", sessionID, reconcile(list(diff.data), { key: "file" }))
-          }),
+        return recoverSessionNotFound(
+          runInflight(inflightDiff, key, () =>
+            retry(() => client.session.diff({ sessionID })).then((diff) => {
+              if (!tracked(directory, sessionID)) return
+              setStore("session_diff", sessionID, reconcile(list(diff.data), { key: "file" }))
+            }),
+          ),
+          () => forgetMissingSession(directory, setStore, sessionID),
         )
       },
       async todo(sessionID: string, opts?: { force?: boolean }) {
@@ -519,13 +538,16 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
         }
 
         const key = keyFor(directory, sessionID)
-        return runInflight(inflightTodo, key, () =>
-          retry(() => client.session.todo({ sessionID })).then((todo) => {
-            if (!tracked(directory, sessionID)) return
-            const list = todo.data ?? []
-            setStore("todo", sessionID, reconcile(list, { key: "id" }))
-            serverSync.todo.set(sessionID, list)
-          }),
+        return recoverSessionNotFound(
+          runInflight(inflightTodo, key, () =>
+            retry(() => client.session.todo({ sessionID })).then((todo) => {
+              if (!tracked(directory, sessionID)) return
+              const list = todo.data ?? []
+              setStore("todo", sessionID, reconcile(list, { key: "id" }))
+              serverSync.todo.set(sessionID, list)
+            }),
+          ),
+          () => forgetMissingSession(directory, setStore, sessionID),
         )
       },
       history: {
@@ -551,15 +573,18 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
           const before = meta.cursor[key]
           if (!before) return
 
-          await loadMessages({
-            directory,
-            client,
-            setStore,
-            sessionID,
-            limit: step,
-            before,
-            mode: "prepend",
-          })
+          await recoverSessionNotFound(
+            loadMessages({
+              directory,
+              client,
+              setStore,
+              sessionID,
+              limit: step,
+              before,
+              mode: "prepend",
+            }),
+            () => forgetMissingSession(directory, setStore, sessionID),
+          )
         },
       },
       evict(sessionID: string, _directory = directory) {


### PR DESCRIPTION
### Issue for this PR

Closes #29323

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Handles a deleted-session race in the app directory sync layer. When a stale sync, diff, todo, or history request receives the SDK-wrapped session-not-found 404 after a session has been deleted, directory sync now removes the local session state/caches and resolves instead of surfacing the stale request error to the UI. Other 404s and non-session errors still rethrow.

### How did you verify your code works?

- `cd packages/app && PATH="$HOME/.bun/bin:$PATH" bun test src/context/directory-sync-error.test.ts`
- `cd packages/app && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `cd packages/app && PATH="$HOME/.bun/bin:$PATH" bun test --preload ./happydom.ts ./src`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`

### Screenshots / recordings

_Not applicable; error handling fix._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR