### PR TITLE
fix(opencode): remove sunsetted gpt-5.2 and gpt-5.3-codex from allowed models for codex subscriptions

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -16,8 +16,6 @@ const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 const ALLOWED_MODELS = new Set([
   "gpt-5.5",
-  "gpt-5.2",
-  "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
   "gpt-5.4",
   "gpt-5.4-mini",


### PR DESCRIPTION
Removes `gpt-5.2` and `gpt-5.3-codex` from the `ALLOWED_MODELS` set in the Codex plugin, as these models have been sunsetted.

fixes: #30306