### PR TITLE
docs: remove ambiguous agent automation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
 - To regenerate the JavaScript SDK, run `./packages/sdk/js/script/build.ts`.
-- ALWAYS USE PARALLEL TOOLS WHEN APPLICABLE.
 - The default branch in this repo is `dev`.
 - Local `main` ref may not exist; use `dev` or `origin/dev` for diffs.
-- Prefer automation: execute requested actions without confirmation unless blocked by missing info or safety/irreversibility.
 
 ## Commits and PR Titles
 


### PR DESCRIPTION
## Summary
- remove redundant instruction to always parallelize tools
- remove overly broad automation guidance that can be mistaken as authorization for irreversible repository actions

## Validation
- documentation-only change; no tests required
