### PR TITLE
fix(opencode): /compact works when default_agent is a subagent (fixes #29277)

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -267,8 +267,9 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     }) {
       yield* revertSvc.cleanup(yield* requireSession(ctx.params.sessionID))
       const messages = yield* SessionError.mapStorageNotFound(session.messages({ sessionID: ctx.params.sessionID }))
-      const defaultAgent = yield* agentSvc.defaultAgent()
-      const currentAgent = messages.findLast((message) => message.info.role === "user")?.info.agent ?? defaultAgent
+      const currentAgent =
+        messages.findLast((message) => message.info.role === "user")?.info.agent ??
+        (yield* agentSvc.defaultAgent())
 
       yield* compactSvc.create({
         sessionID: ctx.params.sessionID,


### PR DESCRIPTION
### Issue for this PR
Closes #29277

### Type of change
- [x] Bug fix

### What does this PR do?
Fix /compact command to work when default_agent is a subagent by deferring the defaultAgent() lookup.

### How did you verify your code works?
- [x] TypeScript typecheck passes
- [x] Existing tests pass

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
