### PR TITLE
fix(core): report process exit before stdio close

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -92,7 +92,7 @@ const toPlatformError = (
   })
 }
 
-type ExitSignal = Deferred.Deferred<readonly [code: number | null, signal: NodeJS.Signals | null]>
+type ProcessSignal = Deferred.Deferred<readonly [code: number | null, signal: NodeJS.Signals | null]>
 
 export const make = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem
@@ -263,21 +263,28 @@ export const make = Effect.gen(function* () {
   }
 
   const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
-    Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
+    Effect.callback<readonly [NodeChildProcess.ChildProcess, ProcessSignal], PlatformError.PlatformError>((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
-      let end = false
+      let exited = false
+      let closed = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
+      const done = (args: readonly [code: number | null, signal: NodeJS.Signals | null]) => {
+        if (exited) return
+        exited = true
+        exit = args
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
+      }
       proc.on("error", (err) => {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
       proc.on("exit", (...args) => {
-        exit = args
+        done(args)
       })
       proc.on("close", (...args) => {
-        if (end) return
-        end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+        if (closed) return
+        closed = true
+        done(exit ?? args)
       })
       proc.on("spawn", () => {
         resume(Effect.succeed([proc, signal]))

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -89,6 +89,45 @@ describe("cross-spawn spawner", () => {
     )
 
     fx.effect(
+      "returns exit code before inherited stdout pipe closes",
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+
+        const tmp = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+        )
+        const pidfile = path.join(tmp.path, "child.pid")
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(async () => {
+            const pid = Number(await fs.readFile(pidfile, "utf8").catch(() => "0"))
+            if (!pid) return
+            try {
+              process.kill(pid, "SIGKILL")
+            } catch {}
+          }),
+        )
+
+        const handle = yield* js(
+          [
+            'const { spawn } = require("node:child_process")',
+            'const fs = require("node:fs")',
+            `const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 10000)"], { detached: true, stdio: ["ignore", "inherit", "ignore"] })`,
+            `fs.writeFileSync(${JSON.stringify(pidfile)}, String(child.pid))`,
+            "child.unref()",
+          ].join("\n"),
+        )
+        const code = yield* handle.exitCode.pipe(
+          Effect.timeoutOrElse({
+            duration: "1 second",
+            orElse: () => Effect.fail(new Error("timed out waiting for process exit code")),
+          }),
+        )
+        expect(code).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+    )
+
+    fx.effect(
       "returns non-zero exit code",
       Effect.gen(function* () {
         const handle = yield* js("process.exit(42)")

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -481,7 +481,7 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -553,6 +553,14 @@ export const ShellTool = Tool.define(
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
+
+          yield* Fiber.join(output).pipe(
+            Effect.timeoutOrElse({
+              duration: "500 millis",
+              orElse: () => Effect.void,
+            }),
+            Effect.ignore,
+          )
 
           return exit.kind === "exit" ? exit.code : null
         }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1026,6 +1026,50 @@ describe("tool.shell permissions", () => {
 })
 
 describe("tool.shell abort", () => {
+  if (process.platform !== "win32") {
+    it.live(
+      "returns when command exits before inherited stdout closes",
+      () =>
+        runIn(
+          projectRoot,
+          Effect.gen(function* () {
+            const tmp = yield* tmpdirScoped()
+            const pidfile = path.join(tmp, "child.pid")
+            yield* Effect.addFinalizer(() =>
+              Effect.promise(async () => {
+                const pid = Number(
+                  await Bun.file(pidfile)
+                    .text()
+                    .catch(() => "0"),
+                )
+                if (!pid) return
+                try {
+                  process.kill(pid, "SIGKILL")
+                } catch {}
+              }),
+            )
+
+            const result = yield* run({
+              command: `${bin} -e ${squote(
+                [
+                  'const cp = require("node:child_process")',
+                  'const fs = require("node:fs")',
+                  `const child = cp.spawn(process.execPath, ["-e", "setTimeout(() => {}, 10000)"], { detached: true, stdio: ["ignore", "inherit", "ignore"] })`,
+                  `fs.writeFileSync(${JSON.stringify(pidfile)}, String(child.pid))`,
+                  "child.unref()",
+                  'console.log("parent done")',
+                ].join(";"),
+              )}`,
+              description: "Spawn detached child inheriting stdout",
+            })
+            expect(result.metadata.exit).toBe(0)
+            expect(result.output).toContain("parent done")
+          }),
+        ),
+      5_000,
+    )
+  }
+
   it.live(
     "preserves output when aborted",
     () =>


### PR DESCRIPTION
### Issue for this PR

Closes #29294

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The cross-spawn process handle used `close` to complete `exitCode`/`isRunning`/`kill`. If a command exited while a detached descendant still held the stdout pipe open, `close` could be delayed indefinitely and the shell tool stayed `running`.

This changes the process signal to complete on the child `exit` event, with `close` only kept as a fallback if it fires first. The shell tool now waits for its output reader to drain after exit, but only for a short bounded window, so normal output is preserved while inherited pipes can no longer wedge the tool forever.

### How did you verify your code works?

TDD check:

- Before the fix, `PATH="$HOME/.bun/bin:$PATH" bun test test/effect/cross-spawn-spawner.test.ts -t "returns exit code before inherited stdout pipe closes"` failed by timing out after 5000ms.
- After the fix, the same regression test passed.

From `packages/core`:

- `PATH="$HOME/.bun/bin:$PATH" bun test test/effect/cross-spawn-spawner.test.ts` - 25 pass, 0 fail
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck` - passed

From `packages/opencode`:

- `PATH="$HOME/.bun/bin:$PATH" bun test test/tool/shell.test.ts -t "returns when command exits before inherited stdout closes"` - passed
- `PATH="$HOME/.bun/bin:$PATH" bun test test/tool/shell.test.ts` - 24 pass, 0 fail
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck` - passed

From the repo root:

- `PATH="$HOME/.bun/bin:$PATH" bunx prettier --check packages/core/src/cross-spawn-spawner.ts packages/core/test/effect/cross-spawn-spawner.test.ts packages/opencode/src/tool/shell.ts packages/opencode/test/tool/shell.test.ts` - passed
- `git diff --check` - passed
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push` - failed in unrelated `@opencode-ai/console-support` typecheck because local dependencies/generated files are missing (`@solidjs/*`, `solid-js/jsx-runtime`, `vite`, and generated `@opencode-ai/console-core/*` schema modules). `@opencode-ai/core:typecheck` and `opencode:typecheck` completed before that failure.

### Screenshots / recordings

_Not a UI rendering change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
