### PR TITLE
fix(opencode): emit SSE event ids

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -13,9 +13,13 @@ function eventData(data: unknown): Sse.Event {
   return {
     _tag: "Event",
     event: "message",
-    id: undefined,
+    id: eventID(data),
     data: JSON.stringify(data),
   }
+}
+
+function eventID(data: unknown) {
+  return data && typeof data === "object" && "id" in data && typeof data.id === "string" ? data.id : undefined
 }
 
 function eventResponse(bus: Bus.Interface) {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -20,9 +20,17 @@ function eventData(data: unknown): Sse.Event {
   return {
     _tag: "Event",
     event: "message",
-    id: undefined,
+    id: eventID(data),
     data: JSON.stringify(data),
   }
+}
+
+function eventID(data: unknown) {
+  if (!data || typeof data !== "object" || !("payload" in data)) return undefined
+  const payload = data.payload
+  return payload && typeof payload === "object" && "id" in payload && typeof payload.id === "string"
+    ? payload.id
+    : undefined
 }
 
 function parseBody(body: string) {

--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -5,6 +5,7 @@ import { Bus } from "../../src/bus"
 import { Event as ServerEvent } from "../../src/server/event"
 import { Server } from "../../src/server/server"
 import { EventPaths } from "../../src/server/routes/instance/httpapi/groups/event"
+import { GlobalPaths } from "../../src/server/routes/instance/httpapi/groups/global"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffectShared } from "../lib/effect"
@@ -13,11 +14,25 @@ void Log.init({ print: false })
 
 const EventData = Schema.Struct({
   id: Schema.optional(Schema.String),
+  sseID: Schema.optional(Schema.String),
   type: Schema.String,
   properties: Schema.Record(Schema.String, Schema.Any),
 })
 
-const readEvent = (reader: ReadableStreamDefaultReader<Uint8Array>) =>
+function parseSseEvent(text: string) {
+  const id = text
+    .split("\n")
+    .find((line) => line.startsWith("id: "))
+    ?.slice("id: ".length)
+  const data = text
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice("data: ".length))
+    .join("\n")
+  return { sseID: id, ...JSON.parse(data) }
+}
+
+const readSseEvent = (reader: ReadableStreamDefaultReader<Uint8Array>) =>
   Effect.gen(function* () {
     const result = yield* Effect.promise(() => reader.read()).pipe(
       Effect.timeoutOrElse({
@@ -26,16 +41,26 @@ const readEvent = (reader: ReadableStreamDefaultReader<Uint8Array>) =>
       }),
     )
     if (result.done || !result.value) return yield* Effect.fail(new Error("event stream closed"))
-    return Schema.decodeUnknownSync(EventData)(
-      JSON.parse(new TextDecoder().decode(result.value).replace(/^data: /, "")),
-    )
+    return parseSseEvent(new TextDecoder().decode(result.value))
   })
+
+const readEvent = (reader: ReadableStreamDefaultReader<Uint8Array>) =>
+  readSseEvent(reader).pipe(Effect.map(Schema.decodeUnknownSync(EventData)))
 
 const openEventStream = (directory: string) =>
   Effect.gen(function* () {
     const response = yield* Effect.promise(async () =>
       Server.Default().app.request(EventPaths.event, { headers: { "x-opencode-directory": directory } }),
     )
+    if (!response.body) return yield* Effect.die("missing SSE response body")
+    const reader = response.body.getReader()
+    yield* Effect.addFinalizer(() => Effect.promise(() => reader.cancel().catch(() => undefined)))
+    return { response, reader }
+  })
+
+const openGlobalEventStream = () =>
+  Effect.gen(function* () {
+    const response = yield* Effect.promise(async () => Server.Default().app.request(GlobalPaths.event))
     if (!response.body) return yield* Effect.die("missing SSE response body")
     const reader = response.body.getReader()
     yield* Effect.addFinalizer(() => Effect.promise(() => reader.cancel().catch(() => undefined)))
@@ -62,7 +87,9 @@ describe("event HttpApi", () => {
         expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
         expect(response.headers.get("x-accel-buffering")).toBe("no")
         expect(response.headers.get("x-content-type-options")).toBe("nosniff")
-        expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+        const event = yield* readEvent(reader)
+        expect(event).toMatchObject({ type: "server.connected", properties: {} })
+        expect(event.sseID).toBe(event.id)
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )
@@ -94,8 +121,21 @@ describe("event HttpApi", () => {
         expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
 
         yield* Bus.use.publish(ServerEvent.Connected, {})
-        expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+        const event = yield* readEvent(reader)
+        expect(event).toMatchObject({ type: "server.connected", properties: {} })
+        expect(event.sseID).toBe(event.id)
       }),
     { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.effect("sets SSE ids on global events", () =>
+    Effect.gen(function* () {
+      const { response, reader } = yield* openGlobalEventStream()
+      expect(response.status).toBe(200)
+
+      const event = yield* readSseEvent(reader)
+      expect(event).toMatchObject({ payload: { type: "server.connected" } })
+      expect(event.sseID).toBe(event.payload.id)
+    }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #29544

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode already assigns IDs to instance and global bus events, but the SSE encoder was not writing those IDs to the standard `id:` field. This makes reconnect clients unable to send a meaningful `Last-Event-ID`.

This PR emits the existing event ID as the SSE ID for `/event` and `/global/event`. It does not add replay buffering; it is a small prerequisite for deterministic reconnect/replay work. Related: #25657, #19584, and #25658.

### How did you verify your code works?

- `bun test --timeout 30000 test/server/httpapi-event.test.ts` from `packages/opencode`
- `bun run typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A, server-side SSE framing change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR