### PR TITLE
fix(app): avoid O(n^2) dedup hang on large diff summaries

### DIFF
--- a/packages/app/src/pages/session/message-timeline.data.ts
+++ b/packages/app/src/pages/session/message-timeline.data.ts
@@ -1,9 +1,10 @@
 import { parseCommentNote, readCommentMetadata } from "@/utils/comment-note"
-import { AssistantMessage, Part, SessionStatus, SnapshotFileDiff, UserMessage } from "@opencode-ai/sdk/v2"
+import { AssistantMessage, Part, SessionStatus, UserMessage } from "@opencode-ai/sdk/v2"
 import { groupParts, PartGroup, renderable } from "@opencode-ai/ui/message-part"
 import { Data, Equal } from "effect"
+import { dedupeSummaryDiffs, type SummaryDiff } from "./message-timeline.diffs"
 
-export type SummaryDiff = SnapshotFileDiff & { file: string }
+export type { SummaryDiff }
 
 export type TimelineRowMap = {
   CommentStrip: {
@@ -212,14 +213,7 @@ export namespace Timeline {
 
     if (isActive && status === "retry") rows.push(new TimelineRow.Retry({ userMessageID: userMessage.id }))
 
-    const diffs = (userMessage.summary?.diffs ?? [])
-      .reduceRight<SummaryDiff[]>((result, diff) => {
-        if (!isSummaryDiff(diff)) return result
-        if (result.some((item) => item.file === diff.file)) return result
-        result.push(diff)
-        return result
-      }, [])
-      .reverse()
+    const diffs = dedupeSummaryDiffs(userMessage.summary?.diffs)
     if (diffs.length > 0 && (status === "idle" || !isActive)) {
       rows.push(
         new TimelineRow.DiffSummary({
@@ -242,10 +236,6 @@ export namespace Timeline {
     }
 
     return rows
-  }
-
-  function isSummaryDiff(value: SnapshotFileDiff): value is SummaryDiff {
-    return typeof value.file === "string"
   }
 
   function reasoningHeading(text: string) {

--- a/packages/app/src/pages/session/message-timeline.diffs.test.ts
+++ b/packages/app/src/pages/session/message-timeline.diffs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import type { SnapshotFileDiff } from "@opencode-ai/sdk/v2"
+import { dedupeSummaryDiffs } from "./message-timeline.diffs"
+
+function diff(file: string | undefined, additions = 0): SnapshotFileDiff {
+  return { file, additions, deletions: 0 } as unknown as SnapshotFileDiff
+}
+
+describe("dedupeSummaryDiffs", () => {
+  test("returns empty for undefined input", () => {
+    expect(dedupeSummaryDiffs(undefined)).toEqual([])
+  })
+
+  test("drops entries without a file path", () => {
+    const result = dedupeSummaryDiffs([diff("a.ts"), diff(undefined), diff("b.ts")])
+    expect(result.map((d) => d.file)).toEqual(["a.ts", "b.ts"])
+  })
+
+  test("keeps the last entry per file, preserving original order", () => {
+    const result = dedupeSummaryDiffs([
+      diff("a.ts", 1),
+      diff("b.ts", 1),
+      diff("a.ts", 2),
+      diff("c.ts", 1),
+      diff("b.ts", 2),
+    ])
+    expect(result.map((d) => [d.file, (d as { additions: number }).additions])).toEqual([
+      ["a.ts", 2],
+      ["c.ts", 1],
+      ["b.ts", 2],
+    ])
+  })
+
+  test("dedupes a large all-unique input quickly (regression guard for O(n^2) hang)", () => {
+    const input = Array.from({ length: 25_000 }, (_, i) => diff(`file-${i}.ts`))
+    const start = performance.now()
+    const result = dedupeSummaryDiffs(input)
+    const elapsed = performance.now() - start
+    expect(result.length).toBe(25_000)
+    expect(result[0].file).toBe("file-0.ts")
+    expect(result[result.length - 1].file).toBe("file-24999.ts")
+    // The old O(n^2) implementation took seconds/minutes on this size and hung the renderer.
+    expect(elapsed).toBeLessThan(1_000)
+  })
+})

--- a/packages/app/src/pages/session/message-timeline.diffs.ts
+++ b/packages/app/src/pages/session/message-timeline.diffs.ts
@@ -1,0 +1,29 @@
+import type { SnapshotFileDiff } from "@opencode-ai/sdk/v2"
+
+export type SummaryDiff = SnapshotFileDiff & { file: string }
+
+export function isSummaryDiff(value: SnapshotFileDiff): value is SummaryDiff {
+  return typeof value.file === "string"
+}
+
+/**
+ * Collapse a message's summary diffs to one entry per file, keeping the last
+ * occurrence of each file in original order.
+ *
+ * Uses a Set for O(n) dedup. The previous implementation scanned the result
+ * array with `.some()` on every entry (O(n^2)), which could hang the renderer
+ * on messages with tens of thousands of diffs.
+ */
+export function dedupeSummaryDiffs(diffs: SnapshotFileDiff[] | undefined): SummaryDiff[] {
+  const seen = new Set<string>()
+  const result: SummaryDiff[] = []
+  const source = diffs ?? []
+  for (let i = source.length - 1; i >= 0; i--) {
+    const diff = source[i]
+    if (!isSummaryDiff(diff)) continue
+    if (seen.has(diff.file)) continue
+    seen.add(diff.file)
+    result.push(diff)
+  }
+  return result.reverse()
+}


### PR DESCRIPTION
### Issue for this PR

Closes #28844

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`constructMessageRows` dedupes a message's `summary.diffs` by calling `result.some()` inside a `reduceRight` — it rescans the whole result array on every entry, so it's O(n^2). I had a session whose message held ~25k diffs, which is ~600M comparisons, and the desktop renderer hung on every launch (macOS "renderer unresponsive").

I moved that dedup into a small pure `dedupeSummaryDiffs` helper that uses a Set, so it's O(n). It keeps the exact same result as before: last entry per file, in original order (the old code got that by iterating right-to-left then reversing; the Set version does the same walk).

Note on scope: #28844 also describes an O(n^2) in `groupParts` over huge *part* counts. This PR does not touch that — it only fixes the separate `summary.diffs` line. The two are complementary.

### How did you verify your code works?

- Added `message-timeline.diffs.test.ts` with 4 cases: undefined input, dropping entries without a file, last-wins ordering, and a 25k-entry guard that asserts it finishes in <1s (the old version effectively hung at that size). `bun test` passes.
- `bun run typecheck` is clean.
- The helper is in its own file because importing `message-timeline.data.ts` in a unit test pulls in kobalte/solid client-only code that throws under the test env, so the dedup couldn't be tested in place.

### Screenshots / recordings

Not a UI change — no visible difference, same diff rows render.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR