### PR TITLE
test: widen provider header timeout margin

### DIFF
--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -23,7 +23,7 @@ const it = testEffect(
 it.live("headerTimeout does not abort delayed SSE body after headers arrive", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
-      Effect.promise(() => delayedBodyServer(250)),
+      Effect.promise(() => delayedBodyServer(1_000)),
       (server) => Effect.sync(() => server.server.close()),
     )
 
@@ -39,7 +39,7 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
 
           expect(yield* Effect.promise(() => result.text)).toBe("late")
         }),
-      { config: providerConfig(server.url, { headerTimeout: 50 }) },
+      { config: providerConfig(server.url, { headerTimeout: 500 }) },
     )
   }),
 )


### PR DESCRIPTION
## Summary
- increase the delayed SSE body fixture from 250ms to 1s
- increase the header timeout assertion margin from 50ms to 500ms
- preserve coverage that the header timeout is cleared once response headers arrive

## Testing
- `bun test test/provider/header-timeout.test.ts`
- `bun test test/provider/header-timeout.test.ts --rerun-each=15 --test-name-pattern='headerTimeout does not abort delayed SSE body after headers arrive'` under deliberate CPU contention