### PR TITLE
fix(tui): prevent prompt corruption when pasting near wide characters

### DIFF
--- a/packages/opencode/src/cli/cmd/prompt-display.ts
+++ b/packages/opencode/src/cli/cmd/prompt-display.ts
@@ -1,6 +1,6 @@
 const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" })
 
-function promptOffsetWidth(value: string) {
+export function promptOffsetWidth(value: string) {
   let width = 0
   for (const part of graphemes.segment(value)) {
     // Textarea offsets count newlines as one position; Bun.stringWidth counts them as zero.

--- a/packages/opencode/src/cli/cmd/run/footer.command.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.command.tsx
@@ -329,7 +329,10 @@ export function RunCommandMenuBody(props: {
               category: "Suggested",
               display: "Manage queued prompts",
               footer: `${props.queued().length} queued`,
-              keywords: props.queued().map((item) => item.prompt.text).join(" "),
+              keywords: props
+                .queued()
+                .map((item) => item.prompt.text)
+                .join(" "),
             },
           ]
         : []),

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -203,7 +203,9 @@ export function RunFooterView(props: RunFooterViewProps) {
   const subagentShortcut = useKeymapSelector(
     (keymap: OpenTuiKeymap) =>
       formatKeyBindings(
-        keymap.getCommandBindings({ visibility: "registered", commands: ["session.child.first"] }).get("session.child.first"),
+        keymap
+          .getCommandBindings({ visibility: "registered", commands: ["session.child.first"] })
+          .get("session.child.first"),
         props.tuiConfig,
       ) ?? "",
   )
@@ -697,7 +699,9 @@ export function RunFooterView(props: RunFooterViewProps) {
                     gap={1}
                     flexShrink={0}
                   >
-                    <Show when={busy() || exiting() || duration().length > 0 || queuedIndicator() || subagentIndicator()}>
+                    <Show
+                      when={busy() || exiting() || duration().length > 0 || queuedIndicator() || subagentIndicator()}
+                    >
                       <box id="run-direct-footer-hint-left" flexDirection="row" gap={1} flexShrink={0} marginLeft={1}>
                         <Show when={exiting()}>
                           <text id="run-direct-footer-hint-exit" fg={theme().highlight} wrapMode="none" truncate>

--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -210,7 +210,6 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
             if (next.type === "error") {
               throw next.error
             }
-
           } finally {
             if (state.ctrl === ctrl) {
               state.ctrl = undefined

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -25,10 +25,11 @@ import { useSync } from "@tui/context/sync"
 import { useEvent } from "@tui/context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "@tui/context/editor"
 import { MessageID, PartID } from "@/session/schema"
+import { promptOffsetWidth } from "@/cli/cmd/prompt-display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { computePromptTraits } from "./traits"
-import { assign, expandPastedTextPlaceholders } from "./part"
+import { assign, expandPastedTextPlaceholders, expandTrackedPastedText } from "./part"
 import { usePromptStash } from "./stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
@@ -1109,11 +1110,15 @@ export function Prompt(props: PromptProps) {
     }
 
     const messageID = MessageID.ascending()
-    let inputText = store.prompt.input
-
-    // Extmark offsets are display-oriented and can drift from JS string indices
-    // around wide characters. Replace the visible placeholders in the text buffer instead.
-    inputText = expandPastedTextPlaceholders(inputText, store.prompt.parts)
+    const inputText = expandTrackedPastedText(
+      store.prompt.input,
+      input.extmarks.getAllForTypeId(promptPartTypeId).flatMap((extmark) => {
+        const partIndex = store.extmarkToPartIndex.get(extmark.id)
+        const part = partIndex === undefined ? undefined : store.prompt.parts[partIndex]
+        if (part?.type !== "text") return []
+        return [{ start: extmark.start, end: extmark.end, text: part.text }]
+      }),
+    )
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
@@ -1232,7 +1237,7 @@ export function Prompt(props: PromptProps) {
   function pasteText(text: string, virtualText: string) {
     const currentOffset = input.cursorOffset
     const extmarkStart = currentOffset
-    const extmarkEnd = extmarkStart + virtualText.length
+    const extmarkEnd = extmarkStart + promptOffsetWidth(virtualText)
 
     input.insertText(virtualText + " ")
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1111,21 +1111,9 @@ export function Prompt(props: PromptProps) {
     const messageID = MessageID.ascending()
     let inputText = store.prompt.input
 
-    // Expand pasted text inline before submitting
-    const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
-    const sortedExtmarks = allExtmarks.sort((a: { start: number }, b: { start: number }) => b.start - a.start)
-
-    for (const extmark of sortedExtmarks) {
-      const partIndex = store.extmarkToPartIndex.get(extmark.id)
-      if (partIndex !== undefined) {
-        const part = store.prompt.parts[partIndex]
-        if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
-          inputText = before + part.text + after
-        }
-      }
-    }
+    // Extmark offsets are display-oriented and can drift from JS string indices
+    // around wide characters. Replace the visible placeholders in the text buffer instead.
+    inputText = expandPastedTextPlaceholders(inputText, store.prompt.parts)
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
@@ -1242,7 +1230,7 @@ export function Prompt(props: PromptProps) {
   const exit = useExit()
 
   function pasteText(text: string, virtualText: string) {
-    const currentOffset = input.visualCursor.offset
+    const currentOffset = input.cursorOffset
     const extmarkStart = currentOffset
     const extmarkEnd = extmarkStart + virtualText.length
 
@@ -1336,7 +1324,7 @@ export function Prompt(props: PromptProps) {
   }
 
   async function pasteAttachment(file: { filename?: string; filepath?: string; content: string; mime: string }) {
-    const currentOffset = input.visualCursor.offset
+    const currentOffset = input.cursorOffset
     const extmarkStart = currentOffset
     const pdf = file.mime === "application/pdf"
     const count = store.prompt.parts.filter((x) => {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
@@ -1,4 +1,5 @@
 import { PartID } from "@/session/schema"
+import { displaySlice } from "@/cli/cmd/prompt-display"
 import type { PromptInfo } from "./history"
 
 type Item = PromptInfo["parts"][number]
@@ -20,4 +21,14 @@ export function expandPastedTextPlaceholders(text: string, parts: PromptInfo["pa
     if (part.type !== "text" || !part.source?.text) return result
     return result.replace(part.source.text.value, part.text)
   }, text)
+}
+
+export function expandTrackedPastedText(text: string, ranges: { start: number; end: number; text: string }[]) {
+  return ranges
+    .slice()
+    .sort((a, b) => b.start - a.start)
+    .reduce(
+      (result, part) => displaySlice(result, 0, part.start) + part.text + displaySlice(result, part.end),
+      text,
+    )
 }

--- a/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { PromptInfo } from "../../../../src/cli/cmd/tui/component/prompt/history"
-import { assign, expandPastedTextPlaceholders, strip } from "../../../../src/cli/cmd/tui/component/prompt/part"
+import { assign, expandTrackedPastedText, strip } from "../../../../src/cli/cmd/tui/component/prompt/part"
 
 describe("prompt part", () => {
   test("strip removes persisted ids from reused file parts", () => {
@@ -45,23 +45,35 @@ describe("prompt part", () => {
     })
   })
 
-  test("expandPastedTextPlaceholders preserves wide characters around pasted text", () => {
-    const parts = [
-      {
-        type: "text" as const,
-        text: "public:\n\tvoid ExecuteTask();\nprivate:",
-        source: {
-          text: {
-            start: 8,
-            end: 26,
-            value: "[Pasted ~3 lines]",
-          },
-        },
-      },
-    ] satisfies PromptInfo["parts"]
+  test("expandTrackedPastedText preserves wide characters around pasted text", () => {
+    const marker = "[Pasted ~3 lines]"
+    const prefix = "你好你好\n"
 
-    expect(expandPastedTextPlaceholders("你好你好\n[Pasted ~3 lines]\n阿斯顿法国红酒看来", parts)).toBe(
+    expect(
+      expandTrackedPastedText(prefix + marker + "\n阿斯顿法国红酒看来", [
+        {
+          start: Bun.stringWidth("你好你好") + 1,
+          end: Bun.stringWidth("你好你好") + 1 + Bun.stringWidth(marker),
+          text: "public:\n\tvoid ExecuteTask();\nprivate:",
+        },
+      ]),
+    ).toBe(
       "你好你好\npublic:\n\tvoid ExecuteTask();\nprivate:\n阿斯顿法国红酒看来",
     )
+  })
+
+  test("expandTrackedPastedText only expands the tracked placeholder occurrence", () => {
+    const marker = "[Pasted ~3 lines]"
+    const prefix = `keep ${marker} then `
+
+    expect(
+      expandTrackedPastedText(prefix + marker + " tail", [
+        {
+          start: Bun.stringWidth(prefix),
+          end: Bun.stringWidth(prefix + marker),
+          text: "alpha\nbeta\ngamma",
+        },
+      ]),
+    ).toBe(`keep ${marker} then alpha\nbeta\ngamma tail`)
   })
 })

--- a/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-part.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { PromptInfo } from "../../../../src/cli/cmd/tui/component/prompt/history"
-import { assign, strip } from "../../../../src/cli/cmd/tui/component/prompt/part"
+import { assign, expandPastedTextPlaceholders, strip } from "../../../../src/cli/cmd/tui/component/prompt/part"
 
 describe("prompt part", () => {
   test("strip removes persisted ids from reused file parts", () => {
@@ -43,5 +43,25 @@ describe("prompt part", () => {
       filename: "tiny.png",
       url: "data:image/png;base64,abc",
     })
+  })
+
+  test("expandPastedTextPlaceholders preserves wide characters around pasted text", () => {
+    const parts = [
+      {
+        type: "text" as const,
+        text: "public:\n\tvoid ExecuteTask();\nprivate:",
+        source: {
+          text: {
+            start: 8,
+            end: 26,
+            value: "[Pasted ~3 lines]",
+          },
+        },
+      },
+    ] satisfies PromptInfo["parts"]
+
+    expect(expandPastedTextPlaceholders("你好你好\n[Pasted ~3 lines]\n阿斯顿法国红酒看来", parts)).toBe(
+      "你好你好\npublic:\n\tvoid ExecuteTask();\nprivate:\n阿斯顿法国红酒看来",
+    )
   })
 })

--- a/packages/opencode/test/cli/run/footer.view.test.tsx
+++ b/packages/opencode/test/cli/run/footer.view.test.tsx
@@ -198,8 +198,8 @@ async function renderFooter(
           onVariantSelect={() => {}}
           onRows={() => {}}
           onLayout={() => {}}
-           onStatus={() => {}}
-           onQueuedRemove={async () => true}
+          onStatus={() => {}}
+          onQueuedRemove={async () => true}
         />
       </OpencodeKeymapProvider>
     )

--- a/packages/opencode/test/cli/run/runtime.queue.test.ts
+++ b/packages/opencode/test/cli/run/runtime.queue.test.ts
@@ -326,9 +326,9 @@ describe("run runtime queue", () => {
     const first = ui.events.find((item) => item.type === "queued.prompts")
     const event = ui.events.findLast((item) => item.type === "queued.prompts")
     expect(first?.type === "queued.prompts" ? first.prompts : []).toEqual([])
-    expect(first?.type === "queued.prompts" && event?.type === "queued.prompts" ? first.prompts === event.prompts : true).toBe(
-      false,
-    )
+    expect(
+      first?.type === "queued.prompts" && event?.type === "queued.prompts" ? first.prompts === event.prompts : true,
+    ).toBe(false)
     expect(ui.events.findLast((item) => item.type === "queue")).toEqual({ type: "queue", queue: 1 })
     expect(event?.type === "queued.prompts" ? event.prompts.map((item) => item.prompt.text) : []).toEqual(["two"])
     if (event?.type === "queued.prompts") ui.removeQueued(event.prompts[0]!.messageID)


### PR DESCRIPTION
### Issue for this PR

Fixes #29707 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes prompt submission for summarized pasted text when wide characters appear around the paste placeholder.

Previously, prompt submission used extmark offsets to slice and replace `[Pasted ~N lines]` with the original pasted text. Those offsets can differ from JavaScript string indices around wide characters such as Chinese text, which could leave a partial `[Pas` prefix in the submitted prompt and drop trailing characters.

This changes submission to expand the visible paste placeholder from the prompt text instead of slicing by extmark offsets. This matches the existing clipboard expansion behavior and keeps the pasted text plus surrounding text intact.
A regression test covers Chinese text before and after a pasted placeholder.

### How did you verify your code works?

- Manually reproduced the bug with Chinese text before and after a summarized paste.
- Verified the submitted prompt no longer contains `[Pas` and preserves trailing text.
- Ran `bun test test/cli/cmd/tui/prompt-part.test.ts`.
- Ran `bun typecheck`.

### Screenshots / recordings

Input:
<img width="1728" height="923" alt="ScreenShot_2026-05-28_162858_557" src="https://github.com/user-attachments/assets/b8613580-93b2-4e8a-9edd-8555611b8a92" />

Before:
<img width="966" height="374" alt="image" src="https://github.com/user-attachments/assets/39651893-e493-4ed7-b8ea-68dcea963836" />

Fix:
<img width="1728" height="923" alt="ScreenShot_2026-05-28_162916_859" src="https://github.com/user-attachments/assets/4f36e98d-c365-4ccc-9aa0-8460f6f000d8" />

Test:
<img width="1730" height="924" alt="ScreenShot_2026-05-28_163528_206" src="https://github.com/user-attachments/assets/ef397c0a-3cbb-43d7-9f96-c34ee511b06f" />
<img width="1815" height="1029" alt="ScreenShot_2026-05-28_163543_630" src="https://github.com/user-attachments/assets/5b2ca774-6755-46a6-8bf0-32a46f3ac68b" />

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

### 中文说明

修复当 `[Pasted ~N lines]` 粘贴占位符前后存在中文等宽字符时，实际提交给模型的内容被截断的问题。

之前提交时使用 extmark 的 `start/end` 对字符串做 `slice()` 替换。但 extmark 偏移和 JavaScript 字符串索引在中文、全角字符等场景下可能不一致，导致提交内容残留 `[Pas`，并吞掉末尾字符。

这次改为直接在当前 prompt 文本中展开可见的粘贴占位符，不再依赖 extmark 偏移进行字符串切片。这样可以保留完整粘贴内容和前后输入文本。