### PR TITLE
fix(opencode): report invalid agent/mode configs instead of crashing or dropping them

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -9,7 +9,6 @@ import { Glob } from "@opencode-ai/core/util/glob"
 import { configEntryNameFromPath } from "./entry-name"
 import * as ConfigMarkdown from "./markdown"
 import { ConfigModelID } from "./model-id"
-import { ConfigParse } from "./parse"
 import { ConfigPermission } from "./permission"
 
 const log = Log.create({ service: "config" })
@@ -104,6 +103,18 @@ export const Info = AgentSchema.pipe(
 ).annotate({ identifier: "AgentConfig" })
 export type Info = Schema.Schema.Type<typeof Info>
 
+// Surface a config-loading failure to the user and log it, so an invalid file is
+// reported instead of crashing the whole load (load) or vanishing silently (loadMode).
+// Publishing requires an instance context that isn't always present (e.g. tests), so a
+// publish failure is swallowed — the log line is the durable record, the event is best-effort.
+async function report(label: string, item: string, message: string, err: unknown) {
+  log.error(`failed to load ${label}`, { [label]: item, err })
+  try {
+    const { Session } = await import("@/session/session")
+    await Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+  } catch {}
+}
+
 export async function load(dir: string) {
   const result: Record<string, Info> = {}
   for (const item of await Glob.scan("{agent,agents}/**/*.md", {
@@ -113,25 +124,24 @@ export async function load(dir: string) {
     symlink: true,
   })) {
     const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-      const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-        ? err.data.message
-        : `Failed to parse agent ${item}`
-      const { Session } = await import("@/session/session")
-      void Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-      log.error("failed to load agent", { agent: item, err })
+      const message = ConfigMarkdown.FrontmatterError.isInstance(err) ? err.data.message : `Failed to parse agent ${item}`
+      await report("agent", item, message, err)
       return undefined
     })
     if (!md) continue
 
     const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
-    const name = configEntryNameFromPath(item, patterns)
-
     const config = {
-      name,
+      name: configEntryNameFromPath(item, patterns),
       ...md.data,
       prompt: md.content.trim(),
     }
-    result[config.name] = ConfigParse.schema(Info, config, item)
+    const parsed = Schema.decodeUnknownExit(Info)(config, { errors: "all", propertyOrder: "original" })
+    if (Exit.isFailure(parsed)) {
+      await report("agent", item, `Failed to parse agent ${item}`, parsed.cause)
+      continue
+    }
+    result[config.name] = parsed.value
   }
   return result
 }
@@ -145,12 +155,8 @@ export async function loadMode(dir: string) {
     symlink: true,
   })) {
     const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-      const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-        ? err.data.message
-        : `Failed to parse mode ${item}`
-      const { Session } = await import("@/session/session")
-      void Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-      log.error("failed to load mode", { mode: item, err })
+      const message = ConfigMarkdown.FrontmatterError.isInstance(err) ? err.data.message : `Failed to parse mode ${item}`
+      await report("mode", item, message, err)
       return undefined
     })
     if (!md) continue
@@ -161,11 +167,13 @@ export async function loadMode(dir: string) {
       prompt: md.content.trim(),
     }
     const parsed = Schema.decodeUnknownExit(Info)(config, { errors: "all", propertyOrder: "original" })
-    if (Exit.isSuccess(parsed)) {
-      result[config.name] = {
-        ...parsed.value,
-        mode: "primary" as const,
-      }
+    if (Exit.isFailure(parsed)) {
+      await report("mode", item, `Failed to parse mode ${item}`, parsed.cause)
+      continue
+    }
+    result[config.name] = {
+      ...parsed.value,
+      mode: "primary" as const,
     }
   }
   return result

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1,6 +1,8 @@
 import { test, expect, describe, mock, afterEach, beforeEach } from "bun:test"
 import { Effect, Layer, Option } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import { Bus } from "@/bus"
+import { Session } from "@/session/session"
 import { Config } from "@/config/config"
 import { ConfigManaged } from "@/config/managed"
 import { ConfigParse } from "../../src/config/parse"
@@ -80,6 +82,22 @@ const listDirs = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.directories()).pipe(Effect.scoped, Effect.provide(layer)))
 const ready = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(layer)))
+
+// Collect Session.Event.Error messages, and return a promise that resolves as soon
+// as the first message containing `pattern` arrives (with a timeout so a missing
+// event fails the test instead of hanging it).
+function subscribeErrors(pattern: string, timeoutMs = 500) {
+  const errors: string[] = []
+  const matched = Promise.withResolvers<void>()
+  Bus.subscribe(Session.Event.Error, (evt) => {
+    const data = evt.properties.error?.data
+    if (!data || !("message" in data) || typeof data.message !== "string") return
+    errors.push(data.message)
+    if (data.message.includes(pattern)) matched.resolve()
+  })
+  const wait = Promise.race([matched.promise, Bun.sleep(timeoutMs)])
+  return { errors, wait }
+}
 
 // Get managed config directory from environment (set in preload.ts)
 const managedConfigDir = process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR!
@@ -887,6 +905,81 @@ Nested agent prompt`,
         mode: "subagent",
         prompt: "Nested agent prompt",
       })
+    },
+  })
+})
+
+test("invalid agent file is reported and does not block valid agents", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const agentDir = path.join(dir, ".opencode", "agent")
+      await fs.mkdir(agentDir, { recursive: true })
+
+      await Filesystem.write(
+        path.join(agentDir, "good.md"),
+        `---
+model: test/model
+---
+Good agent prompt`,
+      )
+
+      await Filesystem.write(
+        path.join(agentDir, "broken.md"),
+        `---
+temperature: "not a number"
+---
+Broken agent prompt`,
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const { errors, wait } = subscribeErrors("broken.md")
+      const config = await load()
+      await wait
+      // The valid agent still loads even though a sibling file is invalid.
+      expect(config.agent?.["good"]).toMatchObject({ name: "good", model: "test/model" })
+      expect(config.agent?.["broken"]).toBeUndefined()
+      // The invalid file is reported rather than crashing the load.
+      expect(errors.some((m) => m.includes("broken.md"))).toBe(true)
+    },
+  })
+})
+
+test("invalid mode file is reported instead of being silently dropped", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const modeDir = path.join(dir, ".opencode", "mode")
+      await fs.mkdir(modeDir, { recursive: true })
+
+      await Filesystem.write(
+        path.join(modeDir, "good.md"),
+        `---
+model: test/model
+---
+Good mode prompt`,
+      )
+
+      await Filesystem.write(
+        path.join(modeDir, "broken.md"),
+        `---
+temperature: "not a number"
+---
+Broken mode prompt`,
+      )
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const { errors, wait } = subscribeErrors("broken.md")
+      const config = await load()
+      await wait
+      expect(config.agent?.["good"]).toMatchObject({ name: "good", mode: "primary" })
+      expect(config.agent?.["broken"]).toBeUndefined()
+      // Previously the invalid mode vanished with no error; now it must be reported.
+      expect(errors.some((m) => m.includes("broken.md"))).toBe(true)
     },
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #27133

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/opencode/src/config/agent.ts` had two near-identical loaders that handled invalid files differently. `load()` called `ConfigParse.schema()` which throws, so one bad agent file aborted the whole load and startup failed with `ConfigInvalidError`. `loadMode()` used `Schema.decodeUnknownExit` with an `if (Exit.isSuccess)` and no `else`, so a bad mode silently disappeared with no error.

Now both decode the same way and on failure they log, publish a `Session.Event.Error`, and skip just the bad file while continuing to load the rest. The shared log + publish logic moved into a small `report()` helper to avoid duplicating it across both functions.

### How did you verify your code works?

- Added two regression tests in `test/config/config.test.ts` that exercise the repro from #27133 at the API level. Both fail on `origin/dev` (agent test throws `ConfigInvalidError`; mode test fails the "error was reported" assertion) and pass with the fix.
- `bun test test/config test/agent`: 212/212 passing.
- `bun typecheck` for the opencode package and `oxlint` on both changed files: clean.
- Manually ran the issue's repro (`bun dev <dir>` against the four-file fixture from #27133): before the fix, startup crashes as described; after, opencode starts cleanly, the `good` entries appear in the agent cycler, and the broken ones are reported via `Session.Event.Error` instead of crashing or vanishing.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR