### PR TITLE
fix(core): resolve spawn completion on exit, not only close (Windows detached-child hang)

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -263,49 +263,33 @@ export const make = Effect.gen(function* () {
   }
 
   const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
-    Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
-      const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
-      const proc = launch(command.command, command.args, opts)
-      let end = false
-      let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
-      proc.on("error", (err) => {
-        resume(Effect.fail(toPlatformError("spawn", err, command)))
-      })
-      // Complete on whichever of "exit"/"close" fires first; both are required.
-      //
-      // "exit" means the process itself terminated; "close" means it ended AND all of
-      // its stdio streams closed. They differ because multiple processes can share the
-      // same stdio streams. We must handle both because neither alone is sufficient:
-      //
-      //  - A detached child that inherits this process's stdio keeps the pipe's write
-      //    end open, so "close" can be delayed indefinitely even after the main process
-      //    exits. Resolving on "exit" returns promptly instead of hanging (issue #24731).
-      //
-      //  - For a failed spawn (e.g. ENOENT), cross-spawn on Windows emits "spawn" then
-      //    "error" then "close" but NEVER "exit" — so exitCode would hang forever if we
-      //    only listened for "exit". "close" is the backstop that completes that path.
-      //    (Verified: raw child_process never reproduces this; it's specific to
-      //    cross-spawn's ENOENT handling, independent of node vs bun.)
-      //
-      // Deferred.doneUnsafe is a no-op once the Deferred is already completed.
-      proc.on("exit", (...args) => {
-        exit = args
-        if (end) return
-        end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(args))
-      })
-      proc.on("close", (...args) => {
-        if (end) return
-        end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
-      })
-      proc.on("spawn", () => {
-        resume(Effect.succeed([proc, signal]))
-      })
-      return Effect.sync(() => {
-        proc.kill("SIGTERM")
-      })
-    })
+    Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal, ExitSignal], PlatformError.PlatformError>(
+      (resume) => {
+        const exited = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
+        const closed = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
+        const proc = launch(command.command, command.args, opts)
+        let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
+        proc.on("error", (err) => {
+          resume(Effect.fail(toPlatformError("spawn", err, command)))
+        })
+        // A detached descendant can hold stdio open after this process exits. Report its
+        // exit promptly, while keeping "close" for kill/escalation and failed spawns.
+        proc.on("exit", (...args) => {
+          exit = args
+          Deferred.doneUnsafe(exited, Exit.succeed(args))
+        })
+        proc.on("close", (...args) => {
+          Deferred.doneUnsafe(closed, Exit.succeed(exit ?? args))
+          Deferred.doneUnsafe(exited, Exit.succeed(exit ?? args))
+        })
+        proc.on("spawn", () => {
+          resume(Effect.succeed([proc, exited, closed]))
+        })
+        return Effect.sync(() => {
+          proc.kill("SIGTERM")
+        })
+      },
+    )
 
   const killGroup = (
     command: ChildProcess.StandardCommand,
@@ -388,7 +372,7 @@ export const make = Effect.gen(function* () {
           const extra = fds(command.options)
           const dir = yield* cwd(command.options)
 
-          const [proc, signal] = yield* Effect.acquireRelease(
+          const [proc, exited, closed] = yield* Effect.acquireRelease(
             spawn(command, {
               cwd: dir,
               env: env(command.options),
@@ -397,11 +381,11 @@ export const make = Effect.gen(function* () {
               shell: command.options.shell,
               windowsHide: process.platform === "win32",
             }),
-            Effect.fnUntraced(function* ([proc, signal]) {
-              const done = yield* Deferred.isDone(signal)
+            Effect.fnUntraced(function* ([proc, exited, closed]) {
+              const done = yield* Deferred.isDone(exited)
               const kill = timeout(proc, command, command.options)
               if (done) {
-                const [code] = yield* Deferred.await(signal)
+                const [code] = yield* Deferred.await(exited)
                 if (process.platform === "win32") return yield* Effect.void
                 if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(kill(killGroup))
                 return yield* Effect.void
@@ -409,11 +393,11 @@ export const make = Effect.gen(function* () {
               const send = (s: NodeJS.Signals) =>
                 Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
               const sig = command.options.killSignal ?? "SIGTERM"
-              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid)
+              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid)
               const escalated = command.options.forceKillAfter
                 ? Effect.timeoutOrElse(attempt, {
                     duration: command.options.forceKillAfter,
-                    orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid),
+                    orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid),
                   })
                 : attempt
               return yield* Effect.ignore(escalated)
@@ -431,8 +415,8 @@ export const make = Effect.gen(function* () {
             all: out.all,
             getInputFd: fd.getInputFd,
             getOutputFd: fd.getOutputFd,
-            isRunning: Effect.map(Deferred.isDone(signal), (done) => !done),
-            exitCode: Effect.flatMap(Deferred.await(signal), ([code, signal]) => {
+            isRunning: Effect.map(Deferred.isDone(exited), (done) => !done),
+            exitCode: Effect.flatMap(Deferred.await(exited), ([code, signal]) => {
               if (Predicate.isNotNull(code)) return Effect.succeed(ExitCode(code))
               return Effect.fail(
                 toPlatformError(
@@ -446,11 +430,11 @@ export const make = Effect.gen(function* () {
               const sig = opts?.killSignal ?? "SIGTERM"
               const send = (s: NodeJS.Signals) =>
                 Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
-              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid)
+              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid)
               if (!opts?.forceKillAfter) return attempt
               return Effect.timeoutOrElse(attempt, {
                 duration: opts.forceKillAfter,
-                orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid),
+                orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid),
               })
             },
             unref: Effect.sync(() => {

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -323,27 +323,6 @@ export const make = Effect.gen(function* () {
       return Effect.fail(toPlatformError("kill", new Error("Failed to kill child process"), command))
     })
 
-  const timeout =
-    (
-      proc: NodeChildProcess.ChildProcess,
-      command: ChildProcess.StandardCommand,
-      opts: ChildProcess.KillOptions | undefined,
-    ) =>
-    <A, E, R>(
-      f: (
-        command: ChildProcess.StandardCommand,
-        proc: NodeChildProcess.ChildProcess,
-        signal: NodeJS.Signals,
-      ) => Effect.Effect<A, E, R>,
-    ) => {
-      const signal = opts?.killSignal ?? "SIGTERM"
-      if (Predicate.isUndefined(opts?.forceKillAfter)) return f(command, proc, signal)
-      return Effect.timeoutOrElse(f(command, proc, signal), {
-        duration: opts.forceKillAfter,
-        orElse: () => f(command, proc, "SIGKILL"),
-      })
-    }
-
   const source = (handle: ChildProcessHandle, from: ChildProcess.PipeFromOption | undefined) => {
     const opt = from ?? "stdout"
     switch (opt) {
@@ -383,13 +362,6 @@ export const make = Effect.gen(function* () {
             }),
             Effect.fnUntraced(function* ([proc, exited, closed]) {
               const done = yield* Deferred.isDone(exited)
-              const kill = timeout(proc, command, command.options)
-              if (done) {
-                const [code] = yield* Deferred.await(exited)
-                if (process.platform === "win32") return yield* Effect.void
-                if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(kill(killGroup))
-                return yield* Effect.void
-              }
               const send = (s: NodeJS.Signals) =>
                 Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
               const sig = command.options.killSignal ?? "SIGTERM"
@@ -400,6 +372,12 @@ export const make = Effect.gen(function* () {
                     orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid),
                   })
                 : attempt
+              if (done) {
+                const [code] = yield* Deferred.await(exited)
+                if (process.platform === "win32") return yield* Effect.void
+                if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(escalated)
+                return yield* Effect.void
+              }
               return yield* Effect.ignore(escalated)
             }),
           )

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -271,8 +271,28 @@ export const make = Effect.gen(function* () {
       proc.on("error", (err) => {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
+      // Complete on whichever of "exit"/"close" fires first; both are required.
+      //
+      // "exit" means the process itself terminated; "close" means it ended AND all of
+      // its stdio streams closed. They differ because multiple processes can share the
+      // same stdio streams. We must handle both because neither alone is sufficient:
+      //
+      //  - A detached child that inherits this process's stdio keeps the pipe's write
+      //    end open, so "close" can be delayed indefinitely even after the main process
+      //    exits. Resolving on "exit" returns promptly instead of hanging (issue #24731).
+      //
+      //  - For a failed spawn (e.g. ENOENT), cross-spawn on Windows emits "spawn" then
+      //    "error" then "close" but NEVER "exit" — so exitCode would hang forever if we
+      //    only listened for "exit". "close" is the backstop that completes that path.
+      //    (Verified: raw child_process never reproduces this; it's specific to
+      //    cross-spawn's ENOENT handling, independent of node vs bun.)
+      //
+      // Deferred.doneUnsafe is a no-op once the Deferred is already completed.
       proc.on("exit", (...args) => {
         exit = args
+        if (end) return
+        end = true
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
       })
       proc.on("close", (...args) => {
         if (end) return

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -332,10 +332,23 @@ export const make = Effect.gen(function* () {
     const sig = opts?.killSignal ?? "SIGTERM"
     const send = (s: NodeJS.Signals) => Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
     const attempt = send(sig).pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid)
-    if (!opts?.forceKillAfter) return attempt
+    const grace = opts?.forceKillAfter
+    if (!grace) return attempt
     return Effect.timeoutOrElse(attempt, {
-      duration: opts.forceKillAfter,
-      orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid),
+      duration: grace,
+      // SIGKILL is the last resort: signal the group, then wait for `closed`
+      // only up to the same grace. A descendant that escaped the group keeps
+      // the inherited stdio open, so `closed` may never fire even now.
+      orElse: () =>
+        send("SIGKILL").pipe(
+          Effect.andThen(
+            Effect.timeoutOrElse(Deferred.await(closed), {
+              duration: grace,
+              orElse: () => Effect.void,
+            }),
+          ),
+          Effect.asVoid,
+        ),
     })
   }
 

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -339,6 +339,31 @@ export const make = Effect.gen(function* () {
     })
   }
 
+  // Best-effort cleanup for a process that has already exited. Signal its group
+  // to sweep any descendants it left behind, but never block on `closed`: a
+  // descendant that escaped the group (or ignores the signal) keeps the
+  // inherited stdio open, which would otherwise hang scope teardown forever.
+  const reap = (
+    command: ChildProcess.StandardCommand,
+    proc: NodeChildProcess.ChildProcess,
+    closed: ExitSignal,
+    opts?: ChildProcess.KillOptions,
+  ) => {
+    const sig = opts?.killSignal ?? "SIGTERM"
+    const send = (s: NodeJS.Signals) => Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
+    if (!opts?.forceKillAfter) return send(sig)
+    // Give the group a grace period to drain, then force-kill stragglers.
+    return send(sig).pipe(
+      Effect.andThen(
+        Effect.timeoutOrElse(Deferred.await(closed), {
+          duration: opts.forceKillAfter,
+          orElse: () => send("SIGKILL"),
+        }),
+      ),
+      Effect.asVoid,
+    )
+  }
+
   const source = (handle: ChildProcessHandle, from: ChildProcess.PipeFromOption | undefined) => {
     const opt = from ?? "stdout"
     switch (opt) {
@@ -382,7 +407,7 @@ export const make = Effect.gen(function* () {
                 const [code] = yield* Deferred.await(exited)
                 if (process.platform === "win32") return yield* Effect.void
                 if (code !== 0 && Predicate.isNotNull(code))
-                  return yield* Effect.ignore(terminate(command, proc, closed, command.options))
+                  return yield* Effect.ignore(reap(command, proc, closed, command.options))
                 return yield* Effect.void
               }
               return yield* Effect.ignore(terminate(command, proc, closed, command.options))

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -323,6 +323,22 @@ export const make = Effect.gen(function* () {
       return Effect.fail(toPlatformError("kill", new Error("Failed to kill child process"), command))
     })
 
+  const terminate = (
+    command: ChildProcess.StandardCommand,
+    proc: NodeChildProcess.ChildProcess,
+    closed: ExitSignal,
+    opts?: ChildProcess.KillOptions,
+  ) => {
+    const sig = opts?.killSignal ?? "SIGTERM"
+    const send = (s: NodeJS.Signals) => Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
+    const attempt = send(sig).pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid)
+    if (!opts?.forceKillAfter) return attempt
+    return Effect.timeoutOrElse(attempt, {
+      duration: opts.forceKillAfter,
+      orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid),
+    })
+  }
+
   const source = (handle: ChildProcessHandle, from: ChildProcess.PipeFromOption | undefined) => {
     const opt = from ?? "stdout"
     switch (opt) {
@@ -362,23 +378,14 @@ export const make = Effect.gen(function* () {
             }),
             Effect.fnUntraced(function* ([proc, exited, closed]) {
               const done = yield* Deferred.isDone(exited)
-              const send = (s: NodeJS.Signals) =>
-                Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
-              const sig = command.options.killSignal ?? "SIGTERM"
-              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid)
-              const escalated = command.options.forceKillAfter
-                ? Effect.timeoutOrElse(attempt, {
-                    duration: command.options.forceKillAfter,
-                    orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid),
-                  })
-                : attempt
               if (done) {
                 const [code] = yield* Deferred.await(exited)
                 if (process.platform === "win32") return yield* Effect.void
-                if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(escalated)
+                if (code !== 0 && Predicate.isNotNull(code))
+                  return yield* Effect.ignore(terminate(command, proc, closed, command.options))
                 return yield* Effect.void
               }
-              return yield* Effect.ignore(escalated)
+              return yield* Effect.ignore(terminate(command, proc, closed, command.options))
             }),
           )
 
@@ -404,17 +411,7 @@ export const make = Effect.gen(function* () {
                 ),
               )
             }),
-            kill: (opts?: ChildProcess.KillOptions) => {
-              const sig = opts?.killSignal ?? "SIGTERM"
-              const send = (s: NodeJS.Signals) =>
-                Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
-              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid)
-              if (!opts?.forceKillAfter) return attempt
-              return Effect.timeoutOrElse(attempt, {
-                duration: opts.forceKillAfter,
-                orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(closed)), Effect.asVoid),
-              })
-            },
+            kill: (opts?: ChildProcess.KillOptions) => terminate(command, proc, closed, opts),
             unref: Effect.sync(() => {
               if (ref) {
                 proc.unref()

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -68,6 +68,16 @@ async function readPid(file: string, timeout = 5_000) {
   throw new Error(`Process did not write its pid to ${file}`)
 }
 
+function stubbornDescendant(pidFile: string, parent: string, opts?: ChildProcess.CommandOptions) {
+  const code = [
+    'const cp = require("node:child_process")',
+    'const fs = require("node:fs")',
+    'cp.spawn(process.execPath, ["-e", "const fs = require(\\"node:fs\\"); process.on(\\"SIGTERM\\", () => {}); fs.writeFileSync(process.argv[1], String(process.pid)); setInterval(() => {}, 1000)", process.argv[1]], { stdio: "inherit" })',
+    parent,
+  ].join("\n")
+  return ChildProcess.make(process.execPath, ["-e", code, pidFile], opts)
+}
+
 describe("cross-spawn spawner", () => {
   describe("basic spawning", () => {
     fx.effect(
@@ -295,15 +305,41 @@ describe("cross-spawn spawner", () => {
           (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
         )
         const pidFile = path.join(tmp.path, "stubborn-child.pid")
-        const code = [
-          'const cp = require("node:child_process")',
-          'const child = cp.spawn(process.execPath, ["-e", "const fs = require(\\"node:fs\\"); process.on(\\"SIGTERM\\", () => {}); fs.writeFileSync(process.argv[1], String(process.pid)); setInterval(() => {}, 1000)", process.argv[1]], { stdio: "inherit" })',
-          "setInterval(() => {}, 1000)",
-        ].join("\n")
-        const handle = yield* ChildProcess.make(process.execPath, ["-e", code, pidFile])
+        const handle = yield* stubbornDescendant(pidFile, "setInterval(() => {}, 1000)")
         const pid = yield* Effect.promise(() => readPid(pidFile))
 
         yield* handle.kill({ forceKillAfter: 100 }).pipe(Effect.ignore)
+        const terminated = yield* Effect.promise(() => gone(pid, 1_000))
+        if (!terminated) {
+          yield* Effect.sync(() => process.kill(pid, "SIGKILL"))
+        }
+        expect(terminated).toBe(true)
+      }),
+      10_000,
+    )
+
+    fx.live(
+      "scope cleanup escalates after a failed parent leaves a stubborn descendant",
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+
+        const tmp = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+        )
+        const pidFile = path.join(tmp.path, "failed-parent-child.pid")
+        const pid = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const handle = yield* stubbornDescendant(
+              pidFile,
+              'const ready = setInterval(() => { if (fs.existsSync(process.argv[1])) { clearInterval(ready); process.exit(42) } }, 10)',
+              { forceKillAfter: 100 },
+            )
+            expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(42))
+            return yield* Effect.promise(() => readPid(pidFile))
+          }),
+        )
+
         const terminated = yield* Effect.promise(() => gone(pid, 1_000))
         if (!terminated) {
           yield* Effect.sync(() => process.kill(pid, "SIGKILL"))

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -58,6 +58,16 @@ async function gone(pid: number, timeout = 5_000) {
   return !alive(pid)
 }
 
+async function readPid(file: string, timeout = 5_000) {
+  const end = Date.now() + timeout
+  while (Date.now() < end) {
+    const value = await fs.readFile(file, "utf-8").catch(() => undefined)
+    if (value) return Number(value)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`Process did not write its pid to ${file}`)
+}
+
 describe("cross-spawn spawner", () => {
   describe("basic spawning", () => {
     fx.effect(
@@ -273,6 +283,34 @@ describe("cross-spawn spawner", () => {
         expect(Date.now() - started).toBeLessThan(1_000)
         expect(Exit.isFailure(exit) ? true : exit.value !== ChildProcessSpawner.ExitCode(0)).toBe(true)
       }),
+    )
+
+    fx.live(
+      "forceKillAfter escalates when the parent exits before a stubborn descendant",
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+
+        const tmp = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+        )
+        const pidFile = path.join(tmp.path, "stubborn-child.pid")
+        const code = [
+          'const cp = require("node:child_process")',
+          'const child = cp.spawn(process.execPath, ["-e", "const fs = require(\\"node:fs\\"); process.on(\\"SIGTERM\\", () => {}); fs.writeFileSync(process.argv[1], String(process.pid)); setInterval(() => {}, 1000)", process.argv[1]], { stdio: "inherit" })',
+          "setInterval(() => {}, 1000)",
+        ].join("\n")
+        const handle = yield* ChildProcess.make(process.execPath, ["-e", code, pidFile])
+        const pid = yield* Effect.promise(() => readPid(pidFile))
+
+        yield* handle.kill({ forceKillAfter: 100 }).pipe(Effect.ignore)
+        const terminated = yield* Effect.promise(() => gone(pid, 1_000))
+        if (!terminated) {
+          yield* Effect.sync(() => process.kill(pid, "SIGKILL"))
+        }
+        expect(terminated).toBe(true)
+      }),
+      10_000,
     )
 
     fx.effect(

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -509,8 +509,3 @@ describe("cross-spawn spawner", () => {
     )
   })
 })
-
-
-
-
-

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -286,6 +286,54 @@ describe("cross-spawn spawner", () => {
     )
   })
 
+  describe("detached children (issue #24731)", () => {
+    fx.live(
+      "exitCode resolves when the main process exits even if a detached child keeps stdio open",
+      Effect.gen(function* () {
+        const tmp = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+        )
+        const pidFile = path.join(tmp.path, "daemon.pid")
+
+        // Mimics playwright-cli / a backgrounded web server: spawn a long-lived
+        // detached child that inherits stdio (keeping the parent's stdout pipe's
+        // write end open), then exit the main process immediately.
+        const code = [
+          'const cp = require("node:child_process")',
+          'const fs = require("node:fs")',
+          'const daemon = cp.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "inherit" })',
+          "daemon.unref()",
+          "fs.writeFileSync(process.argv[1], String(daemon.pid))",
+          'process.stdout.write("started")',
+          "process.exit(0)",
+        ].join("\n")
+
+        const handle = yield* ChildProcess.make(process.execPath, ["-e", code, pidFile])
+
+        const result = yield* Effect.raceAll([
+          handle.exitCode.pipe(Effect.map((exit) => ({ kind: "exit" as const, code: exit }))),
+          Effect.sleep("5 seconds").pipe(Effect.as({ kind: "timeout" as const, code: null })),
+        ])
+
+        // Reap the detached daemon so it does not leak and so the spawner's
+        // "close" can fire during scope teardown.
+        const pid = Number(yield* Effect.promise(() => fs.readFile(pidFile, "utf-8").catch(() => "0")))
+        if (pid) {
+          yield* Effect.sync(() => {
+            try {
+              process.kill(pid)
+            } catch {}
+          })
+        }
+
+        expect(result.kind).toBe("exit")
+        expect(result.code).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+      15_000,
+    )
+  })
+
   describe("error handling", () => {
     fx.effect(
       "fails for invalid command",
@@ -423,3 +471,8 @@ describe("cross-spawn spawner", () => {
     )
   })
 })
+
+
+
+
+

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -214,7 +214,7 @@ describe("cross-spawn spawner", () => {
     fx.effect(
       "captures stdout via .all when no stderr",
       Effect.gen(function* () {
-        const handle = yield* ChildProcess.make("echo", ["hello from stdout"])
+        const handle = yield* ChildProcess.make(process.execPath, ["-e", 'process.stdout.write("hello from stdout")'])
         const all = yield* decodeByteStream(handle.all)
         expect(all).toBe("hello from stdout")
       }),
@@ -332,7 +332,7 @@ describe("cross-spawn spawner", () => {
           Effect.gen(function* () {
             const handle = yield* stubbornDescendant(
               pidFile,
-              'const ready = setInterval(() => { if (fs.existsSync(process.argv[1])) { clearInterval(ready); process.exit(42) } }, 10)',
+              "const ready = setInterval(() => { if (fs.existsSync(process.argv[1])) { clearInterval(ready); process.exit(42) } }, 10)",
               { forceKillAfter: 100 },
             )
             expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(42))

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -387,6 +387,59 @@ describe("cross-spawn spawner", () => {
       10_000,
     )
 
+    fx.live(
+      "kill escalation does not hang when a stubborn descendant escapes the process group",
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+
+        const tmp = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+        )
+        const pidFile = path.join(tmp.path, "escaped-descendant.pid")
+
+        // The parent stays alive and spawns a detached (own session) child that
+        // inherits stdio. SIGKILL to the parent's group never reaches the escaped
+        // child, so the parent's "close" never fires. kill() must escalate to
+        // SIGKILL and still return instead of waiting on "close" forever.
+        const code = [
+          'const cp = require("node:child_process")',
+          'const fs = require("node:fs")',
+          'const child = cp.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "inherit" })',
+          "child.unref()",
+          "fs.writeFileSync(process.argv[1], String(child.pid))",
+          'process.on("SIGTERM", () => {})',
+          "setInterval(() => {}, 1000)",
+        ].join("\n")
+
+        const outcome = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const handle = yield* ChildProcess.make(process.execPath, ["-e", code, pidFile])
+            yield* Effect.promise(() => readPid(pidFile))
+            return yield* handle
+              .kill({ forceKillAfter: 100 })
+              .pipe(
+                Effect.as("returned" as const),
+                Effect.timeoutOrElse({ duration: "4 seconds", orElse: () => Effect.succeed("hung" as const) }),
+              )
+          }),
+        )
+
+        // Reap the escaped descendant so it does not leak across the test run.
+        const pid = yield* Effect.promise(() => readPid(pidFile).catch(() => 0))
+        if (pid) {
+          yield* Effect.sync(() => {
+            try {
+              process.kill(pid, "SIGKILL")
+            } catch {}
+          })
+        }
+
+        expect(outcome).toBe("returned")
+      }),
+      15_000,
+    )
+
     fx.effect(
       "isRunning reflects process state",
       Effect.gen(function* () {

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -349,6 +349,44 @@ describe("cross-spawn spawner", () => {
       10_000,
     )
 
+    fx.live(
+      "scope cleanup does not hang when a failed parent leaves a descendant holding stdio",
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+
+        const tmp = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+        )
+        const pidFile = path.join(tmp.path, "failed-parent-no-force.pid")
+
+        // No forceKillAfter, matching how the shell tool spawns. The descendant
+        // ignores SIGTERM and keeps the inherited stdio open, so the parent's
+        // "close" never fires. Closing the scope must not block on it; the test
+        // timeout below is the regression guard against an unbounded teardown.
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const handle = yield* stubbornDescendant(
+              pidFile,
+              "const ready = setInterval(() => { if (fs.existsSync(process.argv[1])) { clearInterval(ready); process.exit(7) } }, 10)",
+            )
+            expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(7))
+          }),
+        )
+
+        // Reap the descendant so it does not leak across the test run.
+        const pid = yield* Effect.promise(() => readPid(pidFile).catch(() => 0))
+        if (pid) {
+          yield* Effect.sync(() => {
+            try {
+              process.kill(pid, "SIGKILL")
+            } catch {}
+          })
+        }
+      }),
+      10_000,
+    )
+
     fx.effect(
       "isRunning reflects process state",
       Effect.gen(function* () {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -439,6 +439,7 @@ export const ShellTool = Tool.define(
       const list: Chunk[] = []
       let used = 0
       let drained = 0
+      let processing = false
       let file = ""
       let sink: ReturnType<typeof createWriteStream> | undefined
       let cut = false
@@ -484,7 +485,7 @@ export const ShellTool = Tool.define(
 
           const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
-              drained++
+              processing = true
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
               used += size
@@ -519,6 +520,12 @@ export const ShellTool = Tool.define(
                         },
                       }),
                     ),
+                    Effect.ensuring(
+                      Effect.sync(() => {
+                        processing = false
+                        drained++
+                      }),
+                    ),
                   )
                 }
               }
@@ -528,7 +535,14 @@ export const ShellTool = Tool.define(
                   output: last,
                   description: input.description,
                 },
-              })
+              }).pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    processing = false
+                    drained++
+                  }),
+                ),
+              )
             }),
           )
 
@@ -562,12 +576,13 @@ export const ShellTool = Tool.define(
             // normal command this returns the instant the streams end (full output, no
             // fixed delay). A detached child can hold the pipe open forever with no
             // further output, so also stop once the reader has produced nothing for a
-            // full idle window. The window resets on every chunk (`drained`), so a
-            // command that is still producing output is never cut off — only a process
-            // that has exited and left an idle pipe open hits the bound.
+            // full idle window. The window resets after every completely processed
+            // chunk (`drained`) and cannot settle while a chunk is still being written
+            // or reported (`processing`), so only an exited process with an idle pipe
+            // hits the bound.
             const settle = Effect.gen(function* () {
               let seen = -1
-              while (drained !== seen) {
+              while (processing || drained !== seen) {
                 seen = drained
                 yield* Effect.sleep("500 millis")
               }

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -438,6 +438,7 @@ export const ShellTool = Tool.define(
       let last = ""
       const list: Chunk[] = []
       let used = 0
+      let drained = 0
       let file = ""
       let sink: ReturnType<typeof createWriteStream> | undefined
       let cut = false
@@ -483,6 +484,7 @@ export const ShellTool = Tool.define(
 
           const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
+              drained++
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
               used += size
@@ -555,12 +557,22 @@ export const ShellTool = Tool.define(
           }
 
           if (exit.kind === "exit") {
-            // Process exit can arrive before buffered output is handled, while a
-            // detached child can keep the stream open forever. Drain briefly, then stop.
-            yield* Fiber.join(output).pipe(
-              Effect.timeoutOrElse({ duration: "100 millis", orElse: () => Effect.void }),
-              Effect.catch(() => Effect.void),
-            )
+            // The process has exited, but output it already wrote may still be buffered
+            // in the OS pipe / Node streams. Join the reader so it drains to EOF: for a
+            // normal command this returns the instant the streams end (full output, no
+            // fixed delay). A detached child can hold the pipe open forever with no
+            // further output, so also stop once the reader has produced nothing for a
+            // full idle window. The window resets on every chunk (`drained`), so a
+            // command that is still producing output is never cut off — only a process
+            // that has exited and left an idle pipe open hits the bound.
+            const settle = Effect.gen(function* () {
+              let seen = -1
+              while (drained !== seen) {
+                seen = drained
+                yield* Effect.sleep("500 millis")
+              }
+            })
+            yield* Effect.raceAll([Fiber.join(output).pipe(Effect.ignore), settle])
           }
 
           return exit.kind === "exit" ? exit.code : null

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -481,7 +481,7 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -552,6 +552,15 @@ export const ShellTool = Tool.define(
           if (exit.kind === "timeout") {
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
+          }
+
+          if (exit.kind === "exit") {
+            // Process exit can arrive before buffered output is handled, while a
+            // detached child can keep the stream open forever. Drain briefly, then stop.
+            yield* Fiber.join(output).pipe(
+              Effect.timeoutOrElse({ duration: "100 millis", orElse: () => Effect.void }),
+              Effect.catch(() => Effect.void),
+            )
           }
 
           return exit.kind === "exit" ? exit.code : null

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -26,6 +26,7 @@ import { BashArity } from "@/permission/arity"
 export { Parameters } from "./shell/prompt"
 
 const MAX_METADATA_LENGTH = 30_000
+const POST_EXIT_OUTPUT_IDLE_TIMEOUT = "1 second"
 const CWD = new Set(["cd", "chdir", "popd", "pushd", "push-location", "set-location"])
 const FILES = new Set([
   ...CWD,
@@ -530,19 +531,21 @@ export const ShellTool = Tool.define(
                 }
               }
 
-              return ctx.metadata({
-                metadata: {
-                  output: last,
-                  description: input.description,
-                },
-              }).pipe(
-                Effect.ensuring(
-                  Effect.sync(() => {
-                    processing = false
-                    drained++
-                  }),
-                ),
-              )
+              return ctx
+                .metadata({
+                  metadata: {
+                    output: last,
+                    description: input.description,
+                  },
+                })
+                .pipe(
+                  Effect.ensuring(
+                    Effect.sync(() => {
+                      processing = false
+                      drained++
+                    }),
+                  ),
+                )
             }),
           )
 
@@ -571,20 +574,13 @@ export const ShellTool = Tool.define(
           }
 
           if (exit.kind === "exit") {
-            // The process has exited, but output it already wrote may still be buffered
-            // in the OS pipe / Node streams. Join the reader so it drains to EOF: for a
-            // normal command this returns the instant the streams end (full output, no
-            // fixed delay). A detached child can hold the pipe open forever with no
-            // further output, so also stop once the reader has produced nothing for a
-            // full idle window. The window resets after every completely processed
-            // chunk (`drained`) and cannot settle while a chunk is still being written
-            // or reported (`processing`), so only an exited process with an idle pipe
-            // hits the bound.
+            // `echo` reaches EOF immediately; only outliving children inheriting stdio (for example servers) hit this.
+            // Following MSBuild's tradeoff, agents return after 1s with no fully processed output.
             const settle = Effect.gen(function* () {
               let seen = -1
               while (processing || drained !== seen) {
                 seen = drained
-                yield* Effect.sleep("500 millis")
+                yield* Effect.sleep(POST_EXIT_OUTPUT_IDLE_TIMEOUT)
               }
             })
             yield* Effect.raceAll([Fiber.join(output).pipe(Effect.ignore), settle])

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -26,7 +26,7 @@ import { BashArity } from "@/permission/arity"
 export { Parameters } from "./shell/prompt"
 
 const MAX_METADATA_LENGTH = 30_000
-const POST_EXIT_OUTPUT_IDLE_TIMEOUT = "1 second"
+const POST_EXIT_OUTPUT_IDLE_TIMEOUT = "500 millis"
 const CWD = new Set(["cd", "chdir", "popd", "pushd", "push-location", "set-location"])
 const FILES = new Set([
   ...CWD,
@@ -568,7 +568,7 @@ export const ShellTool = Tool.define(
 
           if (exit.kind === "exit") {
             // Ordinary commands reach EOF immediately; outliving children can keep stdio open.
-            // After exit, stop waiting once processed output stays quiet across a 1s check.
+            // After exit, stop waiting once processed output stays quiet across a 500ms check.
             const settle = Effect.gen(function* () {
               let seen = -1
               while (processing || processed !== seen) {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -439,13 +439,18 @@ export const ShellTool = Tool.define(
       let last = ""
       const list: Chunk[] = []
       let used = 0
-      let drained = 0
+      let processed = 0
       let processing = false
       let file = ""
       let sink: ReturnType<typeof createWriteStream> | undefined
       let cut = false
       let expired = false
       let aborted = false
+
+      const markOutputProcessed = Effect.sync(() => {
+        processing = false
+        processed++
+      })
 
       const closeSink = Effect.fnUntraced(function* () {
         const stream = sink
@@ -521,12 +526,7 @@ export const ShellTool = Tool.define(
                         },
                       }),
                     ),
-                    Effect.ensuring(
-                      Effect.sync(() => {
-                        processing = false
-                        drained++
-                      }),
-                    ),
+                    Effect.ensuring(markOutputProcessed),
                   )
                 }
               }
@@ -538,14 +538,7 @@ export const ShellTool = Tool.define(
                     description: input.description,
                   },
                 })
-                .pipe(
-                  Effect.ensuring(
-                    Effect.sync(() => {
-                      processing = false
-                      drained++
-                    }),
-                  ),
-                )
+                .pipe(Effect.ensuring(markOutputProcessed))
             }),
           )
 
@@ -574,12 +567,12 @@ export const ShellTool = Tool.define(
           }
 
           if (exit.kind === "exit") {
-            // `echo` reaches EOF immediately; only outliving children inheriting stdio (for example servers) hit this.
-            // Following MSBuild's tradeoff, agents return after 1s with no fully processed output.
+            // Ordinary commands reach EOF immediately; outliving children can keep stdio open.
+            // After exit, stop waiting once processed output stays quiet across a 1s check.
             const settle = Effect.gen(function* () {
               let seen = -1
-              while (processing || drained !== seen) {
-                seen = drained
+              while (processing || processed !== seen) {
+                seen = processed
                 yield* Effect.sleep(POST_EXIT_OUTPUT_IDLE_TIMEOUT)
               }
             })

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1156,6 +1156,48 @@ describe("tool.shell abort", () => {
       }),
     ),
   )
+
+  it.live(
+    "returns promptly when a command leaves a detached child holding stdio open",
+    () =>
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+        const dir = yield* tmpdirScoped()
+        const pidFile = path.join(dir, "daemon.pid")
+        // Spawn a long-lived detached child that inherits stdio (keeps the shell's
+        // stdout pipe open), record its pid, print output, then exit immediately.
+        const code =
+          'const cp=require("node:child_process");const fs=require("node:fs");' +
+          'const d=cp.spawn(process.execPath,["-e","setTimeout(()=>{},60000)"],{detached:true,stdio:"inherit"});' +
+          'd.unref();fs.writeFileSync(Bun.argv[1],String(d.pid));process.stdout.write("STARTED");process.exit(0)'
+        const command = `${bin} -e ${squote(code)} ${squote(pidFile)}`
+
+        const start = Date.now()
+        const result = yield* runIn(
+          projectRoot,
+          run({ command, description: "Detached child", timeout: 30_000 }),
+        )
+        const elapsed = Date.now() - start
+
+        // Reap the detached daemon so the pipe closes and it does not leak.
+        const fsvc = yield* AppFileSystem.Service
+        const pid = Number(yield* fsvc.readFileString(pidFile).pipe(Effect.catch(() => Effect.succeed("0"))))
+        if (pid)
+          yield* Effect.sync(() => {
+            try {
+              process.kill(pid)
+            } catch {}
+          })
+
+        expect(result.output).toContain("STARTED")
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).not.toContain("exceeding timeout")
+        // Returned via the idle drain (~500ms), not by waiting on the daemon's
+        // inherited pipe (60s) or the command timeout (30s).
+        expect(elapsed).toBeLessThan(10_000)
+      }),
+    40_000,
+  )
 })
 
 describe("tool.shell truncation", () => {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1275,6 +1275,7 @@ describe("tool.shell truncation", () => {
       projectRoot,
       Effect.gen(function* () {
         const byteCount = 1_000_000
+        let delayed = false
         const result = yield* run(
           {
             command: fill("bytes", byteCount),
@@ -1284,8 +1285,9 @@ describe("tool.shell truncation", () => {
             ...ctx,
             metadata: (input) => {
               const output = (input.metadata as { output?: string })?.output
-              if (!output) return Effect.void
-              return Effect.sleep("50 millis")
+              if (!output || delayed) return Effect.void
+              delayed = true
+              return Effect.sleep("1200 millis")
             },
           },
         )

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1227,4 +1227,31 @@ describe("tool.shell truncation", () => {
       }),
     ),
   )
+
+  it.live("saves all fast output while metadata processing is delayed", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const byteCount = 1_000_000
+        const result = yield* run(
+          {
+            command: fill("bytes", byteCount),
+            description: "Generate fast output with delayed metadata",
+          },
+          {
+            ...ctx,
+            metadata: (input) => {
+              const output = (input.metadata as { output?: string })?.output
+              if (!output) return Effect.void
+              return Effect.sleep("50 millis")
+            },
+          },
+        )
+        const filepath = (result.metadata as { outputPath?: string }).outputPath
+        expect(filepath).toBeTruthy()
+        const saved = yield* (yield* AppFileSystem.Service).readFileString(filepath!)
+        expect(saved.length).toBe(byteCount)
+      }),
+    ),
+  )
 })

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -37,7 +37,7 @@ const delayedPipeLayer = Layer.mergeAll(
     ChildProcessSpawner.make(
       Effect.fnUntraced(function* () {
         const all = Stream.make(encoder.encode("STARTED")).pipe(
-          Stream.concat(Stream.fromEffect(Effect.sleep("750 millis").pipe(Effect.as(encoder.encode("LATE"))))),
+          Stream.concat(Stream.fromEffect(Effect.sleep("250 millis").pipe(Effect.as(encoder.encode("LATE"))))),
           Stream.concat(Stream.never),
         )
         return ChildProcessSpawner.makeHandle({
@@ -1231,7 +1231,7 @@ describe("tool.shell abort", () => {
     40_000,
   )
 
-  drainIt.live("keeps inherited output that arrives after a short post-exit pause", () =>
+  drainIt.live("keeps inherited output arriving within the idle check", () =>
     runIn(
       projectRoot,
       Effect.gen(function* () {
@@ -1251,7 +1251,7 @@ describe("tool.shell abort", () => {
         expect(outputAt).toBeGreaterThan(0)
         expect(result.output).toContain("STARTED")
         expect(result.output).toContain("LATE")
-        expect(elapsed).toBeLessThan(2_400)
+        expect(elapsed).toBeLessThan(1_400)
       }),
     ),
   )

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Effect, Exit, Layer, Stream } from "effect"
 import type * as Scope from "effect/Scope"
 import os from "os"
 import path from "path"
@@ -14,6 +14,7 @@ import { Truncate } from "@/tool/truncate"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { ChildProcessSpawner } from "effect/unstable/process"
 import { Plugin } from "../../src/plugin"
 import { testEffect } from "../lib/effect"
 import { Tool } from "@/tool/tool"
@@ -29,6 +30,40 @@ const shellLayer = Layer.mergeAll(
   RuntimeFlags.defaultLayer,
 )
 const it = testEffect(shellLayer)
+const encoder = new TextEncoder()
+const delayedPipeLayer = Layer.mergeAll(
+  Layer.succeed(
+    ChildProcessSpawner.ChildProcessSpawner,
+    ChildProcessSpawner.make(
+      Effect.fnUntraced(function* () {
+        const all = Stream.make(encoder.encode("STARTED")).pipe(
+          Stream.concat(Stream.fromEffect(Effect.sleep("750 millis").pipe(Effect.as(encoder.encode("LATE"))))),
+          Stream.concat(Stream.never),
+        )
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(0),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: { [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") } as any,
+          stdout: Stream.empty,
+          stderr: Stream.empty,
+          all,
+          getInputFd: () => ({ [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") }) as any,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        })
+      }),
+    ),
+  ),
+  AppFileSystem.defaultLayer,
+  Plugin.defaultLayer,
+  Truncate.defaultLayer,
+  Config.defaultLayer,
+  Agent.defaultLayer,
+  RuntimeFlags.defaultLayer,
+)
+const drainIt = testEffect(delayedPipeLayer)
 type ShellTestServices =
   | (typeof shellLayer extends Layer.Layer<infer ROut, infer _E, infer _RIn> ? ROut : never)
   | Scope.Scope
@@ -1173,10 +1208,7 @@ describe("tool.shell abort", () => {
         const command = `${bin} -e ${squote(code)} ${squote(pidFile)}`
 
         const start = Date.now()
-        const result = yield* runIn(
-          projectRoot,
-          run({ command, description: "Detached child", timeout: 30_000 }),
-        )
+        const result = yield* runIn(projectRoot, run({ command, description: "Detached child", timeout: 30_000 }))
         const elapsed = Date.now() - start
 
         // Reap the detached daemon so the pipe closes and it does not leak.
@@ -1192,11 +1224,36 @@ describe("tool.shell abort", () => {
         expect(result.output).toContain("STARTED")
         expect(result.metadata.exit).toBe(0)
         expect(result.output).not.toContain("exceeding timeout")
-        // Returned via the idle drain (~500ms), not by waiting on the daemon's
+        // Returned after a bounded post-exit idle window, not by waiting on the daemon's
         // inherited pipe (60s) or the command timeout (30s).
         expect(elapsed).toBeLessThan(10_000)
       }),
     40_000,
+  )
+
+  drainIt.live("keeps inherited output that arrives after a short post-exit pause", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        let outputAt = 0
+        const result = yield* run(
+          { command: "ignored", description: "Delayed inherited output" },
+          {
+            ...ctx,
+            metadata: (input) =>
+              Effect.sync(() => {
+                const output = (input.metadata as { output?: string }).output
+                if (!outputAt && output?.includes("STARTED")) outputAt = Date.now()
+              }),
+          },
+        )
+        const elapsed = Date.now() - outputAt
+        expect(outputAt).toBeGreaterThan(0)
+        expect(result.output).toContain("STARTED")
+        expect(result.output).toContain("LATE")
+        expect(elapsed).toBeLessThan(2_400)
+      }),
+    ),
   )
 })
 


### PR DESCRIPTION
## What
Fix shell commands that hang after starting a background process.

## Why
The command can finish while its child still keeps output open, leaving the agent waiting forever.

## How
Return when the command exits, keep reading final output until it stays quiet across a 500ms check, and preserve cleanup for stuck children.

Tests cover detached children and delayed output.

Closes #24731
Closes #24784
Closes #20902
Closes #29822
Closes #25038
Closes #28697
Closes #25938