### PR TITLE
fix(tui): accelerate diff viewer scrolling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
@@ -11,6 +11,7 @@ import { createEffect, createMemo, createResource, createSignal, For, Match, onC
 import { DiffViewerFileTree } from "./diff-viewer-file-tree"
 import { Panel, PanelGroup, Separator } from "./diff-viewer-ui"
 import { DialogSelect } from "@tui/ui/dialog-select"
+import { getScrollAcceleration } from "@tui/util/scroll"
 import {
   allExpandedFileTreeDirectories,
   buildFileTree,
@@ -133,6 +134,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
   const [activePatchFileIndex, setActivePatchFileIndex] = createSignal<number | undefined>()
   const [selectedFileIndex, setSelectedFileIndex] = createSignal<number | undefined>()
   const [reviewedFileNames, setReviewedFileNames] = createSignal<ReadonlySet<string>>(new Set())
+  const patchScrollAcceleration = createMemo(() => getScrollAcceleration(props.api.tuiConfig))
   const fileRows = createMemo(() => flattenFileTree(fileTree(), expandedFileNodes()))
   const patchFileIndexes = createMemo(() => orderedPatchFileIndexes(flattenFileTree(fileTree())))
   const focusRunner = (input: Record<DiffViewerFocus, () => void>) => () => input[focus()]()
@@ -713,6 +715,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
                     ref={(element: ScrollBoxRenderable) => (scroll = element)}
                     flexGrow={1}
                     minHeight={0}
+                    scrollAcceleration={patchScrollAcceleration()}
                     verticalScrollbarOptions={{ visible: false }}
                     horizontalScrollbarOptions={{ visible: false }}
                   >


### PR DESCRIPTION
### Issue for this PR

Internal follow-up to the diff viewer work.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Routes the diff viewer patch pane scrollbox through the shared `getScrollAcceleration()` handling already used by other TUI scroll areas. This makes mouse/trackpad scrolling in long diffs respect configured scroll acceleration and scroll speed.

### How did you verify your code works?

- Ran `bun run typecheck` from `packages/opencode`.
- Ran `bun test --timeout 30000 test/cli/tui/diff-viewer.test.tsx` from `packages/opencode`.
- Ran `bunx prettier --check src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx`.
- Ran `git diff --check`.
- Started the TUI preview with `bun run dev` and manually verified diff viewer scrolling behavior.
- The pre-push hook also ran the workspace `bun turbo typecheck` successfully.

### Screenshots / recordings

Not included; this changes scrolling behavior rather than static rendering.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR