### PR TITLE
fix(session): inherit parent directory + workspaceID in subagent sess…

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
-const childProcess = require("child_process")
-const fs = require("fs")
-const path = require("path")
-const os = require("os")
+// ESM imports — required because packages/opencode/package.json has "type": "module".
+// CJS require() is undefined in ESM scope; __filename replaced with import.meta.url.
+import childProcess from "child_process"
+import fs from "fs"
+import path from "path"
+import os from "os"
+import { fileURLToPath } from "url"
 
 const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP"]
 
@@ -45,7 +48,7 @@ function run(target) {
 
 const envPath = process.env.OPENCODE_BIN_PATH
 
-const scriptPath = fs.realpathSync(__filename)
+const scriptPath = fs.realpathSync(fileURLToPath(import.meta.url))
 const scriptDir = path.dirname(scriptPath)
 
 //

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -748,16 +748,39 @@ export const layer: Layer.Layer<
     }) {
       const ctx = yield* InstanceState.context
       const workspace = yield* InstanceState.workspaceID
+
+      // When this is a subagent session (parentID set), inherit the parent's
+      // workspace context — directory and workspaceID. Without this, child
+      // sessions fall back to ctx.directory (daemon process.cwd()), which is
+      // unrelated to the parent's actual project. That mismatch caused every
+      // subagent tool call to read against the wrong worktree, triggering
+      // external_directory permission asks for paths the parent's worktree
+      // fully owns. Effect.catchCause ensures a missing/race-deleted parent
+      // degrades gracefully back to ctx.directory.
+      let directory = ctx.directory
+      let resolvedWorkspaceID = input?.workspaceID ?? workspace
+      if (input?.parentID) {
+        const parent = yield* get(input.parentID).pipe(
+          Effect.catchCause(() => Effect.succeed(undefined)),
+        )
+        if (parent) {
+          directory = parent.directory
+          if (input?.workspaceID === undefined) {
+            resolvedWorkspaceID = parent.workspaceID ?? resolvedWorkspaceID
+          }
+        }
+      }
+
       return yield* createNext({
         parentID: input?.parentID,
-        directory: ctx.directory,
-        path: sessionPath(ctx.worktree, ctx.directory),
+        directory,
+        path: sessionPath(ctx.worktree, directory),
         title: input?.title,
         agent: input?.agent,
         model: input?.model,
         metadata: input?.metadata,
         permission: input?.permission,
-        workspaceID: input?.workspaceID ?? workspace,
+        workspaceID: resolvedWorkspaceID,
       })
     })
 


### PR DESCRIPTION
fix(session): inherit parent directory + workspaceID in subagent sessions

Session.create now inherits the parent's directory and workspaceID when parentID is set. Without this, subagent sessions defaulted to the daemon's process.cwd() (typically the user's $HOME under systemd's WorkingDirectory=%h), causing external_directory permission violations for paths the parent session's worktree fully owned. Uses Effect.catchCause (effect@4.0.0-beta.66 API) so a missing or race- deleted parent degrades gracefully back to ctx.directory.

Also ESM-ifies the packages/opencode/bin/opencode npm shim — the package declares "type": "module" but the shim used CommonJS require(), breaking under Node 22 with "require is not defined in ES module scope".

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode is run in HTTP server mode, the `directory` is always set to `ctx.directory`, which is the daemon's `process.cwd()`, NOT the parent session's context. For subagent sessions (`parentID` set), this is wrong:
they should inherit the parent's directory to maintain workspace coherence.

### How did you verify your code works?

Local build and own developed harness 

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
