### PR TITLE
docs: add opencode-goal-plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -53,6 +53,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                         |
+| [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-goal-plugin` to the ecosystem docs plugin list in `packages/web/src/content/docs/ecosystem.mdx`.

`opencode-goal-plugin` gives OpenCode a session-scoped `/goal` workflow that keeps the current objective in context and automatically continues work until the goal is complete, blocked, or a safety limit is reached.

Project links:
- GitHub: https://github.com/willytop8/OpenCode-goal-plugin
- npm: https://www.npmjs.com/package/opencode-goal-plugin

### How did you verify your code works?

- Confirmed the docs entry was added to the `Plugins` table in `packages/web/src/content/docs/ecosystem.mdx`
- Verified the link target and description text match the plugin's published GitHub repo and npm package
- Confirmed this PR only adds the new ecosystem entry with no unrelated changes

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
