### PR TITLE
fix(server): normalize Windows path separator and drive letter in Web API directory entry points

### DIFF
--- a/packages/opencode/src/server/proxy-util.ts
+++ b/packages/opencode/src/server/proxy-util.ts
@@ -38,6 +38,15 @@ export function websocketProtocols(input: Request | Record<string, string | unde
     .filter(Boolean)
 }
 
+export function canonicalizeWindowsPath(path: string): string {
+  if (process.platform !== "win32") return path
+  // Normalize backslashes to forward slashes for consistent identity keys.
+  path = path.replaceAll("\\", "/")
+  // Lowercase drive letter (C: -> c:) to avoid case-sensitive mismatches.
+  path = path.replace(/^([A-Za-z]):/, (_, d: string) => `${d.toLowerCase()}:`)
+  return path
+}
+
 export function websocketTargetURL(url: string | URL) {
   const next = new URL(url)
   if (next.protocol === "http:") next.protocol = "ws:"

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/v2/location.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/v2/location.ts
@@ -37,10 +37,14 @@ export class V2LocationMiddleware extends HttpApiMiddleware.Service<
   }
 >()("@opencode/ExperimentalHttpApiV2Location") {}
 
+import { canonicalizeWindowsPath } from "@/server/proxy-util"
+
 function ref(request: HttpServerRequest.HttpServerRequest): Location.Ref {
   const query = new URL(request.url, "http://localhost").searchParams
   return {
-    directory: query.get("location[directory]") || request.headers["x-opencode-directory"] || process.cwd(),
+    directory: canonicalizeWindowsPath(
+      query.get("location[directory]") || request.headers["x-opencode-directory"] || process.cwd(),
+    ),
     workspaceID: query.get("location[workspace]") || request.headers["x-opencode-workspace"],
   }
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -5,6 +5,7 @@ import { WorkspaceAdapterRuntime } from "@/control-plane/workspace-adapter-runti
 import { Session } from "@/session/session"
 import { HttpApiProxy } from "./proxy"
 import * as Fence from "@/server/shared/fence"
+import { ProxyUtil } from "@/server/proxy-util"
 import { getWorkspaceRouteSessionID, isLocalWorkspaceRoute, workspaceProxyURL } from "@/server/shared/workspace-routing"
 import { NotFoundError } from "@/storage/storage"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -84,7 +85,9 @@ function selectedV2WorkspaceID(
 }
 
 function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string {
-  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
+  return ProxyUtil.canonicalizeWindowsPath(
+    url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd(),
+  )
 }
 
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {

--- a/packages/opencode/test/server/proxy-util.test.ts
+++ b/packages/opencode/test/server/proxy-util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { ProxyUtil } from "../../src/server/proxy-util"
+import { canonicalizeWindowsPath, ProxyUtil } from "../../src/server/proxy-util"
 
 describe("ProxyUtil", () => {
   describe("websocketTargetURL", () => {
@@ -108,6 +108,49 @@ describe("ProxyUtil", () => {
       expect(result.get("content-type")).toBe("application/json")
       expect(result.get("x-custom")).toBe("val")
       expect(result.get("x-extra")).toBe("added")
+    })
+  })
+
+  describe("canonicalizeWindowsPath", () => {
+    test("normalizes backslashes to forward slashes on Windows", () => {
+      const result = ProxyUtil.canonicalizeWindowsPath("C:\\Users\\project")
+      if (process.platform === "win32") {
+        expect(result).toBe("c:/Users/project")
+      } else {
+        expect(result).toBe("C:\\Users\\project")
+      }
+    })
+
+    test("lowercases drive letter on Windows", () => {
+      const result = ProxyUtil.canonicalizeWindowsPath("D:/Work/foo")
+      if (process.platform === "win32") {
+        expect(result).toBe("d:/Work/foo")
+      } else {
+        expect(result).toBe("D:/Work/foo")
+      }
+    })
+
+    test("preserves POSIX paths", () => {
+      const result = ProxyUtil.canonicalizeWindowsPath("/home/user/project")
+      expect(result).toBe("/home/user/project")
+    })
+
+    test("preserves already-normalized paths", () => {
+      const result = ProxyUtil.canonicalizeWindowsPath("e:/already/forward")
+      if (process.platform === "win32") {
+        expect(result).toBe("e:/already/forward")
+      } else {
+        expect(result).toBe("e:/already/forward")
+      }
+    })
+
+    test("handles mixed slashes", () => {
+      const result = ProxyUtil.canonicalizeWindowsPath("C:\\Users\\foo/bar\\baz")
+      if (process.platform === "win32") {
+        expect(result).toBe("c:/Users/foo/bar/baz")
+      } else {
+        expect(result).toBe("C:\\Users\\foo/bar\\baz")
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

Normalize Windows paths received from Web API query parameters and headers before using them as identity keys for session and workspace lookups. This ensures that `C:\Users\project` and `C:/Users/project` resolve to the same workspace and session.

## Problem

On Windows, the opencode Web UI sends directory paths with forward slashes (`C:/Users/project`) while the TUI and other tooling use backslashes (`C:\Users\project`). These two representations point to the same physical directory but were treated as separate identity keys, causing:
- Conversations started via one path format to be invisible when accessed via the other
- Duplicate workspace entries in the sidebar
- Session filtering mismatches

## Changes

### `packages/opencode/src/server/proxy-util.ts`

Added `canonicalizeWindowsPath()` that:
- Only operates on Windows (`process.platform === win32`)
- Converts backslashes to forward slashes
- Lowercases the drive letter (e.g., `C:` → `c:`)

### `workspace-routing.ts`

Applied normalization in `defaultDirectory()` which reads the `directory` query param and `x-opencode-directory` header.

### `location.ts` (V2 API)

Applied normalization in `ref()` which reads `location[directory]` query param and `x-opencode-directory` header.

### Tests

Added tests covering:
- Backslash to forward slash normalization
- Drive letter lowercasing
- Mixed slashes
- POSIX path passthrough
- Already-normalized path passthrough

## Related

Closes #12940, #14570