### PR TITLE
fix(ui): expose v2 component css via package exports

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,6 +24,7 @@
     "./fonts/*": "./src/assets/fonts/*",
     "./audio/*": "./src/assets/audio/*",
     "./v2/*": "./src/v2/components/*.tsx",
+    "./v2/*.css": "./src/v2/components/*.css",
     "./v2/styles/*": "./src/v2/styles/*"
   },
   "scripts": {


### PR DESCRIPTION
### Issue for this PR

Closes #30292

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `./v2/*.css` to the `@opencode-ai/ui` exports map.

The existing `./v2/*` entry hardcodes a `.tsx` target, so CSS imports like `@opencode-ai/ui/v2/text-input-v2.css` (added in #29689 by `packages/app/src/components/settings-v2/settings-v2.css`) resolved to non-existent `.css.tsx` files and `vite build` failed in `@tailwindcss/vite:generate:build`.

Node's exports-map specificity rule picks the longer key (`./v2/*.css`) for `.css` requests automatically; the existing `./v2/*` continues to handle `.tsx` requests unchanged.

### How did you verify your code works?

```bash
bun run --cwd packages/app build
```

- Without the patch, on `dev` tip: same `Can't resolve '@opencode-ai/ui/v2/text-input-v2.css'` error as `build-cli` run [26783826518](https://github.com/anomalyco/opencode/actions/runs/26783826518) and `deploy` run [26783826509](https://github.com/anomalyco/opencode/actions/runs/26783826509).
- With the patch: build succeeds in ~10s, exit 0.

This is the same build path used by the Nix package and CI (`packages/opencode/script/build.ts:31` shells out to `bun run --cwd packages/app build`).

### Screenshots / recordings

N/A.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR