### PR TITLE
feat(opencode): add single session status endpoint

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -74,6 +74,7 @@ export const PermissionResponsePayload = Schema.Struct({
 export const SessionPaths = {
   list: root,
   status: `${root}/status`,
+  getStatus: `${root}/:sessionID/status`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
@@ -123,6 +124,18 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.status",
             summary: "Get session status",
             description: "Retrieve the current status of all sessions, including active, idle, and completed states.",
+          }),
+        ),
+        HttpApiEndpoint.get("getStatus", SessionPaths.getStatus, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(SessionStatus.Info, "Get session status"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.getStatus",
+            summary: "Get session status",
+            description: "Retrieve the current runtime status for a specific OpenCode session.",
           }),
         ),
         HttpApiEndpoint.get("get", SessionPaths.get, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -75,6 +75,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return Object.fromEntries(yield* statusSvc.list())
     })
 
+    const getStatus = Effect.fn("SessionHttpApi.getStatus")(function* (ctx: { params: { sessionID: SessionID } }) {
+      return yield* statusSvc.get(ctx.params.sessionID)
+    })
+
     const requireSession = Effect.fn("SessionHttpApi.requireSession")(function* (sessionID: SessionID) {
       return yield* SessionError.mapStorageNotFound(session.get(sessionID))
     })
@@ -406,6 +410,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     return handlers
       .handle("list", list)
       .handle("status", status)
+      .handle("getStatus", getStatus)
       .handle("get", get)
       .handle("children", children)
       .handle("todo", todo)

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -732,6 +732,17 @@ const scenarios: Scenario[] = [
     .seeded((ctx) => ctx.session({ title: "Status session" }))
     .json(200, object),
   http.protected
+    .get("/session/{sessionID}/status", "session.getStatus")
+    .seeded((ctx) => ctx.session({ title: "Single status session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/status", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+    }))
+    .json(200, (body) => {
+      object(body)
+      check(isRecord(body) && body.type === "idle", "single session status should default to idle")
+    }),
+  http.protected
     .post("/session", "session.create")
     .mutating()
     .at((ctx) => ({ path: "/session", headers: ctx.headers(), body: { title: "Created session" } }))

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -313,6 +313,9 @@ describe("session HttpApi", () => {
         expect(Object.hasOwn(listed[0]!, "parentID")).toBe(false)
 
         expect(yield* requestJson<Record<string, unknown>>(SessionPaths.status, { headers })).toEqual({})
+        const sessionStatus = yield* request(`/session/${parent.id}/status`, { headers })
+        expect(sessionStatus.status).toBe(200)
+        expect(yield* json<Record<string, unknown>>(sessionStatus)).toEqual({ type: "idle" })
 
         expect(
           yield* requestJson<Session.Info>(pathFor(SessionPaths.get, { sessionID: parent.id }), { headers }),

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -176,6 +176,8 @@ import type {
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
+  SessionGetStatusErrors,
+  SessionGetStatusResponses,
   SessionInitErrors,
   SessionInitResponses,
   SessionListErrors,
@@ -3155,6 +3157,38 @@ export class Session2 extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<SessionStatusResponses, SessionStatusErrors, ThrowOnError>({
       url: "/session/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get session status
+   *
+   * Retrieve the current runtime status for a specific OpenCode session.
+   */
+  public getStatus<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionGetStatusResponses, SessionGetStatusErrors, ThrowOnError>({
+      url: "/session/{sessionID}/status",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -6122,6 +6122,36 @@ export type SessionStatusResponses = {
 
 export type SessionStatusResponse = SessionStatusResponses[keyof SessionStatusResponses]
 
+export type SessionGetStatusData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/status"
+}
+
+export type SessionGetStatusErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type SessionGetStatusError = SessionGetStatusErrors[keyof SessionGetStatusErrors]
+
+export type SessionGetStatusResponses = {
+  /**
+   * Get session status
+   */
+  200: SessionStatus
+}
+
+export type SessionGetStatusResponse = SessionGetStatusResponses[keyof SessionGetStatusResponses]
+
 export type SessionDeleteData = {
   body?: never
   path: {


### PR DESCRIPTION
### Issue for this PR

Closes #29166

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `GET /session/:sessionID/status` for clients that need one session's runtime status without fetching and filtering the full `/session/status` map.

The endpoint follows the existing `/session/:sessionID/...` resource shape and delegates to `SessionStatus.get(sessionID)`, so idle sessions return `{ "type": "idle" }`. The OpenAPI scenario and generated JS SDK were updated; the v2 SDK now exposes `session.getStatus(...)`.

### How did you verify your code works?

- `PATH="$HOME/.bun/bin:$PATH" bun test test/server/httpapi-session.test.ts -t "serves read routes"`
- `PATH="$HOME/.bun/bin:$PATH" bun test test/server/httpapi-session.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun run script/httpapi-exercise.ts --mode coverage --fail-on-missing --fail-on-skip`
- `PATH="$HOME/.bun/bin:$PATH" bun run test:httpapi`
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck` from `packages/opencode`
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck` from `packages/sdk/js`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" bun ./packages/sdk/js/script/build.ts`

I also ran `.husky/pre-push`; it failed in the unrelated `@opencode-ai/console-support` package because local dependencies/types such as `@solidjs/meta`, `@solidjs/router`, `solid-js`, `vite`, and generated `@opencode-ai/console-core/...` modules were missing. The `opencode` and SDK checks above passed.

### Screenshots / recordings

N/A - HTTP API and SDK change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
