### PR TITLE
fix(opencode): cap session-level retries and export MAX_SESSION_RETRIES

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -173,6 +173,8 @@ function parseJSON(value: unknown) {
   })
 }
 
+export const MAX_SESSION_RETRIES = 5
+
 export function policy(opts: {
   provider: string
   parse: (error: unknown) => Err
@@ -182,7 +184,7 @@ export function policy(opts: {
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
-      if (!retry) return Cause.done(meta.attempt)
+      if (!retry || meta.attempt > MAX_SESSION_RETRIES) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -85,6 +85,35 @@ describe("session.retry.delay", () => {
     expect(SessionRetry.delay(1, error)).toBe(SessionRetry.RETRY_MAX_DELAY)
   })
 
+  it.instance("policy stops retrying after MAX_SESSION_RETRIES attempts on persistent failure", () =>
+    Effect.gen(function* () {
+      const error = apiError({ "retry-after-ms": "0" })
+      const sessionID = SessionID.make("session-retry-cap-test")
+      const status = yield* SessionStatus.Service
+
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+          set: (info) =>
+            status.set(sessionID, {
+              type: "retry",
+              attempt: info.attempt,
+              message: info.message,
+              next: info.next,
+            }),
+        }),
+      )
+
+      for (let i = 0; i < SessionRetry.MAX_SESSION_RETRIES; i++) {
+        yield* step(error)
+      }
+
+      const final = yield* Effect.exit(step(error))
+      expect(final._tag).toBe("Failure")
+    }),
+  )
+
   it.instance("policy updates retry status and increments attempts", () =>
     Effect.gen(function* () {
       const sessionID = SessionID.make("session-retry-test")


### PR DESCRIPTION
### Issue for this PR

Closes #29143

### Type of change

- [x] Bug fix

### What does this PR do?

The session retry schedule in `retry.ts` had no attempt cap — persistent provider failures (5xx, 503) would cycle indefinitely since `retryable()` always returned truthy for those errors.

Adds `MAX_SESSION_RETRIES = 5` and exports it so `test/session/retry.test.ts` can drive the schedule to exhaustion to verify the cap fires. Also adds the missing test case.

### How did you verify your code works?

`bun test test/session/retry.test.ts` — 34 pass, 0 fail

![test-results](https://github.com/user-attachments/assets/fe2ea0f8-c1b0-4146-8483-b48d4efd507c)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR