### PR TITLE
fix(project): refresh stale instance context

### DIFF
--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -103,12 +103,26 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
       return true
     })
 
+    const resolveCached = Effect.fn("InstanceStore.resolveCached")(function* (
+      directory: string,
+      input: LoadInput,
+      entry: Entry,
+    ) {
+      const ctx = yield* Deferred.await(entry.deferred)
+      if (yield* project.get(ctx.project.id)) return ctx
+      if (cache.get(directory) !== entry) return yield* load({ ...input, directory })
+      yield* Effect.logInfo("cached instance project missing; reloading instance").pipe(
+        Effect.annotateLogs({ directory, project: ctx.project.id }),
+      )
+      return yield* reload({ directory })
+    })
+
     const load = (input: LoadInput): Effect.Effect<InstanceContext> => {
       const directory = AppFileSystem.resolve(input.directory)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const existing = cache.get(directory)
-          if (existing) return yield* restore(Deferred.await(existing.deferred))
+          if (existing) return yield* restore(resolveCached(directory, input, existing))
 
           const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>() }
           cache.set(directory, entry)

--- a/packages/opencode/test/project/instance.test.ts
+++ b/packages/opencode/test/project/instance.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect } from "bun:test"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { Hash } from "@opencode-ai/core/util/hash"
+import { $ } from "bun"
 import { Deferred, Effect, Fiber, Layer } from "effect"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { registerDisposer } from "../../src/effect/instance-registry"
 import { InstanceBootstrap } from "../../src/project/bootstrap-service"
 import { InstanceStore } from "../../src/project/instance-store"
+import { Project } from "../../src/project/project"
 import { tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -15,7 +19,9 @@ const noopBootstrap = Layer.succeed(
 )
 
 const it = testEffect(
-  Layer.mergeAll(InstanceStore.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(noopBootstrap)),
+  Layer.mergeAll(InstanceStore.defaultLayer, Project.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(
+    Layer.provide(noopBootstrap),
+  ),
 )
 
 const setBootstrap = (run: Effect.Effect<void>) =>
@@ -80,6 +86,25 @@ describe("InstanceStore", () => {
 
       expect(second).toBe(first)
       expect(initialized).toBe(1)
+    }),
+  )
+
+  it.live("reloads cached context when its project row is migrated away", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const projects = yield* Project.Service
+      const remote = `github.com/opencode-test/${crypto.randomUUID()}`
+      const first = yield* store.load({ directory: dir })
+
+      yield* Effect.promise(() => $`git remote add origin ${`https://${remote}.git`}`.cwd(dir).quiet())
+      const migrated = yield* projects.fromDirectory(dir)
+      const refreshed = yield* store.load({ directory: dir })
+
+      expect(yield* projects.get(first.project.id)).toBeUndefined()
+      expect(migrated.project.id).toBe(ProjectV2.ID.make(Hash.fast(`git-remote:${remote}`)))
+      expect(refreshed).not.toBe(first)
+      expect(refreshed.project.id).toBe(migrated.project.id)
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #30236 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`InstanceStore.load` could return a cached instance context without checking whether its `project.id` still existed.

If another opencode process migrated the same repo to a new project ID, the old project row was deleted. A still-running process could then create a session with the stale project ID, which hit a SQLite foreign-key error and came back to the client as `UnknownError`.

This PR checks the cached context before reusing it. If the project row is gone, it reloads the instance for that directory, which re-runs project resolution and picks up the migrated project ID. New sessions from the old process are then inserted with the current project ID.

It also adds a regression test for loading a repo, triggering project ID migration by adding a remote, and then loading from the same instance store again.

### How did you verify your code works?

- Ran `bun test test/project/instance.test.ts` from `packages/opencode`: 10/10 pass.
- Ran a two-server repro with a temp repo and isolated SQLite DB. Server A created a session before the repo had a remote, server B created a session after adding the remote and migrated the project ID, then still-running server A created another session successfully with `HTTP 200` and the migrated project ID.
- Ran `bun typecheck` from `packages/opencode`: clean.

### Screenshots / recordings

Not included. This is a session/project state fix covered by the regression test and the two-server repro.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
