### PR TITLE
fix(opencode): skip watching $HOME to avoid slow FSEvents exclusion setup

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -4,6 +4,7 @@ import { createWrapper } from "@parcel/watcher/wrapper"
 import type ParcelWatcher from "@parcel/watcher"
 import { readdir, realpath } from "fs/promises"
 import path from "path"
+import os from "os"
 import { EventV2 } from "@opencode-ai/core/event"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { EffectBridge } from "@/effect/bridge"
@@ -124,9 +125,18 @@ export const layer = Layer.effect(
           const cfgIgnores = cfg.watcher?.ignore ?? []
 
           if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
-            yield* Effect.forkScoped(
-              subscribe(ctx.directory, [...FileIgnore.PATTERNS, ...cfgIgnores, ...protecteds(ctx.directory)]),
-            )
+            const home = os.homedir()
+            const rel = path.relative(ctx.directory, home)
+            const watchesHome = rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))
+            if (watchesHome) {
+              log.warn("skipping watch of home directory; FSEvents exclusion setup for protected paths is too slow", {
+                directory: ctx.directory,
+              })
+            } else {
+              yield* Effect.forkScoped(
+                subscribe(ctx.directory, [...FileIgnore.PATTERNS, ...cfgIgnores, ...protecteds(ctx.directory)]),
+              )
+            }
           }
 
           if (ctx.project.vcs === "git") {


### PR DESCRIPTION
### Issue for this PR

Closes #27082

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode watches `$HOME` (or any ancestor of it), `protecteds()` adds every protected home subdirectory — `~/Library`, `~/Downloads`, `~/Desktop`, … — to the `ignore` list passed to `@parcel/watcher`. On macOS those absolute directories get registered through `FSEventStreamSetExclusionPaths`, and that registration takes tens of seconds when the dirs are large (a multi-GB `~/Library`), stalling watcher startup.

`protecteds(dir)` only returns entries when `dir` is `$HOME` or above — the protected dirs are children of home — so a normal project dir gets `[]` and is unaffected. This skips the watch entirely for the `$HOME`/ancestor case (the only case that builds the oversized exclusion list) and logs a warning instead.

### How did you verify your code works?

- `cd packages/opencode && bun test test/file/watcher.test.ts` → 6 pass / 0 fail. The suite watches a temp dir, so the normal subscribe path still runs and isn't regressed.
- Locally: opening opencode in `$HOME` previously stalled for ~30s+ during watcher startup while FSEvents registered the home exclusion paths. With this change the watcher logs the skip and continues immediately.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR