### PR TITLE
fix(opencode): accept provider arg in providers logout command

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -505,11 +505,16 @@ export const ProvidersLoginCommand = effectCmd({
 })
 
 export const ProvidersLogoutCommand = effectCmd({
-  command: "logout",
+  command: "logout [provider]",
   describe: "log out from a configured provider",
   // Removes a global auth credential; no project instance needed.
   instance: false,
-  handler: Effect.fn("Cli.providers.logout")(function* (_args) {
+  builder: (yargs) =>
+    yargs.positional("provider", {
+      describe: "provider id or name to log out from (skips provider selection)",
+      type: "string",
+    }),
+  handler: Effect.fn("Cli.providers.logout")(function* (args) {
     const authSvc = yield* Auth.Service
     const modelsDev = yield* ModelsDev.Service
 
@@ -521,14 +526,27 @@ export const ProvidersLogoutCommand = effectCmd({
       return
     }
     const database = yield* modelsDev.get()
-    const selected = yield* Prompt.select({
-      message: "Select provider",
-      options: credentials.map(([key, value]) => ({
-        label: (database[key]?.name || key) + UI.Style.TEXT_DIM + " (" + value.type + ")",
-        value: key,
-      })),
-    })
-    yield* Effect.orDie(authSvc.remove(yield* promptValue(selected)))
+
+    if (args.provider) {
+      const match = credentials.find(
+        ([key]) => key === args.provider || database[key]?.name?.toLowerCase() === args.provider.toLowerCase(),
+      )
+      if (!match) return yield* fail(`Unknown provider "${args.provider}"`)
+      yield* Effect.orDie(authSvc.remove(match[0]))
+      yield* Prompt.outro("Logout successful")
+      return
+    }
+
+    const provider = yield* promptValue(
+      yield* Prompt.select({
+        message: "Select provider",
+        options: credentials.map(([key, value]) => ({
+          label: (database[key]?.name || key) + UI.Style.TEXT_DIM + " (" + value.type + ")",
+          value: key,
+        })),
+      }),
+    )
+    yield* Effect.orDie(authSvc.remove(provider))
     yield* Prompt.outro("Logout successful")
   }),
 })

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -149,9 +149,9 @@ exports[`opencode CLI help-text snapshots every documented command emits stable 
 manage AI providers and credentials
 
 Commands:
-  opencode providers list         list providers and credentials                       [aliases: ls]
-  opencode providers login [url]  log in to a provider
-  opencode providers logout       log out from a configured provider
+  opencode providers list               list providers and credentials                 [aliases: ls]
+  opencode providers login [url]        log in to a provider
+  opencode providers logout [provider]  log out from a configured provider
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -504,9 +504,12 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode providers logout --help 1`] = `
-"opencode providers logout
+"opencode providers logout [provider]
 
 log out from a configured provider
+
+Positionals:
+  provider  provider id or name to log out from (skips provider selection)                  [string]
 
 Options:
   -h, --help        show help                                                              [boolean]


### PR DESCRIPTION
### Issue for this PR

Closes #30313

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`logout` had no positional defined, so passing a name like `opencode providers logout Groq` made yargs treat it as an unrecognised argument and show help text instead. Added `[provider]` positional — matches by ID or display name (case-insensitive), falls back to the interactive prompt when omitted. Follows the same structure as `login [url]`.

### How did you verify your code works?

Ran `bun test` inside an Orbstack Ubuntu 24.04 container (Bun 1.3.14): **2998 pass, 22 skip, 1 todo, 4 fail**.

The 4 failures are pre-existing in `dev` and unrelated to this PR:
- `continues loading tui config when legacy source cannot be stripped`
- `Format > runs matching formatters sequentially for the same file`
- `tool.write > error handling > throws error when OS denies write access`
- `opencode CLI help-text snapshots` (fails on `opencode web`, `opencode mcp add`, `opencode mcp auth` — system deps unavailable in container)

Updated the help-text snapshot for the new `[provider]` positional.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR