### PR TITLE
fix(core): add fallback for JSON parse errors in models-dev

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -189,7 +189,13 @@ export const layer = Layer.effect(
           return yield* fetchAndWrite()
         }),
       )
-      return JSON.parse(text) as Record<string, Provider>
+      return yield* Effect.try({
+        try: () => JSON.parse(text) as Record<string, Provider>,
+        catch: () => new Error(`Failed to parse models JSON from ${source}`),
+      }).pipe(
+        Effect.tapError((e) => Effect.logWarning(e.message)),
+        Effect.orElse(() => Effect.succeed({} as Record<string, Provider>)),
+      )
     }).pipe(Effect.withSpan("ModelsDev.populate"), Effect.orDie)
 
     const [cachedGet, invalidate] = yield* Effect.cachedInvalidateWithTTL(populate, Duration.infinity)

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -122,7 +122,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
                 "-z",
               ],
               {
-                cwd: state.directory,
+                cwd: state.worktree,
                 stdin: feed(files),
               },
             )
@@ -138,7 +138,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
                 ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
               ],
               {
-                cwd: state.directory,
+                cwd: state.worktree,
                 stdin: feed(files),
               },
             )
@@ -149,7 +149,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
             const result = yield* git(
               [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
               {
-                cwd: state.directory,
+                cwd: state.worktree,
                 stdin: feed(files),
               },
             )


### PR DESCRIPTION
Fixes #29366

Wrap JSON.parse in Effect.try with fallback to empty object to prevent crashes when models JSON is malformed.