### PR TITLE
fix: honor v2 session list filters

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -2,7 +2,7 @@ export * as SessionV2 from "./session"
 export * from "./session/schema"
 
 import { DateTime, Effect, Layer, Schema, Context } from "effect"
-import { and, asc, desc, eq, gt, gte, like, lt, or, type SQL } from "drizzle-orm"
+import { and, asc, desc, eq, gt, gte, isNull, like, lt, or, type SQL } from "drizzle-orm"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
 import { ModelV2 } from "./model"
@@ -35,6 +35,9 @@ export type ListCursor = typeof ListCursor.Type
 
 const ListInputBase = {
   workspaceID: WorkspaceV2.ID.pipe(Schema.optional),
+  path: Schema.String.pipe(Schema.optional),
+  roots: Schema.Boolean.pipe(Schema.optional),
+  start: Schema.Finite.pipe(Schema.optional),
   search: Schema.String.pipe(Schema.optional),
   limit: Schema.Int.pipe(Schema.optional),
   order: Schema.Literals(["asc", "desc"]).pipe(Schema.optional),
@@ -209,6 +212,11 @@ export const layer = Layer.effect(
         if ("directory" in input) conditions.push(eq(SessionTable.directory, input.directory))
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
         if ("project" in input) conditions.push(eq(SessionTable.project_id, input.project))
+        if (input.path) {
+          conditions.push(or(eq(SessionTable.path, input.path), like(SessionTable.path, `${input.path}/%`))!)
+        }
+        if (input.roots) conditions.push(isNull(SessionTable.parent_id))
+        if (input.start) conditions.push(gte(sortColumn, input.start))
         if (input.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
         if (input.cursor) {
           conditions.push(

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/v2/session.ts
@@ -119,6 +119,9 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "v2.session
             limit: ctx.query.limit ?? DefaultSessionsLimit,
             order,
             workspaceID: filters.workspaceID,
+            path: filters.path,
+            roots: filters.roots,
+            start: filters.start,
             search: filters.search,
             cursor: decoded ? { id: decoded.id, time: decoded.time, direction: decoded.direction } : undefined,
           }

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -435,6 +435,43 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "honors v2 session list filters",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const nestedDir = path.join(test.directory, "packages", "opencode", "src")
+        yield* Effect.promise(() => mkdir(nestedDir, { recursive: true }))
+
+        const parent = yield* createSession({ title: "v2 parent" })
+        const child = yield* createSession({ title: "v2 child", parentID: parent.id })
+        const nested = yield* createSession({ title: "v2 nested" }).pipe(provideInstanceEffect(nestedDir))
+
+        const roots = yield* requestJson<{ items: Array<{ id: string }> }>("/api/session?roots=true&limit=20", {
+          headers,
+        })
+        const rootIDs = roots.items.map((session) => session.id)
+        expect(rootIDs).toContain(parent.id)
+        expect(rootIDs).not.toContain(child.id)
+
+        const future = yield* requestJson<{ items: Array<{ id: string }> }>(
+          `/api/session?start=${Date.now() + 86_400_000}&limit=20`,
+          { headers },
+        )
+        expect(future.items.map((session) => session.id)).not.toContain(parent.id)
+
+        const pathFiltered = yield* requestJson<{ items: Array<{ id: string }> }>(
+          "/api/session?path=packages/opencode&limit=20",
+          { headers },
+        )
+        const pathIDs = pathFiltered.items.map((session) => session.id)
+        expect(pathIDs).toContain(nested.id)
+        expect(pathIDs).not.toContain(parent.id)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "returns v2 public request errors for cursor and workspace query failures",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Fixes #30109

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v2 session list API accepted filters such as `roots`, `start`, and `path`, but the handler did not pass them through to the session service. This wires those filters into the query path and adds an HTTP API regression test for root-only, start-time, and path filtering.

### How did you verify your code works?

- `bun --cwd packages\opencode test test\server\httpapi-session.test.ts -t "honors v2 session list filters"`
- `bun --cwd packages\opencode test test\server\httpapi-session.test.ts`
- `bun --cwd packages\opencode typecheck`
- `bun --cwd packages\core typecheck`
- `bunx prettier --check packages\core\src\session.ts packages\opencode\src\server\routes\instance\httpapi\handlers\v2\session.ts packages\opencode\test\server\httpapi-session.test.ts`
- `bunx oxlint packages\core\src\session.ts packages\opencode\src\server\routes\instance\httpapi\handlers\v2\session.ts packages\opencode\test\server\httpapi-session.test.ts` (warnings only, no errors)
- `git diff --check`

### Screenshots / recordings

N/A; this is an API behavior fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR