### PR TITLE
feat(tui): show session status in terminal tab title

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -30,6 +30,7 @@ import { EditorContextProvider } from "@tui/context/editor"
 import { useEvent } from "@tui/context/event"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
 import { StartupLoading } from "@tui/component/startup-loading"
+import { SPINNER_FRAMES } from "@tui/component/spinner"
 import { SyncProvider, useSync } from "@tui/context/sync"
 import { SyncProviderV2 } from "@tui/context/sync-v2"
 import { LocalProvider, useLocal } from "@tui/context/local"
@@ -445,6 +446,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   const [pasteSummaryEnabled, setPasteSummaryEnabled] = createSignal(
     kv.get("paste_summary_enabled", !sync.data.config.experimental?.disable_paste_summary),
   )
+  const [spinnerFrame, setSpinnerFrame] = createSignal(0)
+
+  // Spinner animation for terminal title when session is busy
+  createEffect(() => {
+    if (route.data.type !== "session") {
+      setSpinnerFrame(0)
+      return
+    }
+    const isBusy = sync.session.status(route.data.sessionID) !== "idle"
+    if (!isBusy) {
+      setSpinnerFrame(0)
+      return
+    }
+    const interval = setInterval(() => setSpinnerFrame((prev) => (prev + 1) % SPINNER_FRAMES.length), 200)
+    onCleanup(() => clearInterval(interval))
+  })
 
   // Update terminal window title based on current route and session
   createEffect(() => {
@@ -457,13 +474,15 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
 
     if (route.data.type === "session") {
       const session = sync.session.get(route.data.sessionID)
-      if (!session || SessionApi.isDefaultTitle(session.title)) {
+      if (!session) {
         renderer.setTerminalTitle("OpenCode")
         return
       }
 
       const title = session.title.length > 40 ? session.title.slice(0, 37) + "..." : session.title
-      renderer.setTerminalTitle(`OC | ${title}`)
+      const status = sync.session.status(route.data.sessionID)
+      const statusPrefix = status === "idle" ? "▣" : SPINNER_FRAMES[spinnerFrame()]
+      renderer.setTerminalTitle(`${statusPrefix} ${title}`)
       return
     }
 


### PR DESCRIPTION
### Issue for this PR
---
### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
---
### What does this PR do?
Adds a **session status indicator** to the terminal tab title so users can tell at a glance whether a session is idle or working.
**Changes made:**
- `packages/opencode/src/cli/cmd/tui/app.tsx`
**Behavior:**
| Session state    | Tab title format  | Example      |
| ---------------- | ----------------- | ------------ |
| **Idle** (completed) | `▣ {title}`         | `▣ My session` |
| **Busy** (working)   | `{spinner} {title}` | `⠋ My session` |
Works on all platforms — uses only standard Unicode characters and OSC 0 escape sequences.
---
### How did you verify your code works?
1. Ran `bun dev` from `packages/opencode`
2. Confirmed the tab title updates correctly between idle and busy states
3. Type-checked with `bun typecheck` ✅
---
### Screenshots / recordings
<img width="186" height="28" alt="95efcf5ee77737c6fee431c6c02ebc26" src="https://github.com/user-attachments/assets/0b949467-768c-4e35-aaca-11bd20d87e48" />
<img width="187" height="32" alt="645e099b2743a2c35c6d6980928c02b8" src="https://github.com/user-attachments/assets/6ffc3a5a-1ecf-4374-b9be-dfab126b251d" />
<img width="205" height="29" alt="7a34a7ce9f11ddec893785357f33edef" src="https://github.com/user-attachments/assets/4d21eb89-3feb-4b07-9de3-95d115fdb68b" />


### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR