### PR TITLE
fix(app): Keybinding support for mobile sidebar

### DIFF
--- a/packages/app/src/hooks/use-breakpoint.ts
+++ b/packages/app/src/hooks/use-breakpoint.ts
@@ -1,0 +1,26 @@
+import { createMediaQuery } from "@solid-primitives/media"
+
+type Breakpoint = "sm" | "md" | "lg" | "xl" | "2xl"
+
+export function useMinBreakpoint(breakpoint: Breakpoint) {
+  return createMediaQuery(`(min-width: ${cssBreakpoint(breakpoint)})`)
+}
+
+/**
+ * Prefer reading breakpoints from css env vars defined in packages/ui/src/styles/theme.css
+ * to avoid future "breakpoint" drift, use javascript only as a fallback
+ */
+function cssBreakpoint(breakpoint: Breakpoint) {
+  if (typeof window === "undefined") return fallbackBreakpoint(breakpoint)
+  return getComputedStyle(document.documentElement).getPropertyValue(`--breakpoint-${breakpoint}`).trim()
+}
+
+function fallbackBreakpoint(breakpoint: Breakpoint) {
+  return {
+    sm: "40rem",
+    md: "48rem",
+    lg: "64rem",
+    xl: "80rem",
+    "2xl": "96rem",
+  }[breakpoint]
+}

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -34,6 +34,7 @@ import { createStore, produce, reconcile } from "solid-js/store"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { useProviders } from "@/hooks/use-providers"
+import { useMinBreakpoint } from "@/hooks/use-breakpoint"
 import { showToast, Toast, toaster } from "@opencode-ai/ui/toast"
 import { useServerSDK } from "@/context/server-sdk"
 import { clearWorkspaceTerminals, getTerminalServerScope } from "@/context/terminal"
@@ -128,6 +129,7 @@ export default function Layout(props: ParentProps) {
   const theme = useTheme()
   const language = useLanguage()
   const newDesign = createMemo(() => settings.general.newLayoutDesigns())
+  const isDesktopSidebarShown = useMinBreakpoint("xl")
   const initialDirectory = decode64(params.dir)
   const location = useLocation()
   const route = createMemo(() => {
@@ -349,6 +351,14 @@ export default function Layout(props: ParentProps) {
     clearSidebarHoverState()
     navigate(href)
     layout.mobileSidebar.hide()
+  }
+
+  const toggleSidebar = () => {
+    if (isDesktopSidebarShown()) {
+      layout.sidebar.toggle()
+    } else {
+      layout.mobileSidebar.toggle()
+    }
   }
 
   function cycleTheme(direction = 1) {
@@ -1004,7 +1014,7 @@ export default function Layout(props: ParentProps) {
         title: language.t("command.sidebar.toggle"),
         category: language.t("command.category.view"),
         keybind: "mod+b",
-        onSelect: () => layout.sidebar.toggle(),
+        onSelect: toggleSidebar,
       },
       {
         id: "project.open",


### PR DESCRIPTION
### Issue for this PR

Closes #29563

### Type of change

- [x] Bug fix (usability improvement)
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

We detect wether the desktop or mobile sidebar is shown and use that info to proerply toggle the dekstop/mobile sidebar upon the keybinding press.

### How did you verify your code works?

Ran in dev mode and used the keybinding

### Screenshots / recordings

Since it dones tchange ui and only ux i leave this out

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
