### PR TITLE
fix(opencode): handle non-image binary content from MCP tool results

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -346,25 +346,31 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
   const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
   const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
 
-  const providerOptions = {
-    anthropic: {
-      cacheControl: { type: "ephemeral" },
-    },
-    openrouter: {
-      cacheControl: { type: "ephemeral" },
-    },
-    bedrock: {
-      cachePoint: { type: "default" },
-    },
-    openaiCompatible: {
-      cache_control: { type: "ephemeral" },
-    },
-    copilot: {
-      copilot_cache_control: { type: "ephemeral" },
-    },
-    alibaba: {
-      cacheControl: { type: "ephemeral" },
-    },
+  const systemSet = new Set<ModelMessage>(system)
+  function options(msg: ModelMessage) {
+    // Bedrock supports 1h TTL for system cache points and 5m for conversation.
+    // Longer TTL must appear before shorter TTL in the request.
+    const ttl = systemSet.has(msg) ? "1h" : "5m"
+    return {
+      anthropic: {
+        cacheControl: { type: "ephemeral" },
+      },
+      openrouter: {
+        cacheControl: { type: "ephemeral" },
+      },
+      bedrock: {
+        cachePoint: { type: "default", ttl },
+      },
+      openaiCompatible: {
+        cache_control: { type: "ephemeral" },
+      },
+      copilot: {
+        copilot_cache_control: { type: "ephemeral" },
+      },
+      alibaba: {
+        cacheControl: { type: "ephemeral" },
+      },
+    }
   }
 
   for (const msg of unique([...system, ...final])) {
@@ -382,12 +388,12 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
         lastContent.type !== "tool-approval-request" &&
         lastContent.type !== "tool-approval-response"
       ) {
-        lastContent.providerOptions = mergeDeep(lastContent.providerOptions ?? {}, providerOptions)
+        lastContent.providerOptions = mergeDeep(lastContent.providerOptions ?? {}, options(msg))
         continue
       }
     }
 
-    msg.providerOptions = mergeDeep(msg.providerOptions ?? {}, providerOptions)
+    msg.providerOptions = mergeDeep(msg.providerOptions ?? {}, options(msg))
   }
 
   return msgs

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -202,6 +202,7 @@ export interface Interface {
     model: { providerID: ProviderID; modelID: ModelID }
     auto: boolean
     overflow?: boolean
+    variant?: string
   }) => Effect.Effect<void>
 }
 
@@ -587,6 +588,7 @@ export const layer = Layer.effect(
       model: { providerID: ProviderID; modelID: ModelID }
       auto: boolean
       overflow?: boolean
+      variant?: string
     }) {
       const msg = yield* session.updateMessage({
         id: MessageID.ascending(),
@@ -594,6 +596,7 @@ export const layer = Layer.effect(
         model: input.model,
         sessionID: input.sessionID,
         agent: input.agent,
+        variant: input.variant,
         time: { created: Date.now() },
       })
       yield* session.updatePart({

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -866,6 +866,14 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               })
             continue
           }
+          // Drop reasoning parts likely corrupted by the historical trimEnd() bug —
+          // it removed trailing whitespace from thinking text, invalidating the
+          // cryptographic signature. Sending them without metadata produces empty
+          // content blocks that Bedrock rejects. Redacted blocks (empty text with
+          // providerOptions) are kept by normalizeMessages; uncorrupted blocks whose
+          // text still ends with whitespace are preserved as-is.
+          const corrupted = part.text.length > 0 && part.metadata && !/\s$/.test(part.text)
+          if (corrupted) continue
           assistantMessage.parts.push({
             type: "reasoning",
             text: part.text,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -17,7 +17,7 @@ import { MessageTable, PartTable, SessionTable } from "./session.sql"
 import * as ProviderError from "@/provider/error"
 import { iife } from "@/util/iife"
 import { errorMessage } from "@/util/error"
-import { isMedia } from "@/util/media"
+import { isMedia, isTextMime } from "@/util/media"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
@@ -675,14 +675,30 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         type: "content",
         value: [
           ...(outputObject.text ? [{ type: "text", text: outputObject.text }] : []),
-          ...attachments.map((attachment) => ({
-            type: "media",
-            mediaType: attachment.mime,
-            data: iife(() => {
+          ...attachments.flatMap((attachment): Array<{ type: string; [key: string]: string }> => {
+            // Images and PDFs are supported as media by providers
+            if (isMedia(attachment.mime)) {
+              return [
+                {
+                  type: "media",
+                  mediaType: attachment.mime,
+                  data: iife(() => {
+                    const commaIndex = attachment.url.indexOf(",")
+                    return commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
+                  }),
+                },
+              ]
+            }
+            // Text-based files (csv, json, xml, etc.) decoded to text to avoid
+            // unsupported file-data content parts in providers like Anthropic
+            if (isTextMime(attachment.mime)) {
               const commaIndex = attachment.url.indexOf(",")
-              return commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
-            }),
-          })),
+              const base64 = commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
+              return [{ type: "text", text: Buffer.from(base64, "base64").toString("utf-8") }]
+            }
+            // Other binary files cannot be sent as media; use a placeholder
+            return [{ type: "text", text: `[Binary file: ${attachment.mime}]` }]
+          }),
         ],
       }
     }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -76,6 +76,8 @@ interface ProcessorContext extends Input {
   snapshot: string | undefined
   blocked: boolean
   needsCompaction: boolean
+  steered: boolean
+  atToolBoundary: boolean
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
 }
@@ -116,6 +118,8 @@ export const layer = Layer.effect(
         snapshot: initialSnapshot,
         blocked: false,
         needsCompaction: false,
+        steered: false,
+        atToolBoundary: false,
         currentText: undefined,
         reasoningMap: {},
       }
@@ -131,6 +135,7 @@ export const layer = Layer.effect(
       const settleToolCall = Effect.fn("SessionProcessor.settleToolCall")(function* (toolCallID: string) {
         const done = ctx.toolcalls[toolCallID]?.done
         delete ctx.toolcalls[toolCallID]
+        ctx.atToolBoundary = true
         if (done) yield* Deferred.succeed(done, undefined).pipe(Effect.ignore)
       })
 
@@ -378,6 +383,7 @@ export const layer = Layer.effect(
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.name}`)
             }
+            ctx.atToolBoundary = false
             const toolCall = yield* ensureToolCall(value)
             const input = toolInput(value.input)
             if (!toolCall.call.inputEnded) {
@@ -737,7 +743,7 @@ export const layer = Layer.effect(
             state: {
               ...part.state,
               status: "error",
-              error: "Tool execution aborted",
+              error: ctx.steered ? "Skipped: user sent a new message" : "Tool execution aborted",
               metadata: { ...metadata, interrupted: true },
               time: { start: "time" in part.state ? part.state.time.start : end, end },
             },
@@ -780,7 +786,15 @@ export const layer = Layer.effect(
       const process = Effect.fn("SessionProcessor.process")(function* (streamInput: LLM.StreamInput) {
         slog.info("process")
         ctx.needsCompaction = false
+        ctx.steered = false
+        ctx.atToolBoundary = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+
+        const unsub = yield* bus.subscribeCallback(MessageV2.Event.Updated, (event) => {
+          if (event.properties.sessionID === ctx.sessionID && event.properties.info.role === "user") {
+            ctx.steered = true
+          }
+        })
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -791,7 +805,7 @@ export const layer = Layer.effect(
 
             yield* stream.pipe(
               Stream.tap((event) => handleEvent(event)),
-              Stream.takeUntil(() => ctx.needsCompaction),
+              Stream.takeUntil(() => ctx.needsCompaction || (ctx.steered && ctx.atToolBoundary)),
               Stream.runDrain,
             )
           }).pipe(
@@ -842,10 +856,12 @@ export const layer = Layer.effect(
             Effect.ensuring(cleanup()),
           )
 
+          unsub()
+
           if (ctx.needsCompaction) return "compact"
           if (ctx.blocked || ctx.assistantMessage.error) return "stop"
           return "continue"
-        })
+        }).pipe(Effect.onInterrupt(() => Effect.sync(() => { unsub() })))
       })
 
       return {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1324,7 +1324,7 @@ export const layer = Layer.effect(
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
-            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true, variant: lastUser.model.variant })
             continue
           }
 
@@ -1481,6 +1481,7 @@ export const layer = Layer.effect(
                 model: lastUser.model,
                 auto: true,
                 overflow: !handle.message.finish,
+                variant: lastUser.model.variant,
               })
             }
             return "continue" as const

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -9,6 +9,7 @@ import { ToolRegistry } from "@/tool/registry"
 import { Truncate } from "@/tool/truncate"
 import { ModelID } from "@/provider/schema"
 import { Plugin } from "@/plugin"
+import { isTextMime } from "@/util/media"
 import type { TaskPromptOps } from "@/tool/task"
 import { type Tool as AITool, tool, jsonSchema, type ToolExecutionOptions, asSchema } from "ai"
 import { Effect } from "effect"
@@ -164,12 +165,17 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               const { resource } = contentItem
               if (resource.text) textParts.push(resource.text)
               if (resource.blob) {
-                attachments.push({
-                  type: "file",
-                  mime: resource.mimeType ?? "application/octet-stream",
-                  url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
-                  filename: resource.uri,
-                })
+                const mime = resource.mimeType ?? "application/octet-stream"
+                if (isTextMime(mime)) {
+                  textParts.push(Buffer.from(resource.blob, "base64").toString("utf-8"))
+                } else {
+                  attachments.push({
+                    type: "file",
+                    mime,
+                    url: `data:${mime};base64,${resource.blob}`,
+                    filename: resource.uri,
+                  })
+                }
               }
             }
           }

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -12,6 +12,28 @@ export function isImageAttachment(mime: string) {
   return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
 }
 
+export function isTextMime(mime: string) {
+  if (mime.startsWith("text/")) return true
+  const textTypes = [
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/typescript",
+    "application/x-yaml",
+    "application/yaml",
+    "application/toml",
+    "application/x-sh",
+    "application/sql",
+    "application/graphql",
+    "application/x-httpd-php",
+    "application/xhtml+xml",
+    "application/ld+json",
+  ]
+  if (textTypes.includes(mime)) return true
+  if (mime.endsWith("+xml") || mime.endsWith("+json")) return true
+  return false
+}
+
 export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
   if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png"
   if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg"

--- a/packages/opencode/test/util/media.test.ts
+++ b/packages/opencode/test/util/media.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { isTextMime, isMedia } from "../../src/util/media"
+
+describe("isTextMime", () => {
+  test("detects text/* types", () => {
+    expect(isTextMime("text/csv")).toBe(true)
+    expect(isTextMime("text/plain")).toBe(true)
+    expect(isTextMime("text/html")).toBe(true)
+    expect(isTextMime("text/xml")).toBe(true)
+  })
+
+  test("detects common application text types", () => {
+    expect(isTextMime("application/json")).toBe(true)
+    expect(isTextMime("application/xml")).toBe(true)
+    expect(isTextMime("application/x-yaml")).toBe(true)
+    expect(isTextMime("application/yaml")).toBe(true)
+    expect(isTextMime("application/javascript")).toBe(true)
+    expect(isTextMime("application/sql")).toBe(true)
+    expect(isTextMime("application/ld+json")).toBe(true)
+  })
+
+  test("detects +xml and +json suffixes", () => {
+    expect(isTextMime("application/vnd.api+json")).toBe(true)
+    expect(isTextMime("application/svg+xml")).toBe(true)
+    expect(isTextMime("application/atom+xml")).toBe(true)
+  })
+
+  test("rejects images and PDFs", () => {
+    expect(isTextMime("image/png")).toBe(false)
+    expect(isTextMime("image/jpeg")).toBe(false)
+    expect(isTextMime("application/pdf")).toBe(false)
+  })
+
+  test("rejects binary application types", () => {
+    expect(isTextMime("application/octet-stream")).toBe(false)
+    expect(isTextMime("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")).toBe(false)
+    expect(isTextMime("application/zip")).toBe(false)
+  })
+})
+
+describe("MCP resource blob routing", () => {
+  test("text/csv blob is decoded to text instead of binary attachment", () => {
+    const csvContent = "name,age,city\nAlice,30,Seattle\nBob,25,Portland"
+    const blob = Buffer.from(csvContent).toString("base64")
+    const mime = "text/csv"
+
+    // Simulates the tools.ts path: text blobs go to textParts
+    expect(isTextMime(mime)).toBe(true)
+    expect(Buffer.from(blob, "base64").toString("utf-8")).toBe(csvContent)
+  })
+
+  test("image blobs remain as media attachments", () => {
+    expect(isMedia("image/png")).toBe(true)
+    expect(isTextMime("image/png")).toBe(false)
+  })
+
+  test("PDF blobs remain as media attachments", () => {
+    expect(isMedia("application/pdf")).toBe(true)
+    expect(isTextMime("application/pdf")).toBe(false)
+  })
+
+  test("unknown binary blobs are not classified as text", () => {
+    const mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    expect(isMedia(mime)).toBe(false)
+    expect(isTextMime(mime)).toBe(false)
+  })
+})
+
+describe("toModelOutput attachment routing", () => {
+  test("text attachments are decoded to text content parts", () => {
+    const csvContent = "id,value\n1,foo"
+    const url = `data:text/csv;base64,${Buffer.from(csvContent).toString("base64")}`
+    const mime = "text/csv"
+
+    // Simulates message-v2.ts routing: text mime → decode base64 → text part
+    expect(isTextMime(mime)).toBe(true)
+    const commaIndex = url.indexOf(",")
+    const base64 = url.slice(commaIndex + 1)
+    expect(Buffer.from(base64, "base64").toString("utf-8")).toBe(csvContent)
+  })
+
+  test("binary attachments produce placeholder text, not file-data", () => {
+    const mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    expect(isMedia(mime)).toBe(false)
+    expect(isTextMime(mime)).toBe(false)
+    // In the real code this becomes: [Binary file: <mime>]
+  })
+})


### PR DESCRIPTION
Closed — replaced by #30251 (rebased on clean branch).