### PR TITLE
fix(app): vite file watcher

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,6 +1,9 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vite"
 import desktopPlugin from "./vite"
+
+const appRoot = fileURLToPath(new URL(".", import.meta.url))
 
 const sentry =
   process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT
@@ -25,6 +28,9 @@ export default defineConfig({
     host: "0.0.0.0",
     allowedHosts: true,
     port: 3000,
+    watch: {
+      ignored: (path) => !path.startsWith(appRoot),
+    },
   },
   build: {
     target: "esnext",

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -3,9 +3,8 @@ import { fileURLToPath } from "node:url"
 import { defineConfig } from "vite"
 import desktopPlugin from "./vite"
 
-const appRoot = fileURLToPath(new URL(".", import.meta.url))
 const watchRoots = [
-  appRoot,
+  fileURLToPath(new URL(".", import.meta.url)),
   fileURLToPath(new URL("../core/", import.meta.url)),
   fileURLToPath(new URL("../sdk/js/", import.meta.url)),
   fileURLToPath(new URL("../ui/", import.meta.url)),
@@ -40,8 +39,7 @@ export default defineConfig({
     port: 3000,
     watch: {
       ignored: (file) =>
-        ignoredWatchRoots.some((root) => file.startsWith(root)) ||
-        !watchRoots.some((root) => file.startsWith(root)),
+        ignoredWatchRoots.some((root) => file.startsWith(root)) || !watchRoots.some((root) => file.startsWith(root)),
     },
   },
   build: {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -4,6 +4,16 @@ import { defineConfig } from "vite"
 import desktopPlugin from "./vite"
 
 const appRoot = fileURLToPath(new URL(".", import.meta.url))
+const watchRoots = [
+  appRoot,
+  fileURLToPath(new URL("../core/", import.meta.url)),
+  fileURLToPath(new URL("../sdk/js/", import.meta.url)),
+  fileURLToPath(new URL("../ui/", import.meta.url)),
+]
+const ignoredWatchRoots = [
+  fileURLToPath(new URL("../ui/src/assets/icons/file-types/", import.meta.url)),
+  fileURLToPath(new URL("../ui/src/assets/icons/provider/", import.meta.url)),
+]
 
 const sentry =
   process.env.SENTRY_AUTH_TOKEN && process.env.SENTRY_ORG && process.env.SENTRY_PROJECT
@@ -29,7 +39,9 @@ export default defineConfig({
     allowedHosts: true,
     port: 3000,
     watch: {
-      ignored: (path) => !path.startsWith(appRoot),
+      ignored: (file) =>
+        ignoredWatchRoots.some((root) => file.startsWith(root)) ||
+        !watchRoots.some((root) => file.startsWith(root)),
     },
   },
   build: {


### PR DESCRIPTION
### Issue for this PR

Closes #29733

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Trying to run `bun run dev` on `packages/app` inside WSL environment was resulting in the error below.
As it says I was hitting watcher limits set by WSL and couldn't run the app at all. 
This PR limits the files that are watched by the vite dev server. 
I think it's a good DX solution so also the web / desktop app won't reload whenever u change something inside the 'packages/opencode' or anywhere else what is not related

```
neriousy@FILIP:~/programming/opencode/packages/app$ bun run dev
$ vite

  VITE v7.1.4  ready in 343 ms

  ➜  Local:   http://localhost:3000/
  ➜  Network: http://10.255.255.254:3000/
  ➜  Network: http://172.27.212.120:3000/
  ➜  press h + enter to show help
[baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
node:internal/fs/watchers:316
    const error = new UVException({
                  ^

Error: ENOSPC: System limit for number of file watchers reached, watch '/home/neriousy/programming/opencode/packages/ui/src/assets/icons/provider/kimi-for-coding.svg'
    at FSWatcher.<computed> (node:internal/fs/watchers:316:19)
    at Object.watch (node:fs:2537:36)
    at createFsWatchInstance (file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:16662:16)
    at setFsWatchListener (file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:16704:14)
    at NodeFsHandler$1._watchWithNodeFs (file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:16824:20)
    at NodeFsHandler$1._handleFile (file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:16868:24)
    at NodeFsHandler$1._addToNodeFs (file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:17042:26)
    at async file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:17690:18
    at async Promise.all (index 0)
Emitted 'error' event on FSWatcher instance at:
    at FSWatcher._handleError (file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:17850:148)
    at NodeFsHandler$1._addToNodeFs (file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:17047:18)
    at async file:///home/neriousy/programming/opencode/node_modules/.bun/vite@7.1.4+4771ab42a7f7d7d9/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:17690:18
    at async Promise.all (index 0) {
  errno: -28,
  syscall: 'watch',
  code: 'ENOSPC',
  path: '/home/neriousy/programming/opencode/packages/ui/src/assets/icons/provider/kimi-for-coding.svg',
  filename: '/home/neriousy/programming/opencode/packages/ui/src/assets/icons/provider/kimi-for-coding.svg'
}

Node.js v24.14.0
```


**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Try running `bun run dev` inside WSL environment

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
