### PR TITLE
refactor(websearch): support arbitrary providers via config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -41,6 +41,7 @@ import { ConfigReference } from "./reference"
 import { ConfigServer } from "./server"
 import { ConfigSkills } from "./skills"
 import { ConfigVariable } from "./variable"
+import { ConfigWebSearch } from "./websearch"
 import { Npm } from "@opencode-ai/core/npm"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { ConfigExperimental } from "@opencode-ai/core/config/experimental"
@@ -244,6 +245,10 @@ export const Info = Schema.Struct({
   }),
   layout: Schema.optional(ConfigLayout.Layout).annotate({ description: "@deprecated Always uses stretch layout." }),
   permission: Schema.optional(ConfigPermission.Info),
+  websearch: Schema.optional(ConfigWebSearch.Info).annotate({
+    description:
+      "Websearch tool configuration. Register additional providers under `providers` and pick a `default` when more than one is enabled.",
+  }),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),
   attachment: Schema.optional(ConfigAttachment.Info).annotate({
     description: "Attachment processing configuration, including image size limits and resizing behavior",

--- a/packages/opencode/src/config/websearch.ts
+++ b/packages/opencode/src/config/websearch.ts
@@ -1,0 +1,46 @@
+export * as ConfigWebSearch from "./websearch"
+import { Schema } from "effect"
+
+// Per-provider configuration. Every field is optional so users can override only
+// specific knobs on a built-in provider (e.g. `{ "exa": { "enabled": true } }`)
+// or fully define a new provider by supplying `url` + `tool` (+ optionally
+// `args`, `headers`, `label`, `weight`).
+export const Provider = Schema.Struct({
+  enabled: Schema.optional(Schema.Boolean).annotate({
+    description: "Enable or disable this websearch provider. Built-in providers (exa, parallel) are disabled by default.",
+  }),
+  label: Schema.optional(Schema.String).annotate({
+    description: "Display label shown in the UI. Defaults to a label derived from the provider id.",
+  }),
+  url: Schema.optional(Schema.String).annotate({
+    description:
+      "MCP endpoint URL (HTTP JSON-RPC `tools/call`). Supports `{env:NAME}` substitution. Required for user-defined providers.",
+  }),
+  tool: Schema.optional(Schema.String).annotate({
+    description: "MCP tool name to invoke. Required for user-defined providers.",
+  }),
+  headers: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({
+    description: "Optional headers to send with each request. Supports `{env:NAME}` substitution in values.",
+  }),
+  args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)).annotate({
+    description:
+      "Mapping from normalized tool parameters to the MCP tool arguments. String values support `{query}`, `{numResults}`, `{type}`, `{livecrawl}`, `{contextMaxCharacters}`, `{sessionID}` placeholders. Required for user-defined providers.",
+  }),
+  weight: Schema.optional(Schema.Number).annotate({
+    description:
+      "Relative weight for deterministic per-session selection across enabled providers. Defaults to 1. Must be a positive integer.",
+  }),
+}).annotate({ identifier: "WebSearchProviderConfig" })
+export type Provider = Schema.Schema.Type<typeof Provider>
+
+export const Info = Schema.Struct({
+  default: Schema.optional(Schema.String).annotate({
+    description:
+      "Default provider id to use when more than one provider is enabled. Overridden by the `OPENCODE_WEBSEARCH_PROVIDER` environment variable.",
+  }),
+  providers: Schema.optional(Schema.Record(Schema.String, Provider)).annotate({
+    description:
+      "Map of websearch providers keyed by id. Entries for built-in ids (exa, parallel) deep-merge over the built-in descriptor; any other key defines a new provider.",
+  }),
+}).annotate({ identifier: "WebSearchConfig" })
+export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/opencode/src/tool/mcp-websearch.ts
+++ b/packages/opencode/src/tool/mcp-websearch.ts
@@ -1,11 +1,6 @@
 import { Duration, Effect, Schema } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 
-export const EXA_URL = process.env.EXA_API_KEY
-  ? `https://mcp.exa.ai/mcp?exaApiKey=${encodeURIComponent(process.env.EXA_API_KEY)}`
-  : "https://mcp.exa.ai/mcp"
-export const PARALLEL_URL = "https://search.parallel.ai/mcp"
-
 const McpResult = Schema.Struct({
   result: Schema.Struct({
     content: Schema.Array(
@@ -40,56 +35,43 @@ export const parseResponse = Effect.fn("McpWebSearch.parseResponse")(function* (
   return undefined
 })
 
-export const SearchArgs = Schema.Struct({
-  query: Schema.String,
-  type: Schema.String,
-  numResults: Schema.Number,
-  livecrawl: Schema.String,
-  contextMaxCharacters: Schema.optional(Schema.Number),
+const McpRequest = Schema.Struct({
+  jsonrpc: Schema.Literal("2.0"),
+  id: Schema.Literal(1),
+  method: Schema.Literal("tools/call"),
+  params: Schema.Struct({
+    name: Schema.String,
+    arguments: Schema.Unknown,
+  }),
 })
 
-export const ParallelSearchArgs = Schema.Struct({
-  objective: Schema.String,
-  search_queries: Schema.Array(Schema.String),
-  session_id: Schema.optional(Schema.String),
-  model_name: Schema.optional(Schema.String),
-})
+export interface CallInput {
+  url: string
+  tool: string
+  args: unknown
+  headers?: Record<string, string>
+  timeout: Duration.Input
+}
 
-const McpRequest = <F extends Schema.Struct.Fields>(args: Schema.Struct<F>) =>
-  Schema.Struct({
-    jsonrpc: Schema.Literal("2.0"),
-    id: Schema.Literal(1),
-    method: Schema.Literal("tools/call"),
-    params: Schema.Struct({
-      name: Schema.String,
-      arguments: args,
-    }),
-  })
-
-export const call = <F extends Schema.Struct.Fields>(
-  http: HttpClient.HttpClient,
-  url: string,
-  tool: string,
-  args: Schema.Struct<F>,
-  value: Schema.Struct.Type<F>,
-  timeout: Duration.Input,
-  headers?: Record<string, string>,
-) =>
+export const call = (http: HttpClient.HttpClient, input: CallInput) =>
   Effect.gen(function* () {
-    const request = yield* HttpClientRequest.post(url).pipe(
+    const request = yield* HttpClientRequest.post(input.url).pipe(
       HttpClientRequest.accept("application/json, text/event-stream"),
-      HttpClientRequest.setHeaders(headers ?? {}),
-      HttpClientRequest.schemaBodyJson(McpRequest(args))({
+      HttpClientRequest.setHeaders(input.headers ?? {}),
+      HttpClientRequest.schemaBodyJson(McpRequest)({
         jsonrpc: "2.0" as const,
         id: 1 as const,
         method: "tools/call" as const,
-        params: { name: tool, arguments: value },
+        params: { name: input.tool, arguments: input.args },
       }),
     )
     const response = yield* HttpClient.filterStatusOk(http)
       .execute(request)
       .pipe(
-        Effect.timeoutOrElse({ duration: timeout, orElse: () => Effect.die(new Error(`${tool} request timed out`)) }),
+        Effect.timeoutOrElse({
+          duration: input.timeout,
+          orElse: () => Effect.die(new Error(`${input.tool} request timed out`)),
+        }),
       )
     const body = yield* response.text
     return yield* parseResponse(body)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -22,7 +22,7 @@ import z from "zod"
 import { Plugin } from "../plugin"
 import { Provider } from "@/provider/provider"
 
-import { WebSearchTool } from "./websearch"
+import { resolveProviders, WebSearchTool } from "./websearch"
 import { RepoCloneTool } from "./repo_clone"
 import { RepoOverviewTool } from "./repo_overview"
 import { RepositoryCache } from "@/reference/repository-cache"
@@ -58,8 +58,8 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 
 const log = Log.create({ service: "tool.registry" })
 
-export function webSearchEnabled(providerID: ProviderV2.ID, flags = { exa: false, parallel: false }) {
-  return providerID === ProviderV2.ID.opencode || flags.exa || flags.parallel
+export function webSearchEnabled(providerID: ProviderV2.ID, hasProviders: boolean) {
+  return providerID === ProviderV2.ID.opencode || hasProviders
 }
 
 type TaskDef = Tool.InferDef<typeof TaskTool>
@@ -321,9 +321,12 @@ export const layer: Layer.Layer<
     })
 
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
+      const cfg = (yield* config.get()).websearch
+      const hasWebSearchProvider =
+        resolveProviders({ exa: flags.enableExa, parallel: flags.enableParallel }, cfg).length > 0
       const filtered = (yield* all()).filter((tool) => {
         if (tool.id === WebSearchTool.id) {
-          return webSearchEnabled(input.providerID, { exa: flags.enableExa, parallel: flags.enableParallel })
+          return webSearchEnabled(input.providerID, hasWebSearchProvider)
         }
 
         const usePatch =

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -6,6 +6,8 @@ import DESCRIPTION from "./websearch.txt"
 import { checksum } from "@opencode-ai/core/util/encode"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Config } from "@/config/config"
+import { ConfigWebSearch } from "@/config/websearch"
 
 export const Parameters = Schema.Struct({
   query: Schema.String.annotate({ description: "Websearch query" }),
@@ -24,21 +26,235 @@ export const Parameters = Schema.Struct({
   }),
 })
 
-const WebSearchProviderSchema = Schema.Literals(["exa", "parallel"])
-export type WebSearchProvider = Schema.Schema.Type<typeof WebSearchProviderSchema>
+export type Params = Schema.Schema.Type<typeof Parameters>
 
-export function selectWebSearchProvider(sessionID: string, flags = { exa: false, parallel: false }): WebSearchProvider {
+// A resolved websearch provider, ready to invoke. `enabled` is a property of
+// the resolution set (we never put a disabled provider on the list); the
+// descriptor itself only carries what is needed to make the call.
+export interface ResolvedProvider {
+  id: string
+  label: string
+  url: string
+  tool: string
+  weight: number
+  headers: () => Record<string, string>
+  buildArgs: (params: Params, ctx: Tool.Context) => unknown
+}
+
+const USER_AGENT_HEADERS = () => ({ "User-Agent": `opencode/${InstallationVersion}` })
+
+// Built-in providers. Each entry is a function so URLs/headers/args close over
+// `process.env` at *call time*, matching the previous behavior where
+// `EXA_API_KEY` / `PARALLEL_API_KEY` were read lazily.
+const BUILTINS: Record<string, () => ResolvedProvider> = {
+  exa: () => ({
+    id: "exa",
+    label: "Exa Web Search",
+    url: process.env.EXA_API_KEY
+      ? `https://mcp.exa.ai/mcp?exaApiKey=${encodeURIComponent(process.env.EXA_API_KEY)}`
+      : "https://mcp.exa.ai/mcp",
+    tool: "web_search_exa",
+    weight: 1,
+    headers: USER_AGENT_HEADERS,
+    buildArgs: (params) => ({
+      query: params.query,
+      type: params.type || "auto",
+      numResults: params.numResults || 8,
+      livecrawl: params.livecrawl || "fallback",
+      contextMaxCharacters: params.contextMaxCharacters,
+    }),
+  }),
+  parallel: () => ({
+    id: "parallel",
+    label: "Parallel Web Search",
+    url: "https://search.parallel.ai/mcp",
+    tool: "web_search",
+    weight: 1,
+    headers: () =>
+      process.env.PARALLEL_API_KEY
+        ? { ...USER_AGENT_HEADERS(), Authorization: `Bearer ${process.env.PARALLEL_API_KEY}` }
+        : USER_AGENT_HEADERS(),
+    buildArgs: (params, ctx) => ({
+      objective: params.query,
+      search_queries: [params.query],
+      session_id: ctx.sessionID,
+      model_name: webSearchModelName(ctx.extra),
+    }),
+  }),
+}
+
+const BUILTIN_IDS = Object.keys(BUILTINS)
+
+// Resolve a final list of enabled providers from runtime flags + user config.
+// The two backcompat env flags (`OPENCODE_ENABLE_EXA` / `OPENCODE_ENABLE_PARALLEL`,
+// plus the legacy `OPENCODE_EXPERIMENTAL_*` aliases — already collapsed in
+// runtime-flags) seed the built-in `enabled` state; user config can flip it
+// either direction and add new providers.
+export function resolveProviders(
+  flags: { exa: boolean; parallel: boolean },
+  config: ConfigWebSearch.Info | undefined,
+): ResolvedProvider[] {
+  const overrides = config?.providers ?? {}
+  const seen = new Set<string>()
+  const out: ResolvedProvider[] = []
+
+  for (const id of BUILTIN_IDS) {
+    seen.add(id)
+    const override = overrides[id]
+    const envEnabled = id === "exa" ? flags.exa : id === "parallel" ? flags.parallel : false
+    const enabled = override?.enabled ?? envEnabled
+    if (!enabled) continue
+    out.push(applyOverride(BUILTINS[id](), override))
+  }
+
+  for (const [id, override] of Object.entries(overrides)) {
+    if (seen.has(id)) continue
+    if (override.enabled === false) continue
+    // User-defined providers must specify at least url + tool to be callable.
+    if (!override.url || !override.tool) continue
+    out.push(fromConfig(id, override))
+  }
+
+  return out
+}
+
+function applyOverride(base: ResolvedProvider, override: ConfigWebSearch.Provider | undefined): ResolvedProvider {
+  if (!override) return base
+  const merged: ResolvedProvider = { ...base }
+  if (override.label !== undefined) merged.label = override.label
+  if (override.url !== undefined) merged.url = override.url
+  if (override.tool !== undefined) merged.tool = override.tool
+  if (override.weight !== undefined) merged.weight = positiveWeight(override.weight, base.weight)
+  if (override.headers) {
+    const extra = override.headers
+    const baseHeaders = base.headers
+    merged.headers = () => ({ ...baseHeaders(), ...substituteHeaders(extra) })
+  }
+  if (override.args) {
+    const template = override.args
+    merged.buildArgs = (params, ctx) => substituteArgs(template, params, ctx)
+  }
+  return merged
+}
+
+function fromConfig(id: string, cfg: ConfigWebSearch.Provider): ResolvedProvider {
+  const headers = cfg.headers
+  const args = cfg.args
+  return {
+    id,
+    label: cfg.label ?? defaultLabel(id),
+    url: cfg.url!,
+    tool: cfg.tool!,
+    weight: positiveWeight(cfg.weight, 1),
+    headers: () => (headers ? { ...USER_AGENT_HEADERS(), ...substituteHeaders(headers) } : USER_AGENT_HEADERS()),
+    buildArgs: (params, ctx) => (args ? substituteArgs(args, params, ctx) : { query: params.query }),
+  }
+}
+
+function positiveWeight(value: number | undefined, fallback: number) {
+  if (value === undefined) return fallback
+  if (!Number.isFinite(value) || value <= 0) return fallback
+  return Math.floor(value)
+}
+
+function defaultLabel(id: string) {
+  return `${id.charAt(0).toUpperCase()}${id.slice(1)} Web Search`
+}
+
+// `{env:NAME}` is substituted upstream in config loading, but headers may also
+// contain it for user-defined providers added at runtime. Apply the same rule
+// here so behavior is consistent regardless of how the value arrived.
+function substituteHeaders(headers: Record<string, string>) {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) {
+    out[k] = substituteEnv(v)
+  }
+  return out
+}
+
+function substituteEnv(value: string) {
+  return value.replace(/\{env:([^}]+)\}/g, (_, name) => process.env[name] ?? "")
+}
+
+// Apply `{placeholder}` substitution to a template object. String leaves are
+// substituted; arrays and nested objects recurse; non-string leaves pass through.
+function substituteArgs(template: Record<string, unknown>, params: Params, ctx: Tool.Context): unknown {
+  const values: Record<string, unknown> = {
+    query: params.query,
+    numResults: params.numResults,
+    livecrawl: params.livecrawl,
+    type: params.type,
+    contextMaxCharacters: params.contextMaxCharacters,
+    sessionID: ctx.sessionID,
+  }
+  return substituteValue(template, values)
+}
+
+function substituteValue(value: unknown, values: Record<string, unknown>): unknown {
+  if (typeof value === "string") {
+    // Whole-string placeholder like "{numResults}" — preserve original type.
+    const whole = value.match(/^\{([a-zA-Z_][a-zA-Z0-9_]*)\}$/)
+    if (whole) return values[whole[1]]
+    return value.replace(/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g, (_, name) => {
+      const v = values[name]
+      return v === undefined || v === null ? "" : String(v)
+    })
+  }
+  if (Array.isArray(value)) return value.map((item) => substituteValue(item, values))
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) out[k] = substituteValue(v, values)
+    return out
+  }
+  return value
+}
+
+// Pick one provider for this call. Honors the env override, then the
+// configured default, otherwise routes deterministically across enabled
+// providers using a checksum-weighted split (generalizes the prior 50/50).
+export function selectWebSearchProvider(
+  sessionID: string,
+  providers: ResolvedProvider[],
+  options?: { default?: string },
+): ResolvedProvider | undefined {
+  if (providers.length === 0) return undefined
+
   const override = process.env.OPENCODE_WEBSEARCH_PROVIDER
-  if (override === "exa" || override === "parallel") return override
-  if (flags.parallel) return "parallel"
-  if (flags.exa) return "exa"
+  if (override) {
+    const match = providers.find((p) => p.id === override)
+    if (match) return match
+  }
 
-  return Number.parseInt(checksum(sessionID) ?? "0", 36) % 2 === 0 ? "exa" : "parallel"
+  const defaultID = options?.default
+  if (defaultID) {
+    const match = providers.find((p) => p.id === defaultID)
+    if (match) return match
+  }
+
+  // Stable order so the selection is reproducible across runs regardless of
+  // config iteration order or provider registration timing.
+  const sorted = [...providers].sort((a, b) => a.id.localeCompare(b.id))
+  const total = sorted.reduce((sum, p) => sum + p.weight, 0)
+  if (total <= 0) return sorted[0]
+
+  const seed = Number.parseInt(checksum(sessionID) ?? "0", 36)
+  let bucket = ((seed % total) + total) % total
+  for (const provider of sorted) {
+    if (bucket < provider.weight) return provider
+    bucket -= provider.weight
+  }
+  return sorted[sorted.length - 1]
 }
 
 export function webSearchProviderLabel(provider: unknown) {
-  if (provider === "parallel") return "Parallel Web Search"
-  if (provider === "exa") return "Exa Web Search"
+  if (typeof provider === "object" && provider !== null && "label" in provider && typeof provider.label === "string") {
+    return provider.label
+  }
+  if (typeof provider === "string") {
+    if (provider === "parallel") return "Parallel Web Search"
+    if (provider === "exa") return "Exa Web Search"
+    return defaultLabel(provider)
+  }
   return "Web Search"
 }
 
@@ -51,49 +267,14 @@ export function webSearchModelName(extra: Tool.Context["extra"]) {
   return (apiID ?? id)?.slice(0, 100)
 }
 
-function parallelAuthHeaders() {
-  const headers = { "User-Agent": `opencode/${InstallationVersion}` }
-  if (!process.env.PARALLEL_API_KEY) return headers
-  return { ...headers, Authorization: `Bearer ${process.env.PARALLEL_API_KEY}` }
-}
-
-function callProvider(
-  http: HttpClient.HttpClient,
-  provider: WebSearchProvider,
-  params: Schema.Schema.Type<typeof Parameters>,
-  ctx: Tool.Context,
-) {
-  if (provider === "parallel") {
-    return McpWebSearch.call(
-      http,
-      McpWebSearch.PARALLEL_URL,
-      "web_search",
-      McpWebSearch.ParallelSearchArgs,
-      {
-        objective: params.query,
-        search_queries: [params.query],
-        session_id: ctx.sessionID,
-        model_name: webSearchModelName(ctx.extra),
-      },
-      "25 seconds",
-      parallelAuthHeaders(),
-    )
-  }
-
-  return McpWebSearch.call(
-    http,
-    McpWebSearch.EXA_URL,
-    "web_search_exa",
-    McpWebSearch.SearchArgs,
-    {
-      query: params.query,
-      type: params.type || "auto",
-      numResults: params.numResults || 8,
-      livecrawl: params.livecrawl || "fallback",
-      contextMaxCharacters: params.contextMaxCharacters,
-    },
-    "25 seconds",
-  )
+function callProvider(http: HttpClient.HttpClient, provider: ResolvedProvider, params: Params, ctx: Tool.Context) {
+  return McpWebSearch.call(http, {
+    url: provider.url,
+    tool: provider.tool,
+    args: provider.buildArgs(params, ctx),
+    headers: provider.headers(),
+    timeout: "25 seconds",
+  })
 }
 
 export const WebSearchTool = Tool.define(
@@ -101,20 +282,35 @@ export const WebSearchTool = Tool.define(
   Effect.gen(function* () {
     const http = yield* HttpClient.HttpClient
     const flags = yield* RuntimeFlags.Service
+    const config = yield* Config.Service
 
     return {
       get description() {
         return DESCRIPTION.replace("{{year}}", new Date().getFullYear().toString())
       },
       parameters: Parameters,
-      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+      execute: (params: Params, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          const provider = selectWebSearchProvider(ctx.sessionID, {
-            exa: flags.enableExa,
-            parallel: flags.enableParallel,
+          const cfg = (yield* config.get()).websearch
+          const providers = resolveProviders({ exa: flags.enableExa, parallel: flags.enableParallel }, cfg)
+          const provider = selectWebSearchProvider(ctx.sessionID, providers, { default: cfg?.default })
+
+          const metadata: { provider?: string } = {}
+
+          if (!provider) {
+            return {
+              output: "Websearch is not configured. Enable a provider in `websearch.providers` or via env flags.",
+              title: "Web Search",
+              metadata,
+            }
+          }
+
+          metadata.provider = provider.id
+
+          yield* ctx.metadata({
+            title: `${provider.label} "${params.query}"`,
+            metadata,
           })
-          const title = webSearchProviderLabel(provider)
-          yield* ctx.metadata({ title: `${title} "${params.query}"`, metadata: { provider } })
 
           yield* ctx.ask({
             permission: "websearch",
@@ -126,7 +322,7 @@ export const WebSearchTool = Tool.define(
               livecrawl: params.livecrawl,
               type: params.type,
               contextMaxCharacters: params.contextMaxCharacters,
-              provider,
+              provider: provider.id,
             },
           })
 
@@ -134,8 +330,8 @@ export const WebSearchTool = Tool.define(
 
           return {
             output: result ?? "No search results found. Please try a different query.",
-            title: `${title}: ${params.query}`,
-            metadata: { provider },
+            title: `${provider.label}: ${params.query}`,
+            metadata,
           }
         }).pipe(Effect.orDie),
     }

--- a/packages/opencode/test/tool/websearch.test.ts
+++ b/packages/opencode/test/tool/websearch.test.ts
@@ -1,56 +1,151 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { parseResponse } from "../../src/tool/mcp-websearch"
-import { selectWebSearchProvider, webSearchModelName, webSearchProviderLabel } from "../../src/tool/websearch"
-
+import {
+  resolveProviders,
+  selectWebSearchProvider,
+  webSearchModelName,
+  webSearchProviderLabel,
+} from "../../src/tool/websearch"
 import { webSearchEnabled } from "../../src/tool/registry"
 import { it } from "../lib/effect"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 
 const SESSION_ID = "ses_0196aabbccddeeff001122334455"
 
-describe("websearch provider", () => {
-  test("selects a stable provider per session", () => {
-    expect(selectWebSearchProvider(SESSION_ID)).toBe(selectWebSearchProvider(SESSION_ID))
+function resolved(ids: string[], weights?: Record<string, number>) {
+  return ids.map((id) => ({
+    id,
+    label: `${id} label`,
+    url: `https://${id}.example/mcp`,
+    tool: "search",
+    weight: weights?.[id] ?? 1,
+    headers: () => ({}),
+    buildArgs: () => ({}),
+  }))
+}
+
+describe("websearch provider selection", () => {
+  test("returns undefined when no providers are enabled", () => {
+    expect(selectWebSearchProvider(SESSION_ID, [])).toBeUndefined()
   })
 
-  test("supports an operational override", () => {
+  test("selects a stable provider per session", () => {
+    const providers = resolved(["exa", "parallel"])
+    expect(selectWebSearchProvider(SESSION_ID, providers)?.id).toBe(
+      selectWebSearchProvider(SESSION_ID, providers)?.id,
+    )
+  })
+
+  test("supports an operational env override for any provider id", () => {
     const original = process.env.OPENCODE_WEBSEARCH_PROVIDER
-
+    const providers = resolved(["exa", "parallel", "acme"])
     try {
-      process.env.OPENCODE_WEBSEARCH_PROVIDER = "parallel"
-      expect(selectWebSearchProvider(SESSION_ID)).toBe("parallel")
+      process.env.OPENCODE_WEBSEARCH_PROVIDER = "acme"
+      expect(selectWebSearchProvider(SESSION_ID, providers)?.id).toBe("acme")
 
-      process.env.OPENCODE_WEBSEARCH_PROVIDER = "exa"
-      expect(selectWebSearchProvider(SESSION_ID)).toBe("exa")
+      process.env.OPENCODE_WEBSEARCH_PROVIDER = "parallel"
+      expect(selectWebSearchProvider(SESSION_ID, providers)?.id).toBe("parallel")
     } finally {
       if (original === undefined) delete process.env.OPENCODE_WEBSEARCH_PROVIDER
       else process.env.OPENCODE_WEBSEARCH_PROVIDER = original
     }
   })
 
-  test("routes to Exa when the Exa flag is enabled", () => {
-    expect(selectWebSearchProvider(SESSION_ID, { exa: true, parallel: false })).toBe("exa")
+  test("ignores env override when the id is not in the enabled set", () => {
+    const original = process.env.OPENCODE_WEBSEARCH_PROVIDER
+    try {
+      process.env.OPENCODE_WEBSEARCH_PROVIDER = "ghost"
+      const providers = resolved(["exa"])
+      expect(selectWebSearchProvider(SESSION_ID, providers)?.id).toBe("exa")
+    } finally {
+      if (original === undefined) delete process.env.OPENCODE_WEBSEARCH_PROVIDER
+      else process.env.OPENCODE_WEBSEARCH_PROVIDER = original
+    }
   })
 
-  test("routes to Parallel when the Parallel flag is enabled", () => {
-    expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: true })).toBe("parallel")
+  test("honors websearch.default when no env override", () => {
+    const providers = resolved(["exa", "parallel"])
+    expect(selectWebSearchProvider(SESSION_ID, providers, { default: "parallel" })?.id).toBe("parallel")
   })
 
-  test("is only enabled for opencode or explicit websearch provider flags", () => {
-    expect(webSearchEnabled(ProviderV2.ID.opencode, { exa: false, parallel: false })).toBe(true)
-    expect(webSearchEnabled(ProviderV2.ID.openai, { exa: false, parallel: false })).toBe(false)
-    expect(webSearchEnabled(ProviderV2.ID.openai, { exa: true, parallel: false })).toBe(true)
-    expect(webSearchEnabled(ProviderV2.ID.openai, { exa: false, parallel: true })).toBe(true)
+  test("weights bias the deterministic split", () => {
+    // With weight 1000 for "exa" vs 1 for "parallel", a single bucket out of
+    // 1001 hits parallel — over a few different session ids we should see
+    // exa dominate.
+    const providers = resolved(["exa", "parallel"], { exa: 1000, parallel: 1 })
+    let exa = 0
+    for (let i = 0; i < 50; i++) {
+      const id = selectWebSearchProvider(`ses_${i}`, providers)?.id
+      if (id === "exa") exa++
+    }
+    expect(exa).toBeGreaterThan(45)
+  })
+})
+
+describe("resolveProviders", () => {
+  test("env flags enable built-ins", () => {
+    const list = resolveProviders({ exa: true, parallel: false }, undefined)
+    expect(list.map((p) => p.id)).toEqual(["exa"])
   })
 
-  test("uses branded labels", () => {
+  test("config enabled flag flips built-in state", () => {
+    const list = resolveProviders(
+      { exa: false, parallel: false },
+      { providers: { parallel: { enabled: true } } },
+    )
+    expect(list.map((p) => p.id)).toEqual(["parallel"])
+  })
+
+  test("config can disable a built-in that env enabled", () => {
+    const list = resolveProviders(
+      { exa: true, parallel: false },
+      { providers: { exa: { enabled: false } } },
+    )
+    expect(list).toEqual([])
+  })
+
+  test("registers user-defined providers with url + tool", () => {
+    const list = resolveProviders(
+      { exa: false, parallel: false },
+      {
+        providers: {
+          acme: { url: "https://acme.example/mcp", tool: "search", weight: 3 },
+        },
+      },
+    )
+    expect(list).toHaveLength(1)
+    expect(list[0].id).toBe("acme")
+    expect(list[0].weight).toBe(3)
+    expect(list[0].label).toBe("Acme Web Search")
+  })
+
+  test("skips user-defined providers missing url or tool", () => {
+    const list = resolveProviders(
+      { exa: false, parallel: false },
+      { providers: { broken: { url: "https://broken.example/mcp" } } },
+    )
+    expect(list).toEqual([])
+  })
+})
+
+describe("websearch tool gating", () => {
+  test("is only enabled for opencode or when at least one provider is resolved", () => {
+    expect(webSearchEnabled(ProviderV2.ID.opencode, false)).toBe(true)
+    expect(webSearchEnabled(ProviderV2.ID.openai, false)).toBe(false)
+    expect(webSearchEnabled(ProviderV2.ID.openai, true)).toBe(true)
+  })
+})
+
+describe("labels and model names", () => {
+  test("uses branded labels for built-ins and titlecases unknown ids", () => {
     expect(webSearchProviderLabel("parallel")).toBe("Parallel Web Search")
     expect(webSearchProviderLabel("exa")).toBe("Exa Web Search")
+    expect(webSearchProviderLabel("acme")).toBe("Acme Web Search")
     expect(webSearchProviderLabel(undefined)).toBe("Web Search")
   })
 
-  test("uses the provider API model id for Parallel analytics", () => {
+  test("uses the provider API model id for analytics", () => {
     expect(
       webSearchModelName({
         model: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1725,6 +1725,30 @@ export type McpRemoteConfig = {
  */
 export type LayoutConfig = "auto" | "stretch"
 
+export type WebSearchProviderConfig = {
+  enabled?: boolean
+  label?: string
+  url?: string
+  tool?: string
+  headers?: {
+    [key: string]: string
+  }
+  args?: {
+    [key: string]: unknown
+  }
+  /**
+   * Relative weight for deterministic per-session selection across enabled providers. Defaults to 1. Must be a positive integer.
+   */
+  weight?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+}
+
+export type WebSearchConfig = {
+  default?: string
+  providers?: {
+    [key: string]: WebSearchProviderConfig
+  }
+}
+
 export type ImageAttachmentConfig = {
   auto_resize?: boolean
   max_width?: number
@@ -1847,6 +1871,7 @@ export type Config = {
   instructions?: Array<string>
   layout?: LayoutConfig
   permission?: PermissionConfig
+  websearch?: WebSearchConfig
   tools?: {
     [key: string]: boolean
   }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15682,6 +15682,72 @@
         "enum": ["auto", "stretch"],
         "description": "@deprecated Always uses stretch layout."
       },
+      "WebSearchProviderConfig": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "args": {
+            "type": "object"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "enum": ["NaN"]
+              },
+              {
+                "type": "string",
+                "enum": ["Infinity"]
+              },
+              {
+                "type": "string",
+                "enum": ["-Infinity"]
+              },
+              {
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
+              }
+            ],
+            "description": "Relative weight for deterministic per-session selection across enabled providers. Defaults to 1. Must be a positive integer."
+          }
+        },
+        "additionalProperties": false
+      },
+      "WebSearchConfig": {
+        "type": "object",
+        "properties": {
+          "default": {
+            "type": "string"
+          },
+          "providers": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WebSearchProviderConfig"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "ImageAttachmentConfig": {
         "type": "object",
         "properties": {
@@ -16035,6 +16101,9 @@
           },
           "permission": {
             "$ref": "#/components/schemas/PermissionConfig"
+          },
+          "websearch": {
+            "$ref": "#/components/schemas/WebSearchConfig"
           },
           "tools": {
             "type": "object",


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The websearch tool currently hardcodes `exa` and `parallel` as the only providers. Adding another MCP-backed websearch provider means editing the provider schema literal, the `if/else` dispatch branch, and the selection logic, plus introducing new env flags.

This refactor moves that knowledge out of code and into config. There is now a `websearch.providers` map in `opencode.json` where any MCP-backed websearch provider can be registered with `{ url, tool, args, headers }`. The two built-ins are pre-registered using the same shape and remain disabled by default (same as today). Selection generalises the current 50/50 checksum split to N providers with optional weights.

The tool's normalised parameters schema is unchanged, so the model sees the exact same interface.

Backcompat: `OPENCODE_ENABLE_EXA`, `OPENCODE_EXPERIMENTAL_EXA`, `OPENCODE_EXPERIMENTAL`, `OPENCODE_ENABLE_PARALLEL`, `OPENCODE_EXPERIMENTAL_PARALLEL`, `OPENCODE_WEBSEARCH_PROVIDER`, `EXA_API_KEY`, and `PARALLEL_API_KEY` all keep working with no change in behaviour.

### How did you verify your code works?

- `bun typecheck` in `packages/opencode`: clean
- `bun tsc --noEmit` in `packages/sdk/js`: clean
- `bun test test/tool/websearch.test.ts test/tool/parameters.test.ts test/effect/runtime-flags.test.ts`: 113/113 pass
- Updated the websearch tests to cover weighted N-way selection, env override across arbitrary ids, env-flag enable of built-ins, config-driven enable/disable, and user-defined provider registration.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
