### PR TITLE
fix: validate cwd before shell spawn to prevent misleading ENOENT

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -476,6 +476,18 @@ export const ShellTool = Tool.define(
         },
       })
 
+      // Validate cwd exists before spawning. Bun misattributes a missing cwd
+      // as ENOENT on the shell binary (e.g., '/bin/bash'), which is misleading.
+      // See: https://github.com/oven-sh/bun/issues/14535
+      const fs = yield* AppFileSystem.Service
+      if (!(yield* fs.isDir(input.cwd).pipe(Effect.orDie))) {
+        throw Object.assign(new Error(`No such file or directory: '${input.cwd}'`), {
+          code: "ENOENT",
+          errno: -2,
+          path: input.cwd,
+        })
+      }
+
       const code: number | null = yield* Effect.scoped(
         Effect.gen(function* () {
           yield* Effect.addFinalizer(closeSink)


### PR DESCRIPTION
## Problem

When the working directory passed to the shell tool does not exist,
`Bun.spawn` reports `ENOENT` on the shell binary (e.g., `/bin/bash`)
instead of the missing cwd. This is a [known Bun bug](https://github.com/oven-sh/bun/issues/14535).

During long sessions, the cwd can become stale (git operations, build tools,
directory changes), causing intermittent `ENOENT: posix_spawn '/bin/bash'`
errors that make it appear bash itself is missing.

## Fix

Add `fs.isDir(cwd)` validation before `spawner.spawn()` in `tool/shell.ts`,
matching the pattern already used in `file/ripgrep.ts` (PR #3396). This
produces the correct error message (`No such file or directory: /path/to/dir`)
and prevents the misleading `/bin/bash` ENOENT.

## Related

- Fixes #20973
- Same pattern as #3396 / #3158 (ripgrep cwd validation)
- Upstream Bun bug: oven-sh/bun#14535
