### PR TITLE
fix(opencode): reorder write tool schema to declare filePath before c…

### DIFF
--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -18,10 +18,10 @@ import * as Bom from "@/util/bom"
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
 export const Parameters = Schema.Struct({
-  content: Schema.String.annotate({ description: "The content to write to the file" }),
   filePath: Schema.String.annotate({
     description: "The absolute path to the file to write (must be absolute, not relative)",
   }),
+  content: Schema.String.annotate({ description: "The content to write to the file" }),
 })
 
 export const WriteTool = Tool.define(


### PR DESCRIPTION
  ### Issue for this PR                                                                                                                                                                   
   
  Closes #29940                                                                                                                                                                           
                                          
  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?                                                                                                                                                               
   
  Reorders the write tool schema to declare `filePath` before `content`. Local models generate fields in declaration order, so when writing large files they can exhaust their token      
  budget on `content` and never produce `filePath`, causing a schema error.
                                                                                                                                                                                          
  Suggested by @strasharo in #26419.      
  Related: #18108

  ### How did you verify your code works?

  Verified the schema change compiles and the field order is correct. The fix is a single line swap with no behavioral change for models that generate all fields.                        
   
  ### Screenshots / recordings                                                                                                                                                            
                                          
  N/A

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR
