### PR TITLE
fix(transform): skip trailing assistant messages in applyCaching for GitHub Copilot

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -344,7 +344,18 @@ function normalizeMessages(
 
 function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
   const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
-  const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
+  let final = msgs.filter((msg) => msg.role !== "system").slice(-2)
+
+  // Claude via the GitHub Copilot gateway rejects requests where the last message
+  // has cache-control provider options set, because the gateway translates those
+  // into a trailing assistant prefill block that Claude Sonnet 4.5+ does not allow.
+  // Strip any trailing assistant messages from the caching candidates to avoid the
+  // "This model does not support assistant message prefill" 400 error.
+  // See: https://github.com/anomalyco/opencode/issues (reported by user, diagnosed via
+  // AI-assisted analysis of transform.ts — treat with appropriate scepticism).
+  if (model.api.npm === "@ai-sdk/github-copilot") {
+    final = final.filter((msg) => msg.role !== "assistant")
+  }
 
   const providerOptions = {
     anthropic: {


### PR DESCRIPTION
## Problem

When using Claude models via the GitHub Copilot gateway (e.g. `github-copilot/claude-sonnet-4.6`), `applyCaching` stamps `copilot_cache_control` providerOptions onto the **last two non-system messages**, regardless of their role. If the last non-system message is an assistant message, the Copilot gateway translates those options into a trailing assistant prefill block in the HTTP payload, which Claude Sonnet 4.5+ rejects with:

```
400 Bad Request: This model does not support assistant message prefill.
The conversation must end with a user message.
```

This is intermittent — it only triggers when the last message in the message array is an assistant message, which can occur (e.g. after certain compaction or tool-call sequences).

## Fix

Filter out assistant messages from the `final` caching candidates when the provider is `@ai-sdk/github-copilot`. Only user and tool messages receive `copilot_cache_control` options. This is a minimal, provider-scoped change that does not affect any other provider.

```ts
if (model.api.npm === "@ai-sdk/github-copilot") {
  final = final.filter((msg) => msg.role !== "assistant")
}
```

## Confidence caveat

> **Note:** The root cause (providerOptions → Copilot gateway prefill translation → Claude 400) was identified through AI-assisted static analysis of `transform.ts` and the `@ai-sdk/github-copilot` SDK behaviour. The exact mechanism by which `copilot_cache_control` on an assistant message causes the gateway to emit a trailing prefill block has **not** been independently verified against the Copilot gateway source. The fix is conservative and the commit message makes this explicit.

If the maintainers have gateway source access and can confirm or refute the causal chain, that would be valuable.