### PR TITLE
fix(observability): flush OTel spans on exit for opencode run

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -123,6 +123,24 @@ async function toolError(part: ToolPart) {
   }
 }
 
+// Builds the in-process embedded server used by local run modes. Returns the
+// fetch shim the SDK/TUI talk to plus a `dispose` that tears down the server's
+// web handler — releasing its hold on the shared (memoMap-memoized) Observability
+// layer so buffered OTel spans flush on exit rather than being killed by process.exit.
+async function embeddedServer() {
+  const { Server } = await import("@/server/server")
+  const server = Server.Default().app
+  const fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init)
+    const headers = new Headers(request.headers)
+    const { ServerAuth } = await import("@/server/auth")
+    const auth = ServerAuth.header()
+    if (auth) headers.set("Authorization", auth)
+    return server.fetch(new Request(request, { headers }))
+  }) as typeof globalThis.fetch
+  return { fetch, dispose: server.dispose }
+}
+
 export const RunCommand = effectCmd({
   command: "run [message..]",
   describe: "run opencode with a message",
@@ -675,8 +693,19 @@ export const RunCommand = effectCmd({
         }
         const sessionID = sess.id
 
+        // A rejected prompt surfaces the same failure twice: synchronously via
+        // `session.prompt`'s result.error, and asynchronously via the session.error
+        // event drained by `loop`. process.exit() used to mask the second write by
+        // killing the process first; now that shutdown is graceful (runtime/server
+        // disposal is awaited before exit), both would reach stdout. Emit at most one
+        // terminal error record in JSON mode so the output stays a single pure record.
+        let errorEmitted = false
         function emit(type: string, data: Record<string, unknown>) {
           if (args.format === "json") {
+            if (type === "error") {
+              if (errorEmitted) return true
+              errorEmitted = true
+            }
             process.stdout.write(
               JSON.stringify({
                 type,
@@ -902,19 +931,12 @@ export const RunCommand = effectCmd({
       if (interactive && !args.attach && !args.session && !args.continue) {
         const model = pick(args.model)
         const { runInteractiveLocalMode } = await import("./run/runtime")
-        const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
-          const { Server } = await import("@/server/server")
-          const request = new Request(input, init)
-          const headers = new Headers(request.headers)
-          const auth = ServerAuth.header()
-          if (auth) headers.set("Authorization", auth)
-          return Server.Default().app.fetch(new Request(request, { headers }))
-        }) as typeof globalThis.fetch
+        const server = await embeddedServer()
 
         try {
           return await runInteractiveLocalMode({
             directory: directory ?? root,
-            fetch: fetchFn,
+            fetch: server.fetch,
             resolveAgent: localAgent,
             session,
             share,
@@ -932,6 +954,8 @@ export const RunCommand = effectCmd({
           })
         } catch (error) {
           dieInteractive(error)
+        } finally {
+          await server.dispose()
         }
       }
 
@@ -940,20 +964,17 @@ export const RunCommand = effectCmd({
         return await execute(sdk)
       }
 
-      const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
-        const { Server } = await import("@/server/server")
-        const request = new Request(input, init)
-        const headers = new Headers(request.headers)
-        const auth = ServerAuth.header()
-        if (auth) headers.set("Authorization", auth)
-        return Server.Default().app.fetch(new Request(request, { headers }))
-      }) as typeof globalThis.fetch
-      const sdk = createOpencodeClient({
-        baseUrl: "http://opencode.internal",
-        fetch: fetchFn,
-        directory,
-      })
-      await execute(sdk)
+      const server = await embeddedServer()
+      try {
+        const sdk = createOpencodeClient({
+          baseUrl: "http://opencode.internal",
+          fetch: server.fetch,
+          directory,
+        })
+        await execute(sdk)
+      } finally {
+        await server.dispose()
+      }
     })
   }),
 })

--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -77,20 +77,29 @@ export const effectCmd = <Args, A>(opts: EffectCmdOpts<Args, A>) =>
       // yargs typing wraps Args in ArgumentsCamelCase<WithDoubleDash<...>>; cast at the boundary.
       const args = rawArgs as unknown as WithDoubleDash<Args>
       const useInstance = typeof opts.instance === "function" ? opts.instance(args) : opts.instance !== false
-      if (!useInstance) {
-        await AppRuntime.runPromise(opts.handler(args))
-        return
-      }
-      const { InstanceStore } = await import("@/project/instance-store")
-      const { InstanceRef } = await import("@/effect/instance-ref")
-      const directory = opts.directory?.(args) ?? process.cwd()
-      const { store, ctx } = await AppRuntime.runPromise(
-        InstanceStore.Service.use((store) => store.load({ directory }).pipe(Effect.map((ctx) => ({ store, ctx })))),
-      )
       try {
-        await AppRuntime.runPromise(opts.handler(args).pipe(Effect.provideService(InstanceRef, ctx)))
+        if (!useInstance) {
+          await AppRuntime.runPromise(opts.handler(args))
+          return
+        }
+        const { InstanceStore } = await import("@/project/instance-store")
+        const { InstanceRef } = await import("@/effect/instance-ref")
+        const directory = opts.directory?.(args) ?? process.cwd()
+        const { store, ctx } = await AppRuntime.runPromise(
+          InstanceStore.Service.use((store) => store.load({ directory }).pipe(Effect.map((ctx) => ({ store, ctx })))),
+        )
+        try {
+          await AppRuntime.runPromise(opts.handler(args).pipe(Effect.provideService(InstanceRef, ctx)))
+        } finally {
+          await AppRuntime.runPromise(store.dispose(ctx))
+        }
       } finally {
-        await AppRuntime.runPromise(store.dispose(ctx))
+        // effectCmd is the seam that lazily acquires AppRuntime, so it owns teardown.
+        // Disposing the ManagedRuntime releases the app layers — which flushes pending
+        // telemetry (the OTel BatchSpanProcessor's buffer) before the process exits.
+        // Keeping disposal here preserves lazy runtime init: index.ts never imports
+        // app-runtime.ts, so `--help`/`--version`/completion don't load the full runtime.
+        await AppRuntime.dispose().catch(() => {})
       }
     },
   })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -27,6 +27,7 @@ export type Listener = {
 type ServerApp = {
   fetch(request: Request): Response | Promise<Response>
   request(input: string | URL | Request, init?: RequestInit): Response | Promise<Response>
+  dispose(): Promise<void>
 }
 
 type ListenOptions = CorsOptions & {
@@ -54,12 +55,13 @@ class ListenerServerService extends Context.Service<ListenerServerService, Liste
 ) {}
 
 export const Default = lazy(() => {
-  const handler = HttpApiApp.webHandler().handler
+  const web = HttpApiApp.webHandler()
   const app: ServerApp = {
-    fetch: (request: Request) => handler(request, HttpApiApp.context),
+    fetch: (request: Request) => web.handler(request, HttpApiApp.context),
     request(input, init) {
       return app.fetch(input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init))
     },
+    dispose: web.dispose,
   }
   return { app }
 })

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -23,6 +23,39 @@ describe("opencode run (non-interactive subprocess)", () => {
     60_000,
   )
 
+  // Regression for #30087: process.exit() used to kill the event loop before the
+  // OTel BatchSpanProcessor flushed. The LLM is mocked so the run is fast enough
+  // that the processor's periodic export timer never fires — the collector only
+  // sees /v1/traces if disposal (embedded server + AppRuntime) forces the flush.
+  cliIt.concurrent(
+    "flushes server telemetry before exiting",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        const requests: string[] = []
+        const collector = yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            Bun.serve({
+              port: 0,
+              fetch(request) {
+                requests.push(new URL(request.url).pathname)
+                return new Response(null, { status: 200 })
+              },
+            }),
+          ),
+          (server) => Effect.sync(() => server.stop(true)),
+        )
+        yield* llm.text("telemetry response")
+
+        const result = yield* opencode.run("say hi", {
+          env: { OTEL_EXPORTER_OTLP_ENDPOINT: collector.url.toString().replace(/\/$/, "") },
+        })
+
+        opencode.expectExit(result, 0)
+        expect(requests).toContain("/v1/traces")
+      }),
+    60_000,
+  )
+
   cliIt.concurrent(
     "prints each completed text part in order around a tool continuation",
     ({ llm, opencode }) =>


### PR DESCRIPTION
### Issue for this PR

Closes #30087

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run` never emits OTel spans: `process.exit()` in `index.ts` kills the event loop before the `BatchSpanProcessor` flushes its buffer.

The embedded server and `AppRuntime` share a single, `memoMap`-memoized `Observability` layer — one `BatchSpanProcessor` referenced by two scopes — so a flush (`NodeSdk.shutdown()` → `forceFlush()`) only fires once **both** scopes are released. This PR disposes both at their ownership seams:

- **`effectCmd`** disposes `AppRuntime` in its `finally`. This is the seam that already lazily imports the runtime, so `index.ts` never eagerly pulls in the full application graph on every invocation (`--help`/`--version`/completion included). This addresses the review feedback on the original `index.ts` approach.
- **`run.ts`** disposes the embedded server after each local run mode, so the server stops holding the shared span processor open. `Server.Default()` now exposes the web handler's `dispose()`.

This converges with the approach in the (now-closed) #39756.

### How did you verify your code works?

Added `test/cli/run/run-process.test.ts` → **"flushes server telemetry before exiting"**: spawns `opencode run` against a stub OTLP collector with a **mocked** (fast) LLM, and asserts the collector receives `/v1/traces`. The mock keeps the run short enough that the `BatchSpanProcessor`'s periodic export timer never fires, so the test only passes if disposal forces the flush.

```
bun test test/cli/run/run-process.test.ts -t "flushes server telemetry before exiting"
```

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

