### PR TITLE
fix(core): add MiniMax M3 model

### DIFF
--- a/packages/core/src/plugin/provider.ts
+++ b/packages/core/src/plugin/provider.ts
@@ -16,6 +16,7 @@ import { GoogleVertexAnthropicPlugin, GoogleVertexPlugin } from "./provider/goog
 import { GroqPlugin } from "./provider/groq"
 import { KiloPlugin } from "./provider/kilo"
 import { LLMGatewayPlugin } from "./provider/llmgateway"
+import { MiniMaxPlugin } from "./provider/minimax"
 import { MistralPlugin } from "./provider/mistral"
 import { NvidiaPlugin } from "./provider/nvidia"
 import { OpenAIPlugin } from "./provider/openai"
@@ -50,6 +51,7 @@ export const ProviderPlugins = [
   GroqPlugin,
   KiloPlugin,
   LLMGatewayPlugin,
+  MiniMaxPlugin,
   MistralPlugin,
   NvidiaPlugin,
   OpencodePlugin,

--- a/packages/core/src/plugin/provider/minimax.ts
+++ b/packages/core/src/plugin/provider/minimax.ts
@@ -1,0 +1,46 @@
+import { DateTime, Effect } from "effect"
+import { ModelV2 } from "../../model"
+import { PluginV2 } from "../../plugin"
+import { ProviderV2 } from "../../provider"
+
+const provider = ProviderV2.ID.make("minimax")
+const m3 = ModelV2.ID.make("MiniMax-M3")
+
+export const MiniMaxPlugin = PluginV2.define({
+  id: PluginV2.ID.make("minimax"),
+  effect: Effect.gen(function* () {
+    return {
+      "catalog.transform": Effect.fn(function* (evt) {
+        const item = evt.provider.get(provider)
+        if (!item) return
+        evt.model.update(provider, m3, (model) => {
+          model.name = "MiniMax-M3"
+          model.family = ModelV2.Family.make("minimax")
+          model.endpoint = { type: "unknown" }
+          model.capabilities = {
+            tools: true,
+            input: ["text", "image", "video"],
+            output: ["text"],
+          }
+          model.time.released = DateTime.makeUnsafe(Date.parse("2026-05-31"))
+          model.cost = [
+            {
+              input: 0.6,
+              output: 2.4,
+              cache: {
+                read: 0.12,
+                write: 0,
+              },
+            },
+          ]
+          model.limit = {
+            context: 512_000,
+            output: 131_072,
+          }
+          model.enabled = true
+          model.status = "active"
+        })
+      }),
+    }
+  }),
+})

--- a/packages/core/test/plugin/provider-minimax.test.ts
+++ b/packages/core/test/plugin/provider-minimax.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { Catalog } from "@opencode-ai/core/catalog"
+import { MiniMaxPlugin } from "@opencode-ai/core/plugin/provider/minimax"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { it, provider } from "./provider-helper"
+
+describe("MiniMaxPlugin", () => {
+  it.effect("adds MiniMax-M3 to the MiniMax provider", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const catalog = yield* Catalog.Service
+      yield* plugin.add(MiniMaxPlugin)
+      const transform = yield* catalog.transform()
+      yield* transform((catalog) => {
+        const item = provider("minimax", {
+          endpoint: {
+            type: "aisdk",
+            package: "@ai-sdk/openai-compatible",
+            url: "https://api.minimaxi.com/v1",
+          },
+        })
+        catalog.provider.update(item.id, (draft) => {
+          draft.endpoint = item.endpoint
+        })
+      })
+
+      const model = yield* catalog.model.get(ProviderV2.ID.make("minimax"), ModelV2.ID.make("MiniMax-M3"))
+      expect(model.name).toBe("MiniMax-M3")
+      expect(model.limit.context).toBe(512_000)
+      expect(model.capabilities.input).toContain("image")
+      expect(model.capabilities.input).toContain("video")
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #30163

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds MiniMax-M3 to the MiniMax provider catalog when the upstream model feed has not listed it yet.

The model uses the existing MiniMax provider endpoint, with the public M3 limits, modalities, release date, and pricing metadata. I verified the official MiniMax endpoint accepts `MiniMax-M3` on `https://api.minimaxi.com/v1/text/chatcompletion_v2`.

### How did you verify your code works?

- `bun test test/plugin/provider-minimax.test.ts` from `packages/core`
- `bun typecheck` from `packages/core`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
