### PR TITLE
fix(app): avoid suspending on pending child path

### DIFF
--- a/packages/app/src/context/global-sync/child-store.test.ts
+++ b/packages/app/src/context/global-sync/child-store.test.ts
@@ -56,6 +56,7 @@ beforeAll(async () => {
           return options().queryKey?.[1] === "path"
         },
         get data() {
+          if (options().queryKey?.[1] === "path") throw new Error("pending path data read")
           if (options().queryKey?.[1] === "mcp") return options().enabled ? { demo: { status: "disabled" } } : undefined
           if (options().queryKey?.[1] === "lsp") return []
           if (options().queryKey?.[1] === "providers") return provider

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -200,8 +200,9 @@ export function createChildStoreManager(input: {
             },
             config: {},
             get path() {
-              if (pathQuery.data) return pathQuery.data
-              return { state: "", config: "", worktree: "", directory, home: "" }
+              const EMPTY = { state: "", config: "", worktree: "", directory, home: "" }
+              if (pathQuery.isLoading) return EMPTY
+              return pathQuery.data ?? EMPTY
             },
             status: "loading" as const,
             agent: [],


### PR DESCRIPTION
### Issue for this PR

Follow-up to #30167 and #30220.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Avoid reading Solid Query's suspending `data` resource while a child path query is pending. This preserves the requested-directory fallback so the home session list can render before `/path` resolves.

The unit mock now throws if pending path data is read, covering the regression introduced when child directory queries moved from `useQueries()` to `useQuery()`.

### How did you verify your code works?

- Reproduced `e2e/regression/session-list-path-loading.spec.ts` failing on current `dev`
- Ran `bunx playwright test --project=chromium --workers=1` from `packages/app`: 5 passed
- Ran `bun run test:unit` from `packages/app`: 339 passed
- Ran `bun typecheck` from `packages/app`
- Push hook repository typecheck passed

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
