### PR TITLE
fix: convert display-width offsets to char indices when expanding paste extmarks

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1099,6 +1099,21 @@ export function Prompt(props: PromptProps) {
     const messageID = MessageID.ascending()
     let inputText = store.prompt.input
 
+    // Extmark start/end are display-width offsets, NOT JS string indices.
+    // Convert them to char indices before slicing.
+    function visualOffsetToCharIndex(text: string, visualOffset: number): number {
+      let seen = 0
+      let idx = 0
+      while (idx < text.length) {
+        if (seen >= visualOffset) return idx
+        const cp = text.codePointAt(idx)!
+        const char = String.fromCodePoint(cp)
+        seen += char === "\n" ? 1 : Bun.stringWidth(char)
+        idx += char.length
+      }
+      return idx
+    }
+
     // Expand pasted text inline before submitting
     const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
     const sortedExtmarks = allExtmarks.sort((a: { start: number }, b: { start: number }) => b.start - a.start)
@@ -1108,8 +1123,10 @@ export function Prompt(props: PromptProps) {
       if (partIndex !== undefined) {
         const part = store.prompt.parts[partIndex]
         if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
+          const charStart = visualOffsetToCharIndex(inputText, extmark.start)
+          const charEnd = visualOffsetToCharIndex(inputText, extmark.end)
+          const before = inputText.slice(0, charStart)
+          const after = inputText.slice(charEnd)
           inputText = before + part.text + after
         }
       }


### PR DESCRIPTION
### Issue for this PR

Closes #29711

### Type of change

- [x] Bug fix

### What does this PR do?

When submitting a prompt with pasted content after typing CJK characters, extmark `start`/`end` positions are display-width offsets (visual columns), not JS string indices. For CJK characters (visual width 2, string length 1), using these offsets directly with `slice()` cuts at wrong positions, causing `[Pasted text]` to appear literally in the submitted message.

Added `visualOffsetToCharIndex()` that walks the string accumulating visual width until reaching the target offset, then returns the corresponding character index. Used it to convert extmark positions before slicing.

### How did you verify your code works?

Tested by typing Korean characters in the prompt, pasting text after them, and submitting — the pasted content now correctly appears inline instead of `[Pasted text]`.

### Screenshots / recordings

N/A (TUI change, no visible UI difference when working correctly)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR