### PR TITLE
feat(core): add FreeModel.dev provider plugin

### DIFF
--- a/packages/core/src/plugin/provider/freemodel.ts
+++ b/packages/core/src/plugin/provider/freemodel.ts
@@ -1,0 +1,21 @@
+import { Effect } from "effect"
+import { PluginV2 } from "../../plugin"
+
+export const FreeModelPlugin = PluginV2.define({
+  id: PluginV2.ID.make("freemodel"),
+  effect: Effect.gen(function* () {
+    return {
+      "catalog.transform": Effect.fn(function* (evt) {
+        for (const item of evt.data) {
+          if (item.provider.endpoint.type !== "aisdk") continue
+          if (item.provider.endpoint.package !== "@ai-sdk/openai-compatible") continue
+          if (item.provider.endpoint.url !== "https://api.freemodel.dev/v1") continue
+          evt.provider.update(item.provider.id, (provider) => {
+            provider.options.headers["HTTP-Referer"] = "https://opencode.ai/"
+            provider.options.headers["X-Title"] = "opencode"
+          })
+        }
+      }),
+    }
+  }),
+})

--- a/packages/core/src/plugin/provider/index.ts
+++ b/packages/core/src/plugin/provider/index.ts
@@ -8,6 +8,7 @@ import { CloudflareWorkersAIPlugin } from "./cloudflare-workers-ai"
 import { CoherePlugin } from "./cohere"
 import { DeepInfraPlugin } from "./deepinfra"
 import { DynamicProviderPlugin } from "./dynamic"
+import { FreeModelPlugin } from "./freemodel"
 import { GatewayPlugin } from "./gateway"
 import { GithubCopilotPlugin } from "./github-copilot"
 import { GitLabPlugin } from "./gitlab"
@@ -47,6 +48,7 @@ export const ProviderPlugins = [
   GooglePlugin,
   GoogleVertexAnthropicPlugin,
   GoogleVertexPlugin,
+  FreeModelPlugin,
   GroqPlugin,
   KiloPlugin,
   LLMGatewayPlugin,


### PR DESCRIPTION
Adds provider plugin for https://freemodel.dev — a free AI model proxy with OpenAI-compatible API. Uses @ai-sdk/openai-compatible.