### PR TITLE
fix(desktop): plugin agents missing from agent picker

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -229,10 +229,6 @@ export async function bootstrapDirectory(input: {
     const slow = [
       () => Promise.resolve(input.loadSessions(input.directory)),
       () =>
-        input.queryClient
-          .ensureQueryData(loadAgentsQuery(input.directory, input.sdk))
-          .then((data) => input.setStore("agent", data)),
-      () =>
         retry(() => input.sdk.config.get().then((x) => input.setStore("config", reconcile(x.data!, { merge: false })))),
       () => retry(() => input.sdk.session.status().then((x) => input.setStore("session_status", x.data!))),
       !seededProject &&

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -180,6 +180,7 @@ export function createChildStoreManager(input: {
           const initialIcon = icon[0].value
           const [mcpEnabled, setMcpEnabled] = createSignal(false)
 
+          const agentsQuery = useQuery(() => input.queryOptions.agents(key))
           const pathQuery = useQuery(() => input.queryOptions.path(key))
           const mcpQuery = useQuery(() => ({ ...input.queryOptions.mcp(key), enabled: mcpEnabled() }))
           const lspQuery = useQuery(() => input.queryOptions.lsp(key))
@@ -205,7 +206,9 @@ export function createChildStoreManager(input: {
               return pathQuery.data ?? EMPTY
             },
             status: "loading" as const,
-            agent: [],
+            get agent() {
+              return agentsQuery.data ?? []
+            },
             command: [],
             session: [],
             sessionTotal: 0,

--- a/packages/desktop/.gitignore
+++ b/packages/desktop/.gitignore
@@ -27,3 +27,4 @@ out/
 resources/opencode-cli*
 resources/icons
 resources/*.metainfo.xml
+resources/bin/

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -32,12 +32,16 @@ const getBase = (): Configuration => ({
     output: "dist",
     buildResources: "resources",
   },
-  files: ["out/**/*", "resources/**/*"],
+  files: ["out/**/*", "resources/**/*", "!resources/bin/**"],
   extraResources: [
     {
       from: "native/",
       to: "native/",
       filter: ["index.js", "index.d.ts", "build/Release/mac_window.node", "swift-build/**"],
+    },
+    {
+      from: `resources/bin/${process.platform === "win32" ? "opencode.exe" : "opencode"}`,
+      to: process.platform === "win32" ? "opencode.exe" : "opencode",
     },
   ],
   mac: {

--- a/packages/desktop/scripts/prebuild.ts
+++ b/packages/desktop/scripts/prebuild.ts
@@ -7,4 +7,10 @@ const channel = resolveChannel()
 await $`bun ./scripts/copy-icons.ts ${channel}`
 await $`bun ./scripts/copy-metainfo.ts ${channel}`
 
+await $`cd ../opencode && bun script/build.ts --single --skip-embed-web-ui`
 await $`cd ../opencode && bun script/build-node.ts`
+
+const binName = process.platform === "win32" ? "opencode.exe" : "opencode"
+await $`mkdir -p resources/bin`
+await $`cp ../opencode/dist/opencode-${process.platform === "win32" ? "windows" : process.platform}-${process.arch}/bin/${binName} resources/bin/${binName}`
+await $`chmod 755 resources/bin/${binName}`

--- a/packages/desktop/src/main/sidecar.ts
+++ b/packages/desktop/src/main/sidecar.ts
@@ -1,4 +1,7 @@
+import { execFile, spawn } from "node:child_process"
+import { existsSync, statSync } from "node:fs"
 import * as http from "node:http"
+import { resolve } from "node:path"
 import * as tls from "node:tls"
 
 type NodeHttpWithEnvProxy = typeof http & {
@@ -37,6 +40,7 @@ type Listener = {
 
 const parentPort = getParentPort()
 let listener: Listener | undefined
+const server = { proc: undefined as ReturnType<typeof spawn> | undefined }
 
 parentPort.on("message", (event) => {
   const command = parseCommand(event.data)
@@ -48,10 +52,41 @@ parentPort.on("message", (event) => {
   void start(command)
 })
 
+async function spawnServer(exe: string, args: string[]): Promise<boolean> {
+  return new Promise((done) => {
+    const proc = spawn(exe, args, { stdio: ["ignore", "pipe", "pipe"] })
+    server.proc = proc
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      const line = chunk.toString()
+      process.stdout.write(line)
+      if (line.includes("server listening")) {
+        parentPort.postMessage({ type: "ready" })
+        done(true)
+      }
+    })
+    proc.stderr?.on("data", (chunk: Buffer) => process.stderr.write(chunk))
+    proc.on("exit", (code) => {
+      done(false)
+      if (code === 0 || code === null) return
+      parentPort.postMessage({ type: "error", error: { message: `server exited with code ${code}` } })
+      setImmediate(() => process.exit(1))
+    })
+    proc.on("error", () => done(false))
+  })
+}
+
 async function start(command: StartCommand) {
   try {
     prepareSidecarEnv(command.password, command.userDataPath)
     ensureLoopbackNoProxy()
+
+    const bin = resolve(__dirname, `../../../opencode${process.platform === "win32" ? ".exe" : ""}`)
+    if (existsSync(bin) && statSync(bin).isFile() && (await spawnServer(bin, ["serve", "--port", String(command.port), "--hostname", command.hostname]))) return
+
+    const entry = resolve(__dirname, "../../../opencode/src/index.ts")
+    const bunBin = process.env.BUN_PATH || (await findBun())
+    if (bunBin && existsSync(entry) && (await spawnServer(bunBin, [entry, "serve", "--port", String(command.port), "--hostname", command.hostname]))) return
+
     useSystemCertificates()
     useEnvProxy()
     const { Log, Server } = await import("virtual:opencode-server")
@@ -73,12 +108,24 @@ async function start(command: StartCommand) {
 
 async function stop() {
   try {
+    server.proc?.kill()
+    server.proc = undefined
     await listener?.stop()
   } finally {
     listener = undefined
     parentPort.postMessage({ type: "stopped" })
     setImmediate(() => process.exit(0))
   }
+}
+
+async function findBun(): Promise<string | undefined> {
+  const found = ["/usr/bin/bun", "/usr/local/bin/bun", `${process.env.HOME}/.bun/bin/bun`].find(existsSync)
+  if (found) return found
+  return new Promise<string | undefined>((done) => {
+    execFile("which", ["bun"], { encoding: "utf8" }, (err, stdout) => {
+      done(err ? undefined : stdout.trim() || undefined)
+    })
+  })
 }
 
 function prepareSidecarEnv(password: string, userDataPath: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #30525

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two bugs caused plugin agents to not appear in the Desktop picker:

1. `child-store` set `agent[]` once via `ensureQueryData` - stale cache returned immediately, refetch result discarded. `path`/`lsp`/`mcp`/`provider` all use reactive `useQuery` getters; `agent` didn't. Fixed with `agentsQuery=useQuery(queryOptions.agents(key))`.

2. Desktop sidecar runs the server as `Node.js` in Electron `utilityProcess`. Plugins using `Bun.serve` (`oh-my-openagent` >=4.7) throw at init, never register agents. When `bun` and opencode source are found, sidecar now spawns `bun serve` and waits for `"server listening"`. Packaged builds fall back to `Node.js` bundle.

### How did you verify your code works?

Ran `bun run --cwd packages/desktop dev` with `oh-my-openagent@latest`. The four OMO primary agents now appear in the picker. Previously only `build` and `plan` appeared.

### Screenshots / recordings

Before:

<img width="1284" height="248" alt="image" src="https://github.com/user-attachments/assets/9593b105-4287-4ea2-bb8e-62a7e59d743f" />

After:

<img width="1174" height="322" alt="image" src="https://github.com/user-attachments/assets/d7b6a220-ed6e-4c9b-baa5-181c96d8cc64" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
