### PR TITLE
fix(llm): route non-OpenAI Azure deployments via Chat Completions

### DIFF
--- a/packages/llm/src/providers/azure.ts
+++ b/packages/llm/src/providers/azure.ts
@@ -97,11 +97,29 @@ export const configure = (input: Config) => {
 
   return {
     id,
-    model: (modelID: string | ModelID) => (input.useCompletionUrls === true ? chat(modelID) : responses(modelID)),
+    // Azure AI Foundry hosts two distinct families: OpenAI-native deployments
+    // (gpt-*, o-series) which speak the Responses API, and partner deployments
+    // (DeepSeek, Kimi, Llama, etc.) which only speak Chat Completions. Routing
+    // a partner deployment through Responses works at the network layer but
+    // Azure silently drops `max_output_tokens` during the Responses→Chat
+    // translation, capping the underlying call at the chat default (4096
+    // tokens) regardless of the user's `limit.output`. Auto-detect by model id
+    // so the common case Just Works; `useCompletionUrls` remains an explicit
+    // override for either direction.
+    model: (modelID: string | ModelID) => {
+      if (input.useCompletionUrls === true) return chat(modelID)
+      if (input.useCompletionUrls === false) return responses(modelID)
+      return isOpenAIResponsesNative(String(modelID)) ? responses(modelID) : chat(modelID)
+    },
     responses,
     chat,
     configure,
   }
+}
+
+const isOpenAIResponsesNative = (modelID: string) => {
+  const id = modelID.toLowerCase()
+  return id.startsWith("gpt-") || id.startsWith("o1") || id.startsWith("o3") || id.startsWith("o4")
 }
 
 export const provider = {

--- a/packages/llm/test/provider/azure.test.ts
+++ b/packages/llm/test/provider/azure.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { LLM } from "../../src"
+import * as Azure from "../../src/providers/azure"
+import { LLMClient } from "../../src/route"
+import { it } from "../lib/effect"
+
+const azureBase = "https://opencode-test.openai.azure.com/openai/v1/"
+
+const expectRoute = (model: ReturnType<ReturnType<typeof Azure.configure>["model"]>, expected: string) =>
+  Effect.gen(function* () {
+    const prepared = yield* LLMClient.prepare(LLM.request({ model, prompt: "Say hello." }))
+    expect(prepared.route).toBe(expected)
+  })
+
+describe("Azure model() routing", () => {
+  it.effect("routes OpenAI-native model ids to the Responses endpoint by default", () =>
+    expectRoute(Azure.configure({ baseURL: azureBase, apiKey: "k" }).model("gpt-4o-mini"), "azure-openai-responses"),
+  )
+
+  it.effect("routes non-OpenAI Azure AI Foundry model ids to Chat Completions by default", () =>
+    expectRoute(Azure.configure({ baseURL: azureBase, apiKey: "k" }).model("DeepSeek-V4-Pro"), "azure-openai-chat"),
+  )
+
+  it.effect("treats o-series model ids as OpenAI-native (Responses)", () =>
+    expectRoute(Azure.configure({ baseURL: azureBase, apiKey: "k" }).model("o3-mini"), "azure-openai-responses"),
+  )
+
+  it.effect("useCompletionUrls=true forces Chat for OpenAI-native ids", () =>
+    expectRoute(
+      Azure.configure({ baseURL: azureBase, apiKey: "k", useCompletionUrls: true }).model("gpt-4o-mini"),
+      "azure-openai-chat",
+    ),
+  )
+
+  it.effect("useCompletionUrls=false forces Responses for non-OpenAI ids", () =>
+    expectRoute(
+      Azure.configure({ baseURL: azureBase, apiKey: "k", useCompletionUrls: false }).model("DeepSeek-V4-Pro"),
+      "azure-openai-responses",
+    ),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29776

Also likely fixes #12879 (Kimi K2.5 on Azure Foundry rejected with `role: "developer"`) — same root cause: Azure partner deployments routed to Responses API instead of Chat Completions. Different visible symptom (the Responses API emits `role: "developer"` for system instructions, which Azure Foundry's chat-completions endpoint rejects). After this change those models route through Chat Completions and emit `role: "system"`. Marking as "likely fixes" rather than "closes" because I reproduced only the truncation symptom; the role-validation symptom would need confirmation from someone with a Kimi K2.5 deployment.

Related: #20078 (LM Studio case has the same shape — `limit.output` ignored — but a different code path; this PR is the Azure-specific half).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Azure AI Foundry hosts two distinct families of model deployments:
- OpenAI-native (`gpt-*`, `o-series`) which support the Responses API
- Partner deployments (DeepSeek, Kimi, Llama, etc.) which **only** support Chat Completions

`packages/llm/src/providers/azure.ts` currently routes everything through Responses by default. For partner deployments the request gets accepted at the network layer but two things break:

1. **`max_output_tokens` is silently dropped** during Azure's internal Responses→Chat translation. The underlying chat call uses its default of 4096 and the response comes back with `finish_reason: "length"` regardless of what `limit.output` the user set (this is the truncation symptom — see #29776).
2. **System instructions get emitted with `role: "developer"`** (a Responses-API convention). Azure Foundry's chat-completions endpoint only accepts `system | user | assistant | tool`, so it 422s the whole request (see #12879).

Concrete repro of (1) on `DeepSeek-V4-Pro` (Azure AI Foundry, `limit.output: 16384`):

| max_tokens path | actual `tokens.output` | `finish` |
|---|---|---|
| direct curl `/chat/completions` with `max_tokens: 32000` | 14001 | `stop` |
| opencode (default Responses routing) | 4096 | `length` |
| opencode after this change | 14001 | `stop` |

The fix auto-detects by model id: `gpt-*` / `o1-*` / `o3-*` / `o4-*` go through Responses; everything else uses Chat. `useCompletionUrls: true | false` remains as an explicit override either direction, so existing configs aren't affected.

### How did you verify your code works?

- `bun test packages/llm/test/provider/` — 150 pass, 0 fail (new test file `packages/llm/test/provider/azure.test.ts` covers default routing for OpenAI-native ids, default routing for partner ids, o-series, and both `useCompletionUrls` overrides)
- `bun --cwd packages/llm run typecheck` — clean
- Reproduced the truncation symptom (#29776) on `azure/DeepSeek-V4-Pro` and confirmed the fix lifts the 4096 cap: model now emits 14k tokens with `finish: stop`

### Screenshots / recordings

N/A (no UI changes).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
