### PR TITLE
fix(ui): resolve v2 css subpath exports

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
     "./icons/app": "./src/components/app-icons/types.ts",
     "./fonts/*": "./src/assets/fonts/*",
     "./audio/*": "./src/assets/audio/*",
+    "./v2/*.css": "./src/v2/components/*.css",
     "./v2/*": "./src/v2/components/*.tsx",
     "./v2/styles/*": "./src/v2/styles/*"
   },


### PR DESCRIPTION
settings-v2.css imports @opencode-ai/ui/v2/{text-input,button}-v2.css but the exports map only mapped ./v2/* to *.tsx, so .css requests resolved to a nonexistent *.css.tsx and broke the production vite build. Add a more specific ./v2/*.css mapping.

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes vite build

### How did you verify your code works?

```bash
OPENCODE_CHANNEL=dev bun run --cwd packages/app build
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
