### PR TITLE
fix(app): show project sessions before path sync resolves

### DIFF
--- a/packages/app/e2e/regression/session-list-path-loading.spec.ts
+++ b/packages/app/e2e/regression/session-list-path-loading.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test"
+import { fixture, pageMessages } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+test("shows loaded sessions before the directory path request resolves", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    sessions: fixture.sessions,
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    pageMessages,
+  })
+
+  let releasePath!: () => void
+  const pathBlocked = new Promise<void>((resolve) => {
+    releasePath = resolve
+  })
+  await page.route("**/path?*", async (route) => {
+    if (!new URL(route.request().url()).searchParams.has("directory")) return route.fallback()
+    await pathBlocked
+    return route.fallback()
+  })
+
+  await page.addInitScript((directory) => {
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({
+        projects: { local: [{ worktree: directory, expanded: true }] },
+        lastProject: { local: directory },
+      }),
+    )
+  }, fixture.directory)
+
+  await page.goto("/")
+  try {
+    await expect(page.getByText(fixture.expected.sourceTitle).first()).toBeVisible({ timeout: 5_000 })
+  } finally {
+    releasePath()
+  }
+})

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -128,6 +128,35 @@ describe("createChildStoreManager", () => {
     }
   })
 
+  test("falls back to the requested directory before the path query resolves", () => {
+    let manager: ReturnType<typeof createChildStoreManager> | undefined
+
+    const dispose = createOwner((owner) => {
+      manager = createChildStoreManager({
+        owner,
+        isBooting: () => false,
+        isLoadingSessions: () => false,
+        onBootstrap() {},
+        onMcp() {},
+        onDispose() {},
+        translate: (key) => key,
+        queryOptions: queryOptionsApi,
+        global: { provider },
+      })
+    })
+
+    try {
+      if (!manager) throw new Error("manager required")
+
+      const [store] = manager.child("/project", { bootstrap: false })
+
+      expect(store.path.directory).toBe("/project")
+      expect(store.path.worktree).toBe("/project")
+    } finally {
+      dispose()
+    }
+  })
+
   test("enables MCP only when requested for the directory", () => {
     let manager: ReturnType<typeof createChildStoreManager> | undefined
     const offset = queryGroups.length

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -52,7 +52,7 @@ beforeAll(async () => {
     useQueries: (options: () => { queries: Array<{ enabled?: boolean }> }) => {
       queryGroups.push(options)
       return [
-        { isLoading: false, data: { state: "", config: "", worktree: "", directory: "", home: "" } },
+        { isLoading: true, data: undefined },
         { isLoading: false, data: {} },
         { isLoading: false, data: [] },
         { isLoading: false, data: provider },
@@ -128,7 +128,7 @@ describe("createChildStoreManager", () => {
     }
   })
 
-  test("falls back to the requested directory before the path query resolves", () => {
+  test("provides the requested directory while the path query is pending", () => {
     let manager: ReturnType<typeof createChildStoreManager> | undefined
 
     const dispose = createOwner((owner) => {
@@ -151,7 +151,7 @@ describe("createChildStoreManager", () => {
       const [store] = manager.child("/project", { bootstrap: false })
 
       expect(store.path.directory).toBe("/project")
-      expect(store.path.worktree).toBe("/project")
+      expect(store.path.worktree).toBe("")
     } finally {
       dispose()
     }

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -204,9 +204,8 @@ export function createChildStoreManager(input: {
             },
             config: {},
             get path() {
-              if (pathQuery.isLoading || !pathQuery.data)
-                return { state: "", config: "", worktree: "", directory: "", home: "" }
-              return pathQuery.data
+              if (pathQuery.data?.directory) return pathQuery.data
+              return { state: "", config: "", worktree: directory, directory, home: "" }
             },
             status: "loading" as const,
             agent: [],

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -204,8 +204,8 @@ export function createChildStoreManager(input: {
             },
             config: {},
             get path() {
-              if (pathQuery.data?.directory) return pathQuery.data
-              return { state: "", config: "", worktree: directory, directory, home: "" }
+              if (pathQuery.data) return pathQuery.data
+              return { state: "", config: "", worktree: "", directory, home: "" }
             },
             status: "loading" as const,
             agent: [],


### PR DESCRIPTION
Session lists in the web UI filter root sessions against `store.path.directory`. After the sync loading refactor, that path could still be empty on initial page load even when `loadSessions()` had already populated the child store.

That caused the current project to appear empty until a later client navigation warmed the directory state.

Fall back to the requested directory/worktree until the path query resolves, and add a regression test for the child store path fallback.

### Issue for this PR

Closes #30166

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fall back to the requested directory/worktree until the path query resolves, and add a regression test for the child store path fallback.

### How did you verify your code works?

Ran it locally

### Screenshots / recordings

Current behaviour on page load:
<img width="340" height="353" alt="Screenshot 2026-06-01 at 1 28 48 pm" src="https://github.com/user-attachments/assets/78e984aa-65db-4e2c-99b0-bb43a61e0a09" />

Behaviour with this PR on page load:
<img width="324" height="387" alt="Screenshot 2026-06-01 at 1 29 44 pm" src="https://github.com/user-attachments/assets/6c0af03b-df6d-415d-966e-e6c9e853db37" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
