### PR TITLE
fix(tui): prevent shortcut fall-through when modal dialogs are open

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -14,7 +14,7 @@ import * as Clipboard from "@tui/util/clipboard"
 import { useToast } from "../ui/toast"
 import { isConsoleManagedProvider } from "@tui/util/provider-origin"
 import { useConnected } from "./use-connected"
-import { useBindings } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../keymap"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
   opencode: 0,
@@ -240,6 +240,7 @@ function AutoMethod(props: AutoMethodProps) {
   const toast = useToast()
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       {
         key: "c",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-retry-action.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-retry-action.tsx
@@ -5,7 +5,7 @@ import { selectedForeground, useTheme } from "@tui/context/theme"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
 import { Link } from "@tui/ui/link"
 import { BgPulse } from "./bg-pulse"
-import { useBindings } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../keymap"
 
 const GO_URL = "https://opencode.ai/go"
 const PAD_X = 3
@@ -45,6 +45,7 @@ export function DialogRetryAction(props: DialogRetryActionProps) {
   const [selected, setSelected] = createSignal<"dismiss" | "action">("action")
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       {
         key: "left",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-delete-failed.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-delete-failed.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../context/theme"
 import { useDialog } from "../ui/dialog"
 import { createStore } from "solid-js/store"
 import { For } from "solid-js"
-import { useBindings } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../keymap"
 
 export function DialogSessionDeleteFailed(props: {
   session: string
@@ -41,6 +41,7 @@ export function DialogSessionDeleteFailed(props: {
   }
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       { key: "return", desc: "Confirm recovery option", group: "Dialog", cmd: () => void confirm() },
       { key: "left", desc: "Delete broken session", group: "Dialog", cmd: () => setStore("active", "delete") },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-unavailable.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-unavailable.tsx
@@ -3,7 +3,7 @@ import { createStore } from "solid-js/store"
 import { For } from "solid-js"
 import { useTheme } from "../context/theme"
 import { useDialog } from "../ui/dialog"
-import { useBindings } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../keymap"
 
 export function DialogWorkspaceUnavailable(props: { onRestore?: () => boolean | void | Promise<boolean | void> }) {
   const dialog = useDialog()
@@ -24,6 +24,7 @@ export function DialogWorkspaceUnavailable(props: { onRestore?: () => boolean | 
   }
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       { key: "return", desc: "Confirm workspace option", group: "Dialog", cmd: () => void confirm() },
       { key: "left", desc: "Cancel workspace restore", group: "Dialog", cmd: () => setStore("active", "cancel") },

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/plugins.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/plugins.tsx
@@ -4,7 +4,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { fileURLToPath } from "url"
 import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { Show, createEffect, createMemo, createSignal } from "solid-js"
-import { useBindings } from "../../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../../keymap"
 
 const id = "internal:plugin-manager"
 
@@ -41,6 +41,7 @@ function Install(props: { api: TuiPluginApi }) {
 
   useBindings(() => ({
     enabled: !busy(),
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [{ key: "tab", desc: "Toggle install scope", group: "Plugins", cmd: () => setGlobal((value) => !value) }],
   }))
 

--- a/packages/opencode/src/cli/cmd/tui/keymap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/keymap.tsx
@@ -14,6 +14,7 @@ import { TuiKeybind } from "./config/keybind"
 export const LEADER_TOKEN = "leader"
 export const OPENCODE_BASE_MODE = "base"
 export const COMMAND_PALETTE_COMMAND = "command.palette.show"
+export const DIALOG_LAYER_PRIORITY = 1000
 
 const OPENCODE_MODE_KEY = "opencode.mode"
 

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -1,7 +1,7 @@
 import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
-import { useBindings } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../keymap"
 
 export type DialogAlertProps = {
   title: string
@@ -14,6 +14,7 @@ export function DialogAlert(props: DialogAlertProps) {
   const { theme } = useTheme()
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       {
         key: "return",

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
@@ -4,7 +4,7 @@ import { useDialog, type DialogContext } from "./dialog"
 import { createStore } from "solid-js/store"
 import { For } from "solid-js"
 import { Locale } from "@/util/locale"
-import { useBindings } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../keymap"
 
 export type DialogConfirmProps = {
   title: string
@@ -24,6 +24,7 @@ export function DialogConfirm(props: DialogConfirmProps) {
   })
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       {
         key: "return",

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { createStore } from "solid-js/store"
 import { onMount, Show } from "solid-js"
-import { useBindings } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings } from "../keymap"
 
 export type DialogExportOptionsProps = {
   defaultFilename: string
@@ -34,6 +34,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
   })
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       {
         key: "tab",
@@ -57,6 +58,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
 
   useBindings(() => ({
     enabled: store.active !== "filename",
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       {
         key: "space",

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
@@ -1,7 +1,7 @@
 import { TextAttributes } from "@opentui/core"
 import { useTheme } from "@tui/context/theme"
 import { useDialog } from "./dialog"
-import { useBindings, useCommandShortcut } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings, useCommandShortcut } from "../keymap"
 
 export function DialogHelp() {
   const dialog = useDialog()
@@ -9,6 +9,7 @@ export function DialogHelp() {
   const commandShortcut = useCommandShortcut("command.palette.show")
 
   useBindings(() => ({
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       { key: "return", desc: "Close help", group: "Dialog", cmd: () => dialog.clear() },
       { key: "escape", desc: "Close help", group: "Dialog", cmd: () => dialog.clear() },

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -4,7 +4,7 @@ import { useDialog, type DialogContext } from "./dialog"
 import { Show, createEffect, createSignal, onMount, type JSX } from "solid-js"
 import { Spinner } from "../component/spinner"
 import { useTuiConfig } from "../context/tui-config"
-import { useBindings, useCommandShortcut } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings, useCommandShortcut } from "../keymap"
 
 export type DialogPromptProps = {
   title: string
@@ -33,8 +33,7 @@ export function DialogPrompt(props: DialogPromptProps) {
   useBindings(() => ({
     target: textareaTarget,
     enabled: textareaTarget() !== undefined && !props.busy,
-    // Dialog form semantics must win over the global managed textarea input layer.
-    priority: 1,
+    priority: DIALOG_LAYER_PRIORITY,
     commands: [
       {
         name: "dialog.prompt.submit",

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -18,7 +18,7 @@ import { useDialog, type DialogContext } from "@tui/ui/dialog"
 import { Locale } from "@/util/locale"
 import { getScrollAcceleration } from "../util/scroll"
 import { useTuiConfig } from "../context/tui-config"
-import { formatKeyBindings, useBindings, useKeymapSelector } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, formatKeyBindings, useBindings, useKeymapSelector } from "../keymap"
 
 export interface DialogSelectProps<T> {
   title: string
@@ -238,6 +238,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     const enabledActions = actions().filter((item) => !item.disabled)
 
     return {
+      priority: DIALOG_LAYER_PRIORITY,
       commands: [
         {
           name: "dialog.select.prev",

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -6,7 +6,7 @@ import { createStore } from "solid-js/store"
 import { useToast } from "./toast"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Selection from "@tui/util/selection"
-import { useBindings, useOpencodeModeStack } from "../keymap"
+import { DIALOG_LAYER_PRIORITY, useBindings, useOpencodeModeStack } from "../keymap"
 
 export function Dialog(
   props: ParentProps<{
@@ -101,6 +101,7 @@ function init() {
 
   useBindings(() => ({
     enabled: store.stack.length > 0 && !renderer.getSelection()?.getSelectedText(),
+    priority: DIALOG_LAYER_PRIORITY,
     bindings: [
       {
         key: "escape",

--- a/packages/opencode/test/cli/tui/keymap.test.tsx
+++ b/packages/opencode/test/cli/tui/keymap.test.tsx
@@ -5,6 +5,7 @@ import { expect, test } from "bun:test"
 import { onCleanup } from "solid-js"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 import {
+  DIALOG_LAYER_PRIORITY,
   getOpencodeModeStack,
   OPENCODE_BASE_MODE,
   OpencodeKeymapProvider,
@@ -53,6 +54,60 @@ test("legacy page key aliases compile as page keys", async () => {
       up: [["pageup"]],
       down: [["pagedown"]],
     })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("dialog priority beats newer default priority bindings", async () => {
+  const runs: string[] = []
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+    const offDialog = keymap.registerLayer({
+      priority: DIALOG_LAYER_PRIORITY,
+      commands: [
+        {
+          name: "test.dialog",
+          run() {
+            runs.push("dialog")
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+g", cmd: "test.dialog" }],
+    })
+    const offGlobal = keymap.registerLayer({
+      commands: [
+        {
+          name: "test.global",
+          run() {
+            runs.push("global")
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+g", cmd: "test.global" }],
+    })
+
+    onCleanup(() => {
+      offGlobal()
+      offDialog()
+      offKeymap()
+    })
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <box />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { kittyKeyboard: true })
+  try {
+    app.mockInput.pressKey("g", { ctrl: true })
+    expect(runs).toEqual(["dialog"])
   } finally {
     app.renderer.destroy()
   }
@@ -120,8 +175,20 @@ test("mode-less bindings stay active when opencode mode changes", async () => {
   const app = await testRender(() => <Harness />)
   try {
     expect(counts).toEqual({
-      base: { "session.list": 1, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 1 },
-      question: { "session.list": 1, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 0 },
+      base: {
+        "session.list": 1,
+        "session.new": 1,
+        "session.page.up": 2,
+        "session.first": 2,
+        "model.list": 1,
+      },
+      question: {
+        "session.list": 1,
+        "session.new": 1,
+        "session.page.up": 2,
+        "session.first": 2,
+        "model.list": 0,
+      },
       autocomplete: {
         "session.list": 1,
         "session.new": 1,


### PR DESCRIPTION
### Issue for this PR

Closes #29999

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Open dialogs could lose keyboard input when the TUI entered question/autocomplete mode. Keys intended for the dialog could be handled by the prompt state instead.

This PR gives dialog selection bindings higher priority so the active dialog gets first chance to handle its own keyboard input.

Global app/session bindings were also active while dialogs were open. This PR disables those global layers while `dialog.stack` is non-empty, so leader shortcuts and session-level shortcuts do not run from inside an active modal.

### How did you verify your code works?

- Extended the existing mode-less bindings test to cover `COMMAND_PALETTE_COMMAND`.
- Added a modal keybinding test that checks active command counts and key resolution before/after opening a modal.
- Ran `bun test test/cli/tui/keymap.test.tsx` — 3/3 pass.
- Ran `bun typecheck` — clean.

### Screenshots / recordings

Not included. This is a keyboard-state fix covered by keymap tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR