### PR TITLE
fix(provider): respect limit.output config instead of silently capping at 32k

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1259,7 +1259,12 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
 }
 
 export function maxOutputTokens(model: Provider.Model, outputTokenMax = OUTPUT_TOKEN_MAX): number {
-  return Math.min(model.limit.output, outputTokenMax) || outputTokenMax
+  if (model.limit.output > 0) {
+    return outputTokenMax !== OUTPUT_TOKEN_MAX
+      ? Math.min(model.limit.output, outputTokenMax)
+      : model.limit.output
+  }
+  return outputTokenMax
 }
 
 export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3810,3 +3810,49 @@ describe("ProviderTransform.providerOptions - ai-gateway-provider", () => {
     expect(result).toEqual({ openaiCompatible: { reasoningEffort: "high" } })
   })
 })
+
+describe("ProviderTransform.maxOutputTokens", () => {
+  const baseModel = {
+    id: "test/model",
+    providerID: "test",
+    api: { id: "model", url: "https://test.com", npm: "@ai-sdk/openai-compatible" },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+    status: "active",
+    options: {},
+    headers: {},
+  }
+
+  const modelWithOutput = (output: number) =>
+    ({ ...baseModel, limit: { context: 200_000, input: 0, output } }) as any
+
+  test("respects configured limit.output when set", () => {
+    expect(ProviderTransform.maxOutputTokens(modelWithOutput(384_000))).toBe(384_000)
+  })
+
+  test("falls back to OUTPUT_TOKEN_MAX when limit.output is 0", () => {
+    expect(ProviderTransform.maxOutputTokens(modelWithOutput(0))).toBe(32_000)
+  })
+
+  test("respects env var ceiling when set", () => {
+    expect(ProviderTransform.maxOutputTokens(modelWithOutput(384_000), 100_000)).toBe(100_000)
+  })
+
+  test("uses env var as fallback when limit.output is 0", () => {
+    expect(ProviderTransform.maxOutputTokens(modelWithOutput(0), 64_000)).toBe(64_000)
+  })
+
+  test("env var ceiling does not raise above configured limit", () => {
+    // When limit.output < env var ceiling, limit.output wins
+    expect(ProviderTransform.maxOutputTokens(modelWithOutput(50_000), 100_000)).toBe(50_000)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29363

### Type of change

- [x] Bug fix

### What does this PR do?

`ProviderTransform.maxOutputTokens()` used `Math.min(model.limit.output, 32000)` which always applied the 32k floor as a ceiling, making per-model `limit.output` config useless. For example, with `limit.output: 384000` configured, the API still received `max_tokens: 32000`.

The fix makes `maxOutputTokens()` use `limit.output` directly when configured (> 0), fall back to `OUTPUT_TOKEN_MAX` only when no limit is set, and preserve `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` as an optional safety ceiling.

### Comparison with Claude Code

OpenCode actually has better per-model output limit config than Claude Code — which hard-codes a 32k internal ceiling and offers no per-model config at all (users patch the binary to exceed it). Aider supports per-model `max_tokens` via YAML config. Cline has a known issue sending full context limit causing overflows.

The bug here was just that `Math.min(limit.output, 32000)` silently defeated the per-model config.

### Future suggestion

Consider deprecating `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` in favor of a global `limits.maxOutputTokens` in `opencode.json`. This would make the safety ceiling discoverable and configurable without requiring an experimental env var. Per-model `limit.output` stays fully respected below the ceiling.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — passes
- `bun test ./test/provider/transform.test.ts` — 229 tests pass including 5 new tests for `maxOutputTokens`
- `bun test --grep overflow` — 8 tests pass
- `bun test ./test/session/llm.test.ts` — 25 tests pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR