### PR TITLE
fix(cli): emit user prompt as a user event in run --format json

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -789,12 +789,18 @@ export const RunCommand = effectCmd({
           }
 
           const model = pick(args.model)
+          const parts = [...files, { type: "text" as const, text: message }]
+          // Mirror the prompt to --format json consumers. The streamed
+          // message.part events only cover the assistant reply, so without this
+          // the user turn never appears in the stream (it lives only in
+          // `opencode export`).
+          emit("user", { parts })
           const result = await client.session.prompt({
             sessionID,
             agent,
             model,
             variant: args.variant,
-            parts: [...files, { type: "text", text: message }],
+            parts,
           })
           if (result.error) {
             if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -81,4 +81,28 @@ describe("opencode run (non-interactive subprocess)", () => {
       }),
     60_000,
   )
+
+  // Regression for #29997: the user's prompt must surface in --format json as a
+  // `user` event. Previously the stream began at step_start and the prompt was
+  // only retrievable via `opencode export`, so anything rebuilding a transcript
+  // from the stream lost the user turn entirely.
+  cliIt.concurrent(
+    "--format json emits a user event carrying the prompt (regression for #29997)",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("ok")
+        const result = yield* opencode.run("marco", { format: "json" })
+        opencode.expectExit(result, 0)
+
+        const events = opencode.parseJsonEvents(result.stdout)
+        const user = events.find((e) => e.type === "user")
+        expect(user).toBeDefined()
+        expect(JSON.stringify(user!.parts)).toContain("marco")
+
+        // The user turn must precede the assistant's reply in the stream.
+        const types = events.map((e) => e.type)
+        expect(types.indexOf("user")).toBeLessThan(types.indexOf("text"))
+      }),
+    60_000,
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #29997

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --format json` never emits the user's prompt. The stream begins at `step_start`, so anything reconstructing a transcript from it (eval harnesses, loggers, trajectory exporters) loses the user turn.

**The prompt is recorded — it's just dropped from the stream.** Take one session on `dev`: `run --format json` omits the prompt, but `opencode export` of that *same session* contains it.

`opencode run --format json -- say hello` on **`dev`** (the real format is one compact JSON object per line; pretty-printed here, IDs shortened):

```jsonc
{ "type": "step_start",  "sessionID": "ses_…", "part": { "id": "prt_…", "type": "step-start", "snapshot": "…" } }
{ "type": "text",        "sessionID": "ses_…", "part": { "type": "text", "text": "Hello! How can I assist you today?", "time": { "start": 1780155478703, "end": 1780155478922 } } }
{ "type": "step_finish", "sessionID": "ses_…", "part": { "reason": "stop", "type": "step-finish", "tokens": { "total": 14759, "input": 14748, "output": 11 }, "cost": 0.0022188 } }
```

The first event is the assistant's `step_start` — the prompt is nowhere in the stream.

`opencode export <same session>` on **`dev`** (excerpt) — the prompt is right there:

```json
{
  "messages": [
    { "info": { "role": "user" },      "parts": [{ "type": "text", "text": "say hello" }] },
    { "info": { "role": "assistant" }, "parts": [{ "type": "text", "text": "Hello! How can I assist you today?" }] }
  ]
}
```

So the data exists; the `--format json` stream just never emits it.

**Why the stream drops it.** The event loop receives a `message.part.updated` for *every* part, including the user's prompt, but the `text` branch only emits once `part.time?.end` is set:

```ts
// src/cli/cmd/run.ts:688
if (part.type === "text" && part.time?.end) {
  if (emit("text", { part })) continue
  ...
}
```

That gate is deliberate: assistant text streams in as several updates, so it waits for the finished one (the part that has a `time.end`). But the user's prompt is *input*, not streamed generation — its text part arrives once with **no `time` field at all**, so `part.time?.end` is `undefined`, the branch is skipped, and nothing else in the loop handles it. The same guard that dedupes streaming assistant text silently drops the prompt. Logging every event the loop sees confirms it:

```
part.updated  type=text  messageID=<user>       time=undefined                  <- prompt, dropped by the gate
part.updated  type=text  messageID=<assistant>  time={"start":…}                <- partial, correctly skipped
part.updated  type=text  messageID=<assistant>  time={"start":…,"end":…}        <- emitted
```

**The fix.** Emit a `user` event carrying the same parts passed to `session.prompt`, just before the assistant turn starts. It reuses the existing `emit()` helper (a no-op unless `--format json`), so default output is unchanged, and it's additive — consumers that don't know the `user` type ignore it.

With the fix, `opencode run --format json -- say hello` produces the full trajectory below — the new `user` event leads and the rest is identical to `dev`:

```jsonc
{
  "type": "user",
  "timestamp": 1780155194554,
  "sessionID": "ses_1867b634affeNm9y7CZN9ojxPl",
  "parts": [{ "type": "text", "text": "say hello" }]
}
{ "type": "step_start",  "sessionID": "ses_…", "part": { "id": "prt_…", "type": "step-start", "snapshot": "…" } }
{ "type": "text",        "sessionID": "ses_…", "part": { "type": "text", "text": "Hello! How can I assist you today?", "time": { "start": 1780155478703, "end": 1780155478922 } } }
{ "type": "step_finish", "sessionID": "ses_…", "part": { "reason": "stop", "type": "step-finish", "tokens": { "total": 14759, "input": 14748, "output": 11 }, "cost": 0.0022188 } }
```

### How did you verify your code works?

- Captured the run-vs-export contrast above on `dev` (same session): `run --format json` has no user turn, `export` does.
- Added a subprocess regression test in `test/cli/run/run-process.test.ts` (drives the real CLI with `--format json`) asserting a `user` event carries the prompt and precedes the assistant `text`. It **fails on `dev`** (no `user` event → `expect(user).toBeDefined()` fails) and passes with the fix.
- `bun test test/cli/run/run-process.test.ts` → 5 pass.
- `bun typecheck` clean; prettier + oxlint clean on the changed files.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
