### PR TITLE
fix(core): handle JSON parse failure gracefully in models-dev (fixes #29366)

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -192,6 +192,9 @@ export const layer = Layer.effect(
       try {
         return JSON.parse(text) as Record<string, Provider>
       } catch {
+        yield* Effect.logError(
+          `Failed to parse JSON from ${source}/api.json — response may be blocked by network/firewall`,
+        )
         return {}
       }
     }).pipe(Effect.withSpan("ModelsDev.populate"), Effect.orDie)

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -189,7 +189,11 @@ export const layer = Layer.effect(
           return yield* fetchAndWrite()
         }),
       )
-      return JSON.parse(text) as Record<string, Provider>
+      try {
+        return JSON.parse(text) as Record<string, Provider>
+      } catch {
+        return {}
+      }
     }).pipe(Effect.withSpan("ModelsDev.populate"), Effect.orDie)
 
     const [cachedGet, invalidate] = yield* Effect.cachedInvalidateWithTTL(populate, Duration.infinity)


### PR DESCRIPTION
### Issue for this PR

Closes #29366

### Type of change

- [x] Bug fix

### What does this PR do?

Wrap JSON.parse() in models-dev.ts in a try/catch so that network failures (e.g., HTML returned instead of JSON from blocked connections) don't crash opencode on startup. Returns `{}` on parse failure.

### How did you verify your code works?

- [x] TypeScript typecheck passes
- [x] Existing tests pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
