### PR TITLE
feat(github): add option to disable push

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -38,6 +38,11 @@ inputs:
     description: "Base URL for OIDC token exchange API. Only required when running a custom GitHub App install. Defaults to https://api.opencode.ai"
     required: false
 
+  skip_push:
+    description: "Skip pushing changes on the active branch to GitHub. Useful when the agent should only review changes without changing anything itself"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -77,3 +82,4 @@ runs:
         MENTIONS: ${{ inputs.mentions }}
         VARIANT: ${{ inputs.variant }}
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}
+        SKIP_PUSH: ${{ inputs.skip_push }}

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -462,6 +462,7 @@ export const GithubRunCommand = effectCmd({
       const runId = normalizeRunId()
       const share = normalizeShare()
       const oidcBaseUrl = normalizeOidcBaseUrl()
+      const skipPush = normalizeSkipPush()
       const { owner, repo } = context.repo
       // For repo events (schedule, workflow_dispatch), payload has no issue/comment data
       const payload = context.payload as
@@ -589,7 +590,7 @@ export const GithubRunCommand = effectCmd({
             // Agent switched branches (likely created its own branch/PR)
             console.log("Agent managed its own branch, skipping infrastructure push/PR")
             console.log("Response:", response)
-          } else if (dirty) {
+          } else if (dirty && !skipPush) {
             const summary = await summarize(response)
             // workflow_dispatch has an actor for co-author attribution, schedule does not
             await pushToNewBranch(summary, branch, uncommittedChanges, isScheduleEvent)
@@ -623,7 +624,7 @@ export const GithubRunCommand = effectCmd({
             if (switched) {
               console.log("Agent managed its own branch, skipping infrastructure push")
             }
-            if (dirty && !switched) {
+            if (dirty && !switched && !skipPush) {
               const summary = await summarize(response)
               await pushToLocalBranch(summary, uncommittedChanges)
             }
@@ -641,7 +642,7 @@ export const GithubRunCommand = effectCmd({
             if (switched) {
               console.log("Agent managed its own branch, skipping infrastructure push")
             }
-            if (dirty && !switched) {
+            if (dirty && !switched && !skipPush) {
               const summary = await summarize(response)
               await pushToForkBranch(summary, prData, uncommittedChanges)
             }
@@ -663,7 +664,7 @@ export const GithubRunCommand = effectCmd({
             // Don't push the stale infrastructure branch — just comment.
             await createComment(`${response}${footer({ image: true })}`)
             await removeReaction(commentType)
-          } else if (dirty) {
+          } else if (dirty && !skipPush) {
             const summary = await summarize(response)
             await pushToNewBranch(summary, branch, uncommittedChanges, false)
             const pr = await createPR(
@@ -738,6 +739,14 @@ export const GithubRunCommand = effectCmd({
         if (value === "true") return true
         if (value === "false") return false
         throw new Error(`Invalid use_github_token value: ${value}. Must be a boolean.`)
+      }
+
+      function normalizeSkipPush() {
+        const value = process.env["SKIP_PUSH"]
+        if (!value) return false
+        if (value === "true") return true
+        if (value === "false") return false
+        throw new Error(`Invalid skip_push value: ${value}. Must be a boolean.`)
       }
 
       function normalizeOidcBaseUrl(): string {

--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -86,6 +86,7 @@ Or you can set it up manually.
 - `share`: Whether to share the OpenCode session. Defaults to **true** for public repositories.
 - `prompt`: Optional custom prompt to override the default behavior. Use this to customize how OpenCode processes requests.
 - `token`: Optional GitHub access token for performing operations such as creating comments, committing changes, and opening pull requests. By default, OpenCode uses the installation access token from the OpenCode GitHub App, so commits, comments, and pull requests appear as coming from the app.
+- `skip_push`: Optional option to prevent the agent from pushing any changes to the remote. Useful when the agent should only review changes without changing anything itself.
 
   Alternatively, you can use the GitHub Action runner's [built-in `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token) without installing the OpenCode GitHub App. Just make sure to grant the required permissions in your workflow:
 


### PR DESCRIPTION
### Issue for this PR

Closes #21636

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a new option to prevent the agent in the github action from commiting/pushing any dirty changes on the branch it was reviewing. We encountered this issue with "not so good" models, which regularly did changes on a branch they should just review. We tried fixing this by instructing them in the prompt to not do so, but of course that doesn't work all the time. Since the owner of the issue also asked for this, I guess it could be useful for others too.
I know that I ignored the rule of asking to be assigned to the issue, but this isn't a big change, so I wouldn't be angry if this didn't get merged. We can also just use this for our use case as a fork. 

### How did you verify your code works?
Local tests using `act` (github action emulator) and instructing the review agent to always change a file.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
