### PR TITLE
fix(desktop): allow choosing Windows install directory

### DIFF
--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -86,8 +86,9 @@ const getBase = (appId: string): Configuration => ({
     verifyUpdateCodeSignature: false,
   },
   nsis: {
-    oneClick: true,
+    oneClick: false,
     perMachine: false,
+    allowToChangeInstallationDirectory: true,
     installerIcon: `resources/icons/icon.ico`,
     installerHeaderIcon: `resources/icons/icon.ico`,
   },

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -88,6 +88,7 @@ const getBase = (appId: string): Configuration => ({
   nsis: {
     oneClick: false,
     perMachine: false,
+    selectPerMachineByDefault: false,
     allowToChangeInstallationDirectory: true,
     installerIcon: `resources/icons/icon.ico`,
     installerHeaderIcon: `resources/icons/icon.ico`,


### PR DESCRIPTION
### Issue for this PR

Fixes #26818
Related #17044

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Switches the Windows NSIS installer from one-click mode to the assisted installer flow.

With `oneClick: true`, the installer skips the UI that lets users choose the installation scope or install path, so Windows installs default to the per-user location under `%LocalAppData%\Programs`.

This PR keeps per-user installs as the default while giving users both choices in the assisted installer:

- Current user: keep the default per-user install location under `%LocalAppData%\Programs`.
- All users: use the per-machine install mode, which installs under the system-level location such as `Program Files` after elevation.

It also enables `allowToChangeInstallationDirectory` so users can choose a custom directory in the assisted flow.

### How did you verify your code works?

- `git diff --check`
- `npx --yes prettier@3.6.2 --check packages/desktop/electron-builder.config.ts`
- `bun run --cwd packages/desktop typecheck` was attempted locally on Windows, but this checkout materializes the repo symlink `packages/app/src/custom-elements.d.ts` as a text file (`../../ui/src/custom-elements.d.ts`), so TypeScript fails before reaching this installer config. The PR's required typecheck workflow is pending maintainer approval.

### Screenshots / recordings

N/A. This changes Windows installer configuration only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR