### PR TITLE
feat: FreeBSD support

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -141,6 +141,10 @@ const allTargets: {
     arch: "x64",
     avx2: false,
   },
+  {
+    os: "freebsd",
+    arch: "x64",
+  },
 ]
 
 const targets = singleFlag
@@ -187,7 +191,7 @@ for (const item of targets) {
 
   const localPath = path.resolve(dir, "node_modules/@opentui/core/parser.worker.js")
   const rootPath = path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js")
-  const parserWorker = fs.realpathSync(fs.existsSync(localPath) ? localPath : rootPath)
+  const parserWorker = fs.existsSync(localPath) ? localPath : rootPath
   const workerPath = "./src/cli/cmd/tui/worker.ts"
 
   // Use platform-specific bunfs root path based on target OS
@@ -219,10 +223,10 @@ for (const item of targets) {
       OPENCODE_VERSION: `'${Script.version}'`,
       OPENCODE_MIGRATIONS: JSON.stringify(migrations),
       OPENCODE_MODELS_DEV: generated.modelsData,
-      OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
-      OPENCODE_WORKER_PATH: workerPath,
+      OTUI_TREE_SITTER_WORKER_PATH: JSON.stringify(bunfsRoot + workerRelativePath),
+      OPENCODE_WORKER_PATH: JSON.stringify(workerPath),
       OPENCODE_CHANNEL: `'${Script.channel}'`,
-      OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
+      OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "undefined",
     },
   })
 

--- a/packages/opencode/src/cli/cmd/run/keymap.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/keymap.shared.ts
@@ -31,11 +31,8 @@ function hostPlatform() {
     return "windows" as const
   }
 
-  if (process.platform === "linux") {
-    return "linux" as const
-  }
-
-  return "unknown" as const
+  // FreeBSD and other Unix-like systems use the same keybindings as Linux
+  return "linux" as const
 }
 
 function createCommandEvent() {

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -102,7 +102,7 @@ export async function read(): Promise<Content | undefined> {
     }
   }
 
-  if (os === "linux") {
+  if (os === "linux" || os === "freebsd") {
     const wayland = await Process.run(["wl-paste", "-t", "image/png"], { nothrow: true })
     if (wayland.stdout.byteLength > 0) {
       return { data: Buffer.from(wayland.stdout).toString("base64"), mime: "image/png" }
@@ -134,7 +134,7 @@ const getCopyMethod = lazy(async () => {
     }
   }
 
-  if (os === "linux") {
+  if (os === "linux" || os === "freebsd") {
     if (process.env["WAYLAND_DISPLAY"] && which("wl-copy")) {
       console.log("clipboard: using wl-copy")
       return (text: string) => writeWithStdin(["wl-copy"], text)


### PR DESCRIPTION
### Issue for this PR

Closes #29782

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds FreeBSD as a supported platform. Three small changes:

1. `clipboard.ts` — FreeBSD uses the same xclip/xsel/wl-copy tools as Linux for clipboard access. Added `"freebsd"` to the existing `os === "linux"` checks in both read and write paths.

2. `keymap.shared.ts` — `hostPlatform()` returned `"unknown"` for any platform that wasn't darwin/win32/linux, which meant no primary modifier was set. FreeBSD (and any other Unix) should use the same ctrl-based keybindings as Linux, so the function now returns `"linux"` as the default instead of `"unknown"`.

3. `build.ts` — Added `freebsd-x64` to `allTargets`. Also fixed a latent issue where `OTUI_TREE_SITTER_WORKER_PATH` and `OPENCODE_WORKER_PATH` were passed as raw expressions to `define`, which breaks when the resolved path contains characters like `+` or `/` that get parsed as operators. Wrapped them with `JSON.stringify`. Removed the `realpathSync` call that was resolving symlinks into bun's `.bun/` cache paths (which contain `+`). Changed `OPENCODE_LIBC` from `""` to `"undefined"` for non-linux targets since empty string isn't valid in the define parser.

### How did you verify your code works?

Built a standalone `opencode` binary on FreeBSD 15.0-RELEASE x86_64 using a Bun build with FFI enabled. TUI renders, clipboard works with xclip, keybindings use ctrl as primary modifier, headless serve/run modes work. Ollama and OpenAI providers connect and stream responses.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR