### PR TITLE
fix(tui): don't snap viewport while reading history during generation (fixes \#29094)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "@tui/context/theme"
 import { useLocal } from "@tui/context/local"
 import { reasoningSummary, useThinkingMode } from "@tui/context/thinking"
 import { useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
-import { RGBA, TextAttributes, type BoxRenderable, type SyntaxStyle } from "@opentui/core"
+import { RGBA, TextAttributes, type BoxRenderable, type ScrollBoxRenderable, type SyntaxStyle } from "@opentui/core"
 import { useBindings } from "../../keymap"
 import { Locale } from "@/util/locale"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
@@ -28,7 +28,7 @@ import type {
   ToolFileContent,
   ToolTextContent,
 } from "@opencode-ai/sdk/v2"
-import { createEffect, createMemo, createSignal, For, Match, Show, Switch } from "solid-js"
+import { createEffect, createMemo, createSignal, For, Match, onMount, Show, Switch } from "solid-js"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 
 const id = "internal:session-v2-debug"
@@ -70,14 +70,28 @@ function View(props: { api: TuiPluginApi; sessionID: string }) {
     ],
   }))
 
+  let scroll: ScrollBoxRenderable
+  const STICKY_THRESHOLD = 3
+  const [stickToEnd, setStickToEnd] = createSignal(true)
+  onMount(() => {
+    function checkStickyScroll() {
+      if (!scroll || scroll.isDestroyed) return
+      const atBottom = scroll.y + scroll.height >= scroll.scrollHeight - STICKY_THRESHOLD
+      setStickToEnd(atBottom)
+      requestAnimationFrame(checkStickyScroll)
+    }
+    requestAnimationFrame(checkStickyScroll)
+  })
+
   return (
     <box width={dimensions().width} height={dimensions().height} backgroundColor={theme.background}>
       <box flexDirection="row">
         <box flexGrow={1} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
           <scrollbox
+            ref={(r) => (scroll = r)}
             viewportOptions={{ paddingRight: 0 }}
             verticalScrollbarOptions={{ visible: false }}
-            stickyScroll={true}
+            stickyScroll={stickToEnd()}
             stickyStart="bottom"
             flexGrow={1}
           >

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -301,6 +301,17 @@ export function Session() {
 
   let seeded = false
   let scroll: ScrollBoxRenderable
+  const STICKY_THRESHOLD = 3
+  const [stickToEnd, setStickToEnd] = createSignal(true)
+  onMount(() => {
+    function checkStickyScroll() {
+      if (!scroll || scroll.isDestroyed) return
+      const atBottom = scroll.y + scroll.height >= scroll.scrollHeight - STICKY_THRESHOLD
+      setStickToEnd(atBottom)
+      requestAnimationFrame(checkStickyScroll)
+    }
+    requestAnimationFrame(checkStickyScroll)
+  })
   let prompt: PromptRef | undefined
   const bind = (r: PromptRef | undefined) => {
     prompt = r
@@ -1128,7 +1139,7 @@ export function Session() {
                     foregroundColor: theme.border,
                   },
                 }}
-                stickyScroll={true}
+                stickyScroll={stickToEnd()}
                 stickyStart="bottom"
                 flexGrow={1}
                 scrollAcceleration={scrollAcceleration()}


### PR DESCRIPTION
## Problem

When scrolling up to read chat history while the LLM is generating a response, the viewport snaps back down to the bottom when new tokens arrive. This is a re-open of \#4196.

## Root Cause

Both `session/index.tsx` and `session-v2.tsx` set `stickyScroll={true}` unconditionally on their scrollbox components. This causes any content height change (e.g., a new streaming token) to force the viewport back to the bottom, regardless of where the user has scrolled.

## Fix

Replaced the hardcoded `stickyScroll={true}` with a reactive signal that checks whether the user is at the bottom of the scroll viewport. A `requestAnimationFrame` loop monitors the scroll position and enables sticky scroll only when the user is within 3 rows of the bottom.

- If the user scrolls up: sticky scroll is disabled, viewport stays where the user left it.
- If the user scrolls back to the bottom: sticky scroll is re-enabled, new content resumes auto-scrolling.
- Uses a 3-row threshold to avoid disabling sticky scroll from minor viewport fluctuations.