### PR TITLE
fix(project): make identity cache channel-specific (fixes #29375)

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -6,6 +6,7 @@ import { AbsolutePath, withStatics } from "./schema"
 import { AppFileSystem } from "./filesystem"
 import { Git } from "./git"
 import { Hash } from "./util/hash"
+import { InstallationChannel } from "./installation/version"
 
 export const ID = Schema.String.pipe(
   Schema.brand("Project.ID"),
@@ -59,7 +60,8 @@ export const layer = Layer.effect(
     const git = yield* Git.Service
 
     const cached = Effect.fnUntraced(function* (dir: string) {
-      return yield* fs.readFileString(path.join(dir, "opencode")).pipe(
+      const cacheFile = InstallationChannel === "latest" ? "opencode" : `opencode-${InstallationChannel}`
+      return yield* fs.readFileString(path.join(dir, cacheFile)).pipe(
         Effect.map((value) => value.trim()),
         Effect.map((value) => (value ? ID.make(value) : undefined)),
         Effect.catch(() => Effect.succeed(undefined)),
@@ -119,7 +121,8 @@ export const layer = Layer.effect(
     })
 
     const commit = Effect.fn("Project.commit")(function* (input: { store: AbsolutePath; id: ID }) {
-      yield* fs.writeFileString(path.join(input.store, "opencode"), input.id).pipe(Effect.ignore)
+      const cacheFile = InstallationChannel === "latest" ? "opencode" : `opencode-${InstallationChannel}`
+      yield* fs.writeFileString(path.join(input.store, cacheFile), input.id).pipe(Effect.ignore)
     })
 
     return Service.of({ resolve, commit })

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -153,7 +153,7 @@ describe("ProjectV2.resolve", () => {
         (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
       )
       yield* Effect.promise(() => initRepo(tmp.path, { commit: true, remote: "git@github.com:owner/repo.git" }))
-      yield* Effect.promise(() => Bun.write(path.join(tmp.path, ".git", "opencode"), "old-id"))
+      yield* Effect.promise(() => Bun.write(path.join(tmp.path, ".git", "opencode-local"), "old-id"))
       const project = yield* Project.Service
 
       const result = yield* project.resolve(abs(tmp.path))
@@ -174,7 +174,7 @@ describe("ProjectV2.resolve", () => {
 
       yield* project.resolve(abs(tmp.path))
 
-      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, ".git", "opencode")).exists())).toBe(false)
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, ".git", "opencode-local")).exists())).toBe(false)
     }),
   )
 
@@ -205,7 +205,7 @@ describe("ProjectV2.resolve", () => {
         Effect.promise(() => $`rm -rf ${worktree}`.quiet().nothrow()).pipe(Effect.ignore),
       )
       yield* Effect.promise(() => initRepo(tmp.path, { commit: true, remote: "git@github.com:owner/repo.git" }))
-      yield* Effect.promise(() => Bun.write(path.join(tmp.path, ".git", "opencode"), "old-id"))
+      yield* Effect.promise(() => Bun.write(path.join(tmp.path, ".git", "opencode-local"), "old-id"))
       yield* Effect.promise(() => $`git worktree add ${worktree} -b test-${Date.now()}`.cwd(tmp.path).quiet())
       const project = yield* Project.Service
 

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -241,6 +241,19 @@ export const layer = Layer.effect(
       // Phase 2: upsert
       const projectID = ProjectID.make(data.id)
       yield* migrateProjectId(data.previous ? ProjectID.make(data.previous) : undefined, projectID)
+
+      const orphanRows = yield* db((d) =>
+        d
+          .select()
+          .from(ProjectTable)
+          .where(eq(ProjectTable.worktree, worktree))
+          .all()
+          .filter((row) => row.id !== projectID && row.id !== ProjectID.global),
+      )
+      for (const orphan of orphanRows) {
+        yield* migrateProjectId(orphan.id, projectID)
+      }
+
       const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, projectID)).get())
       const existing = row
         ? fromRow(row)


### PR DESCRIPTION
## Summary

Channel-specific databases share the repo-local project identity cache, which breaks project identity migration when different channels run on the same repo.

When a non-latest channel build writes the remote-derived project ID to the shared cache, the main channel sees previous == id, causing migrateProjectId to exit early and leaving old root-commit project rows stranded.

## Changes

### 1. Channel-specific cache filename (packages/core/src/project.ts)

The cache at repo/.git/opencode is now channel-aware:
- Latest channel uses opencode (unchanged, for backward compatibility)
- Non-latest channels use opencode-<channel>

### 2. DB fallback migration (packages/opencode/src/project/project.ts)

In fromDirectory(), after the normal migrateProjectId, we scan the database for project rows with the same worktree but different IDs and migrate each orphan row.

### 3. Test updates (packages/core/test/project.test.ts)

Updated cache filename references to match channel-specific naming.

Fixes #29375