### PR TITLE
fix(tui): keep configured model when navigating sessions

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,6 +1,4 @@
 {
-  "model": "anthropic/claude-opus-4-8",
-  // "default_agent": "custom",
   "$schema": "https://opencode.ai/config.json",
   "provider": {},
   "permission": {},

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,4 +1,6 @@
 {
+  "model": "anthropic/claude-opus-4-8",
+  // "default_agent": "custom",
   "$schema": "https://opencode.ai/config.json",
   "provider": {},
   "permission": {},

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -405,12 +405,9 @@ export function Prompt(props: PromptProps) {
       // Only set agent if it's a primary agent (not a subagent)
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
       if (msg.agent && isPrimaryAgent) {
-        // Keep an explicitly configured agent (--agent flag or config "default_agent") instead
-        // of flipping to the session's last-used agent when navigating between sessions.
-        if (!args.agent && !sync.data.config.default_agent) local.agent.set(msg.agent)
-        // Keep an explicitly configured model (--model flag or config "model") instead of
-        // flipping to the session's last-used model when navigating between sessions.
-        if (msg.model && !args.model && !sync.data.config.model) {
+        // Keep command line --agent if specified.
+        if (!args.agent) local.agent.set(msg.agent)
+        if (msg.model) {
           local.model.set(msg.model)
           local.model.variant.set(msg.model.variant)
         }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -405,9 +405,12 @@ export function Prompt(props: PromptProps) {
       // Only set agent if it's a primary agent (not a subagent)
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
       if (msg.agent && isPrimaryAgent) {
-        // Keep command line --agent if specified.
-        if (!args.agent) local.agent.set(msg.agent)
-        if (msg.model) {
+        // Keep an explicitly configured agent (--agent flag or config "default_agent") instead
+        // of flipping to the session's last-used agent when navigating between sessions.
+        if (!args.agent && !sync.data.config.default_agent) local.agent.set(msg.agent)
+        // Keep an explicitly configured model (--model flag or config "model") instead of
+        // flipping to the session's last-used model when navigating between sessions.
+        if (msg.model && !args.model && !sync.data.config.model) {
           local.model.set(msg.model)
           local.model.variant.set(msg.model.variant)
         }


### PR DESCRIPTION
## Problem

When navigating between sessions in the TUI, the prompt adopts the session's last-used **model** and **agent** from its last user message. That auto-adoption writes into the per-agent model store (the highest-priority slot), which overrides an explicitly configured `model` / `default_agent` (or the `--model` / `--agent` flags). So a user who has pinned a model in their config sees it "flip" away as they browse old sessions.

## Fix

Skip the auto-adoption when an explicit selection already exists:

- Don't set the agent from the session when `--agent` or `config.default_agent` is set.
- Don't set the model (and variant) from the session when `--model` or `config.model` is set.

This mirrors the existing `--agent` guard and makes an explicitly configured choice win, instead of being replaced by whatever the navigated session last used. When no explicit selection exists, the original behavior (reflect the session's last-used agent/model) is preserved.

## Notes

- Context: GitHub issue #13456. The two root causes that issue cited are no longer live (Bug 1 was resolved by the `currentModel` memo refactor that already prioritizes manual selection; Bug 2's per-agent persistence is covered in practice by the `recent` fallback). This PR addresses the remaining observable behavior: explicit config getting flipped on session navigation.
- The branch contains two earlier `wip` commits that net to zero; the meaningful change is a single ~6-line guard. Recommend squash-merge.