### PR TITLE
feat(permission): add rtk to bash arity dictionary

### DIFF
--- a/packages/opencode/src/permission/arity.ts
+++ b/packages/opencode/src/permission/arity.ts
@@ -136,6 +136,15 @@ const ARITY: Record<string, number> = {
   rake: 2, // rake db:migrate
   rbenv: 2, // rbenv install 3.2.0
   "redis-cli": 2, // redis-cli ping
+  rtk: 2, // rtk ls, rtk env, rtk curl
+  "rtk aws": 4, // rtk aws sts get-caller-identity
+  "rtk cargo": 3, // rtk cargo test
+  "rtk docker": 3, // rtk docker ps
+  "rtk gh": 3, // rtk gh pr list
+  "rtk git": 3, // rtk git clone
+  "rtk kubectl": 3, // rtk kubectl pods
+  "rtk pip": 3, // rtk pip list
+  "rtk pnpm": 3, // rtk pnpm list
   rustup: 2, // rustup update
   serverless: 2, // serverless invoke
   sfdx: 3, // sfdx force:org:list


### PR DESCRIPTION
\`rtk\` (github.com/rtk-ai/rtk) ships an explicit OpenCode integration (\`rtk init -g --opencode\`) but is absent from the \`ARITY\` dictionary in \`permission/arity.ts\`. Always-allow prompts for \`rtk\` commands therefore produce \`rtk *\` instead of subcommand-scoped patterns like \`rtk env *\` or \`rtk git clone *\`, which is too broad to approve safely.

This PR adds \`rtk\` and its subcommand prefix depths, consistent with how other multi-level CLI tools (\`aws\`, \`docker\`, \`kubectl\`, etc.) are already represented.

**Before:** \`rtk git clone https://github.com/org/repo\` → always pattern \`rtk *\`
**After:** \`rtk git clone https://github.com/org/repo\` → always pattern \`rtk git clone *\`

Closes #29311

### How did you verify your code works?

Manually verified all nine new entries produce the expected prefix tokens against representative \`rtk\` commands from the README.