### PR TITLE
fix(tui): keep background marker with subagent label

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2218,9 +2218,13 @@ function Task(props: ToolProps<typeof TaskTool>) {
 
   const content = createMemo(() => {
     if (!props.input.description) return ""
-    const description =
-      props.metadata.background === true ? `${props.input.description} (background)` : props.input.description
-    let content = [`${Locale.titlecase(props.input.subagent_type ?? "General")} Task — ${description}`]
+    let content = [
+      formatSubagentTitle(
+        Locale.titlecase(props.input.subagent_type ?? "General"),
+        props.input.description,
+        props.metadata.background === true,
+      ),
+    ]
 
     const retrying = retry()
     if (isRunning() && retrying) {
@@ -2264,6 +2268,10 @@ function Task(props: ToolProps<typeof TaskTool>) {
 
 export function formatSubagentToolcalls(count: number) {
   return `${count} toolcall${count === 1 ? "" : "s"}`
+}
+
+export function formatSubagentTitle(agent: string, description: string, background: boolean) {
+  return `${agent} Task${background ? " (background)" : ""} — ${description}`
 }
 
 export function formatCompletedSubagentDetail(toolcalls: number, duration: string) {

--- a/packages/opencode/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/opencode/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -3,6 +3,7 @@ import { For } from "solid-js"
 import { testRender, type JSX } from "@opentui/solid"
 import {
   formatCompletedSubagentDetail,
+  formatSubagentTitle,
   formatSubagentToolcalls,
   InlineToolRow,
 } from "../../../src/cli/cmd/tui/routes/session/index"
@@ -145,6 +146,13 @@ describe("TUI inline tool wrapping", () => {
     expect(formatCompletedSubagentDetail(1, "501ms")).toBe("1 toolcall · 501ms")
     expect(formatCompletedSubagentDetail(2, "501ms")).toBe("2 toolcalls · 501ms")
     expect(formatSubagentToolcalls(0)).toBe("0 toolcalls")
+  })
+
+  test("keeps background state attached to the subagent identity", () => {
+    expect(formatSubagentTitle("Explore", "Inspect renderer", false)).toBe("Explore Task — Inspect renderer")
+    expect(formatSubagentTitle("Explore", "Inspect renderer", true)).toBe(
+      "Explore Task (background) — Inspect renderer",
+    )
   })
 
   test("snapshots consecutive grep, glob, and read rows at a narrow width", async () => {


### PR DESCRIPTION
## Summary
- move the `(background)` qualifier next to the subagent identity instead of appending it after a potentially long description
- prevent awkward wrapped output such as a dangling `(` followed by `background)` on its own line
- add focused formatting coverage for foreground and background title variants

## Rendering
Before:
```text
Explore Task — Audit background task while its child is actively inspecting the
  deeply nested inline renderer implementation (
  background)
```

After:
```text
Explore Task (background) — Audit background task while its child is actively
  inspecting the deeply nested inline renderer implementation
```

## Stack
- Builds on #30051, which introduces the inline subagent row presentation this adjusts.
- #30269 is stacked above this PR and provides the internal debug-frame harness used for the narrow-width visual check.

## Verification
- `git diff --check`
- `bun run test -- test/cli/tui/inline-tool-wrap-snapshot.test.tsx test/cli/tui/debug-frame.test.ts` on stacked child #30269 (`12 pass`, `6 snapshots`)
- `bun typecheck` from `packages/opencode` on stacked child #30269
- live `cellshot` narrow-width render through #30269 debug frames confirms `(background)` stays attached to the identity while long descriptions wrap cleanly

Scoped `oxlint` remains blocked by the existing malformed `.oxlintrc.json` configuration on the base branch.