### PR TITLE
fix(instance): eliminate dual InstanceStore.Service materialization per directory

### DIFF
--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -38,6 +38,7 @@ import { Command } from "@/command"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
 import { Format } from "@/format"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceLayer } from "@/project/instance-layer"
 import { Project } from "@/project/project"
 import { Vcs } from "@/project/vcs"
@@ -101,7 +102,12 @@ export const AppLayer = Layer.mergeAll(
   SessionShare.defaultLayer,
 ).pipe(
   Layer.provideMerge(Ripgrep.defaultLayer),
-  Layer.provideMerge(InstanceLayer.layer),
+  Layer.provideMerge(
+    InstanceLayer.layer.pipe(
+      Layer.provide(InstanceBootstrap.defaultLayer),
+      Layer.provide(Project.defaultLayer),
+    ),
+  ),
   Layer.provideMerge(Observability.layer),
 )
 

--- a/packages/opencode/src/project/instance-layer.ts
+++ b/packages/opencode/src/project/instance-layer.ts
@@ -1,11 +1,16 @@
-import { Effect, Layer } from "effect"
 import { InstanceStore } from "./instance-store"
 
-export const layer = Layer.unwrap(
-  Effect.promise(async () => {
-    const { InstanceBootstrap } = await import("./bootstrap")
-    return InstanceStore.defaultLayer.pipe(Layer.provide(InstanceBootstrap.defaultLayer))
-  }),
-)
+// `InstanceStore.layer` requires `InstanceBootstrap.Service` and `Project.Service`.
+// Production callers provide `InstanceBootstrap.defaultLayer` and `Project.defaultLayer`
+// alongside this layer (see `routes/instance/httpapi/server.ts:createRoutes`,
+// `worktree/index.ts`, `effect/app-runtime.ts`). Keeping the bootstrap external
+// rather than baking it in here (a) lets tests override `InstanceBootstrap` with a
+// stub without rebuilding the full layer graph, and (b) — critically — keeps this a
+// stable module-level Layer reference so the shared process memoMap materializes a
+// single `InstanceStore.Service` per directory across the TCP listener and the
+// in-process webHandler pipelines. The previous `Layer.unwrap(Effect.promise(...))`
+// form built a fresh inner layer on every build, defeating memoization and yielding
+// two InstanceStore.Service per directory — which wedged the Question tool on submit.
+export const layer = InstanceStore.layer
 
 export * as InstanceLayer from "./instance-layer"

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -24,6 +24,7 @@ import { LSP } from "@/lsp/lsp"
 import { MCP } from "@/mcp"
 import { Permission } from "@/permission"
 import { Installation } from "@/installation"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceLayer } from "@/project/instance-layer"
 import { Plugin } from "@/plugin"
 import { Project } from "@/project/project"
@@ -259,7 +260,12 @@ export function createRoutes(
     ]),
     Layer.provide(Layer.succeed(CorsConfig)(corsOptions)),
     Layer.provideMerge(Ripgrep.defaultLayer),
-    Layer.provide(InstanceLayer.layer),
+    Layer.provide(
+      InstanceLayer.layer.pipe(
+        Layer.provide(InstanceBootstrap.defaultLayer),
+        Layer.provide(Project.defaultLayer),
+      ),
+    ),
     Layer.provideMerge(Observability.layer),
   )
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,6 +1,7 @@
 import "./init-projectors"
 
 import { NodeHttpServer } from "@effect/platform-node"
+import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { ConfigProvider, Context, Effect, Exit, Layer, Scope } from "effect"
 import { HttpRouter, HttpServer } from "effect/unstable/http"
 import { OpenApi } from "effect/unstable/httpapi"
@@ -123,7 +124,12 @@ function startWithPortFallback(opts: ListenOptions) {
 
 function startListener(opts: ListenOptions, port: number) {
   const scope = Scope.makeUnsafe()
-  return Layer.buildWithMemoMap(listenerLayer(opts, port), Layer.makeMemoMapUnsafe(), scope).pipe(
+  // Use the shared process-global memoMap (not a fresh Layer.makeMemoMapUnsafe()) so the
+  // TCP listener pipeline and the in-process webHandler/app-runtime pipeline materialize a
+  // single InstanceStore.Service per directory. A fresh memoMap here builds a second
+  // InstanceStore, so a question registered on one instance and answered on the other never
+  // resolves — wedging the Question tool on submit.
+  return Layer.buildWithMemoMap(listenerLayer(opts, port), memoMap, scope).pipe(
     Effect.provide(HttpApiApp.context),
     Effect.onError(() => Scope.close(scope, Exit.void).pipe(Effect.ignore)),
     Effect.map(

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -1,6 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { path } from "@opencode-ai/core/effect/layer-node-platform"
 import { Global } from "@opencode-ai/core/global"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceLayer } from "@/project/instance-layer"
 import { InstanceStore } from "@/project/instance-store"
 import { Project } from "@/project/project"
@@ -639,7 +640,14 @@ export const appLayer = layer.pipe(
   Layer.provide(NodePath.layer),
 )
 
-export const defaultLayer = appLayer.pipe(Layer.provide(InstanceLayer.layer))
+export const defaultLayer = appLayer.pipe(
+  Layer.provide(
+    InstanceLayer.layer.pipe(
+      Layer.provide(InstanceBootstrap.defaultLayer),
+      Layer.provide(Project.defaultLayer),
+    ),
+  ),
+)
 
 export const node = LayerNode.make(layer, [
   FSUtil.node,

--- a/packages/opencode/test/project/instance-bootstrap.test.ts
+++ b/packages/opencode/test/project/instance-bootstrap.test.ts
@@ -5,13 +5,23 @@ import { pathToFileURL } from "node:url"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Cause, Effect, Exit, Fiber, Layer } from "effect"
 import { bootstrap as cliBootstrap } from "../../src/cli/bootstrap"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
 import { InstanceLayer } from "../../src/project/instance-layer"
 import { InstanceStore } from "../../src/project/instance-store"
+import { Project } from "../../src/project/project"
 import { disposeAllInstances, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { waitGlobalBusEvent } from "../server/global-bus"
 
-const it = testEffect(Layer.mergeAll(InstanceLayer.layer, CrossSpawnSpawner.defaultLayer))
+const it = testEffect(
+  Layer.mergeAll(
+    InstanceLayer.layer.pipe(
+      Layer.provide(InstanceBootstrap.defaultLayer),
+      Layer.provide(Project.defaultLayer),
+    ),
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
 
 // InstanceBootstrap must run before any code touches the instance —
 // originally tracked by PRs #25389 and #25449, now a permanent

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -16,7 +16,9 @@ import { Provider } from "@/provider/provider"
 
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Filesystem } from "@/util/filesystem"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceLayer } from "@/project/instance-layer"
+import { Project } from "@/project/project"
 import { testEffect } from "../lib/effect"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -1647,7 +1649,15 @@ it.instance(
 // scoped tmpdir + provideInstance pattern via it.effect.
 
 const provideMultiInstance = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
-  eff.pipe(Effect.provide(InstanceLayer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+  eff.pipe(
+    Effect.provide(
+      InstanceLayer.layer.pipe(
+        Layer.provide(InstanceBootstrap.defaultLayer),
+        Layer.provide(Project.defaultLayer),
+      ),
+    ),
+    Effect.provide(CrossSpawnSpawner.defaultLayer),
+  )
 
 it.effect("plugin config providers persist after instance dispose", () =>
   Effect.gen(function* () {
@@ -1750,7 +1760,15 @@ it.effect("opencode loader keeps paid models when config apiKey is present", () 
       Provider.use
         .list()
         .pipe(provideInstanceEffect(directory))
-        .pipe(Effect.provide(InstanceLayer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+        .pipe(
+          Effect.provide(
+            InstanceLayer.layer.pipe(
+              Layer.provide(InstanceBootstrap.defaultLayer),
+              Layer.provide(Project.defaultLayer),
+            ),
+          ),
+          Effect.provide(CrossSpawnSpawner.defaultLayer),
+        )
 
     const none = paid(yield* listIn(noneDir))
     const keyedCount = paid(yield* listIn(keyedDir))
@@ -1769,7 +1787,15 @@ it.effect("opencode loader keeps paid models when auth exists", () =>
       Provider.use
         .list()
         .pipe(provideInstanceEffect(directory))
-        .pipe(Effect.provide(InstanceLayer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+        .pipe(
+          Effect.provide(
+            InstanceLayer.layer.pipe(
+              Layer.provide(InstanceBootstrap.defaultLayer),
+              Layer.provide(Project.defaultLayer),
+            ),
+          ),
+          Effect.provide(CrossSpawnSpawner.defaultLayer),
+        )
 
     const none = paid(yield* listIn(noneDir))
 

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -12,6 +12,7 @@ import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import type { WorkspaceAdapter } from "../../src/control-plane/types"
 import { Workspace } from "../../src/control-plane/workspace"
 import { InstanceRef, WorkspaceRef } from "../../src/effect/instance-ref"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
 import { InstanceLayer } from "../../src/project/instance-layer"
 import { Project } from "../../src/project/project"
 import { Session } from "../../src/session/session"
@@ -51,7 +52,10 @@ const it = testEffect(
     testStateLayer,
     NodeHttpServer.layerTest,
     NodeServices.layer,
-    InstanceLayer.layer,
+    InstanceLayer.layer.pipe(
+      Layer.provide(InstanceBootstrap.defaultLayer),
+      Layer.provide(Project.defaultLayer),
+    ),
     Project.defaultLayer,
     workspaceLayer,
   ).pipe(Layer.provide(Ripgrep.defaultLayer)),

--- a/packages/opencode/test/server/httpapi-promptasync-context.test.ts
+++ b/packages/opencode/test/server/httpapi-promptasync-context.test.ts
@@ -20,6 +20,7 @@ import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import type { WorkspaceAdapter } from "../../src/control-plane/types"
 import { Workspace } from "../../src/control-plane/workspace"
 import { InstanceRef, WorkspaceRef } from "../../src/effect/instance-ref"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
 import { InstanceLayer } from "../../src/project/instance-layer"
 import { Project } from "../../src/project/project"
 import { Session } from "../../src/session/session"
@@ -56,7 +57,10 @@ const it = testEffect(
     testStateLayer,
     NodeHttpServer.layerTest,
     NodeServices.layer,
-    InstanceLayer.layer,
+    InstanceLayer.layer.pipe(
+      Layer.provide(InstanceBootstrap.defaultLayer),
+      Layer.provide(Project.defaultLayer),
+    ),
     Project.defaultLayer,
     workspaceLayer,
   ).pipe(Layer.provide(Ripgrep.defaultLayer)),


### PR DESCRIPTION
### Issue for this PR

Closes #29772

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `Question` tool prompt hangs on submit because `InstanceStore.Service` materializes twice for the same directory. The two services own separate `InstanceState` `ScopedCache`s, which split `Question.Service` into parallel instance trees: `Question.ask` lands on one pending map, `Question.reply` arrives at the other and is rejected as `reply for unknown request`.

Root cause: `Server.listen` (the construction site used by `opencode serve`, the TUI worker, `opencode web`, and `opencode acp`) builds two HTTP pipelines from the same `InstanceLayer.layer`, but with different `Layer.MemoMap`s:

| Pipeline | Built at | memoMap |
|---|---|---|
| TCP listener / external HTTP | `packages/opencode/src/server/server.ts` | fresh `Layer.makeMemoMapUnsafe()` |
| In-process `Default` webHandler | `packages/opencode/src/server/routes/instance/httpapi/server.ts` | shared `@opencode-ai/core/effect/memo-map` `memoMap` |

With distinct memoMaps, `Layer.buildWithMemoMap` cannot dedupe across pipelines, so each one materializes its own `InstanceStore.Service` for the same directory.

Two commits:

1. `refactor(project): make InstanceBootstrap injectable into InstanceLayer.layer` — moves `InstanceBootstrap.defaultLayer` out of `InstanceLayer.layer` and provides it explicitly at production/test call sites. Behavior-preserving; makes the layer graph easier to test and audit.
2. `fix(server): share memoMap between TCP listener and in-process webHandler` — changes the TCP listener build to use the shared process memoMap so both pipelines dedupe `InstanceStore.Service` through the same `Layer.MemoMap`.

Risk: the previous per-listener memoMap may have been intentional for listener isolation (`server.ts` also installs a fresh `ConfigProvider` per listener). This change makes service identity process-shared for listener-built layers. That is the intended behavior for `InstanceStore.Service`, but reviewers should sanity-check whether any listener-scoped services relied on the fresh memoMap lifecycle.

### How did you verify your code works?

Local checks with Bun `1.3.14`:

- `bun run typecheck` from `packages/opencode` passed.
- `bun test test/project/` passed on rerun: 80 pass, 1 skip, 0 fail.
- `bun test test/server/httpapi-instance-context.test.ts test/server/httpapi-promptasync-context.test.ts` passed: 10 pass, 0 fail.
- Pre-push hook `bun turbo typecheck` passed: 19 successful, 19 total.

Production-aligned local-patch burn-in on my local machine (real `opencode` process driving both the TUI and external HTTP clients against the same directory):

- One `creating instance` event per directory after deploy (was two before the fix).
- 11/11 `Question` tool submissions completed cleanly across both the TUI and an external client surface.
- Zero `reply for unknown request` warnings during validation.

To reproduce the original bug on `dev` before this PR: launch an `opencode` process (TUI or `opencode serve`) and drive the `Question` tool against the same directory via both the TCP listener (external HTTP client) and the in-process webHandler, then submit a reply — it is rejected as `reply for unknown request` because the reply hit the other pipeline's `Question.Service`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
