### PR TITLE
fix(subagent): inherit parent session allow rules for MCP tool permissions

### DIFF
--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -9,8 +9,9 @@ import type { Agent } from "./agent"
  *    restriction lives on the agent ruleset, not on the session, so a
  *    subagent that only inherited the parent SESSION's permission would
  *    silently bypass it. (#26514)
- * 2. The parent **session's** deny rules and external_directory rules —
- *    same forwarding the original code already did.
+ * 2. The parent **session's** full permission ruleset — includes both deny
+ *    and allow rules, so that previously-granted MCP tool permissions
+ *    and other allowances are inherited by the subagent. (#16491)
  * 3. Default `todowrite` and `task` denies if the subagent's own ruleset
  *    doesn't already permit them.
  */
@@ -25,9 +26,7 @@ export function deriveSubagentSessionPermission(input: {
     input.parentAgent?.permission.filter((rule) => rule.action === "deny" && rule.permission === "edit") ?? []
   return [
     ...parentAgentDenies,
-    ...input.parentSessionPermission.filter(
-      (rule) => rule.permission === "external_directory" || rule.action === "deny",
-    ),
+    ...input.parentSessionPermission,
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),
   ]


### PR DESCRIPTION
## Problem

Subagents spawned via the Task tool can see MCP tools in their tool registry but cannot execute them (issue #16491). When an MCP tool is called, the permission check in session/tools.ts evaluates the subagent's merged ruleset against the tool name with patterns=['*']. Since the subagent session's permission had no matching 'allow' rules, evaluate() returned "needsAsk=true" - but subagents have no interactive user to respond, causing deadlock.

## Root Cause

deriveSubagentSessionPermission() in subagent-permissions.ts only forwarded 'deny' and 'external_directory' rules from the parent session, filtering out all 'allow' rules. MCP tool permissions - which are dynamic and checked at runtime - were never inherited.

## Fix

Forward the parent session's **full** permission ruleset (both deny and allow) instead of filtering. Deny rules still constrain subagent capabilities, but previously-granted MCP tool permissions and other allowances are now properly inherited.

### Before (line 28-30)
`	s
...input.parentSessionPermission.filter(
  (rule) => rule.permission === "external_directory" || rule.action === "deny",
),
`

### After
`	s
...input.parentSessionPermission,
`

## Validation

- Parent deny rules continue to propagate (Plan Mode edit restrictions, etc.)
- Default 	odowrite and 	ask denies remain in place for subagents that don't explicitly permit them
- The cfg.experimental.primary_tools mechanism in 	ask.ts is unaffected and continues to work alongside inherited rules

Fixes #16491