### PR TITLE
fix(opencode): retry stalled SSE streams

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -48,7 +48,7 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
     async pull(ctrl) {
       const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
         const id = setTimeout(() => {
-          const err = new Error("SSE read timed out")
+          const err = new ProviderError.ResponseStreamError("SSE read timed out")
           ctl.abort(err)
           void reader.cancel(err)
           reject(err)

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -10,6 +10,7 @@ import { testProviderConfig } from "../lib/test-provider"
 import { Env } from "@/env"
 import { Plugin } from "@/plugin"
 import { Provider } from "@/provider/provider"
+import { ProviderError } from "@/provider/error"
 import { ModelID, ProviderID } from "@/provider/schema"
 
 afterEach(async () => {
@@ -55,6 +56,35 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
         }
       },
     },
+  ),
+)
+
+it.live("chunkTimeout raises a response stream error when SSE body stalls", () =>
+  provideTmpdirServer(
+    ({ llm }) =>
+      Effect.gen(function* () {
+        yield* llm.push(reply().wait(Bun.sleep(250)).text("late").stop())
+
+        const provider = yield* Provider.Service
+        const model = yield* provider.getModel(ProviderID.make("test"), ModelID.make("test-model"))
+        const result = streamText({
+          model: yield* provider.getLanguage(model),
+          onError() {},
+          messages: [{ role: "user", content: "hello" }],
+        })
+
+        const error = yield* Effect.promise(async () => {
+          try {
+            for await (const part of result.fullStream) {
+              if (part.type === "error") return part.error
+            }
+          } catch (error) {
+            return error
+          }
+        })
+        expect(error).toBeInstanceOf(ProviderError.ResponseStreamError)
+      }),
+    { config: (url) => providerConfig(url, { chunkTimeout: 50 }) },
   ),
 )
 


### PR DESCRIPTION
Closes #20466

## Summary
- surface SSE `chunkTimeout` stalls as `ProviderError.ResponseStreamError`
- reuse existing retryable stream-error classification for automatic session retries
- cover stalled SSE responses with an integration regression test

## Verification
- `bun test test/provider/header-timeout.test.ts test/session/retry.test.ts`
- `bun typecheck`