### PR TITLE
fix(session): add idle timeout to LLM streaming response

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -301,6 +301,10 @@ export const Info = Schema.Struct({
       mcp_timeout: Schema.optional(PositiveInt).annotate({
         description: "Timeout in milliseconds for model context protocol (MCP) requests",
       }),
+      llm_stream_idle_timeout: Schema.optional(PositiveInt).annotate({
+        description:
+          "Idle timeout in milliseconds for the LLM streaming response. Fails the stream if no event arrives within this window. Set to 0 to disable. Default: 120000 (2 minutes).",
+      }),
     }),
   ),
 }).annotate({ identifier: "Config" })

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -30,6 +30,27 @@ import { LLMRequestPrep } from "./llm/request"
 const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 
+/** Default idle-timeout for LLM streaming responses (ms). Overridable via
+ *  `experimental.llm_stream_idle_timeout` in opencode config; 0 disables. */
+export const DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS = 120_000
+
+export class LLMStreamIdleTimeout extends Error {
+  readonly _tag = "LLMStreamIdleTimeout"
+  constructor(public readonly idleMs: number) {
+    super(`LLM stream idle timeout: no events received for ${idleMs}ms`)
+  }
+}
+
+export function withIdleTimeout<A, E, R>(
+  source: Stream.Stream<A, E, R>,
+  idleMs: number,
+): Stream.Stream<A, E | LLMStreamIdleTimeout, R> {
+  return Stream.timeoutOrElse(source, {
+    duration: `${idleMs} millis`,
+    orElse: () => Stream.fail(new LLMStreamIdleTimeout(idleMs)),
+  })
+}
+
 export type StreamInput = {
   user: MessageV2.User
   sessionID: string
@@ -349,19 +370,30 @@ const live: Layer.Layer<
               (ctrl) => Effect.sync(() => ctrl.abort()),
             )
 
+            const cfg = yield* config.get()
+            const idleMs = cfg.experimental?.llm_stream_idle_timeout ?? DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS
+
             const result = yield* run({ ...input, abort: ctrl.signal })
 
-            if (result.type === "native") return result.stream
+            const base =
+              result.type === "native"
+                ? result.stream
+                : // Adapter seam: both runtimes expose the same LLMEvent stream. Native
+                  // already returns one; AI SDK streams are converted here.
+                  (() => {
+                    const state = LLMAISDK.adapterState()
+                    return Stream.fromAsyncIterable(result.result.fullStream, (e) =>
+                      e instanceof Error ? e : new Error(String(e)),
+                    ).pipe(
+                      Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
+                      Stream.flatMap((events) => Stream.fromIterable(events)),
+                    )
+                  })()
 
-            // Adapter seam: both runtimes expose the same LLMEvent stream. Native
-            // already returns one; AI SDK streams are converted here.
-            const state = LLMAISDK.adapterState()
-            return Stream.fromAsyncIterable(result.result.fullStream, (e) =>
-              e instanceof Error ? e : new Error(String(e)),
-            ).pipe(
-              Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
-              Stream.flatMap((events) => Stream.fromIterable(events)),
-            )
+            // Idle-timeout guard. Without this an upstream that silently stalls
+            // (proxy/relay drop, provider hang, transport half-open) leaves the
+            // session loop blocked on the next chunk indefinitely.
+            return idleMs > 0 ? withIdleTimeout(base, idleMs) : base
           }),
         ),
       )

--- a/packages/opencode/test/session/llm-idle-timeout.test.ts
+++ b/packages/opencode/test/session/llm-idle-timeout.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { Cause, Effect, Exit, Option, Stream } from "effect"
+import { LLMStreamIdleTimeout, withIdleTimeout } from "../../src/session/llm"
+
+describe("session.llm.withIdleTimeout", () => {
+  test("fails with LLMStreamIdleTimeout when no event arrives within the idle window", async () => {
+    const stalled = Stream.never as Stream.Stream<number>
+    const exit = await Effect.runPromiseExit(Stream.runCollect(withIdleTimeout(stalled, 30)))
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const err = Cause.findErrorOption(exit.cause)
+      expect(Option.isSome(err) && err.value instanceof LLMStreamIdleTimeout).toBe(true)
+    }
+  })
+
+  test("emits early events then fails when the stream stalls", async () => {
+    const partial = Stream.make(1, 2).pipe(Stream.concat(Stream.never as Stream.Stream<number>))
+    const collected: number[] = []
+    const exit = await Effect.runPromiseExit(
+      Stream.runForEach(withIdleTimeout(partial, 30), (n) =>
+        Effect.sync(() => {
+          collected.push(n)
+        }),
+      ),
+    )
+    expect(collected).toEqual([1, 2])
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  test("does not interfere with streams that complete before the idle window", async () => {
+    const ok = Stream.make("a", "b", "c")
+    const out = await Effect.runPromise(Stream.runCollect(withIdleTimeout(ok, 1_000)))
+    expect(Array.from(out)).toEqual(["a", "b", "c"])
+  })
+})


### PR DESCRIPTION
## Summary
- Adds an idle-timeout guard on the LLM event stream so a silently-stalled provider/transport no longer hangs the session loop indefinitely.
- Applies to both the native runtime and ai-sdk runtime paths.
- Configurable via `experimental.llm_stream_idle_timeout` (ms); defaults to `120000` (2 min). Set to `0` to disable.

## Why
The session loop consumes the LLM stream via `Stream.fromAsyncIterable(result.fullStream, …)` with no read/idle deadline on either runtime path. If the upstream stops sending bytes without delivering `[DONE]`, an error frame, or a TCP close — e.g. an intermittent provider hiccup or a half-open SSE connection — the loop blocks on the next chunk forever. Symptom in practice: the session never advances `step`, no `finishReason` is emitted, and the UI shows it as "not processing and not stopping." Because there is no idle deadline anywhere in the stream pipeline, any provider-side stall is unrecoverable without killing the process.

## What changes
- `packages/opencode/src/session/llm.ts`
  - New exported `LLMStreamIdleTimeout` error (`_tag: "LLMStreamIdleTimeout"`) and `withIdleTimeout(stream, idleMs)` helper built on `Stream.timeoutOrElse`.
  - Wraps the unified `LLMEvent` stream (both native + ai-sdk paths) after the runtime selection so the failure surface is symmetric.
  - Reads the configured idle window from `cfg.experimental?.llm_stream_idle_timeout` with the default constant `DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS = 120_000`. `0` disables.
- `packages/opencode/src/config/config.ts`
  - Adds `experimental.llm_stream_idle_timeout: PositiveInt` (optional), documented inline.
- `packages/opencode/test/session/llm-idle-timeout.test.ts` (new)
  - Stalled stream → fails with `LLMStreamIdleTimeout`.
  - Partial stream (emits some events, then stalls) → emits the early events, then fails.
  - Healthy stream that completes before the window → passes through unchanged.

## Test plan
- [x] `bun run typecheck` (packages/opencode) — clean.
- [x] `bun test test/session/llm-idle-timeout.test.ts` — 3/3 pass.
- [x] `bun test test/session/{llm,llm-native,retry,session}.test.ts` — 78/78 pass; no regressions in the existing LLM/session suites.
- [ ] Manual smoke against `openai/gpt-5.4` with a non-trivial prompt; confirm normal streaming + finish path is unaffected (default 120s window is well above expected gaps).

## Notes
- `Stream.timeoutOrElse` from Effect 4 is per-element/idle, not total — matches the symptom we want to catch.
- The wrap happens *outside* the AbortController lifetime, so on timeout the controller's `acquireRelease` finalizer still aborts the underlying request/transport.
- No behavior change when the default is in effect for healthy sessions; the only observable difference is that previously-hung sessions now fail fast with a tagged error the loop/retry layer can react to.
