### PR TITLE
fix: always show model variant picker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -131,12 +131,7 @@ export function DialogModel(props: { providerID?: string }) {
   function onSelect(providerID: string, modelID: string) {
     local.model.set({ providerID, modelID }, { recent: true })
     const list = local.model.variant.list()
-    const cur = local.model.variant.selected()
-    if (cur === "default" || (cur && list.includes(cur))) {
-      dialog.clear()
-      return
-    }
-    if (list.length > 0) {
+    if (shouldShowVariantDialogAfterModelSelect(list)) {
       dialog.replace(() => <DialogVariant />)
       return
     }
@@ -182,4 +177,8 @@ export function sortModelOptions<T extends { footer?: string; releaseDate: strin
     (option) => option.footer !== "Free",
     (option) => option.title,
   )
+}
+
+export function shouldShowVariantDialogAfterModelSelect(variants: readonly string[]) {
+  return variants.length > 0
 }

--- a/packages/opencode/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/model-options.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { sortModelOptions } from "../../../../src/cli/cmd/tui/component/dialog-model"
+import {
+  shouldShowVariantDialogAfterModelSelect,
+  sortModelOptions,
+} from "../../../../src/cli/cmd/tui/component/dialog-model"
 
 describe("sortModelOptions", () => {
   test("orders provider-scoped model choices by newest release first", () => {
@@ -26,5 +29,10 @@ describe("sortModelOptions", () => {
     )
 
     expect(sorted.map((model) => model.title)).toEqual(["Alpha", "Gamma", "Beta"])
+  })
+
+  test("opens the variant picker whenever the selected model has variants", () => {
+    expect(shouldShowVariantDialogAfterModelSelect(["default", "high"])).toBe(true)
+    expect(shouldShowVariantDialogAfterModelSelect([])).toBe(false)
   })
 })


### PR DESCRIPTION
﻿## Summary
- always open the variant picker after selecting a model that exposes variants
- keep the previous variant preselected through the existing `DialogVariant` current value
- add a small regression check for the model-selection helper

Fixes #30445.

## To verify
- `bun test test/cli/cmd/tui/model-options.test.ts`
- `bun run --cwd packages/opencode typecheck`
- `bun run lint packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx packages/opencode/test/cli/cmd/tui/model-options.test.ts`
- `bunx prettier --check packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx packages/opencode/test/cli/cmd/tui/model-options.test.ts`
- `git diff --check`

Note: the targeted lint command reports one existing warning in `dialog-model.tsx` around the pre-existing `toggleFavorite(option.value as ...)` assertion. This patch does not touch that line.
