### PR TITLE
fix(bedrock): skip cachePoint on messages with non-image file parts

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -367,7 +367,26 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
     },
   }
 
+  const targetsBedrock = model.providerID.includes("bedrock") || model.api.npm === "@ai-sdk/amazon-bedrock"
+
   for (const msg of unique([...system, ...final])) {
+    // Bedrock rejects cachePoint on messages whose only cacheable content is
+    // a DocumentBlock (PDF/CSV/etc.) with "nothing available to cache".
+    // DocumentBlocks are processed server-side and don't count toward the
+    // cacheable token budget. Skip the message so the next-most-recent
+    // eligible message in `unique([...system, ...final])` still gets cached.
+    // See https://github.com/sst/opencode/issues/17300
+    if (
+      targetsBedrock &&
+      Array.isArray(msg.content) &&
+      msg.content.some(
+        (part: any) =>
+          part.type === "file" && typeof part.mediaType === "string" && !part.mediaType.startsWith("image/"),
+      )
+    ) {
+      continue
+    }
+
     const useMessageLevelOptions =
       model.providerID === "anthropic" ||
       model.providerID.includes("bedrock") ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2193,6 +2193,117 @@ describe("ProviderTransform.message - bedrock caching with non-bedrock providerI
   })
 })
 
+describe("ProviderTransform.message - bedrock skips cachePoint on DocumentBlock messages", () => {
+  // https://github.com/sst/opencode/issues/17300
+  // Bedrock rejects `cachePoint` when it lands on a message whose only
+  // cacheable content is a non-image file (PDF, CSV, etc.) with
+  // "There is nothing available to cache. Please remove the invalid cache point".
+  const bedrockModel = {
+    id: "amazon-bedrock/anthropic.claude-opus-4-6",
+    providerID: "amazon-bedrock",
+    api: {
+      id: "anthropic.claude-opus-4-6",
+      url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      npm: "@ai-sdk/amazon-bedrock",
+    },
+    name: "Claude Opus 4.6",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.003, output: 0.015, cache: { read: 0.0003, write: 0.00375 } },
+    limit: { context: 200000, output: 8192 },
+    status: "active",
+    options: {},
+    headers: {},
+  } as any
+
+  test("skips cachePoint on user message containing a PDF file", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Summarize this PDF" },
+          { type: "file", mediaType: "application/pdf", data: "data:application/pdf;base64,abcd" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, bedrockModel, {}) as any[]
+
+    expect(result[0].providerOptions?.bedrock?.cachePoint).toBeUndefined()
+  })
+
+  test("still applies cachePoint on a text-only message before the PDF message", () => {
+    const msgs = [
+      { role: "user", content: "first turn, plain text" },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Summarize this" },
+          { type: "file", mediaType: "application/pdf", data: "data:application/pdf;base64,abcd" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, bedrockModel, {}) as any[]
+
+    // The text-only message still gets the cachePoint applied
+    expect(result[0].providerOptions?.bedrock?.cachePoint).toEqual({ type: "default" })
+    // The PDF-bearing message does not
+    expect(result[1].providerOptions?.bedrock?.cachePoint).toBeUndefined()
+  })
+
+  test("does not skip cachePoint on messages containing only an image file", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image" },
+          { type: "file", mediaType: "image/png", data: "data:image/png;base64,abcd" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, bedrockModel, {}) as any[]
+
+    // Images are cacheable, cachePoint should still apply
+    expect(result[0].providerOptions?.bedrock?.cachePoint).toEqual({ type: "default" })
+  })
+
+  test("non-bedrock providers still cache PDF messages (issue is bedrock-specific)", () => {
+    const anthropicModel = {
+      ...bedrockModel,
+      providerID: "anthropic",
+      api: {
+        id: "claude-3-5-sonnet-20241022",
+        url: "https://api.anthropic.com",
+        npm: "@ai-sdk/anthropic",
+      },
+    }
+
+    const msgs = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Summarize this PDF" },
+          { type: "file", mediaType: "application/pdf", data: "data:application/pdf;base64,abcd" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+
+    // Anthropic direct does not have the cache point limitation
+    expect(result[0].providerOptions?.anthropic?.cacheControl).toEqual({ type: "ephemeral" })
+  })
+})
+
 describe("ProviderTransform.message - cache control on gateway", () => {
   const createModel = (overrides: Partial<any> = {}) =>
     ({


### PR DESCRIPTION
Closes #17300

## What

Bedrock rejects `cachePoint` with `There is nothing available to cache. Please remove the invalid cache point and try again.` (400 ValidationException) when it lands on a message whose only cacheable content is a non-image file (PDF, CSV, doc, etc.).

DocumentBlock content is processed server-side and doesn't count toward the cacheable token budget, so the cache marker is invalid in that position. Image files (ImageBlock) are unaffected — those count as cacheable.

## Fix

In `applyCaching`, when targeting Bedrock, skip messages whose content array contains a `file` part with a non-image mediaType. The loop falls through to the next candidate in the `system + final` selection so we still get caching when there's an eligible message available.

Same `continue` pattern proposed by the issue author. Image files are explicitly not skipped.

## Verified

- 4 new unit tests in `transform.test.ts`:
  - PDF in last message: no cachePoint on that message
  - Text message + PDF message: cachePoint on text, none on PDF
  - Image file message: cachePoint still applied (image is cacheable)
  - Direct Anthropic + PDF: unaffected (the bug is Bedrock-specific)
- All 349 existing provider tests still pass

## Type of change

- [x] Bug fix
