### PR TITLE
fix(session): plumb offset through v1 list, fix v2 archived encode

### DIFF
--- a/packages/core/src/session/schema.ts
+++ b/packages/core/src/session/schema.ts
@@ -53,7 +53,7 @@ export class Info extends Schema.Class<Info>("Session.Info")({
   time: Schema.Struct({
     created: V2Schema.DateTimeUtcFromMillis,
     updated: V2Schema.DateTimeUtcFromMillis,
-    archived: optionalOmitUndefined(V2Schema.DateTimeUtcFromMillis),
+    archived: Schema.optional(V2Schema.DateTimeUtcFromMillis),
   }),
   title: Schema.String,
 }) {}

--- a/packages/core/test/session-v2-schema.test.ts
+++ b/packages/core/test/session-v2-schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { DateTime, Schema } from "effect"
+import { V2Schema } from "@opencode-ai/core/v2-schema"
+
+const ArchivedField = Schema.optional(V2Schema.DateTimeUtcFromMillis)
+const decodeArchived = Schema.decodeUnknownSync(ArchivedField as any)
+const encodeArchived = Schema.encodeUnknownSync(ArchivedField as any)
+
+describe("SessionV2.Info.time.archived field schema", () => {
+  // Regression guard for #30109. The previous wrapper
+  // `optionalOmitUndefined(V2Schema.DateTimeUtcFromMillis)` inverted the
+  // direction of the inner decodeTo transform: encoding a DateTime crashed
+  // with "Expected DateTime.Utc, got <number>" and decoding a number
+  // crashed with "Expected number | undefined, got DateTime.Utc". Replacing
+  // it with plain `Schema.optional` keeps the wire format identical to the
+  // bare `DateTimeUtcFromMillis` field and round-trips cleanly.
+  test("decodes a number to DateTime", () => {
+    const result = decodeArchived(1_780_160_907_969)
+    expect(DateTime.toEpochMillis(result as DateTime.Utc)).toBe(1_780_160_907_969)
+  })
+
+  test("decodes omitted key to undefined", () => {
+    const result = decodeArchived(undefined)
+    expect(result).toBeUndefined()
+  })
+
+  test("encodes DateTime to a number", () => {
+    const result = encodeArchived(DateTime.makeUnsafe(1_780_160_907_969))
+    expect(result).toBe(1_780_160_907_969)
+  })
+
+  test("encodes undefined to omitted key (no wire-format change)", () => {
+    const result = encodeArchived(undefined)
+    expect(result).toBeUndefined()
+  })
+})
+

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -34,6 +34,7 @@ export const ListQuery = Schema.Struct({
   start: Schema.optional(Schema.NumberFromString),
   search: Schema.optional(Schema.String),
   limit: Schema.optional(Schema.NumberFromString),
+  offset: Schema.optional(Schema.NumberFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
 })
 export const DiffQuery = Schema.Struct({
   ...WorkspaceRoutingQueryFields,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -69,6 +69,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         start: ctx.query.start,
         search: ctx.query.search,
         limit: ctx.query.limit,
+        offset: ctx.query.offset,
       })
     })
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -301,6 +301,7 @@ export type ListInput = {
   start?: number
   search?: string
   limit?: number
+  offset?: number
 }
 
 export type GlobalListInput = {
@@ -1074,6 +1075,7 @@ function listByProject(
     .where(and(...conditions))
     .orderBy(desc(SessionTable.time_updated))
     .limit(limit)
+    .offset(input.offset ?? 0)
     .all()
     .pipe(
       Effect.orDie,

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -764,6 +764,37 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "serves paginated session list via offset",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        for (let i = 0; i < 5; i++) {
+          yield* createSession({ title: `page-${i}` })
+        }
+
+        const page1 = yield* requestJson<Session.Info[]>(`${SessionPaths.list}?limit=2&offset=0`, { headers })
+        const page2 = yield* requestJson<Session.Info[]>(`${SessionPaths.list}?limit=2&offset=2`, { headers })
+        const page3 = yield* requestJson<Session.Info[]>(`${SessionPaths.list}?limit=2&offset=4`, { headers })
+
+        expect(page1.length).toBe(2)
+        expect(page2.length).toBe(2)
+        expect(page3.length).toBe(1)
+
+        const ids1 = new Set(page1.map((s) => s.id))
+        const ids2 = new Set(page2.map((s) => s.id))
+        const ids3 = new Set(page3.map((s) => s.id))
+        const allIds = new Set([...ids1, ...ids2, ...ids3])
+
+        expect(allIds.size).toBe(5)
+        expect([...ids1].filter((id) => ids2.has(id))).toEqual([])
+        expect([...ids1].filter((id) => ids3.has(id))).toEqual([])
+        expect([...ids2].filter((id) => ids3.has(id))).toEqual([])
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "uses project-scoped path and directory precedence",
     () =>
       Effect.gen(function* () {

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -237,6 +237,49 @@ describe("session.list", () => {
   )
 
   it.instance(
+    "respects offset parameter across pages",
+    () =>
+      Effect.gen(function* () {
+        yield* withSession({ title: "offset-1" })
+        yield* withSession({ title: "offset-2" })
+        yield* withSession({ title: "offset-3" })
+        yield* withSession({ title: "offset-4" })
+        yield* withSession({ title: "offset-5" })
+
+        const page1 = yield* SessionNs.use.list({ limit: 2, offset: 0 })
+        const page2 = yield* SessionNs.use.list({ limit: 2, offset: 2 })
+        const page3 = yield* SessionNs.use.list({ limit: 2, offset: 4 })
+
+        expect(page1.length).toBe(2)
+        expect(page2.length).toBe(2)
+        expect(page3.length).toBe(1)
+
+        const ids1 = new Set(page1.map((s) => s.id))
+        const ids2 = new Set(page2.map((s) => s.id))
+        const ids3 = new Set(page3.map((s) => s.id))
+
+        expect([...ids1, ...ids2, ...ids3].length).toBe(5)
+        expect([...ids1].filter((id) => ids2.has(id))).toEqual([])
+        expect([...ids1].filter((id) => ids3.has(id))).toEqual([])
+        expect([...ids2].filter((id) => ids3.has(id))).toEqual([])
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "offset past total returns empty",
+    () =>
+      Effect.gen(function* () {
+        yield* withSession({ title: "past-1" })
+        yield* withSession({ title: "past-2" })
+
+        const sessions = yield* SessionNs.use.list({ limit: 10, offset: 5 })
+        expect(sessions.length).toBe(0)
+      }),
+    { git: true },
+  )
+
+  it.instance(
     "includes metadata in listed sessions",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #30109

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two unrelated bugs in the session list surfaced together.

**Bug 1 — "Load More" is stuck.** The v1 `GET /session` endpoint ignored the `offset` query parameter at every layer (`ListQuery`, `ListInput`, the handler, and the drizzle query in `listByProject`). When `directory=` was specified, the response was capped at the directory's total row count regardless of the requested `offset` and `limit`, so the frontend's "Load More" button could only ever re-fetch the same first page. Plumbed `offset` through all four layers.

**Bug 2 — `/api/session?roots=true` 500.** The v2 `Info.time.archived` field was declared as `optionalOmitUndefined(V2Schema.DateTimeUtcFromMillis)`, which inverted the type direction of the inner `decodeTo` transform: the encoder saw the encoded form (a number) but expected the decoded type (`DateTime.Utc`). The result was a 500 crash on any query that returned an archived root session, with `Expected DateTime.Utc, got 1780160907969` at the offending field. Replaced with plain `Schema.optional(...)`, which matches the convention already used for `time.completed`/`time.ran`/`time.pruned` in `packages/core/src/session/message.ts`. The wire format is now identical to the bare `DateTimeUtcFromMillis` (key omitted when undefined, present-with-number when set).

The v1 omit-when-undefined wire-format contract is preserved because the v1 schema uses `optionalOmitUndefined(ArchivedTimestamp = Schema.Finite)` with no `decodeTo` transform — that path was never affected.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck` — clean
- `cd packages/core && bun typecheck` — clean
- `cd packages/core && bun test ./test/session-v2-schema.test.ts` — 4 new round-trip tests on the archived field schema (the canary for fix 2)
- `cd packages/opencode && bun test ./test/server/session-list.test.ts` — 2 new unit tests for offset pagination, plus the 9 pre-existing tests
- `cd packages/opencode && bun test ./test/server/httpapi-session.test.ts` — 1 new HTTP-level test for offset through every layer, plus the 15 pre-existing tests that pass (2 unrelated timeouts in pre-existing tests reproduce on the branch without my changes)
- `cd packages/opencode && bun test ./test/session/session-schema.test.ts ./test/session/schema-decoding.test.ts` — 28 pre-existing v1 schema tests still pass; the v1 omit-when-undefined contract is preserved

### Screenshots / recordings

N/A — backend fix, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR