### PR TITLE
docs: add QVAC local provider

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1796,6 +1796,101 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### QVAC
+
+You can configure opencode to use local models through [QVAC](https://qvac.com), an open-source runtime for local-first, peer-to-peer AI. QVAC exposes an OpenAI-compatible HTTP server via `qvac serve openai`, and the [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) package wraps it as a branded provider.
+
+:::tip
+Once QVAC lands in [models.dev](https://models.dev), it appears automatically in the `/connect` list — the manual config below is the explicit equivalent and is useful for pinning models and context limits.
+:::
+
+First, install [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) and start a server. Coding agents fire concurrent requests (a main chat completion plus a "title generation" call), and QVAC serializes inference per model file — so preload **two different model files** under aliases that match the model IDs you reference in `opencode.json`:
+
+```json title="qvac.config.json"
+{
+  "serve": {
+    "models": {
+      "qwen3-4b": {
+        "model": "QWEN3_4B_INST_Q4_K_M",
+        "preload": true,
+        "config": {
+          "ctx_size": 16384,
+          "reasoning_budget": 0
+        }
+      },
+      "qwen3-1.7b": {
+        "model": "QWEN3_1_7B_INST_Q4",
+        "preload": true,
+        "config": {
+          "ctx_size": 4096,
+          "reasoning_budget": 0
+        }
+      }
+    }
+  }
+}
+```
+
+```bash
+npm i -g @qvac/cli
+qvac serve openai
+```
+
+Then point opencode at it:
+
+```json title="opencode.json" "qvac" {5, 6, 8, 11-12, 18, 25-26}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "qvac": {
+      "npm": "@qvac/ai-sdk-provider",
+      "name": "QVAC (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:11434/v1",
+        "apiKey": "qvac"
+      },
+      "models": {
+        "qwen3-4b": {
+          "name": "Qwen3 4B (local)",
+          "limit": {
+            "context": 16384,
+            "output": 8192
+          }
+        },
+        "qwen3-1.7b": {
+          "name": "Qwen3 1.7B (local)",
+          "limit": {
+            "context": 4096,
+            "output": 2048
+          }
+        }
+      }
+    }
+  },
+  "model": "qvac/qwen3-4b",
+  "small_model": "qvac/qwen3-1.7b"
+}
+```
+
+In this example:
+
+- `qvac` is the custom provider ID. This can be any string you want.
+- `npm` specifies the package to use for this provider — `@qvac/ai-sdk-provider`, the branded QVAC wrapper around `@ai-sdk/openai-compatible`.
+- `options.baseURL` is the endpoint for your local `qvac serve` (set this to match your serve port).
+- `options.apiKey` can be any non-empty string — `qvac serve` does not validate it, but some clients refuse to send a request without an `Authorization` header.
+- The model IDs (`qwen3-4b`, `qwen3-1.7b`) must match the **serve aliases** in `qvac.config.json` — those aliases are what the provider sends as the OpenAI `model` field.
+- `model` is the main chat model; `small_model` is the lighter model opencode uses for titles and other utility calls. Pointing them at two different files lets QVAC run both concurrently.
+
+:::note
+QVAC's LLM `ctx_size` defaults to 1024 tokens — too small for an agent's tool definitions and system prompt. Set it explicitly (16k+ for chat) in `qvac.config.json`, and set `reasoning_budget: 0` to suppress `<think>` blocks that opencode would otherwise render verbatim.
+:::
+
+:::tip
+Local tool-calling quality is bounded by the model. Q4-quantized 4B/8B Instruct models can hold a conversation but won't reliably invoke tools; reliable local agent use generally needs ≥14B parameters with coder/agent post-training. See the [QVAC provider README](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the full agent setup notes.
+:::
+
+---
+
 ### SAP AI Core
 
 SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon, Meta, Mistral, and AI21 through a unified platform.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1886,7 +1886,24 @@ QVAC's LLM `ctx_size` defaults to 1024 tokens — too small for an agent's tool 
 :::
 
 :::tip
-Local tool-calling quality is bounded by the model. Q4-quantized 4B/8B Instruct models can hold a conversation but won't reliably invoke tools; reliable local agent use generally needs ≥14B parameters with coder/agent post-training. See the [QVAC provider README](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the full agent setup notes.
+The Qwen3 models above are a fast, low-footprint starting point, but small Instruct models won't reliably **invoke tools**. For real agent workflows use a larger, agent-tuned model — `gpt-oss-20b` (OpenAI's open-weight model, ~12&nbsp;GB download, ~16&nbsp;GB RAM) is the recommended local backend, and QVAC parses its tool calls natively. Add it as a third model and point `model` at it:
+
+```json title="qvac.config.json"
+"gpt-oss-20b": {
+  "model": "GPT_OSS_20B_INST_Q4_K_M",
+  "preload": true,
+  "config": { "ctx_size": 32768 }
+}
+```
+
+```json title="opencode.json"
+"gpt-oss-20b": {
+  "name": "GPT-OSS 20B (local)",
+  "limit": { "context": 32768, "output": 8192 }
+}
+```
+
+Then set `"model": "qvac/gpt-oss-20b"` and keep a small Qwen3 model as `small_model` for fast title generation. See the [QVAC provider README](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the full agent setup notes.
 :::
 
 ---

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1866,11 +1866,11 @@ In this example:
 - `model` is the main chat model; `small_model` is the model opencode uses for titles, summarization, and compaction. Pointing both at the same QVAC alias is supported; if you want those utility calls to avoid waiting behind a long chat response, add a second lighter model alias and point `small_model` at it.
 
 :::note
-QVAC's LLM `ctx_size` defaults to 1024 tokens — too small for an agent's tool definitions and system prompt. Set it explicitly in `qvac.config.json`, and set `reasoning_budget: 0` for reasoning-tuned models such as Qwen3 if you want to suppress `<think>` blocks that opencode would otherwise render verbatim.
+QVAC's LLM `ctx_size` defaults to 1024 tokens — too small for an agent's tool definitions and system prompt. Set it explicitly in `qvac.config.json`, and set `reasoning_budget: 0` for reasoning-tuned models such as Qwen3.5 if you want to suppress `<think>` blocks that opencode would otherwise render verbatim.
 :::
 
 :::tip
-Local tool-calling quality is bounded by the model. Small Qwen3 Instruct models are a fast, low-footprint starting point but won't reliably **invoke tools**; for real agent workflows, use a larger agent-tuned model such as `gpt-oss-20b`.
+Local tool-calling quality is bounded by the model. Small Qwen3.5 models are a fast, low-footprint starting point but won't reliably **invoke tools**; for real agent workflows, use a larger agent-tuned model such as `gpt-oss-20b`.
 :::
 
 ---

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1798,7 +1798,7 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ### QVAC
 
-You can configure opencode to use local models through [QVAC](https://qvac.com), an open-source runtime for local-first, peer-to-peer AI. QVAC exposes an OpenAI-compatible HTTP server via `qvac serve openai`, and the [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) package wraps it as a branded provider.
+You can configure opencode to use local models through [QVAC](https://qvac.tether.io), an open-source runtime for local-first, peer-to-peer AI. QVAC exposes an OpenAI-compatible HTTP server via `qvac serve openai`, and the [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) package wraps it as a branded provider.
 
 :::tip
 Once QVAC lands in [models.dev](https://models.dev), it appears automatically in the `/connect` list — the manual config below is the explicit equivalent and is useful for pinning models and context limits.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1822,7 +1822,7 @@ First, install [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) and start 
         "model": "QWEN3_1_7B_INST_Q4",
         "preload": true,
         "config": {
-          "ctx_size": 4096,
+          "ctx_size": 8192,
           "reasoning_budget": 0
         }
       }
@@ -1860,8 +1860,8 @@ Then point opencode at it:
         "qwen3-1.7b": {
           "name": "Qwen3 1.7B (local)",
           "limit": {
-            "context": 4096,
-            "output": 2048
+            "context": 8192,
+            "output": 4096
           }
         }
       }
@@ -1876,10 +1876,10 @@ In this example:
 
 - `qvac` is the custom provider ID. This can be any string you want.
 - `npm` specifies the package to use for this provider — `@qvac/ai-sdk-provider`, the branded QVAC wrapper around `@ai-sdk/openai-compatible`.
-- `options.baseURL` is the endpoint for your local `qvac serve` (set this to match your serve port).
+- `options.baseURL` is the endpoint for your local `qvac serve` (set this to match your serve port). Note that `qvac serve openai` defaults to port `11434` — the same default as Ollama. If you run both, pass `--port` to one of them and update `baseURL` to match.
 - `options.apiKey` can be any non-empty string — `qvac serve` does not validate it, but some clients refuse to send a request without an `Authorization` header.
 - The model IDs (`qwen3-4b`, `qwen3-1.7b`) must match the **serve aliases** in `qvac.config.json` — those aliases are what the provider sends as the OpenAI `model` field.
-- `model` is the main chat model; `small_model` is the lighter model opencode uses for titles and other utility calls. Pointing them at two different files lets QVAC run both concurrently.
+- `model` is the main chat model; `small_model` is the lighter model opencode uses for titles, summarization, and compaction. Give it enough context (8k+) for those tasks, and point it at a different file from `model` so QVAC can run both concurrently.
 
 :::note
 QVAC's LLM `ctx_size` defaults to 1024 tokens — too small for an agent's tool definitions and system prompt. Set it explicitly (16k+ for chat) in `qvac.config.json`, and set `reasoning_budget: 0` to suppress `<think>` blocks that opencode would otherwise render verbatim.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1804,26 +1804,17 @@ You can configure opencode to use local models through [QVAC](https://qvac.com),
 Once QVAC lands in [models.dev](https://models.dev), it appears automatically in the `/connect` list — the manual config below is the explicit equivalent and is useful for pinning models and context limits.
 :::
 
-First, install [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) and start a server. Coding agents fire concurrent requests (a main chat completion plus a "title generation" call), and QVAC serializes inference per model file — so preload **two different model files** under aliases that match the model IDs you reference in `opencode.json`:
+First, install [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) and start a server. Preload the model alias you reference in `opencode.json`; QVAC queues same-model completion requests, so opencode's background title, summary, and compaction calls can share the same local model instead of requiring a second model file.
 
 ```json title="qvac.config.json"
 {
   "serve": {
     "models": {
-      "qwen3-4b": {
-        "model": "QWEN3_4B_INST_Q4_K_M",
+      "gpt-oss-20b": {
+        "model": "GPT_OSS_20B_INST_Q4_K_M",
         "preload": true,
         "config": {
-          "ctx_size": 16384,
-          "reasoning_budget": 0
-        }
-      },
-      "qwen3-1.7b": {
-        "model": "QWEN3_1_7B_INST_Q4",
-        "preload": true,
-        "config": {
-          "ctx_size": 8192,
-          "reasoning_budget": 0
+          "ctx_size": 32768
         }
       }
     }
@@ -1850,25 +1841,18 @@ Then point opencode at it:
         "apiKey": "qvac"
       },
       "models": {
-        "qwen3-4b": {
-          "name": "Qwen3 4B (local)",
+        "gpt-oss-20b": {
+          "name": "GPT-OSS 20B (local)",
           "limit": {
-            "context": 16384,
+            "context": 32768,
             "output": 8192
-          }
-        },
-        "qwen3-1.7b": {
-          "name": "Qwen3 1.7B (local)",
-          "limit": {
-            "context": 8192,
-            "output": 4096
           }
         }
       }
     }
   },
-  "model": "qvac/qwen3-4b",
-  "small_model": "qvac/qwen3-1.7b"
+  "model": "qvac/gpt-oss-20b",
+  "small_model": "qvac/gpt-oss-20b"
 }
 ```
 
@@ -1878,32 +1862,15 @@ In this example:
 - `npm` specifies the package to use for this provider — `@qvac/ai-sdk-provider`, the branded QVAC wrapper around `@ai-sdk/openai-compatible`.
 - `options.baseURL` is the endpoint for your local `qvac serve` (set this to match your serve port). Note that `qvac serve openai` defaults to port `11434` — the same default as Ollama. If you run both, pass `--port` to one of them and update `baseURL` to match.
 - `options.apiKey` can be any non-empty string — `qvac serve` does not validate it, but some clients refuse to send a request without an `Authorization` header.
-- The model IDs (`qwen3-4b`, `qwen3-1.7b`) must match the **serve aliases** in `qvac.config.json` — those aliases are what the provider sends as the OpenAI `model` field.
-- `model` is the main chat model; `small_model` is the lighter model opencode uses for titles, summarization, and compaction. Give it enough context (8k+) for those tasks, and point it at a different file from `model` so QVAC can run both concurrently.
+- The model ID (`gpt-oss-20b`) must match the **serve alias** in `qvac.config.json` — that alias is what the provider sends as the OpenAI `model` field.
+- `model` is the main chat model; `small_model` is the model opencode uses for titles, summarization, and compaction. Pointing both at the same QVAC alias is supported; if you want those utility calls to avoid waiting behind a long chat response, add a second lighter model alias and point `small_model` at it.
 
 :::note
-QVAC's LLM `ctx_size` defaults to 1024 tokens — too small for an agent's tool definitions and system prompt. Set it explicitly (16k+ for chat) in `qvac.config.json`, and set `reasoning_budget: 0` to suppress `<think>` blocks that opencode would otherwise render verbatim.
+QVAC's LLM `ctx_size` defaults to 1024 tokens — too small for an agent's tool definitions and system prompt. Set it explicitly in `qvac.config.json`, and set `reasoning_budget: 0` for reasoning-tuned models such as Qwen3 if you want to suppress `<think>` blocks that opencode would otherwise render verbatim.
 :::
 
 :::tip
-The Qwen3 models above are a fast, low-footprint starting point, but small Instruct models won't reliably **invoke tools**. For real agent workflows use a larger, agent-tuned model — `gpt-oss-20b` (OpenAI's open-weight model, ~12&nbsp;GB download, ~16&nbsp;GB RAM) is the recommended local backend, and QVAC parses its tool calls natively. Add it as a third model and point `model` at it:
-
-```json title="qvac.config.json"
-"gpt-oss-20b": {
-  "model": "GPT_OSS_20B_INST_Q4_K_M",
-  "preload": true,
-  "config": { "ctx_size": 32768 }
-}
-```
-
-```json title="opencode.json"
-"gpt-oss-20b": {
-  "name": "GPT-OSS 20B (local)",
-  "limit": { "context": 32768, "output": 8192 }
-}
-```
-
-Then set `"model": "qvac/gpt-oss-20b"` and keep a small Qwen3 model as `small_model` for fast title generation. See the [QVAC provider README](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the full agent setup notes.
+Local tool-calling quality is bounded by the model. Small Qwen3 Instruct models are a fast, low-footprint starting point but won't reliably **invoke tools**; for real agent workflows, use a larger agent-tuned model such as `gpt-oss-20b`.
 :::
 
 ---


### PR DESCRIPTION
### Issue for this PR

_No linked issue — documentation addition._

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a `### QVAC` section to the providers docs, next to the existing llama.cpp / LM Studio / Ollama local-provider entries.

QVAC is a local-first AI runtime that exposes an OpenAI-compatible server via `qvac serve openai`; the `@qvac/ai-sdk-provider` npm package is a branded wrapper around `@ai-sdk/openai-compatible` that points at it. The section shows the `opencode.json` provider block plus the matching `qvac.config.json`, and calls out the non-obvious things needed for it to behave as an agent backend:

- preload the model alias referenced from `opencode.json`;
- set `ctx_size` explicitly because the default 1024-token context is too small for coding-agent prompts;
- use a capable local model for tool-calling quality, with `gpt-oss-20b` as the recommended local backend.

QVAC now queues same-model completion requests, so `model` and `small_model` can point at the same local alias. A separate lighter `small_model` remains optional if users want title, summary, or compaction calls to avoid waiting behind long chat responses.

A QVAC provider entry is also in review at anomalyco/models.dev#1954, so QVAC will show up in `/connect` once that lands; this docs section is the explicit equivalent.

### How did you verify your code works?

Ran `qvac serve openai` locally and pointed OpenCode at it using this provider config. The single-model setup now works for both the main chat model and OpenCode's `small_model` utility calls because QVAC queues same-model completion requests.

### Screenshots / recordings

_Docs-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
