### PR TITLE
fix(plugin): use codex session-id header

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -638,7 +638,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
       if (input.model.providerID !== "openai") return
       output.headers.originator = "opencode"
       output.headers["User-Agent"] = `opencode/${InstallationVersion} (${os.platform()} ${os.release()}; ${os.arch()})`
-      output.headers.session_id = input.sessionID
+      output.headers["session-id"] = input.sessionID
     },
     "chat.params": async (input, output) => {
       if (input.model.providerID !== "openai") return


### PR DESCRIPTION
## Summary
- use the hyphenated Codex `session-id` header instead of `session_id`
- aligns with upstream OpenAI Codex dropping underscored ID headers: https://github.com/openai/codex/pull/22193

## Testing
- `bun typecheck` from `packages/opencode`