### PR TITLE
fix(openai): preserve websocket upgrade error messages

### DIFF
--- a/packages/opencode/src/plugin/openai/ws.ts
+++ b/packages/opencode/src/plugin/openai/ws.ts
@@ -3,6 +3,7 @@
 
 import WebSocket from "ws"
 import { ProviderError } from "@/provider/error"
+import { errorMessage } from "@/util/error"
 
 export const PROTOCOL_HEADER = "responses_websockets=2026-02-06"
 
@@ -94,10 +95,10 @@ export function connectResponsesWebSocket(options: ConnectResponsesWebSocketOpti
       resolve(socket)
     }
 
-    function onError(error: Error) {
+    function onError(error: unknown) {
       socket.on("error", () => {})
       cleanup()
-      reject(error)
+      reject(error instanceof Error ? error : new Error(errorMessage(error), { cause: error }))
     }
 
     function onClose(code: number, reason: Buffer) {

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -39,6 +39,17 @@ describe("plugin.openai.ws", () => {
     ).rejects.toThrow("WebSocket connect timed out")
   })
 
+  test("surfaces websocket upgrade rejection messages", async () => {
+    await using server = await createRejectingWebSocketServer(() => {})
+
+    await expect(
+      OpenAIWebSocket.connectResponsesWebSocket({
+        url: server.wsUrl,
+        headers: {},
+      }),
+    ).rejects.toThrow("Expected 101 status code")
+  })
+
   test("enforces websocket send idle timeout", async () => {
     const socket = new (class extends EventEmitter {
       send(_data: string, _callback: (error?: Error) => void) {}


### PR DESCRIPTION
Fixes failed Responses WebSocket upgrades surfacing as `[object ErrorEvent]` under Bun by preserving the available error message.

Adds regression coverage for rejected WebSocket upgrades.