### PR TITLE
fix(opencode): migrate stale worktree projects

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -232,6 +232,21 @@ export const layer = Layer.effect(
       )
     })
 
+    const migrateProjectWorktree = Effect.fn("Project.migrateProjectWorktree")(function* (
+      worktree: string,
+      projectID: ProjectID,
+    ) {
+      if (projectID === ProjectID.global) return
+      const candidates = yield* db((d) =>
+        d.select({ id: ProjectTable.id }).from(ProjectTable).where(eq(ProjectTable.worktree, worktree)).all(),
+      )
+      yield* Effect.forEach(
+        candidates.filter((row) => row.id !== projectID),
+        (row) => migrateProjectId(row.id, projectID),
+        { concurrency: 1 },
+      )
+    })
+
     const fromDirectory = Effect.fn("Project.fromDirectory")(function* (directory: string) {
       log.info("fromDirectory", { directory })
 
@@ -241,6 +256,7 @@ export const layer = Layer.effect(
       // Phase 2: upsert
       const projectID = ProjectID.make(data.id)
       yield* migrateProjectId(data.previous ? ProjectID.make(data.previous) : undefined, projectID)
+      yield* migrateProjectWorktree(worktree, projectID)
       const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, projectID)).get())
       const existing = row
         ? fromRow(row)

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -254,6 +254,45 @@ describe("Project.fromDirectory", () => {
       ).toBe(remoteID)
     }),
   )
+
+  it.live("migrates root project data when repo cache already contains remote id", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const projects = yield* Project.Service
+      const { project: rootProject } = yield* projects.fromDirectory(tmp)
+      const remoteID = remoteProjectID("github.com/acme/app")
+      const sessionID = crypto.randomUUID() as SessionID
+
+      yield* Effect.sync(() => {
+        Database.use((db) => {
+          db.insert(SessionTable)
+            .values({
+              id: sessionID,
+              project_id: rootProject.id,
+              slug: sessionID,
+              directory: tmp,
+              title: "test",
+              version: "0.0.0-test",
+              time_created: Date.now(),
+              time_updated: Date.now(),
+            })
+            .run()
+        })
+      })
+      yield* Effect.promise(() => $`git remote add origin git@github.com:acme/app.git`.cwd(tmp).quiet())
+      yield* Effect.promise(() => Bun.write(path.join(tmp, ".git", "opencode"), remoteID))
+
+      const { project } = yield* projects.fromDirectory(tmp)
+
+      expect(project.id).toBe(remoteID)
+      expect(
+        Database.use((db) => db.select().from(ProjectTable).where(eq(ProjectTable.id, rootProject.id)).get()),
+      ).toBeUndefined()
+      expect(
+        Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, sessionID)).get())?.project_id,
+      ).toBe(remoteID)
+    }),
+  )
 })
 
 describe("Project.fromDirectory git failure paths", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #29375

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Migrates existing project data for the same worktree even when the repo-local `.git/opencode` cache already contains the final remote-derived project ID.

The previous migration path only used `resolve().previous`. If another channel had already written the remote ID into `.git/opencode`, the main DB saw `previous === id` and skipped migration, leaving old root-commit project rows and sessions behind. This change looks for stale project rows with the same worktree and migrates them into the resolved project ID before the upsert.

### How did you verify your code works?

- `PATH="$HOME/.bun/bin:$PATH" bun test test/project/project.test.ts -t "migrates root project data when repo cache already contains remote id"`
- `PATH="$HOME/.bun/bin:$PATH" bun test test/project/project.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`

I also ran `.husky/pre-push`; it failed in the unrelated `@opencode-ai/console-support` package because local dependencies/types such as `@solidjs/meta`, `@solidjs/router`, `solid-js`, `vite`, and generated `@opencode-ai/console-core/...` modules were missing. The `opencode` package checks above passed.

### Screenshots / recordings

N/A - project migration logic only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
