### PR TITLE
fix: detect attachment mime from file contents

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -20,6 +20,7 @@ import { effectCmd } from "../effect-cmd"
 import { ServerAuth } from "@/server/auth"
 import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
+import { sniffAttachmentMime } from "@/util/media"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
@@ -342,7 +343,13 @@ export const RunCommand = effectCmd({
             process.exit(1)
           }
 
-          const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : "text/plain"
+          let mime: string
+          if (await Filesystem.isDir(resolvedPath)) {
+            mime = "application/x-directory"
+          } else {
+            const head = await Bun.file(resolvedPath).slice(0, 16).bytes()
+            mime = sniffAttachmentMime(head, "text/plain")
+          }
 
           files.push({
             type: "file",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -40,6 +40,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { Image } from "@/image/image"
 import { decodeDataUrl } from "@/util/data-url"
+import { sniffAttachmentMime } from "@/util/media"
 import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Latch, Layer, Option, Scope, Context, Schema, Types } from "effect"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
@@ -206,11 +207,17 @@ export const layer = Layer.effect(
               return
             }
 
+            const refMime =
+              info.value.type === "Directory"
+                ? "application/x-directory"
+                : yield* Effect.promise(async () =>
+                    sniffAttachmentMime(await Bun.file(targetPath).slice(0, 16).bytes(), "text/plain"),
+                  )
             parts.push({
               type: "file",
               url: pathToFileURL(targetPath).href,
               filename: name,
-              mime: info.value.type === "Directory" ? "application/x-directory" : "text/plain",
+              mime: refMime,
             })
             return
           }
@@ -226,11 +233,17 @@ export const layer = Layer.effect(
             return
           }
           const stat = info.value
+          const fileMime =
+            stat.type === "Directory"
+              ? "application/x-directory"
+              : yield* Effect.promise(async () =>
+                  sniffAttachmentMime(await Bun.file(filepath).slice(0, 16).bytes(), "text/plain"),
+                )
           parts.push({
             type: "file",
             url: pathToFileURL(filepath).href,
             filename: name,
-            mime: stat.type === "Directory" ? "application/x-directory" : "text/plain",
+            mime: fileMime,
           })
         }),
         { concurrency: "unbounded", discard: true },


### PR DESCRIPTION
Files attached via the `-f` flag and `@path` references in the prompt are hardcoded as `mime: text/plain` regardless of actual type. When the file is an image or PDF this causes the attachment to be dropped from the user message in `message-v2.ts` (which filters out `text/plain` file parts before serialization), so vision-capable models never see the image.

Use the existing `sniffAttachmentMime` helper from `util/media.ts` (already used by `tool/read.ts`) to detect the type from the first 16 bytes of the file. Falls back to `text/plain` for unknown types, preserving previous behaviour for plain-text attachments.

Fixes #25353, #24698.

### Test

- `bun test` — 3032 pass / 0 fail
- `bun run typecheck` — clean
- `bun run test:httpapi` — 149 / 0
- `bun run lint` — 0 new errors

Verified manually with a 64×64 PNG: pre-fix, default model replied "I cannot process images"; post-fix, model correctly identifies the image content.