### PR TITLE
fix(app): prevent horizontal jitter on /go page

### DIFF
--- a/packages/console/app/src/routes/go/index.css
+++ b/packages/console/app/src/routes/go/index.css
@@ -90,6 +90,7 @@ body {
 
 [data-page="go"] {
   background: var(--color-background);
+  overflow-x: clip;
   --padding: 5rem;
   --vertical-padding: 4rem;
 


### PR DESCRIPTION
### Issue for this PR

Closes #29795

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `/go` page has a subtle horizontal jitter when scrolling. The `LimitsGraph` component's `[data-slot="plot"]` element uses `margin-left: -56px` with `overflow: visible`, and the y-axis labels ("Free", "Go") extend past the viewport edge via `transform: translate(-100%, -50%)`. As content animates in (bars, pills, FAQ expansion), this causes a horizontal scrollbar to flicker in and out, creating the side-to-side shift.

Adding `overflow-x: clip` to `[data-page="go"]` prevents the scrollbar from appearing. `clip` is preferred over `hidden` because it doesn't create a scroll container or affect sticky positioning.

### How did you verify your code works?

Ran the console app locally and compared scrolling behavior on `/go` before and after the change. The horizontal jitter is gone; other pages are unaffected.

### Screenshots / recordings

CSS-only change (single property addition) - visual difference is the absence of horizontal shift during scroll.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
