### PR TITLE
fix(core): include skill base directory in /skill-name command template

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -1,3 +1,5 @@
+import path from "path"
+import { pathToFileURL } from "url"
 import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectBridge } from "@/effect/bridge"
@@ -140,12 +142,24 @@ export const layer = Layer.effect(
 
       for (const item of yield* skill.all()) {
         if (commands[item.name]) continue
+        const dir = path.dirname(item.location)
+        const base = pathToFileURL(dir).href
         commands[item.name] = {
           name: item.name,
           description: item.description,
           source: "skill",
           get template() {
-            return item.content
+            return [
+              `<skill_content name="${item.name}">`,
+              `# Skill: ${item.name}`,
+              "",
+              item.content.trim(),
+              "",
+              `Base directory for this skill: ${base}`,
+              "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",
+              "Note: you can use Glob, Grep, and Read tools to find and inspect reference files.",
+              "</skill_content>",
+            ].join("\n")
           },
           hints: [],
         }


### PR DESCRIPTION
Fixes #24831

When invoking a skill via /skill-name, the command system only injected the raw SKILL.md content as the prompt template. This meant the agent had no knowledge of the skill's base directory or its reference files.

Now the template includes the skill's base directory in the same format as the SkillTool output, so the agent can use Glob/Grep/Read to find and inspect reference files.