### PR TITLE
fix(cli): output error message on .fail() (fixes #29390)

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -179,6 +179,7 @@ const cli = yargs(args)
   .command(PluginCommand)
   .command(DbCommand)
   .fail((msg, err) => {
+    if (msg) process.stderr.write(msg + "\n")
     if (
       msg?.startsWith("Unknown argument") ||
       msg?.startsWith("Not enough non-option arguments") ||


### PR DESCRIPTION
When passing invalid arguments like `--unknown-flag`, the `.fail()` handler received the error message but never wrote it to stderr, making it impossible for the user to know what went wrong. This writes the error message to `process.stderr` before showing help or exiting.

Fixes #29390