### PR TITLE
docs: clarify model config IDs

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -366,7 +366,10 @@ You can configure the providers and models you want to use in your OpenCode conf
 }
 ```
 
+The `model` and `small_model` values use the `provider_id/model_id` format. For built-in providers, use the provider and model IDs shown by `opencode models` or [Models.dev](https://models.dev). For custom providers, `provider_id` is the key under `provider`, and `model_id` is the key under that provider's `models`.
+
 The `small_model` option configures a separate model for lightweight tasks like title generation. By default, OpenCode tries to use a cheaper model if one is available from your provider, otherwise it falls back to your main model.
+The small model can use a different provider than your main model.
 
 Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 


### PR DESCRIPTION
### Issue for this PR

Closes #29639

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Clarifies the `model` and `small_model` config values in `packages/web/src/content/docs/config.mdx`. The docs now state that both values use `provider_id/model_id`, point users to `opencode models` and Models.dev for built-in provider/model IDs, explain how custom provider IDs map to the config keys, and note that `small_model` can use a different provider from the main model.

This addresses the confusion in #29639 about which part of `provider/model` is the provider and confirms the cross-provider `small_model` behavior.

### How did you verify your code works?

- `npm exec --yes prettier@3.6.2 -- --check packages/web/src/content/docs/config.mdx`
- GitHub PR checks pass

I could not run the local Astro check because `bun` is not installed in this environment.

### Screenshots / recordings

N/A, documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR