### PR TITLE
fix(opencode): normalize file tool argument aliases

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -66,6 +66,13 @@ export const EditTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
+      normalizeArguments: (args: unknown) =>
+        Tool.normalizeAliases(args, {
+          filePath: ["file_path", "path"],
+          oldString: ["old_string", "oldText"],
+          newString: ["new_string", "newText"],
+          replaceAll: ["replace_all"],
+        }),
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
           if (!params.filePath) {

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -58,6 +58,7 @@ export interface Def<
   description: string
   parameters: Parameters
   jsonSchema?: JSONSchema7
+  normalizeArguments?(args: unknown): unknown
   execute(args: Schema.Schema.Type<Parameters>, ctx: Context): Effect.Effect<ExecuteResult<M>>
   formatValidationError?(error: unknown): string
 }
@@ -94,6 +95,21 @@ export type InferDef<T> =
       ? Def<P, M>
       : never
 
+export function normalizeAliases(input: unknown, aliases: Record<string, string[]>): unknown {
+  if (!isRecord(input)) return input
+  const output = { ...input }
+  for (const [key, names] of Object.entries(aliases)) {
+    if (output[key] !== undefined) continue
+    const name = names.find((alias) => input[alias] !== undefined)
+    if (name) output[key] = input[name]
+  }
+  return output
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input)
+}
+
 function wrap<Parameters extends Schema.Decoder<unknown>, Result extends Metadata>(
   id: string,
   init: Init<Parameters, Result>,
@@ -116,7 +132,7 @@ function wrap<Parameters extends Schema.Decoder<unknown>, Result extends Metadat
           ...(ctx.callID ? { "tool.call_id": ctx.callID } : {}),
         }
         return Effect.gen(function* () {
-          const decoded = yield* decode(args).pipe(
+          const decoded = yield* decode(toolInfo.normalizeArguments ? toolInfo.normalizeArguments(args) : args).pipe(
             Effect.mapError(
               (error) =>
                 new InvalidArgumentsError({

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -35,6 +35,11 @@ export const WriteTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
+      normalizeArguments: (args: unknown) =>
+        Tool.normalizeAliases(args, {
+          filePath: ["file_path", "path"],
+          content: ["fileContent", "contents"],
+        }),
       execute: (params: { content: string; filePath: string }, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const instance = yield* InstanceState.context

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -54,6 +54,12 @@ const run = Effect.fn("EditToolTest.run")(function* (
   return yield* tool.execute(args, next)
 })
 
+const runUnknown = Effect.fn("EditToolTest.runUnknown")(function* (args: unknown, next: Tool.Context = ctx) {
+  const tool = yield* init()
+  const execute = tool.execute as unknown as (args: unknown, ctx: Tool.Context) => ReturnType<typeof tool.execute>
+  return yield* execute(args, next)
+})
+
 const fail = Effect.fn("EditToolTest.fail")(function* (args: Tool.InferParameters<typeof EditTool>) {
   const exit = yield* run(args).pipe(Effect.exit)
   if (Exit.isFailure(exit)) {
@@ -154,6 +160,18 @@ describe("tool.edit", () => {
 
         expect(result.output).toContain("Edit applied successfully")
         expect(yield* load(filepath)).toBe("new content here")
+      }),
+    )
+
+    it.instance("normalizes common model argument aliases", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "alias.txt")
+        yield* put(filepath, "old content")
+
+        yield* runUnknown({ file_path: filepath, old_string: "old", new_string: "new" })
+
+        expect(yield* load(filepath)).toBe("new content")
       }),
     )
 

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -55,6 +55,12 @@ const run = Effect.fn("WriteToolTest.run")(function* (
   return yield* tool.execute(args, next)
 })
 
+const runUnknown = Effect.fn("WriteToolTest.runUnknown")(function* (args: unknown, next: Tool.Context = ctx) {
+  const tool = yield* init()
+  const execute = tool.execute as unknown as (args: unknown, ctx: Tool.Context) => ReturnType<typeof tool.execute>
+  return yield* execute(args, next)
+})
+
 describe("tool.write", () => {
   describe("new file creation", () => {
     it.instance("writes content to new file", () =>
@@ -68,6 +74,18 @@ describe("tool.write", () => {
 
         const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
         expect(content).toBe("Hello, World!")
+      }),
+    )
+
+    it.instance("normalizes common model argument aliases", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "alias.txt")
+
+        yield* runUnknown({ path: filepath, fileContent: "alias content" })
+
+        const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+        expect(content).toBe("alias content")
       }),
     )
 


### PR DESCRIPTION
### Issue for this PR

Closes #29142

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a narrow tool-execution argument normalization hook before schema decoding, then uses it for `write` and `edit`. The public tool JSON schemas stay canonical, but common OpenAI-compatible model aliases like `path`, `file_path`, `fileContent`, `old_string`, and `new_string` are mapped back to the expected `filePath`, `content`, `oldString`, and `newString` keys before validation.

### How did you verify your code works?

- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/tool/write.test.ts --filter "normalizes common model argument aliases"`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/tool/edit.test.ts --filter "normalizes common model argument aliases"`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/tool/write.test.ts test/tool/edit.test.ts test/tool/tool-define.test.ts test/tool/parameters.test.ts`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`

### Screenshots / recordings

N/A (tool argument handling change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
