### PR TITLE
fix: de-flake compaction backoff-abort and openai ws-pool tests

### DIFF
--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -15,6 +15,9 @@ export interface CreateWebSocketFetchOptions {
   idleTimeout?: number
   maxConnectionAge?: number
   streamRetries?: number
+  // How often the idle pruner runs. Decoupled from idleTimeout so a small idle
+  // timeout doesn't spawn a hyperactive interval that races in-flight requests.
+  pruneInterval?: number
 }
 
 interface PoolEntry {
@@ -38,7 +41,8 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
   const idleTimeout = options?.idleTimeout ?? DEFAULT_IDLE_TIMEOUT
   const maxConnectionAge = options?.maxConnectionAge ?? DEFAULT_MAX_CONNECTION_AGE
   const streamRetries = options?.streamRetries ?? 5
-  const pruneTimer = setInterval(() => prune(), Math.min(idleTimeout, 60_000))
+  const pruneInterval = options?.pruneInterval ?? Math.min(idleTimeout, 60_000)
+  const pruneTimer = setInterval(() => prune(), pruneInterval)
   if (typeof pruneTimer === "object" && "unref" in pruneTimer && typeof pruneTimer.unref === "function") {
     pruneTimer.unref()
   }
@@ -121,6 +125,10 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         onConnectionInvalid: (error) => {
           log.warn("websocket invalidated", { key, error: error.message })
           entry.busy = false
+          // Record the failure as recent activity so the idle pruner doesn't
+          // immediately evict this entry (and reset its retry budget) before the
+          // next request reuses it. Mirrors onTerminal/onAbort/catch.
+          entry.lastUsedAt = Date.now()
           if (!entry.fallback) recordStreamFailure(entry)
           invalidate(entry)
           resolveFirstEvent(false)

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -231,6 +231,40 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
+  test("keeps a just-failed websocket entry alive across an aggressive prune cycle", async () => {
+    let connections = 0
+    await using server = await createWebSocketServer((socket) => {
+      connections += 1
+      socket.once("message", () => {})
+    })
+    // Aggressive pruner (5ms) relative to a generous idle timeout (200ms): an
+    // entry that just failed was used well under 200ms ago, so it must NOT be
+    // pruned. The bug left lastUsedAt at the request's start, making the entry
+    // look stale and letting the pruner reset its retry budget. The wide gap
+    // between the prune interval and the idle timeout keeps this deterministic
+    // under load: a stale entry is evicted within ~5ms, a fresh one survives the
+    // brief wait below with a ~170ms margin.
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      idleTimeout: 200,
+      pruneInterval: 5,
+      streamRetries: 1,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("idle timeout waiting for websocket")
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    const second = await fetch(server.url, streamRequest())
+    const third = await fetch(server.url, streamRequest())
+
+    expect(await second.text()).toBe("http")
+    expect(await third.text()).toBe("http")
+    expect(connections).toBe(2)
+    expect(server.httpRequests).toHaveLength(2)
+    fetch.close()
+  })
+
   test("invalidates but does not reuse a socket after terminal failure frames", async () => {
     let connections = 0
     await using server = await createWebSocketServer((socket) => {
@@ -378,6 +412,9 @@ describe("plugin.openai.ws-pool", () => {
       url: server.url,
       idleTimeout: 20,
       streamRetries: 1,
+      // Exercises the cross-request retry budget, not idle pruning: keep the
+      // pruner dormant so it can't evict the entry between back-to-back fetches.
+      pruneInterval: 60_000,
     })
 
     const first = await fetch(server.url, streamRequest())
@@ -402,6 +439,9 @@ describe("plugin.openai.ws-pool", () => {
       url: server.url,
       idleTimeout: 20,
       streamRetries: 1,
+      // Exercises the cross-request retry budget, not idle pruning: keep the
+      // pruner dormant so it can't evict the entry between back-to-back fetches.
+      pruneInterval: 60_000,
     })
 
     const first = await fetch(server.url, streamRequest())

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1171,7 +1171,14 @@ describe("session.compaction.process", () => {
     }),
   )
 
-  itCompaction.instance(
+  // Runs under TestClock (it.effect) so the retry backoff is virtual time we
+  // control. The previous version measured abort latency against the real wall
+  // clock (`Date.now() - start < 250` plus a `250 millis` await timeout), which
+  // raced the interrupt cleanup path (DB writes + git snapshot.patch) and flaked
+  // under load — on Windows it timed out outright with a dangling git process.
+  // No git instance here: TestClock cannot drive a child process, and snapshots
+  // are irrelevant to backoff interruption (snapshot.track no-ops without git).
+  itCompaction.effect(
     "stops quickly when aborted during retry backoff",
     () => {
       const stub = llm()
@@ -1195,42 +1202,49 @@ describe("session.compaction.process", () => {
         ),
       )
 
-      return Effect.gen(function* () {
-        const ssn = yield* SessionNs.Service
-        const bus = yield* Bus.Service
-        const ready = yield* Deferred.make<void>()
-        const session = yield* ssn.create({})
-        const msg = yield* createUserMessage(session.id, "hello")
-        const msgs = yield* ssn.messages({ sessionID: session.id })
-        const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
-          if (evt.properties.sessionID !== session.id) return
-          if (evt.properties.status.type !== "retry") return
-          Deferred.doneUnsafe(ready, Effect.void)
-        })
-        yield* Effect.addFinalizer(() => Effect.sync(off))
+      return provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const ssn = yield* SessionNs.Service
+            const bus = yield* Bus.Service
+            const ready = yield* Deferred.make<void>()
+            const session = yield* ssn.create({})
+            const msg = yield* createUserMessage(session.id, "hello")
+            const msgs = yield* ssn.messages({ sessionID: session.id })
+            const off = yield* bus.subscribeCallback(SessionStatus.Event.Status, (evt) => {
+              if (evt.properties.sessionID !== session.id) return
+              if (evt.properties.status.type !== "retry") return
+              Deferred.doneUnsafe(ready, Effect.void)
+            })
+            yield* Effect.addFinalizer(() => Effect.sync(off))
 
-        const fiber = yield* SessionCompaction.use
-          .process({
-            parentID: msg.id,
-            messages: msgs,
-            sessionID: session.id,
-            auto: false,
-          })
-          .pipe(Effect.forkChild)
+            const fiber = yield* SessionCompaction.use
+              .process({
+                parentID: msg.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              })
+              .pipe(Effect.forkChild)
 
-        yield* Deferred.await(ready).pipe(Effect.timeout("1 second"))
-        const start = Date.now()
-        yield* Fiber.interrupt(fiber)
-        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout("250 millis"))
+            // The 503 carries `retry-after-ms: 10000`, so the retry schedule
+            // publishes the "retry" status and then sleeps 10s. Waiting on the
+            // status confirms the fiber has parked in that backoff sleep.
+            yield* Deferred.await(ready)
 
-        expect(Exit.isFailure(exit)).toBe(true)
-        if (Exit.isFailure(exit)) {
-          expect(Cause.hasInterrupts(exit.cause)).toBe(true)
-          expect(Date.now() - start).toBeLessThan(250)
-        }
-      }).pipe(withCompaction({ llm: stub.layer }))
+            // We never advance the TestClock, so the 10s backoff can only end by
+            // the interrupt aborting the sleep. If aborting did not cut through
+            // the backoff this would hang until the test runner timed out.
+            yield* Fiber.interrupt(fiber)
+            const exit = yield* Fiber.await(fiber)
+
+            expect(Exit.isFailure(exit)).toBe(true)
+            if (Exit.isFailure(exit)) {
+              expect(Cause.hasInterrupts(exit.cause)).toBe(true)
+            }
+          }).pipe(withCompaction({ llm: stub.layer })),
+      )
     },
-    { git: true },
   )
 
   itCompaction.instance(


### PR DESCRIPTION
Two flaky tests, both wall-clock races. No behavior change except the ws-pool fix below (which is a real bug, not just test noise).

### `session.compaction` › stops quickly when aborted during retry backoff
- **Issue:** asserted abort latency on the real clock (`Date.now() - start < 250` + a 250ms await timeout). That raced the interrupt cleanup (DB writes + `snapshot.patch`) and blew the budget under load — on Windows it timed out outright with a dangling git proc.
- **Fix:** run under `TestClock` and never advance it, so the 10s `retry-after` backoff can only end via the interrupt (proves "stops quickly" without a stopwatch). Dropped the git instance — TestClock can't drive a child process and snapshots are irrelevant here.

### `plugin.openai.ws-pool` › retries websocket idle failures…
- **Issue (real bug):** `onConnectionInvalid` never refreshed `lastUsedAt`, so a just-failed entry looks idle-since-before-the-request. With a small `idleTimeout` the pruner interval is equally small (`min(idleTimeout, 60s)`), so it can evict the entry between back-to-back requests and reset the cross-request retry budget / fallback decision.
- **Fix:** bump `lastUsedAt` on the idle-failure path (now matches `onTerminal`/`onAbort`/catch); add a `pruneInterval` option (default unchanged) to decouple cadence from `idleTimeout`. Existing idle tests hold the pruner dormant; added a deterministic regression test that fails without the `lastUsedAt` bump.
