### PR TITLE
fix(opencode): report invalid agent/mode configs instead of crashing or dropping them

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -9,7 +9,6 @@ import { Glob } from "@opencode-ai/core/util/glob"
 import { configEntryNameFromPath } from "./entry-name"
 import * as ConfigMarkdown from "./markdown"
 import { ConfigModelID } from "./model-id"
-import { ConfigParse } from "./parse"
 import { ConfigPermission } from "./permission"
 
 const log = Log.create({ service: "config" })
@@ -104,6 +103,18 @@ export const Info = AgentSchema.pipe(
 ).annotate({ identifier: "AgentConfig" })
 export type Info = Schema.Schema.Type<typeof Info>
 
+// Surface a config-loading failure to the user and log it, so an invalid file is
+// reported instead of crashing the whole load (load) or vanishing silently (loadMode).
+// Publishing requires an instance context that isn't always present (e.g. tests), so a
+// publish failure is swallowed — the log line is the durable record, the event is best-effort.
+async function report(label: string, item: string, message: string, err: unknown) {
+  log.error(`failed to load ${label}`, { [label]: item, err })
+  const { Session } = await import("@/session/session")
+  await Promise.resolve()
+    .then(() => Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() }))
+    .catch(() => {})
+}
+
 export async function load(dir: string) {
   const result: Record<string, Info> = {}
   for (const item of await Glob.scan("{agent,agents}/**/*.md", {
@@ -113,25 +124,24 @@ export async function load(dir: string) {
     symlink: true,
   })) {
     const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-      const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-        ? err.data.message
-        : `Failed to parse agent ${item}`
-      const { Session } = await import("@/session/session")
-      void Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-      log.error("failed to load agent", { agent: item, err })
+      const message = ConfigMarkdown.FrontmatterError.isInstance(err) ? err.data.message : `Failed to parse agent ${item}`
+      await report("agent", item, message, err)
       return undefined
     })
     if (!md) continue
 
     const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
-    const name = configEntryNameFromPath(item, patterns)
-
     const config = {
-      name,
+      name: configEntryNameFromPath(item, patterns),
       ...md.data,
       prompt: md.content.trim(),
     }
-    result[config.name] = ConfigParse.schema(Info, config, item)
+    const parsed = Schema.decodeUnknownExit(Info)(config, { errors: "all", propertyOrder: "original" })
+    if (Exit.isFailure(parsed)) {
+      await report("agent", item, `Failed to parse agent ${item}`, parsed.cause)
+      continue
+    }
+    result[config.name] = parsed.value
   }
   return result
 }
@@ -145,12 +155,8 @@ export async function loadMode(dir: string) {
     symlink: true,
   })) {
     const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-      const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-        ? err.data.message
-        : `Failed to parse mode ${item}`
-      const { Session } = await import("@/session/session")
-      void Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-      log.error("failed to load mode", { mode: item, err })
+      const message = ConfigMarkdown.FrontmatterError.isInstance(err) ? err.data.message : `Failed to parse mode ${item}`
+      await report("mode", item, message, err)
       return undefined
     })
     if (!md) continue
@@ -161,11 +167,13 @@ export async function loadMode(dir: string) {
       prompt: md.content.trim(),
     }
     const parsed = Schema.decodeUnknownExit(Info)(config, { errors: "all", propertyOrder: "original" })
-    if (Exit.isSuccess(parsed)) {
-      result[config.name] = {
-        ...parsed.value,
-        mode: "primary" as const,
-      }
+    if (Exit.isFailure(parsed)) {
+      await report("mode", item, `Failed to parse mode ${item}`, parsed.cause)
+      continue
+    }
+    result[config.name] = {
+      ...parsed.value,
+      mode: "primary" as const,
     }
   }
   return result

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1,6 +1,8 @@
 import { test, expect, describe, mock, afterEach, beforeEach } from "bun:test"
 import { Effect, Layer, Option } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import { Bus } from "@/bus"
