### PR TITLE
fix(mcp): bind oauth callback to IPv4 loopback

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -3,6 +3,8 @@ import { createServer } from "http"
 import { escapeHtml } from "@/util/html"
 import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH, parseRedirectUri } from "./oauth-provider"
 
+const OAUTH_CALLBACK_HOST = "127.0.0.1"
+
 // Current callback server configuration (may differ from defaults if custom redirectUri is used)
 let currentPort = OAUTH_CALLBACK_PORT
 let currentPath = OAUTH_CALLBACK_PATH
@@ -162,7 +164,7 @@ export async function ensureRunning(redirectUri?: string): Promise<void> {
 
   server = createServer(handleRequest)
   await new Promise<void>((resolve, reject) => {
-    server!.listen(currentPort, () => {
+    server!.listen(currentPort, OAUTH_CALLBACK_HOST, () => {
       resolve()
     })
     server!.on("error", reject)

--- a/packages/opencode/test/mcp/oauth-callback.test.ts
+++ b/packages/opencode/test/mcp/oauth-callback.test.ts
@@ -1,6 +1,40 @@
 import { test, expect, describe, afterEach } from "bun:test"
+import { createConnection, createServer as createNetServer } from "net"
 import { McpOAuthCallback } from "../../src/mcp/oauth-callback"
 import { parseRedirectUri } from "../../src/mcp/oauth-provider"
+
+async function getFreeLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createNetServer()
+    probe.once("error", reject)
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address()
+      probe.close(() => {
+        if (typeof address === "object" && address) {
+          resolve(address.port)
+          return
+        }
+        reject(new Error("Could not allocate a loopback port"))
+      })
+    })
+  })
+}
+
+async function canConnect(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port })
+    const done = (ok: boolean) => {
+      socket.removeAllListeners()
+      socket.destroy()
+      resolve(ok)
+    }
+
+    socket.setTimeout(500)
+    socket.once("connect", () => done(true))
+    socket.once("error", () => done(false))
+    socket.once("timeout", () => done(false))
+  })
+}
 
 describe("parseRedirectUri", () => {
   test("returns defaults when no URI provided", () => {
@@ -68,5 +102,13 @@ describe("McpOAuthCallback.ensureRunning", () => {
     )
 
     expect(await response.text()).toContain('<div class="error">The user denied access</div>')
+  })
+
+  test("binds the callback server to IPv4 loopback", async () => {
+    const port = await getFreeLoopbackPort()
+    await McpOAuthCallback.ensureRunning(`http://127.0.0.1:${port}/custom/callback`)
+
+    expect(await canConnect("127.0.0.1", port)).toBe(true)
+    expect(await canConnect("::1", port)).toBe(false)
   })
 })


### PR DESCRIPTION
﻿### Issue for this PR

Closes #30013
Closes #31824
Relates to: #28567

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The MCP OAuth callback server used `server.listen(port)` without a host. On Linux this can bind to the IPv6 wildcard address. In WSL2, callbacks opened in the Windows browser can fail to reach that socket through localhost forwarding.

This binds the callback server to `127.0.0.1` explicitly, matching the default redirect URI and keeping the server loopback-only. The port-in-use probe already checks `127.0.0.1`, so startup detection and the actual listener now use the same address family.

### How did you verify your code works?

- `bun --cwd packages/opencode test test/mcp/oauth-callback.test.ts`
- `bun run --cwd packages/opencode typecheck`
- `bunx prettier --check packages/opencode/src/mcp/oauth-callback.ts packages/opencode/test/mcp/oauth-callback.test.ts`
- `bunx oxlint packages/opencode/src/mcp/oauth-callback.ts packages/opencode/test/mcp/oauth-callback.test.ts`
- `git diff --check`

### Screenshots / recordings

No screenshot. This changes local OAuth callback socket binding, not UI layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
