### PR TITLE
feat(core): support named migrations

### DIFF
--- a/packages/core/script/migration.ts
+++ b/packages/core/script/migration.ts
@@ -5,18 +5,28 @@ import fs from "fs/promises"
 import os from "os"
 import path from "path"
 import { pathToFileURL } from "url"
+import { parseArgs } from "util"
 
 const root = path.resolve(import.meta.dirname, "../../..")
 const sqlDir = path.join(root, "packages/core/migration")
 const tsDir = path.join(root, "packages/core/src/database/migration")
 const registry = path.join(root, "packages/core/src/database/migration.gen.ts")
+const args = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    check: { type: "boolean" },
+    name: { type: "string" },
+  },
+})
 
-if (Bun.argv.includes("--check")) {
+if (args.values.check) {
   await check()
   process.exit(0)
 }
 
-await $`bun drizzle-kit generate`.cwd(path.join(root, "packages/core"))
+await $`bun drizzle-kit generate ${args.values.name ? ["--name", args.values.name] : []}`.cwd(
+  path.join(root, "packages/core"),
+)
 
 const sqlMigrations = (await Array.fromAsync(new Bun.Glob("*/migration.sql").scan({ cwd: sqlDir })))
   .map((file) => file.split("/")[0])


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `--name` support to the core migration wrapper. The script parses `--name` alongside the existing `--check` option and forwards the value to `drizzle-kit generate`, allowing migrations to be created with a descriptive name via `bun run migration --name <name>`.

### How did you verify your code works?

- Ran `bun run migration --name verify_named_migration` from `packages/core`.
- Ran `bun run migration --check` from `packages/core`.
- Ran `bun typecheck` from `packages/core`.
- Passed the repository pre-push `bun turbo typecheck` hook.

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR