### PR TITLE
fix(core): accept omitted response annotations

### DIFF
--- a/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
@@ -428,29 +428,31 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                     type: z.literal("output_text"),
                     text: z.string(),
                     logprobs: LOGPROBS_SCHEMA.nullish(),
-                    annotations: z.array(
-                      z.discriminatedUnion("type", [
-                        z.object({
-                          type: z.literal("url_citation"),
-                          start_index: z.number(),
-                          end_index: z.number(),
-                          url: z.string(),
-                          title: z.string(),
-                        }),
-                        z.object({
-                          type: z.literal("file_citation"),
-                          file_id: z.string(),
-                          filename: z.string().nullish(),
-                          index: z.number().nullish(),
-                          start_index: z.number().nullish(),
-                          end_index: z.number().nullish(),
-                          quote: z.string().nullish(),
-                        }),
-                        z.object({
-                          type: z.literal("container_file_citation"),
-                        }),
-                      ]),
-                    ),
+                    annotations: z
+                      .array(
+                        z.discriminatedUnion("type", [
+                          z.object({
+                            type: z.literal("url_citation"),
+                            start_index: z.number(),
+                            end_index: z.number(),
+                            url: z.string(),
+                            title: z.string(),
+                          }),
+                          z.object({
+                            type: z.literal("file_citation"),
+                            file_id: z.string(),
+                            filename: z.string().nullish(),
+                            index: z.number().nullish(),
+                            start_index: z.number().nullish(),
+                            end_index: z.number().nullish(),
+                            quote: z.string().nullish(),
+                          }),
+                          z.object({
+                            type: z.literal("container_file_citation"),
+                          }),
+                        ]),
+                      )
+                      .default([]),
                   }),
                 ),
               }),

--- a/packages/core/test/github-copilot/openai-responses-language-model.test.ts
+++ b/packages/core/test/github-copilot/openai-responses-language-model.test.ts
@@ -1,0 +1,76 @@
+import { OpenAIResponsesLanguageModel } from "@opencode-ai/core/github-copilot/responses/openai-responses-language-model"
+import type { LanguageModelV3Prompt } from "@ai-sdk/provider"
+import type { FetchFunction } from "@ai-sdk/provider-utils"
+import { describe, expect, mock, test } from "bun:test"
+
+const TEST_PROMPT: LanguageModelV3Prompt = [{ role: "user", content: [{ type: "text", text: "Hello" }] }]
+
+function createMockFetch(response: unknown): FetchFunction {
+  return Object.assign(
+    mock(async () => {
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    }),
+    { preconnect: () => {} },
+  )
+}
+
+function createModel(fetch: FetchFunction) {
+  return new OpenAIResponsesLanguageModel("gpt-5.5", {
+    provider: "test.responses",
+    url: () => "https://api.test.com/responses",
+    headers: () => ({ Authorization: "Bearer test-token" }),
+    fetch,
+  })
+}
+
+describe("OpenAIResponsesLanguageModel.doGenerate", () => {
+  test("accepts output_text without annotations", async () => {
+    const model = createModel(
+      createMockFetch({
+        id: "resp_1",
+        created_at: 1710000000,
+        model: "gpt-5.5",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            id: "msg_1",
+            content: [
+              {
+                type: "output_text",
+                text: "Hello",
+                logprobs: null,
+              },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: 1,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens: 1,
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      }),
+    )
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    expect(result.content).toMatchObject([
+      {
+        type: "text",
+        text: "Hello",
+        providerMetadata: {
+          openai: {
+            itemId: "msg_1",
+          },
+        },
+      },
+    ])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29187

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some OpenAI-compatible Responses endpoints omit `output_text.annotations` when there are no annotations. The current non-streaming Responses parser requires that field, so a valid text response is rejected before opencode can return the assistant message.

This treats omitted annotations as an empty array while keeping the existing annotation schema unchanged when providers do send annotations.

### How did you verify your code works?

- `bun test test/github-copilot/openai-responses-language-model.test.ts -t "accepts output_text without annotations"` failed before the fix with `output.0.content.0.annotations` missing, then passed after the fix.
- `bun test test/github-copilot/openai-responses-language-model.test.ts`
- `bun test test/github-copilot`
- `bun typecheck`
- `bun x prettier --check src/github-copilot/responses/openai-responses-language-model.ts test/github-copilot/openai-responses-language-model.test.ts`
- `git diff --check`
- `.husky/pre-push` still fails in unrelated `@opencode-ai/console-support` because local dependencies/generated modules such as `@solidjs/*`, `solid-js/jsx-runtime`, `vite`, and `@opencode-ai/console-core/*` are missing. The touched `@opencode-ai/core` package typecheck passed.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
