### PR TITLE
fix(edit): preserve leading whitespace in TrimmedBoundaryReplacer

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -559,10 +559,6 @@ export const TrimmedBoundaryReplacer: Replacer = function* (content, find) {
     return
   }
 
-  // Try to find the trimmed version
-  if (content.includes(trimmedFind)) {
-    yield trimmedFind
-  }
 
   // Also try finding blocks where trimmed content matches
   const lines = content.split("\n")


### PR DESCRIPTION
### Issue for this PR

Closes #29573

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes `TrimmedBoundaryReplacer` which yielded trimmed search text (`find.trim()`) without indentation context. The `content.indexOf(trimmedFind)` call found the match AFTER leading whitespace, but `content.substring(0, index)` preserved those leading spaces. The concatenation then produced doubled indentation. The fix removes the direct `trimmedFind` yield — only blocks matched from actual file content (with correct indentation) are yielded.

### How did you verify your code works?

- [x] TypeScript typecheck passes
- [x] Existing tests pass (50/50)

### Screenshots / recordings

_Not applicable — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
