### PR TITLE
fix(opencode): preserve websocket api errors

### DIFF
--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -97,9 +97,9 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         maxConnectionAge,
         init?.signal,
       )
-      let resolveFirstEvent: (started: boolean) => void = () => {}
+      let resolveFirstEvent: (event: boolean | OpenAIWebSocket.WrappedError) => void = () => {}
       let rejectFirstEvent: (error: Error) => void = () => {}
-      const firstEvent = new Promise<boolean>((resolve, reject) => {
+      const firstEvent = new Promise<boolean | OpenAIWebSocket.WrappedError>((resolve, reject) => {
         resolveFirstEvent = resolve
         rejectFirstEvent = reject
       })
@@ -108,7 +108,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         body,
         idleTimeout,
         signal: init?.signal ?? undefined,
-        onFirstEvent: () => resolveFirstEvent(true),
+        onFirstEvent: (error) => resolveFirstEvent(error ?? true),
         onTerminal: (event) => {
           entry.busy = false
           entry.lastUsedAt = Date.now()
@@ -140,7 +140,14 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
           throw error
         },
       })
-      if (await firstEvent) return response
+      const first = await firstEvent
+      if (first !== false) {
+        if (first === true || first.status < 200 || first.status > 599) return response
+        return new Response(first.body, {
+          status: first.status,
+          headers: { "content-type": "application/json", ...first.headers },
+        })
+      }
       if (!entry.fallback) return response
       log.debug("http fallback", { key, reason: "websocket_retries_exhausted" })
       return httpFetch(input, httpInit)

--- a/packages/opencode/src/plugin/openai/ws.ts
+++ b/packages/opencode/src/plugin/openai/ws.ts
@@ -2,9 +2,11 @@
 // fallback, and continuation state intentionally live above this file.
 
 import WebSocket from "ws"
+import { APICallError } from "ai"
 import { ProviderError } from "@/provider/error"
 import { errorMessage } from "@/util/error"
 import { ProxyEnv } from "@/util/proxy-env"
+import { isRecord } from "@/util/record"
 
 export const PROTOCOL_HEADER = "responses_websockets=2026-02-06"
 
@@ -20,12 +22,18 @@ export interface StreamResponsesWebSocketOptions {
   body: Record<string, unknown>
   idleTimeout?: number
   signal?: AbortSignal
-  onFirstEvent?: () => void
+  onFirstEvent?: (error?: WrappedError) => void
   onComplete?: (event: Record<string, unknown>) => void
   onTerminal?: (event: Record<string, unknown>) => void
   onRetryableTerminal?: (event: Record<string, unknown>) => Promise<WebSocket | undefined>
   onConnectionInvalid?: (error: ProviderError.ResponseStreamError) => void
   onAbort?: (error: Error) => void
+}
+
+export interface WrappedError {
+  status: number
+  headers?: Record<string, string>
+  body: string
 }
 
 export function toWebSocketUrl(url: string) {
@@ -186,7 +194,7 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
       }
     })()
 
-    if (event?.type === "error" && !emitted && options.onRetryableTerminal) {
+    if (event?.type === "error" && options.onRetryableTerminal) {
       cleanupSocket()
       if (idleTimer) clearTimeout(idleTimer)
       idleTimer = undefined
@@ -208,6 +216,25 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
         )
         return
       }
+    }
+
+    const wrappedError = parseWrappedError(event, text)
+    if (wrappedError && event) {
+      if (!emitted) options.onFirstEvent?.(wrappedError)
+      completed = true
+      cleanup()
+      options.onTerminal?.(event)
+      controller?.error(
+        new APICallError({
+          message: wrappedError.message,
+          url: socket.url,
+          requestBodyValues: options.body,
+          statusCode: wrappedError.status,
+          responseHeaders: wrappedError.headers,
+          responseBody: wrappedError.body,
+        }),
+      )
+      return
     }
 
     if (!emitted) options.onFirstEvent?.()
@@ -310,6 +337,26 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
       headers: { "content-type": "text/event-stream" },
     },
   )
