### PR TITLE
fix(opencode): allow pid 0 in Pty.Info for Windows ConPTY

### DIFF
--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -60,7 +60,11 @@ export const Info = Schema.Struct({
   args: Schema.Array(Schema.String),
   cwd: Schema.String,
   status: Schema.Literals(["running", "exited"]),
-  pid: PositiveInt,
+  // Windows ConPTY (@lydell/node-pty >= 1.2.0-beta.12) assigns the child pid
+  // asynchronously, so `proc.pid` is 0 at the synchronous spawn point and only
+  // resolves a tick later. `create` snapshots it immediately, so 0 is a valid
+  // "pid not yet assigned" value here.
+  pid: NonNegativeInt,
 }).annotate({ identifier: "Pty" })
 
 export type Info = Types.DeepMutable<Schema.Schema.Type<typeof Info>>

--- a/packages/opencode/test/pty/info-schema.test.ts
+++ b/packages/opencode/test/pty/info-schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
+import { Pty } from "../../src/pty"
+
+// Windows ConPTY (via @lydell/node-pty >= 1.2.0-beta.12) assigns the child pid
+// asynchronously: `proc.pid` reads back as 0 at the synchronous spawn point and
+// only resolves to the real pid a tick later. `Pty.create` snapshots `proc.pid`
+// while building `Info`, so `Info.pid` legitimately carries 0 right after spawn.
+// `Pty.Info` must be able to represent that, otherwise every `pty.create` on
+// Windows fails to encode/decode and the terminal feature is unusable.
+const sample = (pid: number) => ({
+  id: "pty_01J5Y5H0AH4Q4NXJ6P4C3P5V2K",
+  title: "demo",
+  command: "cmd.exe",
+  args: [],
+  cwd: "C:\\",
+  status: "running",
+  pid,
+})
+
+describe("Pty.Info", () => {
+  test("accepts pid 0 (Windows ConPTY assigns the pid asynchronously)", () => {
+    expect(Schema.decodeUnknownSync(Pty.Info)(sample(0)).pid).toBe(0)
+  })
+
+  test("accepts a positive pid", () => {
+    expect(Schema.decodeUnknownSync(Pty.Info)(sample(48012)).pid).toBe(48012)
+  })
+
+  test("rejects a negative pid", () => {
+    expect(() => Schema.decodeUnknownSync(Pty.Info)(sample(-1))).toThrow()
+  })
+})


### PR DESCRIPTION
## What

`Pty.Info.pid` is `PositiveInt`, but `@lydell/node-pty` `1.2.0-beta.12` (bumped in #29803) changed Windows ConPTY to assign the child pid **asynchronously** — `proc.pid` reads back as `0` at the synchronous spawn point and only resolves a tick later.

`Pty.create` snapshots `proc.pid` while building `Info`, so on Windows `Info.pid` is `0`, which fails the `PositiveInt` filter:

```
Failed to clone terminal Error: Expected a value greater than 0, got 0
  at ["pid"]
```

This breaks **every** `pty.create` on Windows — new terminals and the stale-session `clone` recovery path both fail.

### Verified regression (isolated installs)

| version | sync `pid` at spawn | async `pid` |
|---|---|---|
| beta.10 (before #29803) | `9104` ✅ | `9104` |
| beta.12 (current) | `0` ❌ | `33652` |

## Fix

Relax `Pty.Info.pid` to `NonNegativeInt`. `0` is a valid "pid not yet assigned" value, and nothing in opencode consumes `info.pid` (process kills go through `proc.kill()` / `taskkill`). SDK types already expose `pid: number`, so no SDK regen needed.

## Test

Added `test/pty/info-schema.test.ts` — a platform-independent schema test (CI is Linux, where a live spawn never reproduces pid 0). It fails on `pid: 0` before the fix with the exact production error and passes after; also locks the `NonNegativeInt` boundary (rejects `-1`).