### PR TITLE
fix(tui): order connected provider models by release date

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -73,6 +73,7 @@ export function DialogModel(props: { providerID?: string }) {
           map(([model, info]) => ({
             value: { providerID: provider.id, modelID: model },
             title: info.name ?? model,
+            releaseDate: info.release_date,
             description: favorites.some((item) => item.providerID === provider.id && item.modelID === model)
               ? "(Favorite)"
               : undefined,
@@ -91,10 +92,7 @@ export function DialogModel(props: { providerID?: string }) {
               return false
             return true
           }),
-          sortBy(
-            (x) => x.footer !== "Free",
-            (x) => x.title,
-          ),
+          (options) => sortModelOptions(options, props.providerID !== undefined),
         ),
       ),
     )
@@ -171,5 +169,17 @@ export function DialogModel(props: { providerID?: string }) {
       title={title()}
       current={local.model.current()}
     />
+  )
+}
+
+export function sortModelOptions<T extends { footer?: string; releaseDate: string; title: string }>(
+  options: T[],
+  newestFirst: boolean,
+) {
+  if (newestFirst) return sortBy(options, [(option) => option.releaseDate, "desc"], (option) => option.title)
+  return sortBy(
+    options,
+    (option) => option.footer !== "Free",
+    (option) => option.title,
   )
 }

--- a/packages/opencode/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/model-options.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { sortModelOptions } from "../../../../src/cli/cmd/tui/component/dialog-model"
+
+describe("sortModelOptions", () => {
+  test("orders provider-scoped model choices by newest release first", () => {
+    const sorted = sortModelOptions(
+      [
+        { title: "GPT 5.2", releaseDate: "2025-12-11" },
+        { title: "GPT 5.4", releaseDate: "2026-03-05" },
+        { title: "GPT 5.1", releaseDate: "2025-11-13" },
+      ],
+      true,
+    )
+
+    expect(sorted.map((model) => model.title)).toEqual(["GPT 5.4", "GPT 5.2", "GPT 5.1"])
+  })
+
+  test("preserves free-first alphabetical ordering for the regular picker", () => {
+    const sorted = sortModelOptions(
+      [
+        { title: "Beta", releaseDate: "2026-01-01" },
+        { title: "Alpha", releaseDate: "2025-01-01", footer: "Free" },
+        { title: "Gamma", releaseDate: "2024-01-01", footer: "Free" },
+      ],
+      false,
+    )
+
+    expect(sorted.map((model) => model.title)).toEqual(["Alpha", "Gamma", "Beta"])
+  })
+})


### PR DESCRIPTION
## Summary
- order the provider-specific model picker shown after `/connect` by descending release date
- preserve the existing free-first alphabetical ordering in the general model picker
- add focused ordering tests for both dialog modes

## Tests
- `bun test test/cli/cmd/tui/model-options.test.ts`
- `bun typecheck`
- `git diff --check`