### PR TITLE
fix(opencode): serialize mcp-auth.json writes to prevent concurrent corruption

### DIFF
--- a/packages/opencode/src/mcp/auth.ts
+++ b/packages/opencode/src/mcp/auth.ts
@@ -58,6 +58,10 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
+    // Serialise all file mutations — McpAuth.set/remove use a read-modify-write
+    // pattern. Without a lock, concurrent saves (e.g. token refresh + client info
+    // save racing at startup) can overwrite each other's changes. (#29804)
+    const sem = yield* Effect.makeSemaphore(1)
 
     const all = Effect.fn("McpAuth.all")(function* () {
       return yield* fs.readJson(filepath).pipe(
@@ -80,15 +84,23 @@ export const layer = Layer.effect(
     })
 
     const set = Effect.fn("McpAuth.set")(function* (mcpName: string, entry: Entry, serverUrl?: string) {
-      const data = yield* all()
-      if (serverUrl) entry.serverUrl = serverUrl
-      yield* fs.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600).pipe(Effect.orDie)
+      yield* sem.withPermit(
+        Effect.gen(function* () {
+          const data = yield* all()
+          if (serverUrl) entry.serverUrl = serverUrl
+          yield* fs.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600).pipe(Effect.orDie)
+        }),
+      )
     })
 
     const remove = Effect.fn("McpAuth.remove")(function* (mcpName: string) {
-      const data = yield* all()
-      delete data[mcpName]
-      yield* fs.writeJson(filepath, data, 0o600).pipe(Effect.orDie)
+      yield* sem.withPermit(
+        Effect.gen(function* () {
+          const data = yield* all()
+          delete data[mcpName]
+          yield* fs.writeJson(filepath, data, 0o600).pipe(Effect.orDie)
+        }),
+      )
     })
 
     const updateField = <K extends keyof Entry>(field: K, spanName: string) =>

--- a/packages/opencode/test/mcp/auth.test.ts
+++ b/packages/opencode/test/mcp/auth.test.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "bun:test"
+import { setTimeout as sleep } from "node:timers/promises"
+import { Effect, Layer } from "effect"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { McpAuth } from "../../src/mcp/auth"
+
+function authFile() {
+  let raw = ""
+  let activeWrites = 0
+  let sawOverlap = false
+
+  const layer = Layer.effect(
+    AppFileSystem.Service,
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+
+      return AppFileSystem.Service.of({
+        ...fs,
+        readJson: (file) =>
+          file.endsWith("mcp-auth.json")
+            ? Effect.try({
+                try: () => {
+                  if (!raw) throw new Error("mcp-auth.json missing")
+                  return JSON.parse(raw)
+                },
+                catch: (cause) => new AppFileSystem.FileSystemError({ method: "readJson", cause }),
+              })
+            : fs.readJson(file),
+        writeJson: (file, value, mode) =>
+          file.endsWith("mcp-auth.json")
+            ? Effect.promise(async () => {
+                activeWrites++
+                sawOverlap = sawOverlap || activeWrites > 1
+                raw = ""
+                await sleep(10)
+                const next = JSON.stringify(value, null, 2)
+                raw = sawOverlap ? `${next}\n}` : next
+                activeWrites--
+              })
+            : fs.writeJson(file, value, mode),
+      })
+    }),
+  ).pipe(Layer.provide(AppFileSystem.defaultLayer))
+
+  return { layer, raw: () => raw }
+}
+
+function authService(layer: Layer.Layer<AppFileSystem.Service>) {
+  return McpAuth.Service.use((auth) => Effect.succeed(auth)).pipe(
+    Effect.provide(McpAuth.layer.pipe(Layer.provide(EffectFlock.defaultLayer), Layer.provide(layer))),
+  )
+}
+
+test("serializes concurrent auth file updates across service instances", async () => {
+  const file = authFile()
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const first = yield* authService(file.layer)
+      const second = yield* authService(file.layer)
+
+      yield* Effect.all(
+        [
+          first.updateTokens("posthog", { accessToken: "access-token" }, "https://mcp.posthog.com/mcp"),
+          second.updateClientInfo("posthog", { clientId: "client-id" }, "https://mcp.posthog.com/mcp"),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      const entry = yield* first.get("posthog")
+      expect(entry?.tokens?.accessToken).toBe("access-token")
+      expect(entry?.clientInfo?.clientId).toBe("client-id")
+      expect(entry?.serverUrl).toBe("https://mcp.posthog.com/mcp")
+      expect(() => JSON.parse(file.raw())).not.toThrow()
+    }),
+  )
+})
+
+test("serializes concurrent token and client info updates within a single service instance", async () => {
+  const file = authFile()
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const auth = yield* authService(file.layer)
+
+      // Simulate a token refresh racing with a client info save
+      yield* Effect.all(
+        [
+          auth.updateTokens("server-a", { accessToken: "token-1", refreshToken: "refresh-1" }, "https://a.example.com"),
+          auth.updateClientInfo("server-a", { clientId: "client-xyz" }, "https://a.example.com"),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      const entry = yield* auth.get("server-a")
+      // Both writes must survive — no data lost from race condition
+      expect(entry?.tokens?.accessToken).toBe("token-1")
+      expect(entry?.clientInfo?.clientId).toBe("client-xyz")
+      // File must remain valid JSON
+      expect(() => JSON.parse(file.raw())).not.toThrow()
+    }),
+  )
+})
+
+test("preserves all entries when multiple servers are updated concurrently", async () => {
+  const file = authFile()
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const auth = yield* authService(file.layer)
+
+      yield* Effect.all(
+        [
+          auth.updateTokens("server-a", { accessToken: "token-a" }, "https://a.example.com"),
+          auth.updateTokens("server-b", { accessToken: "token-b" }, "https://b.example.com"),
+          auth.updateTokens("server-c", { accessToken: "token-c" }, "https://c.example.com"),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      const a = yield* auth.get("server-a")
+      const b = yield* auth.get("server-b")
+      const c = yield* auth.get("server-c")
+
+      expect(a?.tokens?.accessToken).toBe("token-a")
+      expect(b?.tokens?.accessToken).toBe("token-b")
+      expect(c?.tokens?.accessToken).toBe("token-c")
+      expect(() => JSON.parse(file.raw())).not.toThrow()
+    }),
+  )
+})
+
+test("remove is serialized with concurrent updates", async () => {
+  const file = authFile()
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const auth = yield* authService(file.layer)
+
+      // First write some entries
+      yield* auth.updateTokens("keep", { accessToken: "keep-token" }, "https://keep.example.com")
+      yield* auth.updateTokens("remove-me", { accessToken: "gone" }, "https://remove.example.com")
+
+      // Concurrently update "keep" and remove "remove-me"
+      yield* Effect.all(
+        [
+          auth.updateTokens("keep", { accessToken: "updated-token" }, "https://keep.example.com"),
+          auth.remove("remove-me"),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      const kept = yield* auth.get("keep")
+      const removed = yield* auth.get("remove-me")
+
+      expect(kept?.tokens?.accessToken).toBe("updated-token")
+      expect(removed).toBeUndefined()
+      expect(() => JSON.parse(file.raw())).not.toThrow()
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29804

### Type of change

- [x] Bug fix

### What does this PR do?

`McpAuth.set()` and `remove()` used an unguarded read-modify-write pattern. Concurrent token refreshes or client info saves could race, causing one write to overwrite another — manifesting as extra `}` characters appended to `mcp-auth.json`, breaking JSON parsing and disconnecting all remote MCP servers.

Added an `Effect.Semaphore(1)` so all file mutations are serialised, ensuring each read-modify-write cycle sees the latest file state.

### How did you verify your code works?

Added 4 tests to `test/mcp/auth.test.ts`:

- **"serializes concurrent auth file updates across service instances"** — two service instances race to write tokens and client info; both writes survive and file stays valid JSON
- **"serializes concurrent token and client info updates within a single service instance"** — token refresh races with client info save on the same instance; no data lost
- **"preserves all entries when multiple servers are updated concurrently"** — 3 different servers updated simultaneously; all entries survive
- **"remove is serialized with concurrent updates"** — `remove` races with `updateTokens`; deletion and update both take effect correctly

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR