### PR TITLE
fix(opencode): load plugins declared in macOS managed preferences (.mobileconfig)

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -518,13 +518,26 @@ export const layer = Layer.effect(
         // macOS managed preferences (.mobileconfig deployed via MDM) override everything
         const managed = yield* Effect.promise(() => ConfigManaged.readManagedPreferences())
         if (managed) {
-          result = mergeConfigConcatArrays(
-            result,
-            yield* loadConfig(managed.text, {
-              dir: path.dirname(managed.source),
-              source: managed.source,
-            }),
-          )
+          const next = yield* loadConfig(managed.text, {
+            dir: path.dirname(managed.source),
+            source: managed.source,
+          })
+          // A managed value-source has no config file on disk, so relative specs ("./plugin.ts") have no
+          // directory to resolve against — drop them with a warning. file://, absolute, and npm specs are fine.
+          if (next.plugin?.length) {
+            const relative = next.plugin.filter((spec) => ConfigPlugin.pluginSpecifier(spec).startsWith("."))
+            if (relative.length)
+              log.warn("ignoring relative plugin specs from managed preferences; use file:// URLs or npm packages", {
+                source: managed.source,
+                specs: relative.map(ConfigPlugin.pluginSpecifier),
+              })
+            next.plugin = next.plugin.filter((spec) => !ConfigPlugin.pluginSpecifier(spec).startsWith("."))
+            // loadConfig only normalizes specs for the on-disk ({ path }) form, so resolve the rest here.
+            yield* Effect.promise(() => resolveLoadedPlugins(next, managed.source))
+          }
+          // Route through merge() (not a bare mergeConfigConcatArrays) so managed plugins reach plugin_origins
+          // and load — matching the managed-config-dir branch above.
+          yield* merge(managed.source, next, "global")
         }
 
         for (const [name, mode] of Object.entries(result.mode ?? {})) {

--- a/packages/opencode/src/config/managed.ts
+++ b/packages/opencode/src/config/managed.ts
@@ -44,6 +44,14 @@ export function parseManagedPlist(json: string): string {
 }
 
 export async function readManagedPreferences() {
+  // Test seam (mirrors OPENCODE_TEST_MANAGED_CONFIG_DIR): read an already-decoded managed payload so the
+  // .mobileconfig path is exercisable without /Library/Managed Preferences, plutil, or a real MDM profile.
+  const testPlist = process.env.OPENCODE_TEST_MANAGED_PLIST
+  if (testPlist) {
+    if (!existsSync(testPlist)) return
+    return { source: `mobileconfig:${testPlist}`, text: parseManagedPlist(await Bun.file(testPlist).text()) }
+  }
+
   if (process.platform !== "darwin") return
 
   const user = (() => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1187,6 +1187,65 @@ it.instance(
   { config: { model: "user/model" } },
 )
 
+it.instance(
+  "loads plugins declared in managed preferences (.mobileconfig)",
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const plist = path.join(dir, "ai.opencode.managed.json")
+    yield* FSUtil.use.writeWithDirs(
+      plist,
+      JSON.stringify({
+        // Payload* keys ride along on a real managed plist and must be stripped before merge.
+        PayloadType: "ai.opencode.managed",
+        plugin: ["file:///opt/acme/plugin.js"],
+        enabled_providers: ["acme"],
+      }),
+    )
+
+    return yield* withProcessEnv(
+      "OPENCODE_TEST_MANAGED_PLIST",
+      plist,
+      Effect.gen(function* () {
+        const config = yield* Config.use.get()
+        // managed values still win over user/project config
+        expect(config.enabled_providers).toEqual(["acme"])
+        // and the managed plugin is now collected + loadable (previously it was silently dropped)
+        const specs = (config.plugin ?? []).map((spec) => ConfigPlugin.pluginSpecifier(spec))
+        expect(specs.some((spec) => spec.includes("acme/plugin.js"))).toBe(true)
+        const origin = config.plugin_origins?.find((item) =>
+          ConfigPlugin.pluginSpecifier(item.spec).includes("acme/plugin.js"),
+        )
+        expect(origin?.scope).toBe("global")
+      }),
+    )
+  }),
+  { config: { enabled_providers: ["user-provider"], plugin: ["user-plugin"] } },
+)
+
+it.instance("ignores relative plugin specs from managed preferences", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const plist = path.join(dir, "ai.opencode.managed.json")
+    yield* FSUtil.use.writeWithDirs(
+      plist,
+      JSON.stringify({ plugin: ["./relative-plugin.ts", "file:///opt/acme/plugin.js"] }),
+    )
+
+    return yield* withProcessEnv(
+      "OPENCODE_TEST_MANAGED_PLIST",
+      plist,
+      Effect.gen(function* () {
+        const config = yield* Config.use.get()
+        const specs = (config.plugin ?? []).map((spec) => ConfigPlugin.pluginSpecifier(spec))
+        // relative spec has no declaring directory in a plist, so it is dropped with a warning
+        expect(specs.some((spec) => spec.includes("relative-plugin"))).toBe(false)
+        // the absolute file:// spec still loads
+        expect(specs.some((spec) => spec.includes("acme/plugin.js"))).toBe(true)
+      }),
+    )
+  }),
+)
+
 it.instance("migrates legacy edit tool to edit permission", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #30500

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Currently, only managed *values* are applied in an `ai.opencode.managed` managed preferences file — a managed *plugin* spec appears in `opencode debug config` but is never actually loaded.

Root cause: the plugin loader walks `cfg.plugin_origins`, but the managed-plist branch in `config/config.ts` merged values via `mergeConfigConcatArrays` without calling `mergePluginOrigins`, so the spec reached `cfg.plugin` but never `plugin_origins`. The adjacent managed-config-dir branch already routes through `merge()`.

Fix: The managed-config-dir branch's behavior should be mirrored as much as possible. A plist has no declaring directory (when deployed via MDM as a .mobileconfig file), so relative specs should be dropped (with a warning). `file://`, absolute, and npm specs should still be handled. Value merge and precedence should be left unchanged (managed still overrides everything), and configs without a managed `plugin` entry behave identically.

Also adds an `OPENCODE_TEST_MANAGED_PLIST` test seam (mirrors the existing `OPENCODE_TEST_MANAGED_CONFIG_DIR`) and tests covering managed plugin loading and relative-spec rejection.

### How did you verify your code works?

- `bun test test/config/config.test.ts` (94 pass, including the new tests)
- `bun run typecheck` (from `packages/opencode`)
- `bunx prettier --check` and `bunx oxlint` on the changed files

### Screenshots / recordings

Not applicable (not a UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
