### PR TITLE
fix(opencode): default display summarized for gateway opus 4.7+ adaptive reasoning

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -697,6 +697,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
               {
                 thinking: {
                   type: "adaptive",
+                  // Opus 4.7+ flips the API default for `display` to "omitted", which
+                  // returns empty thinking blocks. Force "summarized" so summaries
+                  // survive (4.6/Sonnet 4.6 already default to "summarized").
+                  ...(adaptiveOpus ? { display: "summarized" } : {}),
                 },
                 effort,
               },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2681,12 +2681,14 @@ describe("ProviderTransform.variants", () => {
       expect(result.xhigh).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
         },
         effort: "xhigh",
       })
       expect(result.max).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
         },
         effort: "max",
       })
@@ -2704,6 +2706,47 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+    })
+
+    test("anthropic opus 4.8 forces display summarized for adaptive reasoning", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-8",
+        providerID: "gateway",
+        api: {
+          id: "anthropic/claude-opus-4-8",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "high",
+      })
+    })
+
+    test("anthropic opus 4.6 omits display so it keeps the summarized default", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-opus-4-6",
+        providerID: "gateway",
+        api: {
+          id: "anthropic/claude-opus-4-6",
+          url: "https://gateway.ai",
+          npm: "@ai-sdk/gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "high",
+      })
     })
 
     test("anthropic models return anthropic thinking options", () => {


### PR DESCRIPTION
## Summary
- The `@ai-sdk/gateway` Anthropic branch in `ProviderTransform.variants` emitted `thinking: { type: "adaptive" }` without `display`, even for Opus 4.7+.
- Opus 4.7 / 4.8 flipped the Messages API default for `thinking.display` from `"summarized"` to `"omitted"`, so routing those models through the Vercel AI gateway silently returned empty thinking blocks (no summaries).
- The `@ai-sdk/google-vertex/anthropic` and `@ai-sdk/amazon-bedrock` paths already gate `display: "summarized"` on `adaptiveOpus`; this brings the gateway path in line.

Opus 4.6 / Sonnet 4.6 still default to `"summarized"`, so `display` is intentionally omitted for them (`adaptiveOpus` is `false`).

## Context
This is a follow-up to #29911. While verifying that PR, the gateway path was found to be the one adaptive-Anthropic branch that never set `display`. Per Anthropic's adaptive-thinking docs, `display: "summarized"` is valid on 4.6/4.7/4.8 — the *default* is what changed to `"omitted"` on 4.7+, which is exactly the regression class documented in anthropics/claude-code#49268.

## Tests
- `bun test test/provider/transform.test.ts --timeout 30000` (230 pass)
- Updated the existing gateway Opus 4.7 test to expect `display: "summarized"`, and added gateway regression tests for Opus 4.8 (sets `display`) and Opus 4.6 (omits `display`).

Note: `bun typecheck` currently reports a pre-existing, unrelated error in `packages/core/src/config.ts` (`Cannot find module 'jsonc-parser'`) due to a missing dependency in this environment; it is not introduced by this change.