### PR TITLE
fix(github-copilot): keep catalog reasoning variants

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -147,8 +147,9 @@ function build(key: string, remote: Item, url: string, prev?: Model): Model {
       }
     }
   }
-  if (Object.keys(variants).length > 0) {
-    model.variants = variants
+  const mergedVariants = !isMsgApi ? { ...prev?.variants, ...variants } : variants
+  if (Object.keys(mergedVariants).length > 0) {
+    model.variants = mergedVariants
   }
 
   return model

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -215,6 +215,116 @@ test("clears existing variants so refreshed models calculate provider-specific v
   expect(models["claude-opus-4.7"].variants).toBeUndefined()
 })
 
+test("keeps catalog variants when Copilot omits a supported reasoning effort", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "gpt-5.5",
+              name: "GPT-5.5",
+              version: "gpt-5.5-2026-04-23",
+              capabilities: {
+                family: "gpt",
+                limits: {
+                  max_context_window_tokens: 272000,
+                  max_output_tokens: 128000,
+                  max_prompt_tokens: 272000,
+                },
+                supports: {
+                  reasoning_effort: ["low", "medium", "high"],
+                  streaming: true,
+                  tool_calls: true,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const models = await CopilotModels.get(
+    "https://api.githubcopilot.com",
+    {},
+    {
+      "gpt-5.5": {
+        id: "gpt-5.5",
+        providerID: "github-copilot",
+        api: {
+          id: "gpt-5.5",
+          url: "https://api.githubcopilot.com",
+          npm: "@ai-sdk/github-copilot",
+        },
+        name: "GPT-5.5",
+        family: "gpt",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: true,
+          toolcall: true,
+          input: {
+            text: true,
+            audio: false,
+            image: true,
+            video: false,
+            pdf: false,
+          },
+          output: {
+            text: true,
+            audio: false,
+            image: false,
+            video: false,
+            pdf: false,
+          },
+          interleaved: false,
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: {
+            read: 0,
+            write: 0,
+          },
+        },
+        limit: {
+          context: 272000,
+          input: 272000,
+          output: 128000,
+        },
+        options: {},
+        headers: {},
+        release_date: "2026-04-23",
+        variants: {
+          low: {
+            reasoningEffort: "catalog-low",
+          },
+          xhigh: {
+            reasoningEffort: "xhigh",
+            reasoningSummary: "auto",
+            include: ["reasoning.encrypted_content"],
+          },
+        },
+        status: "active",
+      },
+    },
+  )
+
+  expect(models["gpt-5.5"].variants?.xhigh).toEqual({
+    reasoningEffort: "xhigh",
+    reasoningSummary: "auto",
+    include: ["reasoning.encrypted_content"],
+  })
+  expect(models["gpt-5.5"].variants?.low).toEqual({
+    reasoningEffort: "low",
+    reasoningSummary: "auto",
+    include: ["reasoning.encrypted_content"],
+  })
+})
+
 test("remaps fallback oauth model urls to the enterprise host", async () => {
   globalThis.fetch = mock(() => Promise.reject(new Error("timeout"))) as unknown as typeof fetch
 


### PR DESCRIPTION
### Issue for this PR

Fixes #30092

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The GitHub Copilot `/models` response can omit still-supported catalog reasoning variants such as `xhigh`. The merge logic now keeps catalog-defined reasoning variants for non-message API models while still letting the live response refresh variants it does return. Message-API model behavior is unchanged.

### How did you verify your code works?

- `bun run --cwd packages/opencode test test/plugin/github-copilot-models.test.ts`
- `bun run lint -- packages/opencode/src/plugin/github-copilot/models.ts packages/opencode/test/plugin/github-copilot-models.test.ts`
- `bun run --cwd packages/opencode typecheck`
- `bunx prettier --check packages/opencode/src/plugin/github-copilot/models.ts packages/opencode/test/plugin/github-copilot-models.test.ts`
- `git diff --check`

Note: oxlint reports existing `no-unsafe-type-assertion` warnings in this test file; it exits successfully and there are no lint errors.

### Screenshots / recordings

N/A; this is provider catalog merge behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR