### PR TITLE
fix(core): use fallback id for tool call deltas without id

### DIFF
--- a/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
@@ -538,13 +538,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                 const index = toolCallDelta.index
 
                 if (toolCalls[index] == null) {
-                  if (toolCallDelta.id == null) {
-                    throw new InvalidResponseDataError({
-                      data: toolCallDelta,
-                      message: `Expected 'id' to be a string.`,
-                    })
-                  }
-
                   if (toolCallDelta.function?.name == null) {
                     throw new InvalidResponseDataError({
                       data: toolCallDelta,
@@ -552,14 +545,16 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                     })
                   }
 
+                  const toolCallId = toolCallDelta.id ?? generateId()
+
                   controller.enqueue({
                     type: "tool-input-start",
-                    id: toolCallDelta.id,
+                    id: toolCallId,
                     toolName: toolCallDelta.function.name,
                   })
 
                   toolCalls[index] = {
-                    id: toolCallDelta.id,
+                    id: toolCallId,
                     type: "function",
                     function: {
                       name: toolCallDelta.function.name,


### PR DESCRIPTION
## Summary

Fix for clawparty LLM streaming error: `Expected 'id' to be a string.`

## Root Cause

In the streaming response handler in `openai-compatible-chat-language-model.ts`, the code throws an error when `toolCallDelta.id` is `null`, even though the Zod schema defines `id` as `nullish()`.

Some LLM providers (like clawparty/deepseek-v4) may send tool call deltas without an id field in streaming responses.

## Fix

Instead of throwing an `InvalidResponseDataError`, use `generateId()` as a fallback. This is consistent with existing behavior in the same codebase where `toolCall.id ?? generateId()` is already used as a fallback for the tool-call event.