### PR TITLE
feat(opencode): add session status endpoint

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -78,6 +78,7 @@ export const SessionPaths = {
   list: root,
   status: `${root}/status`,
   get: `${root}/:sessionID`,
+  getStatus: `${root}/:sessionID/status`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
   diff: `${root}/:sessionID/diff`,
@@ -138,6 +139,18 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.get",
             summary: "Get session",
             description: "Retrieve detailed information about a specific OpenCode session.",
+          }),
+        ),
+        HttpApiEndpoint.get("getStatus", SessionPaths.getStatus, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(SessionStatus.Info, "Get session status"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.getStatus",
+            summary: "Get session status",
+            description: "Retrieve the current runtime status for a specific OpenCode session.",
           }),
         ),
         HttpApiEndpoint.get("children", SessionPaths.children, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -84,6 +84,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* requireSession(ctx.params.sessionID)
     })
 
+    const getStatus = Effect.fn("SessionHttpApi.getStatus")(function* (ctx: { params: { sessionID: SessionID } }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* statusSvc.get(ctx.params.sessionID)
+    })
+
     const children = Effect.fn("SessionHttpApi.children")(function* (ctx: { params: { sessionID: SessionID } }) {
       yield* requireSession(ctx.params.sessionID)
       return yield* session.children(ctx.params.sessionID)
@@ -414,6 +419,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("list", list)
       .handle("status", status)
       .handle("get", get)
+      .handle("getStatus", getStatus)
       .handle("children", children)
       .handle("todo", todo)
       .handle("diff", diff)

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -275,6 +275,10 @@ describe("session HttpApi", () => {
         expect(get.status).toBe(404)
         expect(yield* responseJson(get)).toEqual(missingSessionBody)
 
+        const status = yield* request(pathFor(SessionPaths.getStatus, { sessionID: missingSession }), { headers })
+        expect(status.status).toBe(404)
+        expect(yield* responseJson(status)).toEqual(missingSessionBody)
+
         const children = yield* request(pathFor(SessionPaths.children, { sessionID: missingSession }), { headers })
         expect(children.status).toBe(404)
         expect(yield* responseJson(children)).toEqual(missingSessionBody)
@@ -344,6 +348,12 @@ describe("session HttpApi", () => {
         expect(
           yield* requestJson<Session.Info>(pathFor(SessionPaths.get, { sessionID: parent.id }), { headers }),
         ).toMatchObject({ id: parent.id, title: "parent" })
+
+        expect(
+          yield* requestJson<Record<string, unknown>>(pathFor(SessionPaths.getStatus, { sessionID: parent.id }), {
+            headers,
+          }),
+        ).toEqual({ type: "idle" })
 
         expect(
           (yield* requestJson<Session.Info[]>(pathFor(SessionPaths.children, { sessionID: parent.id }), {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -177,6 +177,8 @@ import type {
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
+  SessionGetStatusErrors,
+  SessionGetStatusResponses,
   SessionInitErrors,
   SessionInitResponses,
   SessionListErrors,
@@ -3289,6 +3291,38 @@ export class Session2 extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * Get session status
+   *
+   * Retrieve the current runtime status for a specific OpenCode session.
+   */
+  public getStatus<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionGetStatusResponses, SessionGetStatusErrors, ThrowOnError>({
+      url: "/session/{sessionID}/status",
+      ...options,
+      ...params,
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -7003,6 +7003,40 @@ export type SessionUpdateResponses = {
 
 export type SessionUpdateResponse = SessionUpdateResponses[keyof SessionUpdateResponses]
 
+export type SessionGetStatusData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/status"
+}
+
+export type SessionGetStatusErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionGetStatusError = SessionGetStatusErrors[keyof SessionGetStatusErrors]
+
+export type SessionGetStatusResponses = {
+  /**
+   * Get session status
+   */
+  200: SessionStatus
+}
+
+export type SessionGetStatusResponse = SessionGetStatusResponses[keyof SessionGetStatusResponses]
+
 export type SessionChildrenData = {
   body?: never
   path: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -5541,6 +5541,86 @@
         ]
       }
     },
+    "/session/{sessionID}/status": {
+      "get": {
+        "tags": ["session"],
+        "operationId": "session.getStatus",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get session status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve the current runtime status for a specific OpenCode session.",
+        "summary": "Get session status",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.getStatus({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/children": {
       "get": {
         "tags": ["session"],


### PR DESCRIPTION
### Issue for this PR

Closes #29166

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `GET /session/:sessionID/status` by exposing the existing single-session `SessionStatus.Service.get()` method over HTTP. The handler first checks that the session exists, matching the other session-specific read endpoints.

This draft also includes generated OpenAPI/SDK changes and route coverage for idle status and typed 404 responses. I saw the duplicate bot flagged #29165 and #29244; this PR keeps the same scope but includes tests and SDK output.

### How did you verify your code works?

- `bun run script/generate.ts`
- `bun test --timeout 30000 test/server/httpapi-session.test.ts` from `packages/opencode`
- `bun run typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A, API-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR