### PR TITLE
feat(tui): show session status in terminal tab title

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -30,6 +30,7 @@ import { EditorContextProvider } from "@tui/context/editor"
 import { useEvent } from "@tui/context/event"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
 import { StartupLoading } from "@tui/component/startup-loading"
+import { SPINNER_FRAMES } from "@tui/component/spinner"
 import { SyncProvider, useSync } from "@tui/context/sync"
 import { SyncProviderV2 } from "@tui/context/sync-v2"
 import { LocalProvider, useLocal } from "@tui/context/local"
@@ -450,6 +451,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   const [pasteSummaryEnabled, setPasteSummaryEnabled] = createSignal(
     kv.get("paste_summary_enabled", !sync.data.config.experimental?.disable_paste_summary),
   )
+  const [spinnerFrame, setSpinnerFrame] = createSignal(0)
+
+  // Spinner animation for terminal title when session is busy
+  createEffect(() => {
+    if (route.data.type !== "session") {
+      setSpinnerFrame(0)
+      return
+    }
+    const isBusy = sync.session.status(route.data.sessionID) !== "idle"
+    if (!isBusy) {
+      setSpinnerFrame(0)
+      return
+    }
+    const interval = setInterval(() => setSpinnerFrame((prev) => (prev + 1) % SPINNER_FRAMES.length), 200)
+    onCleanup(() => clearInterval(interval))
+  })
 
   // Update terminal window title based on current route and session
   createEffect(() => {
@@ -462,13 +479,19 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
 
     if (route.data.type === "session") {
       const session = sync.session.get(route.data.sessionID)
-      if (!session || SessionApi.isDefaultTitle(session.title)) {
+      if (!session) {
         renderer.setTerminalTitle("OpenCode")
         return
       }
 
-      const title = session.title.length > 40 ? session.title.slice(0, 37) + "..." : session.title
-      renderer.setTerminalTitle(`OC | ${title}`)
+      const status = sync.session.status(route.data.sessionID)
+      const statusPrefix = status === "idle" ? "▣" : SPINNER_FRAMES[spinnerFrame()]
+      if (SessionApi.isDefaultTitle(session.title)) {
+        renderer.setTerminalTitle(`${statusPrefix} OpenCode`)
+      } else {
+        const title = session.title.length > 40 ? session.title.slice(0, 37) + "..." : session.title
+        renderer.setTerminalTitle(`${statusPrefix} OC | ${title}`)
+      }
       return
     }
 


### PR DESCRIPTION
### Issue for this PR
Closes #
---
### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
---
### What does this PR do?
Adds a session status indicator to the terminal tab title so users can tell at a glance whether a session is idle or working.
**Changes made:**
- `packages/opencode/src/cli/cmd/tui/app.tsx`
**Behavior:**
| Session state | Custom title | Default title |
|---|---|---|
| **Idle** | `▣ OC | {title}` | `▣ OpenCode` |
| **Busy** | `{spinner} OC | {title}` | `{spinner} OpenCode` |
<!-- table not formatted: invalid structure -->
The original title display logic is preserved — custom titles show `OC | {title}`, default titles show `OpenCode`. Only the status prefix (`▣` / spinner) is added in front.
Works on all platforms using standard Unicode characters and OSC 0 escape sequences.
---
### How did you verify your code works?
1. Ran `bun dev` from `packages/opencode`
2. Confirmed the tab title updates between idle and busy states
3. Verified typecheck with `bun typecheck` ✅
---
### Screenshots / recordings
<img width="226" height="32" alt="aae084d0d3c7ab37da539b7e0a9292fb" src="https://github.com/user-attachments/assets/0694675e-9147-4d58-b6db-396ef6f0bb78" />
<img width="213" height="33" alt="4bf44cf774c39cc24f5ed32ecde6305f" src="https://github.com/user-attachments/assets/5a265a84-a010-46c8-95fd-42d803e50383" />
<img width="175" height="33" alt="36849d7b65ca60f81fc299b5d764c8a4" src="https://github.com/user-attachments/assets/66d5d7d3-fbdd-42ff-b6d2-8a2e4be1f12a" />
<img width="142" height="30" alt="a085d1d90010dfd402b23555cb6f6349" src="https://github.com/user-attachments/assets/075d0885-6631-4e9b-b847-05d7c4f950aa" />


### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR