### PR TITLE
fix(desktop): inject sidecar version define

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -51,6 +51,7 @@ await Bun.build({
   sourcemap: "linked",
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_MIGRATIONS: JSON.stringify(migrations),
     OPENCODE_MODELS_DEV: generated.modelsData,
     OPENCODE_CHANNEL: `'${Script.channel}'`,

--- a/packages/opencode/test/script/build-node.test.ts
+++ b/packages/opencode/test/script/build-node.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test"
+import path from "path"
+
+test("node sidecar build injects the opencode version", async () => {
+  const source = await Bun.file(path.join(import.meta.dir, "../../script/build-node.ts")).text()
+  const defineBlock = source.match(/define:\s*{(?<body>[\s\S]*?)\n\s*},\n\s*files:/)?.groups?.body
+
+  expect(defineBlock).toContain("OPENCODE_VERSION")
+  expect(defineBlock).toContain("Script.version")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29460

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop app builds its local opencode server from `packages/opencode/script/build-node.ts`. That build only injected `OPENCODE_CHANNEL`, so the sidecar could fall back to `InstallationVersion === "local"` even in a release channel.

That makes dependency setup try to install `@opencode-ai/plugin@local`, matching the install failure reported in #29460 and the related Windows desktop reports such as #28449. This injects `OPENCODE_VERSION` into the node sidecar build, matching the main opencode build.

### How did you verify your code works?

- `bun test test/script/build-node.test.ts -t "node sidecar build injects the opencode version"` failed before the fix because `OPENCODE_VERSION` was missing from the define block, then passed after the fix.
- `bun test test/script/build-node.test.ts`
- `bun typecheck`
- `bun x prettier --check script/build-node.ts test/script/build-node.test.ts`
- `git diff --check`
- `OPENCODE_CHANNEL=latest OPENCODE_VERSION=1.15.10 bun script/build-node.ts`
- Confirmed the generated ignored sidecar output contains `InstallationVersion = "1.15.10"`.
- `.husky/pre-push` still fails in unrelated `@opencode-ai/console-support` because local dependencies/generated modules such as `@solidjs/*`, `solid-js/jsx-runtime`, `vite`, and `@opencode-ai/console-core/*` are missing. The touched `opencode` package typecheck passed.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
