### PR TITLE
fix(opencode): generate reasoning variants for all OpenRouter models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -672,7 +672,11 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
 
   switch (model.api.npm) {
     case "@openrouter/ai-sdk-provider":
-      if (!id.includes("gpt") && !id.includes("gemini-3") && !id.includes("claude")) return {}
+      if (!id.includes("gpt") && !id.includes("gemini-3") && !id.includes("claude")) {
+        return Object.fromEntries(
+          OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]),
+        )
+      }
       return Object.fromEntries(
         (id.includes("gpt") ? openaiCompatibleReasoningEfforts(id) : OPENAI_EFFORTS).map((effort) => [
           effort,


### PR DESCRIPTION
Closes #30216

## What does this PR do?

The `variants()` function in the OpenRouter provider case returns `{}` for any model whose ID doesn't contain `gpt`, `gemini-3`, or `claude`, even when the model has `capabilities.reasoning: true`. OpenRouter's `reasoning.effort` parameter is provider-agnostic and works across all reasoning models, so this filter is unnecessarily restrictive.

The fix replaces the `return {}` with a fallback that generates default variants (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`) for any reasoning-capable model routed through OpenRouter. GPT, Gemini, and Claude models keep their existing model-specific effort lists unchanged.

## How did you verify your code works?

- Built and ran the TUI via `bun dev`
- Connected to OpenRouter and selected `deepseek/deepseek-v4-pro` — variants now appear in the `Ctrl+T` selector
- Tested `xhigh` variant — produces a visible chain-of-thought trace before the final answer
- Confirmed GPT models on OpenRouter still show their model-specific effort levels

Before:
<img width="502" height="179" alt="image" src="https://github.com/user-attachments/assets/24d25a0e-51ff-45d6-9669-6a0ac7d25df4" />

After:
<img width="649" height="192" alt="image" src="https://github.com/user-attachments/assets/7ea1b1a9-34a7-4d3e-9ec2-2657034468cc" />
<img width="811" height="365" alt="image" src="https://github.com/user-attachments/assets/5a95e527-7f47-4c65-9997-099e916ca317" />



## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR