### PR TITLE
fix(shell): avoid non-string stdout parsing in cygpath path resolution

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -343,10 +343,17 @@ export const ShellTool = Tool.define(
     const defaultTimeoutMs = flags.bashDefaultTimeoutMs ?? 2 * 60 * 1000
 
     const cygpath = Effect.fn("ShellTool.cygpath")(function* (shell: string, text: string) {
-      const lines = yield* spawner
-        .lines(ChildProcess.make(shell, ["-lc", 'cygpath -w -- "$1"', "_", text]))
-        .pipe(Effect.catch(() => Effect.succeed([] as string[])))
-      const file = lines[0]?.trim()
+      const file = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const handle = yield* spawner.spawn(ChildProcess.make(shell, ["-lc", 'cygpath -w -- "$1"', "_", text]))
+          const [exitCode, stdout] = yield* Effect.all([
+            handle.exitCode,
+            Stream.runFold(Stream.decodeText(handle.stdout), () => "", (acc, chunk) => acc + chunk),
+          ])
+          if (exitCode !== 0) return
+          return stdout.split("\n")[0]?.trim()
+        }),
+      ).pipe(Effect.catch(() => Effect.succeed(undefined)))
       if (!file) return
       return AppFileSystem.normalizePath(file)
     })


### PR DESCRIPTION
### Issue for this PR

Closes #26932

### What does this PR do?

This replaces the spawner.lines(...) call inside packages/opencode/src/tool/shell.ts's Windows cygpath() helper with an explicit spawn() + stdout decode flow.

That keeps stdout as a guaranteed string before calling .split(), and only parses the first line when the subprocess exits successfully. If the helper fails, behavior stays the same and path resolution falls back cleanly.

### Why this fixes the issue

The reported crash happens before the shell subprocess actually runs because the output handling path assumes stdout is already a string. By collecting and decoding handle.stdout ourselves, this code no longer depends on that brittle path and avoids the (result.stdout ?? "").split is not a function failure.

### Verification

- lsp_diagnostics on packages/opencode/src/tool/shell.ts: no diagnostics
- bun test test/tool/shell.test.ts in packages/opencode: failed due missing dependency module @babel/helper-validator-identifier after install problems
- bun x tsc -p tsconfig.json --noEmit in packages/opencode: failed due existing/missing dependency type resolution errors (for example solid-js, drizzle-orm, zod)
- bun install at repo root: failed because tree-sitter-powershell native build could not find a Visual Studio C++ toolchain on this Windows machine

### Scope

- Single-file fix only: packages/opencode/src/tool/shell.ts
- No lockfiles modified
