### PR TITLE
fix: print empty session json

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -86,7 +86,7 @@ export const SessionListCommand = effectCmd({
   handler: Effect.fn("Cli.session.list")(function* (args) {
     const sessions = yield* Session.Service.use((svc) => svc.list({ roots: true, limit: args.maxCount }))
 
-    if (sessions.length === 0) return
+    if (sessions.length === 0 && args.format !== "json") return
 
     const output = args.format === "json" ? formatSessionJSON(sessions) : formatSessionTable(sessions)
 

--- a/packages/opencode/test/cli/smokes/read-only.test.ts
+++ b/packages/opencode/test/cli/smokes/read-only.test.ts
@@ -87,6 +87,17 @@ describe("opencode read-only commands (smoke)", () => {
     60_000,
   )
 
+  cliIt.live(
+    "session list json: exits 0 and prints an empty array",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const r = yield* opencode.spawn(["session", "list", "--format", "json"])
+        opencode.expectExit(r, 0, "session list --format json")
+        expect(r.stdout.trim()).toBe("[]")
+      }),
+    60_000,
+  )
+
   // `stats` aggregates token usage from the session DB. Empty DB → all zeros.
   cliIt.live(
     "stats: exits 0",


### PR DESCRIPTION
### Issue for this PR

Fixes #30100

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`session list --format json` printed empty stdout when no sessions existed, which makes the command invalid for scripts expecting JSON. This keeps the output machine-readable by returning `[]` for the empty list case and adds a CLI smoke regression.

### How did you verify your code works?

- `bun --cwd packages\opencode test test\cli\smokes\read-only.test.ts -t "session list json"`
- `bun --cwd packages\opencode typecheck`
- `bunx prettier --check packages\opencode\src\cli\cmd\session.ts packages\opencode\test\cli\smokes\read-only.test.ts`
- `bunx oxlint packages\opencode\src\cli\cmd\session.ts packages\opencode\test\cli\smokes\read-only.test.ts` (existing warning only, no errors)
- `git diff --check`

### Screenshots / recordings

N/A; this is CLI JSON output behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR