### PR TITLE
fix(shell): use byte length for preview truncation (fixes #29291)

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -221,8 +221,11 @@ function pathArgs(list: Part[], ps: boolean, cmd = false) {
 }
 
 function preview(text: string) {
-  if (text.length <= MAX_METADATA_LENGTH) return text
-  return "...\n\n" + text.slice(-MAX_METADATA_LENGTH)
+  if (Buffer.byteLength(text, "utf-8") <= MAX_METADATA_LENGTH) return text
+  const buf = Buffer.from(text, "utf-8")
+  let start = buf.length - MAX_METADATA_LENGTH
+  while (start < buf.length && (buf[start] & 0xc0) === 0x80) start++
+  return "...\n\n" + buf.subarray(start).toString("utf-8")
 }
 
 function tail(text: string, maxLines: number, maxBytes: number) {


### PR DESCRIPTION
### Issue for this PR
Closes #29291

### Type of change
- [x] Bug fix

### What does this PR do?
Fix shell tool preview truncation which used UTF-16 code unit length instead of byte length, causing incorrect truncation for multi-byte characters.

### How did you verify your code works?
- [x] TypeScript typecheck passes
- [x] Existing tests pass
- [x] Code pattern matches tail() function in same file

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
