### PR TITLE
docs(zh): improve translation clarity in README.zh.md

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -46,7 +46,7 @@
 ### 安装
 
 ```bash
-# 直接安装 (YOLO)
+# 直接安装 (YOLO) --- 一键脚本安装，不用操心细节
 curl -fsSL https://opencode.ai/install | bash
 
 # 软件包管理器
@@ -88,7 +88,7 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 
 1. `$OPENCODE_INSTALL_DIR` - 自定义安装目录
 2. `$XDG_BIN_DIR` - 符合 XDG 基础目录规范的路径
-3. `$HOME/bin` - 如果存在或可创建的用户二进制目录
+3. `$HOME/bin` - 标准的用户二进制目录（如果存在或可以被创建）
 4. `$HOME/.opencode/bin` - 默认备用路径
 
 ```bash


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Two minor translation clarity improvements in `README.zh.md`:

1. **YOLO comment**: The original Chinese just says "直接安装 (YOLO)" which doesn't explain what YOLO means. Added inline explanation "一键脚本安装，不用操心细节" so Chinese readers understand it's a one-liner install script.
2. **`$HOME/bin` description**: The original "如果存在或可创建的用户二进制目录" has awkward word order that reads like "if exists or creatable user binary directory". Fixed to "标准的用户二进制目录（如果存在或可以被创建）" which matches the English "Standard user binary directory (if it exists or can be created)".

### How did you verify your code works?

Verified by comparing each change against the English `README.md` to ensure semantic accuracy. Both changes are documentation-only and do not affect any code.

### Screenshots / recordings

N/A — text-only documentation change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR