### PR TITLE
fix(opencode): add LiteLLM Bedrock noop tools

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -137,12 +137,9 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
   )
 
   const tools = resolveTools(input)
-  if (
-    input.model.providerID.includes("github-copilot") &&
-    Object.keys(tools).length === 0 &&
-    hasToolCalls(input.messages)
-  ) {
-    // Copilot needs a tools field when replaying prior tool calls, even if no tools are currently enabled.
+  if (requiresNoopTool(input.model) && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
+    // Some provider gateways need a tools field when replaying prior tool calls,
+    // even if no tools are currently enabled.
     tools["_noop"] = aiTool({
       description: "Do not call this tool. It exists only for API compatibility and must never be invoked.",
       inputSchema: jsonSchema({
@@ -191,6 +188,21 @@ function resolveTools(input: Pick<PrepareInput, "tools" | "agent" | "permission"
     Permission.merge(input.agent.permission, input.permission ?? []),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+}
+
+function requiresNoopTool(model: Provider.Model) {
+  if (model.providerID.includes("github-copilot")) return true
+  if (model.api.npm === "@ai-sdk/amazon-bedrock") return true
+  if (model.providerID.toLowerCase().includes("bedrock")) return true
+  if (model.api.npm !== "@ai-sdk/openai-compatible") return false
+  return model.providerID.toLowerCase().includes("litellm") && isBedrockModelID(model.api.id.toLowerCase())
+}
+
+function isBedrockModelID(id: string) {
+  const parts = id.split(".")
+  const first = parts[0]
+  const vendor = ["us", "eu", "global", "apac", "au", "ca", "sa"].includes(first) ? parts[1] : first
+  return ["amazon", "anthropic", "meta", "mistral", "minimax", "openai"].includes(vendor ?? "")
 }
 
 export function hasToolCalls(messages: ModelMessage[]): boolean {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -909,6 +909,97 @@ describe("session.llm.stream", () => {
   )
 
   it.instance(
+    "sends compatibility tool for LiteLLM Bedrock history with disabled tools",
+    () =>
+      Effect.gen(function* () {
+        const providerID = ProviderID.make("litellm-bedrock")
+        const modelID = ModelID.make("us.anthropic.claude-opus-4-6-v1")
+        const request = waitRequest(
+          "/chat/completions",
+          new Response(createChatStream("Hello"), {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+        )
+
+        const resolved = yield* Provider.use.getModel(providerID, modelID)
+        const sessionID = SessionID.make("session-test-litellm-bedrock-noop")
+        const agent = {
+          name: "test",
+          mode: "subagent",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "deny" }],
+        } satisfies Agent.Info
+
+        yield* drain({
+          user: {
+            id: MessageID.make("msg_user-litellm-bedrock-noop"),
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: agent.name,
+            model: { providerID, modelID: resolved.id },
+          } satisfies MessageV2.User,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [
+            { role: "user", content: "Use the external tool." },
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "tool-call",
+                  toolCallId: "call-litellm-bedrock",
+                  toolName: "mcp_lookup",
+                  input: { query: "status" },
+                },
+              ],
+            },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolCallId: "call-litellm-bedrock",
+                  toolName: "mcp_lookup",
+                  output: { type: "text", value: "ok" },
+                },
+              ],
+            },
+            { role: "user", content: "Continue." },
+          ],
+          tools: {},
+        })
+
+        const capture = yield* Effect.promise(() => request)
+        const tools = capture.body.tools as Array<{ function?: { name?: string } }> | undefined
+        expect(tools?.some((item) => item.function?.name === "_noop")).toBe(true)
+      }),
+    {
+      config: () => ({
+        enabled_providers: ["litellm-bedrock"],
+        provider: {
+          "litellm-bedrock": {
+            name: "LiteLLM Bedrock",
+            npm: "@ai-sdk/openai-compatible",
+            env: [],
+            models: {
+              "us.anthropic.claude-opus-4-6-v1": {
+                name: "Claude Opus 4.6 via Bedrock",
+                tool_call: true,
+                limit: { context: 200000, output: 32000 },
+              },
+            },
+            options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1` },
+          },
+        },
+      }),
+    },
+  )
+
+  it.instance(
     "sends responses API payload for OpenAI models",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #29428

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

LiteLLM-backed Bedrock models can reject follow-up requests that replay prior tool calls if the current request omits `tools`. This can happen in Task subagent sessions after permissions disable the currently available tools, leaving tool-call history but an empty tool set.

This extends the existing `_noop` compatibility tool behavior beyond GitHub Copilot to Bedrock providers and LiteLLM OpenAI-compatible Bedrock model IDs. The `_noop` tool is only added when the resolved tool set is empty and the message history already contains tool calls.

A regression test covers a LiteLLM Bedrock-style OpenAI-compatible provider with prior MCP-like tool history and disabled tools.

### How did you verify your code works?

- `PATH="$HOME/.bun/bin:$PATH" bun test test/session/llm.test.ts -t "sends compatibility tool for LiteLLM Bedrock history with disabled tools"`
- `PATH="$HOME/.bun/bin:$PATH" bun test test/session/llm.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck` from `packages/opencode`
- `PATH="$HOME/.bun/bin:$PATH" bunx prettier --check packages/opencode/src/session/llm/request.ts packages/opencode/test/session/llm.test.ts`
- `git diff --check`
- `.husky/pre-push` still fails in unrelated `@opencode-ai/console-support` typecheck because local dependencies/generated modules such as `@solidjs/*`, `solid-js`, `vite`, and `@opencode-ai/console-core/...` are unavailable; `opencode:typecheck` completed successfully before that failure.

### Screenshots / recordings

N/A - non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR