### PR TITLE
fix(session): respect format.retryCount and fix OutputFormat encoding

### DIFF
--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -56,15 +56,17 @@ export const ContentFilterError = NamedError.create("ContentFilterError", {
   message: Schema.String,
 })
 
-export class OutputFormatText extends Schema.Class<OutputFormatText>("OutputFormatText")({
+export const OutputFormatText = Schema.Struct({
   type: Schema.Literal("text"),
-}) {}
+}).annotate({ identifier: "OutputFormatText" })
+export type OutputFormatText = Schema.Schema.Type<typeof OutputFormatText>
 
-export class OutputFormatJsonSchema extends Schema.Class<OutputFormatJsonSchema>("OutputFormatJsonSchema")({
+export const OutputFormatJsonSchema = Schema.Struct({
   type: Schema.Literal("json_schema"),
   schema: Schema.Record(Schema.String, Schema.Any).annotate({ identifier: "JSONSchema" }),
   retryCount: NonNegativeInt.pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed(2))),
-}) {}
+}).annotate({ identifier: "OutputFormatJsonSchema" })
+export type OutputFormatJsonSchema = Schema.Schema.Type<typeof OutputFormatJsonSchema>
 
 export const Format = Schema.Union([OutputFormatText, OutputFormatJsonSchema]).annotate({
   discriminator: "type",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -77,6 +77,12 @@ IMPORTANT:
 
 const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema.`
 
+const STRUCTURED_OUTPUT_RETRY_REMINDER = [
+  "<system-reminder>",
+  "You did not call the StructuredOutput tool. You MUST call StructuredOutput exactly once with your final answer matching the required JSON schema. Do not respond with plain text.",
+  "</system-reminder>",
+].join("\n")
+
 function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   // cleanup() marks abandoned tool_use blocks this way after retries/aborts.
   // They are not pending work and must not trigger an assistant-prefill request.
@@ -1136,6 +1142,7 @@ export const layer = Layer.effect(
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
+        let structuredRetry = 0
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1368,9 +1375,51 @@ export const layer = Layer.effect(
                 return "break" as const
               }
               if (format.type === "json_schema") {
+                const maxRetries = format.retryCount ?? 2
+                if (structuredRetry < maxRetries) {
+                  structuredRetry++
+                  yield* sessions.updateMessage(handle.message)
+                  const reminderMsg: SessionV1.User = {
+                    id: MessageID.ascending(),
+                    sessionID,
+                    role: "user",
+                    time: { created: Date.now() },
+                    agent: lastUser.agent,
+                    model: lastUser.model,
+                    format: lastUser.format,
+                  }
+                  const reminderPart: SessionV1.TextPart = {
+                    id: PartID.ascending(),
+                    messageID: reminderMsg.id,
+                    sessionID,
+                    type: "text",
+                    text: STRUCTURED_OUTPUT_RETRY_REMINDER,
+                    synthetic: true,
+                  }
+                  const parsedInfo = decodeMessageInfo(reminderMsg, { errors: "all", propertyOrder: "original" })
+                  if (Exit.isFailure(parsedInfo)) {
+                    yield* Effect.logError("invalid structured-retry reminder message", {
+                      sessionID,
+                      messageID: reminderMsg.id,
+                      cause: Cause.pretty(parsedInfo.cause),
+                    })
+                  }
+                  const parsedPart = decodeMessagePart(reminderPart, { errors: "all", propertyOrder: "original" })
+                  if (Exit.isFailure(parsedPart)) {
+                    yield* Effect.logError("invalid structured-retry reminder part", {
+                      sessionID,
+                      messageID: reminderMsg.id,
+                      partID: reminderPart.id,
+                      cause: Cause.pretty(parsedPart.cause),
+                    })
+                  }
+                  yield* sessions.updateMessage(reminderMsg)
+                  yield* sessions.updatePart(reminderPart)
+                  return "continue" as const
+                }
                 handle.message.error = new SessionV1.StructuredOutputError({
                   message: "Model did not produce structured output",
-                  retries: 0,
+                  retries: structuredRetry,
                 }).toObject()
                 yield* sessions.updateMessage(handle.message)
                 return "break" as const

--- a/packages/opencode/test/session/structured-output-retry.test.ts
+++ b/packages/opencode/test/session/structured-output-retry.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test"
+import { Exit, Schema } from "effect"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+
+const decodeUser = Schema.decodeUnknownExit(SessionV1.User)
+const encodeUser = Schema.encodeUnknownSync(SessionV1.User)
+const decodePart = Schema.decodeUnknownExit(SessionV1.Part)
+
+describe("structured-output-retry.OutputFormat round-trip", () => {
+  // Regression test for #26929: OutputFormatJsonSchema was a Schema.Class,
+  // so encoding a plain object pulled from the DB crashed Effect's encoder.
+  test("encodes a User message with json_schema format from a plain object", () => {
+    const userPlain = {
+      id: MessageID.ascending(),
+      sessionID: SessionID.descending(),
+      role: "user" as const,
+      time: { created: Date.now() },
+      agent: "default",
+      model: { providerID: "anthropic", modelID: "claude-3" },
+      format: {
+        type: "json_schema" as const,
+        schema: { type: "object", properties: { answer: { type: "number" } } },
+        retryCount: 1,
+      },
+    }
+
+    const decoded = decodeUser(userPlain)
+    expect(Exit.isSuccess(decoded)).toBe(true)
+    if (!Exit.isSuccess(decoded)) return
+
+    const encoded = encodeUser(decoded.value) as Record<string, unknown>
+    expect(encoded.role).toBe("user")
+    const encodedFormat = encoded.format as Record<string, unknown>
+    expect(encodedFormat.type).toBe("json_schema")
+    expect(encodedFormat.retryCount).toBe(1)
+    expect(encodedFormat.schema).toEqual({
+      type: "object",
+      properties: { answer: { type: "number" } },
+    })
+
+    const reDecoded = decodeUser(encoded)
+    expect(Exit.isSuccess(reDecoded)).toBe(true)
+    if (!Exit.isSuccess(reDecoded)) return
+    expect(reDecoded.value.format).toEqual(decoded.value.format)
+  })
+
+  test("encodes text format from a plain object", () => {
+    const userPlain = {
+      id: MessageID.ascending(),
+      sessionID: SessionID.descending(),
+      role: "user" as const,
+      time: { created: Date.now() },
+      agent: "default",
+      model: { providerID: "anthropic", modelID: "claude-3" },
+      format: { type: "text" as const },
+    }
+
+    const decoded = decodeUser(userPlain)
+    expect(Exit.isSuccess(decoded)).toBe(true)
+    if (!Exit.isSuccess(decoded)) return
+
+    const encoded = encodeUser(decoded.value) as Record<string, unknown>
+    expect((encoded.format as Record<string, unknown>).type).toBe("text")
+  })
+})
+
+describe("structured-output-retry.reminder shape", () => {
+  // Documents the structural contract for the synthetic user message
+  // runLoop inserts on a structured-output failure: a User with format preserved
+  // plus a synthetic text part.
+  test("synthetic reminder message + part decode and carry the prior format", () => {
+    const sessionID = SessionID.descending()
+    const priorFormat = {
+      type: "json_schema" as const,
+      schema: { type: "object", properties: { ok: { type: "boolean" } } },
+      retryCount: 2,
+    }
+
+    const reminderMsg = {
+      id: MessageID.ascending(),
+      sessionID,
+      role: "user" as const,
+      time: { created: Date.now() },
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude-3" },
+      format: priorFormat,
+    }
+    const reminderPart = {
+      id: PartID.ascending(),
+      messageID: reminderMsg.id,
+      sessionID,
+      type: "text" as const,
+      text: "any reminder text",
+      synthetic: true,
+    }
+
+    const decodedMsg = decodeUser(reminderMsg)
+    expect(Exit.isSuccess(decodedMsg)).toBe(true)
+    if (!Exit.isSuccess(decodedMsg)) return
+    expect(decodedMsg.value.format?.type).toBe("json_schema")
+    if (decodedMsg.value.format?.type === "json_schema") {
+      expect(decodedMsg.value.format.retryCount).toBe(2)
+      expect(decodedMsg.value.format.schema).toEqual(priorFormat.schema)
+    }
+
+    const decodedPart = decodePart(reminderPart)
+    expect(Exit.isSuccess(decodedPart)).toBe(true)
+    if (!Exit.isSuccess(decodedPart)) return
+    if (decodedPart.value.type !== "text") throw new Error("expected text part")
+    expect(decodedPart.value.synthetic).toBe(true)
+  })
+})
+
+describe("structured-output-retry.StructuredOutputError retries", () => {
+  // Issue #25430: previously the error was constructed with `retries: 0` unconditionally.
+  // After the fix, the loop increments structuredRetry up to format.retryCount and
+  // reports that count when finally giving up. Verify the error preserves the count.
+  test("error preserves the attempted retry count", () => {
+    for (const retries of [0, 1, 2, 5]) {
+      const err = new SessionV1.StructuredOutputError({
+        message: "Model did not produce structured output",
+        retries,
+      })
+      expect(err.data.retries).toBe(retries)
+      const obj = err.toObject()
+      expect(obj.data.retries).toBe(retries)
+    }
+  })
+
+  test("default retryCount from OutputFormatJsonSchema is 2", () => {
+    const decoded = Schema.decodeUnknownSync(SessionV1.OutputFormatJsonSchema)({
+      type: "json_schema",
+      schema: { type: "object" },
+    })
+    expect(decoded.retryCount).toBe(2)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #25430
Closes #26929

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two related bugs in session structured-output:

**#25430** — `format.json_schema.retryCount` was declared in the API schema but never read. When the model finished without calling `StructuredOutput`, the error was unconditionally constructed with `retries: 0` and no retry happened.

After this PR, `runLoop` tracks a `structuredRetry` counter and, on a structured-output failure, persists a synthetic user message containing a `<system-reminder>` pointing the model at the `StructuredOutput` tool, then continues the loop. The new message preserves `format` from the prior user (so `toolChoice: "required"` and the `StructuredOutput` tool injection stay active on the next iteration) and uses `MessageID.ascending()` so `lastUser.id > lastAssistant.id` defeats the loop-exit check at `prompt.ts:1287`. After `format.retryCount ?? 2` attempts, the existing `StructuredOutputError` path runs with the correct `retries` count.

**#26929** — `OutputFormatText` and `OutputFormatJsonSchema` were declared as `Schema.Class`. The DB returns plain objects, and `Schema.Class` requires class instances for encoding, so `GET /session/:id/message` crashed with `Expected OutputFormatJsonSchema, got {...}` whenever a message carried inline JSON schema. Converting to `Schema.Struct` (matching every other shape in the file) round-trips plain objects correctly.

### How did you verify your code works?

- `bun typecheck` — 21/21 packages clean.
- `bun test test/session/` — 370 pass / 0 fail / 1 todo, including 5 new cases in `structured-output-retry.test.ts`.
- `bun run lint` — 0 errors; `prettier --check` clean.
- **#26929**, reproduced at the encode layer (`SessionV1.WithParts` is the success schema for `GET /session/:id/message`):
  - On `dev`: encoding a plain user carrying `{ type: "json_schema", ... }` throws `Expected OutputFormatJsonSchema, got {...}` — the failure that 400s the route.
  - On this branch: the same encode round-trips. Guarded by the new round-trip test.
- **#25430**: tests assert `StructuredOutputError` reports the real `retries` count and that the synthetic retry message/part decode with `format` preserved.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
