### PR TITLE
fix(server): honor workspace header in routing

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -66,17 +66,26 @@ function configuredWorkspaceID(): WorkspaceID | undefined {
   return Flag.OPENCODE_WORKSPACE_ID ? WorkspaceID.make(Flag.OPENCODE_WORKSPACE_ID) : undefined
 }
 
-function selectedWorkspaceID(url: URL, sessionWorkspaceID?: WorkspaceID): WorkspaceID | undefined {
-  const workspaceParam = url.searchParams.get("workspace")
+function selectedWorkspaceParam(request: HttpServerRequest.HttpServerRequest, url: URL): string | undefined {
+  return url.searchParams.get("workspace") ?? request.headers["x-opencode-workspace"]
+}
+
+function selectedWorkspaceID(
+  request: HttpServerRequest.HttpServerRequest,
+  url: URL,
+  sessionWorkspaceID?: WorkspaceID,
+): WorkspaceID | undefined {
+  const workspaceParam = selectedWorkspaceParam(request, url)
   return sessionWorkspaceID ?? (workspaceParam ? WorkspaceID.make(workspaceParam) : undefined)
 }
 
 function selectedV2WorkspaceID(
+  request: HttpServerRequest.HttpServerRequest,
   url: URL,
   sessionWorkspaceID?: WorkspaceID,
 ): WorkspaceID | typeof InvalidWorkspaceID | undefined {
   if (sessionWorkspaceID) return sessionWorkspaceID
-  const workspaceParam = url.searchParams.get("workspace")
+  const workspaceParam = selectedWorkspaceParam(request, url)
   if (!workspaceParam) return undefined
   const workspaceID = Schema.decodeUnknownOption(WorkspaceID)(workspaceParam)
   if (Option.isNone(workspaceID)) return InvalidWorkspaceID
@@ -165,8 +174,8 @@ function planRequest(
     const url = requestURL(request)
     const envWorkspaceID = configuredWorkspaceID()
     const workspaceID = url.pathname.startsWith("/api/")
-      ? selectedV2WorkspaceID(url, sessionWorkspaceID)
-      : selectedWorkspaceID(url, sessionWorkspaceID)
+      ? selectedV2WorkspaceID(request, url, sessionWorkspaceID)
+      : selectedWorkspaceID(request, url, sessionWorkspaceID)
     if (workspaceID === InvalidWorkspaceID) return RequestPlan.InvalidWorkspace()
     const workspace = yield* resolveWorkspace(workspaceID, envWorkspaceID)
 

--- a/packages/opencode/test/server/httpapi-workspace-routing.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace-routing.test.ts
@@ -526,4 +526,38 @@ describe("HttpApi workspace routing middleware", () => {
       })
     }),
   )
+
+  it.live("routes local workspace requests from workspace header", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      const workspaceDir = path.join(dir, ".workspace-local")
+      const workspace = yield* createLocalWorkspace({
+        projectID: project.project.id,
+        type: "local-header-target",
+        directory: workspaceDir,
+      })
+
+      yield* HttpRouter.add(
+        "POST",
+        "/probe",
+        Effect.gen(function* () {
+          const route = yield* WorkspaceRouteContext
+          return yield* HttpServerResponse.json({ directory: route.directory, workspaceID: route.workspaceID })
+        }),
+      ).pipe(Layer.provide(workspaceRoutingTestLayer), HttpRouter.serve, Layer.build)
+
+      const response = yield* HttpClientRequest.post("/probe").pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", dir),
+        HttpClientRequest.setHeader("x-opencode-workspace", workspace.id),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toEqual({
+        directory: workspaceDir,
+        workspaceID: workspace.id,
+      })
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #29468

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Workspace routing selected a workspace only from the `workspace` query parameter. The generated SDK keeps `x-opencode-workspace` as a header for non-GET requests such as `POST /session/:id/prompt_async`, so Web could load/list agents in the selected workspace on GET routes but submit prompts in a different instance context on POST routes.

This makes workspace routing also read `x-opencode-workspace`, matching the existing `x-opencode-directory` fallback. Local workspace POST requests now route to the selected workspace target instead of the fallback directory.

### How did you verify your code works?

- `PATH="$HOME/.bun/bin:$PATH" bun test test/server/httpapi-workspace-routing.test.ts -t "routes local workspace requests from workspace header"`
  - Red before the fix: response used the directory header and no workspace id instead of the selected workspace target.
  - Green after the fix: 1 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun test test/server/httpapi-workspace-routing.test.ts`
  - 10 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun test test/server/httpapi-promptasync-context.test.ts`
  - 2 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun test test/server/httpapi-query-schema-drift.test.ts`
  - 12 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" bun typecheck` from `packages/opencode`.
- `PATH="$HOME/.bun/bin:$PATH" bun x prettier --check src/server/routes/instance/httpapi/middleware/workspace-routing.ts test/server/httpapi-workspace-routing.test.ts`.
- `git diff --check`.
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push` currently fails in unrelated `@opencode-ai/console-support` typecheck because local dependencies/generated console-core modules are missing (`@solidjs/*`, `solid-js/jsx-runtime`, `vite`, `@opencode-ai/console-core/*`). The touched `opencode` package typecheck completed separately and passed.

### Screenshots / recordings

N/A - server routing fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR