### PR TITLE
fix(session): preserve agent and model on async prompt without explicit fields

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -634,7 +634,13 @@ export const layer = Layer.effect(
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
-      const agentName = input.agent
+      const prev = input.agent
+        ? undefined
+        : (yield* MessageV2.filterCompactedEffect(input.sessionID).pipe(Effect.provideService(Database.Service, database))).findLast(
+            (m): m is SessionV1.WithParts & { info: SessionV1.User } =>
+              m.info.role === "user" && !!m.info.agent,
+          )
+      const agentName = input.agent ?? prev?.info.agent
       const ag = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()
       if (!ag) {
         const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
@@ -650,7 +656,7 @@ export const layer = Layer.effect(
         .where(eq(SessionTable.id, input.sessionID))
         .get()
         .pipe(Effect.orDie)
-      const model = input.model ?? ag.model ?? (yield* currentModel(input.sessionID))
+      const model = input.model ?? prev?.info.model ?? ag.model ?? (yield* currentModel(input.sessionID))
       const same = ag.model && model.providerID === ag.model.providerID && model.modelID === ag.model.modelID
       const full =
         !input.variant && ag.variant && same

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2171,6 +2171,41 @@ it.instance(
 // Agent variant
 
 noLLMServer.instance(
+  "prompt without agent and model preserves current session agent and model",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+
+      const next = yield* prompt.prompt({
+        sessionID: session.id,
+        noReply: true,
+        parts: [{ type: "text", text: "hello again" }],
+      })
+      if (next.info.role !== "user") throw new Error("expected user message")
+      expect(next.info.agent).toBe("build")
+      expect(next.info.model).toEqual(ref)
+
+      yield* sessions.remove(session.id)
+    }),
+  {
+    config: {
+      ...cfg,
+      default_agent: "plan",
+    },
+  },
+)
+
+noLLMServer.instance(
   "applies agent variant only when using agent model",
   () =>
     Effect.gen(function* () {
@@ -2238,6 +2273,7 @@ noLLMServer.instance(
     },
   },
 )
+
 
 // Agent / command resolution errors
 


### PR DESCRIPTION
### Issue for this PR

Closes #21728

Re-submission of #21729 (closed by automated cleanup), rebased onto current dev. The previous PR could not be reopened because the branch has been force-pushed since closure. The Linux e2e failure analyzed previously was traced to a different spec and unrelated to this PR.

### Type of change

- [x] Bug fix

### What does this PR do?

When `prompt_async` is called without `agent` or `model` fields, the session previously fell back to the default agent's model — clobbering the active agent/model the user had selected. This is the bug in #21728.

Now `createUserMessage` looks at the most recent user message with an agent set and uses that as the fallback before falling back to defaults. Same fallback chain for the model.

### How did you verify your code works?

New test in `test/session/prompt.test.ts` asserts that a no-agent/no-model `prompt_async` after an initial prompt-with-agent preserves the original agent and model on the new user message.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR