### PR TITLE
fix(session): skip persisting empty text parts when model goes straight to tool call

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -679,7 +679,9 @@ export const layer = Layer.effect(
               ctx.currentText.time = { start: ctx.currentText.time?.start ?? end, end }
             }
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
-            yield* session.updatePart(ctx.currentText)
+            if (ctx.currentText.text.length > 0) {
+              yield* session.updatePart(ctx.currentText)
+            }
             ctx.currentText = undefined
             return
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -920,3 +920,223 @@ it.live("session.processor effect tests mark interruptions aborted without manua
     { config: (url) => providerCfg(url) },
   ),
 )
+
+it.live("session.processor effect tests do not persist empty text when model goes straight to tool call", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        // Model emits text-start immediately followed by tool call, no text-delta in between
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+            ],
+            tail: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    delta: {
+                      tool_calls: [
+                        {
+                          index: 0,
+                          id: "call_1",
+                          type: "function",
+                          function: { name: "lookup", arguments: "" },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    delta: {
+                      tool_calls: [
+                        { index: 0, function: { arguments: '{"query":"weather"}' } },
+                      ],
+                    },
+                  },
+                ],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: {}, finish_reason: "tool_calls" }],
+              },
+            ],
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "tool")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "tool" }],
+          tools: {
+            lookup: tool({
+              description: "Look up information",
+              inputSchema: z.object({ query: z.string() }),
+              execute: async (input) => ({ title: "Weather lookup", output: `result:${input.query}` }),
+            }),
+          },
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const textParts = parts.filter((part): part is MessageV2.TextPart => part.type === "text")
+        const toolParts = parts.filter((part): part is MessageV2.ToolPart => part.type === "tool")
+
+        expect(value).toBe("continue")
+        // No empty text part should be persisted
+        expect(textParts.length).toBe(0)
+        // Tool call should be persisted
+        expect(toolParts.length).toBe(1)
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests persist normal text when text-delta is emitted", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.text("hello world")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "text")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "text" }],
+          tools: {},
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const textParts = parts.filter((part): part is MessageV2.TextPart => part.type === "text")
+
+        expect(value).toBe("continue")
+        expect(textParts.length).toBe(1)
+        expect(textParts[0]?.text).toBe("hello world")
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests persist whitespace-only text when model emits no actual content", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        // Model sends text-start, then a single space via text-delta, then text-end
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { content: " " } }],
+              },
+            ],
+            tail: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: {}, finish_reason: "stop" }],
+              },
+            ],
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "space")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "space" }],
+          tools: {},
+        })
+
+        const parts = MessageV2.parts(msg.id)
+        const textParts = parts.filter((part): part is MessageV2.TextPart => part.type === "text")
+
+        expect(value).toBe("continue")
+        // Whitespace-only text should be persisted (length > 0 even if just a space)
+        expect(textParts.length).toBe(1)
+        expect(textParts[0]?.text).toBe(" ")
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #29650

### Type of change

- [x] Bug fix

### What does this PR do?

When the model emits `text-start` followed immediately by a tool call (without any `text-delta` in between), the `text-end` handler was writing an empty text part to the SQLite database, causing blank assistant messages in the UI.

**Root cause:** The `text-start` handler writes `text: ""` to the database immediately. If the model goes straight to a tool call (no `text-delta`), `text-end` fires with `ctx.currentText.text` still empty, and `updatePart` was overwriting the empty text part.

**Fix:** Add a guard at `text-end` in `processor.ts:682`: only persist the text part if its content has `length > 0`.

**Before:**
```typescript
if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
yield* session.updatePart(ctx.currentText)
```

**After:**
```typescript
if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
if (ctx.currentText.text.length > 0) {
  yield* session.updatePart(ctx.currentText)
}
```

Since `updatePart` is a full-row overwrite, skipping it when text is empty leaves the row in its previous state (identical since `text-start` already wrote `text: ""`).

### How did you verify your code works?

- Added 3 test cases in `processor-effect.test.ts`:
  - `text-start` → tool call without `text-delta`: no empty text part persisted
  - `text-start` → `text-delta` → `text-end`: normal text IS persisted
  - `text-start` → `text-delta` (whitespace only) → `text-end`: whitespace-only text IS persisted
- `bun test ./test/session/processor-effect.test.ts` passes (16 tests)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR