### PR TITLE
feat(plugin): expose skills API to plugins via PluginInput.skills

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -31,6 +31,7 @@ import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
+import { Skill } from "../skill"
 
 type State = {
   hooks: Hooks[]
@@ -126,6 +127,7 @@ export const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const config = yield* Config.Service
     const flags = yield* RuntimeFlags.Service
+    const skill = yield* Skill.Service
 
     const state = yield* InstanceState.make<State>(
       Effect.fn("Plugin.state")(function* (ctx) {
@@ -161,6 +163,23 @@ export const layer = Layer.effect(
           },
           // @ts-expect-error
           $: typeof Bun === "undefined" ? undefined : Bun.$,
+          skills: {
+            all: () =>
+              bridge.promise(
+                skill.all().pipe(
+                  Effect.orDie,
+                  Effect.map((items) => items.map((item) => ({ ...item, description: item.description ?? "" }))),
+                ),
+              ),
+            get: (name: string) =>
+              bridge.promise(
+                skill.get(name).pipe(
+                  Effect.orDie,
+                  Effect.map((item) => (item ? { ...item, description: item.description ?? "" } : item)),
+                ),
+              ),
+            dirs: () => bridge.promise(skill.dirs().pipe(Effect.orDie)),
+          },
         }
 
         for (const plugin of flags.disableDefaultPlugins ? [] : internalPlugins(flags)) {
@@ -184,9 +203,9 @@ export const layer = Layer.effect(
             items: plugins,
             kind: "server",
             report: {
-              start(candidate) {},
-              missing(candidate, _retry, message) {},
-              error(candidate, _retry, stage, error, resolved) {
+              start(_candidate) {},
+              missing(_candidate, _retry, _message) {},
+              error(candidate, _retry, stage, error, _resolved) {
                 const spec = candidate.plan.spec
                 const cause = error instanceof Error ? (error.cause ?? error) : error
                 const message = stage === "load" ? errorMessage(error) : errorMessage(cause)
@@ -308,9 +327,10 @@ export const layer = Layer.effect(
 export const defaultLayer = layer.pipe(
   Layer.provide(EventV2Bridge.defaultLayer),
   Layer.provide(Config.defaultLayer),
+  Layer.provide(Skill.defaultLayer),
   Layer.provide(RuntimeFlags.defaultLayer),
 )
 
-export const node = LayerNode.make(layer, [EventV2Bridge.node, Config.node, RuntimeFlags.node])
+export const node = LayerNode.make(layer, [EventV2Bridge.node, Config.node, Skill.node, RuntimeFlags.node])
 
 export * as Plugin from "."

--- a/packages/opencode/test/agent/plugin-agent-regression.test.ts
+++ b/packages/opencode/test/agent/plugin-agent-regression.test.ts
@@ -36,6 +36,7 @@ const configLayer = Config.layer.pipe(
 const pluginLayer = Plugin.layer.pipe(
   Layer.provide(EventV2Bridge.defaultLayer),
   Layer.provide(configLayer),
+  Layer.provide(SkillTest.empty),
   Layer.provide(RuntimeFlags.layer({ disableDefaultPlugins: true })),
 )
 const agentLayer = Agent.layer.pipe(

--- a/packages/opencode/test/plugin/auth-override.test.ts
+++ b/packages/opencode/test/plugin/auth-override.test.ts
@@ -10,6 +10,7 @@ import { Plugin } from "@/plugin"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Auth } from "@/auth"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { Skill } from "@/skill"
 import { TestConfig } from "../fixture/config"
 import { testEffect } from "../lib/effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -24,6 +25,7 @@ function layer(directory: string, plugins: string[]) {
       Plugin.layer.pipe(
         Layer.provide(EventV2Bridge.defaultLayer),
         Layer.provide(RuntimeFlags.layer()),
+        Layer.provide(Skill.defaultLayer),
         Layer.provide(
           TestConfig.layer({
             get: () =>

--- a/packages/opencode/test/plugin/cloudflare.test.ts
+++ b/packages/opencode/test/plugin/cloudflare.test.ts
@@ -11,6 +11,11 @@ const pluginInput = {
   },
   serverUrl: new URL("https://example.com"),
   $: {} as never,
+  skills: {
+    all: async () => [],
+    get: async () => undefined,
+    dirs: async () => [],
+  },
 }
 
 function makeHookInput(overrides: { providerID?: string; apiId?: string; reasoning?: boolean }) {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -218,6 +218,11 @@ describe("plugin.codex", () => {
         },
         serverUrl: new URL("https://example.com"),
         $: {} as never,
+        skills: {
+          all: async () => [],
+          get: async () => undefined,
+          dirs: async () => [],
+        },
       },
       {
         issuer: server.url.origin,

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -299,6 +299,11 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
     },
     serverUrl: new URL("https://example.com"),
     $: {} as never,
+    skills: {
+      all: async () => [],
+      get: async () => undefined,
+      dirs: async () => [],
+    },
   })
 
   const models = await hooks.provider!.models!(

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, spyOn } from "bun:test"
+import { afterAll, afterEach, describe, expect, spyOn } from "bun:test"
 import { Effect, Layer } from "effect"
 import fs from "fs/promises"
 import path from "path"
@@ -8,13 +8,32 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
+const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+const configContent = process.env.OPENCODE_CONFIG_CONTENT
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+delete process.env.OPENCODE_CONFIG_CONTENT
+
 const { Plugin } = await import("../../src/plugin/index")
 const { PluginLoader } = await import("../../src/plugin/loader")
 const { readPackageThemes } = await import("../../src/plugin/shared")
 const { EventV2Bridge } = await import("../../src/event-v2-bridge")
+const { Skill } = await import("../../src/skill")
 const { Npm } = await import("@opencode-ai/core/npm")
 const { TestConfig } = await import("../fixture/config")
 const { RuntimeFlags } = await import("../../src/effect/runtime-flags")
+
+afterAll(() => {
+  if (disableDefault === undefined) {
+    delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+  } else {
+    process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disableDefault
+  }
+  if (configContent === undefined) {
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    return
+  }
+  process.env.OPENCODE_CONFIG_CONTENT = configContent
+})
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -48,6 +67,7 @@ function load(dir: string, flags?: Parameters<typeof RuntimeFlags.layer>[0]) {
         Plugin.layer.pipe(
           Layer.provide(EventV2Bridge.defaultLayer),
           Layer.provide(RuntimeFlags.layer({ disableDefaultPlugins: true, ...flags })),
+          Layer.provide(Skill.defaultLayer),
           Layer.provide(
             TestConfig.layer({
               get: () =>

--- a/packages/opencode/test/plugin/native-skills.test.ts
+++ b/packages/opencode/test/plugin/native-skills.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
+
+const disable = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+const cfg = process.env.OPENCODE_CONFIG_DIR
+const content = process.env.OPENCODE_CONFIG_CONTENT
+const home = process.env.OPENCODE_TEST_HOME
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Effect } = await import("effect")
+const { MessageID, SessionID } = await import("../../src/session/schema")
+const { ToolRegistry } = await import("../../src/tool/registry")
+
+afterEach(async () => {
+  if (disable === undefined) delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+  else process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disable
+  if (cfg === undefined) delete process.env.OPENCODE_CONFIG_DIR
+  else process.env.OPENCODE_CONFIG_DIR = cfg
+  if (content === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+  else process.env.OPENCODE_CONFIG_CONTENT = content
+  if (home === undefined) delete process.env.OPENCODE_TEST_HOME
+  else process.env.OPENCODE_TEST_HOME = home
+  await disposeAllInstances()
+})
+
+// Validates the OMO+superpowers coexistence pattern:
+// A plugin captures ctx.skills during server(), then calls ctx.skills.all()
+// LAZILY (via a tool execute) after plugin loading completes.
+// Native skills must be visible in the lazy call.
+test("plugin tool can lazily call ctx.skills.all() and see native skills", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create a native skill in the standard location
+      const skill = path.join(dir, ".opencode", "skill", "test-native")
+      await fs.mkdir(skill, { recursive: true })
+      await Bun.write(
+        path.join(skill, "SKILL.md"),
+        ["---", "name: test-native", "description: A test native skill", "---", "", "# Test Native Skill", ""].join("\n"),
+      )
+
+      // Create a plugin that captures ctx.skills and exposes a tool
+      // whose execute calls ctx.skills.all() lazily
+      const plugin = path.join(dir, ".opencode", "plugin")
+      await fs.mkdir(plugin, { recursive: true })
+      const out = JSON.stringify(path.join(dir, "skills-result.json"))
+      await Bun.write(
+        path.join(plugin, "skill-reader.ts"),
+        [
+          'import { writeFileSync } from "fs"',
+          "",
+          "export default {",
+          '  id: \"test.skill-reader\",',
+          "  server: async (ctx) => {",
+          "    // Capture ctx.skills — do NOT call all() during server()",
+          "    const skills = ctx.skills",
+          "    return {",
+          "      tool: {",
+          "        check_native_skills: {",
+          '          description: \"Returns native skills found via ctx.skills.all()\",',
+          "          args: {},",
+          "          execute: async () => {",
+          "            // LAZY call — runs after server() has returned",
+          "            const all = await skills.all()",
+          `            writeFileSync(${out}, JSON.stringify(all.map(s => s.name)))`,
+          '            return all.map(s => s.name).join(\", \")',
+          "          }",
+          "        }",
+          "      }",
+          "    }",
+          "  },",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.OPENCODE_CONFIG_DIR = path.join(tmp.path, ".config")
+  delete process.env.OPENCODE_CONFIG_CONTENT
+  await fs.mkdir(process.env.OPENCODE_CONFIG_DIR, { recursive: true })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* ToolRegistry.Service
+      const tools = yield* svc.all()
+      const tool = tools.find((t) => t.id === "check_native_skills")
+      if (!tool) throw new Error("Plugin tool not found")
+      yield* tool.execute(
+        {},
+        {
+          sessionID: SessionID.make("ses_test"),
+          messageID: MessageID.make("msg_test"),
+          agent: "test",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+    }).pipe(
+      provideInstance(tmp.path),
+      Effect.provide(testInstanceStoreLayer),
+      Effect.provide(ToolRegistry.defaultLayer),
+      Effect.provide(Ripgrep.defaultLayer),
+    ),
+  )
+
+  const names = (await Bun.file(path.join(tmp.path, "skills-result.json")).json()) as string[]
+  expect(names).toContain("test-native")
+}, 30000)

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "bun:test"
+import { afterAll, describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -19,6 +19,10 @@ import { AuthTest } from "../fake/auth"
 import { NpmTest } from "../fake/npm"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { Skill } from "../../src/skill"
+
+const configContent = process.env.OPENCODE_CONFIG_CONTENT
+delete process.env.OPENCODE_CONFIG_CONTENT
 
 const configLayer = Config.layer.pipe(
   Layer.provide(EffectFlock.defaultLayer),
@@ -34,12 +38,21 @@ const it = testEffect(
     Plugin.layer.pipe(
       Layer.provide(EventV2Bridge.defaultLayer),
       Layer.provide(configLayer),
+      Layer.provide(Skill.defaultLayer),
       Layer.provide(RuntimeFlags.layer({ disableDefaultPlugins: true })),
     ),
     CrossSpawnSpawner.defaultLayer,
   ),
 )
 const systemHook = "experimental.chat.system.transform"
+
+afterAll(() => {
+  if (configContent === undefined) {
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    return
+  }
+  process.env.OPENCODE_CONFIG_CONTENT = configContent
+})
 
 function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
   return Effect.gen(function* () {

--- a/packages/opencode/test/plugin/workspace-adapter.test.ts
+++ b/packages/opencode/test/plugin/workspace-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterAll, afterEach, describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -27,6 +27,10 @@ import { testEffect } from "../lib/effect"
 import { AccountTest } from "../fake/account"
 import { AuthTest } from "../fake/auth"
 import { NpmTest } from "../fake/npm"
+import { Skill } from "../../src/skill"
+
+const configContent = process.env.OPENCODE_CONFIG_CONTENT
+delete process.env.OPENCODE_CONFIG_CONTENT
 
 const configLayer = Config.layer.pipe(
   Layer.provide(EffectFlock.defaultLayer),
@@ -40,6 +44,7 @@ const configLayer = Config.layer.pipe(
 const pluginLayer = Plugin.layer.pipe(
   Layer.provide(EventV2Bridge.defaultLayer),
   Layer.provide(configLayer),
+  Layer.provide(Skill.defaultLayer),
   Layer.provide(RuntimeFlags.layer({ disableDefaultPlugins: true })),
 )
 const noopBootstrapLayer = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
@@ -62,6 +67,14 @@ const it = testEffect(
 
 afterEach(async () => {
   await disposeAllInstances()
+})
+
+afterAll(() => {
+  if (configContent === undefined) {
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    return
+  }
+  process.env.OPENCODE_CONFIG_CONTENT = configContent
 })
 
 describe("plugin.workspace", () => {

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -48,6 +48,7 @@ process.env["OPENCODE_TEST_HOME"] = testHome
 // Set test managed config directory to isolate tests from system managed settings
 const testManagedConfigDir = path.join(dir, "managed")
 process.env["OPENCODE_TEST_MANAGED_CONFIG_DIR"] = testManagedConfigDir
+delete process.env["OPENCODE_CONFIG_CONTENT"]
 
 // Write the cache version file to prevent global/index.ts from clearing the cache
 const cacheDir = path.join(dir, "cache", "opencode")

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -8,6 +8,12 @@ import { Config } from "../../src/config/config"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { Tool } from "../../src/tool/tool"
+import { ToolRegistry } from "../../src/tool/registry"
 import { provideInstance, provideTmpdirInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import path from "path"
@@ -44,6 +50,18 @@ const itWithoutExternalSkills = testEffect(
     testInstanceStoreLayer,
   ),
 )
+const kit = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, node).pipe(Layer.provide(Ripgrep.defaultLayer)))
+
+const toolCtx: Tool.Context = {
+  sessionID: SessionID.make("ses_test-plugin-skill"),
+  messageID: MessageID.make("msg_test-plugin-skill"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
 
 async function createGlobalSkill(homeDir: string) {
   const skillDir = path.join(homeDir, ".claude", "skills", "global-test-skill")
@@ -567,5 +585,247 @@ description: A skill in the .opencode/skills directory.
         }),
       { git: true },
     ),
+  )
+  it.live("discovers skills from config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(root, "config-skill", "SKILL.md"),
+              `---
+name: config-skill
+description: A skill registered via config.skills.paths.
+---
+
+# Config Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          const item = (yield* skill.all()).find((x) => x.name === "config-skill")
+          expect(item).toBeDefined()
+          expect(item!.description).toBe("A skill registered via config.skills.paths.")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("returns skill from config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(root, "get-test-skill", "SKILL.md"),
+              `---
+name: get-test-skill
+description: Skill for get() test.
+---
+
+# Get Test Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          const item = yield* skill.get("get-test-skill")
+          expect(item).toBeDefined()
+          expect(item!.name).toBe("get-test-skill")
+          expect(item!.description).toBe("Skill for get() test.")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("includes config.skills.paths directories in dirs", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          const item = path.join(root, "dirs-test-skill")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(item, "SKILL.md"),
+              `---
+name: dirs-test-skill
+description: Skill for dirs() test.
+---
+
+# Dirs Test Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          expect(yield* skill.dirs()).toContain(item)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("returns undefined for missing skills", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const skill = yield* Skill.Service
+          expect(yield* skill.get("nonexistent-skill")).toBeUndefined()
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("keeps opencode and claude skill loading with config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".opencode", "skill", "opencode-skill", "SKILL.md"),
+                `---
+name: opencode-skill
+description: Skill in .opencode/skill directory.
+---
+
+# OpenCode Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".claude", "skills", "claude-skill", "SKILL.md"),
+                `---
+name: claude-skill
+description: Skill in .claude/skills directory.
+---
+
+# Claude Skill
+`,
+              ),
+              Bun.write(
+                path.join(root, "config-skill", "SKILL.md"),
+                `---
+name: config-skill
+description: Skill in config.skills.paths.
+---
+
+# Config Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, "opencode.json"),
+                JSON.stringify({
+                  $schema: "https://opencode.ai/config.json",
+                  skills: { paths: [root] },
+                }),
+              ),
+            ]),
+          )
+          const skill = yield* Skill.Service
+          const list = (yield* skill.all()).filter((x) => x.location !== "<built-in>")
+          expect(list.length).toBe(3)
+          expect(list.find((x) => x.name === "opencode-skill")).toBeDefined()
+          expect(list.find((x) => x.name === "claude-skill")).toBeDefined()
+          expect(list.find((x) => x.name === "config-skill")).toBeDefined()
+        }),
+      { git: true },
+    ),
+  )
+
+  kit.live(
+    "PluginInput.skills works in plugin tool execute after config hooks populate skills.paths",
+    () =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const plugin = path.join(dir, ".opencode", "plugin")
+            yield* Effect.promise(() => fs.mkdir(plugin, { recursive: true }))
+            yield* Effect.promise(() =>
+              Bun.write(
+                path.join(dir, "plugin-config-skills", "plugin-config-skill", "SKILL.md"),
+                `---
+name: plugin-config-skill
+description: A skill registered by a plugin config hook.
+---
+
+# Plugin Config Skill
+`,
+              ),
+            )
+            yield* Effect.promise(() =>
+              Bun.write(
+                path.join(plugin, "plugin-skill-check.ts"),
+                [
+                  'import { tool } from "@opencode-ai/plugin"',
+                  "",
+                  "export default async (input) => ({",
+                  "  config: async (config) => {",
+                  "    config.skills ??= {}",
+                  "    config.skills.paths ??= []",
+                  '    config.skills.paths.push("./plugin-config-skills")',
+                  "  },",
+                  "  tool: {",
+                  '    "plugin-skill-check": tool({',
+                  '      description: "Checks PluginInput.skills access",',
+                  "      args: {},",
+                  "      execute: async () => {",
+                  '        const skill = await input.skills.get("plugin-config-skill")',
+                  "        const dirs = await input.skills.dirs()",
+                  "        const all = await input.skills.all()",
+                  '        return [skill?.name ?? "", skill?.description ?? "", String(all.length), ...dirs].join("\\n")',
+                  "      },",
+                  "    }),",
+                  "  },",
+                  "})",
+                  "",
+                ].join("\n"),
+              ),
+            )
+            const list = yield* ToolRegistry.Service.use((svc) =>
+              svc.tools({
+                providerID: ProviderV2.ID.make("opencode"),
+                modelID: ModelV2.ID.make("gpt-5"),
+                agent: { name: "build", mode: "primary", permission: [], options: {} },
+              }),
+            )
+            const tool = list.find((item) => item.id === "plugin-skill-check")
+            expect(tool).toBeDefined()
+            const out = yield* tool!.execute({}, toolCtx)
+            const lines = out.output.split("\n")
+            expect(lines[0]).toBe("plugin-config-skill")
+            expect(lines[1]).toBe("A skill registered by a plugin config hook.")
+            expect(Number(lines[2])).toBeGreaterThanOrEqual(1)
+            expect(lines).toContain(path.join(dir, "plugin-config-skills", "plugin-config-skill"))
+          }),
+        { git: true },
+      ),
+    30000,
   )
 })

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -53,6 +53,13 @@ export type WorkspaceAdapter = {
   target(config: WorkspaceInfo): WorkspaceTarget | Promise<WorkspaceTarget>
 }
 
+export type SkillInfo = {
+  name: string
+  description: string
+  location: string
+  content: string
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -63,6 +70,11 @@ export type PluginInput = {
   }
   serverUrl: URL
   $: BunShell
+  skills: {
+    all(): Promise<SkillInfo[]>
+    get(name: string): Promise<SkillInfo | undefined>
+    dirs(): Promise<string[]>
+  }
 }
 
 export type PluginOptions = Record<string, unknown>


### PR DESCRIPTION
### Issue for this PR

Closes #18688

Re-submission of #18686 (closed by automated cleanup), rebased onto current dev. The previous PR could not be reopened because the branch has been force-pushed since closure.

### Type of change

- [ ] Bug fix
- [x] New feature

### What does this PR do?

Exposes the native skills API (`skill.all()`, `skill.get(name)`, `skill.dirs()`) to plugins via `PluginInput.skills`, matching the feature request in #18688. This lets plugins discover and reason about user-defined skills the same way the agent runtime does.

### How did you verify your code works?

New `test/plugin/native-skills.test.ts` covers the plugin-input surface end-to-end. Adjacent tests updated to provide the new `Skill` layer dependency. `bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR