### PR TITLE
fix(lsp): bootstrap symbol requests

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/lsp.ts
+++ b/packages/opencode/src/cli/cmd/debug/lsp.ts
@@ -1,4 +1,5 @@
 import { LSP } from "@/lsp/lsp"
+import { LSPWorkspaceSymbol } from "@/lsp/workspace-symbol"
 import { Effect } from "effect"
 import { effectCmd } from "../../effect-cmd"
 import { cmd } from "../cmd"
@@ -34,7 +35,7 @@ export const SymbolsCommand = effectCmd({
   builder: (yargs) => yargs.positional("query", { type: "string", demandOption: true }),
   handler: Effect.fn("Cli.debug.lsp.symbols")(function* (args) {
     using _ = Log.Default.time("symbols")
-    const results = yield* LSP.Service.use((lsp) => lsp.workspaceSymbol(args.query))
+    const results = yield* LSPWorkspaceSymbol.search(args.query)
     process.stdout.write(JSON.stringify(results, null, 2) + EOL)
   }),
 })

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -428,6 +428,7 @@ export const layer = Layer.effect(
 
     const documentSymbol = Effect.fn("LSP.documentSymbol")(function* (uri: string) {
       const file = fileURLToPath(uri)
+      yield* touchFile(file)
       const results = yield* run(file, (client) =>
         client.connection.sendRequest("textDocument/documentSymbol", { textDocument: { uri } }).catch(() => []),
       )

--- a/packages/opencode/src/lsp/workspace-symbol.ts
+++ b/packages/opencode/src/lsp/workspace-symbol.ts
@@ -1,0 +1,49 @@
+import * as InstanceState from "@/effect/instance-state"
+import { Ripgrep } from "@/file/ripgrep"
+import { LSP } from "@/lsp/lsp"
+import path from "path"
+import { Effect, Stream } from "effect"
+
+const seedLimit = 200
+const ignoredExtensions = new Set([".json", ".jsonc", ".yaml", ".yml", ".toml", ".md", ".txt", ".lock"])
+
+export const search = Effect.fn("LSPWorkspaceSymbol.search")(function* (query: string) {
+  const lsp = yield* LSP.Service
+  const existing = yield* lsp.workspaceSymbol(query)
+  if (existing.length) return existing
+
+  const ripgrep = yield* Ripgrep.Service
+  const instance = yield* InstanceState.context
+  const matches = query
+    ? yield* ripgrep.search({ cwd: instance.directory, pattern: query, limit: seedLimit }).pipe(
+        Effect.map((result) => result.items.map((item) => item.path.text)),
+        Effect.catch(() => Effect.succeed([])),
+      )
+    : []
+  const files = matches.length
+    ? matches
+    : yield* ripgrep.files({ cwd: instance.directory }).pipe(
+        Stream.take(seedLimit),
+        Stream.runCollect,
+        Effect.map((chunk) => [...chunk]),
+        Effect.catch(() => Effect.succeed([])),
+      )
+  const seeded = new Set<string>()
+
+  for (const file of files) {
+    const extension = path.extname(file) || file
+    if (ignoredExtensions.has(extension)) continue
+    if (seeded.has(extension)) continue
+
+    const absolute = path.join(instance.directory, file)
+    if (!(yield* lsp.hasClients(absolute))) continue
+
+    seeded.add(extension)
+    yield* lsp.touchFile(absolute)
+  }
+
+  if (!seeded.size) return []
+  return yield* lsp.workspaceSymbol(query)
+})
+
+export * as LSPWorkspaceSymbol from "./workspace-symbol"

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -1,6 +1,7 @@
 import * as InstanceState from "@/effect/instance-state"
 import { File } from "@/file"
 import { Ripgrep } from "@/file/ripgrep"
+import { LSPWorkspaceSymbol } from "@/lsp/workspace-symbol"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
@@ -27,8 +28,8 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
       })
     })
 
-    const findSymbol = Effect.fn("FileHttpApi.findSymbol")(function* () {
-      return []
+    const findSymbol = Effect.fn("FileHttpApi.findSymbol")(function* (ctx: { query: { query: string } }) {
+      return yield* LSPWorkspaceSymbol.search(ctx.query.query)
     })
 
     const list = Effect.fn("FileHttpApi.list")(function* (ctx: { query: { path: string } }) {

--- a/packages/opencode/test/fixture/lsp/fake-lsp-server.js
+++ b/packages/opencode/test/fixture/lsp/fake-lsp-server.js
@@ -6,6 +6,7 @@ let lastChange = null
 let initializeParams = null
 let diagnosticRequestCount = 0
 let registeredCapability = false
+const openedDocuments = new Set()
 const pendingClientRequests = new Map()
 let pullConfig = {
   delayMs: 0,
@@ -139,12 +140,14 @@ function handle(raw) {
   }
 
   if (data.method === "textDocument/didOpen") {
+    if (data.params?.textDocument?.uri) openedDocuments.add(data.params.textDocument.uri)
     maybeRegister("didOpen")
     return
   }
 
   if (data.method === "textDocument/didChange") {
     lastChange = data.params
+    if (data.params?.textDocument?.uri) openedDocuments.add(data.params.textDocument.uri)
     maybeRegister("didChange")
     return
   }
@@ -232,6 +235,51 @@ function handle(raw) {
         items: workspaceDiagnosticsForIdentifier(data.params?.identifier ?? ""),
       },
       workspaceDelayForIdentifier(data.params?.identifier ?? ""),
+    )
+    return
+  }
+
+  if (data.method === "textDocument/documentSymbol") {
+    if (!openedDocuments.has(data.params?.textDocument?.uri)) {
+      sendResponse(data.id, [])
+      return
+    }
+    sendResponse(data.id, [
+      {
+        name: "FakeDocumentSymbol",
+        kind: 12,
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 18 },
+        },
+        selectionRange: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 18 },
+        },
+      },
+    ])
+    return
+  }
+
+  if (data.method === "workspace/symbol") {
+    const firstDocument = Array.from(openedDocuments)[0]
+    sendResponse(
+      data.id,
+      firstDocument
+        ? [
+            {
+              name: data.params?.query || "FakeWorkspaceSymbol",
+              kind: 12,
+              location: {
+                uri: firstDocument,
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 0, character: 18 },
+                },
+              },
+            },
+          ]
+        : [],
     )
     return
   }

--- a/packages/opencode/test/lsp/index.test.ts
+++ b/packages/opencode/test/lsp/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, spyOn } from "bun:test"
 import path from "path"
+import { pathToFileURL } from "url"
 import { Deferred, Effect, Layer } from "effect"
 import { Bus } from "@/bus"
 import { Config } from "@/config/config"
@@ -110,6 +111,32 @@ describe("lsp.spawn", () => {
           yield* lsp.touchFile(file)
           yield* awaitWithTimeout(Deferred.await(updated), "lsp.updated event was not published")
         }),
+      {
+        config: {
+          lsp: {
+            fake: {
+              command: [process.execPath, fakeServerPath],
+              extensions: [".repro"],
+            },
+          },
+        },
+      },
+    ),
+  )
+
+  it.live("opens documents before requesting document symbols", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        LSP.Service.use((lsp) =>
+          Effect.gen(function* () {
+            const file = path.join(dir, "sample.repro")
+            yield* Effect.promise(() => Bun.write(file, "function test() {}\n"))
+
+            const result = yield* lsp.documentSymbol(pathToFileURL(file).href)
+
+            expect(result).toContainEqual(expect.objectContaining({ name: "FakeDocumentSymbol" }))
+          }),
+        ),
       {
         config: {
           lsp: {

--- a/packages/opencode/test/server/httpapi-file.test.ts
+++ b/packages/opencode/test/server/httpapi-file.test.ts
@@ -10,6 +10,7 @@ import { disposeAllInstances, tmpdir } from "../fixture/fixture"
 void Log.init({ print: false })
 
 const context = Context.empty() as Context.Context<unknown>
+const fakeServerPath = path.join(__dirname, "../fixture/lsp/fake-lsp-server.js")
 
 function request(route: string, directory: string, query?: Record<string, string>) {
   const url = new URL(`http://localhost${route}`)
@@ -72,5 +73,25 @@ describe("file HttpApi", () => {
 
     expect(symbols.status).toBe(200)
     expect(await symbols.json()).toEqual([])
+  })
+
+  test("serves workspace symbols through configured LSP", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        lsp: {
+          fake: {
+            command: [process.execPath, fakeServerPath],
+            extensions: [".repro"],
+          },
+        },
+      },
+    })
+    await Bun.write(path.join(tmp.path, "hello.repro"), "function HelloSymbol() {}\n")
+
+    const symbols = await request(FilePaths.findSymbol, tmp.path, { query: "HelloSymbol" })
+
+    expect(symbols.status).toBe(200)
+    expect(await symbols.json()).toContainEqual(expect.objectContaining({ name: "HelloSymbol" }))
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #29111

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bootstraps LSP symbol lookups instead of returning empty results when no client exists yet.

- Opens documents before `textDocument/documentSymbol` requests.
- Routes `/find/symbol` and `opencode debug lsp symbols` through a shared workspace-symbol bootstrap path.
- Seeds LSP clients from project files matching the symbol query, with a bounded fallback scan and non-code config files filtered out.

### How did you verify your code works?

- `bun test test/server/httpapi-file.test.ts`
- `bun test test/lsp/index.test.ts test/lsp/lifecycle.test.ts test/tool/lsp.test.ts`
- `bun typecheck`
- `bun x prettier --check packages/opencode/src/lsp/lsp.ts packages/opencode/src/lsp/workspace-symbol.ts packages/opencode/src/cli/cmd/debug/lsp.ts packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts packages/opencode/test/fixture/lsp/fake-lsp-server.js packages/opencode/test/lsp/index.test.ts packages/opencode/test/server/httpapi-file.test.ts`
- `git diff --check`
- Manual: a temp project with the fake LSP returned `HelloSymbol` from `opencode debug lsp symbols HelloSymbol` and exited 0.
- `.husky/pre-push` still fails in unrelated `@opencode-ai/console-support` typecheck because local dependencies/generated console modules such as `@solidjs/*`, `solid-js/jsx-runtime`, `vite`, and `@opencode-ai/console-core/*` are missing. The touched `opencode` package typecheck passes.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR