### PR TITLE
fix(test): stabilize flaky shell test (fixes #29214)

### DIFF
--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -192,6 +192,18 @@ describe("tool.shell", () => {
       yield* runIn(
         tmp,
         Effect.gen(function* () {
+          const prevSHELL = process.env.SHELL
+          Shell.acceptable.reset()
+          Shell.preferred.reset()
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              if (prevSHELL === undefined) delete process.env.SHELL
+              else process.env.SHELL = prevSHELL
+              Shell.acceptable.reset()
+              Shell.preferred.reset()
+            }),
+          )
+
           const bash = yield* initBash()
           const fallback = Shell.name(Shell.acceptable("fish"))
           expect(fallback).not.toBe("fish")


### PR DESCRIPTION
### Issue for this PR

Closes #29214

### Type of change

- [x] Bug fix

### What does this PR do?

Stabilize the flaky "falls back from terminal-only configured shell" test by saving/restoring `process.env.SHELL` and resetting Shell lazy caches before assertions.

### How did you verify your code works?

- [x] TypeScript typecheck passes
- [x] Existing tests pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
