### PR TITLE
fix(acp): flush updated text chunks

### DIFF
--- a/packages/opencode/src/acp-next/event.ts
+++ b/packages/opencode/src/acp-next/event.ts
@@ -40,6 +40,7 @@ export class Subscription {
   private readonly abort = new AbortController()
   private readonly shellSnapshots = new Map<string, string>()
   private readonly toolStarts = new Set<string>()
+  private readonly streamedText = new Map<string, string>()
   private started = false
 
   constructor(
@@ -105,6 +106,13 @@ export class Subscription {
     const sessionId = part.sessionID || event.properties.sessionID
     const session = await Effect.runPromise(this.input.session.tryGet(sessionId))
     if (!session) return
+    const known = await Effect.runPromise(
+      this.input.session.tryGetPartMetadata({
+        sessionId: session.id,
+        messageId: part.messageID,
+        partId: part.id,
+      }),
+    )
 
     await Effect.runPromise(
       this.input.session.recordPartMetadata({
@@ -112,12 +120,19 @@ export class Subscription {
         messageId: part.messageID,
         partId: part.id,
         partType: part.type,
-        role: part.type === "reasoning" ? "assistant" : undefined,
+        role: part.type === "reasoning" ? "assistant" : known?.role,
         ignored: part.type === "text" ? part.ignored : undefined,
         toolCallId: part.type === "tool" ? part.callID : undefined,
         metadata: "metadata" in part ? part.metadata : undefined,
       }),
     )
+    if (part.type === "text" || part.type === "reasoning") {
+      if (known?.role !== "assistant") return
+      if (known.partType !== part.type) return
+      if (part.type === "text" && (known.ignored === true || part.ignored === true)) return
+      await this.flushUpdatedText(session.id, part.messageID, part.id, part.type, part.text)
+      return
+    }
     if (part.type === "tool") {
       await this.handleToolPart(session.id, part)
     }
@@ -152,6 +167,7 @@ export class Subscription {
           },
         },
       })
+      this.appendStreamedText(session.id, props.messageID, props.partID, props.delta)
       return
     }
 
@@ -167,7 +183,44 @@ export class Subscription {
           },
         },
       })
+      this.appendStreamedText(session.id, props.messageID, props.partID, props.delta)
     }
+  }
+
+  private async flushUpdatedText(
+    sessionId: string,
+    messageId: string,
+    partId: string,
+    partType: "text" | "reasoning",
+    text: string,
+  ) {
+    const key = this.streamedTextKey(sessionId, messageId, partId)
+    const streamed = this.streamedText.get(key) ?? ""
+    if (!text.startsWith(streamed)) return
+    const delta = text.slice(streamed.length)
+    if (delta.length === 0) return
+
+    await this.input.connection.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: partType === "text" ? "agent_message_chunk" : "agent_thought_chunk",
+        messageId,
+        content: {
+          type: "text",
+          text: delta,
+        },
+      },
+    })
+    this.streamedText.set(key, text)
+  }
+
+  private appendStreamedText(sessionId: string, messageId: string, partId: string, delta: string) {
+    const key = this.streamedTextKey(sessionId, messageId, partId)
+    this.streamedText.set(key, (this.streamedText.get(key) ?? "") + delta)
+  }
+
+  private streamedTextKey(sessionId: string, messageId: string, partId: string) {
+    return `${sessionId}:${messageId}:${partId}`
   }
 
   private async fetchPartMetadata(sessionId: string, cwd: string, messageId: string, partId: string) {

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -146,6 +146,8 @@ export class Agent implements ACPAgent {
   private eventStarted = false
   private shellSnapshots = new Map<string, string>()
   private toolStarts = new Set<string>()
+  private streamedText = new Map<string, string>()
+  private partMetadata = new Map<string, { role: Role; type: string; ignored?: boolean }>()
   private permissionQueues = new Map<string, Promise<void>>()
   private permissionOptions: PermissionOption[] = [
     { optionId: "once", kind: "allow_once", name: "Allow once" },
@@ -427,11 +429,18 @@ export class Agent implements ACPAgent {
           }
         }
 
-        // ACP clients already know the prompt they just submitted, so replaying
-        // live user parts duplicates the message. We still replay user history in
-        // loadSession() and forkSession() via processMessage().
-        if (part.type !== "text" && part.type !== "file") return
+        if (part.type === "text" || part.type === "reasoning") {
+          const metadata = this.partMetadata.get(this.partKey(sessionId, part.messageID, part.id))
+          if (metadata?.role !== "assistant") return
+          if (metadata.type !== part.type) return
+          if (part.type === "text" && (metadata.ignored === true || part.ignored === true)) return
+          await this.flushUpdatedText(sessionId, part.messageID, part.id, part.type, part.text)
+          return
+        }
 
+        // ACP clients already know the prompt they just submitted, so replaying
+        // live user/file parts duplicates the message. We still replay user
+        // history in loadSession() and forkSession() via processMessage().
         return
       }
 
@@ -460,6 +469,11 @@ export class Agent implements ACPAgent {
 
         const part = message.parts.find((p) => p.id === props.partID)
         if (!part) return
+        this.partMetadata.set(this.partKey(sessionId, props.messageID, props.partID), {
+          role: message.info.role,
+          type: part.type,
+          ignored: part.type === "text" ? part.ignored : undefined,
+        })
 
         if (part.type === "text" && props.field === "text" && part.ignored !== true) {
           await this.connection
@@ -477,6 +491,7 @@ export class Agent implements ACPAgent {
             .catch((error) => {
               log.error("failed to send text delta to ACP", { error })
             })
+          this.appendStreamedText(sessionId, props.messageID, props.partID, props.delta)
           return
         }
 
@@ -496,10 +511,47 @@ export class Agent implements ACPAgent {
             .catch((error) => {
               log.error("failed to send reasoning delta to ACP", { error })
             })
+          this.appendStreamedText(sessionId, props.messageID, props.partID, props.delta)
         }
         return
       }
     }
+  }
+
+  private async flushUpdatedText(
+    sessionId: string,
+    messageId: string,
+    partId: string,
+    partType: "text" | "reasoning",
+    text: string,
+  ) {
+    const key = this.partKey(sessionId, messageId, partId)
+    const streamed = this.streamedText.get(key) ?? ""
+    if (!text.startsWith(streamed)) return
+    const delta = text.slice(streamed.length)
+    if (delta.length === 0) return
+
+    await this.connection.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: partType === "text" ? "agent_message_chunk" : "agent_thought_chunk",
+        messageId,
+        content: {
+          type: "text",
+          text: delta,
+        },
+      },
+    })
+    this.streamedText.set(key, text)
+  }
+
+  private appendStreamedText(sessionId: string, messageId: string, partId: string, delta: string) {
+    const key = this.partKey(sessionId, messageId, partId)
+    this.streamedText.set(key, (this.streamedText.get(key) ?? "") + delta)
+  }
+
+  private partKey(sessionId: string, messageId: string, partId: string) {
+    return `${sessionId}:${messageId}:${partId}`
   }
 
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {

--- a/packages/opencode/test/acp-next/event.test.ts
+++ b/packages/opencode/test/acp-next/event.test.ts
@@ -154,6 +154,24 @@ function partUpdated(sessionID: string, messageID: string, partID: string, type:
   }
 }
 
+function textPartUpdated(sessionID: string, messageID: string, partID: string, text: string): Event {
+  return {
+    id: `evt_${sessionID}_${messageID}_${partID}_updated`,
+    type: "message.part.updated",
+    properties: {
+      sessionID,
+      time: Date.now(),
+      part: {
+        id: partID,
+        sessionID,
+        messageID,
+        type: "text",
+        text,
+      },
+    },
+  }
+}
+
 function toolUpdated(part: ToolPart): Event {
   return {
     id: `evt_${part.sessionID}_${part.messageID}_${part.id}_${part.state.status}`,
@@ -344,6 +362,28 @@ describe("acp-next event routing", () => {
     expect(
       harness.updates.filter((update) => update.sessionId === "ses_b").map((update) => update.update.sessionUpdate),
     ).toEqual(["agent_thought_chunk", "agent_thought_chunk"])
+  })
+
+  it("emits only the missing text suffix from message.part.updated", async () => {
+    const harness = createHarness()
+    await createKnownSession(harness.session, "ses_tail", {
+      messageId: "msg_tail",
+      partId: "part_tail",
+      partType: "text",
+    })
+
+    await harness.subscription.handle(textDelta("ses_tail", "msg_tail", "part_tail", "hello"))
+    await harness.subscription.handle(textPartUpdated("ses_tail", "msg_tail", "part_tail", "hello world"))
+
+    expect(
+      harness.updates
+        .filter((update) => update.update.sessionUpdate === "agent_message_chunk")
+        .map((update) =>
+          update.update.sessionUpdate === "agent_message_chunk" && update.update.content.type === "text"
+            ? update.update.content.text
+            : "",
+        ),
+    ).toEqual(["hello", " world"])
   })
 
   it("does not create extra subscriptions on repeated loadSession", async () => {

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -146,6 +146,27 @@ function completedToolEvent(
   return { directory: cwd, payload }
 }
 
+function textPartUpdated(sessionId: string, cwd: string, messageID: string, partID: string, text: string) {
+  return {
+    directory: cwd,
+    payload: {
+      id: `evt_${sessionId}_${messageID}_${partID}_updated`,
+      type: "message.part.updated",
+      properties: {
+        sessionID: sessionId,
+        time: Date.now(),
+        part: {
+          id: partID,
+          sessionID: sessionId,
+          messageID,
+          type: "text",
+          text,
+        },
+      },
+    },
+  } satisfies GlobalEventEnvelope
+}
+
 function createEventStream() {
   const queue: GlobalEventEnvelope[] = []
   const waiters: Array<(value: GlobalEventEnvelope | undefined) => void> = []
@@ -477,6 +498,47 @@ describe("acp.agent event subscription", () => {
         expect(b).toContain(tokenB.join(""))
         for (const part of tokenB) expect(a).not.toContain(part)
         for (const part of tokenA) expect(b).not.toContain(part)
+
+        stop()
+      },
+    })
+  })
+
+  test("emits only the missing text suffix from message.part.updated", async () => {
+    await using tmp = await tmpdir()
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, chunks, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.delta",
+            properties: {
+              sessionID: sessionId,
+              messageID: "msg_tail",
+              partID: "msg_tail_part",
+              field: "text",
+              delta: "hello",
+            },
+          },
+        } as any)
+        controller.push(textPartUpdated(sessionId, cwd, "msg_tail", "msg_tail_part", "hello world"))
+
+        await pollUntil(() => (chunks.get(sessionId) ?? "") === "hello world", "updated text suffix never arrived")
+
+        expect(
+          sessionUpdates
+            .filter((u) => u.sessionId === sessionId && u.update.sessionUpdate === "agent_message_chunk")
+            .map((u) =>
+              u.update.sessionUpdate === "agent_message_chunk" && u.update.content.type === "text"
+                ? u.update.content.text
+                : "",
+            ),
+        ).toEqual(["hello", " world"])
 
         stop()
       },


### PR DESCRIPTION
### Issue for this PR

Closes #29488

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ACP streaming forwarded live `message.part.delta` chunks, but ignored the final text carried by `message.part.updated`. Some clients/providers can miss the tail of a streaming response until another interaction causes the full message to be observed later.

This records the text already streamed for each assistant text/reasoning part in both ACP implementations. When `message.part.updated` arrives with the complete part text, ACP now sends only the missing suffix, so clients receive the tail without duplicating earlier chunks.

### How did you verify your code works?

- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/acp-next/event.test.ts -t "emits only the missing text suffix from message.part.updated"`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/acp/event-subscription.test.ts -t "emits only the missing text suffix from message.part.updated"`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/acp-next/event.test.ts test/acp/event-subscription.test.ts`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun test test/acp test/acp-next test/cli/acp test/cli/acp-next`
- `cd packages/opencode && PATH="$HOME/.bun/bin:$PATH" bun typecheck`
- `PATH="$HOME/.bun/bin:$PATH" bun x prettier --check packages/opencode/src/acp/agent.ts packages/opencode/src/acp-next/event.ts packages/opencode/test/acp/event-subscription.test.ts packages/opencode/test/acp-next/event.test.ts`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" .husky/pre-push` was attempted; it still fails in unrelated `@opencode-ai/console-support` typecheck because local Solid/Vite/generated console-core modules are missing.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
