### PR TITLE
fix(tui): support copying over ssh with `set-clipboard on` tmux config

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -23,7 +23,8 @@ function command(command: string, args: string[] = [], input?: string) {
 function writeOsc52(text: string) {
   if (!process.stdout.isTTY) return
   const sequence = `\x1b]52;c;${Buffer.from(text).toString("base64")}\x07`
-  process.stdout.write(process.env.TMUX || process.env.STY ? `\x1bPtmux;\x1b${sequence}\x1b\\` : sequence)
+  // enabling `set-clipboard on` in tmux parses raw osc52
+  process.stdout.write(process.env.STY ? `\x1bPtmux;\x1b${sequence}\x1b\\` : sequence)
 }
 
 export async function read() {

--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -23,8 +23,8 @@ function command(command: string, args: string[] = [], input?: string) {
 function writeOsc52(text: string) {
   if (!process.stdout.isTTY) return
   const sequence = `\x1b]52;c;${Buffer.from(text).toString("base64")}\x07`
-  // enabling `set-clipboard on` in tmux parses raw osc52
-  process.stdout.write(process.env.STY ? `\x1bPtmux;\x1b${sequence}\x1b\\` : sequence)
+  const passthrough = `\x1bPtmux;\x1b${sequence}\x1b\\`
+  process.stdout.write(process.env.TMUX ? sequence + passthrough : process.env.STY ? passthrough : sequence)
 }
 
 export async function read() {


### PR DESCRIPTION
### Issue for this PR

Closes #25253
Closes #25252
Closes #19982
Closes #15907
Maybe Closes #36646
(possibly more?)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

the appropriate config for clipboard management in modern tmux versions is `set-clipboard`: https://github.com/tmux/tmux/wiki/Clipboard

this PR makes it so that the copy to clipboard feature sends raw OSC52 when inside tmux, because that is what the `set-clipboard` feature is expecting (see tmux maintainer commentary: https://github.com/tmux/tmux/issues/4214#issuecomment-2439605818)

because opencode currently sends the `\x1bPtmux;\x1b` escape sequence when it recognizes the `TMUX` env, the `set-clipboard` feature does not function as-intended, forcing people to use `allow-passthrough` (which has its own security implications)

### How did you verify your code works?

i built the darwin and x86 binaries, and tested locally + on my remote by sending a prompt and then using the copy feature to copy the text. then, i pasted elsewhere to validate

- in all cases, testing *outside* of tmux works as expected, both in the old and new binary
- with a default tmux config, local works & remote fails for both the old and new binary (expected, unfortunately)
- with a `set-clipboard on` tmux config:
  - local works before & after
  - remote fails before & works after (**this is the primary fix for this PR**)
- with a `allow-passthrough on` tmux config:
  - local works before & after
  - remote works before, but not after (unless `set-clipboard on`)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


