### PR TITLE
feat(opencode): add experimental OpenAI Responses WebSocket

### DIFF
--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -320,7 +320,8 @@ const lowerToolResultOutput = Effect.fn("OpenAIResponses.lowerToolResultOutput")
   // Text/json/error results are encoded as a plain string for backward
   // compatibility with existing cassettes and provider expectations.
   if (part.result.type !== "content") return ProviderShared.toolResultText(part)
-  return yield* Effect.forEach(part.result.value, lowerToolResultContentItem)
+  const content: ReadonlyArray<ToolResultContentPart> = part.result.value
+  return yield* Effect.forEach(content, lowerToolResultContentItem)
 })
 
 const lowerMessages = Effect.fn("OpenAIResponses.lowerMessages")(function* (request: LLMRequest) {

--- a/packages/llm/src/route/executor.ts
+++ b/packages/llm/src/route/executor.ts
@@ -22,6 +22,15 @@ import {
   TransportReason,
   UnknownProviderReason,
 } from "../schema"
+import {
+  REDACTED,
+  REDACT_JSON_FIELD,
+  REDACT_QUERY_FIELD,
+  isSensitiveHeaderName,
+  isSensitiveQueryName,
+  redactHeaders,
+  redactUrl,
+} from "./redaction"
 
 export interface Interface {
   readonly execute: (
@@ -35,43 +44,6 @@ const BODY_LIMIT = 16_384
 const MAX_RETRIES = 2
 const BASE_DELAY_MS = 500
 const MAX_DELAY_MS = 10_000
-const REDACTED = "<redacted>"
-
-// One source of truth for what counts as a sensitive name across headers,
-// URL query keys, and field names embedded inside request/response bodies.
-//
-// `SENSITIVE_NAME` is used as both a substring matcher (for free-form header
-// names like `Authorization` / `X-API-Key`) and as the body-field alternation
-// list. `SHORT_QUERY_NAME` covers anchored short keys like `?key=…` / `?sig=…`
-// that are too generic to redact substring-style without false positives.
-const SENSITIVE_NAME_SOURCE =
-  "authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|token|secret|credential|signature|x-amz-signature"
-const SENSITIVE_NAME = new RegExp(SENSITIVE_NAME_SOURCE, "i")
-const SHORT_QUERY_NAME = /^(key|sig)$/i
-const SENSITIVE_BODY_FIELD = new RegExp(`(?:${SENSITIVE_NAME_SOURCE}|key)`, "i")
-const REDACT_JSON_FIELD = new RegExp(`("(?:${SENSITIVE_BODY_FIELD.source})"\\s*:\\s*)"[^"]*"`, "gi")
-const REDACT_QUERY_FIELD = new RegExp(`((?:${SENSITIVE_BODY_FIELD.source})=)[^&\\s"]+`, "gi")
-
-const isSensitiveHeaderName = (name: string) => SENSITIVE_NAME.test(name)
-
-const isSensitiveQueryName = (name: string) => isSensitiveHeaderName(name) || SHORT_QUERY_NAME.test(name)
-
-const redactHeaders = (headers: Headers.Headers, redactedNames: ReadonlyArray<string | RegExp>) =>
-  Object.fromEntries(
-    Object.entries(Headers.redact(headers, [...redactedNames, SENSITIVE_NAME])).map(([name, value]) => [
-      name,
-      String(value),
-    ]),
-  )
-
-const redactUrl = (value: string) => {
-  if (!URL.canParse(value)) return REDACTED
-  const url = new URL(value)
-  url.searchParams.forEach((_, key) => {
-    if (isSensitiveQueryName(key)) url.searchParams.set(key, REDACTED)
-  })
-  return url.toString()
-}
 
 const normalizedHeaders = (headers: Headers.Headers) =>
   Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]))

--- a/packages/llm/src/route/redaction.ts
+++ b/packages/llm/src/route/redaction.ts
@@ -1,0 +1,40 @@
+import { Headers } from "effect/unstable/http"
+
+export const REDACTED = "<redacted>"
+
+// One source of truth for what counts as a sensitive name across headers,
+// URL query keys, and field names embedded inside request/response bodies.
+//
+// `SENSITIVE_NAME` is used as both a substring matcher (for free-form header
+// names like `Authorization` / `X-API-Key`) and as the body-field alternation
+// list. `SHORT_QUERY_NAME` covers anchored short keys like `?key=...` / `?sig=...`
+// that are too generic to redact substring-style without false positives.
+const SENSITIVE_NAME_SOURCE =
+  "authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|token|secret|credential|signature|x-amz-signature"
+const SENSITIVE_NAME = new RegExp(SENSITIVE_NAME_SOURCE, "i")
+const SHORT_QUERY_NAME = /^(key|sig)$/i
+const SENSITIVE_BODY_FIELD = new RegExp(`(?:${SENSITIVE_NAME_SOURCE}|key)`, "i")
+
+export const REDACT_JSON_FIELD = new RegExp(`("(?:${SENSITIVE_BODY_FIELD.source})"\\s*:\\s*)"[^"]*"`, "gi")
+export const REDACT_QUERY_FIELD = new RegExp(`((?:${SENSITIVE_BODY_FIELD.source})=)[^&\\s"]+`, "gi")
+
+export const isSensitiveHeaderName = (name: string) => SENSITIVE_NAME.test(name)
+
+export const isSensitiveQueryName = (name: string) => isSensitiveHeaderName(name) || SHORT_QUERY_NAME.test(name)
+
+export const redactHeaders = (headers: Headers.Headers, redactedNames: ReadonlyArray<string | RegExp>) =>
+  Object.fromEntries(
+    Object.entries(Headers.redact(headers, [...redactedNames, SENSITIVE_NAME])).map(([name, value]) => [
+      name,
+      String(value),
+    ]),
+  )
+
+export const redactUrl = (value: string) => {
+  if (!URL.canParse(value)) return REDACTED
+  const url = new URL(value)
+  url.searchParams.forEach((_, key) => {
+    if (isSensitiveQueryName(key)) url.searchParams.set(key, REDACTED)
+  })
+  return url.toString()
+}

--- a/packages/llm/src/route/transport/websocket.ts
+++ b/packages/llm/src/route/transport/websocket.ts
@@ -1,6 +1,7 @@
 import { Cause, Context, Effect, Layer, Queue, Stream } from "effect"
 import { Headers } from "effect/unstable/http"
 import { LLMError, TransportReason } from "../../schema"
+import { redactUrl } from "../redaction"
 import * as HttpTransport from "./http"
 import type { Transport } from "./index"
 
@@ -124,7 +125,7 @@ const webSocketUrl = (value: string) =>
 
 export const open = (input: WebSocketRequest) =>
   Effect.logInfo("llm websocket open").pipe(
-    Effect.annotateLogs({ "llm.websocket.url": input.url }),
+    Effect.annotateLogs({ "llm.websocket.url": redactUrl(input.url) }),
     Effect.andThen(
       Effect.try({
         try: () =>

--- a/packages/llm/src/route/transport/websocket.ts
+++ b/packages/llm/src/route/transport/websocket.ts
@@ -123,15 +123,21 @@ const webSocketUrl = (value: string) =>
   })
 
 export const open = (input: WebSocketRequest) =>
-  Effect.try({
-    try: () =>
-      new (globalThis.WebSocket as unknown as WebSocketConstructorWithHeaders)(input.url, { headers: input.headers }),
-    catch: (error) =>
-      transportError("open", error instanceof Error ? error.message : "Failed to construct WebSocket", {
-        url: input.url,
-        kind: "open",
+  Effect.logInfo("llm websocket open").pipe(
+    Effect.annotateLogs({ "llm.websocket.url": input.url }),
+    Effect.andThen(
+      Effect.try({
+        try: () =>
+          new (globalThis.WebSocket as unknown as WebSocketConstructorWithHeaders)(input.url, { headers: input.headers }),
+        catch: (error) =>
+          transportError("open", error instanceof Error ? error.message : "Failed to construct WebSocket", {
+            url: input.url,
+            kind: "open",
+          }),
       }),
-  }).pipe(Effect.flatMap((ws) => fromWebSocket(ws, input)))
+    ),
+    Effect.flatMap((ws) => fromWebSocket(ws, input)),
+  )
 
 export const layer: Layer.Layer<Service> = Layer.succeed(Service, Service.of({ open }))
 

--- a/packages/llm/test/executor.test.ts
+++ b/packages/llm/test/executor.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect } from "bun:test"
-import { Effect, Fiber, Layer, Random, Ref } from "effect"
+import { Effect, Fiber, Layer, Logger, Random, Ref, References } from "effect"
 import * as TestClock from "effect/testing/TestClock"
 import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { LLM, LLMError } from "../src"
-import { LLMClient, RequestExecutor } from "../src/route"
+import { LLMClient, RequestExecutor, WebSocketExecutor } from "../src/route"
 import * as OpenAIChat from "../src/protocols/openai-chat"
 import { dynamicResponse } from "./lib/http"
 import { deltaChunk } from "./lib/openai-chunks"
@@ -73,6 +73,49 @@ const expectLLMError = (error: unknown) => {
 const errorHttp = (error: LLMError) => ("http" in error.reason ? error.reason.http : undefined)
 
 describe("RequestExecutor", () => {
+  it.effect("redacts sensitive WebSocket URL query params in open logs", () =>
+    Effect.gen(function* () {
+      class OpenWebSocket {
+        static readonly OPEN = 1
+        static readonly CLOSING = 2
+        static readonly CLOSED = 3
+        readyState = OpenWebSocket.OPEN
+        addEventListener() {}
+        removeEventListener() {}
+        send() {}
+        close() {
+          this.readyState = OpenWebSocket.CLOSED
+        }
+      }
+
+      const annotations: Array<Record<string, unknown>> = []
+      const logger = Logger.make((options) => {
+        annotations.push(options.fiber.getRef(References.CurrentLogAnnotations))
+      })
+
+      yield* Effect.acquireUseRelease(
+        Effect.sync(() => {
+          const original = globalThis.WebSocket
+          globalThis.WebSocket = OpenWebSocket as unknown as typeof globalThis.WebSocket
+          return original
+        }),
+        () =>
+          WebSocketExecutor.open({
+            url: "wss://provider.test/realtime?api_key=query-secret-123&key=short-secret&debug=1",
+            headers: Headers.empty,
+          }).pipe(Effect.flatMap((connection) => connection.close)),
+        (original) =>
+          Effect.sync(() => {
+            globalThis.WebSocket = original
+          }),
+      ).pipe(Effect.provide(Logger.layer([logger])))
+
+      expect(annotations.find((item) => item["llm.websocket.url"])?.["llm.websocket.url"]).toBe(
+        "wss://provider.test/realtime?api_key=%3Credacted%3E&key=%3Credacted%3E&debug=1",
+      )
+    }),
+  )
+
   it.effect("returns redacted diagnostics for retryable rate limits", () =>
     Effect.gen(function* () {
       const executor = yield* RequestExecutor.Service

--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -54,6 +54,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   outputTokenMax: positiveInteger("OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX"),
   bashDefaultTimeoutMs: positiveInteger("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS"),
   experimentalNativeLlm: bool("OPENCODE_EXPERIMENTAL_NATIVE_LLM"),
+  experimentalOpenAIWebSocket: bool("OPENCODE_EXPERIMENTAL_OPENAI_WEBSOCKET"),
   client: Config.string("OPENCODE_CLIENT").pipe(Config.withDefault("cli")),
 }) {}
 

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -10,7 +10,7 @@ const log = Log.create({ service: "plugin.codex" })
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
-const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+export const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 const ALLOWED_MODELS = new Set([
@@ -108,6 +108,28 @@ function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string):
     originator: "opencode",
   })
   return `${ISSUER}/oauth/authorize?${params.toString()}`
+}
+
+
+function codexBaseURL(codexApiEndpoint: string): string {
+  const url = new URL(codexApiEndpoint)
+  if (url.pathname.endsWith("/responses")) url.pathname = url.pathname.slice(0, -"/responses".length)
+  return url.toString().replace(/\/$/, "")
+}
+
+function headersInit(init: HeadersInit | undefined): Headers {
+  const headers = new Headers()
+  if (!init) return headers
+  if (init instanceof Headers) {
+    init.forEach((value, key) => headers.set(key, value))
+    return headers
+  }
+  if (Array.isArray(init)) {
+    for (const [key, value] of init) if (value !== undefined) headers.set(key, String(value))
+    return headers
+  }
+  for (const [key, value] of Object.entries(init)) if (value !== undefined) headers.set(key, String(value))
+  return headers
 }
 
 interface TokenResponse {
@@ -419,85 +441,58 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
             }>
           | undefined
 
+        const codexAuthHeaders = async (init?: HeadersInit) => {
+          const currentAuth = await getAuth()
+          if (currentAuth.type !== "oauth") return headersInit(init)
+
+          const authWithAccount = currentAuth as typeof currentAuth & { accountId?: string }
+          if (!currentAuth.access || currentAuth.expires < Date.now()) {
+            if (!refreshPromise) {
+              log.info("refreshing codex access token")
+              refreshPromise = refreshAccessToken(currentAuth.refresh, issuer)
+                .then(async (tokens) => {
+                  const accountId = extractAccountId(tokens) || authWithAccount.accountId
+                  await input.client.auth.set({
+                    path: { id: "openai" },
+                    body: {
+                      type: "oauth",
+                      refresh: tokens.refresh_token,
+                      access: tokens.access_token,
+                      expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                      ...(accountId && { accountId }),
+                    },
+                  })
+                  return { access: tokens.access_token, accountId }
+                })
+                .finally(() => {
+                  refreshPromise = undefined
+                })
+            }
+
+            const refreshed = await refreshPromise
+            currentAuth.access = refreshed.access
+            authWithAccount.accountId = refreshed.accountId
+          }
+
+          const headers = headersInit(init)
+          headers.delete("authorization")
+          headers.delete("Authorization")
+          headers.set("authorization", `Bearer ${currentAuth.access}`)
+          if (authWithAccount.accountId) headers.set("ChatGPT-Account-Id", authWithAccount.accountId)
+          return headers
+        }
+
         return {
           apiKey: OAUTH_DUMMY_KEY,
+          codexWebSocket: {
+            baseURL: codexBaseURL(codexApiEndpoint),
+            async headers(init?: HeadersInit) {
+              return Object.fromEntries((await codexAuthHeaders(init)).entries())
+            },
+          },
           async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
-            // Remove dummy API key authorization header
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                init.headers.delete("authorization")
-                init.headers.delete("Authorization")
-              } else if (Array.isArray(init.headers)) {
-                init.headers = init.headers.filter(([key]) => key.toLowerCase() !== "authorization")
-              } else {
-                delete init.headers["authorization"]
-                delete init.headers["Authorization"]
-              }
-            }
-
             const currentAuth = await getAuth()
             if (currentAuth.type !== "oauth") return fetch(requestInput, init)
-
-            // Cast to include accountId field
-            const authWithAccount = currentAuth as typeof currentAuth & { accountId?: string }
-
-            // Check if token needs refresh
-            if (!currentAuth.access || currentAuth.expires < Date.now()) {
-              if (!refreshPromise) {
-                log.info("refreshing codex access token")
-                refreshPromise = refreshAccessToken(currentAuth.refresh, issuer)
-                  .then(async (tokens) => {
-                    const accountId = extractAccountId(tokens) || authWithAccount.accountId
-                    await input.client.auth.set({
-                      path: { id: "openai" },
-                      body: {
-                        type: "oauth",
-                        refresh: tokens.refresh_token,
-                        access: tokens.access_token,
-                        expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                        ...(accountId && { accountId }),
-                      },
-                    })
-                    return {
-                      access: tokens.access_token,
-                      accountId,
-                    }
-                  })
-                  .finally(() => {
-                    refreshPromise = undefined
-                  })
-              }
-
-              const refreshed = await refreshPromise
-              currentAuth.access = refreshed.access
-              authWithAccount.accountId = refreshed.accountId
-            }
-
-            // Build headers
-            const headers = new Headers()
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                init.headers.forEach((value, key) => headers.set(key, value))
-              } else if (Array.isArray(init.headers)) {
-                for (const [key, value] of init.headers) {
-                  if (value !== undefined) headers.set(key, String(value))
-                }
-              } else {
-                for (const [key, value] of Object.entries(init.headers)) {
-                  if (value !== undefined) headers.set(key, String(value))
-                }
-              }
-            }
-
-            // Set authorization header with access token
-            headers.set("authorization", `Bearer ${currentAuth.access}`)
-
-            // Set ChatGPT-Account-Id header for organization subscriptions
-            if (authWithAccount.accountId) {
-              headers.set("ChatGPT-Account-Id", authWithAccount.accountId)
-            }
-
-            // Rewrite URL to Codex endpoint
             const parsed =
               requestInput instanceof URL
                 ? requestInput
@@ -509,7 +504,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
 
             return fetch(url, {
               ...init,
-              headers,
+              headers: await codexAuthHeaders(init?.headers),
             })
           },
         }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -233,6 +233,7 @@ const live: Layer.Layer<
           providerOptions: prepared.params.options,
           headers: prepared.headers,
           abort: input.abort,
+          experimentalOpenAIWebSocket: flags.experimentalOpenAIWebSocket,
         })
         if (native.type === "supported") {
           yield* Effect.logInfo("llm runtime selected").pipe(

--- a/packages/opencode/src/session/llm/native-request.ts
+++ b/packages/opencode/src/session/llm/native-request.ts
@@ -1,4 +1,5 @@
 import type { JsonSchema, LLMRequest, ProviderMetadata } from "@opencode-ai/llm"
+import type { AuthShape } from "@opencode-ai/llm/route"
 import { LLM, Message, SystemPart, ToolCallPart, ToolDefinition, ToolResultPart } from "@opencode-ai/llm"
 import {
   AmazonBedrock,
@@ -32,6 +33,8 @@ export type RequestInput = {
   readonly maxOutputTokens?: number
   readonly providerOptions?: LLMRequest["providerOptions"]
   readonly headers?: Record<string, string>
+  readonly routeAuth?: AuthShape
+  readonly useOpenAIWebSocket?: boolean
 }
 
 const providerMetadata = (value: unknown): ProviderMetadata | undefined => {
@@ -153,8 +156,7 @@ const requireBaseURL = (model: Provider.Model, url: string | undefined) => {
 export const model = (input: Provider.Model | RequestInput, headers?: Record<string, string>) => {
   const model = "model" in input ? input.model : input
   const url = baseURL(input)
-  const options = {
-    ...("model" in input && input.apiKey ? { apiKey: input.apiKey } : {}),
+  const baseOptions = {
     ...(url ? { baseURL: url } : {}),
     headers: Object.keys({ ...model.headers, ...headers }).length === 0 ? undefined : { ...model.headers, ...headers },
     limits: {
@@ -162,7 +164,14 @@ export const model = (input: Provider.Model | RequestInput, headers?: Record<str
       output: model.limit.output,
     },
   }
-  if (model.api.npm === "@ai-sdk/openai") return OpenAI.configure(options).responses(model.api.id)
+  const options =
+    "model" in input && input.routeAuth
+      ? { ...baseOptions, auth: input.routeAuth }
+      : { ...baseOptions, ...("model" in input && input.apiKey ? { apiKey: input.apiKey } : {}) }
+  if (model.api.npm === "@ai-sdk/openai")
+    return "model" in input && input.useOpenAIWebSocket
+      ? OpenAI.configure(options).responsesWebSocket(model.api.id)
+      : OpenAI.configure(options).responses(model.api.id)
   if (model.api.npm === "@ai-sdk/azure")
     return Azure.configure({ ...options, baseURL: requireBaseURL(model, url) }).responses(model.api.id)
   if (model.api.npm === "@ai-sdk/anthropic") return Anthropic.configure(options).model(model.api.id)

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -6,9 +6,9 @@ import { isRecord } from "@/util/record"
 import { asSchema, type ModelMessage, type Tool } from "ai"
 import { Effect } from "effect"
 import * as Stream from "effect/Stream"
-import { FetchHttpClient } from "effect/unstable/http"
+import { FetchHttpClient, Headers } from "effect/unstable/http"
 import { tool as nativeTool, ToolFailure, type JsonSchema, type LLMEvent } from "@opencode-ai/llm"
-import type { LLMClientShape } from "@opencode-ai/llm/route"
+import { Auth as RouteAuth, type LLMClientShape } from "@opencode-ai/llm/route"
 import { LLMNative } from "./native-request"
 
 export type RuntimeStatus =
@@ -33,6 +33,7 @@ type StreamInput = {
   readonly providerOptions?: Record<string, any>
   readonly headers: Record<string, string>
   readonly abort: AbortSignal
+  readonly experimentalOpenAIWebSocket?: boolean
 }
 
 export function status(input: Pick<StreamInput, "model" | "provider" | "auth">): RuntimeStatus {
@@ -82,7 +83,9 @@ export function stream(input: StreamInput): StreamResult {
     request: LLMNative.request({
       model: input.model,
       apiKey: current.apiKey,
-      baseURL: current.baseURL,
+      baseURL: openAIWebSocketBaseURL(input) ?? current.baseURL,
+      routeAuth: openAIWebSocketAuth(input),
+      useOpenAIWebSocket: shouldUseOpenAIWebSocket(input),
       messages: ProviderTransform.message(input.messages, input.model, input.providerOptions ?? {}),
       toolChoice: input.toolChoice,
       temperature: input.temperature,
@@ -99,6 +102,49 @@ export function stream(input: StreamInput): StreamResult {
     ...current,
     stream: fetch ? stream.pipe(Stream.provideService(FetchHttpClient.Fetch, fetch)) : stream,
   }
+}
+
+
+function shouldUseOpenAIWebSocket(input: Pick<StreamInput, "model" | "provider" | "auth" | "experimentalOpenAIWebSocket">) {
+  if (!input.experimentalOpenAIWebSocket) return false
+  if (input.model.providerID !== "openai" || input.model.api.npm !== "@ai-sdk/openai") return false
+  if (input.auth?.type === "oauth" && !codexWebSocket(input.provider.options)) return false
+  return true
+}
+
+function codexWebSocket(options: Record<string, unknown>):
+  | {
+      readonly baseURL?: string
+      readonly headers?: (headers?: Headers.Headers) => Promise<Record<string, string>>
+    }
+  | undefined {
+  const value = options["codexWebSocket"]
+  if (!isRecord(value)) return undefined
+  const headers = value.headers
+  if (headers !== undefined && typeof headers !== "function") return undefined
+  return {
+    baseURL: typeof value.baseURL === "string" ? value.baseURL : undefined,
+    headers:
+      typeof headers === "function"
+        ? (headers as (headers?: Headers.Headers) => Promise<Record<string, string>>)
+        : undefined,
+  }
+}
+
+function openAIWebSocketBaseURL(input: Pick<StreamInput, "model" | "provider" | "auth" | "experimentalOpenAIWebSocket">) {
+  if (!shouldUseOpenAIWebSocket(input)) return undefined
+  return codexWebSocket(input.provider.options)?.baseURL
+}
+
+function openAIWebSocketAuth(input: Pick<StreamInput, "model" | "provider" | "auth" | "experimentalOpenAIWebSocket">) {
+  if (!shouldUseOpenAIWebSocket(input)) return undefined
+  const helper = codexWebSocket(input.provider.options)
+  if (!helper?.headers) return undefined
+  return RouteAuth.custom((authInput) =>
+    Effect.promise(() => helper.headers?.(authInput.headers) ?? Promise.resolve({})).pipe(
+      Effect.map((headers) => Headers.setAll(authInput.headers, headers)),
+    ),
+  )
 }
 
 function providerFetch(input: Pick<StreamInput, "provider" | "auth">): typeof globalThis.fetch | undefined {

--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -63,6 +63,7 @@ describe("RuntimeFlags", () => {
       expect(flags.experimentalWorkspaces).toBe(true)
       expect(flags.experimentalIconDiscovery).toBe(true)
       expect(flags.experimentalNativeLlm).toBe(false)
+      expect(flags.experimentalOpenAIWebSocket).toBe(false)
       expect(flags.client).toBe("desktop")
     }),
   )
@@ -91,6 +92,18 @@ describe("RuntimeFlags", () => {
     }),
   )
 
+  it.effect("enables OpenAI WebSocket via dedicated flag only", () =>
+    Effect.gen(function* () {
+      const explicit = yield* readFlags.pipe(
+        Effect.provide(fromConfig({ OPENCODE_EXPERIMENTAL_OPENAI_WEBSOCKET: "true" })),
+      )
+      const umbrella = yield* readFlags.pipe(Effect.provide(fromConfig({ OPENCODE_EXPERIMENTAL: "true" })))
+
+      expect(explicit.experimentalOpenAIWebSocket).toBe(true)
+      expect(umbrella.experimentalOpenAIWebSocket).toBe(false)
+    }),
+  )
+
   it.effect("layer accepts partial test overrides and fills defaults from Config definitions", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(
@@ -110,6 +123,7 @@ describe("RuntimeFlags", () => {
       expect(flags.enableExa).toBe(false)
       expect(flags.experimentalIconDiscovery).toBe(false)
       expect(flags.experimentalOxfmt).toBe(false)
+      expect(flags.experimentalOpenAIWebSocket).toBe(false)
       expect(flags.outputTokenMax).toBeUndefined()
       expect(flags.bashDefaultTimeoutMs).toBe(1_000)
       expect(flags.enableExperimentalModels).toBe(false)
@@ -355,6 +369,7 @@ describe("RuntimeFlags", () => {
       expect(flags.enableExa).toBe(false)
       expect(flags.experimentalIconDiscovery).toBe(false)
       expect(flags.experimentalOxfmt).toBe(false)
+      expect(flags.experimentalOpenAIWebSocket).toBe(false)
       expect(flags.outputTokenMax).toBeUndefined()
       expect(flags.bashDefaultTimeoutMs).toBeUndefined()
       expect(flags.client).toBe("cli")

--- a/packages/opencode/test/session/llm-native.test.ts
+++ b/packages/opencode/test/session/llm-native.test.ts
@@ -372,6 +372,83 @@ describe("session.llm-native.request", () => {
     expect(openrouter.route.endpoint.baseURL).toBe("https://openrouter.ai/api/v1")
   })
 
+  test("selects OpenAI Responses WebSocket route when requested", () => {
+    const request = LLMNative.request({
+      model: baseModel,
+      apiKey: "test-openai-key",
+      messages: [{ role: "user", content: "hello" }],
+      useOpenAIWebSocket: true,
+    })
+
+    expect(request.model).toMatchObject({
+      id: "gpt-5-mini",
+      provider: "openai",
+      route: { id: "openai-responses-websocket" },
+    })
+  })
+
+  test("streams Codex OAuth requests through OpenAI Responses WebSocket when enabled", async () => {
+    const opened: Array<{ url: string; headers: Record<string, string>; message: string }> = []
+    const webSocketLayer = Layer.succeed(
+      WebSocketExecutor.Service,
+      WebSocketExecutor.Service.of({
+        open: (input) =>
+          Effect.succeed({
+            sendText: (message) =>
+              Effect.sync(() => {
+                opened.push({ url: input.url, headers: input.headers, message })
+              }),
+            messages: Stream.empty,
+            close: Effect.void,
+          }),
+      }),
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const llmClient = yield* LLMClient.Service
+        const native = LLMNativeRuntime.stream({
+          model: baseModel,
+          provider: {
+            ...providerInfo,
+            options: {
+              apiKey: OAUTH_DUMMY_KEY,
+              fetch: async () => new Response(),
+              codexWebSocket: {
+                baseURL: "https://chatgpt.test/backend-api/codex",
+                async headers(headers?: Record<string, string>) {
+                  return { ...headers, authorization: "Bearer access", "ChatGPT-Account-Id": "acc-123" }
+                },
+              },
+            },
+          },
+          auth: { type: "oauth", refresh: "refresh", access: "access", expires: Date.now() + 60_000 },
+          llmClient,
+          messages: [{ role: "user", content: "hello" }],
+          tools: {},
+          headers: {},
+          abort: new AbortController().signal,
+          experimentalOpenAIWebSocket: true,
+        })
+        expect(native.type).toBe("supported")
+        if (native.type === "unsupported") throw new Error(native.reason)
+        yield* native.stream.pipe(Stream.runCollect)
+      }).pipe(
+        Effect.provide(LLMClient.layer.pipe(Layer.provide(Layer.mergeAll(RequestExecutor.defaultLayer, webSocketLayer)))),
+      ),
+    )
+
+    expect(opened).toHaveLength(1)
+    expect(opened[0]?.url).toBe("wss://chatgpt.test/backend-api/codex/responses")
+    expect(opened[0]?.headers.authorization).toBe("Bearer access")
+    expect(opened[0]?.headers["ChatGPT-Account-Id"] ?? opened[0]?.headers["chatgpt-account-id"]).toBe("acc-123")
+    expect(JSON.parse(opened[0]?.message ?? "{}")).toMatchObject({
+      type: "response.create",
+      model: "gpt-5-mini",
+      input: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
+    })
+  })
+
   test("fails fast for unsupported provider packages", () => {
     expect(() =>
       LLMNative.request({


### PR DESCRIPTION
### Issue for this PR

Refs #29079
Closes #14891

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an opt-in Responses WebSocket path for the OpenAI native runtime:

- `OPENCODE_EXPERIMENTAL_OPENAI_WEBSOCKET` gates the path.
- Native OpenAI requests can select `responsesWebSocket`.
- Codex OAuth exposes the same refreshed bearer/account headers and Codex base URL for WebSocket handshake auth.
- WebSocket transport logs the opened URL for local verification without logging headers or bodies.

The path is off by default. The existing native flag and AI SDK fallback remain unchanged.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `cd packages/llm && bun typecheck`
- `cd packages/opencode && bun test test/session/llm-native.test.ts`
- `cd packages/opencode && bun test test/effect/runtime-flags.test.ts`
- Built binary with `OPENCODE_CHANNEL=latest bun ./script/build.ts --single`
- Live smoke using OpenAI OAuth:
  `OPENCODE_EXPERIMENTAL_NATIVE_LLM=true OPENCODE_EXPERIMENTAL_OPENAI_WEBSOCKET=true ./packages/opencode/dist/opencode-darwin-arm64/bin/opencode --print-logs --log-level DEBUG run --model openai/gpt-5.4-mini-fast --format json "Reply with exactly: websocket-binary-final-ok"`

Verified logs showed `llm.runtime=native`, `llm.websocket.url=wss://chatgpt.com/backend-api/codex/responses`, and output `websocket-binary-final-ok`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
