### PR TITLE
fix(opencode): expose OpenRouter reasoning variants for more models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -665,14 +665,14 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (id.includes("grok")) return {}
 
   switch (model.api.npm) {
-    case "@openrouter/ai-sdk-provider":
-      if (!id.includes("gpt") && !id.includes("gemini-3") && !id.includes("claude")) return {}
-      return Object.fromEntries(
-        (id.includes("gpt") ? openaiCompatibleReasoningEfforts(id) : OPENAI_EFFORTS).map((effort) => [
-          effort,
-          { reasoning: { effort } },
-        ]),
-      )
+    case "@openrouter/ai-sdk-provider": {
+      const efforts = id.includes("gpt")
+        ? openaiCompatibleReasoningEfforts(id)
+        : id.includes("gemini-3") || id.includes("claude")
+          ? OPENAI_EFFORTS
+          : WIDELY_SUPPORTED_EFFORTS
+      return Object.fromEntries(efforts.map((effort) => [effort, { reasoning: { effort } }]))
+    }
 
     case "ai-gateway-provider": {
       // Cloudflare AI Gateway routes every upstream through its OpenAI-compatible

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2504,7 +2504,7 @@ describe("ProviderTransform.variants", () => {
   })
 
   describe("@openrouter/ai-sdk-provider", () => {
-    test("returns empty object for non-qualifying models", () => {
+    test("returns widely supported efforts for other reasoning models", () => {
       const model = createMockModel({
         id: "openrouter/test-model",
         providerID: "openrouter",
@@ -2515,7 +2515,23 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
-      expect(result).toEqual({})
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      expect(result.low).toEqual({ reasoning: { effort: "low" } })
+    })
+
+    test("deepseek-v4-pro returns widely supported efforts", () => {
+      const model = createMockModel({
+        id: "deepseek/deepseek-v4-pro",
+        providerID: "openrouter",
+        api: {
+          id: "deepseek/deepseek-v4-pro",
+          url: "https://openrouter.ai",
+          npm: "@openrouter/ai-sdk-provider",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+      expect(result.medium).toEqual({ reasoning: { effort: "medium" } })
     })
 
     test("gpt models return OPENAI_EFFORTS with reasoning", () => {


### PR DESCRIPTION
## Summary
- OpenRouter reasoning effort variants were only generated for GPT, Gemini 3, and Claude model IDs
- Reasoning-capable models like `deepseek/deepseek-v4-pro` therefore showed no `/variant` options despite having `reasoning: true`
- Return the widely supported effort set (`low`, `medium`, `high`) for other OpenRouter reasoning models

Closes #30216

## Test plan
- [x] `bun test test/provider/transform.test.ts --test-name-pattern "@openrouter/ai-sdk-provider"` from `packages/opencode`
- [x] `bun typecheck` from `packages/opencode`
- [x] pre-push `bun turbo typecheck`

Made with [Cursor](https://cursor.com)