### PR TITLE
fix(core): encode optional transformed fields

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -22,7 +22,7 @@ export const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))
  */
 export const optionalOmitUndefined = <S extends Schema.Top>(schema: S) =>
   Schema.optionalKey(schema).pipe(
-    Schema.decodeTo(Schema.optional(schema), {
+    Schema.decodeTo(Schema.optional(Schema.toType(schema)), {
       decode: SchemaGetter.passthrough({ strict: false }),
       encode: SchemaGetter.transformOptional(Option.filter((value) => value !== undefined)),
     }),

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { DateTime, Schema } from "effect"
+import { optionalOmitUndefined } from "@opencode-ai/core/schema"
+import { V2Schema } from "@opencode-ai/core/v2-schema"
+
+describe("optionalOmitUndefined", () => {
+  test("omits undefined while preserving transformed schema encoding", () => {
+    const schema = Schema.Struct({
+      timestamp: optionalOmitUndefined(V2Schema.DateTimeUtcFromMillis),
+    })
+
+    expect(Schema.encodeUnknownSync(schema)({ timestamp: DateTime.makeUnsafe(123) })).toEqual({ timestamp: 123 })
+    expect(Object.hasOwn(Schema.encodeUnknownSync(schema)({ timestamp: undefined }), "timestamp")).toBe(false)
+  })
+})

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -438,6 +438,30 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "lists v2 sessions with archived timestamps",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const session = yield* createSession({ title: "archived v2" })
+        const archived = 1779479694402
+        yield* Session.Service.use((svc) => svc.setArchived({ sessionID: session.id, time: archived }))
+
+        const response = yield* request(`/api/session?limit=10`, {
+          headers: { "x-opencode-directory": test.directory },
+        })
+
+        const failure = response.status === 200 ? "" : yield* Effect.promise(() => response.clone().text())
+        expect(response.status, failure).toBe(200)
+        const body = yield* responseJson(response)
+        const item = (body as { items: Array<{ id: string; time: { archived?: number } }> }).items.find(
+          (item) => item.id === session.id,
+        )
+        expect(item?.time.archived).toBe(archived)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "returns v2 public not found errors for missing sessions",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #28959

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes `optionalOmitUndefined` so optional fields backed by transformed schemas encode from the schema type, not from the schema's encoded shape. This prevents `DateTime` values from being converted to epoch milliseconds and then validated again as `DateTime.Utc`.

The visible regression was `GET /api/session` returning `InvalidRequestError` when an archived session was present, because `time.archived` uses the shared optional helper with a DateTime millis schema.

### How did you verify your code works?

- `bun test test/schema.test.ts` from `packages/core`
- `bun test test/server/httpapi-session.test.ts` from `packages/opencode`
- `bun test test/session/session-schema.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/opencode`
- `bun x prettier --check packages/core/src/schema.ts packages/core/test/schema.test.ts packages/opencode/test/server/httpapi-session.test.ts`
- `git diff --check`
- `.husky/pre-push` was also run; it fails in unrelated `@opencode-ai/console-support` typecheck because local dependencies for `@solidjs/*`, `solid-js/jsx-runtime`, `vite`, and generated `@opencode-ai/console-core/*` modules are missing. The touched package typechecks above pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
