### PR TITLE
fix: preserve Copilot catalog variants

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -147,8 +147,9 @@ function build(key: string, remote: Item, url: string, prev?: Model): Model {
       }
     }
   }
-  if (Object.keys(variants).length > 0) {
-    model.variants = variants
+  const mergedVariants = !isMsgApi ? { ...prev?.variants, ...variants } : variants
+  if (Object.keys(mergedVariants).length > 0) {
+    model.variants = mergedVariants
   }
 
   return model

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -215,6 +215,105 @@ test("clears existing variants so refreshed models calculate provider-specific v
   expect(models["claude-opus-4.7"].variants).toBeUndefined()
 })
 
+test("keeps catalog variants missing from the Copilot models endpoint", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "gpt-5.2",
+              name: "GPT-5.2",
+              version: "gpt-5.2-2026-02-01",
+              capabilities: {
+                family: "gpt",
+                limits: {
+                  max_context_window_tokens: 400000,
+                  max_output_tokens: 128000,
+                  max_prompt_tokens: 400000,
+                },
+                supports: {
+                  reasoning_effort: ["low", "medium", "high"],
+                  streaming: true,
+                  tool_calls: true,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const models = await CopilotModels.get(
+    "https://api.githubcopilot.com",
+    {},
+    {
+      "gpt-5.2": {
+        id: "gpt-5.2",
+        providerID: "github-copilot",
+        api: {
+          id: "gpt-5.2",
+          url: "https://api.githubcopilot.com",
+          npm: "@ai-sdk/github-copilot",
+        },
+        name: "GPT-5.2",
+        family: "gpt",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: true,
+          toolcall: true,
+          input: {
+            text: true,
+            audio: false,
+            image: true,
+            video: false,
+            pdf: false,
+          },
+          output: {
+            text: true,
+            audio: false,
+            image: false,
+            video: false,
+            pdf: false,
+          },
+          interleaved: false,
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: {
+            read: 0,
+            write: 0,
+          },
+        },
+        limit: {
+          context: 400000,
+          input: 400000,
+          output: 128000,
+        },
+        options: {},
+        headers: {},
+        release_date: "2026-02-01",
+        variants: {
+          xhigh: {
+            reasoningEffort: "xhigh",
+            reasoningSummary: "auto",
+            include: ["reasoning.encrypted_content"],
+          },
+        },
+        status: "active",
+      },
+    },
+  )
+
+  expect(models["gpt-5.2"].variants?.xhigh?.reasoningEffort).toBe("xhigh")
+  expect(models["gpt-5.2"].variants?.low?.reasoningEffort).toBe("low")
+})
+
 test("remaps fallback oauth model urls to the enterprise host", async () => {
   globalThis.fetch = mock(() => Promise.reject(new Error("timeout"))) as unknown as typeof fetch
 


### PR DESCRIPTION
## Summary
- keep existing catalog variants when refreshing GitHub Copilot models from the `/models` endpoint
- still let the endpoint-provided variants override matching catalog keys
- keep message-API models on their provider-specific variant path so stale Copilot variants are not carried across

Fixes #30092.

## To verify
- bun --cwd packages\opencode test test\plugin\github-copilot-models.test.ts
- bunx prettier --check packages\opencode\src\plugin\github-copilot\models.ts packages\opencode\test\plugin\github-copilot-models.test.ts
- bun --cwd packages\opencode typecheck
- bunx oxlint packages\opencode\src\plugin\github-copilot\models.ts packages\opencode\test\plugin\github-copilot-models.test.ts