### PR TITLE
fix(shell): case-insensitive pwsh env var lookup (fixes #29290)

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -142,7 +142,6 @@ function home(text: string) {
 }
 
 function envValue(key: string) {
-  if (process.platform !== "win32") return process.env[key]
   const name = Object.keys(process.env).find((item) => item.toLowerCase() === key.toLowerCase())
   return name ? process.env[name] : undefined
 }


### PR DESCRIPTION
### Issue for this PR
Closes #29290

### Type of change
- [x] Bug fix

### What does this PR do?
Fix pwsh `$env:` expansion to use case-insensitive env var lookup on all platforms, not just Windows.

### How did you verify your code works?
- [x] TypeScript typecheck passes
- [x] Existing tests pass

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
