### PR TITLE
fix(opencode): suppress vertex metadata lookup warning

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,4 +1,5 @@
 import "./init-projectors"
+import "@/util/warning"
 
 import { NodeHttpServer } from "@effect/platform-node"
 import * as Log from "@opencode-ai/core/util/log"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import os from "os"
+import "@/util/warning"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import * as Log from "@opencode-ai/core/util/log"

--- a/packages/opencode/src/util/warning.ts
+++ b/packages/opencode/src/util/warning.ts
@@ -1,0 +1,10 @@
+const emitWarning = process.emitWarning.bind(process)
+
+// Google ADC checks the metadata service during local Vertex authentication.
+// That expected miss should not write directly over the interactive UI.
+process.emitWarning = ((...args: Parameters<typeof process.emitWarning>) => {
+  const type = typeof args[1] === "string" ? args[1] : args[1]?.type
+  const name = type ?? (args[0] instanceof Error ? args[0].name : undefined)
+  if (name === "MetadataLookupWarning") return
+  emitWarning(...args)
+}) as typeof process.emitWarning

--- a/packages/opencode/test/util/warning.test.ts
+++ b/packages/opencode/test/util/warning.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { Process } from "@/util/process"
+
+test("suppresses metadata lookup warnings without hiding other warnings", async () => {
+  const out = await Process.run([
+    process.execPath,
+    "-e",
+    'await import("./src/util/warning.ts"); process.emitWarning("metadata", "MetadataLookupWarning"); process.emitWarning("visible", "VisibleWarning")',
+  ])
+
+  expect(out.stderr.toString()).not.toContain("MetadataLookupWarning")
+  expect(out.stderr.toString()).toContain("VisibleWarning: visible")
+})


### PR DESCRIPTION
## Summary
- suppress only `MetadataLookupWarning` emitted by Google ADC metadata-server detection so it does not overwrite the interactive UI
- leave metadata detection and all other process warnings unchanged
- apply the filter in both server and session prompt runtime paths that already configure provider warning output

## Context
Native Google Vertex authentication uses `google-auth-library`, which probes the GCP metadata endpoint during ADC discovery. On local machines, `gcp-metadata` can emit `MetadataLookupWarning: received unexpected error = code = UNKNOWN` even when Vertex requests work. Since this is emitted with `process.emitWarning()`, it currently leaks directly into the TUI.

Setting `METADATA_SERVER_DETECTION=none` globally would avoid the output but would also disable valid metadata-based credentials for users running on GCE, so this change filters only the noisy warning output.

## Validation
- `packages/opencode`: `bun typecheck`
- `packages/opencode`: `bun test "test/util/warning.test.ts"` (`1 pass`)
- `packages/opencode`: `env -u OPENCODE_EXPERIMENTAL -u OPENCODE_ENABLE_EXPERIMENTAL_MODELS bun test "test/provider/provider.test.ts"` (`88 pass`)

The environment variables are unset for the provider test because the active local OpenCode worker sets experimental model flags that intentionally contradict its default alpha-model assertion.
