### PR TITLE
fix(mcp): invalidate stale credentials before re-authentication

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -785,6 +785,11 @@ export const layer = Layer.effect(
       const url = remoteURL(mcpName, mcpConfig.url)
       if (!url) throw new Error(`Invalid MCP URL for "${mcpName}"`)
 
+      // Invalidate any stale credentials so the SDK triggers a fresh OAuth flow
+      // instead of reusing tokens that may belong to a different account/API key.
+      yield* auth.remove(mcpName)
+      pendingOAuthTransports.delete(mcpName)
+
       // OAuth config is optional - if not provided, we'll use auto-discovery
       const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined
 


### PR DESCRIPTION
### Issue for this PR

Closes #29227

### Type of change

- [x] Bug fix

### What does this PR do?

`startAuth()` was not clearing stored credentials before starting a new OAuth flow. When tokens existed in `mcp-auth.json` for a previous account, `McpOAuthProvider.tokens()` returned them and the SDK used them — the server rejected them and returned `needs_auth`. Since the tokens were never removed, the cycle repeated on every re-auth attempt.

The fix removes stored credentials at the start of `startAuth()` so the SDK triggers a fresh OAuth flow.

### How did you verify your code works?

- `bun typecheck` in packages/opencode — clean
- `bun test --grep mcp` — all 12 tests pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR