### PR TITLE
feat(provider): support per-model limit overrides in user config

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -199,9 +199,9 @@ export const layer = Layer.effect(
     const populate = Effect.gen(function* () {
       const fromDisk = yield* loadFromDisk
       if (fromDisk) return fromDisk
+      if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
       const snapshot = yield* loadSnapshot
       if (snapshot) return snapshot
-      if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
       // Flock is cross-process: concurrent opencode CLIs can race on this cache file.
       const text = yield* Effect.scoped(
         Effect.gen(function* () {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1598,6 +1598,13 @@ export const layer = Layer.effect(
                 (v) => omit(v, ["disabled"]),
               )
             }
+
+            const configLimit = configProvider?.models?.[modelID]?.limit
+            if (configLimit) {
+              if (configLimit.context) model.limit.context = configLimit.context
+              if (configLimit.input) model.limit.input = configLimit.input
+              if (configLimit.output) model.limit.output = configLimit.output
+            }
           }
 
           if (Object.keys(provider.models).length === 0) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1099,6 +1099,31 @@ it.instance(
 )
 
 it.instance(
+  "config provider model limit overrides individual fields",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.make("limit-override")].models[ModelV2.ID.make("model")]
+    expect(model.limit.context).toBe(100000)
+    expect(model.limit.input).toBe(80000)
+    expect(model.limit.output).toBe(16000)
+  }),
+  {
+    config: {
+      provider: {
+        "limit-override": {
+          name: "Limit Override Provider",
+          npm: "@ai-sdk/openai-compatible",
+          env: [],
+          models: { model: { name: "Model", tool_call: true, limit: { context: 100000, input: 80000, output: 16000 } } },
+          options: { apiKey: "test" },
+        },
+      },
+    },
+  },
+)
+
+
+it.instance(
   "provider options are deeply merged",
   Effect.gen(function* () {
     yield* set("ANTHROPIC_API_KEY", "test-api-key")


### PR DESCRIPTION
### Issue for this PR

Closes #21564
Refs #8140

### Type of change

- [ ] Bug fix
- [x] New feature

### What does this PR do?

Users can already configure custom limits on a model in `opencode.json` (`limit.context`, `limit.input`, `limit.output`), but those values were being dropped when the model was sourced from models.dev — the materialised model always used the upstream metadata. This blocks workarounds for cases where models.dev lags actual provider behaviour (Copilot models, beta context-window extensions, etc.).

In `provider/provider.ts`, after the models.dev model is materialised, this merges the configured limit fields over the default values. Each field falls back individually so users can override just one and leave the others at defaults.

Also a small ordering fix in `core/models-dev.ts`: `OPENCODE_DISABLE_MODELS_FETCH` was being checked after a fetch attempt could still occur — moved it earlier so it actually short-circuits.

This was previously part of #20671 (closed as mixed scope); this PR contains only the model-limit override piece.

### How did you verify your code works?

`test/provider/provider.test.ts` adds a config provider with `limit: { context: 100000, input: 80000, output: 16000 }` and asserts the materialised model carries those values. `bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR