### PR TITLE
fix(web): use release version for embedded UI

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -11,6 +11,8 @@ import { authFromToken } from "@/utils/server"
 import pkg from "../package.json"
 import { ServerConnection } from "./context/server"
 
+const appVersion = import.meta.env.VITE_OPENCODE_VERSION ?? pkg.version
+
 const DEFAULT_SERVER_URL_KEY = "opencode.settings.dat:defaultServerUrl"
 
 const getLocale = () => {
@@ -121,7 +123,7 @@ const clearAuthToken = () => {
 
 const platform: Platform = {
   platform: "web",
-  version: pkg.version,
+  version: appVersion,
   openLink,
   back,
   forward,
@@ -138,7 +140,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE,
-    release: import.meta.env.VITE_SENTRY_RELEASE ?? `web@${pkg.version}`,
+    release: import.meta.env.VITE_SENTRY_RELEASE ?? `web@${appVersion}`,
     initialScope: {
       tags: {
         platform: "web",

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -1,6 +1,7 @@
 interface ImportMetaEnv {
   readonly VITE_OPENCODE_SERVER_HOST: string
   readonly VITE_OPENCODE_SERVER_PORT: string
+  readonly VITE_OPENCODE_VERSION?: string
   readonly VITE_OPENCODE_CHANNEL?: "dev" | "beta" | "prod"
 
   readonly VITE_SENTRY_DSN?: string

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -58,7 +58,7 @@ const createEmbeddedWebUIBundle = async () => {
   console.log(`Building Web UI to embed in the binary`)
   const appDir = path.join(import.meta.dirname, "../../app")
   const dist = path.join(appDir, "dist")
-  await $`OPENCODE_CHANNEL=${Script.channel} bun run --cwd ${appDir} build`
+  await $`OPENCODE_CHANNEL=${Script.channel} VITE_OPENCODE_VERSION=${Script.version} bun run --cwd ${appDir} build`
   const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: dist })))
     .map((file) => file.replaceAll("\\", "/"))
     .filter((file) => !file.endsWith(".map"))


### PR DESCRIPTION
### Issue for this PR

Closes #29301
Refs #24286
Refs #18712

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Embedded release builds were reading the Web UI version from `packages/app/package.json`, while the CLI binary uses `OPENCODE_VERSION` / `Script.version`. Because package versions are synced later in the release flow, the embedded settings dialog could show the previous release.

This passes `Script.version` into the embedded Web UI build as `VITE_OPENCODE_VERSION`, uses it for `platform.version`, and keeps `package.json` as the local/dev fallback.

### How did you verify your code works?

- `VITE_OPENCODE_VERSION=9.9.9 bun run --cwd packages/app build`
- confirmed the built app assets contain `9.9.9`
- `bun run --cwd packages/app typecheck`
- `OPENCODE_VERSION=9.9.9 bun ./packages/opencode/script/build.ts --single --skip-install`
- confirmed `dist/opencode-linux-x64/bin/opencode --version` reports `9.9.9`
- `bun turbo typecheck` passed locally: 19/19 tasks

### Screenshots / recordings

N/A. This does not change layout or styling; it changes the release-time source for the version string shown in settings.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
