### PR TITLE
fix(server): use persisted session directory for existing-session routes

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -159,14 +159,14 @@ function planWorkspaceRequest(
 
 function planRequest(
   request: HttpServerRequest.HttpServerRequest,
-  sessionWorkspaceID?: WorkspaceID,
+  session?: Session.Info,
 ): Effect.Effect<RequestPlan, never, Workspace.Service> {
   return Effect.gen(function* () {
     const url = requestURL(request)
     const envWorkspaceID = configuredWorkspaceID()
     const workspaceID = url.pathname.startsWith("/api/")
-      ? selectedV2WorkspaceID(url, sessionWorkspaceID)
-      : selectedWorkspaceID(url, sessionWorkspaceID)
+      ? selectedV2WorkspaceID(url, session?.workspaceID)
+      : selectedWorkspaceID(url, session?.workspaceID)
     if (workspaceID === InvalidWorkspaceID) return RequestPlan.InvalidWorkspace()
     const workspace = yield* resolveWorkspace(workspaceID, envWorkspaceID)
 
@@ -178,7 +178,10 @@ function planRequest(
       return yield* planWorkspaceRequest(request, url, workspace)
     }
 
-    return RequestPlan.Local({ directory: defaultDirectory(request, url), workspaceID: envWorkspaceID ?? workspaceID })
+    return RequestPlan.Local({
+      directory: session?.directory || defaultDirectory(request, url),
+      workspaceID: envWorkspaceID ?? workspaceID,
+    })
   })
 }
 
@@ -226,7 +229,7 @@ function routeHttpApiWorkspace<E>(
           Effect.catchDefect(() => Effect.succeed(undefined)),
         )
       : undefined
-    const plan = yield* planRequest(request, session?.workspaceID)
+    const plan = yield* planRequest(request, session)
     return yield* routeWorkspace(client, effect, plan)
   })
 }

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
 import { Cause, Effect, Exit, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { registerAdapter } from "../../src/control-plane/adapters"
 import type { WorkspaceAdapter } from "../../src/control-plane/types"
@@ -27,7 +28,9 @@ import * as DateTime from "effect/DateTime"
 import * as Log from "@opencode-ai/core/util/log"
 import { eq } from "drizzle-orm"
 import { resetDatabase } from "../fixture/db"
-import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { disposeAllInstances, provideInstanceEffect, TestInstance, tmpdirScoped } from "../fixture/fixture"
+import { TestLLMServer } from "../lib/llm-server"
+import { testProviderConfig } from "../lib/test-provider"
 import { testEffect } from "../lib/effect"
 
 void Log.init({ print: false })
@@ -366,6 +369,47 @@ describe("session HttpApi", () => {
         ).toMatchObject([{ type: "assistant" }])
       }),
     { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.live("uses the persisted session directory for prompt requests", () =>
+    Effect.gen(function* () {
+      const llm = yield* TestLLMServer
+      yield* llm.text("ok", { usage: { input: 1, output: 1 } })
+
+      const config = testProviderConfig(llm.url)
+      const sessionDirectory = yield* tmpdirScoped({ git: true, config })
+      const requestDirectory = yield* tmpdirScoped({ git: true, config })
+      const session = yield* createSession({ title: "directory regression" }).pipe(provideInstanceEffect(sessionDirectory))
+
+      const response = yield* request(
+        `${pathFor(SessionPaths.prompt, { sessionID: session.id })}?directory=${encodeURIComponent(requestDirectory)}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            agent: "build",
+            model: { providerID: "test", modelID: "test-model" },
+            parts: [{ type: "text", text: "which directory?" }],
+          }),
+        },
+      )
+
+      expect(response.status).toBe(200)
+      yield* responseJson(response)
+
+      // The prompt records the active instance directory on the assistant
+      // message; that's the resolved cwd used for tools, snapshots, and the
+      // system prompt. Asserting it directly avoids substring-matching a
+      // multi-thousand-token LLM payload.
+      const messages = yield* Session.use
+        .messages({ sessionID: session.id })
+        .pipe(provideInstanceEffect(sessionDirectory), Effect.orDie)
+      const assistant = messages.find((message) => message.info.role === "assistant")
+      expect(assistant?.info.role === "assistant" ? assistant.info.path : undefined).toEqual({
+        cwd: sessionDirectory,
+        root: sessionDirectory,
+      })
+    }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
   )
 
   it.instance(

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -397,10 +397,6 @@ describe("session HttpApi", () => {
       expect(response.status).toBe(200)
       yield* responseJson(response)
 
-      // The prompt records the active instance directory on the assistant
-      // message; that's the resolved cwd used for tools, snapshots, and the
-      // system prompt. Asserting it directly avoids substring-matching a
-      // multi-thousand-token LLM payload.
       const messages = yield* Session.use
         .messages({ sessionID: session.id })
         .pipe(provideInstanceEffect(sessionDirectory), Effect.orDie)


### PR DESCRIPTION
## Summary

When a session was opened from a different working directory than the one it was created in, existing-session HttpApi routes inherited the caller's directory through `?directory`, `x-opencode-directory`, or `process.cwd()`. Downstream prompt context, tool execution, system prompt environment, and instructions all resolved against the wrong instance.

`WorkspaceRoutingMiddleware` already loads the session row early enough to know the persisted directory, but only forwarded `session.workspaceID` into `planRequest`. The session's stored `directory` was discarded.

This change passes the full `Session.Info` into `planRequest` and prefers `session.directory` when routing stays local. Workspace selection (env-configured workspace, query workspace, remote workspace proxying) is unchanged.

## Changes

- `packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts`: thread `Session.Info` through `planRequest`; prefer `session.directory` for local existing-session requests.
- `packages/opencode/test/server/httpapi-session.test.ts`: regression test that creates a session in one tmpdir, calls `POST /session/:sessionID/message` with a conflicting `?directory`, and asserts the persisted assistant message records the original session directory (read from `path.cwd` / `path.root` written in `session/prompt.ts`).

## Test plan

- New `it.live("uses the persisted session directory for prompt requests", ...)` passes against the fix and fails without it.
- `bun typecheck` clean.