### PR TITLE
test(task): lock in markdown subagent descriptions

### DIFF
--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { Effect, Exit, Fiber, Layer } from "effect"
 import { Agent } from "../../src/agent/agent"
 import { BackgroundJob } from "@/background/job"
@@ -16,7 +18,7 @@ import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
 import { RuntimeFlags } from "@/effect/runtime-flags"
-import { disposeAllInstances } from "../fixture/fixture"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 afterEach(async () => {
@@ -201,6 +203,38 @@ describe("tool.task", () => {
         },
       },
     },
+  )
+
+  it.instance("description includes markdown-defined subagent frontmatter descriptions", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const agentFile = path.join(test.directory, ".opencode", "agents", "test.md")
+      yield* Effect.promise(() => fs.mkdir(path.dirname(agentFile), { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          agentFile,
+          [
+            "---",
+            'description: "Test agent — does X and Y"',
+            "mode: subagent",
+            "---",
+            "You are a test agent.",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const agent = yield* Agent.Service
+      const custom = (yield* agent.list()).find((item) => item.name === "test")
+      expect(custom?.description).toBe("Test agent — does X and Y")
+
+      const build = yield* agent.get("build")
+      const registry = yield* ToolRegistry.Service
+      const description =
+        (yield* registry.tools({ ...ref, agent: build })).find((tool) => tool.id === TaskTool.id)?.description ?? ""
+
+      expect(description).toContain("- test: Test agent — does X and Y")
+    }),
   )
 
   it.instance("execute resumes an existing task session from task_id", () =>


### PR DESCRIPTION
## Summary
- add a regression test for markdown-defined subagents loaded from .opencode/agents/*.md
- verify the frontmatter description survives into Agent.list()
- verify the Task tool description renders that description instead of any generic fallback text

## Why
Issue #27831 reports that markdown-defined subagents can fall back to a generic manual-only description in the Task tool even when description is present in frontmatter. On current dev, the production code path already preserves that field, but there was no regression coverage for the markdown-defined agent path.

Closes #27831

## Verification
- lsp_diagnostics on packages/opencode/test/tool/task.test.ts -> no diagnostics
- un run test test/tool/task.test.ts (from packages/opencode) -> 16 pass, 0 fail
- attempted un install in the worktree, but it failed on 	ree-sitter-powershell because this Windows environment does not have the required Visual Studio C++ toolchain; no lockfiles were modified