### PR TITLE
feat(provider): add free model resolution for --model free

### DIFF
--- a/packages/opencode/src/cli/bootstrap.ts
+++ b/packages/opencode/src/cli/bootstrap.ts
@@ -1,10 +1,10 @@
 import { InstanceRuntime } from "../project/instance-runtime"
-import { context } from "../project/instance-context"
+import { context, type InstanceContext } from "../project/instance-context"
 
-export async function bootstrap<T>(directory: string, cb: () => Promise<T>) {
+export async function bootstrap<T>(directory: string, cb: (ctx: InstanceContext) => Promise<T>) {
   const ctx = await InstanceRuntime.load({ directory })
   try {
-    return await context.provide(ctx, cb)
+    return await context.provide(ctx, () => cb(ctx))
   } finally {
     await InstanceRuntime.disposeInstance(ctx)
   }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -26,6 +26,7 @@ import { Permission } from "@/permission"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { InstanceRef } from "@/effect/instance-ref"
 import { FormatError, FormatUnknownError } from "../error"
+import { Provider } from "@/provider/provider"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
 
 const runtimeTask = import("./run/runtime")
@@ -771,15 +772,16 @@ export const RunCommand = effectCmd({
             console.error(e)
             process.exit(1)
           })
+          const resolved = await Provider.resolveSelection(args.model, args.variant, localInstance)
 
           if (args.command) {
             const result = await client.session.command({
               sessionID,
               agent,
-              model: args.model,
+              model: resolved.model,
               command: args.command,
               arguments: message,
-              variant: args.variant,
+              variant: resolved.variant,
             })
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
@@ -788,12 +790,12 @@ export const RunCommand = effectCmd({
             return
           }
 
-          const model = pick(args.model)
+          const model = resolved.model ? Provider.parseModel(resolved.model) : undefined
           const result = await client.session.prompt({
             sessionID,
             agent,
             model,
-            variant: args.variant,
+            variant: resolved.variant,
             parts: [...files, { type: "text", text: message }],
           })
           if (result.error) {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -491,6 +491,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           })
         local.model.set({ providerID, modelID }, { recent: true })
       }
+      if (args.variant) local.model.variant.set(args.variant)
       if (args.sessionID && !args.fork) {
         route.navigate({
           type: "session",

--- a/packages/opencode/src/cli/cmd/tui/context/args.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/args.tsx
@@ -2,6 +2,7 @@ import { createSimpleContext } from "./helper"
 
 export interface Args {
   model?: string
+  variant?: string
   agent?: string
   prompt?: string
   continue?: boolean

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -21,6 +21,8 @@ import {
   sanitizedProcessEnv,
 } from "@opencode-ai/core/util/opencode-process"
 import { validateSession } from "./validate-session"
+import { Provider } from "@/provider/provider"
+import { bootstrap } from "@/cli/bootstrap"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -111,6 +113,10 @@ export const TuiThreadCommand = cmd({
       .option("agent", {
         type: "string",
         describe: "agent to use",
+      })
+      .option("variant", {
+        type: "string",
+        describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
       }),
   handler: async (args) => {
     // Keep ENABLE_PROCESSED_INPUT cleared even if other code flips it.
@@ -138,6 +144,12 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
+      // TUI handler runs outside effectCmd, so the Instance ALS context that
+      // Provider.Service.list needs isn't established. Provide it here. The
+      // worker spawned below sets up its own.
+      const pick = await bootstrap(cwd, (ctx) => Provider.resolveSelection(args.model, args.variant, ctx))
+      const model = pick.model
+      const variant = pick.variant
       const env = sanitizedProcessEnv({
         [OPENCODE_PROCESS_ROLE]: "worker",
         [OPENCODE_RUN_ID]: ensureRunID(),
@@ -246,7 +258,8 @@ export const TuiThreadCommand = cmd({
             continue: args.continue,
             sessionID: args.session,
             agent: args.agent,
-            model: args.model,
+            model,
+            variant,
             prompt,
             fork: args.fork,
           },

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -21,6 +21,7 @@ import { Effect, Layer, Context, Schema, Types } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectPromise } from "@/effect/promise"
+import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { isRecord } from "@/util/record"
 import { optionalOmitUndefined } from "@opencode-ai/core/schema"
@@ -29,6 +30,8 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { InstanceRef } from "@/effect/instance-ref"
+import type { InstanceContext } from "@/project/instance-context"
 
 const log = Log.create({ service: "provider" })
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
@@ -1890,6 +1893,65 @@ export function sort<T extends { id: string }>(models: T[]) {
     [(model) => (model.id.includes("latest") ? 0 : 1), "asc"],
     [(model) => model.id, "desc"],
   )
+}
+
+const FREE = "free"
+export const ANY = "any"
+
+export function isFree(model: Model) {
+  // Catalog includes zero-cost promotional models (e.g. "big-pickle") that
+  // aren't part of the OpenCode Zen free tier. The only catalog signal is the
+  // "-free" id suffix, so guard on it in addition to cost.
+  if (!model.id.endsWith("-free")) return false
+  const extra = model.cost.experimentalOver200K
+  return (
+    model.providerID === ProviderV2.ID.opencode &&
+    model.cost.input === 0 &&
+    model.cost.output === 0 &&
+    model.cost.cache.read === 0 &&
+    model.cost.cache.write === 0 &&
+    (!extra || (extra.input === 0 && extra.output === 0 && extra.cache.read === 0 && extra.cache.write === 0))
+  )
+}
+
+function freeVariants(model: Model) {
+  return Object.keys(model.variants ?? {})
+    .toSorted()
+    .filter((item) => item !== "default")
+}
+
+const { runPromise } = makeRuntime(Service, defaultLayer)
+
+export async function resolveSelection(model?: string, variant?: string, instance?: InstanceContext) {
+  if (!model) return { model, variant }
+  if (model !== FREE) return { model, variant }
+  // Service.list() requires InstanceRef in the Effect fiber. Callers from plain
+  // async code (run.ts handler post-await, thread.ts bootstrap callback) have no
+  // current fiber, so we provide it explicitly when given. Tests run inside an
+  // Effect fiber that already has InstanceRef set up, so the arg is optional.
+  const providers = await runPromise((svc) =>
+    instance ? svc.list().pipe(Effect.provideService(InstanceRef, instance)) : svc.list(),
+  )
+  const provider = providers[ProviderV2.ID.opencode]
+  const models = sort(Object.values(provider?.models ?? {}).filter(isFree))
+  // Unseeded by design: the same `--model free` in two terminals picks
+  // different models.
+  const pick = models[Math.floor(Math.random() * models.length)]
+  if (!pick)
+    throw new Error(
+      `No free opencode models found. The opencode provider must be configured (set OPENCODE_API_KEY) and at least one model in its catalog must have all costs set to 0.`,
+    )
+  const value =
+    variant === ANY
+      ? (() => {
+          const choices = freeVariants(pick)
+          return choices[Math.floor(Math.random() * choices.length)]
+        })()
+      : variant
+  return {
+    model: `${pick.providerID}/${pick.id}`,
+    variant: value,
+  }
 }
 
 export function parseModel(model: string) {

--- a/packages/opencode/test/cli/cmd/run.test.ts
+++ b/packages/opencode/test/cli/cmd/run.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as SDK from "@opencode-ai/sdk/v2"
+import { Provider } from "../../../src/provider/provider"
+
+const seen = {
+  prompt: [] as any[],
+  command: [] as any[],
+  variant: [] as any[],
+}
+
+function setup() {
+  spyOn(Provider, "resolveSelection").mockImplementation(async (model, variant) => ({
+    model: model === "free" ? "opencode/freebie" : model,
+    variant: variant === "any" ? "high" : variant,
+  }))
+  spyOn(SDK, "createOpencodeClient").mockImplementation(
+    () =>
+      ({
+        config: {
+          get: async () => ({ data: { share: "manual" } }),
+        },
+        event: {
+          subscribe: async () => ({
+            stream: (async function* () {})(),
+          }),
+        },
+        path: {
+          get: async () => ({ data: { directory: process.cwd() } }),
+        },
+        session: {
+          create: async () => ({ data: { id: "session-1" } }),
+          prompt: async (input: any) => {
+            seen.prompt.push(input)
+            seen.variant.push(input.variant)
+            return {}
+          },
+          command: async (input: any) => {
+            seen.command.push(input)
+            seen.variant.push(input.variant)
+            return {}
+          },
+        },
+      }) as any,
+  )
+}
+
+describe("run command", () => {
+  afterEach(() => {
+    mock.restore()
+    seen.prompt.length = 0
+    seen.command.length = 0
+    seen.variant.length = 0
+  })
+
+  async function call(extra?: Record<string, unknown>) {
+    setup()
+    const { RunCommand } = await import("../../../src/cli/cmd/run")
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+
+    try {
+      await RunCommand.handler({
+        _: [],
+        $0: "opencode",
+        message: ["hi"],
+        command: undefined,
+        continue: false,
+        session: undefined,
+        fork: false,
+        share: false,
+        model: "free",
+        agent: undefined,
+        format: "default",
+        file: undefined,
+        title: undefined,
+        attach: "http://127.0.0.1:4096",
+        password: undefined,
+        dir: undefined,
+        port: undefined,
+        variant: undefined,
+        thinking: false,
+        "dangerously-skip-permissions": false,
+        "--": [],
+        ...extra,
+      } as any)
+    } finally {
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+    }
+  }
+
+  test("resolves free before prompting", async () => {
+    await call()
+
+    expect(seen.prompt).toHaveLength(1)
+    expect(String(seen.prompt[0].model.providerID)).toBe("opencode")
+    expect(String(seen.prompt[0].model.modelID)).toBe("freebie")
+  })
+
+  test("passes the resolved model to command sessions", async () => {
+    await call({ command: "echo" })
+
+    expect(seen.command).toHaveLength(1)
+    expect(seen.command[0].model).toBe("opencode/freebie")
+  })
+
+  test("passes the resolved any variant to sessions", async () => {
+    await call({ variant: "any" })
+
+    expect(seen.prompt).toHaveLength(1)
+    expect(seen.variant[0]).toBe("high")
+  })
+})

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -1,19 +1,155 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { tmpdir } from "../../fixture/fixture"
-import { resolveThreadDirectory } from "../../../src/cli/cmd/tui/thread"
+import * as App from "../../../src/cli/cmd/tui/app"
+import { UI } from "../../../src/cli/ui"
+import * as Timeout from "../../../src/util/timeout"
+import * as Network from "../../../src/cli/network"
+import * as Win32 from "../../../src/cli/cmd/tui/win32"
+import { Provider } from "../../../src/provider/provider"
+import { Effect } from "effect"
+
+const stop = new Error("stop")
+const packageRoot = path.resolve(import.meta.dir, "../../..")
+const seen = {
+  tui: [] as string[],
+  model: [] as (string | undefined)[],
+  variant: [] as (string | undefined)[],
+}
+
+class TestWorker extends EventTarget {
+  onerror: Worker["onerror"] = null
+  onmessage: Worker["onmessage"] = null
+  onmessageerror: Worker["onmessageerror"] = null
+
+  postMessage(data: string) {
+    const parsed = JSON.parse(data)
+    if (!parsed || typeof parsed !== "object" || !("method" in parsed) || !("id" in parsed)) return
+    if (typeof parsed.method !== "string" || typeof parsed.id !== "number") return
+    const result =
+      parsed.method === "fetch"
+        ? { status: 200, headers: {}, body: "" }
+        : parsed.method === "server"
+          ? { url: "http://127.0.0.1" }
+          : parsed.method === "snapshot"
+            ? ""
+            : undefined
+    queueMicrotask(() => {
+      this.onmessage?.(
+        new MessageEvent("message", { data: JSON.stringify({ type: "rpc.result", result, id: parsed.id }) }),
+      )
+    })
+  }
+
+  terminate() {}
+}
+
+function setup() {
+  // Intentionally avoid mock.module() here: Bun keeps module overrides in cache
+  // and mock.restore() does not reset mock.module values. If this switches back
+  // to module mocks, later suites can see mocked @/config/tui and fail (e.g.
+  // plugin-loader tests expecting real TuiConfig.waitForDependencies). See:
+  // https://github.com/oven-sh/bun/issues/7823 and #12823.
+  spyOn(App, "createTuiRenderer").mockImplementation(async () => ({}) as never)
+  spyOn(App, "tui").mockImplementation((input) => {
+    if (input.directory) seen.tui.push(input.directory)
+    seen.model.push(input.args.model)
+    seen.variant.push(input.args.variant)
+    return {
+      ready: Promise.resolve(),
+      done: Promise.reject(stop),
+      exit: {} as never,
+    }
+  })
+  spyOn(UI, "error").mockImplementation(() => {})
+  spyOn(Timeout, "withTimeout").mockImplementation((input) => input)
+  spyOn(Network, "resolveNetworkOptions").mockImplementation(() =>
+    Effect.succeed({
+      mdns: false,
+      port: 0,
+      hostname: "127.0.0.1",
+      mdnsDomain: "opencode.local",
+      cors: [],
+    }),
+  )
+  spyOn(Win32, "win32DisableProcessedInput").mockImplementation(() => {})
+  spyOn(Win32, "win32InstallCtrlCGuard").mockReturnValue(undefined)
+  spyOn(Provider, "resolveSelection").mockImplementation(async (model, variant) => ({
+    model: model === "free" ? "opencode/freebie" : model,
+    variant: variant === "any" ? "high" : variant,
+  }))
+}
 
 describe("tui thread", () => {
-  async function check(project?: string) {
+  setup()
+
+  async function call(project?: string, model?: string, variant?: string) {
+    const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
+    const args: Parameters<NonNullable<typeof TuiThreadCommand.handler>>[0] = {
+      _: [],
+      $0: "opencode",
+      project,
+      prompt: "hi",
+      model,
+      variant,
+      agent: undefined,
+      session: undefined,
+      continue: false,
+      fork: false,
+      port: 0,
+      hostname: "127.0.0.1",
+      mdns: false,
+      "mdns-domain": "opencode.local",
+      mdnsDomain: "opencode.local",
+      cors: [],
+    }
+    return TuiThreadCommand.handler(args)
+  }
+
+  async function check(
+    project?: string,
+    model?: string,
+    variant?: string,
+    expected?: { model?: string; variant?: string },
+  ) {
+    const pwd = process.env.PWD
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
     await using tmp = await tmpdir({ git: true })
     const link = path.join(path.dirname(tmp.path), path.basename(tmp.path) + "-link")
     const type = process.platform === "win32" ? "junction" : "dir"
+    seen.tui.length = 0
+    seen.model.length = 0
+    seen.variant.length = 0
+    await fs.symlink(tmp.path, link, type)
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    Object.defineProperty(globalThis, "Worker", { configurable: true, value: TestWorker })
 
     try {
-      await fs.symlink(tmp.path, link, type)
-      expect(resolveThreadDirectory(project, link, tmp.path)).toBe(tmp.path)
+      process.chdir(tmp.path)
+      process.env.PWD = link
+      let error: unknown
+      try {
+        await call(project, model, variant)
+      } catch (caught) {
+        error = caught
+      }
+      expect(error).toBe(stop)
+      expect(seen.tui[0]).toBe(tmp.path)
+      if (expected?.model) expect(seen.model[0]).toBe(expected.model)
+      if (expected?.variant) expect(seen.variant[0]).toBe(expected.variant)
     } finally {
+      process.chdir(packageRoot)
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      Object.defineProperty(globalThis, "Worker", { configurable: true, value: worker })
       await fs.rm(link, { recursive: true, force: true }).catch(() => undefined)
     }
   }
@@ -24,5 +160,13 @@ describe("tui thread", () => {
 
   test("uses the real cwd after resolving a relative project from PWD", async () => {
     await check(".")
+  })
+
+  test("resolves the free model alias before launching the tui", async () => {
+    await check(undefined, "free", undefined, { model: "opencode/freebie" })
+  })
+
+  test("passes the resolved any variant before launching the tui", async () => {
+    await check(undefined, "free", "any", { model: "opencode/freebie", variant: "high" })
   })
 })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test"
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
 import { mkdir, unlink } from "fs/promises"
 import path from "path"
 import { Effect, Layer } from "effect"
@@ -75,6 +75,43 @@ const paid = (providers: Record<string, { models: Record<string, { cost: { input
 }
 
 const languageBaseURL = (language: unknown) => (language as { config: { baseURL: string } }).config.baseURL
+
+function free(model: { cost: { input: number; output: number; cache: { read: number; write: number } } }) {
+  return (
+    model.cost.input === 0 && model.cost.output === 0 && model.cost.cache.read === 0 && model.cost.cache.write === 0
+  )
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+const freeConfig = {
+  provider: {
+    opencode: {
+      whitelist: ["alpha-free", "plain-free"],
+      options: { apiKey: "test-api-key" },
+      models: {
+        "alpha-free": {
+          name: "Alpha Free",
+          reasoning: true,
+          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+          limit: { context: 128000, output: 4096 },
+          variants: {
+            low: { effort: "low" },
+            high: { effort: "high" },
+          },
+        },
+        "plain-free": {
+          name: "Plain Free",
+          reasoning: false,
+          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+          limit: { context: 128000, output: 4096 },
+        },
+      },
+    },
+  },
+}
 
 const it = testEffect(Layer.mergeAll(Provider.defaultLayer, Env.defaultLayer, Plugin.defaultLayer))
 const experimentalModels = testEffect(providerLayer({ enableExperimentalModels: true }))
@@ -342,6 +379,225 @@ it.instance("defaultModel returns first available model when no config set", () 
     expect(model.providerID).toBeDefined()
     expect(model.modelID).toBeDefined()
   }),
+)
+
+it.instance(
+  "resolveSelection picks only zero-cost opencode models, not other providers",
+  Effect.gen(function* () {
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.opencode]).toBeDefined()
+    expect(providers[ProviderV2.ID.openrouter]).toBeDefined()
+
+    spyOn(Math, "random").mockReturnValue(0)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free"))
+    const parsed = Provider.parseModel(result.model!)
+
+    // Must pick from opencode only, not openrouter.
+    expect(String(parsed.providerID)).toBe("opencode")
+    // Must be a zero-cost model (not the paid one).
+    const model = providers[ProviderV2.ID.opencode].models[String(parsed.modelID)]
+    expect(model).toBeDefined()
+    expect(model.cost.input).toBe(0)
+    expect(model.cost.output).toBe(0)
+    expect(String(parsed.modelID)).not.toBe("free-router")
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          options: { apiKey: "test-api-key" },
+          models: {
+            "my-zero-cost-free": {
+              name: "My Zero Cost",
+              cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+            "my-paid": {
+              name: "My Paid",
+              cost: { input: 1, output: 2, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+        openrouter: {
+          options: { apiKey: "test-api-key" },
+          models: {
+            "free-router": {
+              name: "Free Router",
+              cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+              tool_call: true,
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "resolveSelection picks a variant from the chosen free model",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const provider = providers[ProviderV2.ID.opencode]
+    const models = Provider.sort(Object.values(provider.models).filter(free))
+    const index = models.findIndex((item) => String(item.id) === "alpha-free")
+    const choices = Object.keys(provider.models["alpha-free"].variants ?? {}).toSorted()
+
+    expect(index).toBeGreaterThanOrEqual(0)
+    expect(choices.length).toBeGreaterThan(0)
+
+    let count = 0
+    spyOn(Math, "random").mockImplementation(() => {
+      count += 1
+      if (count === 1) return (index + 0.1) / models.length
+      return (choices.length - 1 + 0.1) / choices.length
+    })
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "any"))
+
+    expect(result.model).toBe("opencode/alpha-free")
+    expect(result.variant).toBe(choices.at(-1))
+  }),
+  { config: freeConfig },
+)
+
+it.instance(
+  "resolveSelection keeps explicit variants unchanged",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const provider = providers[ProviderV2.ID.opencode]
+    const models = Provider.sort(Object.values(provider.models).filter(free))
+    const index = models.findIndex((item) => String(item.id) === "alpha-free")
+
+    expect(index).toBeGreaterThanOrEqual(0)
+
+    spyOn(Math, "random").mockReturnValue((index + 0.1) / models.length)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "max"))
+
+    expect(result.model).toBe("opencode/alpha-free")
+    expect(result.variant).toBe("max")
+  }),
+  { config: freeConfig },
+)
+
+it.instance(
+  "resolveSelection falls back to no variant when the chosen free model has none",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const provider = providers[ProviderV2.ID.opencode]
+    const models = Provider.sort(Object.values(provider.models).filter(free))
+    const index = models.findIndex((item) => String(item.id) === "plain-free")
+
+    expect(index).toBeGreaterThanOrEqual(0)
+    expect(provider.models["plain-free"].variants ?? {}).toEqual({})
+
+    spyOn(Math, "random").mockReturnValue((index + 0.1) / models.length)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "any"))
+
+    expect(result.model).toBe("opencode/plain-free")
+    expect(result.variant).toBeUndefined()
+  }),
+  { config: freeConfig },
+)
+
+test("resolveSelection passes through when model is undefined", async () => {
+  const result = await Provider.resolveSelection(undefined, "any")
+  expect(result.model).toBeUndefined()
+  expect(result.variant).toBe("any")
+})
+
+test("resolveSelection short-circuits with an explicit non-free model", async () => {
+  const result = await Provider.resolveSelection("opencode/big-pickle", "any")
+  expect(result.model).toBe("opencode/big-pickle")
+  expect(result.variant).toBe("any")
+})
+
+it.instance(
+  "resolveSelection throws with actionable message when no free models are available",
+  Effect.gen(function* () {
+    const result = yield* Effect.tryPromise(() => Provider.resolveSelection("free")).pipe(Effect.exit)
+    expect(result._tag).toBe("Failure")
+    if (result._tag === "Failure") {
+      const message = String((result.cause as { error?: Error }).error ?? result.cause)
+      expect(message).toContain("OPENCODE_API_KEY")
+    }
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          whitelist: ["paid-only"],
+          options: { apiKey: "test-api-key" },
+          models: {
+            "paid-only": {
+              name: "Paid Only",
+              cost: { input: 1, output: 2, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "resolveSelection skips zero-cost opencode models that lack the -free suffix (promo guard)",
+  Effect.gen(function* () {
+    spyOn(Math, "random").mockReturnValue(0)
+    const result = yield* Effect.tryPromise(() => Provider.resolveSelection("free")).pipe(Effect.exit)
+    // Only model in catalog is zero-cost but unsuffixed — should be treated as a promo and rejected.
+    expect(result._tag).toBe("Failure")
+    if (result._tag === "Failure") {
+      const message = String((result.cause as { error?: Error }).error ?? result.cause)
+      expect(message).toContain("OPENCODE_API_KEY")
+    }
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          whitelist: ["big-pickle-clone"],
+          options: { apiKey: "test-api-key" },
+          models: {
+            "big-pickle-clone": {
+              name: "Big Pickle Clone",
+              cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "build catalog exposes at least one opencode free model and resolveSelection picks one",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const opencode = providers[ProviderV2.ID.opencode]
+    expect(opencode).toBeDefined()
+
+    const freeModels = Object.values(opencode.models).filter(Provider.isFree)
+    // Surface the count in test output so catalog drift is visible at a glance.
+    console.log(
+      `[free-model-resolution] catalog has ${freeModels.length} free opencode model(s): ${freeModels.map((m) => String(m.id)).join(", ")}`,
+    )
+    expect(freeModels.length).toBeGreaterThan(0)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free"))
+    expect(result.model).toBeDefined()
+    const parsed = Provider.parseModel(result.model!)
+    expect(String(parsed.providerID)).toBe("opencode")
+    const ids = new Set(freeModels.map((m) => String(m.id)))
+    expect(ids.has(String(parsed.modelID))).toBe(true)
+  }),
+  { config: { provider: { opencode: { options: { apiKey: "test-api-key" } } } } },
 )
 
 it.instance(


### PR DESCRIPTION
## Summary
- Resolve `--model free` to a randomly-chosen OpenCode Zen free-tier model (zero-cost across input/output/cache, `-free` id suffix guard against zero-cost promotional models).
- Wire the resolver through CLI `run`, TUI `args`/`app`/`thread`, and the `Provider` service. Adds `--variant` arg with `any` → random pick from the chosen model's variants.

## Files
- `src/provider/provider.ts` — `resolveSelection()`, `isFree()`, `freeVariants()`
- `src/cli/cmd/run.ts`, `src/cli/cmd/tui/{app.tsx,context/args.tsx,thread.ts}` — wire through
- `test/{provider/provider.test.ts, cli/cmd/run.test.ts, cli/tui/thread.test.ts}` — 104 tests, all green

## Test Plan
- [x] `bun test test/provider/provider.test.ts` — 97/97 pass
- [x] `bun test test/cli/cmd/run.test.ts` — 3/3 pass
- [x] `bun test test/cli/tui/thread.test.ts` — 4/4 pass
- [x] `bun run build` succeeds across all 12 platform targets, smoke test passes
- [x] Manual probe (`probe-free.ts`, 60 samples): every pick was `opencode/*-free`, all zero-cost; promotional `big-pickle` correctly filtered out