### PR TITLE
fix(opencode): install openai websocket fetch for configured keys

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1417,15 +1417,29 @@ export const layer = Layer.effect(
           if (!plugin.auth) continue
           const providerID = ProviderID.make(plugin.auth.provider)
           if (disabled.has(providerID)) continue
-
-          const stored = yield* auth.get(providerID).pipe(Effect.orDie)
-          if (!stored) continue
           if (!plugin.auth.loader) continue
+
+          const data = database[plugin.auth.provider]
+          if (!data) continue
+          const stored = yield* auth.get(providerID).pipe(Effect.orDie)
+          const configuredKey = iife(() => {
+            const key = providers[providerID]?.key ?? data.options.apiKey
+            return typeof key === "string" && key !== "" ? key : undefined
+          })
+          const syntheticAuth = !stored && configuredKey ? { type: "api" as const, key: configuredKey } : undefined
+          const pluginAuth = stored ?? syntheticAuth
+          if (!pluginAuth) continue
 
           const options = yield* Effect.promise(() =>
             plugin.auth!.loader!(
-              () => bridge.promise(auth.get(providerID).pipe(Effect.orDie)) as any,
-              toPublicInfo(database[plugin.auth!.provider]),
+              () =>
+                bridge.promise(
+                  auth.get(providerID).pipe(
+                    Effect.orDie,
+                    Effect.map((current) => current ?? syntheticAuth),
+                  ),
+                ) as any,
+              toPublicInfo(data),
             ),
           )
           const opts = options ?? {}

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -77,6 +77,7 @@ const languageBaseURL = (language: unknown) => (language as { config: { baseURL:
 
 const it = testEffect(Layer.mergeAll(Provider.defaultLayer, Env.defaultLayer, Plugin.defaultLayer))
 const experimentalModels = testEffect(providerLayer({ enableExperimentalModels: true }))
+const experimentalWebSockets = testEffect(providerLayer({ experimentalWebSockets: true }))
 
 const alphaProviderConfig = {
   provider: {
@@ -119,6 +120,42 @@ it.instance(
     expect(providers[ProviderID.anthropic]).toBeDefined()
   }),
   { config: { provider: { anthropic: { options: { apiKey: "config-api-key" } } } } },
+)
+
+experimentalWebSockets.instance(
+  "openai config apiKey installs websocket fetch without stored auth",
+  Effect.gen(function* () {
+    yield* setProcessEnv("OPENCODE_AUTH_CONTENT", "{}")
+    const providers = yield* list
+    expect(providers[ProviderID.openai]).toBeDefined()
+    expect(providers[ProviderID.openai].options.baseURL).toBe("https://api.openai.com/v1")
+    expect(providers[ProviderID.openai].options.fetch).toBeFunction()
+  }),
+  {
+    config: {
+      provider: {
+        openai: {
+          options: {
+            baseURL: "https://api.openai.com/v1",
+            apiKey: "sk-test",
+          },
+        },
+      },
+    },
+  },
+)
+
+experimentalWebSockets.instance(
+  "openai env apiKey installs websocket fetch without stored auth",
+  Effect.gen(function* () {
+    yield* setProcessEnv("OPENCODE_AUTH_CONTENT", "{}")
+    yield* setProcessEnv("OPENAI_API_KEY", "test-openai-key")
+    const providers = yield* list
+    expect(providers[ProviderID.openai]).toBeDefined()
+    expect(providers[ProviderID.openai].source).toBe("env")
+    expect(providers[ProviderID.openai].key).toBe("test-openai-key")
+    expect(providers[ProviderID.openai].options.fetch).toBeFunction()
+  }),
 )
 
 it.instance(


### PR DESCRIPTION
### Issue for this PR

Fixes #29843

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Installs the OpenAI plugin WebSocket fetch when API auth comes from provider config (`provider.openai.options.apiKey`) or env (`OPENAI_API_KEY`) and no stored auth entry exists. The previous loader only ran when `auth.get("openai")` returned saved auth, so configured keys could build the provider but miss the WebSocket fetch needed for Responses/WebSocket calls.

Stored OpenAI auth still takes precedence when present, preserving `opencode auth login openai` behavior.

### How did you verify your code works?

- `bun test test/provider/provider.test.ts --timeout 30000`
- `bun typecheck`
- pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR