### PR TITLE
fix(app): show MCP status in directory popover

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -1,91 +1,173 @@
 import { describe, expect, test } from "bun:test"
 import { createStore } from "solid-js/store"
 import { QueryClient } from "@tanstack/solid-query"
-import type { Config, OpencodeClient, Project } from "@opencode-ai/sdk/v2/client"
+import type { Config, McpStatus, OpencodeClient, Project } from "@opencode-ai/sdk/v2/client"
 import type { NormalizedProviderListResponse } from "@opencode-ai/ui/context"
 import { bootstrapDirectory } from "./bootstrap"
 import type { State, VcsCache } from "./types"
 
 const provider = { all: new Map(), connected: [], default: {} } satisfies NormalizedProviderListResponse
+const path = { state: "", config: "", worktree: "/project", directory: "/project", home: "/home" }
+
+function createState(input?: { mcp?: Record<string, McpStatus>; command?: State["command"] }) {
+  return createStore<State>({
+    status: "loading",
+    agent: [],
+    command: input?.command ?? [],
+    project: "",
+    projectMeta: undefined,
+    icon: undefined,
+    provider_ready: true,
+    provider,
+    config: {},
+    path,
+    session: [],
+    sessionTotal: 0,
+    session_status: {},
+    session_working(id: string) {
+      return this.session_status[id]?.type !== "idle"
+    },
+    session_diff: {},
+    todo: {},
+    permission: {},
+    question: {},
+    mcp_ready: true,
+    mcp: input?.mcp ?? {},
+    lsp_ready: true,
+    lsp: [],
+    vcs: undefined,
+    limit: 5,
+    message: {},
+    part: {},
+    part_text_accum_delta: {},
+  })
+}
+
+function createSdk(input?: { mcp?: Record<string, McpStatus>; command?: State["command"]; reads?: string[] }) {
+  return {
+    app: { agents: async () => ({ data: [{ name: "build", mode: "primary" }] }) },
+    config: { get: async () => ({ data: {} }) },
+    project: { current: async () => ({ data: { id: "project" } }) },
+    session: { status: async () => ({ data: {} }) },
+    vcs: { get: async () => ({ data: undefined }) },
+    command: {
+      list: async () => {
+        input?.reads?.push("command")
+        return { data: input?.command ?? [] }
+      },
+    },
+    permission: { list: async () => ({ data: [] }) },
+    question: { list: async () => ({ data: [] }) },
+    mcp: {
+      status: async () => {
+        input?.reads?.push("status")
+        return { data: input?.mcp ?? {} }
+      },
+    },
+    provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+  } as unknown as OpencodeClient
+}
+
+async function bootstrap(input: {
+  store: State
+  setStore: ReturnType<typeof createState>[1]
+  sdk: OpencodeClient
+  mcp: boolean
+}) {
+  await bootstrapDirectory({
+    directory: "/project",
+    mcp: input.mcp,
+    global: {
+      config: {} satisfies Config,
+      path,
+      project: [{ id: "project", worktree: "/project" } as Project],
+      provider,
+    },
+    sdk: input.sdk,
+    store: input.store,
+    setStore: input.setStore,
+    vcsCache: { setStore() {} } as unknown as VcsCache,
+    loadSessions() {},
+    translate: (key) => key,
+    queryClient: new QueryClient(),
+  })
+}
+
+async function waitForComplete(store: State) {
+  await new Promise((resolve) => setTimeout(resolve, 80))
+  expect(store.status).toBe("complete")
+}
 
 describe("bootstrapDirectory", () => {
   test("marks a loading directory partial during bootstrap and complete after success", async () => {
     const mcpReads: string[] = []
-    const [store, setStore] = createStore<State>({
-      status: "loading",
-      agent: [],
-      command: [],
-      project: "",
-      projectMeta: undefined,
-      icon: undefined,
-      provider_ready: true,
-      provider,
-      config: {},
-      path: { state: "", config: "", worktree: "/project", directory: "/project", home: "/home" },
-      session: [],
-      sessionTotal: 0,
-      session_status: {},
-      session_working(id: string) {
-        return this.session_status[id]?.type !== "idle"
-      },
-      session_diff: {},
-      todo: {},
-      permission: {},
-      question: {},
-      mcp_ready: true,
-      mcp: {},
-      lsp_ready: true,
-      lsp: [],
-      vcs: undefined,
-      limit: 5,
-      message: {},
-      part: {},
-      part_text_accum_delta: {},
-    })
+    const [store, setStore] = createState()
 
-    await bootstrapDirectory({
-      directory: "/project",
-      mcp: false,
-      global: {
-        config: {} satisfies Config,
-        path: { state: "", config: "", worktree: "/project", directory: "/project", home: "/home" },
-        project: [{ id: "project", worktree: "/project" } as Project],
-        provider,
-      },
-      sdk: {
-        app: { agents: async () => ({ data: [{ name: "build", mode: "primary" }] }) },
-        config: { get: async () => ({ data: {} }) },
-        session: { status: async () => ({ data: {} }) },
-        vcs: { get: async () => ({ data: undefined }) },
-        command: {
-          list: async () => {
-            mcpReads.push("command")
-            return { data: [] }
-          },
-        },
-        permission: { list: async () => ({ data: [] }) },
-        question: { list: async () => ({ data: [] }) },
-        mcp: {
-          status: async () => {
-            mcpReads.push("status")
-            return { data: {} }
-          },
-        },
-        provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
-      } as unknown as OpencodeClient,
+    await bootstrap({
       store,
       setStore,
-      vcsCache: { setStore() {} } as unknown as VcsCache,
-      loadSessions() {},
-      translate: (key) => key,
-      queryClient: new QueryClient(),
+      mcp: false,
+      sdk: createSdk({ reads: mcpReads }),
     })
 
     expect(store.status).toBe("partial")
 
-    await new Promise((resolve) => setTimeout(resolve, 80))
-
-    expect(store.status).toBe("complete")
+    await waitForComplete(store)
     expect(mcpReads).toEqual([])
+  })
+
+  test("hydrates connected MCP status during MCP bootstrap", async () => {
+    // given
+    const [store, setStore] = createState()
+
+    // when
+    await bootstrap({
+      store,
+      setStore,
+      mcp: true,
+      sdk: createSdk({ mcp: { qa: { status: "connected" } } }),
+    })
+    await waitForComplete(store)
+
+    // then
+    expect(store.mcp).toEqual({ qa: { status: "connected" } })
+  })
+
+  test("clears stale MCP status when bootstrap returns no configured MCPs", async () => {
+    // given
+    const [store, setStore] = createState({ mcp: { stale: { status: "connected" } } })
+
+    // when
+    await bootstrap({
+      store,
+      setStore,
+      mcp: true,
+      sdk: createSdk({ mcp: {} }),
+    })
+    await waitForComplete(store)
+
+    // then
+    expect(store.mcp).toEqual({})
+  })
+
+  test("hydrates MCP status without dropping command results from the same bootstrap function", async () => {
+    // given
+    const [store, setStore] = createState()
+
+    // when
+    await bootstrap({
+      store,
+      setStore,
+      mcp: true,
+      sdk: createSdk({
+        command: [{ name: "dev", template: "bun dev", hints: [] }],
+        mcp: { qa: { status: "connected" } },
+      }),
+    })
+    await waitForComplete(store)
+
+    // then
+    expect(store.command).toEqual([{ name: "dev", template: "bun dev", hints: [] }])
+    expect(store.mcp).toEqual({ qa: { status: "connected" } })
   })
 })

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -305,7 +305,11 @@ export async function bootstrapDirectory(input: {
           }),
         ),
       () => Promise.resolve(input.loadSessions(input.directory)),
-      input.mcp && (() => input.queryClient.fetchQuery(loadMcpQuery(input.directory, input.sdk))),
+      input.mcp &&
+        (() =>
+          input.queryClient
+            .fetchQuery(loadMcpQuery(input.directory, input.sdk))
+            .then((data) => input.setStore("mcp", reconcile(data, { merge: false })))),
       () =>
         input.queryClient.fetchQuery(loadProvidersQuery(input.directory, input.sdk)).catch((err) => {
           const project = getFilename(input.directory)
@@ -315,7 +319,7 @@ export async function bootstrapDirectory(input: {
             description: formatServerError(err, input.translate),
           })
         }),
-    ].filter(Boolean) as (() => Promise<any>)[]
+    ].filter(Boolean) as Array<() => Promise<unknown>>
 
     await waitForPaint()
     const slowErrs = errors(await runAll(slow))

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test"
 import { createRoot, getOwner, type Owner } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { NormalizedProviderListResponse } from "@opencode-ai/ui/context"
@@ -7,6 +7,7 @@ import type { QueryOptionsApi } from "../server-sync"
 
 let createChildStoreManager: typeof import("./child-store").createChildStoreManager
 const queryGroups: Array<() => { queries: Array<{ enabled?: boolean }> }> = []
+let mcpQueryData: unknown
 
 const child = () => createStore({} as State)
 const provider = { all: new Map(), connected: [], default: {} } satisfies NormalizedProviderListResponse
@@ -31,6 +32,24 @@ const queryOptionsApi = {
   sessions: (directory: string) => ({ queryKey: [directory, "loadSessions"] as const }),
 } as unknown as QueryOptionsApi
 
+class TestQueryClient {
+  fetchQuery(options: { queryFn?: () => unknown }) {
+    return Promise.resolve(options.queryFn?.())
+  }
+
+  ensureQueryData(options: { queryFn?: () => unknown }) {
+    return Promise.resolve(options.queryFn?.())
+  }
+
+  invalidateQueries() {
+    return Promise.resolve()
+  }
+
+  refetchQueries() {
+    return Promise.resolve()
+  }
+}
+
 function createOwner(callback: (owner: Owner) => void) {
   return createRoot((dispose) => {
     const owner = getOwner()
@@ -49,11 +68,16 @@ beforeAll(async () => {
     persisted: (_target: string, store: unknown[]) => [store[0], store[1], null, () => true],
   }))
   mock.module("@tanstack/solid-query", () => ({
+    QueryClient: TestQueryClient,
+    queryOptions: (options: unknown) => options,
+    useMutation: () => ({ isPending: false, mutate() {}, mutateAsync: async () => undefined }),
+    useQuery: () => ({ isPending: false, refetch: async () => undefined }),
+    useQueryClient: () => new TestQueryClient(),
     useQueries: (options: () => { queries: Array<{ enabled?: boolean }> }) => {
       queryGroups.push(options)
       return [
         { isLoading: false, data: { state: "", config: "", worktree: "", directory: "", home: "" } },
-        { isLoading: false, data: {} },
+        { isLoading: false, data: mcpQueryData },
         { isLoading: false, data: [] },
         { isLoading: false, data: provider },
       ]
@@ -61,6 +85,10 @@ beforeAll(async () => {
   }))
 
   createChildStoreManager = (await import("./child-store")).createChildStoreManager
+})
+
+afterAll(() => {
+  mock.restore()
 })
 
 describe("createChildStoreManager", () => {
@@ -164,6 +192,66 @@ describe("createChildStoreManager", () => {
       manager.disableMcp("/project")
       expect(queries().queries[1]?.enabled).toBe(false)
       expect(manager.mcp("/project")).toBe(false)
+    } finally {
+      dispose()
+    }
+  })
+
+  test("loads MCP when requested while the child store is still loading", () => {
+    let manager: ReturnType<typeof createChildStoreManager> | undefined
+    const mcpLoads: string[] = []
+
+    const dispose = createOwner((owner) => {
+      manager = createChildStoreManager({
+        owner,
+        isBooting: () => true,
+        isLoadingSessions: () => false,
+        onBootstrap() {},
+        onMcp(directory) {
+          mcpLoads.push(directory)
+        },
+        onDispose() {},
+        translate: (key) => key,
+        queryOptions: queryOptionsApi,
+        global: { provider },
+      })
+    })
+
+    try {
+      if (!manager) throw new Error("manager required")
+
+      manager.child("/project", { bootstrap: false, mcp: true })
+
+      expect(mcpLoads).toEqual(["/project"])
+    } finally {
+      dispose()
+    }
+  })
+
+  test("allows bootstrap to hydrate MCP status into the child store", () => {
+    let manager: ReturnType<typeof createChildStoreManager> | undefined
+
+    const dispose = createOwner((owner) => {
+      manager = createChildStoreManager({
+        owner,
+        isBooting: () => false,
+        isLoadingSessions: () => false,
+        onBootstrap() {},
+        onMcp() {},
+        onDispose() {},
+        translate: (key) => key,
+        queryOptions: queryOptionsApi,
+        global: { provider },
+      })
+    })
+
+    try {
+      if (!manager) throw new Error("manager required")
+      const [store, setStore] = manager.child("/project", { bootstrap: false, mcp: true })
+
+      setStore("mcp", { qa: { status: "connected" } })
+
+      expect(store.mcp).toEqual({ qa: { status: "connected" } })
     } finally {
       dispose()
     }

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -1,5 +1,5 @@
-import { createRoot, createSignal, getOwner, onCleanup, runWithOwner, type Owner } from "solid-js"
-import { createStore, type SetStoreFunction, type Store } from "solid-js/store"
+import { createEffect, createRoot, createSignal, getOwner, onCleanup, runWithOwner, type Owner } from "solid-js"
+import { createStore, reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import { Persist, persisted } from "@/utils/persist"
 import type { VcsInfo } from "@opencode-ai/sdk/v2/client"
 import {
@@ -225,9 +225,7 @@ export function createChildStoreManager(input: {
             get mcp_ready() {
               return !mcpQuery.isLoading
             },
-            get mcp() {
-              return mcpQuery.isLoading ? {} : (mcpQuery.data ?? {})
-            },
+            mcp: {},
             get lsp_ready() {
               return !lspQuery.isLoading
             },
@@ -243,6 +241,13 @@ export function createChildStoreManager(input: {
           children[key] = child
           disposers.set(key, dispose)
           mcpToggles.set(key, setMcpEnabled)
+
+          createEffect(() => {
+            if (mcpQuery.isLoading) return
+            const data = mcpQuery.data
+            if (data === undefined) return
+            child[1]("mcp", reconcile(data, { merge: false }))
+          })
 
           const onPersistedInit = (init: Promise<string> | string | null, run: () => void) => {
             if (!(init instanceof Promise)) return
@@ -304,7 +309,7 @@ export function createChildStoreManager(input: {
     if (mcpDirectories.has(key)) return
     mcpDirectories.add(key)
     mcpToggles.get(key)?.(true)
-    if (childStore[0].status !== "loading") input.onMcp(directory, childStore[1])
+    input.onMcp(directory, childStore[1])
   }
 
   function disableMcp(directory: string) {

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -218,6 +218,16 @@ export function createServerSyncContext() {
           description: formatServerError(err, language.t),
         })
       })
+      void queryClient
+        .fetchQuery(queryOptionsApi.mcp(directoryKey(directory)))
+        .then((data) => setStore("mcp", reconcile(data, { merge: false })))
+        .catch((err) => {
+          showToast({
+            variant: "error",
+            title: language.t("toast.project.reloadFailed.title", { project: getFilename(directory) }),
+            description: formatServerError(err, language.t),
+          })
+        })
     },
     onDispose: (directory) => {
       const key = directoryKey(directory)

--- a/packages/opencode/src/bus/global.ts
+++ b/packages/opencode/src/bus/global.ts
@@ -8,15 +8,21 @@ export type GlobalEvent = {
   payload: any
 }
 
-class GlobalBusEmitter extends EventEmitter<{
+const bus = new EventEmitter<{
   event: [GlobalEvent]
-}> {
-  override emit(eventName: "event", event: GlobalEvent): boolean {
+}>()
+
+export const GlobalBus = {
+  emit(eventName: "event", event: GlobalEvent): boolean {
     if (event.payload && typeof event.payload === "object" && !("id" in event.payload)) {
       event.payload.id = event.payload.syncEvent?.id ?? Identifier.create("evt", "ascending")
     }
-    return super.emit(eventName, event)
-  }
+    return bus.emit(eventName, event)
+  },
+  on(eventName: "event", listener: (event: GlobalEvent) => void) {
+    return bus.on(eventName, listener)
+  },
+  off(eventName: "event", listener: (event: GlobalEvent) => void) {
+    return bus.off(eventName, listener)
+  },
 }
-
-export const GlobalBus = new GlobalBusEmitter()

--- a/packages/opencode/test/bus/global.test.ts
+++ b/packages/opencode/test/bus/global.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test"
+import { GlobalBus, type GlobalEvent } from "@/bus/global"
+
+describe("GlobalBus", () => {
+  test("adds an event id and delivers the event to listeners", () => {
+    // given
+    const received: GlobalEvent[] = []
+    const listener = (event: GlobalEvent) => {
+      received.push(event)
+    }
+    GlobalBus.on("event", listener)
+
+    try {
+      const event: GlobalEvent = {
+        payload: {
+          type: "server.connected",
+          properties: {},
+        },
+      }
+
+      // when
+      const emitted = GlobalBus.emit("event", event)
+
+      // then
+      expect(emitted).toBe(true)
+      expect(received).toEqual([event])
+      expect(typeof event.payload.id).toBe("string")
+    } finally {
+      GlobalBus.off("event", listener)
+    }
+  })
+
+  test("removes listeners with off", () => {
+    // given
+    const received: GlobalEvent[] = []
+    const listener = (event: GlobalEvent) => {
+      received.push(event)
+    }
+    GlobalBus.on("event", listener)
+    GlobalBus.off("event", listener)
+
+    // when
+    const emitted = GlobalBus.emit("event", {
+      payload: {
+        id: "evt_existing",
+        type: "server.connected",
+        properties: {},
+      },
+    })
+
+    // then
+    expect(emitted).toBe(false)
+    expect(received).toEqual([])
+  })
+
+  test("preserves an existing sync event id", () => {
+    // given
+    const event: GlobalEvent = {
+      payload: {
+        syncEvent: { id: "sync_123" },
+        type: "session.updated",
+        properties: {},
+      },
+    }
+
+    // when
+    GlobalBus.emit("event", event)
+
+    // then
+    expect(event.payload.id).toBe("sync_123")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #30171

Investigated Discord reports `1510653911319580682` and `1510634872203382855`.

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the app status popover dropping MCP status for a directory even when the backend reports MCPs as connected.

The bug was: `bootstrapDirectory(..., mcp: true)` fetched `/mcp` but never wrote the result into the directory store; the child store exposed `mcp` as a getter-only query projection, so bootstrap writes could not stick; and `enableMcp` skipped `onMcp` while the store was still loading.

This PR hydrates fetched MCP status into `store.mcp`, makes child-store MCP state writable and mirrored from query data, and fetches MCP status when MCP display is enabled. It also fixes a Bun 1.3.14 typecheck blocker in `GlobalBus` by avoiding a narrow `EventEmitter.emit` override while preserving event id injection, now covered by a focused bus behavior test.

### How did you verify your code works?

- RED before fix: `bun test src/context/global-sync/bootstrap.test.ts` failed MCP hydration, empty MCP clearing, and command-adjacent MCP cases.
- RED before fix: child-store test showed MCP enable while loading dropped `onMcp`.
- `mise x bun@1.3.14 -- bun run test:unit` from `packages/app`: 343 pass.
- `mise x bun@1.3.14 -- bun run typecheck` from `packages/app`: pass.
- `mise x bun@1.3.14 -- bun run build` from `packages/app`: pass with existing Vite warnings.
- `mise x bun@1.3.14 -- bun test test/bus/global.test.ts` from `packages/opencode`: 3 pass.
- `mise x bun@1.3.14 -- bun run --cwd packages/opencode typecheck`: pass.
- `mise x bun@1.3.14 -- bun typecheck` from repo root: pass.
- LSP diagnostics on changed files: no errors.

### Screenshots / recordings

Manual QA used a real local server and app:

- Backend `/mcp` on port 4097 returned `{"qa":{"status":"connected"}}` for the test workspace.
- Browser QA on port 4445 opened the directory status popover, selected `1 MCP`, and showed row `qa` with the switch checked.

Screenshot artifact from local QA: `/tmp/opencode-mcp-qa-20260601T025249Z/agent-browser-after-green-current.png`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
