### PR TITLE
fix(session): stop prompt loop by assistant parent

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1274,7 +1274,7 @@ export const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastAssistant.parentID === lastUser.id
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is MessageV2.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -365,10 +365,10 @@ const succeedVoid = (deferred: Deferred.Deferred<void>) => {
   Effect.runSync(Deferred.succeed(deferred, void 0).pipe(Effect.ignore))
 }
 
-const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
+const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string, id?: MessageID) {
   const session = yield* Session.Service
   const msg = yield* session.updateMessage({
-    id: MessageID.ascending(),
+    id: id ?? MessageID.ascending(),
     role: "user",
     sessionID,
     agent: "build",
@@ -385,11 +385,14 @@ const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: strin
   return msg
 })
 
-const seed = Effect.fn("test.seed")(function* (sessionID: SessionID, opts?: { finish?: string }) {
+const seed = Effect.fn("test.seed")(function* (
+  sessionID: SessionID,
+  opts?: { finish?: string; userID?: MessageID; assistantID?: MessageID },
+) {
   const session = yield* Session.Service
-  const msg = yield* user(sessionID, "hello")
+  const msg = yield* user(sessionID, "hello", opts?.userID)
   const assistant: MessageV2.Assistant = {
-    id: MessageID.ascending(),
+    id: opts?.assistantID ?? MessageID.ascending(),
     role: "assistant",
     parentID: msg.id,
     sessionID,
@@ -455,6 +458,24 @@ noLLMServer.instance(
       if (result.info.role === "assistant") expect(result.info.finish).toBe("stop")
     }),
   { config: cfg },
+)
+
+it.instance("loop exits when a client user id sorts after its assistant id", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const seeded = yield* seed(chat.id, {
+      finish: "stop",
+      userID: MessageID.make("msg_000000000002_web"),
+      assistantID: MessageID.make("msg_000000000001_server"),
+    })
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(result.info.id).toBe(seeded.assistant.id)
+    expect(yield* llm.hits).toHaveLength(0)
+  }),
 )
 
 it.instance("loop exits without an LLM request for interrupted orphan tool calls", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #29478

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionPrompt.run` used `lastUser.id < lastAssistant.id` to decide whether a finished assistant message should stop the prompt loop. Web clients can submit their own user message IDs, and those IDs can sort after the server-created assistant ID even when the assistant is the final answer for that user message.

This switches the stop condition to the actual turn relationship: `lastAssistant.parentID === lastUser.id`. The loop now exits when the latest finished assistant answers the latest user message, independent of client/server ID ordering.

The regression test seeds a Web-style user ID that sorts after its assistant ID and verifies the loop returns that finished assistant without making another LLM request.

### How did you verify your code works?

- `PATH="$HOME/.bun/bin:$PATH" bun test test/session/prompt.test.ts -t "loop exits when a client user id sorts after its assistant id"`
  - Red before the fix: expected the seeded assistant ID, received a new assistant ID from an extra LLM call.
  - Green after the fix: 1 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun test test/session/prompt.test.ts`
  - 55 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck` from `packages/opencode`.
- `PATH="$HOME/.bun/bin:$PATH" bun x prettier --check src/session/prompt.ts test/session/prompt.test.ts`.
- `git diff --check`.
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push` currently fails in unrelated `@opencode-ai/console-support` typecheck because local dependencies/generated console-core modules are missing (`@solidjs/*`, `solid-js/jsx-runtime`, `vite`, `@opencode-ai/console-core/*`). The touched `opencode` package typecheck completed separately and passed.

### Screenshots / recordings

N/A - backend/session loop fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR