### PR TITLE
fix(httpapi): deduplicate EventV2 entries in BusEvent.effectPayloads

### DIFF
--- a/packages/opencode/src/bus/bus-event.ts
+++ b/packages/opencode/src/bus/bus-event.ts
@@ -31,6 +31,7 @@ export function effectPayloads() {
       .toArray(),
     ...EventV2.registry
       .values()
+      .filter((definition) => !registry.has(definition.type))
       .map((definition) =>
         Schema.Struct({
           id: Schema.String,


### PR DESCRIPTION
### Issue for this PR

Closes #28826

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The sync init loop re-registers every versioned+aggregated EventV2 definition into BusEvent.registry. effectPayloads then iterated both registries, emitting each session.next.* schema twice in the generated OpenAPI Event/GlobalEvent unions. Skip EventV2 entries already present in the BusEvent registry, matching the dedupe pattern SyncEvent already uses.

### How did you verify your code works?

Run it locally and verify the spec emitted by OpenCode does not have the duplicates any longer.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
