### PR TITLE
fix(core): stabilize migration registry generation

### DIFF
--- a/packages/core/script/migration.ts
+++ b/packages/core/script/migration.ts
@@ -113,8 +113,10 @@ function escapeTemplate(line: string) {
 function renderRegistry(names: string[]) {
   return `import type { DatabaseMigration } from "./migration"
 
-export const migrations = (await Promise.all([
-${names.map((name) => `  import("./migration/${name}"),`).join("\n")}
-])).map((module) => module.default) satisfies DatabaseMigration.Migration[]
+export const migrations = (
+  await Promise.all([
+${names.map((name) => `    import("./migration/${name}"),`).join("\n")}
+  ])
+).map((module) => module.default) satisfies DatabaseMigration.Migration[]
 `
 }


### PR DESCRIPTION
## Summary

- align the core migration registry renderer with the Prettier-stable multiline output
- prevent the migration drift check from failing on formatting-only registry differences

## Root cause

The migration check compares migration.gen.ts to the exact string emitted by renderRegistry(). A generated commit formatted migration.gen.ts into the Prettier multiline shape, but the renderer still emitted the older compact shape, so bun script/migration.ts --check failed even though Drizzle reported no schema changes.

## Validation

- bun script/migration.ts --check
- bun test test/database-migration.test.ts --timeout 30000 from packages/core
- bun typecheck from packages/core
- pre-push bun turbo typecheck
