### PR TITLE
fix(opencode): require read before write overwrite

### DIFF
--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -44,6 +44,9 @@ export const WriteTool = Tool.define(
           yield* assertExternalDirectoryEffect(ctx, filepath)
 
           const exists = yield* fs.existsSafe(filepath)
+          if (exists && !hasRead(ctx.messages, filepath, instance.directory)) {
+            throw new Error(`File must be read before overwriting: ${filepath}`)
+          }
           const source = exists ? yield* Bom.readFile(fs, filepath) : { bom: false, text: "" }
           const next = Bom.split(params.content)
           const desiredBom = source.bom || next.bom
@@ -102,3 +105,16 @@ export const WriteTool = Tool.define(
     }
   }),
 )
+
+function hasRead(messages: Tool.Context["messages"], filepath: string, directory: string) {
+  const target = AppFileSystem.normalizePath(filepath)
+  return messages.some((msg) =>
+    msg.parts.some((part) => {
+      if (part.type !== "tool" || part.tool !== "read" || part.state.status !== "completed") return false
+      if (part.state.time.compacted) return false
+      const input = part.state.input.filePath
+      if (typeof input !== "string") return false
+      return AppFileSystem.normalizePath(path.isAbsolute(input) ? input : path.join(directory, input)) === target
+    }),
+  )
+}

--- a/packages/opencode/src/tool/write.txt
+++ b/packages/opencode/src/tool/write.txt
@@ -2,7 +2,7 @@ Writes a file to the local filesystem.
 
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path.
-- If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
+- If this is an existing file, you MUST use the Read tool first to read the file's contents in the current conversation. This tool will fail if you did not read the file first.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -10,7 +10,8 @@ import { Format } from "../../src/format"
 import { Truncate } from "@/tool/truncate"
 import { Tool } from "@/tool/tool"
 import { Agent } from "../../src/agent/agent"
-import { SessionID, MessageID } from "../../src/session/schema"
+import { SessionID, MessageID, PartID } from "../../src/session/schema"
+import type { MessageV2 } from "../../src/session/message-v2"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -25,6 +26,33 @@ const ctx = {
   metadata: () => Effect.void,
   ask: () => Effect.void,
 }
+
+const ctxWithRead = (filePath: string): Tool.Context => ({
+  ...ctx,
+  messages: [
+    {
+      info: {} as MessageV2.Info,
+      parts: [
+        {
+          id: PartID.make("prt_read"),
+          sessionID: ctx.sessionID,
+          messageID: MessageID.make("msg_read"),
+          type: "tool",
+          callID: "call_read",
+          tool: "read",
+          state: {
+            status: "completed",
+            input: { filePath },
+            output: "",
+            title: filePath,
+            metadata: {},
+            time: { start: 0, end: 1 },
+          },
+        } as MessageV2.ToolPart,
+      ],
+    },
+  ],
+})
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -94,12 +122,25 @@ describe("tool.write", () => {
   })
 
   describe("existing file overwrite", () => {
+    it.instance("rejects overwriting an existing file that has not been read", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "existing.txt")
+        yield* Effect.promise(() => fs.writeFile(filepath, "old content", "utf-8"))
+        const exit = yield* run({ filePath: filepath, content: "new content" }).pipe(Effect.exit)
+
+        expect(exit._tag).toBe("Failure")
+        const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+        expect(content).toBe("old content")
+      }),
+    )
+
     it.instance("overwrites existing file content", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance
         const filepath = path.join(test.directory, "existing.txt")
         yield* Effect.promise(() => fs.writeFile(filepath, "old content", "utf-8"))
-        const result = yield* run({ filePath: filepath, content: "new content" })
+        const result = yield* run({ filePath: filepath, content: "new content" }, ctxWithRead(filepath))
 
         expect(result.output).toContain("Wrote file successfully")
         expect(result.metadata.exists).toBe(true)
@@ -116,7 +157,7 @@ describe("tool.write", () => {
         const bom = String.fromCharCode(0xfeff)
         yield* Effect.promise(() => fs.writeFile(filepath, `${bom}using System;\n`, "utf-8"))
 
-        yield* run({ filePath: filepath, content: "using Up;\n" })
+        yield* run({ filePath: filepath, content: "using Up;\n" }, ctxWithRead(filepath))
 
         const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
         expect(content.charCodeAt(0)).toBe(0xfeff)
@@ -133,7 +174,7 @@ describe("tool.write", () => {
           const bom = String.fromCharCode(0xfeff)
           yield* Effect.promise(() => fs.writeFile(filepath, `${bom}using System;\n`, "utf-8"))
 
-          yield* run({ filePath: filepath, content: "using Up;\n" })
+          yield* run({ filePath: filepath, content: "using Up;\n" }, ctxWithRead(filepath))
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content.charCodeAt(0)).toBe(0xfeff)
@@ -161,7 +202,7 @@ describe("tool.write", () => {
         const test = yield* TestInstance
         const filepath = path.join(test.directory, "file.txt")
         yield* Effect.promise(() => fs.writeFile(filepath, "old", "utf-8"))
-        const result = yield* run({ filePath: filepath, content: "new" })
+        const result = yield* run({ filePath: filepath, content: "new" }, ctxWithRead(filepath))
 
         expect(result.metadata).toHaveProperty("filepath", filepath)
         expect(result.metadata).toHaveProperty("exists", true)
@@ -255,7 +296,9 @@ describe("tool.write", () => {
         const readonlyPath = path.join(test.directory, "readonly.txt")
         yield* Effect.promise(() => fs.writeFile(readonlyPath, "test", "utf-8"))
         yield* Effect.promise(() => fs.chmod(readonlyPath, 0o444))
-        const exit = yield* run({ filePath: readonlyPath, content: "new content" }).pipe(Effect.exit)
+        const exit = yield* run({ filePath: readonlyPath, content: "new content" }, ctxWithRead(readonlyPath)).pipe(
+          Effect.exit,
+        )
         expect(exit._tag).toBe("Failure")
       }),
     )


### PR DESCRIPTION
### Issue for this PR

Closes #29451

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The write tool description says existing files must be read first and that the tool will fail if they were not read. The implementation did not enforce that, so an agent could overwrite an existing file without having the previous contents in context.

This PR makes that contract true for existing files. Before overwriting, the write tool now checks the current conversation for a completed, uncompacted `read` tool call for the same file path. New file creation is unchanged.

The tool description was also clarified to say the read must happen in the current conversation.

### How did you verify your code works?

- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/tool/write.test.ts -t "rejects overwriting an existing file that has not been read"`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/tool/write.test.ts`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push` was attempted; it still fails in unrelated `@opencode-ai/console-support` typecheck due missing Solid/Vite/generated console-core modules.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
