### PR TITLE
fix(tui): show home sessions in global project

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -117,6 +117,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     function sessionListQuery(): { scope?: "project"; path?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
       if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
+      if (project.data.project.id === "global" && project.data.instance.path.directory === project.data.instance.path.home) {
+        return { scope: "project" }
+      }
       return {
         path: path
           .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)


### PR DESCRIPTION
## Summary

Fix `/sessions` from the global home project hiding older home sessions.

When opencode is opened from the user home directory, the global project can report the worktree as `/`. The TUI session query then filters by a path like `home/user`, which excludes older home sessions stored with an empty path. Treat the global home directory as project scope so the dialog includes both legacy empty-path home sessions and newer home sessions.

## Verification

- `cd packages/opencode && bun typecheck`
- `bunx oxlint packages/opencode/src/cli/cmd/tui/context/sync.tsx` (pre-existing warnings only)
- `git diff --check`
- `cd packages/opencode && bun run build --single --skip-install --skip-embed-web-ui`
- local TUI verification from `/home/cagedbird`: missing home session reappeared in `/sessions`
