### PR TITLE
fix(opencode): route agent list by directory

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -164,17 +164,25 @@ function planRequest(
   return Effect.gen(function* () {
     const url = requestURL(request)
     const envWorkspaceID = configuredWorkspaceID()
+    const local = shouldStayOnControlPlane(request, url)
     const workspaceID = url.pathname.startsWith("/api/")
       ? selectedV2WorkspaceID(url, sessionWorkspaceID)
       : selectedWorkspaceID(url, sessionWorkspaceID)
     if (workspaceID === InvalidWorkspaceID) return RequestPlan.InvalidWorkspace()
+    // Control-plane reads can carry stale workspace params from clients; route
+    // them by directory instead of requiring the workspace to still exist.
+    if (local)
+      return RequestPlan.Local({
+        directory: defaultDirectory(request, url),
+        workspaceID: envWorkspaceID ?? workspaceID,
+      })
     const workspace = yield* resolveWorkspace(workspaceID, envWorkspaceID)
 
     if (workspaceID && workspace === undefined && !envWorkspaceID) {
       return RequestPlan.MissingWorkspace({ workspaceID })
     }
 
-    if (workspace !== undefined && !envWorkspaceID && !shouldStayOnControlPlane(request, url)) {
+    if (workspace !== undefined && !envWorkspaceID) {
       return yield* planWorkspaceRequest(request, url, workspace)
     }
 

--- a/packages/opencode/src/server/shared/workspace-routing.ts
+++ b/packages/opencode/src/server/shared/workspace-routing.ts
@@ -4,6 +4,7 @@ type Rule = { method?: string; path: string; exact?: boolean; action: "local" | 
 
 const RULES: Array<Rule> = [
   { path: "/experimental/workspace", action: "local" },
+  { method: "GET", path: "/agent", exact: true, action: "local" },
   { path: "/session/status", action: "forward" },
   { method: "GET", path: "/session", action: "local" },
 ]

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -126,6 +126,34 @@ const scenarios: Scenario[] = [
     .status(400, undefined, "status"),
   http.protected.get("/command", "command.list").json(200, array, "status"),
   http.protected.get("/agent", "app.agents").json(200, array, "status"),
+  http.protected
+    .get("/agent", "app.agents.custom")
+    .inProject({
+      git: true,
+      config: {
+        agent: {
+          "custom-primary": {
+            mode: "primary",
+            description: "Custom primary agent",
+          },
+        },
+      },
+    })
+    .at((ctx) => ({
+      path: `/agent?directory=${encodeURIComponent(ctx.directory ?? "")}&workspace=wrk_stale`,
+      headers: ctx.headers(),
+    }))
+    .json(
+      200,
+      (body) => {
+        array(body)
+        check(
+          body.some((item) => isRecord(item) && item.name === "custom-primary" && item.mode === "primary"),
+          "agent list should include custom primary agents from the requested directory",
+        )
+      },
+      "status",
+    ),
   http.protected.get("/skill", "app.skills").json(200, array, "status"),
   http.protected.get("/lsp", "lsp.status").json(200, array),
   http.protected.get("/formatter", "formatter.status").json(200, array),


### PR DESCRIPTION
### Issue for this PR

Closes #29468

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`GET /agent` now stays on the local directory route before workspace lookup. This lets the web client load project custom primary agents even when the request also carries a stale workspace parameter.

The HTTP API exercise adds a regression case for `/agent?directory=...&workspace=wrk_stale` with a custom primary agent in project config.

### How did you verify your code works?

- `bun run script/httpapi-exercise.ts --mode effect --include app.agents.custom --progress` failed before the fix with `Workspace not found: wrk_stale`, then passed after the fix.
- `bun run test:httpapi`
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts packages/opencode/src/server/shared/workspace-routing.ts packages/opencode/test/server/httpapi-exercise/index.ts`
- `git diff --check`
- `.husky/pre-push` still fails locally in unrelated `@opencode-ai/console-support` typecheck because Solid/Vite/generated console-core modules are missing in this checkout.

### Screenshots / recordings

N/A, server/API routing behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR