### PR TITLE
fix(opencode): show error message in CLI .fail() handler

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -185,7 +185,10 @@ const cli = yargs(args)
       msg?.startsWith("Invalid values:")
     ) {
       if (err) throw err
+      UI.error(msg)
+      process.stderr.write(EOL)
       cli.showHelp(show)
+      return
     }
     if (err) throw err
     process.exit(1)


### PR DESCRIPTION
### Issue for this PR

Closes #29390

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The CLI .fail() handler receives the error message in `msg` but never writes it to stderr before showing help. Added `UI.error(msg)` before `cli.showHelp(show)` so users see what argument was wrong.

### How did you verify your code works?

Ran `bun run ./src/index.ts --unknown-flag` and confirmed the output now shows `Error: Unknown arguments: unknown-flag` before the help text.

### Screenshots / recordings

N/A — CLI change only

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


