### PR TITLE
fix(opencode): skip watching $HOME to avoid slow FSEvents exclusion setup

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -4,6 +4,7 @@ import { createWrapper } from "@parcel/watcher/wrapper"
 import type ParcelWatcher from "@parcel/watcher"
 import { readdir, realpath } from "fs/promises"
 import path from "path"
+import os from "os"
 import { EventV2 } from "@opencode-ai/core/event"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { EffectBridge } from "@/effect/bridge"
@@ -124,9 +125,18 @@ export const layer = Layer.effect(
           const cfgIgnores = cfg.watcher?.ignore ?? []
 
           if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
-            yield* Effect.forkScoped(
-              subscribe(ctx.directory, [...FileIgnore.PATTERNS, ...cfgIgnores, ...protecteds(ctx.directory)]),
-            )
+            const home = os.homedir()
+            const rel = path.relative(ctx.directory, home)
+            const watchesHome = rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))
+            if (watchesHome) {
+              log.warn("skipping watch of home directory; FSEvents exclusion setup for protected paths is too slow", {
+                directory: ctx.directory,
+              })
+            } else {
+              yield* Effect.forkScoped(
+                subscribe(ctx.directory, [...FileIgnore.PATTERNS, ...cfgIgnores, ...protecteds(ctx.directory)]),
+              )
+            }
           }
 
           if (ctx.project.vcs === "git") {


### PR DESCRIPTION
### Issue for this PR

Closes #27082

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#27082 reports `FSEventStreamSetExclusionPaths` blocking for tens of seconds. That API gets its exclusion paths from the absolute directories in the `ignore` list handed to `@parcel/watcher`. The only place opencode injects absolute paths there is `protecteds()`, and `protecteds(dir)` only returns entries when `dir` is `$HOME` or an ancestor — the protected dirs (`~/Library`, `~/Downloads`, `~/Desktop`, …) are children of home. For a normal project dir it returns `[]`, so no large exclusion list is built and nothing is slow.

So the slow path only triggers when you watch `$HOME` (or above). This guards exactly that case: skip the directory watch (with a warning) instead of handing ~20 large home dirs to FSEvents as exclusion paths.

### How did you verify your code works?

- `cd packages/opencode && bun test test/file/watcher.test.ts` → 6 pass / 0 fail. The suite watches a temp project dir (not `$HOME`), so `watchesHome` is false and the normal subscribe path runs unchanged — confirming the guard doesn't regress ordinary watches.
- Honest caveat: I did not reproduce the multi-second `FSEventStreamSetExclusionPaths` stall itself. On my own machine the ~30–140s startup hang traced to a *different* cause — macOS Gatekeeper doing an online assessment of the un-notarized embedded native dylibs during `dlopen` (a signing/notarization issue), which this code does not touch. I'm offering this strictly as a guard for the exclusion-path scenario the issue describes, not as a verified fix for that hang.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR