### PR TITLE
fix: export v2 stylesheets and declare core node types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -290,6 +290,7 @@
         "@tsconfig/bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/cross-spawn": "catalog:",
+        "@types/node": "catalog:",
         "@types/npm-package-arg": "6.1.4",
         "@types/npmcli__arborist": "6.3.3",
         "@types/semver": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "@tsconfig/bun": "catalog:",
     "@types/bun": "catalog:",
     "@types/cross-spawn": "catalog:",
+    "@types/node": "catalog:",
     "@types/npm-package-arg": "6.1.4",
     "@types/npmcli__arborist": "6.3.3",
     "@types/semver": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
     "./icons/app": "./src/components/app-icons/types.ts",
     "./fonts/*": "./src/assets/fonts/*",
     "./audio/*": "./src/assets/audio/*",
+    "./v2/*.css": "./src/v2/components/*.css",
     "./v2/*": "./src/v2/components/*.tsx",
     "./v2/styles/*": "./src/v2/styles/*"
   },


### PR DESCRIPTION
## Summary
- export v2 component CSS files from the UI package so settings v2 stylesheet imports resolve during the embedded web UI build
- declare the Node types dependency used by the core SQLite adapter so the repository typecheck resolves the Node 24 SQLite API

## Testing
- bun run build --single (from packages/opencode)
- bun run typecheck