### PR TITLE
fix(permission): add rtk to bash arity dictionary (fixes #29311)

### DIFF
--- a/packages/opencode/src/permission/arity.ts
+++ b/packages/opencode/src/permission/arity.ts
@@ -41,6 +41,8 @@ const ARITY: Record<string, number> = {
   pwd: 1, // pwd
   rm: 1, // rm file.txt
   rmdir: 1, // rmdir empty-dir
+  rtk: 2, // rtk env
+  "rtk git": 3, // rtk git clone
   sleep: 1, // sleep 5
   source: 1, // source ~/.bashrc
   tail: 1, // tail -f log.txt


### PR DESCRIPTION
Adds `rtk` (github.com/rtk-ai/rtk) to the ARITY dictionary in `permission/arity.ts` with proper subcommand arity:

- `rtk: 2` — covers `rtk env`, `rtk init`, etc.
- `rtk git: 3` — covers `rtk git clone`, etc.

This ensures "Always allow" prompts for rtk commands produce subcommand-scoped patterns instead of overly broad `rtk *` wildcards.

Fixes #29311