### PR TITLE
fix(opencode): replay remote next session events

### DIFF
--- a/packages/opencode/src/session/projectors-next.ts
+++ b/packages/opencode/src/session/projectors-next.ts
@@ -178,6 +178,9 @@ export default [
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Tool.Called), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.tool.called", data })
   }),
+  SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Tool.Progress), (db, data, event) => {
+    update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.tool.progress", data })
+  }),
   SyncEvent.project(EventV2Bridge.toSyncDefinition(SessionEvent.Tool.Success), (db, data, event) => {
     update(db, { id: SessionMessage.ID.make(event.id), type: "session.next.tool.success", data })
   }),

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -112,6 +112,12 @@ export const layer = Layer.effect(Service)(
             data: EffectSchema.decodeUnknownSync(EffectSchema.toCodecJson(EffectSchema.toType(v2.data)))(event.data),
           }
         : event
+      const aggregateID = replayAggregate(replayed.data, def.aggregate)
+      if (aggregateID !== replayed.aggregateID) {
+        throw new Error(
+          `Aggregate mismatch for event "${event.type}": envelope ${replayed.aggregateID}, data ${String(aggregateID)}`,
+        )
+      }
       process(def, replayed, {
         bus,
         bridge,
@@ -209,6 +215,11 @@ export const layer = Layer.effect(Service)(
 export const defaultLayer = layer.pipe(Layer.provide([ProjectBus.defaultLayer, RuntimeFlags.defaultLayer]))
 
 export const use = serviceUse(Service)
+
+function replayAggregate(data: unknown, field: string): unknown {
+  if (typeof data !== "object" || data === null) return undefined
+  return Reflect.get(data, field)
+}
 
 export const registry = new Map<string, Definition>()
 let projectors: Map<string, ProjectorFunc> | undefined

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -105,7 +105,14 @@ export const layer = Layer.effect(Service)(
       // full Effect context, so the forked publish + GlobalBus emit run with
       // the right state without a per-call attachWith.
       const bridge = yield* EffectBridge.make()
-      process(def, event, {
+      const v2 = EventV2.registry.get(def.type)
+      const replayed = v2
+        ? {
+            ...event,
+            data: EffectSchema.decodeUnknownSync(EffectSchema.toCodecJson(EffectSchema.toType(v2.data)))(event.data),
+          }
+        : event
+      process(def, replayed, {
         bus,
         bridge,
         publish,

--- a/packages/opencode/test/control-plane/workspace.test.ts
+++ b/packages/opencode/test/control-plane/workspace.test.ts
@@ -15,7 +15,7 @@ import { ProjectID } from "@/project/schema"
 import { ProjectTable } from "@/project/project.sql"
 import { Session as SessionNs } from "@/session/session"
 import { SessionID } from "@/session/schema"
-import { SessionTable } from "@/session/session.sql"
+import { SessionMessageTable, SessionTable } from "@/session/session.sql"
 import { SyncEvent } from "@/sync"
 import { EventSequenceTable } from "@/sync/event.sql"
 import { resetDatabase } from "../fixture/db"
@@ -1461,7 +1461,7 @@ describe("workspace sync state", () => {
     })
   })
 
-  it.live("sync history replays serialized next events before subsequent legacy events", () => {
+  it.live("sync history projects serialized tool progress before subsequent legacy events", () => {
     let historySessionID: SessionID | undefined
     let historyNextSeq = 0
     return Effect.gen(function* () {
@@ -1474,33 +1474,60 @@ describe("workspace sync state", () => {
             return HttpServerResponse.fromWeb(
               Response.json([
                 {
-                  id: `evt_${unique("history-next-agent")}`,
+                  id: `evt_${unique("history-next-step")}`,
                   aggregate_id: historySessionID!,
                   seq: historyNextSeq,
-                  type: "session.next.agent.switched.1",
+                  type: "session.next.step.started.1",
                   data: {
                     sessionID: historySessionID!,
                     timestamp: "2026-05-26T21:48:56.202Z",
                     agent: "build",
+                    model: { id: "model", providerID: "provider", variant: "default" },
                   },
                 },
                 {
-                  id: `evt_${unique("history-after-next")}`,
+                  id: `evt_${unique("history-tool-input")}`,
                   aggregate_id: historySessionID!,
                   seq: historyNextSeq + 1,
-                  type: "session.next.tool.progress.1",
+                  type: "session.next.tool.input.started.1",
                   data: {
                     sessionID: historySessionID!,
                     timestamp: "2026-05-26T21:48:57.202Z",
                     callID: "call_history",
-                    structured: {},
-                    content: [],
+                    name: "bash",
+                  },
+                },
+                {
+                  id: `evt_${unique("history-tool-called")}`,
+                  aggregate_id: historySessionID!,
+                  seq: historyNextSeq + 2,
+                  type: "session.next.tool.called.1",
+                  data: {
+                    sessionID: historySessionID!,
+                    timestamp: "2026-05-26T21:48:58.202Z",
+                    callID: "call_history",
+                    tool: "bash",
+                    input: { command: "pwd" },
+                    provider: { executed: true },
+                  },
+                },
+                {
+                  id: `evt_${unique("history-tool-progress")}`,
+                  aggregate_id: historySessionID!,
+                  seq: historyNextSeq + 3,
+                  type: "session.next.tool.progress.1",
+                  data: {
+                    sessionID: historySessionID!,
+                    timestamp: "2026-05-26T21:48:59.202Z",
+                    callID: "call_history",
+                    structured: { phase: "running" },
+                    content: [{ type: "text", text: "halfway" }],
                   },
                 },
                 {
                   id: `evt_${unique("history-after-next")}`,
                   aggregate_id: historySessionID!,
-                  seq: historyNextSeq + 2,
+                  seq: historyNextSeq + 4,
                   type: sessionUpdatedType(),
                   data: { sessionID: historySessionID!, info: { title: "after next history" } },
                 },
@@ -1530,10 +1557,25 @@ describe("workspace sync state", () => {
 
             yield* eventuallyEffect(
               Effect.gen(function* () {
-                expect(sessionSequence(session.id)).toBe(historyNextSeq + 2)
+                expect(sessionSequence(session.id)).toBe(historyNextSeq + 4)
                 expect(yield* sessionSvc.get(session.id).pipe(Effect.orDie)).toMatchObject({
-                  agent: "build",
                   title: "after next history",
+                })
+                expect(
+                  Database.use((db) =>
+                    db.select().from(SessionMessageTable).where(eq(SessionMessageTable.session_id, session.id)).get(),
+                  )?.data,
+                ).toMatchObject({
+                  content: [
+                    {
+                      type: "tool",
+                      state: {
+                        status: "running",
+                        structured: { phase: "running" },
+                        content: [{ type: "text", text: "halfway" }],
+                      },
+                    },
+                  ],
                 })
               }),
             )

--- a/packages/opencode/test/control-plane/workspace.test.ts
+++ b/packages/opencode/test/control-plane/workspace.test.ts
@@ -1399,6 +1399,68 @@ describe("workspace sync state", () => {
     })
   })
 
+  it.live("sync history decodes a serialized next event before projection", () => {
+    let historySessionID: SessionID | undefined
+    let historyNextSeq = 0
+    return Effect.gen(function* () {
+      yield* HttpServer.serveEffect()(
+        Effect.gen(function* () {
+          const req = yield* HttpServerRequest.HttpServerRequest
+          const url = new URL(req.url, "http://localhost")
+          if (url.pathname === "/history-decoded-next/global/event") {
+            return HttpServerResponse.fromWeb(eventStreamResponse())
+          }
+          if (url.pathname === "/history-decoded-next/sync/history") {
+            return HttpServerResponse.fromWeb(
+              Response.json([
+                {
+                  id: `evt_${unique("history-decoded-agent")}`,
+                  aggregate_id: historySessionID!,
+                  seq: historyNextSeq,
+                  type: "session.next.agent.switched.1",
+                  data: {
+                    sessionID: historySessionID!,
+                    timestamp: "2026-05-26T21:48:56.202Z",
+                    agent: "build",
+                  },
+                },
+              ]),
+            )
+          }
+          return HttpServerResponse.text("unexpected", { status: 500 })
+        }),
+      )
+      const url = yield* serverUrl()
+      yield* provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const workspace = yield* Workspace.Service
+            const sessionSvc = yield* SessionNs.Service
+            const instance = yield* requireInstance
+            const type = unique("history-decoded-next")
+            const info = workspaceInfo(instance.project.id, type)
+            insertWorkspace(info)
+            registerAdapter(instance.project.id, type, remoteAdapter(`${url}/history-decoded-next`).adapter)
+            const session = yield* sessionSvc.create({})
+            attachSessionToWorkspace(session.id, info.id)
+            historySessionID = session.id
+            historyNextSeq = (sessionSequence(session.id) ?? -1) + 1
+
+            yield* workspace.startWorkspaceSyncing(instance.project.id)
+
+            yield* eventuallyEffect(
+              Effect.gen(function* () {
+                expect(sessionSequence(session.id)).toBe(historyNextSeq)
+                expect((yield* sessionSvc.get(session.id).pipe(Effect.orDie)).agent).toBe("build")
+              }),
+            )
+            yield* workspace.remove(info.id)
+          }),
+        { git: true },
+      )
+    })
+  })
+
   it.live("sync history replays serialized next events before subsequent legacy events", () => {
     let historySessionID: SessionID | undefined
     let historyNextSeq = 0
@@ -1554,7 +1616,7 @@ describe("workspace sync state", () => {
     }),
   )
 
-  it.live("SSE sync events are replayed and forwarded", () => {
+  it.live("SSE serialized next events are replayed and forwarded", () => {
     let sseSessionID: SessionID | undefined
     let sseNextSeq = 0
     return Effect.gen(function* () {
@@ -1575,8 +1637,12 @@ describe("workspace sync state", () => {
                         id: `evt_${unique("sse")}`,
                         aggregateID: sseSessionID!,
                         seq: sseNextSeq,
-                        type: sessionUpdatedType(),
-                        data: { sessionID: sseSessionID!, info: { title: "from sse" } },
+                        type: "session.next.agent.switched.1",
+                        data: {
+                          sessionID: sseSessionID!,
+                          timestamp: "2026-05-26T21:48:58.202Z",
+                          agent: "build",
+                        },
                       },
                     },
                   },
@@ -1610,7 +1676,8 @@ describe("workspace sync state", () => {
 
               yield* eventuallyEffect(
                 Effect.gen(function* () {
-                  expect((yield* sessionSvc.get(session.id).pipe(Effect.orDie)).title).toBe("from sse")
+                  expect(sessionSequence(session.id)).toBe(sseNextSeq)
+                  expect((yield* sessionSvc.get(session.id).pipe(Effect.orDie)).agent).toBe("build")
                 }),
               )
               expect(

--- a/packages/opencode/test/control-plane/workspace.test.ts
+++ b/packages/opencode/test/control-plane/workspace.test.ts
@@ -1399,6 +1399,89 @@ describe("workspace sync state", () => {
     })
   })
 
+  it.live("sync history replays serialized next events before subsequent legacy events", () => {
+    let historySessionID: SessionID | undefined
+    let historyNextSeq = 0
+    return Effect.gen(function* () {
+      yield* HttpServer.serveEffect()(
+        Effect.gen(function* () {
+          const req = yield* HttpServerRequest.HttpServerRequest
+          const url = new URL(req.url, "http://localhost")
+          if (url.pathname === "/history-next/global/event") return HttpServerResponse.fromWeb(eventStreamResponse())
+          if (url.pathname === "/history-next/sync/history") {
+            return HttpServerResponse.fromWeb(
+              Response.json([
+                {
+                  id: `evt_${unique("history-next-agent")}`,
+                  aggregate_id: historySessionID!,
+                  seq: historyNextSeq,
+                  type: "session.next.agent.switched.1",
+                  data: {
+                    sessionID: historySessionID!,
+                    timestamp: "2026-05-26T21:48:56.202Z",
+                    agent: "build",
+                  },
+                },
+                {
+                  id: `evt_${unique("history-after-next")}`,
+                  aggregate_id: historySessionID!,
+                  seq: historyNextSeq + 1,
+                  type: "session.next.tool.progress.1",
+                  data: {
+                    sessionID: historySessionID!,
+                    timestamp: "2026-05-26T21:48:57.202Z",
+                    callID: "call_history",
+                    structured: {},
+                    content: [],
+                  },
+                },
+                {
+                  id: `evt_${unique("history-after-next")}`,
+                  aggregate_id: historySessionID!,
+                  seq: historyNextSeq + 2,
+                  type: sessionUpdatedType(),
+                  data: { sessionID: historySessionID!, info: { title: "after next history" } },
+                },
+              ]),
+            )
+          }
+          return HttpServerResponse.text("unexpected", { status: 500 })
+        }),
+      )
+      const url = yield* serverUrl()
+      yield* provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const workspace = yield* Workspace.Service
+            const sessionSvc = yield* SessionNs.Service
+            const instance = yield* requireInstance
+            const type = unique("history-next-replay")
+            const info = workspaceInfo(instance.project.id, type)
+            insertWorkspace(info)
+            registerAdapter(instance.project.id, type, remoteAdapter(`${url}/history-next`).adapter)
+            const session = yield* sessionSvc.create({ title: "before next history" })
+            attachSessionToWorkspace(session.id, info.id)
+            historySessionID = session.id
+            historyNextSeq = (sessionSequence(session.id) ?? -1) + 1
+
+            yield* workspace.startWorkspaceSyncing(instance.project.id)
+
+            yield* eventuallyEffect(
+              Effect.gen(function* () {
+                expect(sessionSequence(session.id)).toBe(historyNextSeq + 2)
+                expect(yield* sessionSvc.get(session.id).pipe(Effect.orDie)).toMatchObject({
+                  agent: "build",
+                  title: "after next history",
+                })
+              }),
+            )
+            yield* workspace.remove(info.id)
+          }),
+        { git: true },
+      )
+    })
+  })
+
   it.live("SSE forwards non-heartbeat events and ignores heartbeats", () =>
     Effect.gen(function* () {
       yield* HttpServer.serveEffect()(

--- a/packages/opencode/test/sync/index.test.ts
+++ b/packages/opencode/test/sync/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, beforeEach, afterAll } from "bun:test"
+import { describe, expect, beforeEach, afterAll, test } from "bun:test"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { Deferred, Effect, Layer, Schema } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -11,6 +11,8 @@ import { MessageID } from "../../src/session/schema"
 import { initProjectors } from "../../src/server/projectors"
 import { awaitWithTimeout, testEffect } from "../lib/effect"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { EventV2 } from "@opencode-ai/core/event"
+import nextProjectors from "../../src/session/projectors-next"
 
 const it = testEffect(
   Layer.mergeAll(
@@ -21,6 +23,25 @@ const it = testEffect(
     CrossSpawnSpawner.defaultLayer,
   ),
 )
+
+describe("session next projectors", () => {
+  test("covers every versioned next session event", () => {
+    const definitions = EventV2.registry
+      .values()
+      .flatMap((definition) =>
+        definition.type.startsWith("session.next.") && definition.version !== undefined && definition.aggregate !== undefined
+          ? [SyncEvent.versionedType(definition.type, definition.version)]
+          : [],
+      )
+      .toArray()
+      .sort()
+    const projected = nextProjectors
+      .map(([definition]) => SyncEvent.versionedType(definition.type, definition.version))
+      .sort()
+
+    expect(projected).toEqual(definitions)
+  })
+})
 
 beforeEach(() => {
   Database.close()

--- a/packages/opencode/test/sync/index.test.ts
+++ b/packages/opencode/test/sync/index.test.ts
@@ -7,7 +7,7 @@ import { GlobalBus, type GlobalEvent } from "../../src/bus/global"
 import { SyncEvent } from "../../src/sync"
 import { Database, eq } from "@/storage/db"
 import { EventSequenceTable, EventTable } from "../../src/sync/event.sql"
-import { MessageID } from "../../src/session/schema"
+import { MessageID, SessionID } from "../../src/session/schema"
 import { initProjectors } from "../../src/server/projectors"
 import { awaitWithTimeout, testEffect } from "../lib/effect"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -29,7 +29,9 @@ describe("session next projectors", () => {
     const definitions = EventV2.registry
       .values()
       .flatMap((definition) =>
-        definition.type.startsWith("session.next.") && definition.version !== undefined && definition.aggregate !== undefined
+        definition.type.startsWith("session.next.") &&
+        definition.version !== undefined &&
+        definition.aggregate !== undefined
           ? [SyncEvent.versionedType(definition.type, definition.version)]
           : [],
       )
@@ -260,6 +262,58 @@ describe("SyncEvent", () => {
             }),
             /Unknown event type/,
           )
+        }),
+      ),
+    )
+
+    it.live(
+      "does not advance sequence when serialized next event data cannot decode",
+      provideTmpdirInstance(() =>
+        Effect.gen(function* () {
+          SyncEvent.reset()
+          initProjectors()
+          const id = SessionID.descending("ses_invalid_timestamp")
+
+          const exit = yield* Effect.exit(
+            SyncEvent.use.replay({
+              id: "evt_bad_next",
+              type: "session.next.agent.switched.1",
+              seq: 0,
+              aggregateID: id,
+              data: { sessionID: id, timestamp: "not-a-timestamp", agent: "build" },
+            }),
+          )
+
+          expect(exit._tag).toBe("Failure")
+          expect(Database.use((db) => db.select().from(EventSequenceTable).all())).toEqual([])
+          expect(Database.use((db) => db.select().from(EventTable).all())).toEqual([])
+        }),
+      ),
+    )
+
+    it.live(
+      "does not project or advance a replay event with mismatched aggregate data",
+      provideTmpdirInstance(() =>
+        Effect.gen(function* () {
+          SyncEvent.reset()
+          initProjectors()
+          const envelope = SessionID.descending("ses_replay_envelope")
+          const data = SessionID.descending("ses_replay_data")
+
+          const exit = yield* Effect.exit(
+            SyncEvent.use.replay({
+              id: "evt_mismatched_aggregate",
+              type: "session.next.agent.switched.1",
+              seq: 0,
+              aggregateID: envelope,
+              data: { sessionID: data, timestamp: "2026-05-26T21:48:56.202Z", agent: "build" },
+            }),
+          )
+
+          expect(exit._tag).toBe("Failure")
+          expect(String(exit._tag === "Failure" ? exit.cause : "")).toContain("Aggregate mismatch")
+          expect(Database.use((db) => db.select().from(EventSequenceTable).all())).toEqual([])
+          expect(Database.use((db) => db.select().from(EventTable).all())).toEqual([])
         }),
       ),
     )


### PR DESCRIPTION
## Problem

A central OpenCode instance syncing a remote workspace could not replay serialized `session.next.*` events. Persisted and transported next events carry JSON values such as ISO timestamp strings, while their projectors require decoded EventV2 values such as `DateTime.Utc`. When projection fails, the sequence fence does not advance and later ordered history cannot apply.

A second gap allowed `session.next.tool.progress` to be registered for sync without a projector. Missing next-event projectors are skipped before sequence advancement, which independently stalls ordered replay.

## Cause

- `SyncEvent.replay(...)` passed serialized EventV2 payload data directly to typed projectors.
- `SessionEvent.Tool.Progress` had no next-session projector.
- During adversarial review, an additional invariant was identified: an incoming replay envelope could name aggregate A while its decoded payload named aggregate B. Projection would mutate B while sequence/history advanced for A.

## Fix

- Decode serialized EventV2 data at `SyncEvent.replay(...)`, the common boundary shared by history replay, live SSE replay, and `/sync/replay`.
- Validate that decoded replay data contains the same aggregate identity as `event.aggregateID` before projection or sequence persistence.
- Project `session.next.tool.progress` into persisted session messages.
- Keep legacy sync event replay behavior unchanged apart from the aggregate identity invariant.

## Regression Coverage

- Remote `/sync/history` decodes a serialized `session.next.agent.switched.1` event before projection.
- Ordered remote history projects a serialized running-tool progress lifecycle and then continues through a legacy event, proving both persisted progress mutation and fence advancement.
- Live SSE decodes and projects a serialized next event.
- Every currently versioned, aggregated `session.next.*` EventV2 definition is required to have a next projector.
- Malformed serialized next-event data fails without inserting event rows or advancing sequence state.
- Aggregate-envelope mismatch fails without projecting or advancing sequence state.

## Verification

```text
cd packages/opencode
bun run test -- test/control-plane/workspace.test.ts test/sync/index.test.ts test/server/httpapi-sync.test.ts
bun typecheck
```

Result after adversarial-review fixes:

```text
54 pass
1 skip
0 fail
```

The push hook also passed repository typecheck (`bun turbo typecheck`, 19 successful tasks).

## Follow-ups

These are not blockers for this targeted fix, but should be addressed before expanding this event family:

- Before introducing any `session.next.*` version 2 event, move replay decoding behind an exact versioned codec. The current EventV2 lookup is sufficient for today’s version-1-only registry, but must not become the old-version replay contract.
- Align the public/generated sync-event timestamp schema with actual persisted/SSE JSON, which currently serializes EventV2 `DateTime` values as ISO strings.
- Map malformed `/sync/replay` EventV2 wire payloads to an explicit client error rather than the current generic server defect response.

The parent remote request-body fix landed in #29458; this PR is now based directly on `dev`.