### PR TITLE
keep session navigation active in prompt modes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -81,6 +81,7 @@ import { DialogVariant } from "./component/dialog-variant"
 
 const appGlobalBindingCommands = [
   "session.list",
+  "session.new",
   "session.quick_switch.1",
   "session.quick_switch.2",
   "session.quick_switch.3",
@@ -94,7 +95,6 @@ const appGlobalBindingCommands = [
 
 const appBindingCommands = [
   "command.palette.show",
-  "session.new",
   "model.list",
   "model.cycle_recent",
   "model.cycle_recent_reverse",

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -79,10 +79,8 @@ import {
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
 
-const appBindingCommands = [
-  "command.palette.show",
+const appGlobalBindingCommands = [
   "session.list",
-  "session.new",
   "session.quick_switch.1",
   "session.quick_switch.2",
   "session.quick_switch.3",
@@ -92,6 +90,11 @@ const appBindingCommands = [
   "session.quick_switch.7",
   "session.quick_switch.8",
   "session.quick_switch.9",
+] as const
+
+const appBindingCommands = [
+  "command.palette.show",
+  "session.new",
   "model.list",
   "model.cycle_recent",
   "model.cycle_recent_reverse",
@@ -927,6 +930,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   useBindings(() => ({
     mode: OPENCODE_BASE_MODE,
     bindings: tuiConfig.keybinds.gather("app", appBindingCommands),
+  }))
+
+  useBindings(() => ({
+    bindings: tuiConfig.keybinds.gather("app.global", appGlobalBindingCommands),
   }))
 
   useBindings(() => ({

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -156,6 +156,8 @@ const sessionGlobalBindingCommands = [
   "session.half.page.down",
 ] as const
 
+const sessionGlobalUnfocusedBindingCommands = ["session.first", "session.last"] as const
+
 const context = createContext<{
   width: number
   sessionID: string
@@ -1066,6 +1068,11 @@ export function Session() {
 
   useBindings(() => ({
     bindings: tuiConfig.keybinds.gather("session.global", sessionGlobalBindingCommands),
+  }))
+
+  useBindings(() => ({
+    enabled: () => renderer.currentFocusedEditor === null,
+    bindings: tuiConfig.keybinds.gather("session.global.unfocused", sessionGlobalUnfocusedBindingCommands),
   }))
 
   useBindings(() => ({

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -133,12 +133,6 @@ const sessionBindingCommands = [
   "session.toggle.actions",
   "session.toggle.scrollbar",
   "session.toggle.generic_tool_output",
-  "session.page.up",
-  "session.page.down",
-  "session.line.up",
-  "session.line.down",
-  "session.half.page.up",
-  "session.half.page.down",
   "session.first",
   "session.last",
   "session.messages_last_user",
@@ -151,6 +145,15 @@ const sessionBindingCommands = [
   "session.parent",
   "session.child.next",
   "session.child.previous",
+] as const
+
+const sessionGlobalBindingCommands = [
+  "session.page.up",
+  "session.page.down",
+  "session.line.up",
+  "session.line.down",
+  "session.half.page.up",
+  "session.half.page.down",
 ] as const
 
 const context = createContext<{
@@ -1059,6 +1062,10 @@ export function Session() {
 
   useBindings(() => ({
     commands: sessionCommands(),
+  }))
+
+  useBindings(() => ({
+    bindings: tuiConfig.keybinds.gather("session.global", sessionGlobalBindingCommands),
   }))
 
   useBindings(() => ({

--- a/packages/opencode/test/cli/tui/keymap.test.tsx
+++ b/packages/opencode/test/cli/tui/keymap.test.tsx
@@ -71,8 +71,14 @@ test("mode-less bindings stay active when opencode mode changes", async () => {
         { name: "session.list", run() {} },
         { name: "session.new", run() {} },
         { name: "session.page.up", run() {} },
+        { name: "session.first", run() {} },
       ],
-      bindings: config.keybinds.gather("test.global", ["session.list", "session.new", "session.page.up"]),
+      bindings: config.keybinds.gather("test.global", [
+        "session.list",
+        "session.new",
+        "session.page.up",
+        "session.first",
+      ]),
     })
     const offBase = keymap.registerLayer({
       mode: OPENCODE_BASE_MODE,
@@ -84,7 +90,7 @@ test("mode-less bindings stay active when opencode mode changes", async () => {
         Array.from(
           keymap.getCommandBindings({
             visibility: "active",
-            commands: ["session.list", "session.new", "session.page.up", "model.list"],
+            commands: ["session.list", "session.new", "session.page.up", "session.first", "model.list"],
           }),
           ([command, bindings]) => [command, bindings.length],
         ),
@@ -114,9 +120,15 @@ test("mode-less bindings stay active when opencode mode changes", async () => {
   const app = await testRender(() => <Harness />)
   try {
     expect(counts).toEqual({
-      base: { "session.list": 1, "session.new": 1, "session.page.up": 2, "model.list": 1 },
-      question: { "session.list": 1, "session.new": 1, "session.page.up": 2, "model.list": 0 },
-      autocomplete: { "session.list": 1, "session.new": 1, "session.page.up": 2, "model.list": 0 },
+      base: { "session.list": 1, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 1 },
+      question: { "session.list": 1, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 0 },
+      autocomplete: {
+        "session.list": 1,
+        "session.new": 1,
+        "session.page.up": 2,
+        "session.first": 2,
+        "model.list": 0,
+      },
     })
   } finally {
     app.renderer.destroy()

--- a/packages/opencode/test/cli/tui/keymap.test.tsx
+++ b/packages/opencode/test/cli/tui/keymap.test.tsx
@@ -4,7 +4,12 @@ import { testRender, useRenderer } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { onCleanup } from "solid-js"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
-import { OpencodeKeymapProvider, registerOpencodeKeymap } from "@/cli/cmd/tui/keymap"
+import {
+  getOpencodeModeStack,
+  OPENCODE_BASE_MODE,
+  OpencodeKeymapProvider,
+  registerOpencodeKeymap,
+} from "@/cli/cmd/tui/keymap"
 
 test("legacy page key aliases compile as page keys", async () => {
   const sequences: Record<string, string[][]> = {}
@@ -47,6 +52,64 @@ test("legacy page key aliases compile as page keys", async () => {
     expect(sequences).toEqual({
       up: [["pageup"]],
       down: [["pagedown"]],
+    })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("mode-less bindings stay active when opencode mode changes", async () => {
+  const counts: Record<string, Record<string, number>> = {}
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offGlobal = keymap.registerLayer({
+      commands: [{ name: "session.list", run() {} }],
+      bindings: config.keybinds.gather("test.global", ["session.list"]),
+    })
+    const offBase = keymap.registerLayer({
+      mode: OPENCODE_BASE_MODE,
+      commands: [{ name: "session.new", run() {} }],
+      bindings: config.keybinds.gather("test.base", ["session.new"]),
+    })
+    const activeCounts = () =>
+      Object.fromEntries(
+        Array.from(
+          keymap.getCommandBindings({ visibility: "active", commands: ["session.list", "session.new"] }),
+          ([command, bindings]) => [command, bindings.length],
+        ),
+      )
+
+    counts.base = activeCounts()
+    const popQuestion = getOpencodeModeStack(keymap).push("question")
+    counts.question = activeCounts()
+    popQuestion()
+    const popAutocomplete = getOpencodeModeStack(keymap).push("autocomplete")
+    counts.autocomplete = activeCounts()
+    popAutocomplete()
+
+    onCleanup(() => {
+      offBase()
+      offGlobal()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    expect(counts).toEqual({
+      base: { "session.list": 1, "session.new": 1 },
+      question: { "session.list": 1, "session.new": 0 },
+      autocomplete: { "session.list": 1, "session.new": 0 },
     })
   } finally {
     app.renderer.destroy()

--- a/packages/opencode/test/cli/tui/keymap.test.tsx
+++ b/packages/opencode/test/cli/tui/keymap.test.tsx
@@ -67,18 +67,25 @@ test("mode-less bindings stay active when opencode mode changes", async () => {
     const config = createTuiResolvedConfig()
     const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
     const offGlobal = keymap.registerLayer({
-      commands: [{ name: "session.list", run() {} }],
-      bindings: config.keybinds.gather("test.global", ["session.list"]),
+      commands: [
+        { name: "session.list", run() {} },
+        { name: "session.new", run() {} },
+        { name: "session.page.up", run() {} },
+      ],
+      bindings: config.keybinds.gather("test.global", ["session.list", "session.new", "session.page.up"]),
     })
     const offBase = keymap.registerLayer({
       mode: OPENCODE_BASE_MODE,
-      commands: [{ name: "session.new", run() {} }],
-      bindings: config.keybinds.gather("test.base", ["session.new"]),
+      commands: [{ name: "model.list", run() {} }],
+      bindings: config.keybinds.gather("test.base", ["model.list"]),
     })
     const activeCounts = () =>
       Object.fromEntries(
         Array.from(
-          keymap.getCommandBindings({ visibility: "active", commands: ["session.list", "session.new"] }),
+          keymap.getCommandBindings({
+            visibility: "active",
+            commands: ["session.list", "session.new", "session.page.up", "model.list"],
+          }),
           ([command, bindings]) => [command, bindings.length],
         ),
       )
@@ -107,9 +114,9 @@ test("mode-less bindings stay active when opencode mode changes", async () => {
   const app = await testRender(() => <Harness />)
   try {
     expect(counts).toEqual({
-      base: { "session.list": 1, "session.new": 1 },
-      question: { "session.list": 1, "session.new": 0 },
-      autocomplete: { "session.list": 1, "session.new": 0 },
+      base: { "session.list": 1, "session.new": 1, "session.page.up": 2, "model.list": 1 },
+      question: { "session.list": 1, "session.new": 1, "session.page.up": 2, "model.list": 0 },
+      autocomplete: { "session.list": 1, "session.new": 1, "session.page.up": 2, "model.list": 0 },
     })
   } finally {
     app.renderer.destroy()


### PR DESCRIPTION
- Fixes #29072.
- Keeps session switch, new session, and quick-switch bindings active outside base mode.
- Keeps message scroll bindings active during question/autocomplete modes.
- Enables first/last message shortcuts when no text editor is focused.