### PR TITLE
fix(tui): prevent terminal window close on /exit for Windows non-ConPTY consoles

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
@@ -13,6 +13,7 @@ import { Session as SessionApi } from "@/session/session"
 import * as Locale from "@/util/locale"
 import { withRunSpan } from "./otel"
 import { resolveInteractiveStdin } from "./runtime.stdin"
+import { win32FreeConsole } from "@/cli/cmd/tui/win32"
 import { entrySplash, exitSplash, splashMeta } from "./splash"
 import { resolveRunTheme } from "./theme"
 import type {
@@ -97,6 +98,7 @@ function shutdown(renderer: CliRenderer): void {
   if (!renderer.isDestroyed) {
     renderer.destroy()
   }
+  win32FreeConsole()
 }
 
 function splashInfo(title: string | undefined, history: RunPrompt[]) {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -18,7 +18,7 @@ import {
   Show,
   on,
 } from "solid-js"
-import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
+import { win32DisableProcessedInput, win32FlushInputBuffer, win32FreeConsole, win32InstallCtrlCGuard } from "./win32"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import semver from "semver"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
@@ -322,6 +322,7 @@ function createTuiLifecycle(input: {
       input.renderer.setTerminalTitle("")
       input.renderer.destroy()
     }
+    win32FreeConsole()
     win32FlushInputBuffer()
     if (reason) {
       const formatted = FormatError(reason) ?? FormatUnknownError(reason)
@@ -351,6 +352,7 @@ function createTuiLifecycle(input: {
       exiting = true
       await cleanup().catch(() => {})
       if (!input.renderer.isDestroyed) input.renderer.destroy()
+      win32FreeConsole()
       completeExit()
       throw error
     },

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -11,7 +11,7 @@ import { withNetworkOptions, resolveNetworkOptionsNoConfig } from "@/cli/network
 import { Filesystem } from "@/util/filesystem"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
-import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
+import { win32DisableProcessedInput, win32InstallCtrlCGuard, win32TerminateSelf } from "./win32"
 import { writeHeapSnapshot } from "v8"
 import { TuiConfig } from "./config/tui"
 import {
@@ -258,7 +258,7 @@ export const TuiThreadCommand = cmd({
     } finally {
       unguard?.()
     }
-    process.exit(0)
+    win32TerminateSelf(0)
   },
 })
 // scratch

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -10,6 +10,9 @@ const kernel = () =>
     GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
     SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
     FlushConsoleInputBuffer: { args: ["ptr"], returns: "i32" },
+    FreeConsole: { args: [], returns: "i32" },
+    GetCurrentProcess: { args: [], returns: "ptr" },
+    TerminateProcess: { args: ["ptr", "u32"], returns: "i32" },
   })
 
 let k32: ReturnType<typeof kernel> | undefined
@@ -127,4 +130,26 @@ export function win32InstallCtrlCGuard() {
   }
 
   return unhook
+}
+
+/**
+ * Detach the current process from its console so the terminal window
+ * remains open when the process exits.
+ */
+export function win32FreeConsole() {
+  if (process.platform !== "win32") return
+  if (!load()) return
+  k32!.symbols.FreeConsole()
+}
+
+/**
+ * Terminate the current process using TerminateProcess (WIN32 API).
+ * Bypasses Bun's process.exit() which may reattach to the console.
+ */
+export function win32TerminateSelf(exitCode: number = 0) {
+  if (process.platform !== "win32") return
+  if (!load()) return
+  const hProc = k32!.symbols.GetCurrentProcess()
+  if (!hProc) return
+  k32!.symbols.TerminateProcess(hProc, exitCode)
 }

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -37,6 +37,7 @@ import { Database } from "@/storage/db"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
+import { win32TerminateSelf } from "./cli/cmd/tui/win32"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
 import { isRecord } from "@/util/record"
@@ -244,8 +245,14 @@ try {
   process.exitCode = 1
 } finally {
   // Some subprocesses don't react properly to SIGTERM and similar signals.
-  // Most notably, some docker-container-based MCP servers don't handle such signals unless
-  // run using `docker run --init`.
+  // Most notably, some docker-container-based MCP servers don't handle such signals
+  // unless run using `docker run --init`.
   // Explicitly exit to avoid any hanging subprocesses.
-  process.exit()
+  // On Windows, process.exit() triggers CTRL_CLOSE_EVENT which closes the
+  // terminal.  Use TerminateProcess via win32TerminateSelf instead.
+  if (process.platform === "win32") {
+    win32TerminateSelf(Number(process.exitCode) || 0)
+  } else {
+    process.exit()
+  }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #27653

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows non-ConPTY terminals (PowerShell, PowerShell 7, Alacritty, etc.),
calling `/exit` in the TUI closes the terminal window along with the process.
Windows Terminal (ConPTY-based) is unaffected.

**Root Cause**

The native `destroyRenderer` FFI call in opentui modifies the console state.
When followed by `process.exit()`, Bun's cleanup handlers can reattach to the
console, causing conhost.exe to send `CTRL_CLOSE_EVENT` to all attached
processes — including the parent shell — which closes the terminal window.

**Fix**

Three-pronged approach that ensures the process is fully detached from the
console before terminating:

1. **`win32.ts`** — Add `FreeConsole` / `GetCurrentProcess` / `TerminateProcess`
   FFI bindings and two helpers:
   - `win32FreeConsole()` — detaches the process from its console via Win32
     `FreeConsole()` so the terminal window is no longer associated with this
     process.
   - `win32TerminateSelf()` — terminates the process via Win32
     `TerminateProcess()` instead of `process.exit()`, bypassing Bun's exit
     cleanup handlers that could reattach to the console.

2. **`app.tsx`** — Call `win32FreeConsole()` after `renderer.destroy()` in both
   the `exit` (graceful /exit) and `fail` (error) paths.

3. **Exit points** — Replace `process.exit()` with `win32TerminateSelf()`:
   - `thread.ts`: TUI thread clean exit.
   - `index.ts`: CLI entry fallback (platform-conditional: Windows uses
     TerminateProcess, other platforms keep process.exit).
   - `runtime.lifecycle.ts`: split-footer renderer shutdown path.
### How did you verify your code works?
- reproduce issuse: open latest version opencode tui on `powershell, pwsh, or alacritty` on `windows10(11)`, open any project.wait for few seconds after tui open, use `/exit` to quit .terminal will close
- after: same operation, terminal not closes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
