### PR TITLE
fix(opencode): add service tier and flex pricing estimates

### DIFF
--- a/packages/app/src/components/session/session-context-raw.test.ts
+++ b/packages/app/src/components/session/session-context-raw.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import type { Message, Part } from "@opencode-ai/sdk/v2/client"
+import { formatSessionContextRaw, getSessionContextRawDerived } from "./session-context-raw"
+
+const assistant = (providerID = "openai") => {
+  return {
+    id: "a1",
+    role: "assistant",
+    providerID,
+    time: { created: 1 },
+  } as unknown as Message
+}
+
+const user = () => {
+  return {
+    id: "u1",
+    role: "user",
+    time: { created: 1 },
+  } as unknown as Message
+}
+
+describe("getSessionContextRawDerived", () => {
+  test("prefers finish-step metadata and extracts service tier", () => {
+    const parts = [
+      {
+        type: "text",
+        text: "done",
+        metadata: { openai: { itemId: "msg_1" } },
+      },
+      {
+        type: "step-finish",
+        reason: "stop",
+        cost: 0,
+        tokens: {
+          input: 1,
+          output: 1,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        metadata: { openai: { responseId: "resp_1", serviceTier: "flex" } },
+      },
+    ] as unknown as Part[]
+
+    expect(getSessionContextRawDerived(assistant(), parts)).toEqual({
+      providerMetadata: { openai: { responseId: "resp_1", serviceTier: "flex" } },
+      serviceTier: "flex",
+    })
+  })
+
+  test("falls back to latest part metadata when no finish-step metadata exists", () => {
+    const parts = [
+      {
+        type: "tool",
+        metadata: { providerExecuted: true },
+      },
+      {
+        type: "text",
+        text: "done",
+        metadata: { openai: { itemId: "msg_1" } },
+      },
+    ] as unknown as Part[]
+
+    expect(getSessionContextRawDerived(assistant(), parts)).toEqual({
+      providerMetadata: { openai: { itemId: "msg_1" } },
+    })
+  })
+
+  test("returns undefined for non-assistant messages", () => {
+    expect(getSessionContextRawDerived(user(), [])).toBeUndefined()
+  })
+
+  test("omits reasoningEncryptedContent from formatted raw output", () => {
+    const parts = [
+      {
+        type: "reasoning",
+        text: "thinking",
+        metadata: {
+          openai: {
+            itemId: "rs_1",
+            reasoningEncryptedContent: "very-large-opaque-value",
+          },
+        },
+      },
+      {
+        type: "step-finish",
+        reason: "stop",
+        cost: 0,
+        tokens: {
+          input: 1,
+          output: 1,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        metadata: { openai: { responseId: "resp_1", serviceTier: "flex" } },
+      },
+    ] as unknown as Part[]
+
+    const raw = formatSessionContextRaw(assistant(), parts)
+
+    expect(raw).toContain('"serviceTier": "flex"')
+    expect(raw).not.toContain("reasoningEncryptedContent")
+    expect(raw).toContain('"responseId": "resp_1"')
+  })
+})

--- a/packages/app/src/components/session/session-context-raw.ts
+++ b/packages/app/src/components/session/session-context-raw.ts
@@ -1,0 +1,74 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2/client"
+
+export type SessionContextRawDerived = {
+  providerMetadata: Record<string, unknown>
+  serviceTier?: string
+}
+
+export function getSessionContextRawDerived(
+  message: Message,
+  parts: Part[],
+): SessionContextRawDerived | undefined {
+  if (message.role !== "assistant") return
+
+  const providerMetadata = stepFinishMetadata(parts) ?? latestPartMetadata(parts)
+  if (!providerMetadata) return
+
+  const serviceTier = serviceTierForProvider(message.providerID, providerMetadata)
+  if (serviceTier === undefined) return { providerMetadata }
+  return { providerMetadata, serviceTier }
+}
+
+export function formatSessionContextRaw(message: Message, parts: Part[]) {
+  const derived = getSessionContextRawDerived(message, parts)
+  return JSON.stringify(
+    {
+      message,
+      ...(derived?.serviceTier ? { serviceTier: derived.serviceTier } : {}),
+      ...(derived?.providerMetadata ? { providerMetadata: derived.providerMetadata } : {}),
+      parts,
+    },
+    omitLargeReasoningFields,
+    2,
+  )
+}
+
+function stepFinishMetadata(parts: Part[]) {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i]
+    if (part.type !== "step-finish") continue
+    if (!isRecord(part.metadata)) continue
+    return part.metadata
+  }
+}
+
+function latestPartMetadata(parts: Part[]) {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const metadata = partMetadata(parts[i])
+    if (!metadata) continue
+    const { providerExecuted: _, ...rest } = metadata
+    if (Object.keys(rest).length > 0) return rest
+  }
+}
+
+function partMetadata(part: Part) {
+  if (!("metadata" in part)) return
+  if (!isRecord(part.metadata)) return
+  return part.metadata
+}
+
+function serviceTierForProvider(providerID: string, providerMetadata: Record<string, unknown>) {
+  const info = providerMetadata[providerID]
+  if (!isRecord(info)) return
+  if (typeof info.serviceTier !== "string") return
+  return info.serviceTier
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function omitLargeReasoningFields(key: string, value: unknown) {
+  if (key === "reasoningEncryptedContent") return undefined
+  return value
+}

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -17,6 +17,7 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { getSessionContextMetrics } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
 import { createSessionContextFormatter } from "./session-context-format"
+import { formatSessionContextRaw } from "./session-context-raw"
 
 const BREAKDOWN_COLOR: Record<SessionContextBreakdownKey, string> = {
   system: "var(--syntax-info)",
@@ -38,7 +39,7 @@ function Stat(props: { label: string; value: JSX.Element }) {
 function RawMessageContent(props: { message: Message; getParts: (id: string) => Part[]; onRendered: () => void }) {
   const file = createMemo(() => {
     const parts = props.getParts(props.message.id)
-    const contents = JSON.stringify({ message: props.message, parts }, null, 2)
+    const contents = formatSessionContextRaw(props.message, parts)
     return {
       name: `${props.message.role}-${props.message.id}.json`,
       contents,

--- a/packages/app/src/context/directory-sync.ts
+++ b/packages/app/src/context/directory-sync.ts
@@ -13,8 +13,7 @@ import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { SESSION_CACHE_LIMIT, dropSessionCaches, pickSessionCacheEvictions } from "./global-sync/session-cache"
 import { diffs as list, message as clean } from "@/utils/diffs"
 import { useServerSDK } from "./server-sdk"
-
-const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
+import { includeSessionPart } from "./session-part-filter"
 
 function sortParts(parts: Part[]) {
   return parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id))
@@ -338,7 +337,7 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
         batch(() => {
           input.setStore("message", input.sessionID, reconcile(message, { key: "id" }))
           for (const p of next.part) {
-            const filtered = p.part.filter((x) => !SKIP_PARTS.has(x.type))
+            const filtered = p.part.filter(includeSessionPart)
             if (filtered.length) input.setStore("part", p.id, filtered)
           }
           setMeta("limit", key, message.length)

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -249,6 +249,61 @@ describe("applyDirectoryEvent", () => {
     }
   })
 
+  test("keeps step-finish parts from live message events", () => {
+    const message = userMessage("msg_1", "ses_1")
+    const [store, setStore] = createStore(
+      baseState({
+        message: { ses_1: [message] },
+      }),
+    )
+
+    applyDirectoryEvent({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "prt_1",
+            messageID: message.id,
+            sessionID: "ses_1",
+            type: "step-finish",
+            reason: "stop",
+            cost: 0,
+            tokens: {
+              input: 1,
+              output: 1,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            metadata: { openai: { serviceTier: "flex" } },
+          } satisfies Part,
+        },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    expect(store.part[message.id]).toEqual([
+      {
+        id: "prt_1",
+        messageID: message.id,
+        sessionID: "ses_1",
+        type: "step-finish",
+        reason: "stop",
+        cost: 0,
+        tokens: {
+          input: 1,
+          output: 1,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        metadata: { openai: { serviceTier: "flex" } },
+      },
+    ])
+  })
+
   test("cleans caches for trimmed sessions on session.created", () => {
     const dropped = rootSession({ id: "ses_b" })
     const kept = rootSession({ id: "ses_a" })

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -15,8 +15,7 @@ import type { State, VcsCache } from "./types"
 import { trimSessions } from "./session-trim"
 import { dropSessionCaches } from "./session-cache"
 import { diffs as list, message as clean } from "@/utils/diffs"
-
-const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
+import { includeSessionPart } from "../session-part-filter"
 
 export function applyGlobalEvent(input: {
   event: { type: string; properties?: unknown }
@@ -225,7 +224,7 @@ export function applyDirectoryEvent(input: {
     }
     case "message.part.updated": {
       const part = (event.properties as { part: Part }).part
-      if (SKIP_PARTS.has(part.type)) break
+      if (!includeSessionPart(part)) break
       input.setStore(
         produce((draft) => {
           delete draft.part_text_accum_delta[part.id]

--- a/packages/app/src/context/session-part-filter.test.ts
+++ b/packages/app/src/context/session-part-filter.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test"
+import { includeSessionPart } from "./session-part-filter"
+
+describe("includeSessionPart", () => {
+  test("keeps step-finish parts for session metadata", () => {
+    expect(includeSessionPart({ type: "step-finish" })).toBe(true)
+  })
+
+  test("still hides structural parts that are not useful in the UI", () => {
+    expect(includeSessionPart({ type: "step-start" })).toBe(false)
+    expect(includeSessionPart({ type: "patch" })).toBe(false)
+  })
+})

--- a/packages/app/src/context/session-part-filter.ts
+++ b/packages/app/src/context/session-part-filter.ts
@@ -1,0 +1,7 @@
+import type { Part } from "@opencode-ai/sdk/v2/client"
+
+const HIDDEN_PARTS = new Set(["patch", "step-start"])
+
+export function includeSessionPart(part: Pick<Part, "type">) {
+  return !HIDDEN_PARTS.has(part.type)
+}

--- a/packages/core/src/session/legacy.ts
+++ b/packages/core/src/session/legacy.ts
@@ -230,6 +230,7 @@ export const StepFinishPart = Schema.Struct({
   type: Schema.Literal("step-finish"),
   reason: Schema.String,
   snapshot: Schema.optional(Schema.String),
+  metadata: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
   cost: Schema.Finite,
   tokens: Schema.Struct({
     total: Schema.optional(Schema.Finite),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -583,6 +583,7 @@ export const layer = Layer.effect(
               id: PartID.ascending(),
               reason: value.reason,
               snapshot: completedSnapshot,
+              metadata: value.providerMetadata,
               messageID: ctx.assistantMessage.id,
               sessionID: ctx.assistantMessage.sessionID,
               type: "step-finish",

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -433,13 +433,26 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   }
 
   const contextTokens = inputTokens
-  const costInfo =
+  const baseCostInfo =
     input.model.cost?.tiers
       ?.filter((item) => item.tier.type === "context" && contextTokens > item.tier.size)
       .sort((a, b) => b.tier.size - a.tier.size)[0] ??
     (input.model.cost?.experimentalOver200K && contextTokens > 200_000
       ? input.model.cost.experimentalOver200K
       : input.model.cost)
+  // OpenAI reports the selected service tier in metadata but not the billed amount.
+  // Apply flex's discounted rates locally until the catalog carries service-tier pricing.
+  const costInfo =
+    isOpenAIFlex(input.model, input.metadata) && baseCostInfo
+      ? {
+          input: flexRate(baseCostInfo.input),
+          output: flexRate(baseCostInfo.output),
+          cache: {
+            read: flexRate(baseCostInfo.cache.read),
+            write: flexRate(baseCostInfo.cache.write),
+          },
+        }
+      : baseCostInfo
   return {
     cost: safe(
       new Decimal(0)
@@ -454,6 +467,15 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
     ),
     tokens,
   }
+}
+
+function isOpenAIFlex(model: Provider.Model, metadata?: ProviderMetadata) {
+  const openai = metadata?.["openai"]
+  return model.providerID === "openai" && openai?.["serviceTier"] === "flex"
+}
+
+function flexRate(value: number) {
+  return new Decimal(value).div(2).toNumber()
 }
 
 export class BusyError extends Schema.TaggedErrorClass<BusyError>()("SessionBusyError", {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -63,10 +63,11 @@ function createModel(opts: {
   input?: number
   cost?: Provider.Model["cost"]
   npm?: string
+  providerID?: string
 }): Provider.Model {
   return {
     id: "test-model",
-    providerID: "test",
+    providerID: opts.providerID ?? "test",
     name: "Test",
     limit: {
       context: opts.context,
@@ -1337,6 +1338,78 @@ describe("session.compaction.process", () => {
   )
 
   itCompaction.instance(
+    "stores finish-step provider metadata on the persisted part",
+    () => {
+      const fakeProvider = wide()
+      const stub = llm()
+
+      stub.push(
+        Stream.make(
+          LLMEvent.textStart({ id: "txt-0" }),
+          LLMEvent.textDelta({ id: "txt-0", text: "done" }),
+          LLMEvent.textEnd({ id: "txt-0" }),
+          LLMEvent.stepFinish({
+            index: 0,
+            reason: "stop",
+            usage: basicUsage(),
+            providerMetadata: { openai: { responseId: "resp_1", serviceTier: "flex" } },
+          }),
+          LLMEvent.finish({
+            reason: "stop",
+            usage: basicUsage(),
+          }),
+        ),
+      )
+
+      return Effect.gen(function* () {
+        const test = yield* TestInstance
+        const processors = yield* SessionProcessorModule.SessionProcessor.Service
+        const ssn = yield* SessionNs.Service
+
+        const session = yield* ssn.create({})
+        const prompt = yield* createUserMessage(session.id, "hi")
+        const reply = yield* createAssistantMessage(session.id, prompt.id, test.directory)
+        const model = fakeProvider.model
+        const handle = yield* processors.create({
+          assistantMessage: reply,
+          sessionID: session.id,
+          model,
+        })
+
+        const result = yield* handle.process({
+          user: {
+            id: prompt.id,
+            sessionID: session.id,
+            role: "user",
+            time: prompt.time,
+            agent: prompt.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionLegacy.User,
+          sessionID: session.id,
+          model,
+          agent: {
+            name: "build",
+            mode: "primary",
+            options: {},
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
+          system: [],
+          messages: [{ role: "user", content: "hi" }],
+          tools: {},
+        })
+
+        const finish = (yield* MessageV2.parts(reply.id)).find(
+          (part): part is SessionLegacy.StepFinishPart => part.type === "step-finish",
+        )
+
+        expect(result).toBe("continue")
+        expect(finish?.metadata).toEqual({ openai: { responseId: "resp_1", serviceTier: "flex" } })
+      }).pipe(withCompaction({ llm: stub.layer, provider: fakeProvider }))
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
     "does not allow tool calls while generating the summary",
     () => {
       const stub = llm()
@@ -1674,6 +1747,39 @@ describe("SessionNs.getUsage", () => {
     expect(result.cost).toBe(3 + 1.5)
   })
 
+  test("applies OpenAI flex discount to cost", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      providerID: "openai",
+      cost: {
+        input: 2,
+        output: 8,
+        cache: { read: 0.5, write: 0 },
+      },
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({
+        inputTokens: 1_200_000,
+        outputTokens: 250_000,
+        reasoningTokens: 50_000,
+        totalTokens: 1_450_000,
+        cacheReadInputTokens: 200_000,
+      }),
+      metadata: {
+        openai: {
+          serviceTier: "flex",
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(1_000_000)
+    expect(result.tokens.output).toBe(200_000)
+    expect(result.tokens.reasoning).toBe(50_000)
+    expect(result.cost).toBe(1 + 1 + 0.05)
+  })
+
   test("uses matching context cost tier before over-200k fallback", () => {
     const model = createModel({
       context: 1_000_000,
@@ -1715,6 +1821,49 @@ describe("SessionNs.getUsage", () => {
 
     expect(result.tokens.input).toBe(550_000)
     expect(result.cost).toBe(2.75 + 0.6 + 0.05)
+  })
+
+  test("applies OpenAI flex discount after selecting a context cost tier", () => {
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      providerID: "openai",
+      cost: {
+        input: 1,
+        output: 2,
+        cache: { read: 0.1, write: 0.5 },
+        tiers: [
+          {
+            input: 4,
+            output: 6,
+            cache: { read: 0.2, write: 1 },
+            tier: { type: "context", size: 200_000 },
+          },
+        ],
+        experimentalOver200K: {
+          input: 100,
+          output: 100,
+          cache: { read: 100, write: 100 },
+        },
+      },
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({
+        inputTokens: 300_000,
+        outputTokens: 100_000,
+        totalTokens: 400_000,
+        cacheReadInputTokens: 50_000,
+      }),
+      metadata: {
+        openai: {
+          serviceTier: "flex",
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(250_000)
+    expect(result.cost).toBe(0.5 + 0.3 + 0.005)
   })
 
   test("falls back to over-200k pricing when no cost tier matches", () => {

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -145,6 +145,12 @@ describe("step-finish token propagation via event", () => {
           reasoning: 200,
           cache: { read: 100, write: 50 },
         }
+        const metadata = {
+          openai: {
+            responseId: "resp_1",
+            serviceTier: "flex",
+          },
+        }
 
         const partInput = {
           id: PartID.ascending(),
@@ -152,6 +158,7 @@ describe("step-finish token propagation via event", () => {
           sessionID: info.id,
           type: "step-finish" as const,
           reason: "stop",
+          metadata,
           cost: 0.005,
           tokens,
         }
@@ -168,6 +175,7 @@ describe("step-finish token propagation via event", () => {
         expect(finish.tokens.cache.read).toBe(100)
         expect(finish.tokens.cache.write).toBe(50)
         expect(finish.cost).toBe(0.005)
+        expect(finish.metadata).toEqual(metadata)
         expect(receivedPart).not.toBe(partInput)
 
         yield* session.remove(info.id)

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -529,6 +529,9 @@ export type StepFinishPart = {
   type: "step-finish"
   reason: string
   snapshot?: string
+  metadata?: {
+    [key: string]: unknown
+  }
   cost: number
   tokens: {
     total?: number


### PR DESCRIPTION
### Issue for this PR

Closes #11597
Closes #28566

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds provider metadata (including service tier) to messages, allowing accurate estimates of flex-discounted pricing, as well as being able to see other raw provider metadata fields, for debugging / info purposes.

### How did you verify your code works?

Use the following OpenCode config:

```jsonc
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "openai": {
      "models": {
        "gpt-5.4": {
          "options": {
            "serviceTier": "flex",
          },
        },
        "gpt-5.5": {
          "options": {
            "serviceTier": "flex",
          },
        },
      },
    },
  },
}
```

Verify that messages come back with service tier and adjusted cost estimates

### Screenshots / recordings

<img width="576" height="618" alt="Screenshot 2026-06-01 at 3 05 21 pm" src="https://github.com/user-attachments/assets/005264d5-523b-4cd3-aaf0-6d0caae90b9a" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Totally happy to have another approach to this – I realise including full provider metadata might not be desirable for all users (just is for me)