+}
+
+function parseWrappedError(event: Record<string, unknown> | undefined, body: string) {
+  if (event?.type !== "error") return
+  const status = event.status ?? event.status_code
+  if (typeof status !== "number" || (status >= 200 && status < 300)) return
+  return {
+    status,
+    headers: isRecord(event.headers)
+      ? Object.fromEntries(
+          Object.entries(event.headers).flatMap(([key, value]) =>
+            typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+              ? [[key, String(value)]]
+              : [],
+          ),
+        )
+      : undefined,
+    body,
+    message: isRecord(event.error) && typeof event.error.message === "string" ? event.error.message : `${status}`,
+  }
 }
 
 function cancelError(reason: unknown) {

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events"
 import { createServer, type IncomingMessage, type Server as HttpServer } from "node:http"
 import net, { type AddressInfo, type Socket } from "node:net"
 import WebSocket, { WebSocketServer } from "ws"
+import { APICallError } from "ai"
 import { ProviderError } from "../../src/provider/error"
 import { OpenAIWebSocket } from "../../src/plugin/openai/ws"
 import { OpenAIWebSocketPool, TITLE_HEADER } from "../../src/plugin/openai/ws-pool"
@@ -250,6 +251,72 @@ describe("plugin.openai.ws-pool", () => {
     expect(await second.text()).toContain('data: {"type":"response.completed"}')
     expect(connections).toBe(2)
     expect(server.httpRequests).toHaveLength(0)
+    fetch.close()
+  })
+
+  test("returns initial websocket error frames as HTTP-style API errors", async () => {
+    const error = {
+      type: "invalid_request_error",
+      message: "The model is not supported when using Codex with a ChatGPT account.",
+    }
+    const event = {
+      type: "error",
+      status: 400,
+      error,
+      headers: {
+        "x-codex-primary-window-minutes": 15,
+        ignored: { nested: true },
+      },
+    }
+    await using server = await createWebSocketServer((socket) => {
+      socket.once("message", () => {
+        socket.send(JSON.stringify(event))
+      })
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+    })
+
+    const response = await fetch(server.url, streamRequest())
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get("content-type")).toContain("application/json")
+    expect(response.headers.get("x-codex-primary-window-minutes")).toBe("15")
+    expect(response.headers.get("ignored")).toBeNull()
+    expect(await response.json()).toEqual(event)
+    fetch.close()
+  })
+
+  test("fails mid-stream wrapped websocket errors as HTTP-style API errors", async () => {
+    const event = {
+      type: "error",
+      status_code: 429,
+      error: {
+        type: "usage_limit_reached",
+        message: "The usage limit has been reached",
+      },
+      headers: {
+        "x-codex-primary-used-percent": "100.0",
+      },
+    }
+    await using server = await createWebSocketServer((socket) => {
+      socket.once("message", () => {
+        socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
+        socket.send(JSON.stringify(event))
+      })
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+    })
+
+    const response = await fetch(server.url, streamRequest())
+    const error = await readTextError(response.text())
+
+    expect(APICallError.isInstance(error)).toBe(true)
+    if (!APICallError.isInstance(error)) throw new Error("Expected APICallError")
+    expect(error.statusCode).toBe(429)
+    expect(error.responseHeaders).toEqual({ "x-codex-primary-used-percent": "100.0" })
+    expect(error.responseBody).toBe(JSON.stringify(event))
     fetch.close()
   })
 


### PR DESCRIPTION
## Summary
- preserve wrapped Responses websocket API errors instead of dropping them into synthetic SSE frames
- return first-frame websocket API errors as HTTP-style JSON responses and surface mid-stream errors as `APICallError`
- match Codex CLI handling for `status`, `status_code`, embedded headers, and connection-limit retries

## Testing
- `bun test test/plugin/openai-ws.test.ts`
- `bun test test/plugin/codex.test.ts`
- `bunx prettier --check src/plugin/openai/ws.ts src/plugin/openai/ws-pool.ts test/plugin/openai-ws.test.ts`
- `git diff --check origin/dev...HEAD`