### PR TITLE
fix(tui): prevent spinner garbage in non-TTY environments

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -17,6 +17,17 @@ type Spin = {
   stop: (msg: string, code?: number) => void
 }
 
+function ttySpinner(): Spin {
+  if (process.stdout.isTTY) return spinner()
+  return {
+    start: (msg: string) => console.log(msg),
+    stop: (msg: string, code?: number) => {
+      if (code) console.error(msg)
+      else console.log(msg)
+    },
+  }
+}
+
 export type PlugDeps = {
   spinner: () => Spin
   log: {
@@ -45,7 +56,7 @@ export type PlugCtx = {
 }
 
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => ttySpinner(),
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),


### PR DESCRIPTION
### Issue for this PR

Closes #27908

### Type of change

- [x] Bug fix

### What does this PR do?

The plugin install spinner from @clack/prompts outputs ANSI escape sequences unconditionally. When stdout is not a TTY (CI, subprocess, piped output), carriage return and CSI sequences appear as garbage text.

Added a TTY-aware spinner wrapper that falls back to plain console.log/console.error when stdout is not a terminal.

### How did you verify your code works?

- bun typecheck (clean)
- bun test test/skill/ (22 pass)
- bun test test/tool/skill.test.ts (2 pass)
- bun test test/cli/cmd/ (50 pass)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
