### PR TITLE
fix(tui): scope diff viewer to session directory

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
@@ -89,11 +89,15 @@ function DiffViewer(props: { api: TuiPluginApi }) {
         }
       | undefined
   const mode = () => params()?.mode ?? "git"
-  const diffInput = createMemo(() => ({
-    mode: mode(),
-    sessionID: params()?.sessionID,
-    messageID: params()?.messageID,
-  }))
+  const diffInput = createMemo(() => {
+    const sessionID = params()?.sessionID
+    return {
+      mode: mode(),
+      sessionID,
+      messageID: params()?.messageID,
+      directory: sessionID ? props.api.state.session.get(sessionID)?.directory : undefined,
+    }
+  })
   const [diff] = createResource(diffInput, async (input) => {
     if (input.mode === "last-turn") {
       const sessionID = input.sessionID
@@ -106,7 +110,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     }
 
     const result = await props.api.client.vcs.diff(
-      { mode: "git", context: WORKING_TREE_DIFF_CONTEXT_LINES },
+      { directory: input.directory, mode: "git", context: WORKING_TREE_DIFF_CONTEXT_LINES },
       { throwOnError: true },
     )
     return normalizeDiffs(result.data ?? [])

--- a/packages/opencode/test/cli/tui/diff-viewer.test.tsx
+++ b/packages/opencode/test/cli/tui/diff-viewer.test.tsx
@@ -6,6 +6,7 @@ import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { testRender, useRenderer } from "@opentui/solid"
 import { Global } from "@opencode-ai/core/global"
 import type { TuiPluginApi, TuiPluginMeta, TuiRouteCurrent, TuiRouteDefinition } from "@opencode-ai/plugin/tui"
+import type { Session } from "@opencode-ai/sdk/v2"
 import { KVProvider } from "../../../src/cli/cmd/tui/context/kv"
 import { ThemeProvider } from "../../../src/cli/cmd/tui/context/theme"
 import { TuiConfigProvider } from "../../../src/cli/cmd/tui/context/tui-config"
@@ -22,6 +23,7 @@ test("closing the diff viewer returns to the route it opened from", async () => 
   >()
   let current = startRoute
   let renderDiff: TuiRouteDefinition["render"] | undefined
+  let vcsDiffInput: unknown
   await mkdir(Global.Path.state, { recursive: true })
   await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
 
@@ -36,9 +38,19 @@ test("closing the diff viewer returns to the route it opened from", async () => 
     const base = createTuiPluginApi({
       keymap,
       client: {
-        vcs: { diff: async () => ({ data: [] }) },
+        vcs: {
+          diff: async (input: unknown) => {
+            vcsDiffInput = input
+            return { data: [] }
+          },
+        },
         session: { diff: async () => ({ data: [] }) },
       } as unknown as TuiPluginApi["client"],
+      state: {
+        session: {
+          get: () => session,
+        },
+      },
     })
     const api = {
       ...base,
@@ -76,6 +88,7 @@ test("closing the diff viewer returns to the route it opened from", async () => 
   try {
     await waitForCommand(app, commands, "diff.close")
     expect(current).toEqual({ name: "diff", params: { mode: "git", sessionID: "session-1", returnRoute: startRoute } })
+    expect(vcsDiffInput).toEqual({ directory: "/repo/session", mode: "git", context: 12 })
 
     expect(commands.has("diff.close")).toBe(true)
     commands.get("diff.close")!.run?.({} as never)
@@ -84,6 +97,19 @@ test("closing the diff viewer returns to the route it opened from", async () => 
     app.renderer.destroy()
   }
 })
+
+const session = {
+  id: "session-1",
+  slug: "session-1",
+  projectID: "project-1",
+  directory: "/repo/session",
+  title: "Session",
+  version: "1",
+  time: {
+    created: 0,
+    updated: 0,
+  },
+} satisfies Session
 
 async function waitForCommand(
   app: Awaited<ReturnType<typeof testRender>>,


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Passes the active session directory when the TUI diff viewer requests working-tree changes. Previously the request fell back to the directory where the TUI started, so opening `/diff` from a session rooted elsewhere could show `No diff!` even when that session directory had Git changes.

The session directory is included in the diff resource input so the request also refetches if synchronized session data becomes available after the viewer mounts.

### How did you verify your code works?

- `bun test test/cli/tui/diff-viewer.test.tsx` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- Commit hook: `bun turbo typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR