### PR TITLE
fix(console): correct sharable to shareable in FAQ strings

### DIFF
--- a/packages/console/app/src/i18n/en.ts
+++ b/packages/console/app/src/i18n/en.ts
@@ -170,7 +170,7 @@ export const dict = {
   "home.faq.a6":
     "OpenCode is 100% free to use. It also comes with a set of free models. There might be additional costs if you connect any other provider.",
   "home.faq.q7": "What about data and privacy?",
-  "home.faq.a7.p1": "Your data and information is only stored when you use our free models or create sharable links.",
+  "home.faq.a7.p1": "Your data and information is only stored when you use our free models or create shareable links.",
   "home.faq.a7.p2.beforeModels": "Learn more about",
   "home.faq.a7.p2.modelsLink": "our models",
   "home.faq.a7.p2.and": "and",
@@ -724,7 +724,7 @@ export const dict = {
     "Any additional costs will come from your subscription to a model provider. While OpenCode works with any model provider, we recommend using",
   "download.faq.a5.p2.afterZen": ".",
 
-  "download.faq.a6.p1": "Your data and information is only stored when you create sharable links in OpenCode.",
+  "download.faq.a6.p1": "Your data and information is only stored when you create shareable links in OpenCode.",
   "download.faq.a6.p2.beforeShare": "Learn more about",
   "download.faq.a6.shareLink": "share pages",
 


### PR DESCRIPTION
### Issue for this PR

Closes #18573

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The English FAQ strings in `packages/console/app/src/i18n/en.ts` use the
non-standard spelling "sharable" in two places (`home.faq.a7.p1` and
`download.faq.a6.p1`). The standard English spelling is "shareable".
This is a straightforward string replacement with no logic changes.

### How did you verify your code works?

Searched the file for "sharable" (0 results after change) and
"shareable" (2 results after change). No other occurrences in the
codebase.

### Screenshots / recordings

_N/A — string-only change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
