### PR TITLE
fix: honor v2 session list filters

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -2,7 +2,7 @@ export * as SessionV2 from "./session"
 export * from "./session/schema"
 
 import { Cause, DateTime, Effect, Layer, Schema, Context, Stream } from "effect"
-import { and, asc, desc, eq, gt, like, lt, or, type SQL } from "drizzle-orm"
+import { and, asc, desc, eq, gt, gte, isNull, like, lt, or, type SQL } from "drizzle-orm"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
 import { ModelV2 } from "./model"
@@ -48,6 +48,9 @@ export type ListAnchor = typeof ListAnchor.Type
 
 const ListInputBase = {
   workspaceID: WorkspaceV2.ID.pipe(Schema.optional),
+  path: Schema.String.pipe(Schema.optional),
+  roots: Schema.Boolean.pipe(Schema.optional),
+  start: Schema.Finite.pipe(Schema.optional),
   search: Schema.String.pipe(Schema.optional),
   limit: PositiveInt.pipe(Schema.optional),
   order: Schema.Literals(["asc", "desc"]).pipe(Schema.optional),
@@ -266,6 +269,11 @@ export const layer = Layer.effect(
         if ("directory" in input) conditions.push(eq(SessionTable.directory, input.directory))
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
         if ("project" in input) conditions.push(eq(SessionTable.project_id, input.project))
+        if (input.path) {
+          conditions.push(or(eq(SessionTable.path, input.path), like(SessionTable.path, `${input.path}/%`))!)
+        }
+        if (input.roots) conditions.push(isNull(SessionTable.parent_id))
+        if (input.start) conditions.push(gte(sortColumn, input.start))
         if (input.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
         if (input.anchor) {
           conditions.push(

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -437,6 +437,43 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "honors v2 session list filters",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const nestedDir = path.join(test.directory, "packages", "opencode", "src")
+        yield* Effect.promise(() => mkdir(nestedDir, { recursive: true }))
+
+        const parent = yield* createSession({ title: "v2 parent" })
+        const child = yield* createSession({ title: "v2 child", parentID: parent.id })
+        const nested = yield* createSession({ title: "v2 nested" }).pipe(provideInstanceEffect(nestedDir))
+
+        const roots = yield* requestJson<{ data: Array<{ id: string }> }>("/api/session?roots=true&limit=20", {
+          headers,
+        })
+        const rootIDs = roots.data.map((session) => session.id)
+        expect(rootIDs).toContain(parent.id)
+        expect(rootIDs).not.toContain(child.id)
+
+        const future = yield* requestJson<{ data: Array<{ id: string }> }>(
+          `/api/session?start=${Date.now() + 86_400_000}&limit=20`,
+          { headers },
+        )
+        expect(future.data.map((session) => session.id)).not.toContain(parent.id)
+
+        const pathFiltered = yield* requestJson<{ data: Array<{ id: string }> }>(
+          "/api/session?path=packages/opencode&limit=20",
+          { headers },
+        )
+        const pathIDs = pathFiltered.data.map((session) => session.id)
+        expect(pathIDs).toContain(nested.id)
+        expect(pathIDs).not.toContain(parent.id)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "returns v2 public request errors for cursor and workspace query failures",
     () =>
       Effect.gen(function* () {

--- a/packages/server/src/groups/session.ts
+++ b/packages/server/src/groups/session.ts
@@ -5,7 +5,7 @@ import { SessionV2 } from "@opencode-ai/core/session"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { AbsolutePath, PositiveInt, RelativePath, withStatics } from "@opencode-ai/core/schema"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
-import { Schema, Struct } from "effect"
+import { Schema, SchemaGetter, Struct } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import {
   ConflictError,
@@ -20,8 +20,18 @@ import { AgentV2 } from "@opencode-ai/core/agent"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { Location } from "@opencode-ai/core/location"
 
+const QueryBoolean = Schema.Literals(["true", "false"]).pipe(
+  Schema.decodeTo(Schema.Boolean, {
+    decode: SchemaGetter.transform((value) => value === "true"),
+    encode: SchemaGetter.transform((value) => (value ? "true" : "false")),
+  }),
+)
+
 const SessionsQueryFields = {
   workspace: WorkspaceV2.ID.pipe(Schema.optional),
+  path: Schema.String.pipe(Schema.optional),
+  roots: QueryBoolean.pipe(Schema.optional),
+  start: Schema.NumberFromString.pipe(Schema.decodeTo(Schema.Finite), Schema.optional),
   limit: Schema.NumberFromString.pipe(Schema.decodeTo(PositiveInt), Schema.optional).annotate({
     description: "Maximum number of sessions to return. Defaults to the newest 50 sessions.",
   }),


### PR DESCRIPTION
### Issue for this PR

Fixes #30109

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v2 session list API accepted filters such as `roots`, `start`, and `path`, but the handler did not pass them through to the session service. This wires those filters into the query path and adds an HTTP API regression test for root-only, start-time, and path filtering.

### How did you verify your code works?

- `bun --cwd packages\opencode test test\server\httpapi-session.test.ts -t "honors v2 session list filters"`
- `bun --cwd packages\opencode test test\server\httpapi-session.test.ts`
- `bun --cwd packages\opencode typecheck`
- `bun --cwd packages\core typecheck`
- `bunx prettier --check packages\core\src\session.ts packages\opencode\src\server\routes\instance\httpapi\handlers\v2\session.ts packages\opencode\test\server\httpapi-session.test.ts`
- `bunx oxlint packages\core\src\session.ts packages\opencode\src\server\routes\instance\httpapi\handlers\v2\session.ts packages\opencode\test\server\httpapi-session.test.ts` (warnings only, no errors)
- `git diff --check`

### Screenshots / recordings

N/A; this is an API behavior fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR