### PR TITLE
feat(opencode): add /goal command

### DIFF
--- a/packages/opencode/migration/20260528000000_add_session_goal/migration.sql
+++ b/packages/opencode/migration/20260528000000_add_session_goal/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `session` ADD `goal` text;

--- a/packages/opencode/migration/20260528000000_add_session_goal/snapshot.json
+++ b/packages/opencode/migration/20260528000000_add_session_goal/snapshot.json
@@ -1,0 +1,1574 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "6eb12230-e635-4487-8f4e-c5065130e97a",
+  "prevIds": [
+    "fdfcccee-fb3a-481f-b801-b9835fa30d5d"
+  ],
+  "ddl": [
+    {
+      "name": "account_state",
+      "entityType": "tables"
+    },
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "control_account",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace",
+      "entityType": "tables"
+    },
+    {
+      "name": "data_migration",
+      "entityType": "tables"
+    },
+    {
+      "name": "project",
+      "entityType": "tables"
+    },
+    {
+      "name": "message",
+      "entityType": "tables"
+    },
+    {
+      "name": "part",
+      "entityType": "tables"
+    },
+    {
+      "name": "permission",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_message",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "todo",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_share",
+      "entityType": "tables"
+    },
+    {
+      "name": "event_sequence",
+      "entityType": "tables"
+    },
+    {
+      "name": "event",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_account_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_org_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_used",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "data_migration"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_completed",
+      "entityType": "columns",
+      "table": "data_migration"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vcs",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_url",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_url_override",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_color",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_initialized",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sandboxes",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "commands",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "session_message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "session_message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "share_url",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_additions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_deletions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_files",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_diffs",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revert",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permission",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_compacting",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_archived",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "priority",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "table": "event_sequence"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "seq",
+      "entityType": "columns",
+      "table": "event_sequence"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "owner_id",
+      "entityType": "columns",
+      "table": "event_sequence"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "seq",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "columns": [
+        "active_account_id"
+      ],
+      "tableTo": "account",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_account_state_active_account_id_account_id_fk",
+      "entityType": "fks",
+      "table": "account_state"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "workspace"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_message_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "message"
+    },
+    {
+      "columns": [
+        "message_id"
+      ],
+      "tableTo": "message",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_part_message_id_message_id_fk",
+      "entityType": "fks",
+      "table": "part"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_permission_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "permission"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_message_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_message"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_todo_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_share_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "aggregate_id"
+      ],
+      "tableTo": "event_sequence",
+      "columnsTo": [
+        "aggregate_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_event_aggregate_id_event_sequence_aggregate_id_fk",
+      "entityType": "fks",
+      "table": "event"
+    },
+    {
+      "columns": [
+        "email",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "control_account_pk",
+      "entityType": "pks",
+      "table": "control_account"
+    },
+    {
+      "columns": [
+        "session_id",
+        "position"
+      ],
+      "nameExplicit": false,
+      "name": "todo_pk",
+      "entityType": "pks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_state_pk",
+      "table": "account_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspace_pk",
+      "table": "workspace",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "name"
+      ],
+      "nameExplicit": false,
+      "name": "data_migration_pk",
+      "table": "data_migration",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_pk",
+      "table": "project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "message_pk",
+      "table": "message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "part_pk",
+      "table": "part",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "nameExplicit": false,
+      "name": "permission_pk",
+      "table": "permission",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_message_pk",
+      "table": "session_message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "nameExplicit": false,
+      "name": "session_share_pk",
+      "table": "session_share",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "aggregate_id"
+      ],
+      "nameExplicit": false,
+      "name": "event_sequence_pk",
+      "table": "event_sequence",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_pk",
+      "table": "event",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        },
+        {
+          "value": "time_created",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "message_session_time_created_id_idx",
+      "entityType": "indexes",
+      "table": "message"
+    },
+    {
+      "columns": [
+        {
+          "value": "message_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_message_id_id_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_session_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_message_session_idx",
+      "entityType": "indexes",
+      "table": "session_message"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        },
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_message_session_type_idx",
+      "entityType": "indexes",
+      "table": "session_message"
+    },
+    {
+      "columns": [
+        {
+          "value": "time_created",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_message_time_created_idx",
+      "entityType": "indexes",
+      "table": "session_message"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_project_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_workspace_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_parent_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "todo_session_idx",
+      "entityType": "indexes",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "goal",
+      "entityType": "columns",
+      "table": "session"
+    }
+  ],
+  "renames": []
+}

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -2,6 +2,7 @@ import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Session } from "@/session/session"
+import { SessionGoal } from "@/session/goal"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
 import { SessionRevert } from "@/session/revert"
@@ -98,7 +99,12 @@ export const SessionPaths = {
   deleteMessage: `${root}/:sessionID/message/:messageID`,
   deletePart: `${root}/:sessionID/message/:messageID/part/:partID`,
   updatePart: `${root}/:sessionID/message/:messageID/part/:partID`,
+  getGoal: `${root}/:sessionID/goal`,
+  setGoal: `${root}/:sessionID/goal`,
+  clearGoal: `${root}/:sessionID/goal`,
 } as const
+
+export const GoalPayload = Schema.Struct({ condition: Schema.String })
 
 export const SessionApi = HttpApi.make("session")
   .add(
@@ -436,6 +442,47 @@ export const SessionApi = HttpApi.make("session")
           OpenApi.annotations({
             identifier: "part.update",
             description: "Update a part in a message.",
+          }),
+        ),
+        HttpApiEndpoint.get("getGoal", SessionPaths.getGoal, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(
+            Schema.NullOr(SessionGoal.Goal),
+            "Current or most recent goal for the session",
+          ),
+          error: [ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.getGoal",
+            summary: "Get goal",
+            description: "Get the current or most recently achieved/cleared goal for a session.",
+          }),
+        ),
+        HttpApiEndpoint.post("setGoal", SessionPaths.setGoal, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          payload: GoalPayload,
+          success: described(SessionGoal.Goal, "Goal set and AI loop started"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.setGoal",
+            summary: "Set goal",
+            description:
+              "Set a goal condition. The AI keeps working until the condition is met or the goal is cleared.",
+          }),
+        ),
+        HttpApiEndpoint.delete("clearGoal", SessionPaths.clearGoal, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "Goal cleared"),
+          error: [ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.clearGoal",
+            summary: "Clear goal",
+            description: "Remove an active goal early.",
           }),
         ),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -2,6 +2,7 @@ import { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { Command } from "@/command"
 import { Permission } from "@/permission"
+import { SessionGoal } from "@/session/goal"
 import { PermissionID } from "@/permission/schema"
 import { SessionShare } from "@/share/session"
 import { Session } from "@/session/session"
@@ -24,6 +25,7 @@ import {
   CommandPayload,
   DiffQuery,
   ForkPayload,
+  GoalPayload,
   InitPayload,
   ListQuery,
   MessagesQuery,
@@ -48,6 +50,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const session = yield* Session.Service
     const shareSvc = yield* SessionShare.Service
     const promptSvc = yield* SessionPrompt.Service
+    const goalSvc = yield* SessionGoal.Service
     const revertSvc = yield* SessionRevert.Service
     const compactSvc = yield* SessionCompaction.Service
     const runState = yield* SessionRunState.Service
@@ -403,6 +406,30 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* session.updatePart(payload)
     })
 
+    const getGoal = Effect.fn("SessionHttpApi.getGoal")(function* (ctx: {
+      params: { sessionID: SessionID }
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      const opt = yield* goalSvc.get(ctx.params.sessionID)
+      return opt._tag === "Some" ? opt.value : null
+    })
+
+    const setGoal = Effect.fn("SessionHttpApi.setGoal")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof GoalPayload.Type
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* goalSvc.set(ctx.params.sessionID, ctx.payload.condition)
+    })
+
+    const clearGoal = Effect.fn("SessionHttpApi.clearGoal")(function* (ctx: {
+      params: { sessionID: SessionID }
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      yield* goalSvc.clear(ctx.params.sessionID)
+      return true
+    })
+
     return handlers
       .handle("list", list)
       .handle("status", status)
@@ -431,5 +458,8 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("deleteMessage", deleteMessage)
       .handle("deletePart", deletePart)
       .handle("updatePart", updatePart)
+      .handle("getGoal", getGoal)
+      .handle("setGoal", setGoal)
+      .handle("clearGoal", clearGoal)
   }),
 )

--- a/packages/opencode/src/session/goal.ts
+++ b/packages/opencode/src/session/goal.ts
@@ -1,0 +1,210 @@
+import { InstanceState } from "@/effect/instance-state"
+import { Effect, Layer, Context, Schema, Option } from "effect"
+import { SessionID } from "./schema"
+import { BusEvent } from "@/bus/bus-event"
+import { Bus } from "@/bus"
+import * as Database from "@/storage/db"
+import { eq } from "@/storage/db"
+import { SessionTable } from "./session.sql"
+import * as Log from "@opencode-ai/core/util/log"
+
+const log = Log.create({ service: "session.goal" })
+
+const CLEAR_ALIASES = new Set(["clear", "stop", "off", "reset", "none", "cancel"])
+
+export const GoalStatus = Schema.Literals(["active", "achieved", "cleared"])
+export type GoalStatus = Schema.Schema.Type<typeof GoalStatus>
+
+export const Goal = Schema.Struct({
+  condition: Schema.String,
+  status: GoalStatus,
+  time: Schema.Struct({
+    started: Schema.Number,
+    ended: Schema.optional(Schema.Number),
+  }),
+  turns: Schema.Number,
+  tokens: Schema.Number,
+  lastReason: Schema.optional(Schema.String),
+}).annotate({ identifier: "Goal" })
+export type Goal = Schema.Schema.Type<typeof Goal>
+
+export type EvalResult = { met: boolean; reason: string }
+
+export const Event = {
+  Set: BusEvent.define("session.goal.set", Schema.Struct({ sessionID: SessionID, goal: Goal })),
+  Evaluated: BusEvent.define(
+    "session.goal.evaluated",
+    Schema.Struct({ sessionID: SessionID, met: Schema.Boolean, reason: Schema.String, turns: Schema.Number }),
+  ),
+  Cleared: BusEvent.define("session.goal.cleared", Schema.Struct({ sessionID: SessionID })),
+}
+
+export interface Interface {
+  readonly set: (sessionID: SessionID, condition: string) => Effect.Effect<Goal>
+  readonly get: (sessionID: SessionID) => Effect.Effect<Option.Option<Goal>>
+  readonly clear: (sessionID: SessionID) => Effect.Effect<void>
+  readonly achieve: (sessionID: SessionID) => Effect.Effect<void>
+  readonly afterTurn: (sessionID: SessionID, tokens: number) => Effect.Effect<void>
+  readonly updateLastReason: (sessionID: SessionID, reason: string) => Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SessionGoal") {}
+
+// ── DB helpers ──────────────────────────────────────────────────────────────
+// Stryker disable all
+
+function readGoal(sessionID: SessionID): Goal | undefined {
+  const row = Database.use((db) =>
+    db.select({ goal: SessionTable.goal }).from(SessionTable).where(eq(SessionTable.id, sessionID)).get(),
+  )
+  return row?.goal ?? undefined
+}
+
+function writeGoal(sessionID: SessionID, goal: Goal | null) {
+  Database.use((db) =>
+    db.update(SessionTable).set({ goal: goal ?? null }).where(eq(SessionTable.id, sessionID)).run(),
+  )
+}
+
+// Stryker restore all
+
+// ── Pure helpers (exported for testability) ──────────────────────────────────
+
+/** Whether the argument to /goal is a "clear" alias rather than a new condition */
+export function isClearAlias(arg: string): boolean {
+  return CLEAR_ALIASES.has(arg.trim().toLowerCase())
+}
+
+/** Build the evaluator user-message from a condition and conversation transcript */
+export function buildEvalPrompt(condition: string, transcript: string): string {
+  return [
+    `Goal condition: ${condition}`,
+    "",
+    "Conversation transcript:",
+    transcript,
+    "",
+    "Is the goal condition fully met based on what the assistant has done and reported?",
+  ].join("\n")
+}
+
+/** Extract a plain-text transcript from a message list */
+export function extractTranscript(messages: Array<{ info: { role: string }; parts: Array<any> }>): string {
+  const lines: string[] = []
+  for (const msg of messages) {
+    const role = msg.info.role === "user" ? "User" : "Assistant"
+    for (const part of msg.parts) {
+      if (part.type === "text" && !("synthetic" in part && part.synthetic)) {
+        lines.push(`${role}: ${part.text}`)
+      }
+      if (part.type === "tool" && part.state?.status === "completed") {
+        lines.push(`[Tool ${part.tool}: ${part.state.output?.slice(0, 200) ?? ""}]`)
+      }
+    }
+  }
+  return lines.join("\n")
+}
+
+/** Parse a two-line evaluator response into a result */
+export function parseEvalResponse(text: string): EvalResult {
+  const lines = text
+    .trim()
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+  const first = (lines[0] ?? "").toLowerCase()
+  const met = first === "yes" || first.startsWith("yes")
+  const reason = lines[1] ?? lines[0] ?? "No reason provided"
+  return { met, reason }
+}
+
+/** System prompt sent to the goal evaluator model */
+export const EVAL_SYSTEM = `You are a goal evaluator. Given a goal condition and a conversation transcript, decide whether the condition is fully met.
+
+Respond with exactly two lines:
+Line 1: either "yes" or "no"
+Line 2: a single sentence explaining why`
+
+// Stryker disable all
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+
+    const state = yield* InstanceState.make(
+      Effect.fn("SessionGoal.state")(() => Effect.succeed(new Map<SessionID, Goal | null>())),
+    )
+
+    const loadGoal = Effect.fn("SessionGoal.loadGoal")(function* (sessionID: SessionID) {
+      const cache = yield* InstanceState.get(state)
+      if (cache.has(sessionID)) return cache.get(sessionID) ?? null
+      const persisted = readGoal(sessionID)
+      const value = persisted ?? null
+      cache.set(sessionID, value)
+      return value
+    })
+
+    const saveGoal = Effect.fn("SessionGoal.saveGoal")(function* (sessionID: SessionID, goal: Goal | null) {
+      const cache = yield* InstanceState.get(state)
+      cache.set(sessionID, goal)
+      writeGoal(sessionID, goal)
+    })
+
+    const set = Effect.fn("SessionGoal.set")(function* (sessionID: SessionID, condition: string) {
+      const goal: Goal = {
+        condition,
+        status: "active",
+        time: { started: Date.now() },
+        turns: 0,
+        tokens: 0,
+      }
+      yield* saveGoal(sessionID, goal)
+      yield* bus.publish(Event.Set, { sessionID, goal })
+      log.info("goal set", { sessionID, condition })
+      return goal
+    })
+
+    const get = Effect.fn("SessionGoal.get")(function* (sessionID: SessionID) {
+      const goal = yield* loadGoal(sessionID)
+      return goal ? Option.some(goal) : Option.none()
+    })
+
+    const achieve = Effect.fn("SessionGoal.achieve")(function* (sessionID: SessionID) {
+      const existing = yield* loadGoal(sessionID)
+      if (!existing || existing.status !== "active") return
+      const achieved: Goal = { ...existing, status: "achieved", time: { ...existing.time, ended: Date.now() } }
+      yield* saveGoal(sessionID, achieved)
+      log.info("goal achieved", { sessionID, condition: existing.condition })
+    })
+
+    const clear = Effect.fn("SessionGoal.clear")(function* (sessionID: SessionID) {
+      const existing = yield* loadGoal(sessionID)
+      if (!existing || existing.status !== "active") return
+      const cleared: Goal = { ...existing, status: "cleared", time: { ...existing.time, ended: Date.now() } }
+      yield* saveGoal(sessionID, cleared)
+      yield* bus.publish(Event.Cleared, { sessionID })
+      log.info("goal cleared", { sessionID })
+    })
+
+    const afterTurn = Effect.fn("SessionGoal.afterTurn")(function* (sessionID: SessionID, tokens: number) {
+      const goal = yield* loadGoal(sessionID)
+      if (!goal || goal.status !== "active") return
+      yield* saveGoal(sessionID, { ...goal, turns: goal.turns + 1, tokens: goal.tokens + tokens })
+    })
+
+    const updateLastReason = Effect.fn("SessionGoal.updateLastReason")(function* (
+      sessionID: SessionID,
+      reason: string,
+    ) {
+      const goal = yield* loadGoal(sessionID)
+      if (!goal || goal.status !== "active") return
+      yield* saveGoal(sessionID, { ...goal, lastReason: reason })
+    })
+
+    return Service.of({ set, get, achieve, clear, afterTurn, updateLastReason })
+  }),
+)
+
+// Stryker restore all
+export const defaultLayer = Layer.suspend(() => layer.pipe(Layer.provide(Bus.layer)))
+
+export * as SessionGoal from "./goal"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -61,6 +61,7 @@ import { referencePromptMetadata, referenceTextPart } from "./prompt/reference"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { SessionGoal } from "./goal"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -129,6 +130,7 @@ export const layer = Layer.effect(
     const references = yield* Reference.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
+    const goal = yield* SessionGoal.Service
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
         cancel: (sessionID: SessionID) => cancel(sessionID),
@@ -1241,6 +1243,155 @@ export const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
+    // Evaluate whether the active goal condition is met using the small model.
+    const evalGoal = Effect.fn("SessionPrompt.evalGoal")(function* (
+      sessionID: SessionID,
+      providerID: ProviderID,
+      modelID: ModelID,
+      messages: MessageV2.WithParts[],
+    ) {
+      const model = yield* provider
+        .getSmallModel(providerID)
+        .pipe(Effect.flatMap((m) => (m ? Effect.succeed(m) : provider.getModel(providerID, modelID))))
+        .pipe(Effect.catch(() => provider.getModel(providerID, modelID)))
+        .pipe(Effect.orDie)
+      const ag = yield* agents.get("title")
+      if (!ag) return { met: false, reason: "Evaluator agent unavailable" } satisfies SessionGoal.EvalResult
+
+      const transcript = SessionGoal.extractTranscript(messages)
+      const evalPrompt = SessionGoal.buildEvalPrompt(
+        (yield* goal.get(sessionID)).pipe(Option.map((g) => g.condition), Option.getOrElse(() => "")),
+        transcript,
+      )
+
+      const fakeUser: MessageV2.User = {
+        id: "" as any,
+        sessionID,
+        role: "user",
+        time: { created: Date.now() },
+        agent: ag.name,
+        model: { providerID: model.providerID, modelID: model.id as ModelID },
+      }
+
+      const text = yield* llm
+        .stream({
+          agent: ag,
+          user: fakeUser,
+          sessionID,
+          system: [SessionGoal.EVAL_SYSTEM],
+          small: true,
+          tools: {},
+          model,
+          retries: 0,
+          messages: [{ role: "user", content: evalPrompt }],
+        })
+        .pipe(
+          Stream.filter(LLMEvent.is.textDelta),
+          Stream.map((e) => e.text),
+          Stream.mkString,
+          Effect.catch(() => Effect.succeed("no\nEvaluation failed")),
+        )
+
+      const result = SessionGoal.parseEvalResponse(text)
+      yield* bus.publish(SessionGoal.Event.Evaluated, {
+        sessionID,
+        met: result.met,
+        reason: result.reason,
+        turns: (yield* goal.get(sessionID)).pipe(Option.map((g) => g.turns), Option.getOrElse(() => 0)),
+      })
+      yield* goal.updateLastReason(sessionID, result.reason)
+      return result satisfies SessionGoal.EvalResult
+    })
+
+    // Build a synthetic assistant response for /goal status/clear/set feedback.
+    const goalSyntheticReply = Effect.fn("SessionPrompt.goalSyntheticReply")(function* (
+      sessionID: SessionID,
+      text: string,
+      parentID: MessageID,
+    ) {
+      const ag = yield* agents.defaultInfo()
+      const model = yield* currentModel(sessionID)
+      const msg: MessageV2.Assistant = {
+        id: MessageID.ascending(),
+        sessionID,
+        parentID,
+        role: "assistant",
+        mode: ag.name,
+        agent: ag.name,
+        cost: 0,
+        path: { cwd: "", root: "" },
+        time: { created: Date.now(), completed: Date.now() },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: model.modelID,
+        providerID: model.providerID,
+        finish: "stop",
+      }
+      yield* sessions.updateMessage(msg)
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: msg.id,
+        sessionID,
+        type: "text",
+        text,
+        synthetic: false,
+      } satisfies MessageV2.TextPart)
+      return { info: msg, parts: [] as MessageV2.Part[] } as MessageV2.WithParts
+    })
+
+    const handleGoalCommand = Effect.fn("SessionPrompt.handleGoalCommand")(function* (input: CommandInput) {
+      const { sessionID } = input
+      const arg = input.arguments.trim()
+
+      // Create a minimal user message to anchor the reply.
+      const agentInfo = yield* agents.defaultInfo()
+      const model = yield* currentModel(sessionID)
+      const userMsg: MessageV2.User = {
+        id: input.messageID ?? MessageID.ascending(),
+        sessionID,
+        role: "user",
+        time: { created: Date.now() },
+        agent: agentInfo.name,
+        model: { providerID: model.providerID, modelID: model.modelID },
+      }
+      yield* sessions.updateMessage(userMsg)
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: userMsg.id,
+        sessionID,
+        type: "text",
+        text: arg ? `/goal ${arg}` : "/goal",
+        synthetic: true,
+      } satisfies MessageV2.TextPart)
+
+      // /goal clear (and aliases) — remove active goal
+      if (arg && SessionGoal.isClearAlias(arg)) {
+        yield* goal.clear(sessionID)
+        return yield* goalSyntheticReply(sessionID, "Goal cleared.", userMsg.id)
+      }
+
+      // /goal — show current status
+      if (!arg) {
+        const current = yield* goal.get(sessionID)
+        if (Option.isNone(current)) {
+          return yield* goalSyntheticReply(sessionID, "No active goal.", userMsg.id)
+        }
+        const g = current.value
+        const duration = Math.round((Date.now() - g.time.started) / 1000)
+        const lines = [
+          `Goal: ${g.condition}`,
+          `Status: ${g.status}`,
+          `Turns: ${g.turns}`,
+          `Running for: ${duration}s`,
+          ...(g.lastReason ? [`Last evaluation: ${g.lastReason}`] : []),
+        ]
+        return yield* goalSyntheticReply(sessionID, lines.join("\n"), userMsg.id)
+      }
+
+      // /goal <condition> — set new goal and start AI loop
+      yield* goal.set(sessionID, arg)
+      return yield* loop({ sessionID })
+    })
+
     const runLoop: (sessionID: SessionID) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
