### PR TITLE
feat(session/llm): scaffold OpenAI Realtime (WebSocket) transport

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -301,6 +301,10 @@ export const Info = Schema.Struct({
       mcp_timeout: Schema.optional(PositiveInt).annotate({
         description: "Timeout in milliseconds for model context protocol (MCP) requests",
       }),
+      openai_realtime: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Use the OpenAI Realtime (WebSocket) transport for OpenAI text models. Default: false. See packages/opencode/src/session/llm/REALTIME-DESIGN.md.",
+      }),
     }),
   ),
 }).annotate({ identifier: "Config" })

--- a/packages/opencode/src/session/llm/REALTIME-DESIGN.md
+++ b/packages/opencode/src/session/llm/REALTIME-DESIGN.md
@@ -1,0 +1,110 @@
+# OpenAI Realtime (WebSocket) Transport — Design Note
+
+**Status:** Draft scaffold. Not wired into the live `stream()` path yet.
+**Scope:** OpenAI Realtime API (`wss://api.openai.com/v1/realtime`) only. **Not** a
+replacement for the HTTP/SSE chat or Responses transports — those remain the
+default and unchanged.
+
+## Motivation
+
+OpenAI's Realtime API is event-based over WebSocket and exposes lower-latency
+streaming, server-side VAD, and audio modalities that aren't accessible through
+`@ai-sdk/openai`'s `responses(modelID)` LanguageModelV2 adapter. Some users want
+to drive text-mode tool calls through Realtime to get faster first-token + reduced
+head-of-line blocking. This scaffold adds the plumbing so that work can be done
+behind a flag without disturbing the current chat path.
+
+## Non-goals
+
+- Replacing `@ai-sdk/openai` or the existing `responses()` path.
+- Audio/voice features (the WS schema supports them, but text-mode tool-calling
+  is the only thing the session loop needs today).
+- Cross-provider WS abstraction. This is OpenAI-Realtime-specific; other
+  providers ship their own protocols.
+
+## Surface
+
+New file: `packages/opencode/src/session/llm/realtime.ts`
+
+```
+export function status(input): RuntimeStatus           // mirrors native-runtime.ts
+export function stream(input): Effect<StreamResult>    // returns Stream<LLMEvent>
+export const REALTIME_URL = "wss://api.openai.com/v1/realtime"
+```
+
+The shape intentionally matches `native-runtime.ts`'s `status()` / `StreamResult`
+so that, when wired in, the dispatch site in `session/llm.ts` can pick
+`realtime → native → ai-sdk` in priority order with the same selection pattern
+already used.
+
+## Config flag
+
+Added to `experimental` in `packages/opencode/src/config/config.ts`:
+
+```
+openai_realtime: Schema.optional(Schema.Boolean).annotate({
+  description: "Use OpenAI Realtime (WebSocket) transport for OpenAI text models. Default: false."
+})
+```
+
+Default is `false`. When unset, nothing about today's behavior changes.
+
+## Event mapping
+
+Realtime emits a tagged event stream over the socket. The skeleton maps a
+minimum useful subset onto `@opencode-ai/llm` `LLMEvent`:
+
+| Realtime event                              | LLMEvent                              |
+| ------------------------------------------- | ------------------------------------- |
+| `session.created`                           | (no-op)                               |
+| `response.created`                          | `stepStart({ index })`                |
+| `response.output_item.added` (type=message) | `textStart({ id })`                   |
+| `response.output_text.delta`                | `textDelta({ id, text })`             |
+| `response.output_text.done`                 | `textEnd({ id })`                     |
+| `response.function_call_arguments.delta`    | `toolInputDelta({ id, name, text })`  |
+| `response.function_call_arguments.done`     | `toolInputEnd({ id, name })`          |
+| `response.output_item.done` (type=tool)     | `toolCall({ id, name, input })`       |
+| `response.done`                             | `stepFinish` + `finish`               |
+| `error`                                     | `Stream.fail`                         |
+
+Items not listed (audio.*, transcript.*, rate_limits.updated, etc.) are dropped
+in the skeleton. They become no-ops in `toLLMEvents()` and remain easy to add
+later without touching the transport.
+
+## Lifecycle / cleanup
+
+- `Effect.acquireRelease` owns the `WebSocket`. The finalizer sends a
+  `close()` and unregisters listeners regardless of completion or failure.
+- The caller's `AbortSignal` is bridged to `ws.close(1000, "abort")`.
+- An idle-timeout is applied at the same layer the SSE path uses
+  (`Stream.timeoutOrElse`), keeping symmetry with the
+  `feat/llm-stream-idle-timeout` PR.
+
+## Auth
+
+Realtime accepts the standard `Authorization: Bearer <key>` over the WS
+upgrade headers, plus an `OpenAI-Beta: realtime=v1` header. No OAuth path
+yet — initial scope is API-key only; OAuth can layer in once the provider
+auth code supports passing an access token through `upgrade` headers.
+
+## Why scaffold-only
+
+- The Realtime event surface is wide and still evolving (OpenAI has rolled
+  several non-breaking additions in 2025-2026).
+- The wiring into `session/llm.ts` is mechanically simple but should follow
+  the maintainers' preferred dispatch pattern — better to land the skeleton
+  first and iterate on integration in review.
+- Sessions that depend on existing tool-call semantics shouldn't be migrated
+  silently; the flag-gate ensures opt-in.
+
+## Open questions for maintainers
+
+1. **Provider model** — register Realtime as a separate `providerID`
+   (e.g. `openai-realtime`) with its own model list, or keep it under
+   `openai` and switch transport based on the flag + model id prefix?
+2. **Tool schema translation** — Realtime expects `function` tool defs in
+   the `session.update` event; should this reuse `ProviderTransform.tools`
+   or stay a Realtime-specific path?
+3. **Reasoning models** — `gpt-5*` reasoning items aren't first-class in
+   Realtime today. Block them at `status()` time, or pass through and let
+   the API return a clear error?

--- a/packages/opencode/src/session/llm/realtime.ts
+++ b/packages/opencode/src/session/llm/realtime.ts
@@ -1,0 +1,176 @@
+/**
+ * OpenAI Realtime (WebSocket) transport — scaffold only.
+ *
+ * This module is NOT wired into the live `session/llm.ts` stream path yet.
+ * See `REALTIME-DESIGN.md` (same directory) for the design rationale and
+ * open questions for maintainers.
+ *
+ * What this file provides today:
+ *   - `REALTIME_URL` — the wss endpoint constant.
+ *   - `adapterState()` / `toLLMEvents()` — a pure mapper from parsed Realtime
+ *     JSON events onto the unified `LLMEvent` shape, with no I/O. Unit-testable.
+ *   - `stream()` — a stub Effect that fails with `RealtimeNotImplemented` so
+ *     accidental wiring is loud, not silent.
+ *
+ * Future work (out of scope for this PR):
+ *   - WebSocket lifecycle (open, send `session.update`, push messages, close).
+ *   - AbortSignal -> ws.close bridge.
+ *   - Idle-timeout integration (see feat/llm-stream-idle-timeout PR).
+ *   - Provider dispatch in `session/llm.ts`.
+ */
+
+import { LLMEvent } from "@opencode-ai/llm"
+import { Effect } from "effect"
+import * as Stream from "effect/Stream"
+
+export const REALTIME_URL = "wss://api.openai.com/v1/realtime"
+export const REALTIME_BETA_HEADER = "OpenAI-Beta"
+export const REALTIME_BETA_VALUE = "realtime=v1"
+
+export class RealtimeNotImplemented extends Error {
+  readonly _tag = "RealtimeNotImplemented"
+  constructor() {
+    super("OpenAI Realtime transport is a scaffold and not yet wired into the live stream path")
+  }
+}
+
+/**
+ * Per-stream mapper state. Mirrors the shape of `ai-sdk.ts`'s `adapterState()`
+ * on purpose so the dispatch site in `session/llm.ts` can treat both adapters
+ * uniformly when this gets wired in.
+ */
+export function adapterState() {
+  return {
+    step: 0,
+    activeTextID: undefined as string | undefined,
+    // Realtime gives each output item its own id; we map call_id -> tool name
+    // so subsequent argument-delta events can resolve the name without
+    // re-reading the original `response.output_item.added` payload.
+    toolNames: {} as Record<string, string>,
+  }
+}
+
+export type State = ReturnType<typeof adapterState>
+
+/**
+ * Loosely-typed Realtime server event. The protocol is wide and additive, so
+ * this scaffold treats every field as optional and unknown — the mapper
+ * narrows what it needs case-by-case. Unknown event types fall through to
+ * `[]` in `toLLMEvents()`.
+ */
+export interface RealtimeEvent {
+  readonly type: string
+  readonly item_id?: string
+  readonly call_id?: string
+  readonly delta?: string
+  readonly name?: string
+  readonly response?: { readonly id?: string; readonly status?: string }
+  readonly item?: {
+    readonly id?: string
+    readonly type?: string
+    readonly name?: string
+    readonly call_id?: string
+    readonly arguments?: string
+  }
+  readonly error?: { readonly message?: string }
+}
+
+export function toLLMEvents(state: State, event: RealtimeEvent): ReadonlyArray<LLMEvent> {
+  switch (event.type) {
+    case "session.created":
+      return []
+
+    case "response.created":
+      return [LLMEvent.stepStart({ index: state.step })]
+
+    case "response.output_item.added": {
+      const item = event.item ?? {}
+      if (item.type === "message" && item.id) {
+        state.activeTextID = item.id
+        return [LLMEvent.textStart({ id: item.id })]
+      }
+      if ((item.type === "function_call" || item.type === "tool_call") && item.call_id && item.name) {
+        state.toolNames[item.call_id] = item.name
+        return [LLMEvent.toolInputStart({ id: item.call_id, name: item.name })]
+      }
+      return []
+    }
+
+    case "response.output_text.delta": {
+      const id = event.item_id ?? state.activeTextID
+      if (!id || !event.delta) return []
+      return [LLMEvent.textDelta({ id, text: event.delta })]
+    }
+
+    case "response.output_text.done": {
+      const id = event.item_id ?? state.activeTextID
+      if (!id) return []
+      state.activeTextID = undefined
+      return [LLMEvent.textEnd({ id })]
+    }
+
+    case "response.function_call_arguments.delta": {
+      if (!event.call_id || !event.delta) return []
+      const name = state.toolNames[event.call_id]
+      if (!name) return []
+      return [LLMEvent.toolInputDelta({ id: event.call_id, name, text: event.delta })]
+    }
+
+    case "response.function_call_arguments.done": {
+      if (!event.call_id) return []
+      const name = event.name ?? state.toolNames[event.call_id]
+      if (!name) return []
+      return [LLMEvent.toolInputEnd({ id: event.call_id, name })]
+    }
+
+    case "response.output_item.done": {
+      const item = event.item ?? {}
+      if ((item.type !== "function_call" && item.type !== "tool_call") || !item.call_id) return []
+      const name = item.name ?? state.toolNames[item.call_id] ?? "unknown"
+      delete state.toolNames[item.call_id]
+      let input: unknown = item.arguments
+      if (typeof input === "string") {
+        try {
+          input = JSON.parse(input)
+        } catch {
+          // Leave as string; the loop will surface the parse failure when
+          // invoking the tool. This matches how the SSE path treats malformed
+          // function-call arguments.
+        }
+      }
+      return [LLMEvent.toolCall({ id: item.call_id, name, input })]
+    }
+
+    case "response.done": {
+      const reason = event.response?.status === "failed" ? "error" : "stop"
+      const out: LLMEvent[] = [
+        LLMEvent.stepFinish({ index: state.step, reason }),
+        LLMEvent.finish({ reason }),
+      ]
+      // Reset so the same adapter state can be reused for a follow-up turn.
+      // The ai-sdk adapter does the same thing on `finish`.
+      Object.assign(state, adapterState())
+      return out
+    }
+
+    case "error":
+      // Surfaced by the caller via Stream.fail; here we just drop it so the
+      // pure mapper stays total. The transport layer is responsible for
+      // catching `error` events on the socket and short-circuiting the stream.
+      return []
+
+    default:
+      return []
+  }
+}
+
+/**
+ * Live streaming entry point. Returns a stream that immediately fails so the
+ * scaffold can't be wired in by accident. Future PR will replace this with an
+ * acquireRelease over a WebSocket.
+ */
+export function stream(): Effect.Effect<Stream.Stream<LLMEvent, RealtimeNotImplemented>> {
+  return Effect.succeed(Stream.fail(new RealtimeNotImplemented()))
+}
+
+export * as LLMRealtime from "./realtime"

--- a/packages/opencode/test/session/llm-realtime.test.ts
+++ b/packages/opencode/test/session/llm-realtime.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { adapterState, toLLMEvents, type RealtimeEvent } from "../../src/session/llm/realtime"
+
+function run(events: RealtimeEvent[]) {
+  const state = adapterState()
+  return events.flatMap((e) => toLLMEvents(state, e))
+}
+
+describe("session.llm.realtime.toLLMEvents", () => {
+  test("text turn: response.created -> text deltas -> text done -> response.done", () => {
+    const out = run([
+      { type: "session.created" },
+      { type: "response.created" },
+      { type: "response.output_item.added", item: { id: "msg_1", type: "message" } },
+      { type: "response.output_text.delta", item_id: "msg_1", delta: "Hello" },
+      { type: "response.output_text.delta", item_id: "msg_1", delta: " world" },
+      { type: "response.output_text.done", item_id: "msg_1" },
+      { type: "response.done", response: { status: "completed" } },
+    ])
+
+    const types = out.map((e) => e.type)
+    expect(types).toEqual([
+      "step-start",
+      "text-start",
+      "text-delta",
+      "text-delta",
+      "text-end",
+      "step-finish",
+      "finish",
+    ])
+    expect(out.filter((e) => e.type === "text-delta").map((e: any) => e.text).join("")).toBe("Hello world")
+  })
+
+  test("tool call: function_call item -> argument deltas -> output_item.done emits toolCall with parsed args", () => {
+    const out = run([
+      { type: "response.created" },
+      {
+        type: "response.output_item.added",
+        item: { id: "item_1", type: "function_call", call_id: "call_abc", name: "read_file" },
+      },
+      { type: "response.function_call_arguments.delta", call_id: "call_abc", delta: '{"path"' },
+      { type: "response.function_call_arguments.delta", call_id: "call_abc", delta: ':"a.txt"}' },
+      { type: "response.function_call_arguments.done", call_id: "call_abc" },
+      {
+        type: "response.output_item.done",
+        item: { id: "item_1", type: "function_call", call_id: "call_abc", arguments: '{"path":"a.txt"}' },
+      },
+      { type: "response.done" },
+    ])
+
+    const tc = out.find((e) => e.type === "tool-call") as any
+    expect(tc).toBeDefined()
+    expect(tc.id).toBe("call_abc")
+    expect(tc.name).toBe("read_file")
+    expect(tc.input).toEqual({ path: "a.txt" })
+
+    const inputDeltas = out.filter((e) => e.type === "tool-input-delta") as any[]
+    expect(inputDeltas.map((d) => d.text).join("")).toBe('{"path":"a.txt"}')
+  })
+
+  test("unknown event types and out-of-order text deltas are dropped without throwing", () => {
+    const out = run([
+      { type: "rate_limits.updated" } as any,
+      { type: "response.audio.delta", delta: "..." } as any,
+      // delta without a matching active text id is silently dropped
+      { type: "response.output_text.delta", delta: "stray" },
+    ])
+    expect(out).toEqual([])
+  })
+
+  test("response.done with status=failed surfaces reason=error on stepFinish + finish", () => {
+    const out = run([
+      { type: "response.created" },
+      { type: "response.done", response: { status: "failed" } },
+    ])
+    const finish = out.find((e) => e.type === "finish") as any
+    const step = out.find((e) => e.type === "step-finish") as any
+    expect(finish.reason).toBe("error")
+    expect(step.reason).toBe("error")
+  })
+})


### PR DESCRIPTION
## Summary
- Scaffolds an **OpenAI Realtime API** (WebSocket) transport for the session LLM stream.
- Ships behind a new `experimental.openai_realtime` flag (default `false`) — **no behavior change** until the flag is enabled and the wiring lands.
- Includes a pure event mapper (Realtime JSON → `LLMEvent`) with unit tests, a stub `stream()` that fails loudly, and a design note documenting the protocol mapping and open questions.

## Why a scaffold, not a full transport?

The Realtime event surface is wide and additive; the right dispatch shape inside `session/llm.ts` is a maintainer call. Landing the scaffold first lets reviewers shape that integration without a churny diff. This PR is intentionally inert at runtime — `stream()` throws `RealtimeNotImplemented` if accidentally invoked.

## What changes

- **`packages/opencode/src/session/llm/realtime.ts`** (new) — `adapterState()`, `toLLMEvents()`, `REALTIME_URL`, `RealtimeNotImplemented`, stub `stream()`. The mapper shape mirrors `ai-sdk.ts`'s `adapterState()` / `toLLMEvents()` on purpose so the eventual dispatch site treats both adapters uniformly.
- **`packages/opencode/src/session/llm/REALTIME-DESIGN.md`** (new) — scope, non-goals, protocol mapping table, lifecycle plan, auth, open questions for maintainers.
- **`packages/opencode/src/config/config.ts`** — adds `experimental.openai_realtime: Schema.optional(Schema.Boolean)`.
- **`packages/opencode/test/session/llm-realtime.test.ts`** (new) — four unit tests covering text turns, function-call argument streaming, unknown-event passthrough, and failed-response status.

## Realtime → LLMEvent mapping (summary)

| Realtime event                              | LLMEvent                              |
| ------------------------------------------- | ------------------------------------- |
| `response.created`                          | `stepStart`                           |
| `response.output_item.added` (message)      | `textStart`                           |
| `response.output_text.delta`                | `textDelta`                           |
| `response.output_text.done`                 | `textEnd`                             |
| `response.output_item.added` (function_call)| `toolInputStart`                      |
| `response.function_call_arguments.delta`    | `toolInputDelta`                      |
| `response.function_call_arguments.done`     | `toolInputEnd`                        |
| `response.output_item.done` (function_call) | `toolCall` (with parsed `arguments`)  |
| `response.done`                             | `stepFinish` + `finish`               |

Unknown event types (audio.*, rate_limits.*, etc.) drop to `[]` rather than fail.

## Open questions (called out in the design note)

1. Register Realtime as a separate `providerID` (`openai-realtime`) or keep it under `openai` and switch transport by flag?
2. Reuse `ProviderTransform.tools` for tool-schema translation, or build a Realtime-specific path?
3. How to treat `gpt-5*` reasoning items (which aren't first-class in Realtime yet) — block at `status()` or pass through?

## Test plan
- [x] `bun run typecheck` (packages/opencode) — clean.
- [x] `bun test test/session/llm-realtime.test.ts` — 4/4 pass.
- [ ] Once wiring lands in a follow-up: live smoke against `gpt-4o-realtime-preview` / `gpt-5.x-realtime` with a tool-call prompt.

## Notes for reviewers

- The scaffold deliberately stops short of opening a socket — happy to push the lifecycle (acquireRelease + AbortSignal bridge + idle timeout) in a follow-up once the integration shape is agreed.
- This is independent of #29348 (idle-timeout PR) but the eventual live wiring will reuse the same `Stream.timeoutOrElse` idle guard so both transports fail-fast on stalls.
