### PR TITLE
fix(project): update worktree when original directory no longer exists

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -276,6 +276,14 @@ export const layer = Layer.effect(
         { concurrency: "unbounded" },
       ).pipe(Effect.map((arr) => arr.filter((x): x is string => x !== undefined)))
 
+      if (projectID !== ProjectID.global) {
+        const worktreeExists = yield* fs.exists(result.worktree).pipe(Effect.orDie)
+        if (!worktreeExists) {
+          result.worktree = data.directory
+          result.sandboxes = result.sandboxes.filter((s) => s !== data.directory)
+        }
+      }
+
       yield* db((d) =>
         d
           .insert(ProjectTable)


### PR DESCRIPTION
### Issue for this PR

Closes #30005

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a project is moved from its original location to a new path, closing the old workspace in the GUI and re-adding it at the new path does not update the stored worktree. The database keeps the old (non-existent) path, and the GUI's sandbox auto-routing closes the newly added project and re-opens the old one.

This adds an existence check in `fromDirectory()`: after filtering sandboxes, if the stored `worktree` no longer exists on disk, update it to the current directory and remove from sandboxes.

### How did you verify your code works?

- Existing behavior unchanged when worktree path is valid (all existing tests pass)
- When worktree path no longer exists, it is updated to the current directory and removed from sandboxes

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR