### PR TITLE
fix(tui): handle prompt_skills keybind (fixes #29148)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -634,6 +634,7 @@ export function Prompt(props: PromptProps) {
       "prompt.submit",
       "prompt.editor",
       "prompt.editor_context.clear",
+      "prompt.skills",
       "prompt.stash",
       "prompt.stash.pop",
       "prompt.stash.list",


### PR DESCRIPTION
Fixes #29148 — the `prompt_skills` keybind configured in `tui.json` was not handled when pressed.

The `prompt.skills` command was already defined in `promptCommands()` and had a keybinding mapping in `CommandMap`, but it was missing from the `prompt.palette` bindings array in `useBindings()`, so pressing the configured keybind did nothing.

Added `"prompt.skills"` to the `tuiConfig.keybinds.gather("prompt.palette", [...])` array to wire up the keybind.