### PR TITLE
fix(opencode): add mcp WebSocket subprotocol for JetBrains compatibility

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/editor.ts
@@ -449,12 +449,13 @@ function pathContainsLength(parent: string, child: string) {
 }
 
 function openEditorSocket(connection: EditorConnection, WebSocketImpl: typeof WebSocket) {
-  if (!connection.authToken) return new WebSocketImpl(connection.url)
+  if (!connection.authToken) return new WebSocketImpl(connection.url, ["mcp"])
 
   return new WebSocketImpl(connection.url, {
     headers: {
       "x-claude-code-ide-authorization": connection.authToken,
     },
+    protocols: ["mcp"],
   } as any)
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #30082

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Claude Code JetBrains plugin uses Ktor as its WebSocket server, and Ktor requires a matching `Sec-WebSocket-Protocol` header to accept the upgrade — in this case `mcp`. Without it the server returns `400 Bad Request` immediately and opencode never connects, so the active file and selection are never picked up from IntelliJ.

The fix adds `"mcp"` as the subprotocol in `openEditorSocket`. VS Code's server doesn't enforce this so it was never an issue there.

I found the root cause by decompiling the plugin JAR — `WebSocketMcpServerTransportKt.class` has a `MCP_SUBPROTOCOL = "mcp"` constant, and confirmed it with curl: the handshake fails without the header and succeeds with it.

### How did you verify your code works?

Built from source and ran against IntelliJ IDEA 2026.1 with Claude Code JetBrains plugin 0.1.14-beta. Switching files in IntelliJ now correctly updates the hint line in opencode.

### Screenshots / recordings

_N/A — not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR