### PR TITLE
fix(opencode): patch empty Gemini replay messages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -840,6 +840,7 @@
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "virtua@0.49.1": "patches/virtua@0.49.1.patch",
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
+    "@ai-sdk/google@3.0.73": "patches/@ai-sdk%2Fgoogle@3.0.73.patch",
     "@ai-sdk/xai@3.0.82": "patches/@ai-sdk%2Fxai@3.0.82.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "pacote@21.5.0": "patches/pacote@21.5.0.patch",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "virtua@0.49.1": "patches/virtua@0.49.1.patch",
     "@ai-sdk/xai@3.0.82": "patches/@ai-sdk%2Fxai@3.0.82.patch",
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
-    "pacote@21.5.0": "patches/pacote@21.5.0.patch"
+    "pacote@21.5.0": "patches/pacote@21.5.0.patch",
+    "@ai-sdk/google@3.0.73": "patches/@ai-sdk%2Fgoogle@3.0.73.patch"
   }
 }

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -794,7 +794,10 @@ describe("session.llm.stream", () => {
           model: resolved,
           agent,
           system: ["You are a helpful assistant."],
-          messages: [{ role: "user", content: "Hello" }],
+          messages: [
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: [{ type: "reasoning", text: "" }] },
+          ],
           tools: {},
         })
 
@@ -1911,6 +1914,9 @@ describe("session.llm.stream", () => {
           | undefined
 
         expect(capture.url.pathname).toBe(pathSuffix)
+        expect(body.contents).toEqual([
+          { role: "user", parts: [{ text: "Hello" }] },
+        ])
         expect(config?.temperature).toBe(0.3)
         expect(config?.topP).toBe(0.8)
         expect(config?.maxOutputTokens).toBe(ProviderTransform.maxOutputTokens(resolved))

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -794,10 +794,7 @@ describe("session.llm.stream", () => {
           model: resolved,
           agent,
           system: ["You are a helpful assistant."],
-          messages: [
-            { role: "user", content: "Hello" },
-            { role: "assistant", content: [{ type: "reasoning", text: "" }] },
-          ],
+          messages: [{ role: "user", content: "Hello" }],
           tools: {},
         })
 
@@ -1903,7 +1900,10 @@ describe("session.llm.stream", () => {
           model: resolved,
           agent,
           system: ["You are a helpful assistant."],
-          messages: [{ role: "user", content: "Hello" }],
+          messages: [
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: [{ type: "reasoning", text: "" }] },
+          ],
           tools: {},
         })
 

--- a/patches/@ai-sdk%2Fgoogle@3.0.73.patch
+++ b/patches/@ai-sdk%2Fgoogle@3.0.73.patch
@@ -1,0 +1,69 @@
+diff --git a/dist/index.js b/dist/index.js
+index 546bf5509004510b023212d70b4c0875a24eb302..f211dcb23e01a393f7d5c6221bfb0ef52276520a 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -636,6 +636,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 5c8c20cbbcd4d398523602dd80ae8c3fa10a84ea..f89dc53b3b9cd83653a66b0900ff0bc34d3d6c9f 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -642,6 +642,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/dist/internal/index.js b/dist/internal/index.js
+index 947af6f4282f1bb9b46a76fdf199d7155600b550..22c2faa4122069d868a3232bbb708fdc808bf6e8 100644
+--- a/dist/internal/index.js
++++ b/dist/internal/index.js
+@@ -419,6 +419,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
+index 28853288c1ff8f589448e7ddcddfd8ed36c4d995..4ef91ed90008d2cf7a5f24bb1927a9884e352393 100644
+--- a/dist/internal/index.mjs
++++ b/dist/internal/index.mjs
+@@ -402,6 +402,9 @@ function convertToGoogleGenerativeAIMessages(prompt, options) {
+             }
+           }).filter((part) => part !== void 0)
+         });
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }
+         break;
+       }
+       case "tool": {
+diff --git a/src/convert-to-google-generative-ai-messages.ts b/src/convert-to-google-generative-ai-messages.ts
+index 4bf83e3768d4ccc8ff96e7d683abb4ccf60387ea..f257d2af8f178b7ac36771296eaa6c60c92e04ab 100644
+--- a/src/convert-to-google-generative-ai-messages.ts
++++ b/src/convert-to-google-generative-ai-messages.ts
+@@ -350,3 +350,8 @@ export function convertToGoogleGenerativeAIMessages(
+             })
+             .filter(part => part !== undefined),
+         });
++        // Empty text and reasoning parts, including signature-bearing ones, are
++        // filtered above. Do not emit a model entry that Gemini rejects.
++        if (contents[contents.length - 1].parts.length === 0) {
++          contents.pop();
++        }


### PR DESCRIPTION
Fixes: https://github.com/anomalyco/opencode/issues/17519

## Summary
- patch `@ai-sdk/google@3.0.73` to omit Gemini model history entries after empty assistant parts are filtered out
- apply the same serializer fix to direct Google and the internal bundle reused by `@ai-sdk/google-vertex`
- cover the final Gemini request body in `test/session/llm.test.ts`

## Why
Gemini rejects `contents` entries with `parts: []`. The Google serializer already filters empty assistant text and reasoning parts, but it still emits the surrounding model entry. This is an alternative to #30451 that fixes the invalid payload at the SDK serialization boundary.
