### PR TITLE
fix(opencode): recover stale snapshot index locks

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -1,4 +1,4 @@
-import { Cause, Duration, Effect, Layer, Schedule, Schema, Semaphore, Context } from "effect"
+import { Cause, Duration, Effect, Layer, Schedule, Schema, Semaphore, Context, Option } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { formatPatch, structuredPatch } from "diff"
 import path from "path"
@@ -31,6 +31,7 @@ export type FileDiff = typeof FileDiff.Type
 const log = Log.create({ service: "snapshot" })
 const prune = "7.days"
 const limit = 2 * 1024 * 1024
+const staleLockAge = Duration.seconds(30)
 const core = ["-c", "core.longpaths=true", "-c", "core.symlinks=true"]
 const cfg = ["-c", "core.autocrlf=false", ...core]
 const quote = [...cfg, "-c", "core.quotepath=false"]
@@ -165,6 +166,19 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
           const remove = (file: string) => fs.remove(file).pipe(Effect.catch(() => Effect.void))
           const locked = <A, E, R>(fx: Effect.Effect<A, E, R>) => lock(state.gitdir).withPermits(1)(fx)
 
+          const removeStaleLock = Effect.fnUntraced(function* () {
+            const lockfile = path.join(state.gitdir, "index.lock")
+            const stat = yield* fs.stat(lockfile).pipe(Effect.catch(() => Effect.void))
+            if (!stat || stat.type !== "File") return
+            const age = Date.now() - Option.getOrElse(stat.mtime, () => new Date()).getTime()
+            if (age <= Duration.toMillis(staleLockAge)) return
+            yield* remove(lockfile)
+            log.warn("removed stale snapshot index lock", {
+              lock: lockfile,
+              age,
+            })
+          })
+
           const enabled = Effect.fnUntraced(function* () {
             if (state.vcs !== "git") return false
             return (yield* config.get()).snapshot !== false
@@ -194,6 +208,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
           })
 
           const add = Effect.fnUntraced(function* () {
+            yield* removeStaleLock()
             yield* sync()
             const [diff, other] = yield* Effect.all(
               [
@@ -263,6 +278,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
               Effect.gen(function* () {
                 if (!(yield* enabled())) return
                 if (!(yield* exists(state.gitdir))) return
+                yield* removeStaleLock()
                 const result = yield* git(args(["gc", `--prune=${prune}`]), { cwd: state.directory })
                 if (result.code !== 0) {
                   log.warn("cleanup failed", {
@@ -337,6 +353,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
           const restore = Effect.fnUntraced(function* (snapshot: string) {
             return yield* locked(
               Effect.gen(function* () {
+                yield* removeStaleLock()
                 log.info("restore", { commit: snapshot })
                 const result = yield* git([...core, ...args(["read-tree", snapshot])], { cwd: state.worktree })
                 if (result.code === 0) {
@@ -363,6 +380,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
           const revert = Effect.fnUntraced(function* (patches: Patch[]) {
             return yield* locked(
               Effect.gen(function* () {
+                yield* removeStaleLock()
                 const ops: { hash: string; file: string; rel: string }[] = []
                 const seen = new Set<string>()
                 for (const item of patches) {
@@ -498,6 +516,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
           const diffFull = Effect.fnUntraced(function* (from: string, to: string) {
             return yield* locked(
               Effect.gen(function* () {
+                yield* removeStaleLock()
                 type Row = {
                   file: string
                   status: "added" | "deleted" | "modified"

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -2,9 +2,12 @@ import { afterEach, expect } from "bun:test"
 import { $ } from "bun"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Global } from "@opencode-ai/core/global"
+import { Hash } from "@opencode-ai/core/util/hash"
 import fs from "fs/promises"
 import path from "path"
 import { Effect, Fiber, Layer } from "effect"
+import { InstanceState } from "../../src/effect/instance-state"
 import { Snapshot } from "../../src/snapshot"
 import { disposeAllInstances, provideInstance, TestInstance, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -71,6 +74,10 @@ const bootstrapScoped = Effect.fn("SnapshotTest.bootstrapScoped")(function* () {
 })
 
 const scopedGitTmpdir = () => tmpdirScoped({ git: true }).pipe(Effect.provide(CrossSpawnSpawner.defaultLayer))
+const snapshotGitdir = Effect.gen(function* () {
+  const ctx = yield* InstanceState.context
+  return path.join(Global.Path.data, "snapshot", ctx.project.id, Hash.fast(ctx.worktree))
+})
 
 const cleanupWorktree = (repo: string, worktree: string, files: string[] = []) =>
   Effect.promise(async () => {
@@ -440,6 +447,30 @@ it.live(
       expect(patch.files).not.toContain(fwd(dir, "build/new-build.js"))
     }).pipe(provideInstance(dir))
   }),
+)
+
+it.instance(
+  "removes stale snapshot index lock before tracking",
+  Effect.gen(function* () {
+    const tmp = yield* bootstrap()
+    const snapshot = yield* Snapshot.Service
+    const before = yield* snapshot.track()
+    expect(before).toBeTruthy()
+    const lock = path.join(yield* snapshotGitdir, "index.lock")
+    yield* write(lock, "stale")
+    yield* Effect.promise(() => {
+      const stale = new Date(Date.now() - 60_000)
+      return fs.utimes(lock, stale, stale)
+    })
+    yield* write(`${tmp.path}/after-lock.txt`, "tracked after stale lock")
+    const after = yield* snapshot.track()
+    expect(after).toBeTruthy()
+    expect(after).not.toBe(before)
+    expect(yield* exists(lock)).toBe(false)
+    const diffs = yield* snapshot.diffFull(before!, after!)
+    expect(diffs.some((x) => x.file === "after-lock.txt")).toBe(true)
+  }),
+  { git: true },
 )
 
 it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #28952
Closes #22275
Closes #29413

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Snapshot uses an internal gitdir for project change tracking. If opencode or the terminal exits while git is writing the index, a stale `index.lock` can remain and later snapshot operations fail or return an empty tree.

This removes an `index.lock` from the snapshot gitdir only when it is older than 30 seconds, before snapshot git operations run. Fresh locks are left alone.

### How did you verify your code works?

- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/snapshot/snapshot.test.ts -t "removes stale snapshot index lock before tracking"`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/snapshot/snapshot.test.ts`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`

I also ran `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push`; it failed in untouched `@opencode-ai/console-support` because local dependencies/types such as `@solidjs/meta`, `@solidjs/router`, `solid-js`, `vite`, and `@opencode-ai/console-core/...` were unresolved.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._