### PR TITLE
docs(web): fix invalid YAML indentation in GitHub workflow example

### DIFF
--- a/packages/web/src/content/docs/ar/github.mdx
+++ b/packages/web/src/content/docs/ar/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **تخزين مفاتيح API ضمن secrets**

--- a/packages/web/src/content/docs/bs/github.mdx
+++ b/packages/web/src/content/docs/bs/github.mdx
@@ -61,13 +61,13 @@ Ili ga možete postaviti ručno.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
 ```
 
 3. **Sačuvaj API ključeve u tajne**

--- a/packages/web/src/content/docs/da/github.mdx
+++ b/packages/web/src/content/docs/da/github.mdx
@@ -64,13 +64,13 @@ Eller du kan indstille det manuelt.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Opbevar API-nøglerne i hemmeligheder**

--- a/packages/web/src/content/docs/de/github.mdx
+++ b/packages/web/src/content/docs/de/github.mdx
@@ -64,13 +64,13 @@ Oder Sie können es manuell einrichten.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Speichern Sie die API-Schlüssel in Secrets**

--- a/packages/web/src/content/docs/es/github.mdx
+++ b/packages/web/src/content/docs/es/github.mdx
@@ -64,13 +64,13 @@ O puede configurarlo manualmente.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Guarda las claves API en secretos**

--- a/packages/web/src/content/docs/fr/github.mdx
+++ b/packages/web/src/content/docs/fr/github.mdx
@@ -64,13 +64,13 @@ Ajoutez le fichier de workflow suivant à `.github/workflows/opencode.yml` dans 
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
 ```
 
 3. **Stockez les clés API dans les secrets**

--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -64,13 +64,13 @@ Or you can set it up manually.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Store the API keys in secrets**

--- a/packages/web/src/content/docs/it/github.mdx
+++ b/packages/web/src/content/docs/it/github.mdx
@@ -64,13 +64,13 @@ In alternativa, puoi configurarlo manualmente.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Salva le API key nei secret**

--- a/packages/web/src/content/docs/ja/github.mdx
+++ b/packages/web/src/content/docs/ja/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
 ```
 
 3. **API キーをシークレットに保存する**

--- a/packages/web/src/content/docs/ko/github.mdx
+++ b/packages/web/src/content/docs/ko/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Store the API keys in secrets**

--- a/packages/web/src/content/docs/nb/github.mdx
+++ b/packages/web/src/content/docs/nb/github.mdx
@@ -64,13 +64,13 @@ Eller du kan sette den opp manuelt.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Lagre API-nøklene i hemmeligheter**

--- a/packages/web/src/content/docs/pl/github.mdx
+++ b/packages/web/src/content/docs/pl/github.mdx
@@ -64,13 +64,13 @@ Można też uszkodzić to rozwiązanie.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Przechowuj klucze API w tajemnicy**

--- a/packages/web/src/content/docs/pt-br/github.mdx
+++ b/packages/web/src/content/docs/pt-br/github.mdx
@@ -64,13 +64,13 @@ Ou você pode configurá-lo manualmente.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Armazene as chaves de API em segredos**

--- a/packages/web/src/content/docs/ru/github.mdx
+++ b/packages/web/src/content/docs/ru/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Храните ключи API в секрете**

--- a/packages/web/src/content/docs/th/github.mdx
+++ b/packages/web/src/content/docs/th/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **เก็บคีย์ API เป็นความลับ**

--- a/packages/web/src/content/docs/tr/github.mdx
+++ b/packages/web/src/content/docs/tr/github.mdx
@@ -64,13 +64,13 @@ Veya manuel olarak ayarlayabilirsiniz.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **API anahtarlarını gizli olarak saklayın**

--- a/packages/web/src/content/docs/zh-cn/github.mdx
+++ b/packages/web/src/content/docs/zh-cn/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **将 API 密钥存储到 Secrets 中**

--- a/packages/web/src/content/docs/zh-tw/github.mdx
+++ b/packages/web/src/content/docs/zh-tw/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **將 API 金鑰儲存到 Secrets 中**


### PR DESCRIPTION
### Issue for this PR

Closes #18717

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The "Manual Setup" workflow example in `github.mdx` has a misindented `Run OpenCode` step. Its `uses:`/`env:`/`with:` keys are indented 11 spaces while the list item `- name:` puts `name:` at 12 spaces, so the keys sit one space short of the mapping. YAML requires sibling keys in a block mapping to share the same indentation, so a parser hits the `uses:` line, sees it dedented below `name:`, and treats it as the end of the `steps` block collection — which is a syntax error. Anyone copying the example into `.github/workflows/opencode.yml` gets a file GitHub rejects.

The fix adds one space to that step so its keys align with `name:` and its `env`/`with` children sit at the next level, exactly matching the `Checkout repository` step right above it. The same block was duplicated verbatim into every translated copy, so I applied the identical fix to all 18 `github.mdx` files (en + 17 locales). It is whitespace-only — no prose or values changed.

### How did you verify your code works?

I extracted the fenced YAML and dedented it (what a reader actually copies from the rendered code block), then parsed it with a libyaml-based parser:

- Before: fails with `did not find expected '-' indicator while parsing a block collection`.
- After: parses cleanly and both steps resolve to `["Checkout repository", "Run OpenCode"]`.

### Screenshots / recordings

N/A — docs-only, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR