### PR TITLE
fix(opencode): skip env-var prefixes in shell permission pattern matching

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -120,7 +120,15 @@ function parts(node: Node) {
 }
 
 function source(node: Node) {
-  return (node.parent?.type === "redirected_statement" ? node.parent.text : node.text).trim()
+  const target = node.parent?.type === "redirected_statement" ? node.parent : node
+  // Filter out variable_assignment children so env-var prefixes like
+  // "GOFLAGS=-mod=vendor" don't leak into the permission pattern (#14110)
+  const children = []
+  for (let i = 0; i < target.childCount; i++) {
+    const child = target.child(i)
+    if (child && child.type !== "variable_assignment") children.push(child.text)
+  }
+  return (children.length > 0 ? children.join(" ") : target.text).trim()
 }
 
 function commands(node: Node) {


### PR DESCRIPTION
### Issue for this PR

Closes #14110

### Type of change

- [x] Bug fix

### What does this PR do?

The `source()` function in shell.ts returned the full tree-sitter node text including `variable_assignment` children. This meant commands like `GOFLAGS=-mod=vendor go test ./...` produced the pattern `"GOFLAGS=-mod=vendor go test ./..."` instead of `"go test ./..."`, so permission rules like `"go *": "allow"` never matched.

Now `source()` filters out `variable_assignment` child nodes before constructing the pattern text, so env-var prefixed commands correctly match their permission rules.

### How did you verify your code works?

Given a bash AST for `GOFLAGS=-mod=vendor go test ./...`, tree-sitter parses it as a `command` node with children `[variable_assignment("GOFLAGS=-mod=vendor"), word("go"), word("test"), word("./...")]`. The fix skips the `variable_assignment` node and joins the rest → `"go test ./..."`, which matches `"go *"`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR