### PR TITLE
feat(opencode): emit session.activated event when a session is viewed

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -80,7 +80,9 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     })
 
     const get = Effect.fn("SessionHttpApi.get")(function* (ctx: { params: { sessionID: SessionID } }) {
-      return yield* requireSession(ctx.params.sessionID)
+      const result = yield* requireSession(ctx.params.sessionID)
+      yield* bus.publish(Session.Event.Activated, { sessionID: ctx.params.sessionID })
+      return result
     })
 
     const children = Effect.fn("SessionHttpApi.children")(function* (ctx: { params: { sessionID: SessionID } }) {

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -366,6 +366,12 @@ export const Event = {
       error: MessageV2.Assistant.fields.error,
     }),
   ),
+  Activated: BusEvent.define(
+    "session.activated",
+    Schema.Struct({
+      sessionID: SessionID,
+    }),
+  ),
 }
 
 export function plan(input: { slug: string; time: { created: number } }, instance: InstanceContext) {


### PR DESCRIPTION
The /switch command, session list selection, fork, quick-switch, and subagent navigation all happened silently with no bus event, making it impossible for plugins and external tools to track which session the user is actively viewing. Now every call to session.get (which the TUI makes on every navigation) publishes a session.activated event with the sessionID, giving plugins a reliable signal to update their state.

### Issue for this PR

Closes #29400

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins and external tools had no way to know when the user switched to a different session. The /switch command, session list picker, fork, quick-switch, and subagent navigation all happened silently. This PR publishes a `session.activated` event (via the existing bus system) every time `session.get` is called, which the TUI triggers on every navigation. This gives plugins a reliable signal that the active session changed.

### How did you verify your code works?

Wrote a test plugin that subscribes to bus events, then navigated between sessions using the session list, /switch command, and subagent navigation. Verified the plugin received the `session.activated` event with the correct sessionID in each case.

### Screenshots / recordings

N/A — no UI changes, this is an internal event.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR