### PR TITLE
fix(openai): support websocket custom base URLs

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -506,7 +506,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               ...init,
               headers,
             }
-            if (websocketFetch && parsed.pathname.includes("/v1/responses")) return websocketFetch(url, requestInit)
+            if (websocketFetch && parsed.pathname.endsWith("/responses")) return websocketFetch(url, requestInit)
             return fetch(url, OpenAIWebSocketPool.withoutInternalHeaders(requestInit))
           },
         }


### PR DESCRIPTION
### Issue for this PR

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows codex oauth websocket to handle custom openai baseURL that use `/responses` path

### How did you verify your code works?

added logs to see I was connected through websockets for both default openai and through a custom baseURL, see below

### Screenshots / recordings

<img width="1222" height="177" alt="image" src="https://github.com/user-attachments/assets/293297d2-06f3-4c55-9d36-4273adedeba6" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
