### PR TITLE
fix(opencode): remove shell tool detached flag to prevent zombie processes

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -301,7 +301,7 @@ function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv
     cwd,
     env,
     stdin: "ignore",
-    detached: process.platform !== "win32",
+    detached: false,
   })
 }
 const parser = lazy(async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #29506

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Linux, `tool/shell.ts` spawns child shell processes with `detached: true`, which calls `setsid()` to put them in their own process group/session. When these child processes exit before the parent calls `waitpid()`, and with no `SIGCHLD` handler anywhere in the codebase, they become `<defunct>` zombie processes. Observed 11 zombies from 8 `opencode run` sessions.

This PR changes `detached: process.platform !== "win32"` to `detached: false`. Without `setsid()`, child processes remain in the parent's process group and are properly reaped by Node.js when `handle.exitCode` resolves. Explicit process cleanup is already handled via `handle.kill()` in abort/timeout paths -- signal isolation via `detached` is unnecessary.

Related: #29294 (`detached: true` causes parent to retain write-end FDs of child stdout pipes), #28654 (timeout detection)

### How did you verify your code works?

Verified on Linux (Ubuntu 24.04): ran multiple `opencode run` sessions with shell tool invocations, confirmed zero zombie processes accumulate (previously 11 zombies from 8 sessions). Confirmed abort/timeout kill paths still work via `handle.kill()`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR