### PR TITLE
fix(tui): publish synthetic reject event when permission/question ask is interrupted

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -111,8 +111,20 @@ export const layer = Layer.effect(
       yield* events.publish(Event.Asked, info)
       return yield* Effect.ensuring(
         Deferred.await(deferred),
-        Effect.sync(() => {
+        Effect.gen(function* () {
+          // If the entry is still here, this finalizer is running because ask was
+          // interrupted (tool cancelled, session ended, parent killed). The reply
+          // path deletes the entry itself before publishing Event.Replied, so we
+          // only fire a synthetic "reject" here for the orphan case — otherwise
+          // the TUI's sync.data.permission never receives a terminal event and the
+          // prompt stays visible forever with no way to dismiss it.
+          if (!pending.has(id)) return
           pending.delete(id)
+          yield* events.publish(Event.Replied, {
+            sessionID: info.sessionID,
+            requestID: info.id,
+            reply: "reject",
+          })
         }),
       )
     })

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -171,8 +171,19 @@ export const layer = Layer.effect(
 
       return yield* Effect.ensuring(
         Deferred.await(deferred),
-        Effect.sync(() => {
+        Effect.gen(function* () {
+          // If the entry is still here, this finalizer is running because ask was
+          // interrupted (tool cancelled, session ended, parent killed). The reply
+          // and reject paths delete the entry themselves before publishing their
+          // event, so we only fire Rejected here for the orphan case — otherwise
+          // the TUI's sync.data.question never receives a terminal event and the
+          // prompt stays visible forever.
+          if (!pending.has(id)) return
           pending.delete(id)
+          yield* events.publish(Event.Rejected, {
+            sessionID: info.sessionID,
+            requestID: info.id,
+          })
         }),
       )
     })

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -965,6 +965,67 @@ it.instance(
   { git: true },
 )
 
+it.live("interrupt - publishes Replied(reject) so TUI orphans get dismissed", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped({ git: true })
+    const store = yield* InstanceStore.Service
+    return yield* store.provide(
+      { directory: dir },
+      Effect.gen(function* () {
+        const events = yield* EventV2Bridge.Service
+        const seen = yield* Deferred.make<{
+          sessionID: SessionID
+          requestID: PermissionV1.ID
+          reply: PermissionV1.Reply
+        }>()
+        const unsub = yield* events.listen((event) => {
+          if (event.type === Permission.Event.Replied.type)
+            Deferred.doneUnsafe(
+              seen,
+              Effect.succeed(
+                event.data as { sessionID: SessionID; requestID: PermissionV1.ID; reply: PermissionV1.Reply },
+              ),
+            )
+          return Effect.void
+        })
+        yield* Effect.addFinalizer(() => unsub)
+
+        const fiber = yield* ask({
+          id: PermissionV1.ID.make("per_interrupt"),
+          sessionID: SessionID.make("session_interrupt"),
+          permission: "read",
+          patterns: [".env.template"],
+          metadata: {},
+          always: ["*"],
+          ruleset: [],
+        }).pipe(Effect.forkScoped)
+
+        yield* waitForPending(1)
+
+        // Simulate the tool execution being interrupted before the user replies
+        // (session ended, parent killed, scope torn down, etc.). Without the
+        // finalizer publishing a synthetic reject, the TUI's sync.data.permission
+        // would keep showing the prompt forever.
+        yield* Fiber.interrupt(fiber)
+
+        expect(
+          yield* Deferred.await(seen).pipe(
+            Effect.timeoutOrElse({
+              duration: "1 second",
+              orElse: () => Effect.fail(new Error("timed out waiting for synthetic permission reject event")),
+            }),
+          ),
+        ).toEqual({
+          sessionID: SessionID.make("session_interrupt"),
+          requestID: PermissionV1.ID.make("per_interrupt"),
+          reply: "reject",
+        })
+        expect(yield* list()).toHaveLength(0)
+      }),
+    )
+  }),
+)
+
 it.live("permission requests stay isolated by directory", () =>
   Effect.gen(function* () {
     const one = yield* tmpdirScoped({ git: true })

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -282,6 +282,47 @@ it.instance(
   { git: true },
 )
 
+it.instance(
+  "interrupt - publishes Rejected event so TUI orphans get dismissed",
+  () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2Bridge.Service
+      const received = yield* Queue.unbounded<{ sessionID: SessionID; requestID: QuestionID }>()
+      const off = yield* events.listen((event) => {
+        if (event.type === Question.Event.Rejected.type)
+          Queue.offerUnsafe(received, event.data as { sessionID: SessionID; requestID: QuestionID })
+        return Effect.void
+      })
+      yield* Effect.addFinalizer(() => off)
+
+      const fiber = yield* askEffect({
+        sessionID: SessionID.make("ses_test"),
+        questions: [
+          {
+            question: "What would you like to do?",
+            header: "Action",
+            options: [{ label: "Option 1", description: "First option" }],
+          },
+        ],
+      }).pipe(Effect.forkScoped)
+
+      const pending = yield* waitForPending(1)
+      const requestID = pending[0].id
+
+      // Simulate the tool execution being interrupted before the user replies
+      // (session ended, parent killed, scope torn down, etc.).
+      yield* Fiber.interrupt(fiber)
+
+      expect(yield* Queue.take(received).pipe(Effect.timeout("1 second"))).toEqual({
+        sessionID: SessionID.make("ses_test"),
+        requestID,
+      })
+      const after = yield* listEffect
+      expect(after.length).toBe(0)
+    }),
+  { git: true },
+)
+
 // multiple questions tests
 
 it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #28312

### Type of change

- [x] Bug fix

### What does this PR do?

When a permission or question ask is interrupted (tool cancel, session end, fiber kill), the cleanup finalizer used to just remove the pending entry without publishing anything. The TUI subscribes to `Event.Replied`/`Event.Rejected` to dismiss prompts, so without that final event the prompt stayed visible forever and `Enter` did nothing because the underlying entry was already gone.

This adds a synthetic reject publish inside the finalizer, but only when the entry is still in `pending` — the reply path deletes the entry *before* publishing its event, so this only fires on the orphan path and never races with a real reply.

### How did you verify your code works?

- New live test in `test/permission/next.test.ts` that forks `ask()`, interrupts the fiber, and asserts a `reject` event was published.
- Equivalent live test in `test/question/question.test.ts`.
- `bun typecheck` + focused tests pass locally.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR