### PR TITLE
feat(tui): sort skills alphabetically when all are shown

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -296,7 +296,7 @@ export const layer = Layer.effect(
 
     const all = Effect.fn("Skill.all")(function* () {
       const s = yield* InstanceState.get(state)
-      return Object.values(s.skills)
+      return Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
     })
 
     const dirs = Effect.fn("Skill.dirs")(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #17321

### Type of change

- [x] New feature
- [x] Refactor / code improvement

### What does this PR do?

Upon using the /skills command, it shows the list of skills in alphabetical order. Searching still shows the closest related result and remains unchanged.

### How did you verify your code works?

- Ran `bun test` inside the packages/opencode directory
- Ran `bun typecheck`
- User testing (using /skills command, typing in the skills to make sure search works as intended)

### Screenshots / recordings

<img width="588" height="337" alt="image" src="https://github.com/user-attachments/assets/84900683-c238-4a7a-8a84-bc0ca5d42af8" />
<img width="599" height="199" alt="image" src="https://github.com/user-attachments/assets/58b2175b-f1bb-4356-8b80-00f07aa8e4f8" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR