### PR TITLE
docs: add deliberation to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -80,4 +80,5 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | Name                                                              | Description                                                  |
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
+| [deliberation](https://github.com/antonbabenko/deliberation)      | Second opinions or fixes from GPT, Gemini, Grok, OpenRouter   |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |


### PR DESCRIPTION
### Issue for this PR

Closes # _(no issue - docs-only ecosystem listing)_

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the Agents table on the ecosystem page for `deliberation`, an
MCP server that lets you ask GPT (Codex), Gemini, Grok, or OpenRouter for a
second opinion or a fix. The row sits between Agentic and opencode-agents to
keep the table alphabetical, and I padded the cells to match the existing
column widths so the diff stays clean.

This is just a new list entry - no code, no behavior change.

### How did you verify your code works?

Edited `packages/web/src/content/docs/ecosystem.mdx` by hand and checked the
Markdown table by eye: the new row has the same pipe layout and column widths as
the surrounding rows, so it renders as a normal table row. No build step is
needed for a content row.

### Screenshots / recordings

N/A - one Markdown table row, no UI/visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
