### PR TITLE
fix(provider): add anthropic leading tool boundary

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -342,6 +342,43 @@ function normalizeMessages(
   return msgs
 }
 
+function addAnthropicLeadingUserBoundary(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
+  if (!["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) return msgs
+
+  const first = msgs.findIndex((msg) => msg.role !== "system")
+  if (first === -1) return msgs
+
+  const msg = msgs[first]
+  if (msg?.role !== "assistant" || !Array.isArray(msg.content)) return msgs
+
+  const toolCallIDs = msg.content
+    .filter((part) => part.type === "tool-call")
+    .map((part) => part.toolCallId)
+  if (toolCallIDs.length === 0) return msgs
+
+  const next = msgs[first + 1]
+  if (next?.role !== "tool" || !Array.isArray(next.content)) return msgs
+
+  const toolResultIDs = new Set(
+    next.content.filter((part) => part.type === "tool-result").map((part) => part.toolCallId),
+  )
+  if (!toolCallIDs.every((id) => toolResultIDs.has(id))) return msgs
+
+  return [
+    ...msgs.slice(0, first),
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Previous user turn was omitted from the compacted conversation; continue from the following tool exchange.",
+        },
+      ],
+    } satisfies ModelMessage,
+    ...msgs.slice(first),
+  ]
+}
+
 function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
   const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
   const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
@@ -434,6 +471,7 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
+  msgs = addAnthropicLeadingUserBoundary(msgs, model)
   if (
     (model.providerID === "anthropic" ||
       model.providerID === "google-vertex-anthropic" ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import type { ModelMessage } from "ai"
 import { ProviderTransform } from "@/provider/transform"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 
@@ -1678,6 +1679,121 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
       { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
     ])
+  })
+
+  test("prepends user boundary when anthropic history starts with assistant tool calls", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+          { type: "tool-result", toolCallId: "toolu_2", toolName: "glob", output: { type: "text", value: "[]" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Update the anchored summary below using the conversation history above." }],
+      },
+    ] satisfies ModelMessage[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {})
+
+    expect(result).toHaveLength(4)
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Previous user turn was omitted from the compacted conversation; continue from the following tool exchange.",
+        },
+      ],
+    })
+    expect(result[1]).toMatchObject({ role: "assistant" })
+    expect(result[2]).toMatchObject({ role: "tool" })
+    expect(result[3]).toMatchObject({ role: "user" })
+  })
+
+  test("does not prepend user boundary when anthropic history already starts with user", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Check my home directory for PDFs" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } }],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+        ],
+      },
+    ] satisfies ModelMessage[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {})
+
+    expect(result).toHaveLength(3)
+    expect(result.map((msg) => msg.role)).toEqual(["user", "assistant", "tool"])
+  })
+
+  test("does not prepend user boundary when leading anthropic tool calls are incomplete", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
+          { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+        ],
+      },
+    ] satisfies ModelMessage[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {})
+
+    expect(result).toHaveLength(2)
+    expect(result.map((msg) => msg.role)).toEqual(["assistant", "tool"])
+  })
+
+  test("does not prepend user boundary for non-anthropic providers", () => {
+    const openaiModel = {
+      ...anthropicModel,
+      providerID: "openai",
+      api: {
+        id: "gpt-5.1",
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+    }
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } }],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "toolu_1", toolName: "read", output: { type: "text", value: "ok" } },
+        ],
+      },
+    ] satisfies ModelMessage[]
+
+    const result = ProviderTransform.message(msgs, openaiModel, {})
+
+    expect(result).toHaveLength(2)
+    expect(result.map((msg) => msg.role)).toEqual(["assistant", "tool"])
   })
 
   test("splits vertex anthropic assistant messages when text trails tool calls", () => {


### PR DESCRIPTION
## Summary
- prepend a synthetic user boundary for Anthropic histories that start with assistant tool calls after compaction
- only apply when the immediately following tool message satisfies every leading tool call
- keep non-Anthropic providers and already-user-led histories unchanged

## Verification
- bun test test/provider/transform.test.ts --timeout 30000
- bun run typecheck
- pre-push hook: bun turbo typecheck
- deployed mtb-verified artifact to mtb -> ops -> fob and verified direct/server-attach Anthropic smoke on all three hosts

Generated with AI assistance by Hephaestus.