### PR TITLE
fix(tui): handle events across workspaces

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -958,11 +958,13 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     bindings: tuiConfig.keybinds.gather("app_exit", ["app.exit"]),
   }))
 
-  event.on(TuiEvent.CommandExecute.type, (evt) => {
+  event.on(TuiEvent.CommandExecute.type, (evt, { workspace }) => {
+    if (workspace !== project.workspace.current()) return
     keymap.dispatchCommand(evt.properties.command)
   })
 
-  event.on(TuiEvent.ToastShow.type, (evt) => {
+  event.on(TuiEvent.ToastShow.type, (evt, { workspace }) => {
+    if (workspace !== project.workspace.current()) return
     toast.show({
       title: evt.properties.title,
       message: evt.properties.message,
@@ -971,7 +973,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     })
   })
 
-  event.on(TuiEvent.SessionSelect.type, (evt) => {
+  event.on(TuiEvent.SessionSelect.type, (evt, { workspace }) => {
+    if (workspace !== project.workspace.current()) return
     route.navigate({
       type: "session",
       sessionID: evt.properties.sessionID,
@@ -988,7 +991,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
   })
 
-  event.on("session.error", (evt) => {
+  event.on("session.error", (evt, { workspace }) => {
+    if (workspace !== project.workspace.current()) return
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return
     const message = errorMessage(error)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -319,7 +319,8 @@ export function Prompt(props: PromptProps) {
   let promptPartTypeId = 0
   const event = useEvent()
 
-  event.on(TuiEvent.PromptAppend.type, (evt) => {
+  event.on(TuiEvent.PromptAppend.type, (evt, { workspace }) => {
+    if (workspace !== project.workspace.current()) return
     if (!input || input.isDestroyed) return
     input.insertText(evt.properties.text)
     setTimeout(() => {

--- a/packages/opencode/src/cli/cmd/tui/context/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/event.ts
@@ -1,4 +1,5 @@
 import type { Event } from "@opencode-ai/sdk/v2"
+import * as Log from "@opencode-ai/core/util/log"
 import { useProject } from "./project"
 import { useSDK } from "./sdk"
 
@@ -16,9 +17,7 @@ export function useEvent() {
         return
       }
 
-      if (event.directory === "global" || event.project === project.project()) {
-        handler(event.payload, { workspace: event.workspace })
-      }
+      handler(event.payload, { workspace: event.workspace })
     })
   }
 

--- a/packages/opencode/test/cli/tui/use-event.test.tsx
+++ b/packages/opencode/test/cli/tui/use-event.test.tsx
@@ -113,19 +113,6 @@ describe("useEvent", () => {
     }
   })
 
-  test("ignores events for other projects", async () => {
-    const { app, emit, seen } = await mount()
-
-    try {
-      emit(event(vcs("other"), { directory, project: "proj_other" }))
-      await Bun.sleep(30)
-
-      expect(seen).toHaveLength(0)
-    } finally {
-      app.renderer.destroy()
-    }
-  })
-
   test("delivers current project events regardless of active workspace", async () => {
     const { app, emit, project, seen } = await mount()
 


### PR DESCRIPTION
### Issue for this PR

No linked issue; maintainer-authored follow-up fix.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Delivers non-sync TUI events across open workspaces rather than filtering them by project at the event context boundary. Actions that should only affect the visible workspace, including prompt appends, command dispatch, toasts, session selection, and session errors, are filtered at their handlers.

This lets background workspace consumers observe relevant events without allowing inactive workspaces to change the current interactive UI.

### How did you verify your code works?

- Ran `bun test test/cli/tui/use-event.test.tsx` from `packages/opencode`.
- Pushed with the repository pre-push hook enabled; `bun turbo typecheck` passed for all packages.

### Screenshots / recordings

Not applicable; this changes event routing behavior without a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
