### PR TITLE
fix(tui): stop idle background task spinner

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2200,9 +2200,13 @@ function Task(props: ToolProps<typeof TaskTool>) {
   )
 
   const status = createMemo(() => sync.data.session_status[props.metadata.sessionId ?? ""])
-  const isRunning = createMemo(
-    () => props.part.state.status === "running" || (props.metadata.background === true && status() !== undefined),
-  )
+  const isRunning = createMemo(() => {
+    const value = status()
+    return (
+      props.part.state.status === "running" ||
+      (props.metadata.background === true && value !== undefined && value.type !== "idle")
+    )
+  })
   const retry = createMemo(() => {
     const value = status()
     if (value?.type !== "retry") return


### PR DESCRIPTION
## Summary
- Treat idle child session status as not running for background task rows.
- Preserve parent tool running state for foreground/in-flight task invocations.

## Testing
- bun test test/cli/tui/inline-tool-wrap-snapshot.test.tsx passed in the main checkout before isolating this PR branch.
- The same command could not run in the temporary PR worktree because @opentui/solid/preload was not present there.