### PR TITLE
fix(opencode): defer summarize default agent lookup

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -267,8 +267,8 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     }) {
       yield* revertSvc.cleanup(yield* requireSession(ctx.params.sessionID))
       const messages = yield* SessionError.mapStorageNotFound(session.messages({ sessionID: ctx.params.sessionID }))
-      const defaultAgent = yield* agentSvc.defaultAgent()
-      const currentAgent = messages.findLast((message) => message.info.role === "user")?.info.agent ?? defaultAgent
+      const currentAgent =
+        messages.findLast((message) => message.info.role === "user")?.info.agent ?? (yield* agentSvc.defaultAgent())
 
       yield* compactSvc.create({
         sessionID: ctx.params.sessionID,

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1116,6 +1116,7 @@ const scenarios: Scenario[] = [
     ),
   http.protected
     .post("/session/{sessionID}/summarize", "session.summarize")
+    .inProject({ git: true, config: { default_agent: "explore" } })
     .preserveDatabase()
     .withLlm()
     .seeded((ctx) =>


### PR DESCRIPTION
### Issue for this PR

Closes #29277

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/session/{sessionID}/summarize` now reuses the last user message agent before falling back to the configured default agent. This avoids validating a `default_agent` that is a subagent when the session already has a valid user agent.

The HTTP API exercise now covers summarize with `default_agent: "explore"` to prevent this regression.

### How did you verify your code works?

- `bun run script/httpapi-exercise.ts --mode effect --include session.summarize --progress` failed before the fix with 500, then passed after the fix.
- `bun run test:httpapi`
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts packages/opencode/test/server/httpapi-exercise/index.ts`
- `git diff --check`
- `.husky/pre-push` still fails locally in unrelated `@opencode-ai/console-support` typecheck because Solid/Vite/generated console-core modules are missing in this checkout.

### Screenshots / recordings

N/A, server/API behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR