### PR TITLE
fix(cli): add trailing newline to --help output

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -61,10 +61,10 @@ function show(out: string) {
   const text = out.trimStart()
   if (!text.startsWith("opencode ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
-    process.stderr.write(text)
+    process.stderr.write(text + EOL)
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(out + EOL)
 }
 
 const cli = yargs(args)


### PR DESCRIPTION
Fixes #28606. Adds missing trailing newline to CLI --help output so the shell prompt appears on a new line.