### PR TITLE
fix(desktop): bump @lydell/node-pty to 1.2.0-beta.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -312,12 +312,12 @@
         "zod-openapi": "5.4.6",
       },
       "optionalDependencies": {
-        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.10",
-        "@lydell/node-pty-darwin-x64": "1.2.0-beta.10",
-        "@lydell/node-pty-linux-arm64": "1.2.0-beta.10",
-        "@lydell/node-pty-linux-x64": "1.2.0-beta.10",
-        "@lydell/node-pty-win32-arm64": "1.2.0-beta.10",
-        "@lydell/node-pty-win32-x64": "1.2.0-beta.10",
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.12",
         "@parcel/watcher-darwin-arm64": "2.5.1",
         "@parcel/watcher-darwin-x64": "2.5.1",
         "@parcel/watcher-linux-arm64-glibc": "2.5.1",
@@ -824,7 +824,7 @@
     "@effect/sql-sqlite-bun": "4.0.0-beta.66",
     "@hono/zod-validator": "0.4.2",
     "@kobalte/core": "0.13.11",
-    "@lydell/node-pty": "1.2.0-beta.10",
+    "@lydell/node-pty": "1.2.0-beta.12",
     "@npmcli/arborist": "9.4.0",
     "@octokit/rest": "22.0.0",
     "@openauthjs/openauth": "0.0.0-20250322224806",
@@ -1508,19 +1508,19 @@
 
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
-    "@lydell/node-pty": ["@lydell/node-pty@1.2.0-beta.10", "", { "optionalDependencies": { "@lydell/node-pty-darwin-arm64": "1.2.0-beta.10", "@lydell/node-pty-darwin-x64": "1.2.0-beta.10", "@lydell/node-pty-linux-arm64": "1.2.0-beta.10", "@lydell/node-pty-linux-x64": "1.2.0-beta.10", "@lydell/node-pty-win32-arm64": "1.2.0-beta.10", "@lydell/node-pty-win32-x64": "1.2.0-beta.10" } }, "sha512-Fv+A3+MZVA8qhkBIZsM1E6dCdHNMyXXz22mAYiMWd03LlyK///F3OH6CKPX9mj4id7LUlxpr45yPzyBVy9aDPw=="],
+    "@lydell/node-pty": ["@lydell/node-pty@1.2.0-beta.12", "", { "optionalDependencies": { "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12", "@lydell/node-pty-darwin-x64": "1.2.0-beta.12", "@lydell/node-pty-linux-arm64": "1.2.0-beta.12", "@lydell/node-pty-linux-x64": "1.2.0-beta.12", "@lydell/node-pty-win32-arm64": "1.2.0-beta.12", "@lydell/node-pty-win32-x64": "1.2.0-beta.12" } }, "sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g=="],
 
-    "@lydell/node-pty-darwin-arm64": ["@lydell/node-pty-darwin-arm64@1.2.0-beta.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C+eqDyRNHRYvx7RaHj6VVCx6nCpRBPuuxhTcc3JH3GuBMoxTsYeY4GkWH2XOktrgbAq1BG8e/Y8bu/wNQreCEw=="],
+    "@lydell/node-pty-darwin-arm64": ["@lydell/node-pty-darwin-arm64@1.2.0-beta.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ=="],
 
-    "@lydell/node-pty-darwin-x64": ["@lydell/node-pty-darwin-x64@1.2.0-beta.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZoIK6HtJO5BiT4ELm683U4dyHtt8b7wNgq3NJqYAQwSXrcPv576Z8vY3BIulVxfcFkht/SPLKou9TtdFXdNpg=="],
+    "@lydell/node-pty-darwin-x64": ["@lydell/node-pty-darwin-x64@1.2.0-beta.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q=="],
 
-    "@lydell/node-pty-linux-arm64": ["@lydell/node-pty-linux-arm64@1.2.0-beta.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-0cKX2iMyXFNBE4fGtGK6B7IkdXcDMZajyEDoGMOgQQs/DDtoI5tSPcBcqNY9VitVrsRQA8+gFt6eKYU9Ye/lUA=="],
+    "@lydell/node-pty-linux-arm64": ["@lydell/node-pty-linux-arm64@1.2.0-beta.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw=="],
 
-    "@lydell/node-pty-linux-x64": ["@lydell/node-pty-linux-x64@1.2.0-beta.10", "", { "os": "linux", "cpu": "x64" }, "sha512-J9HnxvSzEeMH748+Ul1VrmCLWMo7iCVJy9EGijRR62+YO/Yk5GaCydUTZ+KzlH0/X5aTrgt5cfiof4vx45tRRg=="],
+    "@lydell/node-pty-linux-x64": ["@lydell/node-pty-linux-x64@1.2.0-beta.12", "", { "os": "linux", "cpu": "x64" }, "sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ=="],
 
-    "@lydell/node-pty-win32-arm64": ["@lydell/node-pty-win32-arm64@1.2.0-beta.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-PlDJpJX/pnKyy6OmADKzhf+INZDDnzTBGaI0LT4laVNc6NblZNqUSkCMjLFWbeakeuQp0VG37M49WQSN9FDfeA=="],
+    "@lydell/node-pty-win32-arm64": ["@lydell/node-pty-win32-arm64@1.2.0-beta.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g=="],
 
-    "@lydell/node-pty-win32-x64": ["@lydell/node-pty-win32-x64@1.2.0-beta.10", "", { "os": "win32", "cpu": "x64" }, "sha512-ExFgWrzyldNAMi45U9PLIOu+g/RatP+f0c/dZxaooifME6yLW32BoHveH26/TtoAjZyJrc2iL0u48pgnR1fzmg=="],
+    "@lydell/node-pty-win32-x64": ["@lydell/node-pty-win32-x64@1.2.0-beta.12", "", { "os": "win32", "cpu": "x64" }, "sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw=="],
 
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
       "@sentry/vite-plugin": "4.6.0",
       "solid-js": "1.9.10",
       "vite-plugin-solid": "2.11.10",
-      "@lydell/node-pty": "1.2.0-beta.10"
+      "@lydell/node-pty": "1.2.0-beta.12"
     }
   },
   "devDependencies": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -59,12 +59,12 @@
     "zod-openapi": "5.4.6"
   },
   "optionalDependencies": {
-    "@lydell/node-pty-darwin-arm64": "1.2.0-beta.10",
-    "@lydell/node-pty-darwin-x64": "1.2.0-beta.10",
-    "@lydell/node-pty-linux-arm64": "1.2.0-beta.10",
-    "@lydell/node-pty-linux-x64": "1.2.0-beta.10",
-    "@lydell/node-pty-win32-arm64": "1.2.0-beta.10",
-    "@lydell/node-pty-win32-x64": "1.2.0-beta.10",
+    "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+    "@lydell/node-pty-linux-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+    "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-win32-x64": "1.2.0-beta.12",
     "@parcel/watcher-darwin-arm64": "2.5.1",
     "@parcel/watcher-darwin-x64": "2.5.1",
     "@parcel/watcher-linux-arm64-glibc": "2.5.1",

--- a/packages/opencode/src/pty/pty.node.ts
+++ b/packages/opencode/src/pty/pty.node.ts
@@ -1,4 +1,3 @@
-/** @ts-expect-error */
 import * as pty from "@lydell/node-pty"
 import type { Opts, Proc } from "./pty"
 


### PR DESCRIPTION
## Summary

Bumps `@lydell/node-pty` (and its per-platform packages) from `1.2.0-beta.10` → `1.2.0-beta.12` to fix the repeated Windows desktop sidecar crash / stderr flood reported in #29599.

## Root cause (reproduced headlessly on Windows, node v24.14.1)

The desktop sidecar resolves `@lydell/node-pty` to `@lydell/node-pty-win32-x64` (via `electron.vite.config.ts`). On every PTY `kill()`, node-pty's `WindowsPtyAgent` does `child_process.fork('conpty_console_list_agent')`, and in **beta.10** that agent calls `getConsoleProcessList(shellPid)` with **no error handling**:

```js
// @lydell/node-pty-win32-x64@1.2.0-beta.10/lib/conpty_console_list_agent.js
var consoleProcessList = getConsoleProcessList(shellPid); // line 13 — throws uncaught
```

`kill()` forks this agent and then *synchronously* kills the pty, so by the time the agent runs `AttachConsole(shellPid)` the shell is already gone (and the Electron utilityProcess has no console at all) → native throws `Error: AttachConsole failed` → the forked process exits with the stack dumped to stderr, which the desktop surfaces as `sidecar stderr {...}`. This matches the issue's "Error 1" line-for-line and fires on **every terminal close** (reproduced 40/40, including in a detached no-console process).

## Fix

`@lydell/node-pty@1.2.0-beta.12` carries the upstream fix that wraps the call in `try/catch` and guards `innerPid <= 0`:

```js
// beta.12
var consoleProcessList = [];
if (shellPid > 0) {
  try { consoleProcessList = getConsoleProcessList(shellPid); }
  catch (_a) { consoleProcessList = []; } // AttachConsole can fail if the process already exited or is invalid.
}
```

Verified locally: after the bump, spawning + killing a PTY produces **no** `AttachConsole failed` output.

## Changes

- `package.json` — catalog `@lydell/node-pty` → `1.2.0-beta.12`
- `packages/desktop/package.json` — the 6 `@lydell/node-pty-<platform>` optional deps → `1.2.0-beta.12`
- `bun.lock` — regenerated
- `packages/opencode/src/pty/pty.node.ts` — drop the now-redundant `@ts-expect-error` on the `@lydell/node-pty` import (beta.12 ships `node-pty.d.ts`, so the directive became unused → TS2578)

## Notes / not addressed here

- The same forked agent still flashes a console window per terminal close (node-pty's `fork` has no `windowsHide`); beta.12 reduces but doesn't fully remove this.
- This bump stops the crash/stderr flood. Sidecar **supervision/auto-restart** (so a sidecar crash doesn't leave the renderer permanently on `net::ERR_FAILED` / "fetch failed") is a separate follow-up in `packages/desktop/src/main/index.ts`.

Refs #29599
