### PR TITLE
fix(core):Plugins dialog selection highlight jumps around when moving the mouse

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/plugins.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/plugins.tsx
@@ -150,7 +150,6 @@ function showInstall(api: TuiPluginApi) {
 function View(props: { api: TuiPluginApi }) {
   const size = useTerminalDimensions()
   const [list, setList] = createSignal(props.api.plugins.list())
-  const [cur, setCur] = createSignal<string | undefined>()
   const [lock, setLock] = createSignal(false)
 
   createEffect(() => {
@@ -202,15 +201,12 @@ function View(props: { api: TuiPluginApi }) {
     <DialogSelect
       title="Plugins"
       options={rows()}
-      current={cur()}
-      onMove={(item) => setCur(item.value)}
       actions={[
         {
           title: "toggle",
           command: "plugins.toggle",
           disabled: lock(),
           onTrigger: (item) => {
-            setCur(item.value)
             flip(item.value)
           },
         },
@@ -224,7 +220,6 @@ function View(props: { api: TuiPluginApi }) {
         },
       ]}
       onSelect={(item) => {
-        setCur(item.value)
         flip(item.value)
       }}
     />


### PR DESCRIPTION
### Issue for this PR

Closes #29970

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Unnecessary cur state and onMove callback in plugins.tsx have been directly removed. DialogSelect internally manages the highlight index through store.selected; the sorting of the plugin list is based on source and id (unrelated to the active state), so after toggling, the index still points to the correct plugin, eliminating the need for external synchronization of the highlight state through current.


### How did you verify your code works?

By building and running opencode

### Screenshots / recordings

https://github.com/user-attachments/assets/f2a3905a-6ee9-4273-a46f-1c0e1bc6f7ee


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
