### PR TITLE
fix(plugin): restore private git install fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -842,6 +842,7 @@
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
     "@ai-sdk/xai@3.0.82": "patches/@ai-sdk%2Fxai@3.0.82.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
+    "pacote@21.5.0": "patches/pacote@21.5.0.patch",
     "@npmcli/agent@4.0.0": "patches/@npmcli%2Fagent@4.0.0.patch",
     "@silvia-odwyer/photon-node@0.3.4": "patches/@silvia-odwyer%2Fphoton-node@0.3.4.patch",
   },

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "virtua@0.49.1": "patches/virtua@0.49.1.patch",
     "@ai-sdk/xai@3.0.82": "patches/@ai-sdk%2Fxai@3.0.82.patch",
-    "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch"
+    "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
+    "pacote@21.5.0": "patches/pacote@21.5.0.patch"
   }
 }

--- a/patches/pacote@21.5.0.patch
+++ b/patches/pacote@21.5.0.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/git.js b/lib/git.js
+index 000ee9fc..a2a6cbb7 100644
+--- a/lib/git.js
++++ b/lib/git.js
+@@ -254,8 +254,11 @@ class GitFetcher extends Fetcher {
+           resolved: this.resolved,
+           integrity: null, // it'll always be different, if we have one
+         }).extract(tmp).then(() => handler(`${tmp}${this.spec.gitSubdir || ''}`), er => {
+-          // fall back to ssh download if tarball fails
+-          if (er.constructor.name.match(/^Http/)) {
++          // fall back to clone if the tarball download fails due to an
++          // HTTP error or if the response is not a valid tarball (e.g.
++          // a hosted provider returning an HTML sign-in page with 200)
++          if ((typeof er.statusCode === 'number' && er.statusCode >= 400) ||
++              /^TAR_/.test(er.code)) {
+             return this.#clone(handler, false)
+           } else {
+             throw er


### PR DESCRIPTION
## Summary
Private Git plugin URLs go through Arborist and pacote. For GitHub repos, pacote resolves the commit SHA and tries a faster `codeload.github.com` tarball before falling back to `git clone`.

For private SSH-only repos, the codeload request is anonymous and returns `404`. Pacote should recover by cloning over SSH, but `pacote@21.5.0` identifies HTTP errors using the error constructor name:

```js
if (er.constructor.name.match(/^Http/)) {
  return this.#clone(handler, false)
}
```

opencode release binaries are minified, which can rename that constructor. The fallback check then fails and plugin installation stops at the codeload `404`.

This backports [npm/pacote#481](https://github.com/npm/pacote/pull/481), which checks stable error properties instead:

```js
if ((typeof er.statusCode === "number" && er.statusCode >= 400) ||
    /^TAR_/.test(er.code)) {
  return this.#clone(handler, false)
}
```

The initial anonymous codeload request still happens. This restores the intended Git clone fallback.

## Verification
- reproduced the codeload `404` with a disposable private GitHub repo and a minified installer harness
- rebuilt the same harness with this patch and confirmed installation succeeds via SSH fallback
- ran `bun install --frozen-lockfile`