### PR TITLE
fix(provider): reject unsupported image MIME attachments

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -6,6 +6,7 @@ import type * as ModelsDev from "@opencode-ai/core/models-dev"
 import { iife } from "@/util/iife"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
+const SUPPORTED_IMAGE_MIMES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"])
 
 function mimeToModality(mime: string): Modality | undefined {
   if (mime.startsWith("image/")) return "image"
@@ -418,6 +419,13 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
       const filename = part.type === "file" ? part.filename : undefined
       const modality = mimeToModality(mime)
       if (!modality) return part
+      if (modality === "image" && !SUPPORTED_IMAGE_MIMES.has(mime)) {
+        const name = filename ? `"${filename}"` : mime
+        return {
+          type: "text" as const,
+          text: `ERROR: Cannot read ${name} (unsupported image MIME type: ${mime}). Inform the user.`,
+        }
+      }
       if (model.capabilities.input[modality]) return part
 
       const name = filename ? `"${filename}"` : modality

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1381,6 +1381,33 @@ describe("ProviderTransform.message - empty image handling", () => {
     expect(result[0].content[1]).toEqual({ type: "image", image: `data:image/png;base64,${validBase64}` })
   })
 
+  test("should replace unsupported image file MIME types with error text", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Use this icon" },
+          {
+            type: "file",
+            url: "data:image/vnd.microsoft.icon;base64,AAABAA==",
+            mediaType: "image/vnd.microsoft.icon",
+            filename: "toolbox.ico",
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, mockModel, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(2)
+    expect(result[0].content[0]).toEqual({ type: "text", text: "Use this icon" })
+    expect(result[0].content[1]).toEqual({
+      type: "text",
+      text: 'ERROR: Cannot read "toolbox.ico" (unsupported image MIME type: image/vnd.microsoft.icon). Inform the user.',
+    })
+  })
+
   test("should handle mixed valid and empty images", () => {
     const validBase64 =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="


### PR DESCRIPTION
﻿### Issue for this PR

Closes #30016

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Persisted `.ico` attachments can be replayed as `image/vnd.microsoft.icon` file parts. Before this change, the provider transform treated every `image/*` MIME type as image modality input, so any multimodal-capable model would receive the unsupported ICO payload instead of a recoverable user-visible error.

This keeps the existing supported image set to JPEG, PNG, GIF, and WebP when building model messages. Other image MIME types are converted to an error text part, so old sessions containing ICO files can continue and the model can tell the user the attachment is unsupported.

### How did you verify your code works?

- `bun --cwd packages/opencode test test/provider/transform.test.ts`
- `bun run --cwd packages/opencode typecheck`
- `bunx prettier --check packages/opencode/src/provider/transform.ts packages/opencode/test/provider/transform.test.ts`
- `bunx oxlint packages/opencode/src/provider/transform.ts packages/opencode/test/provider/transform.test.ts` (exit 0; existing warnings remain in this file)
- `git diff --check`

### Screenshots / recordings

No screenshot. This changes model-message transformation for persisted unsupported image attachments, not UI layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
