### PR TITLE
fix(ui): heal incomplete backticks in streaming text rendering

### DIFF
--- a/packages/ui/src/components/markdown-stream.test.ts
+++ b/packages/ui/src/components/markdown-stream.test.ts
@@ -20,6 +20,20 @@ describe("markdown stream", () => {
     ])
   })
 
+  test("heals incomplete backticks in trailing code fence tail", () => {
+    expect(stream("summary\n\n```sh\nrm -rf `", true)).toEqual([
+      { raw: "summary\n\n", src: "summary\n\n", mode: "live" },
+      { raw: "```sh\nrm -rf `", src: "```sh\nrm -rf ``", mode: "live" },
+    ])
+  })
+
+  test("handles backtick-heavy content that ends without trailing newline", () => {
+    const input = "run `git status` and `git"
+    const result = stream(input, true)
+    expect(result[0].raw).toBe(input)
+    expect(result[0].src).toContain("git status")
+  })
+
   test("keeps reference-style markdown as one block", () => {
     expect(stream("[docs][1]\n\n[1]: https://example.com", true)).toEqual([
       {

--- a/packages/ui/src/components/markdown-stream.ts
+++ b/packages/ui/src/components/markdown-stream.ts
@@ -44,6 +44,6 @@ export function stream(text: string, live: boolean) {
   if (!head) return [{ raw: code.raw, src: code.raw, mode: "live" }] satisfies Block[]
   return [
     { raw: head, src: heal(head), mode: "live" },
-    { raw: code.raw, src: code.raw, mode: "live" },
+    { raw: code.raw, src: heal(code.raw), mode: "live" },
   ] satisfies Block[]
 }

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -188,7 +188,7 @@ export type PartComponent = Component<MessagePartProps>
 export const PART_MAPPING: Record<string, PartComponent | undefined> = {}
 
 const TEXT_RENDER_PACE_MS = 24
-const TEXT_RENDER_SNAP = /[\s.,!?;:)\]]/
+const TEXT_RENDER_SNAP = /[\s.,!?;:)\]\`]/
 
 function step(size: number) {
   if (size <= 12) return 2


### PR DESCRIPTION
### Issue for this PR

Closes #15774

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Streaming responses that contain backticks get truncated at the end. Two problems:

1. In `markdown-stream.ts`, when a partial code fence is detected at the end of the stream, the tail block is split out but `heal()` from the `remend` library is never called on it. The unclosed backticks inside the tail never get corrected, so `marked` misparses and cuts off.

2. In `message-part.tsx`, `TEXT_RENDER_SNAP` is the set of characters the pacing loop stops at while incrementally revealing text during streaming. Backtick was missing. When the streamed text ends inside a backtick sequence, the pacing loop holds the content back waiting for a snap character that never comes.

Fix: call `heal()` on the tail block in `markdown-stream.ts:47`, and add backtick to the snap regex in `message-part.tsx:191`.

### How did you verify your code works?

Added two tests to `markdown-stream.test.ts`:
- Verifies `heal()` is applied to a trailing code fence that contains an unclosed backtick
- Verifies backtick-heavy content that ends without a trailing newline is still processed correctly

### Screenshots / recordings

N/A — this is a streaming rendering bug in the markdown pipeline, no persistent UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR