### PR TITLE
fix(tui): animate pending inline tools

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -587,6 +587,7 @@ function InlineTool(props: {
   const [showError, setShowError] = createSignal(false)
   const error = createMemo(() => (props.part.state.status === "error" ? props.part.state.error.message : undefined))
   const complete = createMemo(() => !!props.complete)
+  const active = createMemo(() => props.part.state.status === "pending" || props.part.state.status === "running")
   const denied = createMemo(() => {
     const message = error()
     if (!message) return false
@@ -632,7 +633,7 @@ function InlineTool(props: {
     >
       <box flexShrink={0}>
         <Switch>
-          <Match when={props.spinner}>
+          <Match when={props.spinner || (!complete() && active())}>
             <Spinner color={theme.text} />
           </Match>
           <Match when={complete()}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1795,6 +1795,7 @@ function InlineTool(props: {
   const sync = useSync()
   const renderer = useRenderer()
   const [hover, setHover] = createSignal(false)
+  const active = createMemo(() => props.part.state.status === "pending" || props.part.state.status === "running")
 
   const permission = createMemo(() => {
     const callID = sync.data.permission[ctx.sessionID]?.at(0)?.tool?.callID
@@ -1854,8 +1855,12 @@ function InlineTool(props: {
       }}
     >
       <Switch>
-        <Match when={props.spinner}>
-          <Spinner color={fg()} children={props.children} />
+        <Match when={props.spinner || (!props.complete && active())}>
+          <Spinner color={fg()}>
+            <Show when={props.complete} fallback={props.pending}>
+              {props.children}
+            </Show>
+          </Spinner>
         </Match>
         <Match when={true}>
           <text paddingLeft={3} fg={fg()} attributes={denied() ? TextAttributes.STRIKETHROUGH : undefined}>


### PR DESCRIPTION
## Summary
- render the existing spinner while inline tools are active but still waiting for displayable content
- remove the momentary `~ Delegating...` presentation and apply the same treatment to equivalent pending tool rows
- keep inactive and failed fallback rows static rather than suggesting continued progress

## Verification
- `bunx prettier --check packages/opencode/src/cli/cmd/tui/routes/session/index.tsx packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx`
- `bun typecheck` from `packages/opencode`
- `bun run test -- test/cli/tui/app-lifecycle.test.ts` from `packages/opencode`
- `git diff --check origin/dev...HEAD`

## Notes
- File-scoped `oxlint` reports existing warnings in the touched renderer files; the changed lines introduce no new lint warning.