### PR TITLE
fix(tui): keep retry attempt before message

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2228,7 +2228,7 @@ function Task(props: ToolProps<typeof TaskTool>) {
 
     const retrying = retry()
     if (isRunning() && retrying) {
-      content.push(`↳ ${Locale.truncate(retrying.message, 80)} [retrying attempt #${retrying.attempt}]`)
+      content.push(`↳ ${formatSubagentRetry(retrying.attempt, Locale.truncate(retrying.message, 80))}`)
     } else if (isRunning() && tools().length > 0) {
       if (current()) {
         const state = current()!.state
@@ -2272,6 +2272,10 @@ export function formatSubagentToolcalls(count: number) {
 
 export function formatSubagentTitle(agent: string, description: string, background: boolean) {
   return `${agent} Task${background ? " (background)" : ""} — ${description}`
+}
+
+export function formatSubagentRetry(attempt: number, message: string) {
+  return `Retry #${attempt} · ${message}`
 }
 
 export function formatCompletedSubagentDetail(toolcalls: number, duration: string) {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2275,7 +2275,7 @@ export function formatSubagentTitle(agent: string, description: string, backgrou
 }
 
 export function formatSubagentRetry(attempt: number, message: string) {
-  return `Retry #${attempt} · ${message}`
+  return `Retrying (attempt ${attempt}) · ${message}`
 }
 
 export function formatCompletedSubagentDetail(toolcalls: number, duration: string) {

--- a/packages/opencode/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/opencode/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -157,7 +157,9 @@ describe("TUI inline tool wrapping", () => {
   })
 
   test("keeps retry status ahead of wrapping messages", () => {
-    expect(formatSubagentRetry(2, "Rate limited by provider")).toBe("Retry #2 · Rate limited by provider")
+    expect(formatSubagentRetry(2, "Rate limited by provider")).toBe(
+      "Retrying (attempt 2) · Rate limited by provider",
+    )
   })
 
   test("snapshots consecutive grep, glob, and read rows at a narrow width", async () => {

--- a/packages/opencode/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/opencode/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -3,6 +3,7 @@ import { For } from "solid-js"
 import { testRender, type JSX } from "@opentui/solid"
 import {
   formatCompletedSubagentDetail,
+  formatSubagentRetry,
   formatSubagentTitle,
   formatSubagentToolcalls,
   InlineToolRow,
@@ -153,6 +154,10 @@ describe("TUI inline tool wrapping", () => {
     expect(formatSubagentTitle("Explore", "Inspect renderer", true)).toBe(
       "Explore Task (background) — Inspect renderer",
     )
+  })
+
+  test("keeps retry status ahead of wrapping messages", () => {
+    expect(formatSubagentRetry(2, "Rate limited by provider")).toBe("Retry #2 · Rate limited by provider")
   })
 
   test("snapshots consecutive grep, glob, and read rows at a narrow width", async () => {


### PR DESCRIPTION
## Summary
- format retrying subagent detail rows as `Retrying (attempt N) · message` instead of trailing bracketed metadata
- keep retry state and attempt count readable when a long message wraps at narrow terminal widths
- add focused formatting coverage for retry details

## Rendering
Before:
```text
↳ Rate limited by provider; retrying after quota window [
  retrying attempt #2]
```

After:
```text
↳ Retrying (attempt 2) · Rate limited by provider; retrying
  after quota window
```

## Stack
- Builds on merged #30271, which places the background marker beside the subagent identity.
- #30269 is stacked above this PR and supplies the internal debug-frame harness used for narrow-width real-TUI verification.

## Verification
- `git diff --check`
- `bun run test -- test/cli/tui/inline-tool-wrap-snapshot.test.tsx test/cli/tui/debug-frame.test.ts` on stacked child #30269 (`14 pass`, `6 snapshots`)
- `bun typecheck` from `packages/opencode` on stacked child #30269
- pre-push `bun turbo typecheck` passed while rebasing/pushing #30269 above this updated PR
- live real-TUI debug-frame render confirms `Retrying (attempt 2) ·` stays ahead of the wrapping message

Scoped `oxlint` remains blocked by the existing malformed `.oxlintrc.json` configuration on the base branch.