### PR TITLE
Add toolcall-stats to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [toolcall-stats](https://github.com/smithjj/toolcall-stats)                                        | Profile tool calls – track duration, frequency, errors, and visualize with Chart.js                |
 
 ---
 


### PR DESCRIPTION
Adds [toolcall-stats](https://github.com/smithjj/toolcall-stats) to the plugins list — an OpenCode plugin that profiles tool calls, tracking duration, frequency, errors, and generating Chart.js dashboards.