### PR TITLE
fix(opencode): keep SSE streams alive after serialization errors

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -14,7 +14,16 @@ function eventData(data: unknown): Sse.Event {
     _tag: "Event",
     event: "message",
     id: undefined,
-    data: JSON.stringify(data),
+    data: eventJSON(data),
+  }
+}
+
+function eventJSON(data: unknown) {
+  try {
+    return JSON.stringify(data)
+  } catch (cause) {
+    log.warn("failed to serialize SSE event", { cause })
+    return JSON.stringify({ id: Bus.createID(), type: "server.heartbeat", properties: {} })
   }
 }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -21,8 +21,26 @@ function eventData(data: unknown): Sse.Event {
     _tag: "Event",
     event: "message",
     id: undefined,
-    data: JSON.stringify(data),
+    data: eventJSON(data),
   }
+}
+
+function eventJSON(data: unknown) {
+  try {
+    return JSON.stringify(data)
+  } catch (cause) {
+    log.warn("failed to serialize global SSE event", { cause })
+    return JSON.stringify({
+      directory: eventDirectory(data),
+      payload: { id: Bus.createID(), type: "server.heartbeat", properties: {} },
+    })
+  }
+}
+
+function eventDirectory(data: unknown) {
+  return data && typeof data === "object" && "directory" in data && typeof data.directory === "string"
+    ? data.directory
+    : "global"
 }
 
 function parseBody(body: string) {

--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect } from "bun:test"
 import { Effect, Schema } from "effect"
 import * as Log from "@opencode-ai/core/util/log"
 import { Bus } from "../../src/bus"
+import { BusEvent } from "../../src/bus/bus-event"
 import { Event as ServerEvent } from "../../src/server/event"
 import { Server } from "../../src/server/server"
 import { EventPaths } from "../../src/server/routes/instance/httpapi/groups/event"
@@ -48,6 +49,7 @@ afterEach(async () => {
 })
 
 const it = testEffectShared(Bus.defaultLayer)
+const UnserializableEvent = BusEvent.define("test.unserializable", Schema.Struct({ value: Schema.Any }))
 
 describe("event HttpApi", () => {
   it.instance(
@@ -92,6 +94,23 @@ describe("event HttpApi", () => {
         const { directory } = yield* TestInstance
         const { reader } = yield* openEventStream(directory)
         expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+
+        yield* Bus.use.publish(ServerEvent.Connected, {})
+        expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "keeps the stream alive when an event cannot be serialized",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+        const { reader } = yield* openEventStream(directory)
+        expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+
+        yield* Bus.use.publish(UnserializableEvent, { value: BigInt(1) })
+        expect(yield* readEvent(reader)).toMatchObject({ type: "server.heartbeat", properties: {} })
 
         yield* Bus.use.publish(ServerEvent.Connected, {})
         expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })


### PR DESCRIPTION
### Issue for this PR

Closes #28729

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A single unserializable bus payload could make `JSON.stringify` throw inside the SSE stream mapper. In Bun this can leave clients waiting on an open connection with no more events.

This catches serialization failures for both `/event` and `/global/event`, logs the failure, and emits a serializable heartbeat frame so the stream keeps moving.

### How did you verify your code works?

- `bun test --timeout 30000 test/server/httpapi-event.test.ts` from `packages/opencode`
- `bun run typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A, server-side SSE robustness change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR