### PR TITLE
fix(opencode): filter empty Gemini replay messages

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -184,6 +184,19 @@ function normalizeMessages(
       .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
   }
 
+  // Gemini rejects contents entries without parts. Empty reasoning-only blocks
+  // can survive UI message conversion after step-start splitting.
+  if (model.api.npm === "@ai-sdk/google" || model.api.npm === "@ai-sdk/google-vertex") {
+    msgs = msgs.filter((msg) => {
+      if (msg.content === "") return false
+      if (!Array.isArray(msg.content)) return true
+      return msg.content.some((part) => {
+        if (part.type !== "text" && part.type !== "reasoning") return true
+        return part.text !== ""
+      })
+    })
+  }
+
   if (model.api.id.includes("claude")) {
     const scrub = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
     msgs = msgs.map((msg) => {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -184,8 +184,8 @@ function normalizeMessages(
       .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
   }
 
-  // Gemini rejects contents entries without parts. Empty reasoning-only blocks
-  // can survive UI message conversion after step-start splitting.
+  // Gemini rejects contents entries without parts. The Google serializer drops
+  // empty text and reasoning parts, so remove messages that would become empty.
   if (model.api.npm === "@ai-sdk/google" || model.api.npm === "@ai-sdk/google-vertex") {
     msgs = msgs.filter((msg) => {
       if (msg.content === "") return false

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -185,7 +185,8 @@ function normalizeMessages(
   }
 
   // Gemini rejects contents entries without parts. The Google serializer drops
-  // empty text and reasoning parts, so remove messages that would become empty.
+  // empty text and reasoning parts, including signature-bearing ones, so remove
+  // messages that would become empty. Keep this aligned with the serializer.
   if (model.api.npm === "@ai-sdk/google" || model.api.npm === "@ai-sdk/google-vertex") {
     msgs = msgs.filter((msg) => {
       if (msg.content === "") return false

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1408,7 +1408,7 @@ describe("ProviderTransform.message - empty image handling", () => {
   })
 })
 
-describe("ProviderTransform.message - anthropic empty content filtering", () => {
+describe("ProviderTransform.message - empty content filtering", () => {
   const anthropicModel = {
     id: "anthropic/claude-3-5-sonnet",
     providerID: "anthropic",
@@ -1440,6 +1440,26 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     options: {},
     headers: {},
   } as any
+  const vertexModel = {
+    ...anthropicModel,
+    id: "google-vertex/gemini-3.1-pro-preview-customtools",
+    providerID: "google-vertex",
+    api: {
+      id: "gemini-3.1-pro-preview-customtools",
+      url: "https://aiplatform.googleapis.com",
+      npm: "@ai-sdk/google-vertex",
+    },
+  }
+  const googleModel = {
+    ...vertexModel,
+    id: "google/gemini-3.1-pro-preview-customtools",
+    providerID: "google",
+    api: {
+      ...vertexModel.api,
+      url: "https://generativelanguage.googleapis.com",
+      npm: "@ai-sdk/google",
+    },
+  }
 
   test("filters out messages with empty string content", () => {
     const msgs = [
@@ -1588,7 +1608,22 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[1].content[0]).toEqual({ type: "text", text: "Answer" })
   })
 
-  test("does not filter for non-anthropic providers", () => {
+  test("filters empty reasoning-only messages for google providers", () => {
+    const msgs = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "reasoning", text: "" }] },
+      { role: "user", content: [{ type: "text", text: "Continue" }] },
+    ] as any[]
+
+    ;[googleModel, vertexModel].forEach((model) => {
+      const result = ProviderTransform.message(msgs, model, {})
+
+      expect(result).toHaveLength(2)
+      expect(result).toMatchObject([msgs[0], msgs[2]])
+    })
+  })
+
+  test("does not filter for openai provider", () => {
     const openaiModel = {
       ...anthropicModel,
       providerID: "openai",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1623,6 +1623,19 @@ describe("ProviderTransform.message - empty content filtering", () => {
     })
   })
 
+  test("filters signed empty reasoning-only messages for google providers", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "", providerOptions: { vertex: { thoughtSignature: "sig" } } }],
+      },
+    ] as any[]
+
+    ;[googleModel, vertexModel].forEach((model) => {
+      expect(ProviderTransform.message(msgs, model, {})).toHaveLength(0)
+    })
+  })
+
   test("does not filter for openai provider", () => {
     const openaiModel = {
       ...anthropicModel,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1623,19 +1623,6 @@ describe("ProviderTransform.message - empty content filtering", () => {
     })
   })
 
-  test("filters signed empty reasoning-only messages for google providers", () => {
-    const msgs = [
-      {
-        role: "assistant",
-        content: [{ type: "reasoning", text: "", providerOptions: { vertex: { thoughtSignature: "sig" } } }],
-      },
-    ] as any[]
-
-    ;[googleModel, vertexModel].forEach((model) => {
-      expect(ProviderTransform.message(msgs, model, {})).toHaveLength(0)
-    })
-  })
-
   test("does not filter for openai provider", () => {
     const openaiModel = {
       ...anthropicModel,


### PR DESCRIPTION
Fixes: #17519

## Summary
- filter Google and Vertex Gemini replay messages that would serialize without any content parts
- cover direct Google and Vertex reasoning-only replay histories
- preserve existing behavior for non-Gemini providers

## Why
Gemini rejects `contents` entries without `parts`. An empty reasoning block can survive UI message conversion after `step-start` splitting, then serialize to an empty Vertex `parts` array.

## Test plan
- `bun test test/provider/transform.test.ts`
- `git diff --check origin/dev...HEAD`