### PR TITLE
fix(tui): show home sessions in global project

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -117,6 +117,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     function sessionListQuery(): { scope?: "project"; path?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
       if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
+      if (project.data.project.id === "global" && project.data.instance.path.directory === project.data.instance.path.home) {
+        return { scope: "project" }
+      }
       return {
         path: path
           .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)


### PR DESCRIPTION
### Issue for this PR

Closes #29581

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes `/sessions` from the global home project hiding older home sessions.

When opencode is opened from the user's home directory, the global project can report the worktree as `/`. The TUI then filters sessions by a path like `home/user`, excluding older home sessions stored with an empty path.

This treats the global home directory as project scope, so both empty-path home sessions and newer home-path sessions are shown.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `bunx oxlint packages/opencode/src/cli/cmd/tui/context/sync.tsx` (existing warnings only)
- `git diff --check`
- `cd packages/opencode && bun run build --single --skip-install --skip-embed-web-ui`
- Built local binary and verified from `/home/cagedbird` that the missing home session reappeared in `/sessions`.

### Screenshots / recordings

Not applicable. This changes the session query used by the TUI; local verification was done in the TUI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
