### PR TITLE
fix: detect attachment mime from file contents

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -20,6 +20,7 @@ import { effectCmd } from "../effect-cmd"
 import { ServerAuth } from "@/server/auth"
 import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
+import { sniffAttachmentMime } from "@/util/media"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
@@ -342,7 +343,13 @@ export const RunCommand = effectCmd({
             process.exit(1)
           }
 
-          const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : "text/plain"
+          let mime: string
+          if (await Filesystem.isDir(resolvedPath)) {
+            mime = "application/x-directory"
+          } else {
+            const head = await Bun.file(resolvedPath).slice(0, 16).bytes()
+            mime = sniffAttachmentMime(head, "text/plain")
+          }
 
           files.push({
             type: "file",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -40,6 +40,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { Image } from "@/image/image"
 import { decodeDataUrl } from "@/util/data-url"
+import { sniffAttachmentMime } from "@/util/media"
 import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Latch, Layer, Option, Scope, Context, Schema, Types } from "effect"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
@@ -206,11 +207,17 @@ export const layer = Layer.effect(
               return
             }
 
+            const refMime =
+              info.value.type === "Directory"
+                ? "application/x-directory"
+                : yield* Effect.promise(async () =>
+                    sniffAttachmentMime(await Bun.file(targetPath).slice(0, 16).bytes(), "text/plain"),
+                  )
             parts.push({
               type: "file",
               url: pathToFileURL(targetPath).href,
               filename: name,
-              mime: info.value.type === "Directory" ? "application/x-directory" : "text/plain",
+              mime: refMime,
             })
             return
           }
@@ -226,11 +233,17 @@ export const layer = Layer.effect(
             return
           }
           const stat = info.value
+          const fileMime =
+            stat.type === "Directory"
+              ? "application/x-directory"
+              : yield* Effect.promise(async () =>
+                  sniffAttachmentMime(await Bun.file(filepath).slice(0, 16).bytes(), "text/plain"),
+                )
           parts.push({
             type: "file",
             url: pathToFileURL(filepath).href,
             filename: name,
-            mime: stat.type === "Directory" ? "application/x-directory" : "text/plain",
+            mime: fileMime,
           })
         }),
         { concurrency: "unbounded", discard: true },


### PR DESCRIPTION
### Issue for this PR

Closes #25353

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`-f <path>` and `@path` references were hardcoding the attachment mime as `text/plain` regardless of the actual file. So a PNG/JPG/PDF passed via `-f` was sent to the model with `mime: text/plain`, and downstream model adapters then either rejected it or treated the binary bytes as text.

Fix: use the existing `sniffAttachmentMime` helper in `@/util/media` to read the first 16 bytes and identify the real mime. No new sniffing logic — just calling the helper that's already in the tree, with `text/plain` kept as the fallback so real text files behave unchanged.

Two call sites touched:
- `packages/opencode/src/cli/cmd/run.ts` — the `-f` flag in the CLI
- `packages/opencode/src/session/prompt.ts` — `@path` references (both the `ref` branch and the inline-file branch)

Directories still resolve to `application/x-directory`.

Note: a previous PR (#25317) tried to fix the same issue using file extensions. This one sniffs magic bytes instead, which is more robust for files without extensions or with misleading ones.

### How did you verify your code works?

Built the branch locally (`bun install && bun dev`) and ran end-to-end against Claude Opus 4.7:

1. Generated a 256×256 checkerboard PNG (8×8 black/white squares) with the Python stdlib.
2. Ran `bun dev run -m anthropic/claude-opus-4-7 -f checker.png -- "Describe this image precisely: size, colors, pattern. If it's a checkerboard, how many squares per side?"`
3. Server log at the `session.prompt` boundary showed `service=session.prompt mime=image/png file` — confirming the fix in `run.ts` correctly sniffed the PNG magic bytes instead of defaulting to `text/plain`.
4. Claude replied: *"8x8 checkerboard pattern, black and white squares alternating. Standard chessboard layout: 8 squares per side, 64 total. Top-left square is white."* — accurate on every dimension, which only works if the bytes arrived as an image part, not text.

Without the fix, the same setup would have sent `mime: text/plain` and the model would either error out or hallucinate textual content.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR