### PR TITLE
fix(opencode): resolve absolute glob roots

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -39,8 +39,8 @@ export const GlobTool = Tool.define(
             },
           })
 
-          let search = params.path ?? ins.directory
-          search = path.isAbsolute(search) ? search : path.resolve(ins.directory, search)
+          const target = resolveGlobTarget(params, ins.directory)
+          const search = target.path
           yield* reference.ensure(search)
           const info = yield* fs.stat(search).pipe(Effect.catch(() => Effect.succeed(undefined)))
           if (info?.type === "File") {
@@ -53,7 +53,7 @@ export const GlobTool = Tool.define(
 
           const limit = 100
           let truncated = false
-          const files = yield* rg.files({ cwd: search, glob: [params.pattern], signal: ctx.abort }).pipe(
+          const files = yield* rg.files({ cwd: search, glob: [target.pattern], signal: ctx.abort }).pipe(
             Stream.mapEffect((file) =>
               Effect.gen(function* () {
                 const full = path.resolve(search, file)
@@ -101,3 +101,30 @@ export const GlobTool = Tool.define(
     }
   }),
 )
+
+function resolveGlobTarget(params: { pattern: string; path?: string }, directory: string) {
+  if (params.path) {
+    return {
+      path: path.isAbsolute(params.path) ? params.path : path.resolve(directory, params.path),
+      pattern: params.pattern,
+    }
+  }
+
+  if (!path.isAbsolute(params.pattern)) {
+    return {
+      path: directory,
+      pattern: params.pattern,
+    }
+  }
+
+  const parsed = path.parse(params.pattern)
+  const parts = params.pattern.slice(parsed.root.length).split(/[\\/]+/).filter(Boolean)
+  const index = parts.findIndex((part) => /[*?[\]{}]/.test(part))
+  const root = index === -1 ? parts.slice(0, -1) : parts.slice(0, index)
+  const pattern = index === -1 ? parts.slice(-1) : parts.slice(index)
+
+  return {
+    path: path.join(parsed.root, ...root),
+    pattern: pattern.join("/") || "*",
+  }
+}

--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -118,6 +118,26 @@ describe("tool.glob", () => {
     }),
   )
 
+  it.instance("matches files from an absolute glob pattern", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const skill = path.join(test.directory, ".config", "opencode", "skills", "test-skill", "SKILL.md")
+      yield* Effect.promise(() => Bun.write(skill, "# Test Skill\n"))
+
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      const result = yield* glob.execute(
+        {
+          pattern: path.join(test.directory, ".config", "opencode", "skills", "**", "SKILL.md"),
+        },
+        ctx,
+      )
+
+      expect(result.metadata.count).toBe(1)
+      expect(result.output).toContain(skill)
+    }),
+  )
+
   it.instance("rejects exact file paths", () =>
     Effect.gen(function* () {
       const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #29437

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Glob tool previously passed an absolute glob pattern directly to ripgrep while keeping the search cwd as the current working directory. With patterns like `/home/user/.config/opencode/skills/**/SKILL.md`, ripgrep walked the current directory tree and compared its relative file output against an absolute glob, which could return no matches and emit permission errors from unrelated directories.

This PR resolves an absolute pattern without an explicit `path` into:

- a concrete search root before the first glob segment
- a relative glob passed to ripgrep from that root

Relative patterns and calls with an explicit `path` keep their existing behavior.

### How did you verify your code works?

- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/tool/glob.test.ts -t "matches files from an absolute glob pattern"`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/tool/glob.test.ts`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push` was attempted; it still fails in unrelated `@opencode-ai/console-support` typecheck due missing Solid/Vite/generated console-core modules.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
