### PR TITLE
fix(opencode): support vertex opus adaptive reasoning

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -597,7 +597,7 @@ function openaiCompatibleReasoningEfforts(id: string) {
 }
 
 function anthropicOpus47OrLater(apiId: string) {
-  const version = /opus-(\d+)[.-](\d+)(?:[.-]|$)/i.exec(apiId)
+  const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)/i.exec(apiId)
   if (!version) return false
   const major = Number(version[1])
   const minor = Number(version[2])

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3298,6 +3298,30 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  describe("@ai-sdk/google-vertex/anthropic", () => {
+    test("opus 4.8 uses adaptive reasoning for Vertex model IDs", () => {
+      const result = ProviderTransform.variants(
+        createMockModel({
+          id: "google-vertex-anthropic/claude-opus-4-8@default",
+          providerID: "google-vertex-anthropic",
+          api: {
+            id: "claude-opus-4-8@default",
+            url: "https://us-central1-aiplatform.googleapis.com",
+            npm: "@ai-sdk/google-vertex/anthropic",
+          },
+        }),
+      )
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "high",
+      })
+    })
+  })
+
   describe("@ai-sdk/amazon-bedrock", () => {
     test("anthropic sonnet 4.6 returns adaptive reasoning options", () => {
       const model = createMockModel({


### PR DESCRIPTION
## Summary
- recognize Vertex Anthropic Opus model IDs with `@default` suffixes as Opus 4.7+
- use adaptive reasoning variants for Vertex Claude Opus 4.8 instead of legacy budget thinking
- add a Vertex-specific regression test for `claude-opus-4-8@default`

Fixes #29863

## Tests
- `bun test test/provider/transform.test.ts --timeout 30000`
- `bun typecheck`