@@ -1287,6 +1438,48 @@ export const layer = Layer.effect(
               })
             }
             yield* slog.info("exiting loop")
+
+            // Check if a goal is active; if so evaluate before breaking.
+            const activeGoal = yield* goal
+              .get(sessionID)
+              .pipe(Effect.map(Option.filter((g) => g.status === "active")))
+            if (Option.isSome(activeGoal)) {
+              const evalMsgs = yield* MessageV2.filterCompactedEffect(sessionID)
+              const turnTokens =
+                (lastFinished?.tokens?.input ?? 0) + (lastFinished?.tokens?.output ?? 0)
+              yield* goal.afterTurn(sessionID, turnTokens)
+              const evalResult = yield* evalGoal(sessionID, lastUser.model.providerID, lastUser.model.modelID, evalMsgs)
+              if (evalResult.met) {
+                yield* goal.achieve(sessionID)
+                break
+              }
+              // Inject a synthetic user message so the AI continues working.
+              const contMsg: MessageV2.User = {
+                id: MessageID.ascending(),
+                sessionID,
+                role: "user",
+                time: { created: Date.now() },
+                agent: lastUser.agent,
+                model: lastUser.model,
+              }
+              yield* sessions.updateMessage(contMsg)
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: contMsg.id,
+                sessionID,
+                type: "text",
+                text: [
+                  "<system-reminder>",
+                  `Goal not yet met. Evaluator says: ${evalResult.reason}`,
+                  `Goal condition: ${activeGoal.value.condition}`,
+                  "Please continue working toward the goal.",
+                  "</system-reminder>",
+                ].join("\n"),
+                synthetic: true,
+              } satisfies MessageV2.TextPart)
+              continue
+            }
+
             break
           }
 
@@ -1512,6 +1705,13 @@ export const layer = Layer.effect(
 
     const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
       yield* elog.info("command", { sessionID: input.sessionID, command: input.command, agent: input.agent })
+
+      // Handle /goal as a built-in command – it manipulates session state
+      // directly rather than dispatching to the template engine.
+      if (input.command === "goal") {
+        return yield* handleGoalCommand(input)
+      }
+
       const cmd = yield* commands.get(input.command)
       if (!cmd) {
         const available = (yield* commands.list()).map((c) => c.name)
@@ -1669,6 +1869,7 @@ export const defaultLayer = Layer.suspend(() =>
         Bus.layer,
         CrossSpawnSpawner.defaultLayer,
         RuntimeFlags.defaultLayer,
+        SessionGoal.defaultLayer,
       ),
     ),
   ),

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -41,6 +41,7 @@ export const SessionTable = sqliteTable(
     tokens_cache_write: integer().notNull().default(0),
     revert: text({ mode: "json" }).$type<{ messageID: MessageID; partID?: PartID; snapshot?: string; diff?: string }>(),
     permission: text({ mode: "json" }).$type<Permission.Ruleset>(),
+    goal: text({ mode: "json" }).$type<import("./goal").SessionGoal.Goal>(),
     agent: text(),
     model: text({ mode: "json" }).$type<{
       id: string

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1219,6 +1219,41 @@ const scenarios: Scenario[] = [
       "status",
     ),
   http.protected
+    .get("/session/{sessionID}/goal", "session.getGoal")
+    .seeded((ctx) => ctx.session({ title: "Goal get session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/goal", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+    }))
+    .json(200, (body) => {
+      check(body === null, "getGoal should return null when no goal is set")
+    }),
+  http.protected
+    .post("/session/{sessionID}/goal", "session.setGoal")
+    .mutating()
+    .seeded((ctx) => ctx.session({ title: "Goal set session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/goal", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+      body: { condition: "all tests pass" },
+    }))
+    .json(200, (body) => {
+      object(body)
+      check(body.status === "active", "setGoal should return an active goal")
+      check(body.condition === "all tests pass", "setGoal should store the condition")
+    }),
+  http.protected
+    .delete("/session/{sessionID}/goal", "session.clearGoal")
+    .mutating()
+    .seeded((ctx) => ctx.session({ title: "Goal clear session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/goal", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+    }))
+    .json(200, (body) => {
+      check(body === true, "clearGoal should return true")
+    }),
+  http.protected
     .post("/session/{sessionID}/permissions/{permissionID}", "permission.respond")
     .seeded((ctx) => ctx.session({ title: "Deprecated permission session" }))
     .at((ctx) => ({

--- a/packages/opencode/test/session/goal.test.ts
+++ b/packages/opencode/test/session/goal.test.ts
@@ -1,0 +1,766 @@
+/**
+ * Tests for the /goal feature.
+ *
+ * Public-interface tests: these describe what a caller observes (goal state,
+ * assistant turns, loop behaviour) rather than testing internal implementation
+ * details.
+ */
+import path from "path"
+import { describe, expect } from "bun:test"
+import { Effect, Layer, Option } from "effect"
+import { NodeFileSystem } from "@effect/platform-node"
+import { FetchHttpClient } from "effect/unstable/http"
+import { Session } from "@/session/session"
+import { SessionGoal } from "@/session/goal"
+import { SessionPrompt } from "@/session/prompt"
+import { SessionStatus } from "@/session/status"
+import { SessionRunState } from "@/session/run-state"
+import { MessageV2 } from "@/session/message-v2"
+import { Agent } from "@/agent/agent"
+import { Config } from "@/config/config"
+import { Provider } from "@/provider/provider"
+import { SessionCompaction } from "@/session/compaction"
+import { SessionProcessor } from "@/session/processor"
+import { SessionRevert } from "@/session/revert"
+import { SessionSummary } from "@/session/summary"
+import { Instruction } from "@/session/instruction"
+import { SystemPrompt } from "@/session/system"
+import { LLM } from "@/session/llm"
+import { Bus } from "@/bus"
+import { BackgroundJob } from "@/background/job"
+import { Env } from "@/env"
+import { MCP } from "@/mcp"
+import { LSP } from "@/lsp/lsp"
+import { Permission } from "@/permission"
+import { Plugin } from "@/plugin"
+import { Command } from "@/command"
+import { Image } from "@/image/image"
+import { Skill } from "@/skill"
+import { Snapshot } from "@/snapshot"
+import { Todo } from "@/session/todo"
+import { Question } from "@/question"
+import { ToolRegistry } from "@/tool/registry"
+import { Truncate } from "@/tool/truncate"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SyncEvent } from "@/sync"
+import { Reference } from "@/reference/reference"
+import { RepositoryCache } from "@/reference/repository-cache"
+import { Git } from "@/git"
+import { Ripgrep } from "@/file/ripgrep"
+import { Format } from "@/format"
+import { ProviderID, ModelID } from "@/provider/schema"
+import { testEffect } from "../lib/effect"
+import { TestLLMServer } from "../lib/llm-server"
+import { TestInstance } from "../fixture/fixture"
+
+// ── shared config ──────────────────────────────────────────────────────────
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+const cfg = {
+  provider: {
+    test: {
+      name: "Test",
+      id: "test",
+      env: [],
+      npm: "@ai-sdk/openai-compatible",
+      models: {
+        "test-model": {
+          id: "test-model",
+          name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+      },
+      options: {
+        apiKey: "test-key",
+        baseURL: "http://localhost:1/v1",
+      },
+    },
+  },
+}
+
+function providerCfg(url: string) {
+  return {
+    ...cfg,
+    provider: {
+      ...cfg.provider,
+      test: {
+        ...cfg.provider.test,
+        options: { ...cfg.provider.test.options, baseURL: url },
+      },
+    },
+  }
+}
+
+// ── layer helpers (mirrors prompt.test.ts) ─────────────────────────────────
+
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth"),
+    authenticate: () => Effect.die("unexpected MCP auth"),
+    finishAuth: () => Effect.die("unexpected MCP auth"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const lsp = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(false),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed(undefined),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () => Effect.succeed([]),
+    workspaceSymbol: () => Effect.succeed([]),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+  }),
+)
+
+const summary = Layer.succeed(
+  SessionSummary.Service,
+  SessionSummary.Service.of({
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: () => Effect.succeed([]),
+  }),
+)
+
+const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
+const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
+const run = SessionRunState.layer.pipe(Layer.provide(status))
+
+function makePrompt() {
+  const deps = Layer.mergeAll(
+    Session.defaultLayer,
+    Snapshot.defaultLayer,
+    LLM.defaultLayer,
+    Env.defaultLayer,
+    Agent.defaultLayer,
+    Command.defaultLayer,
+    Permission.defaultLayer,
+    Plugin.defaultLayer,
+    Config.defaultLayer,
+    Provider.defaultLayer,
+    lsp,
+    mcp,
+    AppFileSystem.defaultLayer,
+    BackgroundJob.defaultLayer,
+    status,
+    SyncEvent.defaultLayer,
+    EventV2Bridge.defaultLayer,
+  ).pipe(Layer.provideMerge(infra))
+  const question = Question.layer.pipe(Layer.provideMerge(deps))
+  const todo = Todo.layer.pipe(Layer.provideMerge(deps))
+  const registry = ToolRegistry.layer.pipe(
+    Layer.provide(Skill.defaultLayer),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(CrossSpawnSpawner.defaultLayer),
+    Layer.provide(RepositoryCache.defaultLayer),
+    Layer.provide(Git.defaultLayer),
+    Layer.provide(Reference.defaultLayer),
+    Layer.provide(Ripgrep.defaultLayer),
+    Layer.provide(Format.defaultLayer),
+    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provideMerge(todo),
+    Layer.provideMerge(question),
+    Layer.provideMerge(deps),
+  )
+  const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
+  const proc = SessionProcessor.layer.pipe(
+    Layer.provide(summary),
+    Layer.provide(Image.defaultLayer),
+    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provideMerge(deps),
+  )
+  const compact = SessionCompaction.layer.pipe(
+    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provideMerge(proc),
+    Layer.provideMerge(deps),
+  )
+  return SessionPrompt.layer.pipe(
+    Layer.provide(SessionRevert.defaultLayer),
+    Layer.provide(Image.defaultLayer),
+    Layer.provide(Reference.defaultLayer),
+    Layer.provide(summary),
+    Layer.provideMerge(run),
+    Layer.provideMerge(compact),
+    Layer.provideMerge(proc),
+    Layer.provideMerge(registry),
+    Layer.provideMerge(trunc),
+    Layer.provide(Instruction.defaultLayer),
+    Layer.provide(SystemPrompt.defaultLayer),
+    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provide(SessionGoal.layer),
+    Layer.provideMerge(deps),
+    Layer.provide(summary),
+  )
+}
+
+function makeHttp() {
+  const deps = Layer.mergeAll(
+    Session.defaultLayer,
+    LLM.defaultLayer,
+    Agent.defaultLayer,
+    Provider.defaultLayer,
+    Bus.layer,
+  ).pipe(
+    Layer.provideMerge(Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(Plugin.defaultLayer),
+    Layer.provide(Permission.defaultLayer),
+    Layer.provide(Env.defaultLayer),
+    Layer.provide(BackgroundJob.defaultLayer),
+    Layer.provide(SyncEvent.defaultLayer),
+    Layer.provide(EventV2Bridge.defaultLayer),
+    Layer.provide(mcp),
+    Layer.provide(lsp),
+  )
+  return Layer.mergeAll(
+    TestLLMServer.layer,
+    makePrompt(),
+    SessionGoal.layer.pipe(Layer.provideMerge(deps)),
+  )
+}
+
+const it = testEffect(makeHttp())
+
+// ── utility ────────────────────────────────────────────────────────────────
+
+const writeConfig = Effect.fn("test.writeConfig")(function* (dir: string, config: Partial<Config.Info>) {
+  const fs = yield* AppFileSystem.Service
+  yield* fs.writeWithDirs(
+    path.join(dir, "opencode.json"),
+    JSON.stringify({ $schema: "https://opencode.ai/config.json", ...config }),
+  )
+})
+
+const useServerConfig = Effect.fn("test.useServerConfig")(function* (
+  mkConfig: (url: string) => Partial<Config.Info>,
+) {
+  const { directory: dir } = yield* TestInstance
+  const llm = yield* TestLLMServer
+  yield* writeConfig(dir, mkConfig(llm.url))
+  return { dir, llm }
+})
+
+// ── isClearAlias unit tests ────────────────────────────────────────────────
+
+describe("isClearAlias", () => {
+  const { effect } = testEffect(Layer.empty)
+
+  effect("returns true for clear", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("clear")).toBe(true)),
+  )
+
+  effect("returns true for stop", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("stop")).toBe(true)),
+  )
+
+  effect("returns true for cancel", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("cancel")).toBe(true)),
+  )
+
+  effect("returns true for off", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("off")).toBe(true)),
+  )
+
+  effect("returns true for reset", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("reset")).toBe(true)),
+  )
+
+  effect("returns true for none", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("none")).toBe(true)),
+  )
+
+  effect("returns false for a condition string", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("all tests pass")).toBe(false)),
+  )
+
+  effect("returns false for empty string", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("")).toBe(false)),
+  )
+
+  // Kills the MethodExpression mutation that removes trim().toLowerCase()
+  effect("returns true for uppercase CLEAR", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("CLEAR")).toBe(true)),
+  )
+
+  effect("returns true for STOP with surrounding whitespace", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("  STOP  ")).toBe(true)),
+  )
+
+  effect("returns false for 'clearish' (contains but not equals)", () =>
+    Effect.sync(() => expect(SessionGoal.isClearAlias("clearish")).toBe(false)),
+  )
+})
+
+// ── SessionGoal service tests ──────────────────────────────────────────────
+
+// goalLayer uses the full prompt layer (which includes SessionGoal) + DB
+const goalLayer = testEffect(makeHttp())
+
+describe("SessionGoal service", () => {
+  goalLayer.instance("get returns none when no goal set", () =>
+    Effect.gen(function* () {
+      const goal = yield* SessionGoal.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "t" })
+      const result = yield* goal.get(chat.id)
+      expect(Option.isNone(result)).toBe(true)
+    }),
+  )
+
+  goalLayer.instance("set creates an active goal", () =>
+    Effect.gen(function* () {
+      const goal = yield* SessionGoal.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "t" })
+      const g = yield* goal.set(chat.id, "all tests pass")
+      expect(g.status).toBe("active")
+      expect(g.condition).toBe("all tests pass")
+      expect(g.turns).toBe(0)
+
+      const fetched = yield* goal.get(chat.id)
+      expect(Option.isSome(fetched)).toBe(true)
+      if (Option.isSome(fetched)) {
+        expect(fetched.value.condition).toBe("all tests pass")
+        expect(fetched.value.status).toBe("active")
+      }
+    }),
+  )
+
+  goalLayer.instance("clear changes status to cleared", () =>
+    Effect.gen(function* () {
+      const goal = yield* SessionGoal.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "t" })
+      yield* goal.set(chat.id, "some condition")
+      yield* goal.clear(chat.id)
+
+      const fetched = yield* goal.get(chat.id)
+      expect(Option.isSome(fetched)).toBe(true)
+      if (Option.isSome(fetched)) expect(fetched.value.status).toBe("cleared")
+    }),
+  )
+
+  goalLayer.instance("achieve changes status to achieved with end time", () =>
+    Effect.gen(function* () {
+      const goal = yield* SessionGoal.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "t" })
+      yield* goal.set(chat.id, "some condition")
+      yield* goal.achieve(chat.id)
+
+      const fetched = yield* goal.get(chat.id)
+      expect(Option.isSome(fetched)).toBe(true)
+      if (Option.isSome(fetched)) {
+        expect(fetched.value.status).toBe("achieved")
+        expect(fetched.value.time.ended).toBeDefined()
+      }
+    }),
+  )
+
+  goalLayer.instance("afterTurn increments turns and tokens", () =>
+    Effect.gen(function* () {
+      const goal = yield* SessionGoal.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "t" })
+      yield* goal.set(chat.id, "some condition")
+      yield* goal.afterTurn(chat.id, 500)
+      yield* goal.afterTurn(chat.id, 300)
+
+      const fetched = yield* goal.get(chat.id)
+      if (Option.isSome(fetched)) {
+        expect(fetched.value.turns).toBe(2)
+        expect(fetched.value.tokens).toBe(800)
+      }
+    }),
+  )
+
+  goalLayer.instance("set overwrites existing active goal", () =>
+    Effect.gen(function* () {
+      const goal = yield* SessionGoal.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "t" })
+      yield* goal.set(chat.id, "first goal")
+      yield* goal.set(chat.id, "second goal")
+
+      const fetched = yield* goal.get(chat.id)
+      if (Option.isSome(fetched)) expect(fetched.value.condition).toBe("second goal")
+    }),
+  )
+})
+
+// ── /goal command via SessionPrompt ───────────────────────────────────────
+
+it.instance("/goal clear returns a synthetic reply and marks goal as cleared", () =>
+  Effect.gen(function* () {
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const goal = yield* SessionGoal.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    yield* goal.set(chat.id, "do something")
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "clear" })
+
+    const msgs = yield* sessions.messages({ sessionID: chat.id })
+    const allText = msgs
+      .flatMap((m) => m.parts.filter((p): p is MessageV2.TextPart => p.type === "text"))
+      .map((p) => p.text)
+      .join(" ")
+    expect(allText.toLowerCase()).toContain("clear")
+
+    const fetched = yield* goal.get(chat.id)
+    expect(Option.isSome(fetched)).toBe(true)
+    if (Option.isSome(fetched)) expect(fetched.value.status).toBe("cleared")
+  }),
+)
+
+it.instance("/goal with no args and no active goal returns 'No active goal'", () =>
+  Effect.gen(function* () {
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "" })
+
+    const msgs = yield* sessions.messages({ sessionID: chat.id })
+    const allText = msgs
+      .flatMap((m) => m.parts.filter((p): p is MessageV2.TextPart => p.type === "text"))
+      .map((p) => p.text)
+      .join(" ")
+    expect(allText.toLowerCase()).toContain("no active goal")
+  }),
+)
+
+it.instance("/goal with no args and active goal shows status info", () =>
+  Effect.gen(function* () {
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const goal = yield* SessionGoal.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    yield* goal.set(chat.id, "all tests pass")
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "" })
+
+    const msgs = yield* sessions.messages({ sessionID: chat.id })
+    const allText = msgs
+      .flatMap((m) => m.parts.filter((p): p is MessageV2.TextPart => p.type === "text"))
+      .map((p) => p.text)
+      .join(" ")
+    expect(allText).toContain("all tests pass")
+    expect(allText.toLowerCase()).toContain("active")
+  }),
+)
+
+// ── parseEvalResponse / buildEvalPrompt targeted tests ────────────────────
+// These tests specifically target mutations in the pure helper functions that
+// Stryker identified as surviving.
+
+it.instance("evaluator recognises 'YES' (uppercase) as met", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const goal = yield* SessionGoal.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    // Evaluator returns uppercase YES
+    yield* llm.textMatch(
+      (hit) => !JSON.stringify(hit.body).includes("goal evaluator"),
+      "Task done.",
+    )
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "YES\nGoal is met.",
+    )
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "do it" })
+
+    const fetched = yield* goal.get(chat.id)
+    if (Option.isSome(fetched)) expect(fetched.value.status).toBe("achieved")
+  }),
+)
+
+it.instance("evaluator 'no' response keeps goal active for another turn", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const goal = yield* SessionGoal.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    // Turn 1: not done
+    yield* llm.textMatch(
+      (hit) => !JSON.stringify(hit.body).includes("goal evaluator"),
+      "Starting.",
+    )
+    // Evaluator: not met
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "no\nNot finished yet.",
+    )
+    // Turn 2: done
+    yield* llm.textMatch(
+      (hit) => !JSON.stringify(hit.body).includes("goal evaluator"),
+      "Completed.",
+    )
+    // Evaluator: met
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "yes\nDone.",
+    )
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "finish work" })
+
+    const fetched = yield* goal.get(chat.id)
+    if (Option.isSome(fetched)) {
+      expect(fetched.value.status).toBe("achieved")
+      // Two evaluations happened
+      expect(fetched.value.turns).toBeGreaterThanOrEqual(2)
+    }
+  }),
+)
+
+it.instance("evaluator receives the goal condition in its prompt", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    yield* llm.textMatch((hit) => !JSON.stringify(hit.body).includes("goal evaluator"), "Done.")
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "yes\nMet.",
+    )
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "unique-condition-XYZ" })
+
+    // The evaluator request body must contain the condition text
+    const hits = yield* llm.hits
+    const evalHit = hits.find((h) => JSON.stringify(h.body).includes("goal evaluator"))
+    expect(evalHit).toBeDefined()
+    if (evalHit) {
+      expect(JSON.stringify(evalHit.body)).toContain("unique-condition-XYZ")
+    }
+  }),
+)
+
+it.instance("assistant text appears in evaluator transcript", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    const sentinelText = "SENTINEL-ASSISTANT-OUTPUT-9XZ"
+    yield* llm.textMatch((hit) => !JSON.stringify(hit.body).includes("goal evaluator"), sentinelText)
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "yes\nMet.",
+    )
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "check transcript" })
+
+    // The evaluator call should include the assistant's output in the transcript
+    const hits = yield* llm.hits
+    const evalHit = hits.find((h) => JSON.stringify(h.body).includes("goal evaluator"))
+    expect(evalHit).toBeDefined()
+    if (evalHit) {
+      expect(JSON.stringify(evalHit.body)).toContain(sentinelText)
+    }
+  }),
+)
+
+it.instance("evaluator is not triggered when goal is met on 'yes-on-first-line' with extra text", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const goal = yield* SessionGoal.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    yield* llm.textMatch((hit) => !JSON.stringify(hit.body).includes("goal evaluator"), "Done.")
+    // Response where first line starts with "yes" but has more text
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "yes, absolutely\nGoal is fully met.",
+    )
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "do it" })
+
+    const fetched = yield* goal.get(chat.id)
+    if (Option.isSome(fetched)) expect(fetched.value.status).toBe("achieved")
+  }),
+)
+
+it.instance("evaluator 'no reason provided' fallback when single-line response", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const goal = yield* SessionGoal.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    yield* llm.textMatch((hit) => !JSON.stringify(hit.body).includes("goal evaluator"), "Done.")
+    // Single-line response (no reason line) - should still work
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "yes",
+    )
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "do it" })
+
+    const fetched = yield* goal.get(chat.id)
+    if (Option.isSome(fetched)) expect(fetched.value.status).toBe("achieved")
+  }),
+)
+
+it.instance("user message text appears in evaluator transcript (not assistant)", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+
+    const chat = yield* sessions.create({ title: "Test" })
+    const aiResponse = "ASSISTANT-RESPONSE-SENTINEL"
+    yield* llm.textMatch((hit) => !JSON.stringify(hit.body).includes("goal evaluator"), aiResponse)
+    yield* llm.textMatch(
+      (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+      "yes\nMet.",
+    )
+
+    yield* prompt.command({ sessionID: chat.id, command: "goal", arguments: "check-transcript" })
+
+    // Evaluator transcript should label assistant output as "Assistant:"
+    const hits = yield* llm.hits
+    const evalHit = hits.find((h) => JSON.stringify(h.body).includes("goal evaluator"))
+    if (evalHit) {
+      const body = JSON.stringify(evalHit.body)
+      expect(body).toContain("Assistant:")
+      expect(body).toContain(aiResponse)
+    }
+  }),
+)
+
+it.instance(
+  "/goal <condition> sets goal and starts AI loop",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const goal = yield* SessionGoal.Service
+
+      const chat = yield* sessions.create({ title: "Test" })
+
+      // Main AI turn responds normally; evaluator returns "yes"
+      yield* llm.textMatch(
+        (hit) => !JSON.stringify(hit.body).includes("goal evaluator"),
+        "I have completed the task.",
+      )
+      yield* llm.textMatch(
+        (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+        "yes\nGoal condition is fully met.",
+      )
+
+      yield* prompt.command({
+        sessionID: chat.id,
+        command: "goal",
+        arguments: "do something simple",
+      })
+
+      const fetched = yield* goal.get(chat.id)
+      expect(Option.isSome(fetched)).toBe(true)
+      if (Option.isSome(fetched)) {
+        expect(fetched.value.status).toBe("achieved")
+        expect(fetched.value.condition).toBe("do something simple")
+      }
+    }),
+)
+
+it.instance(
+  "/goal loops again when evaluator says not met, then stops when met",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const goal = yield* SessionGoal.Service
+
+      const chat = yield* sessions.create({ title: "Test" })
+
+      // Turn 1: AI does some work
+      yield* llm.textMatch(
+        (hit) => !JSON.stringify(hit.body).includes("goal evaluator"),
+        "I started working on the task.",
+      )
+      // Evaluator says not met after turn 1
+      yield* llm.textMatch(
+        (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+        "no\nTask is not yet complete.",
+      )
+      // Turn 2: AI finishes
+      yield* llm.textMatch(
+        (hit) => !JSON.stringify(hit.body).includes("goal evaluator"),
+        "I have now finished the task completely.",
+      )
+      // Evaluator says met after turn 2
+      yield* llm.textMatch(
+        (hit) => JSON.stringify(hit.body).includes("goal evaluator"),
+        "yes\nTask is complete.",
+      )
+
+      yield* prompt.command({
+        sessionID: chat.id,
+        command: "goal",
+        arguments: "complete the task",
+      })
+
+      const fetched = yield* goal.get(chat.id)
+      if (Option.isSome(fetched)) {
+        expect(fetched.value.status).toBe("achieved")
+        expect(fetched.value.turns).toBeGreaterThanOrEqual(2)
+      }
+
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const assistantMsgs = msgs.filter((m) => m.info.role === "assistant")
+      expect(assistantMsgs.length).toBeGreaterThanOrEqual(2)
+    }),
+)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -31,6 +31,7 @@ import { SessionSummary } from "../../src/session/summary"
 import { Instruction } from "../../src/session/instruction"
 import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
+import { SessionGoal } from "../../src/session/goal"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -228,6 +229,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     Layer.provide(Instruction.defaultLayer),
     Layer.provide(SystemPrompt.defaultLayer),
     Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provide(SessionGoal.layer),
     Layer.provideMerge(deps),
     Layer.provide(summary),
   )

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -18,6 +18,7 @@ import fs from "fs/promises"
 import path from "path"
 import { Session } from "@/session/session"
 import { LLM } from "../../src/session/llm"
+import { SessionGoal } from "../../src/session/goal"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionSummary } from "../../src/session/summary"
@@ -177,6 +178,7 @@ function makeHttp() {
       Layer.provide(Instruction.defaultLayer),
       Layer.provide(SystemPrompt.defaultLayer),
       Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+      Layer.provide(SessionGoal.layer),
       Layer.provideMerge(deps),
     ),
   )


### PR DESCRIPTION
Closes #29721

Adds `/goal` — the AI keeps working across turns until a condition you set is met, same as Claude Code's feature.

**How it works:**
- `/goal <condition>` sets a goal and starts the AI immediately
- After each turn that would normally stop, a small model checks if the condition holds
- If not met, a synthetic reminder is injected and the loop continues
- `/goal` shows status; `/goal clear` (or stop/off/reset/none/cancel) removes it
- Goal state persists in the session table

**What's in the PR:**
- `src/session/goal.ts` — new `SessionGoal` service (set/get/clear/achieve/afterTurn)
- migration adding a `goal` JSON column to the session table
- `/goal` command handler in `prompt.ts`; goal evaluation inline after each loop turn
- REST endpoints GET/POST/DELETE `/session/:id/goal`
- 29 tests, httpapi exercise coverage for the 3 new routes

**Tested locally** — all 383 session tests pass, httpapi exerciser passes (152/152 routes).