### PR TITLE
fix(app): restore deferred MCP status updates

### DIFF
--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -6,8 +6,7 @@ import type { State } from "./types"
 import type { QueryOptionsApi } from "../server-sync"
 
 let createChildStoreManager: typeof import("./child-store").createChildStoreManager
-const queryGroups: Array<() => { queries: Array<{ enabled?: boolean }> }> = []
-const querySingles: Array<() => { enabled?: boolean }> = []
+const querySingles: Array<() => { queryKey?: unknown[]; enabled?: boolean }> = []
 
 const child = () => createStore({} as State)
 const provider = { all: new Map(), connected: [], default: {} } satisfies NormalizedProviderListResponse
@@ -50,20 +49,17 @@ beforeAll(async () => {
     persisted: (_target: string, store: unknown[]) => [store[0], store[1], null, () => true],
   }))
   mock.module("@tanstack/solid-query", () => ({
-    useQueries: (options: () => { queries: Array<{ enabled?: boolean }> }) => {
-      queryGroups.push(options)
-      return [
-        { isLoading: true, data: undefined },
-        { isLoading: false, data: [] },
-        { isLoading: false, data: provider },
-      ]
-    },
-    useQuery: (options: () => { enabled?: boolean }) => {
+    useQuery: (options: () => { queryKey?: unknown[]; enabled?: boolean }) => {
       querySingles.push(options)
       return {
-        isLoading: false,
+        get isLoading() {
+          return options().queryKey?.[1] === "path"
+        },
         get data() {
-          return options().enabled ? { demo: { status: "disabled" } } : undefined
+          if (options().queryKey?.[1] === "mcp") return options().enabled ? { demo: { status: "disabled" } } : undefined
+          if (options().queryKey?.[1] === "lsp") return []
+          if (options().queryKey?.[1] === "providers") return provider
+          return undefined
         },
       }
     },
@@ -190,7 +186,8 @@ describe("createChildStoreManager", () => {
     try {
       if (!manager) throw new Error("manager required")
       const [store, setStore] = manager.child("/project", { bootstrap: false })
-      const query = querySingles[offset]
+      expect(querySingles.length - offset).toBe(4)
+      const query = querySingles[offset + 1]
       if (!query) throw new Error("query required")
       expect(query().enabled).toBe(false)
 

--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -7,6 +7,7 @@ import type { QueryOptionsApi } from "../server-sync"
 
 let createChildStoreManager: typeof import("./child-store").createChildStoreManager
 const queryGroups: Array<() => { queries: Array<{ enabled?: boolean }> }> = []
+const querySingles: Array<() => { enabled?: boolean }> = []
 
 const child = () => createStore({} as State)
 const provider = { all: new Map(), connected: [], default: {} } satisfies NormalizedProviderListResponse
@@ -53,10 +54,18 @@ beforeAll(async () => {
       queryGroups.push(options)
       return [
         { isLoading: true, data: undefined },
-        { isLoading: false, data: {} },
         { isLoading: false, data: [] },
         { isLoading: false, data: provider },
       ]
+    },
+    useQuery: (options: () => { enabled?: boolean }) => {
+      querySingles.push(options)
+      return {
+        isLoading: false,
+        get data() {
+          return options().enabled ? { demo: { status: "disabled" } } : undefined
+        },
+      }
     },
   }))
 
@@ -159,7 +168,7 @@ describe("createChildStoreManager", () => {
 
   test("enables MCP only when requested for the directory", () => {
     let manager: ReturnType<typeof createChildStoreManager> | undefined
-    const offset = queryGroups.length
+    const offset = querySingles.length
     const mcpLoads: string[] = []
 
     const dispose = createOwner((owner) => {
@@ -180,18 +189,19 @@ describe("createChildStoreManager", () => {
 
     try {
       if (!manager) throw new Error("manager required")
-      const [, setStore] = manager.child("/project", { bootstrap: false })
-      const queries = queryGroups[offset]
-      if (!queries) throw new Error("queries required")
-      expect(queries().queries[1]?.enabled).toBe(false)
+      const [store, setStore] = manager.child("/project", { bootstrap: false })
+      const query = querySingles[offset]
+      if (!query) throw new Error("query required")
+      expect(query().enabled).toBe(false)
 
       setStore("status", "complete")
       manager.child("/project", { bootstrap: false, mcp: true })
-      expect(queries().queries[1]?.enabled).toBe(true)
+      expect(query().enabled).toBe(true)
+      expect(store.mcp).toEqual({ demo: { status: "disabled" } })
       expect(mcpLoads).toEqual(["/project"])
 
       manager.disableMcp("/project")
-      expect(queries().queries[1]?.enabled).toBe(false)
+      expect(query().enabled).toBe(false)
       expect(manager.mcp("/project")).toBe(false)
     } finally {
       dispose()

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -14,7 +14,7 @@ import {
   type VcsCache,
 } from "./types"
 import { canDisposeDirectory, pickDirectoriesToEvict } from "./eviction"
-import { useQueries, useQuery } from "@tanstack/solid-query"
+import { useQuery } from "@tanstack/solid-query"
 import { QueryOptionsApi } from "../server-sync"
 import { directoryKey, type DirectoryKey } from "./utils"
 import { NormalizedProviderListResponse } from "@opencode-ai/ui/context"
@@ -180,14 +180,10 @@ export function createChildStoreManager(input: {
           const initialIcon = icon[0].value
           const [mcpEnabled, setMcpEnabled] = createSignal(false)
 
-          const [pathQuery, lspQuery, providerQuery] = useQueries(() => ({
-            queries: [
-              input.queryOptions.path(key),
-              input.queryOptions.lsp(key),
-              input.queryOptions.providers(key),
-            ],
-          }))
+          const pathQuery = useQuery(() => input.queryOptions.path(key))
           const mcpQuery = useQuery(() => ({ ...input.queryOptions.mcp(key), enabled: mcpEnabled() }))
+          const lspQuery = useQuery(() => input.queryOptions.lsp(key))
+          const providerQuery = useQuery(() => input.queryOptions.providers(key))
 
           const child = createStore<State>({
             project: "",

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -14,7 +14,7 @@ import {
   type VcsCache,
 } from "./types"
 import { canDisposeDirectory, pickDirectoriesToEvict } from "./eviction"
-import { useQueries } from "@tanstack/solid-query"
+import { useQueries, useQuery } from "@tanstack/solid-query"
 import { QueryOptionsApi } from "../server-sync"
 import { directoryKey, type DirectoryKey } from "./utils"
 import { NormalizedProviderListResponse } from "@opencode-ai/ui/context"
@@ -180,14 +180,14 @@ export function createChildStoreManager(input: {
           const initialIcon = icon[0].value
           const [mcpEnabled, setMcpEnabled] = createSignal(false)
 
-          const [pathQuery, mcpQuery, lspQuery, providerQuery] = useQueries(() => ({
+          const [pathQuery, lspQuery, providerQuery] = useQueries(() => ({
             queries: [
               input.queryOptions.path(key),
-              { ...input.queryOptions.mcp(key), enabled: mcpEnabled() },
               input.queryOptions.lsp(key),
               input.queryOptions.providers(key),
             ],
           }))
+          const mcpQuery = useQuery(() => ({ ...input.queryOptions.mcp(key), enabled: mcpEnabled() }))
 
           const child = createStore<State>({
             project: "",


### PR DESCRIPTION
- MCP is lazily enabled, but we destructured its result from `useQueries()` while it was disabled. When it was enabled later, `useQueries()` replaced that array entry and the child store kept reading the original disabled result, so the request completed without appearing in the status popover.
- TanStack's Parallel Queries docs say: "When the number of parallel queries does not change, ... use any number of TanStack Query's `useQuery` ... functions side-by-side" and reserve `useQueries()` for when "the number of queries you need to execute changes." These are four fixed directory queries, so use individual `useQuery()` observers and keep MCP lazy with `enabled: mcpEnabled()`.
