### PR TITLE
docs: add iFlow Search MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -509,3 +509,37 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### iFlow Search
+
+Add the [iFlow Search MCP server](https://www.npmjs.com/package/@iflow-ai/search-mcp) to search the web, search images, and fetch the readable content of a page. This is a community/third-party MCP stdio server published as `@iflow-ai/search-mcp` and listed in the [MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.zhengyanglsun/iflow-search`.
+
+```json title="opencode.json" {4-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "iflow_search": {
+      "type": "local",
+      "command": ["npx", "-y", "@iflow-ai/search-mcp"],
+      "environment": {
+        "IFLOW_MCP_CLIENT": "opencode"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+The server reads its iFlow API credential from the `IFLOW_API_KEY` environment variable of its own process. Provide it through the shell or secret manager that launches OpenCode rather than embedding it in `opencode.json`:
+
+```bash
+export IFLOW_API_KEY=YOUR_IFLOW_API_KEY
+```
+
+Once configured, three tools become available: `iflow_web_search`, `iflow_image_search`, and `iflow_web_fetch`. You can reference the server by its name in prompts.
+
+```txt "use iflow_search"
+Find recent posts about MCP stdio transports. use iflow_search
+```


### PR DESCRIPTION
### Issue for this PR

Closes #

_No tracking issue — the Examples section of `mcp-servers.mdx` explicitly invites PRs that document additional MCP servers, so I went straight to a PR per that guidance._

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one new example block, `### iFlow Search`, to the Examples section of `packages/web/src/content/docs/mcp-servers.mdx`, right after the existing Grep by Vercel example.

iFlow Search is a community/third-party MCP **stdio** server published on npm as [`@iflow-ai/search-mcp`](https://www.npmjs.com/package/@iflow-ai/search-mcp) and listed in the [MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.zhengyanglsun/iflow-search`. It exposes three tools:

- `iflow_web_search`
- `iflow_image_search`
- `iflow_web_fetch`

The new section mirrors the structure of the existing Sentry / Context7 / Grep by Vercel entries: short description with links, an `opencode.json` snippet, and a usage hint. It uses the stable npm package (`npx -y @iflow-ai/search-mcp`) and a `type: "local"` mcp block, which matches the existing `@modelcontextprotocol/server-everything` stdio example already in the page.

Security choices made deliberately so users don't accidentally commit a credential:

- The `IFLOW_API_KEY` is **not** placed in `opencode.json`. The docs tell users to export it in the shell (or pull from a secret manager) that launches OpenCode.
- The `environment` block in the example only carries a non-secret attribution value (`IFLOW_MCP_CLIENT: "opencode"`).
- The shell example uses the placeholder `YOUR_IFLOW_API_KEY`, not a real key.

No runtime code changes; this is docs-only. No implied OpenCode endorsement — the section is labeled community/third-party.

### How did you verify your code works?

- Read the file end-to-end and aligned the new block with the existing example sections (Sentry / Context7 / Grep by Vercel / `@modelcontextprotocol/server-everything`) so that headings, code fences, file-title hints, and highlight ranges follow the same pattern.
- `git diff --check` — clean (no whitespace errors).
- `git diff --stat` — change is scoped to one file: `packages/web/src/content/docs/mcp-servers.mdx` (+34 / -0).
- Manual secret scan over the diff for `sk-`, `ghp_`, `github_pat_`, `npm_`, `Bearer <token>`, real `IFLOW_API_KEY=...` literals, and tunnel URLs (`trycloudflare.com`, `ngrok.io`) — only the placeholder `YOUR_IFLOW_API_KEY` is present.
- Upstream PR CI passed: `check-standards`, `check-compliance`, `check-duplicates`, `add-contributor-label` are all green.
- I did **not** run `astro build` locally for the `packages/web` site — the change is structurally identical to the three existing example blocks already in the same file, and pulling the full Astro / Starlight / Cloudflare adapter toolchain just to re-render a prose addition felt disproportionate. Happy to run the build if a maintainer prefers.

### Screenshots / recordings

N/A — text-only docs addition, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
