### PR TITLE
fix(app): support authenticated web app manifests

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon-v3.svg" />
     <link rel="shortcut icon" href="/favicon-v3.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v3.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <meta name="theme-color" content="#F8F7F7" />
     <meta property="og:image" content="/social-share.png" />
     <meta property="twitter:image" content="/social-share.png" />

--- a/packages/ui/src/components/favicon.tsx
+++ b/packages/ui/src/components/favicon.tsx
@@ -6,7 +6,7 @@ export const Favicon = () => {
       <Link rel="icon" type="image/png" href="/favicon-96x96-v3.png" sizes="96x96" />
       <Link rel="shortcut icon" href="/favicon-v3.ico" />
       <Link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v3.png" />
-      <Link rel="manifest" href="/site.webmanifest" />
+      <Link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
       <Meta name="apple-mobile-web-app-title" content="OpenCode" />
     </>
   )


### PR DESCRIPTION
### Issue for this PR

Fixes #30405

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `crossorigin="use-credentials"` to the web app manifest link.

MDN's [Web application manifest](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest#deploying_a_manifest) documentation says:

> If the manifest requires credentials to fetch, the [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) attribute must be set to use-credentials, even if the manifest file is in the same origin as the current page.

### Why do you need this PR?

I am running `opencode web` behind a `nginx` reverse proxy for TLS and `authentik` for SSO authentication. I could load the `opencode` web app but the PWA option was not available.  The reason was that the browser was not sending credentials for `/site.webmanifest` and so it was redirected to the auth page. 

### How did you verify your code works?

I applied the patch, reloaded on mobile, and installed the PWA via the prompt.

### Screenshots / recordings

N/A - link attribute change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


### Use of AI

`codex` was used to diagnose the issue and prepare the PR. The final PR and description were prepared by me, a human (@chadvoegele)
