### PR TITLE
feat(desktop-app): add menu item and shortcut to open the opencode config file

### DIFF
--- a/packages/app/src/desktop-menu.ts
+++ b/packages/app/src/desktop-menu.ts
@@ -145,6 +145,12 @@ export const DESKTOP_MENU: DesktopMenu[] = [
       { type: "item", label: "Toggle Terminal", command: "terminal.toggle", accelerator: { macos: "Ctrl+`" } },
       { type: "item", label: "Toggle File Tree", command: "fileTree.toggle" },
       { type: "separator" },
+      {
+        type: "item",
+        label: "Open Config File...",
+        command: "settings.openConfig",
+      },
+      { type: "separator" },
       { type: "item", label: "Reload", action: "view.reload", role: "reload" },
       { type: "item", label: "Toggle Developer Tools", action: "view.toggleDevTools", role: "toggleDevTools" },
       { type: "separator" },

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1046,6 +1046,17 @@ export default function Layout(props: ParentProps) {
         keybind: "mod+comma",
         onSelect: () => openSettings(),
       },
+      ...(platform.platform === "desktop" && platform.openPath
+        ? [
+            {
+              id: "settings.openConfig",
+              title: "Open Config File",
+              category: language.t("command.category.settings"),
+              keybind: "mod+alt+comma",
+              onSelect: () => openConfigFile(),
+            },
+          ]
+        : []),
       ...(platform.platform === "desktop" && platform.exportDebugLogs
         ? [
             {
@@ -1231,6 +1242,35 @@ export default function Layout(props: ParentProps) {
       if (dialogDead || dialogRun !== run) return
       dialog.show(() => <x.DialogSettings />)
     })
+  }
+
+  function openConfigFile() {
+    const openPath = platform.openPath
+    const dir = serverSync.data.path.config
+    if (!openPath || !dir) {
+      showToast({
+        variant: "error",
+        title: "Unable to open config",
+        description: "Config directory is not available yet.",
+      })
+      return
+    }
+
+    const files = ["opencode.jsonc", "opencode.json", "config.json"].map((file) => `${dir}/${file}`)
+    const app = platform.os === "macos" ? "TextEdit" : undefined
+    const open = (index = 0): Promise<void> => {
+      const file = files[index]
+      if (file) return openPath(file, app).catch(() => open(index + 1))
+      return openPath(dir).catch(() => {
+        showToast({
+          variant: "error",
+          title: "Unable to open config",
+          description: dir,
+        })
+      })
+    }
+
+    void open()
   }
 
   function projectRoot(directory: string) {

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -153,7 +153,11 @@ export function registerIpcHandlers(deps: Deps) {
   })
 
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
-    if (!app) return shell.openPath(path)
+    if (!app) {
+      const error = await shell.openPath(path)
+      if (error) throw new Error(error)
+      return
+    }
     await new Promise<void>((resolve, reject) => {
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an Open Config File… command to the desktop app menu and command palette.

The command opens the user’s OpenCode config file directly, trying opencode.jsonc, opencode.json, then config.json, and falls back to the config directory if no config file exists. It supports customizable keybindings via Shortcuts in Settings, and is implemented for macOS, Windows, and Linux.

### How did you verify your code works?

Tested on macOS.

### Screenshots / recordings

<img width="378" height="358" alt="image" src="https://github.com/user-attachments/assets/2dc53012-8fe5-4bc8-a62b-8f88afbefbdb" />
<img width="959" height="594" alt="image" src="https://github.com/user-attachments/assets/75477178-52b1-4813-bf0b-8b42292ba658" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR