### PR TITLE
fix(provider): distinguish unknown model pricing

### DIFF
--- a/packages/app/src/components/dialog-select-model-unpaid.tsx
+++ b/packages/app/src/components/dialog-select-model-unpaid.tsx
@@ -59,7 +59,7 @@ export const DialogSelectModelUnpaid: Component<{ model?: ModelState }> = (props
                 <ModelTooltip
                   model={item}
                   latest={item.latest}
-                  free={item.provider.id === "opencode" && (!item.cost || item.cost.input === 0)}
+                  free={item.provider.id === "opencode" && item.costKnown !== false && item.cost?.input === 0}
                 />
               }
             >

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -13,8 +13,8 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
 
-const isFree = (provider: string, cost: { input: number } | undefined) =>
-  provider === "opencode" && (!cost || cost.input === 0)
+const isFree = (provider: string, cost: { input: number } | undefined, costKnown?: boolean) =>
+  provider === "opencode" && costKnown !== false && cost?.input === 0
 
 type ModelState = ReturnType<typeof useLocal>["model"]
 
@@ -58,7 +58,13 @@ const ModelList: Component<{
           class="w-full"
           placement="right-start"
           gutter={12}
-          value={<ModelTooltip model={item} latest={item.latest} free={isFree(item.provider.id, item.cost)} />}
+          value={
+            <ModelTooltip
+              model={item}
+              latest={item.latest}
+              free={isFree(item.provider.id, item.cost, item.costKnown)}
+            />
+          }
         >
           {node}
         </Tooltip>
@@ -73,7 +79,7 @@ const ModelList: Component<{
       {(i) => (
         <div class="w-full flex items-center gap-x-2 text-13-regular">
           <span class="truncate">{i.name}</span>
-          <Show when={isFree(i.provider.id, i.cost)}>
+          <Show when={isFree(i.provider.id, i.cost, i.costKnown)}>
             <Tag>{language.t("model.tag.free")}</Tag>
           </Show>
           <Show when={i.latest}>

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -46,7 +46,9 @@ const SettingsProvidersContent: Component = () => {
   const connected = createMemo(() => {
     return providers
       .connected()
-      .filter((p) => p.id !== "opencode" || Object.values(p.models).find((m) => m.cost?.input))
+      .filter(
+        (p) => p.id !== "opencode" || Object.values(p.models).find((m) => m.costKnown === false || m.cost?.input !== 0),
+      )
   })
 
   const popular = createMemo(() => {

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -53,7 +53,10 @@ export function useProviders() {
           providers().all,
           ([id]) =>
             connected.has(id) &&
-            (id !== "opencode" || Object.values(providers().all.get(id)?.models ?? {}).some((m) => m.cost?.input)),
+            (id !== "opencode" ||
+              Object.values(providers().all.get(id)?.models ?? {}).some(
+                (m) => m.costKnown === false || m.cost?.input !== 0,
+              )),
         ),
       ]
     },

--- a/packages/opencode/src/cli/cmd/run/footer.command.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.command.tsx
@@ -979,7 +979,7 @@ export function RunModelSelectBody(props: {
             const current = props.current()?.providerID === provider.id && props.current()?.modelID === modelID
             const footer = current
               ? "current"
-              : model.cost?.input === 0 && provider.id === "opencode"
+              : model.costKnown !== false && model.cost?.input === 0 && provider.id === "opencode"
                 ? "Free"
                 : title !== modelID
                   ? modelID

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -189,7 +189,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
 
       if (!ok) {
         for (const [key, value] of Object.entries(input.models)) {
-          if (value.cost.input === 0) continue
+          if (value.costKnown !== false && value.cost.input === 0) continue
           delete input.models[key]
         }
       }
@@ -1010,6 +1010,7 @@ export const Model = Schema.Struct({
   family: optionalOmitUndefined(Schema.String),
   capabilities: ProviderCapabilities,
   cost: ProviderCost,
+  costKnown: optionalOmitUndefined(Schema.Boolean),
   limit: ProviderLimit,
   status: ModelStatus,
   options: Schema.Record(Schema.String, Schema.Any),
@@ -1170,6 +1171,7 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
     headers: {},
     options: {},
     cost: cost(model.cost),
+    costKnown: model.cost !== undefined,
     limit: {
       context: model.limit.context,
       input: model.limit.input,
@@ -1218,6 +1220,7 @@ export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
         id: ModelV2.ID.make(id),
         name: `${model.name} ${mode[0].toUpperCase()}${mode.slice(1)}`,
         cost: opts.cost ? mergeDeep(base.cost, cost(opts.cost)) : base.cost,
+        costKnown: opts.cost ? true : base.costKnown,
         options: opts.provider?.body
           ? Object.fromEntries(
               Object.entries(opts.provider.body).map(([k, v]) => [
@@ -1434,6 +1437,7 @@ export const layer = Layer.effect(
                   write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
                 },
               },
+              costKnown: model.cost !== undefined ? true : (existingModel?.costKnown ?? false),
               options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
               limit: {
                 context: model.limit?.context ?? existingModel?.limit?.context ?? 0,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1310,6 +1310,27 @@ test("models.dev normalization fills required response fields", () => {
   expect(model.release_date).toBe("")
 })
 
+test("models.dev normalization marks omitted cost as unknown", () => {
+  const provider = {
+    id: "snowflake-cortex",
+    name: "Snowflake Cortex",
+    env: [],
+    models: {
+      "claude-sonnet-4-5": {
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        family: "claude",
+        limit: { context: 200_000, output: 64_000 },
+      },
+    },
+  } as unknown as ModelsDev.Provider
+
+  const model = Provider.fromModelsDevProvider(provider).models["claude-sonnet-4-5"]
+  expect(model.cost.input).toBe(0)
+  expect(model.cost.output).toBe(0)
+  expect(model.costKnown).toBe(false)
+})
+
 it.instance("model variants are generated for reasoning models", () =>
   Effect.gen(function* () {
     yield* set("ANTHROPIC_API_KEY", "test-api-key")

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1498,6 +1498,7 @@ export type Model = {
       }
     }
   }
+  costKnown?: boolean
   limit: {
     context: number
     output: number

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2135,6 +2135,7 @@ export type Model = {
       }
     }
   }
+  costKnown?: boolean
   limit: {
     context: number
     input?: number

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -20068,6 +20068,9 @@
             "required": ["input", "output", "cache"],
             "additionalProperties": false
           },
+          "costKnown": {
+            "type": "boolean"
+          },
           "limit": {
             "type": "object",
             "properties": {

--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -41,7 +41,8 @@ export function DialogModel(props: { providerID?: string }) {
             description: provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
-            footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer:
+              model.costKnown !== false && model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
             onSelect: () => {
               onSelect(provider.id, model.id)
             },
@@ -79,7 +80,8 @@ export function DialogModel(props: { providerID?: string }) {
               : undefined,
             category: connected() ? provider.name : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
-            footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer:
+              info.costKnown !== false && info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
             onSelect() {
               onSelect(provider.id, model)
             },

--- a/packages/tui/src/component/use-connected.tsx
+++ b/packages/tui/src/component/use-connected.tsx
@@ -6,7 +6,8 @@ export function useConnected() {
   return createMemo(() =>
     sync.data.provider.some(
       (provider) =>
-        provider.id !== "opencode" || Object.values(provider.models).some((model) => model.cost?.input !== 0),
+        provider.id !== "opencode" ||
+        Object.values(provider.models).some((model) => model.costKnown === false || model.cost?.input !== 0),
     ),
   )
 }

--- a/packages/tui/src/feature-plugins/home/tips.tsx
+++ b/packages/tui/src/feature-plugins/home/tips.tsx
@@ -41,7 +41,9 @@ const tui: TuiPlugin = async (api) => {
         const first = createMemo(() => api.state.session.count() === 0)
         const connected = createMemo(() =>
           api.state.provider.some(
-            (item) => item.id !== "opencode" || Object.values(item.models).some((model) => model.cost?.input !== 0),
+            (item) =>
+              item.id !== "opencode" ||
+              Object.values(item.models).some((model) => model.costKnown === false || model.cost?.input !== 0),
           ),
         )
         const show = createMemo(() => (!first() || !connected()) && !hidden())

--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -11,7 +11,9 @@ function View(props: { api: TuiPluginApi; sessionID: string }) {
   const theme = () => props.api.theme.current
   const has = createMemo(() =>
     props.api.state.provider.some(
-      (item) => item.id !== "opencode" || Object.values(item.models).some((model) => model.cost?.input !== 0),
+      (item) =>
+        item.id !== "opencode" ||
+        Object.values(item.models).some((model) => model.costKnown === false || model.cost?.input !== 0),
     ),
   )
   const done = createMemo(() => props.api.kv.get("dismissed_getting_started", false))


### PR DESCRIPTION
﻿### Issue for this PR

Closes #29971

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode was treating missing model pricing from `models.dev` as if the price were actually zero. That made unknown-cost OpenCode-hosted models show up as `Free`, and it also let them through paths that should only contain models with known zero cost.

This patch keeps a separate `costKnown` flag while generating provider metadata. The UI and SDK can now distinguish three cases cleanly: known paid, known free, and unknown price. Unknown price is no longer displayed as free.

### How did you verify your code works?

- `bun install --frozen-lockfile --ignore-scripts`
- `bun ./script/generate.ts`
- `bun run --cwd packages/opencode typecheck`
- `bun run --cwd packages/sdk/js typecheck`
- `bun --cwd packages/opencode test test/provider/provider.test.ts --timeout 30000`
- `bunx prettier --check packages/opencode/src/provider/models.ts packages/opencode/test/provider/provider.test.ts packages/sdk/js/src/gen/models.gen.ts sdks.gen/model/*.ts`
- `bunx oxlint packages/opencode/src/provider/models.ts packages/opencode/test/provider/provider.test.ts packages/sdk/js/src/gen/models.gen.ts`
- `git diff --check`

One local limitation: `bun run --cwd packages/app typecheck` fails on this Windows checkout before reaching this patch because `packages/app/src/custom-elements.d.ts` is checked out as a Git symlink placeholder (`120000`) and `tsgo` parses the link text.

### Screenshots / recordings

No screenshot. This is provider metadata generation and model pricing classification, not a visual layout change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
