### PR TITLE
fix(github): avoid overriding git author identity

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -663,8 +663,6 @@ async function configureGit(appToken: string) {
 
   await $`git config --local --unset-all ${config}`
   await $`git config --local ${config} "AUTHORIZATION: basic ${newCredentials}"`
-  await $`git config --global user.name "opencode-agent[bot]"`
-  await $`git config --global user.email "opencode-agent[bot]@users.noreply.github.com"`
 }
 
 async function restoreGitConfig() {


### PR DESCRIPTION
### Issue for this PR

Closes #30409

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the GitHub Action runtime setup, we should keep the already configured git author identity instead of overwriting it.

This change keeps the auth header setup for git operations, but removes the two global overrides:
- git config --global user.name ...
- git config --global user.email ...

That lets commits use the existing identity provided by the environment/workflow.

### How did you verify your code works?

- Verified the change is isolated to github/index.ts and only affects identity overrides.
- Ran bun typecheck in packages/opencode to ensure the main package remains type-safe.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR