### PR TITLE
fix(tui): restore thinking spinner

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -442,16 +442,25 @@ function ReasoningHeader(props: { toggleable: boolean; open: boolean; done: bool
       : theme.warning
 
   return (
-    <text fg={fg()} wrapMode="none">
-      <Show when={props.toggleable}>
-        <span>{props.open ? "- " : "+ "}</span>
-      </Show>
-      <span>{props.done ? "Thought" : "Thinking"}</span>
-      <Show when={props.title}>
-        <span>: </span>
-        <span>{props.title}</span>
-      </Show>
-    </text>
+    <Switch>
+      <Match when={!props.done}>
+        <box flexDirection="row">
+          <Spinner color={fg()}>{props.title ? "Thinking: " + props.title : "Thinking"}</Spinner>
+        </box>
+      </Match>
+      <Match when={true}>
+        <text fg={fg()} wrapMode="none">
+          <Show when={props.toggleable}>
+            <span>{props.open ? "- " : "+ "}</span>
+          </Show>
+          <span>Thought</span>
+          <Show when={props.title}>
+            <span>: </span>
+            <span>{props.title}</span>
+          </Show>
+        </text>
+      </Match>
+    </Switch>
   )
 }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1595,24 +1595,33 @@ function ReasoningHeader(props: {
       : theme.warning
 
   return (
-    <text fg={fg()} wrapMode="none">
-      <Show when={props.toggleable}>
-        <span>{props.open ? "- " : "+ "}</span>
-      </Show>
-      <span>{props.done ? "Thought" : "Thinking"}</span>
-      <Show when={props.title || props.duration}>
-        <span>: </span>
-      </Show>
-      <Show when={props.title}>
-        <span>{props.title}</span>
-      </Show>
-      <Show when={props.duration}>
-        <span>
-          {props.title ? " · " : ""}
-          {props.duration}
-        </span>
-      </Show>
-    </text>
+    <Switch>
+      <Match when={!props.done}>
+        <box flexDirection="row">
+          <Spinner color={fg()}>{props.title ? "Thinking: " + props.title : "Thinking"}</Spinner>
+        </box>
+      </Match>
+      <Match when={true}>
+        <text fg={fg()} wrapMode="none">
+          <Show when={props.toggleable}>
+            <span>{props.open ? "- " : "+ "}</span>
+          </Show>
+          <span>Thought</span>
+          <Show when={props.title || props.duration}>
+            <span>: </span>
+          </Show>
+          <Show when={props.title}>
+            <span>{props.title}</span>
+          </Show>
+          <Show when={props.duration}>
+            <span>
+              {props.title ? " · " : ""}
+              {props.duration}
+            </span>
+          </Show>
+        </text>
+      </Match>
+    </Switch>
   )
 }
 


### PR DESCRIPTION
## Summary
- restore the animated spinner for active thinking blocks
- keep completed thought headers static with expand/collapse markers
- avoid showing +/- next to the active spinner to prevent layout shift

## Test
- bun typecheck