### PR TITLE
fix(opencode): handle text MCP resource blobs

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -308,12 +308,12 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 
             // For providers that don't support media in tool results, extract media files
             // (images, PDFs) to be sent as a separate user message
-            const mediaAttachments = attachments.filter((a) => isMedia(a.mime))
-            const extractedMedia = mediaAttachments.filter((a) => !supportsMediaInToolResult(a))
+            const mediaAttachments = attachments.filter((attachment) => isMedia(attachment.mime))
+            const extractedMedia = mediaAttachments.filter((attachment) => !supportsMediaInToolResult(attachment))
             if (extractedMedia.length > 0) {
               media.push(...extractedMedia)
             }
-            const finalAttachments = attachments.filter((a) => !isMedia(a.mime) || supportsMediaInToolResult(a))
+            const finalAttachments = mediaAttachments.filter((attachment) => supportsMediaInToolResult(attachment))
 
             const output =
               finalAttachments.length > 0

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -166,12 +166,16 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               const { resource } = contentItem
               if (resource.text) textParts.push(resource.text)
               if (resource.blob) {
-                attachments.push({
-                  type: "file",
-                  mime: resource.mimeType ?? "application/octet-stream",
-                  url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
-                  filename: resource.uri,
-                })
+                const mime = resource.mimeType ?? "application/octet-stream"
+                const text = blobText(mime, resource.blob)
+                if (text !== undefined) textParts.push(text)
+                if (text === undefined)
+                  attachments.push({
+                    type: "file",
+                    mime,
+                    url: `data:${mime};base64,${resource.blob}`,
+                    filename: resource.uri,
+                  })
               }
             }
           }
@@ -206,5 +210,25 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
 
   return tools
 })
+
+function blobText(mime: string, blob: string) {
+  if (!textMime(mime)) return undefined
+  return Buffer.from(blob, "base64").toString("utf8")
+}
+
+function textMime(mime: string) {
+  const type = mime.toLowerCase().split(";")[0]?.trim()
+  if (!type) return false
+  return (
+    type.startsWith("text/") ||
+    [
+      "application/json",
+      "application/ld+json",
+      "application/x-ndjson",
+      "application/xml",
+      "application/javascript",
+    ].includes(type)
+  )
+}
 
 export * as SessionTools from "./tools"

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -410,6 +410,82 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("omits non-media tool-result attachments from model messages", async () => {
+    const userID = "m-user-csv"
+    const assistantID = "m-assistant-csv"
+
+    const input: SessionLegacy.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1-csv"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as SessionLegacy.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1-csv"),
+            type: "tool",
+            callID: "call-csv-1",
+            tool: "get_csv",
+            state: {
+              status: "completed",
+              input: {},
+              output: "name,age\nAlice,30",
+              title: "Get CSV",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-csv-1"),
+                  type: "file",
+                  mime: "text/csv",
+                  filename: "test.csv",
+                  url: "data:text/csv;base64,bmFtZSxhZ2UKQWxpY2UsMzA=",
+                },
+              ],
+            },
+          },
+        ] as SessionLegacy.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-csv-1",
+            toolName: "get_csv",
+            input: {},
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-csv-1",
+            toolName: "get_csv",
+            output: { type: "text", value: "name,age\nAlice,30" },
+          },
+        ],
+      },
+    ])
+  })
+
   test("preserves jpeg tool-result media for anthropic models", async () => {
     const anthropicModel: Provider.Model = {
       ...model,


### PR DESCRIPTION
### Issue for this PR

Closes #30249

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents non-image/non-PDF MCP resource blobs such as `text/csv` from being replayed to models as media/file-data tool-result attachments. Text-like MCP resource blobs are decoded into the tool output text, while model message replay now only includes media attachments that OpenCode knows how to send to providers.

This keeps CSV-style MCP tool results available to the model as text and avoids Anthropic rejecting unsupported `file-data` content parts.

### How did you verify your code works?

- `npm exec --yes --package bun@1.3.14 -- bun test test/session/message-v2.test.ts` from `packages/opencode`
- `npm exec --yes --package bun@1.3.14 -- bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`
- `npm exec --yes prettier@3.6.2 -- --check packages/opencode/src/session/tools.ts packages/opencode/src/session/message-v2.ts packages/opencode/test/session/message-v2.test.ts`
- `git diff --check`

### Screenshots / recordings

N/A, backend/session message handling change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR