### PR TITLE
fix(tui): handle missing subagent session in Task messages (fixes #29350)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2062,7 +2062,7 @@ function Task(props: ToolProps<typeof TaskTool>) {
 
   onMount(() => {
     if (props.metadata.sessionId && !sync.data.message[props.metadata.sessionId]?.length)
-      void sync.session.sync(props.metadata.sessionId)
+      void sync.session.sync(props.metadata.sessionId).catch(() => {})
   })
 
   const messages = createMemo(() => sync.data.message[props.metadata.sessionId ?? ""] ?? [])


### PR DESCRIPTION
### Issue for this PR
Closes #29350

### Type of change
- [x] Bug fix

### What does this PR do?
Fix TUI crash when rendering Task messages that reference removed subagent sessions by silently handling 404 rejections from the sync call.

### How did you verify your code works?
- [x] TypeScript typecheck passes
- [x] Existing tests pass

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
