### PR TITLE
fix(opencode): resolve snapshots from git subdirectories

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -122,7 +122,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
                 "-z",
               ],
               {
-                cwd: state.directory,
+                cwd: state.worktree,
                 stdin: feed(files),
               },
             )
@@ -138,7 +138,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
                 ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
               ],
               {
-                cwd: state.directory,
+                cwd: state.worktree,
                 stdin: feed(files),
               },
             )
@@ -149,7 +149,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
             const result = yield* git(
               [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
               {
-                cwd: state.directory,
+                cwd: state.worktree,
                 stdin: feed(files),
               },
             )
@@ -200,7 +200,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
                 git([...quote, ...args(["diff-files", "--name-only", "-z", "--", "."])], {
                   cwd: state.directory,
                 }),
-                git([...quote, ...args(["ls-files", "--others", "--exclude-standard", "-z", "--", "."])], {
+                git([...quote, ...args(["ls-files", "--full-name", "--others", "--exclude-standard", "-z", "--", "."])], {
                   cwd: state.directory,
                 }),
               ],
@@ -239,7 +239,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
               (yield* Effect.all(
                 allow.map((item) =>
                   fs
-                    .stat(path.join(state.directory, item))
+                    .stat(path.join(state.worktree, item))
                     .pipe(Effect.catch(() => Effect.void))
                     .pipe(
                       Effect.map((stat) => {

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -608,6 +608,29 @@ it.live(
 )
 
 it.live(
+  "tracks changes when opened from a git subdirectory",
+  Effect.gen(function* () {
+    const tmp = yield* bootstrapScoped()
+    const subdir = path.join(tmp.path, "src")
+    yield* mkdirp(subdir)
+    yield* write(path.join(subdir, "file.txt"), "before")
+
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+
+      yield* write(path.join(subdir, "file.txt"), "after")
+      yield* write(path.join(subdir, "new.txt"), "new")
+
+      const patch = yield* snapshot.patch(before!)
+      expect(patch.files).toContain(fwd(tmp.path, "src", "file.txt"))
+      expect(patch.files).toContain(fwd(tmp.path, "src", "new.txt"))
+    }).pipe(provideInstance(subdir))
+  }),
+)
+
+it.live(
   "revert only removes files in invoking worktree",
   Effect.gen(function* () {
     const tmp = yield* bootstrapScoped()


### PR DESCRIPTION
### Issue for this PR

Closes #27688

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode is launched from a git subdirectory, snapshot candidate paths can be worktree-relative while later pathspec operations run from the launch directory. This can make git resolve paths like `src/file.txt` under `src/src/file.txt` and fail to record the snapshot.

This PR resolves pathspec-consuming snapshot operations from the worktree root, makes untracked file paths worktree-relative, and adds a regression test for launching from a subdirectory.

Related prior attempts: #27737, #28131.

### How did you verify your code works?

- `bun test test/snapshot/snapshot.test.ts --timeout 30000`
- `bun typecheck`

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR