### PR TITLE
fix(opencode): support sap-ai-core anthropic opus 4.7+ adaptive reasoning

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -597,10 +597,12 @@ function openaiCompatibleReasoningEfforts(id: string) {
 }
 
 function anthropicOpus47OrLater(apiId: string) {
-  const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)/i.exec(apiId)
+  // Matches "opus-4.7" (Anthropic/Bedrock/Vertex) and "claude-4.7-opus" (SAP AI Core inverted).
+  // Greedy \d+ correctly extends to multi-digit majors (e.g. "claude-10.0-opus") for forward compatibility.
+  const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)/i.exec(apiId)
   if (!version) return false
-  const major = Number(version[1])
-  const minor = Number(version[2])
+  const major = Number(version[1] ?? version[3])
+  const minor = Number(version[2] ?? version[4])
   return major > 4 || (major === 4 && minor >= 7)
 }
 
@@ -608,7 +610,18 @@ function anthropicAdaptiveEfforts(apiId: string): string[] | null {
   if (anthropicOpus47OrLater(apiId)) {
     return ["low", "medium", "high", "xhigh", "max"]
   }
-  if (["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) => apiId.includes(v))) {
+  if (
+    [
+      "opus-4-6",
+      "opus-4.6",
+      "4-6-opus",
+      "4.6-opus",
+      "sonnet-4-6",
+      "sonnet-4.6",
+      "4-6-sonnet",
+      "4.6-sonnet",
+    ].some((v) => apiId.includes(v))
+  ) {
     return ["low", "medium", "high", "max"]
   }
   return null
@@ -995,6 +1008,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
               {
                 thinking: {
                   type: "adaptive",
+                  ...(adaptiveOpus ? { display: "summarized" } : {}),
                 },
                 effort,
               },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3570,7 +3570,7 @@ describe("ProviderTransform.variants", () => {
       },
       {
         name: "opus 4.8",
-        apiIds: ["anthropic--claude-4.8-opus"],
+        apiIds: ["anthropic--claude-4.8-opus", "anthropic--claude-4-8-opus"],
         efforts: ["low", "medium", "high", "xhigh", "max"],
         expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
       },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3675,6 +3675,109 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(result).toEqual({})
     })
+
+    test("anthropic opus 4.6 dot-format models return adaptive thinking variants without display", () => {
+      const model = createMockModel({
+        id: "sap-ai-core/anthropic--claude-4.6-opus",
+        providerID: "sap-ai-core",
+        api: {
+          id: "anthropic--claude-4.6-opus",
+          url: "https://api.ai.sap",
+          npm: "@jerome-benoit/sap-ai-provider-v2",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+      expect(result.high).toEqual({ thinking: { type: "adaptive" }, effort: "high" })
+      expect(result.max).toEqual({ thinking: { type: "adaptive" }, effort: "max" })
+    })
+
+    test("anthropic opus 4.6 dash-format models return adaptive thinking variants without display", () => {
+      const model = createMockModel({
+        id: "sap-ai-core/anthropic--claude-4-6-opus",
+        providerID: "sap-ai-core",
+        api: {
+          id: "anthropic--claude-4-6-opus",
+          url: "https://api.ai.sap",
+          npm: "@jerome-benoit/sap-ai-provider-v2",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+      expect(result.high).toEqual({ thinking: { type: "adaptive" }, effort: "high" })
+    })
+
+    test("anthropic opus 4.7 dot-format models return adaptive thinking variants with xhigh and display summarized", () => {
+      const model = createMockModel({
+        id: "sap-ai-core/anthropic--claude-4.7-opus",
+        providerID: "sap-ai-core",
+        api: {
+          id: "anthropic--claude-4.7-opus",
+          url: "https://api.ai.sap",
+          npm: "@jerome-benoit/sap-ai-provider-v2",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: "high",
+      })
+      expect(result.xhigh).toEqual({
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: "xhigh",
+      })
+    })
+
+    test("anthropic opus 4.7 dash-format models return adaptive thinking variants with xhigh and display summarized", () => {
+      const model = createMockModel({
+        id: "sap-ai-core/anthropic--claude-4-7-opus",
+        providerID: "sap-ai-core",
+        api: {
+          id: "anthropic--claude-4-7-opus",
+          url: "https://api.ai.sap",
+          npm: "@jerome-benoit/sap-ai-provider-v2",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: "high",
+      })
+    })
+
+    test("anthropic opus 4.8 dot-format models return adaptive thinking variants with xhigh and display summarized", () => {
+      const model = createMockModel({
+        id: "sap-ai-core/anthropic--claude-4.8-opus",
+        providerID: "sap-ai-core",
+        api: {
+          id: "anthropic--claude-4.8-opus",
+          url: "https://api.ai.sap",
+          npm: "@jerome-benoit/sap-ai-provider-v2",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: "high",
+      })
+    })
+
+    test("non-anthropic models with opus-like substrings do not get adaptive thinking", () => {
+      const model = createMockModel({
+        id: "sap-ai-core/aws--llama-opus-4.7-fake",
+        providerID: "sap-ai-core",
+        api: {
+          id: "aws--llama-opus-4.7-fake",
+          url: "https://api.ai.sap",
+          npm: "@jerome-benoit/sap-ai-provider-v2",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({})
+    })
   })
 
   describe("ai-gateway-provider (cloudflare-ai-gateway)", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3538,245 +3538,86 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@jerome-benoit/sap-ai-provider-v2", () => {
-    test("anthropic models return thinking variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-sonnet-4",
+    const sapModel = (apiId: string) =>
+      createMockModel({
+        id: `sap-ai-core/${apiId}`,
         providerID: "sap-ai-core",
         api: {
-          id: "anthropic--claude-sonnet-4",
+          id: apiId,
           url: "https://api.ai.sap",
           npm: "@jerome-benoit/sap-ai-provider-v2",
         },
       })
-      const result = ProviderTransform.variants(model)
+
+    for (const testCase of [
+      {
+        name: "sonnet 4.6",
+        apiIds: ["anthropic--claude-sonnet-4-6"],
+        efforts: ["low", "medium", "high", "max"],
+        expectedHigh: { thinking: { type: "adaptive" }, effort: "high" },
+      },
+      {
+        name: "opus 4.6",
+        apiIds: ["anthropic--claude-4.6-opus", "anthropic--claude-4-6-opus"],
+        efforts: ["low", "medium", "high", "max"],
+        expectedHigh: { thinking: { type: "adaptive" }, effort: "high" },
+      },
+      {
+        name: "opus 4.7",
+        apiIds: ["anthropic--claude-4.7-opus", "anthropic--claude-4-7-opus"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      },
+      {
+        name: "opus 4.8",
+        apiIds: ["anthropic--claude-4.8-opus"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      },
+    ]) {
+      for (const apiId of testCase.apiIds) {
+        test(`${testCase.name} ${apiId} returns adaptive thinking variants`, () => {
+          const result = ProviderTransform.variants(sapModel(apiId))
+          expect(Object.keys(result)).toEqual(testCase.efforts)
+          expect(result.high).toEqual(testCase.expectedHigh)
+          if (testCase.efforts.includes("xhigh")) {
+            expect(result.xhigh).toEqual({ ...testCase.expectedHigh, effort: "xhigh" })
+          }
+        })
+      }
+    }
+
+    test("anthropic sonnet 4 returns budget-tokens variants", () => {
+      const result = ProviderTransform.variants(sapModel("anthropic--claude-sonnet-4"))
       expect(Object.keys(result)).toEqual(["high", "max"])
-      expect(result.high).toEqual({
-        thinking: {
-          type: "enabled",
-          budgetTokens: 16000,
-        },
-      })
-      expect(result.max).toEqual({
-        thinking: {
-          type: "enabled",
-          budgetTokens: 31999,
-        },
-      })
+      expect(result.high).toEqual({ thinking: { type: "enabled", budgetTokens: 16000 } })
+      expect(result.max).toEqual({ thinking: { type: "enabled", budgetTokens: 31999 } })
     })
 
-    test("anthropic 4.6 models return adaptive thinking variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-sonnet-4-6",
-        providerID: "sap-ai-core",
-        api: {
-          id: "anthropic--claude-sonnet-4-6",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
-      expect(result.low).toEqual({
-        thinking: {
-          type: "adaptive",
-        },
-        effort: "low",
-      })
-      expect(result.max).toEqual({
-        thinking: {
-          type: "adaptive",
-        },
-        effort: "max",
-      })
-    })
-
-    test("gemini 2.5 models return thinkingConfig variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/gcp--gemini-2.5-pro",
-        providerID: "sap-ai-core",
-        api: {
-          id: "gcp--gemini-2.5-pro",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
+    test("gemini 2.5 returns thinkingConfig variants", () => {
+      const result = ProviderTransform.variants(sapModel("gcp--gemini-2.5-pro"))
       expect(Object.keys(result)).toEqual(["high", "max"])
-      expect(result.high).toEqual({
-        thinkingConfig: {
-          includeThoughts: true,
-          thinkingBudget: 16000,
-        },
-      })
-      expect(result.max).toEqual({
-        thinkingConfig: {
-          includeThoughts: true,
-          thinkingBudget: 24576,
-        },
-      })
+      expect(result.high).toEqual({ thinkingConfig: { includeThoughts: true, thinkingBudget: 16000 } })
+      expect(result.max).toEqual({ thinkingConfig: { includeThoughts: true, thinkingBudget: 24576 } })
     })
 
-    test("gpt models return reasoningEffort variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/azure-openai--gpt-4o",
-        providerID: "sap-ai-core",
-        api: {
-          id: "azure-openai--gpt-4o",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
+    for (const apiId of ["azure-openai--gpt-4o", "azure-openai--o3-mini"]) {
+      test(`${apiId} returns reasoningEffort variants`, () => {
+        const result = ProviderTransform.variants(sapModel(apiId))
+        expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+        expect(result.low).toEqual({ reasoningEffort: "low" })
+        expect(result.high).toEqual({ reasoningEffort: "high" })
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
-      expect(result.low).toEqual({ reasoningEffort: "low" })
-      expect(result.high).toEqual({ reasoningEffort: "high" })
-    })
+    }
 
-    test("o-series models return reasoningEffort variants", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/azure-openai--o3-mini",
-        providerID: "sap-ai-core",
-        api: {
-          id: "azure-openai--o3-mini",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
+    for (const apiId of ["perplexity--sonar-pro", "mistral--mistral-large"]) {
+      test(`${apiId} returns empty object`, () => {
+        expect(ProviderTransform.variants(sapModel(apiId))).toEqual({})
       })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
-      expect(result.low).toEqual({ reasoningEffort: "low" })
-      expect(result.high).toEqual({ reasoningEffort: "high" })
-    })
-
-    test("sonar models return empty object", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/perplexity--sonar-pro",
-        providerID: "sap-ai-core",
-        api: {
-          id: "perplexity--sonar-pro",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
-    })
-
-    test("mistral models return empty object", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/mistral--mistral-large",
-        providerID: "sap-ai-core",
-        api: {
-          id: "mistral--mistral-large",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
-    })
-
-    test("anthropic opus 4.6 dot-format models return adaptive thinking variants without display", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-4.6-opus",
-        providerID: "sap-ai-core",
-        api: {
-          id: "anthropic--claude-4.6-opus",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
-      expect(result.high).toEqual({ thinking: { type: "adaptive" }, effort: "high" })
-      expect(result.max).toEqual({ thinking: { type: "adaptive" }, effort: "max" })
-    })
-
-    test("anthropic opus 4.6 dash-format models return adaptive thinking variants without display", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-4-6-opus",
-        providerID: "sap-ai-core",
-        api: {
-          id: "anthropic--claude-4-6-opus",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
-      expect(result.high).toEqual({ thinking: { type: "adaptive" }, effort: "high" })
-    })
-
-    test("anthropic opus 4.7 dot-format models return adaptive thinking variants with xhigh and display summarized", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-4.7-opus",
-        providerID: "sap-ai-core",
-        api: {
-          id: "anthropic--claude-4.7-opus",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
-      expect(result.high).toEqual({
-        thinking: { type: "adaptive", display: "summarized" },
-        effort: "high",
-      })
-      expect(result.xhigh).toEqual({
-        thinking: { type: "adaptive", display: "summarized" },
-        effort: "xhigh",
-      })
-    })
-
-    test("anthropic opus 4.7 dash-format models return adaptive thinking variants with xhigh and display summarized", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-4-7-opus",
-        providerID: "sap-ai-core",
-        api: {
-          id: "anthropic--claude-4-7-opus",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
-      expect(result.high).toEqual({
-        thinking: { type: "adaptive", display: "summarized" },
-        effort: "high",
-      })
-    })
-
-    test("anthropic opus 4.8 dot-format models return adaptive thinking variants with xhigh and display summarized", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/anthropic--claude-4.8-opus",
-        providerID: "sap-ai-core",
-        api: {
-          id: "anthropic--claude-4.8-opus",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
-      expect(result.high).toEqual({
-        thinking: { type: "adaptive", display: "summarized" },
-        effort: "high",
-      })
-    })
+    }
 
     test("non-anthropic models with opus-like substrings do not get adaptive thinking", () => {
-      const model = createMockModel({
-        id: "sap-ai-core/aws--llama-opus-4.7-fake",
-        providerID: "sap-ai-core",
-        api: {
-          id: "aws--llama-opus-4.7-fake",
-          url: "https://api.ai.sap",
-          npm: "@jerome-benoit/sap-ai-provider-v2",
-        },
-      })
-      const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
+      expect(ProviderTransform.variants(sapModel("aws--llama-opus-4.7-fake"))).toEqual({})
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #29990

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

SAP AI Core (`@jerome-benoit/sap-ai-provider-v2`) uses an inverted Anthropic naming convention `anthropic--claude-{N}.{M}-opus` (family at the end), confirmed in `SAP/ai-sdk-java` (`OrchestrationAiModel.CLAUDE_4_7_OPUS`), `SAP/ai-sdk-js` (`scripts/sap-models.json`, `model-types.ts`), and `models.dev` (`reasoning = true`). The existing `anthropicOpus47OrLater` regex required `opus-` BEFORE the version, so SAP Opus 4.7+ never matched, and the `@jerome-benoit/sap-ai-provider-v2` branch in `variants()` never spread `display: "summarized"`.

Three minimal in-place changes in `packages/opencode/src/provider/transform.ts`:

- Extend `anthropicOpus47OrLater` regex with a second alternation arm matching `claude-{N}.{M}-opus` (and dash form). Single shared `major > 4 || (major === 4 && minor >= 7)` comparison preserved.
- Extend `anthropicAdaptiveEfforts` substring list with `4-6-opus`, `4.6-opus`, `4-6-sonnet`, `4.6-sonnet` so SAP 4.6 also reaches the 4-effort adaptive path.
- Add `...(adaptiveOpus ? { display: "summarized" } : {})` to the SAP anthropic adaptive branch, mirroring `@ai-sdk/anthropic` and `@ai-sdk/amazon-bedrock`.

No new helpers extracted (style guide: no preemptive abstraction). The version-comparison logic stays in one place.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — clean
- `bun test test/provider/transform.test.ts` — 234/234 pass
- 6 new tests in the existing `describe("@jerome-benoit/sap-ai-provider-v2", ...)` block:
  - opus 4.6 dot + dash → 4-effort adaptive without `display`
  - opus 4.7 dot + dash → 5-effort adaptive with `display: "summarized"` and `xhigh`
  - opus 4.8 dot → forward-compat regression
  - non-anthropic id with `opus-4.7` substring → empty (defensive guard test)

To reproduce locally: configure SAP AI Core with `anthropic--claude-4.7-opus`, select reasoning. Before: budget-tokens fallback, 2 keys. After: adaptive, 5 keys, `display: "summarized"`.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR