### PR TITLE
fix(opencode): preserve copilot catalog variants

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -147,8 +147,9 @@ function build(key: string, remote: Item, url: string, prev?: Model): Model {
       }
     }
   }
-  if (Object.keys(variants).length > 0) {
-    model.variants = variants
+  const merged = isMsgApi ? variants : { ...(prev?.variants ?? {}), ...variants }
+  if (Object.keys(merged).length > 0) {
+    model.variants = merged
   }
 
   return model

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -317,7 +317,11 @@ test("preserves catalog variants missing from Copilot reasoning effort response"
     low: { reasoningEffort: "low" },
     medium: { reasoningEffort: "medium" },
     high: { reasoningEffort: "high" },
-    xhigh: { reasoningEffort: "xhigh" },
+    xhigh: {
+      reasoningEffort: "xhigh",
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+    },
   })
 })
 

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -215,6 +215,112 @@ test("clears existing variants so refreshed models calculate provider-specific v
   expect(models["claude-opus-4.7"].variants).toBeUndefined()
 })
 
+test("preserves catalog variants missing from Copilot reasoning effort response", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "gpt-5.5",
+              name: "GPT-5.5",
+              version: "gpt-5.5-2026-04-23",
+              capabilities: {
+                family: "gpt-5",
+                limits: {
+                  max_context_window_tokens: 400000,
+                  max_output_tokens: 128000,
+                  max_prompt_tokens: 272000,
+                },
+                supports: {
+                  reasoning_effort: ["low", "medium", "high"],
+                  streaming: true,
+                  tool_calls: true,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const models = await CopilotModels.get(
+    "https://api.githubcopilot.com",
+    {},
+    {
+      "gpt-5.5": {
+        id: "gpt-5.5",
+        providerID: "github-copilot",
+        api: {
+          id: "gpt-5.5",
+          url: "https://api.githubcopilot.com",
+          npm: "@ai-sdk/github-copilot",
+        },
+        name: "GPT-5.5",
+        family: "gpt-5",
+        capabilities: {
+          temperature: false,
+          reasoning: true,
+          attachment: true,
+          toolcall: true,
+          input: {
+            text: true,
+            audio: false,
+            image: true,
+            video: false,
+            pdf: false,
+          },
+          output: {
+            text: true,
+            audio: false,
+            image: false,
+            video: false,
+            pdf: false,
+          },
+          interleaved: false,
+        },
+        cost: {
+          input: 0,
+          output: 0,
+          cache: {
+            read: 0,
+            write: 0,
+          },
+        },
+        limit: {
+          context: 400000,
+          input: 272000,
+          output: 128000,
+        },
+        options: {},
+        headers: {},
+        release_date: "2026-04-23",
+        variants: {
+          high: {
+            reasoningEffort: "catalog-high",
+          },
+          xhigh: {
+            reasoningEffort: "xhigh",
+            reasoningSummary: "auto",
+            include: ["reasoning.encrypted_content"],
+          },
+        },
+        status: "active",
+      },
+    },
+  )
+
+  expect(models["gpt-5.5"].variants).toMatchObject({
+    low: { reasoningEffort: "low" },
+    medium: { reasoningEffort: "medium" },
+    high: { reasoningEffort: "high" },
+    xhigh: { reasoningEffort: "xhigh" },
+  })
+})
+
 test("remaps fallback oauth model urls to the enterprise host", async () => {
   globalThis.fetch = mock(() => Promise.reject(new Error("timeout"))) as unknown as typeof fetch
 


### PR DESCRIPTION
### Issue for this PR

Closes #30092

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves catalog-defined GitHub Copilot variants when refreshing models from the Copilot `/models` endpoint. The live API still wins for variants it returns, but catalog-only variants such as `xhigh` are no longer dropped when the endpoint only advertises `low`, `medium`, and `high`.

The existing behavior for Copilot models served through `/v1/messages` is kept: those models still rebuild provider-specific variants instead of carrying over incompatible OpenAI-style variants.

### How did you verify your code works?

- `npm exec --yes --package bun@1.3.14 -- bun test test/plugin/github-copilot-models.test.ts` from `packages/opencode`
- `npm exec --yes --package bun@1.3.14 -- bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`
- `npm exec --yes prettier@3.6.2 -- --check packages/opencode/src/plugin/github-copilot/models.ts packages/opencode/test/plugin/github-copilot-models.test.ts`
- `git diff --check`

### Screenshots / recordings

N/A, provider model metadata change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR