### PR TITLE
tui: truncate sidebar file paths

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/files.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/files.tsx
@@ -1,8 +1,15 @@
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { InternalTuiPlugin } from "../../plugin/internal"
 import { createMemo, For, Show, createSignal } from "solid-js"
+import { Locale } from "@/util/locale"
 
 const id = "internal:sidebar-files"
+
+function changeCountWidth(item: { additions: number; deletions: number }) {
+  return [item.additions ? `+${item.additions}` : "", item.deletions ? `-${item.deletions}` : ""]
+    .filter(Boolean)
+    .join(" ").length
+}
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const [open, setOpen] = createSignal(true)
@@ -25,7 +32,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
             {(item) => (
               <box flexDirection="row" gap={1} justifyContent="space-between">
                 <text fg={theme().textMuted} wrapMode="none">
-                  {item.file}
+                  {Locale.truncateLeft(item.file, Math.max(2, 36 - changeCountWidth(item)))}
                 </text>
                 <box flexDirection="row" gap={1} flexShrink={0}>
                   <Show when={item.additions}>


### PR DESCRIPTION
Keep long paths from crowding out diff counts in the file sidebar. Preserve the path tail so filenames remain visible when space is limited.

Fix #30514
