### PR TITLE
fix(tui): always show variant dialog when selecting a model

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -131,11 +131,6 @@ export function DialogModel(props: { providerID?: string }) {
   function onSelect(providerID: string, modelID: string) {
     local.model.set({ providerID, modelID }, { recent: true })
     const list = local.model.variant.list()
-    const cur = local.model.variant.selected()
-    if (cur === "default" || (cur && list.includes(cur))) {
-      dialog.clear()
-      return
-    }
     if (list.length > 0) {
       dialog.replace(() => <DialogVariant />)
       return


### PR DESCRIPTION
### Issue for this PR

Closes #30445

See also: #27893 (closed), #28024 (open, different approach)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When selecting a model in the TUI model picker (`/models`), the variant selection dialog was skipped if the model had a previously saved variant. This made it impossible to change reasoning strength without manually cycling after selection.

This PR removes the early-return condition in `onSelect()` so the variant dialog **always appears** when the selected model supports variants. The previous variant is pre-selected — press Enter to keep it, or navigate to change.

**Difference from #28024**: #28024 only opens the variant picker when no saved variant exists. This PR goes further — always opens it, even when a variant was previously saved. This is the expected UX: users should be able to choose reasoning strength every time they pick a model, not just the first time.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` passes ✅
- `bun run build` succeeds — produced working binary
- Single file changed: 5 lines removed in `dialog-model.tsx`
- Installed and tested locally — variant dialog now appears on every model selection

### Screenshots / recordings

N/A — behavioral change, not visual. The variant dialog (existing UI) now consistently appears.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
