### PR TITLE
fix(opencode): print CLI parser errors

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -185,6 +185,7 @@ const cli = yargs(args)
       msg?.startsWith("Invalid values:")
     ) {
       if (err) throw err
+      process.stderr.write(msg + EOL + EOL)
       cli.showHelp(show)
     }
     if (err) throw err

--- a/packages/opencode/test/cli/invalid-args.test.ts
+++ b/packages/opencode/test/cli/invalid-args.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../lib/cli-process"
+
+describe("opencode CLI invalid arguments", () => {
+  cliIt.live(
+    "prints the parser error before top-level help for unknown arguments",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const result = yield* opencode.spawn(["--unkown-flag"])
+
+        opencode.expectExit(result, 1, "opencode --unkown-flag")
+        expect(result.stdout).toBe("")
+        expect(result.stderr).toContain("Unknown arguments: unkown-flag")
+        expect(result.stderr).toContain("Commands:")
+      }),
+    60_000,
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29390

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prints the yargs parser error message before showing top-level help for invalid CLI arguments.

Before this change, `opencode --unkown-flag` exited non-zero but produced the same visible output as `opencode --help`, so users could not tell what was wrong. The fail handler already receives the parser message; this writes it to stderr before rendering help.

### How did you verify your code works?

- `PATH="$HOME/.bun/bin:$PATH" bun test test/cli/invalid-args.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun test test/cli/invalid-args.test.ts test/cli/help/help-snapshots.test.ts test/cli/smokes/read-only.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`

I also ran `.husky/pre-push`; it failed in the unrelated `@opencode-ai/console-support` package because local dependencies/types such as `@solidjs/meta`, `@solidjs/router`, `solid-js`, `vite`, and generated `@opencode-ai/console-core/...` modules were missing. The `opencode` package checks above passed.

### Screenshots / recordings

N/A - CLI stderr behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