+import { Session } from "@/session/session"
 import { Config } from "@/config/config"
 import { ConfigManaged } from "@/config/managed"
 import { ConfigParse } from "../../src/config/parse"
@@ -887,6 +889,91 @@ Nested agent prompt`,
         mode: "subagent",
         prompt: "Nested agent prompt",
       })
+    },
+  })
+})
+
+test("invalid agent file is reported and does not block valid agents", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const agentDir = path.join(dir, ".opencode", "agent")
+      await fs.mkdir(agentDir, { recursive: true })
+
+      await Filesystem.write(
+        path.join(agentDir, "good.md"),
+        `---
+model: test/model
+---
+Good agent prompt`,
+      )
+
+      await Filesystem.write(
+        path.join(agentDir, "broken.md"),
+        `---
+temperature: "not a number"
+---
+Broken agent prompt`,
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const errors: string[] = []
+      Bus.subscribe(Session.Event.Error, (evt) => {
+        const data = evt.properties.error?.data
+        if (data && "message" in data && typeof data.message === "string") errors.push(data.message)
+      })
+      await Bun.sleep(10)
+      const config = await load()
+      await Bun.sleep(10)
+      // The valid agent still loads even though a sibling file is invalid.
+      expect(config.agent?.["good"]).toMatchObject({ name: "good", model: "test/model" })
+      expect(config.agent?.["broken"]).toBeUndefined()
+      // The invalid file is reported rather than crashing the load.
+      expect(errors.some((m) => m.includes("broken.md"))).toBe(true)
+    },
+  })
+})
+
+test("invalid mode file is reported instead of being silently dropped", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const modeDir = path.join(dir, ".opencode", "mode")
+      await fs.mkdir(modeDir, { recursive: true })
+
+      await Filesystem.write(
+        path.join(modeDir, "good.md"),
+        `---
+model: test/model
+---
+Good mode prompt`,
+      )
+
+      await Filesystem.write(
+        path.join(modeDir, "broken.md"),
+        `---
+temperature: "not a number"
+---
+Broken mode prompt`,
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const errors: string[] = []
+      Bus.subscribe(Session.Event.Error, (evt) => {
+        const data = evt.properties.error?.data
+        if (data && "message" in data && typeof data.message === "string") errors.push(data.message)
+      })
+      await Bun.sleep(10)
+      const config = await load()
+      await Bun.sleep(10)
+      expect(config.agent?.["good"]).toMatchObject({ name: "good", mode: "primary" })
+      expect(config.agent?.["broken"]).toBeUndefined()
+      // Previously the invalid mode vanished with no error; now it must be reported.
+      expect(errors.some((m) => m.includes("broken.md"))).toBe(true)
     },
   })
 })


### PR DESCRIPTION
Fixes #27133

Both config loaders in `packages/opencode/src/config/agent.ts` handled an invalid file inconsistently:

- `load()` (agents) called `ConfigParse.schema(...)`, which throws. One bad file aborted the whole load, so no agents loaded and startup failed with `ConfigInvalidError`.
- `loadMode()` (modes) used `Schema.decodeUnknownExit` and skipped invalid entries with no `else`, so a bad mode was silently dropped with no error.

Now both decode with `decodeUnknownExit`, and on failure they log, publish a `Session.Event.Error`, and skip just the bad file while loading the rest. I pulled the shared report-and-skip logic into a small helper, which also removes the duplicated `.catch` block the two functions had.

## How I verified

- `bun typecheck` (opencode package): clean.
- `oxlint` on both changed files: no new warnings.
- Added two regression tests in `test/config/config.test.ts`. Both fail on the current code (agent test throws `ConfigInvalidError`; mode test fails the "error was reported" assertion) and pass with the fix.
- `bun test test/config test/agent`: passing.
- Manually: ran `bun dev <dir>` against a dir with a valid + invalid file in both `agent/` and `mode/`. Before, startup crashed; after, opencode starts, the valid entries load, and the invalid ones are reported instead of crashing or vanishing.