### PR TITLE
docs(ecosystem): add opencode-mempalace-persistence to plugins table

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -32,6 +32,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations     |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                 |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                          |
+| [opencode-mempalace-persistence](https://github.com/geco/opencode-mempalace-persistence)           | Persist conversations to MemPalace in real-time — vector DB + Knowledge Graph, zero cron           |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                            |
 | [opencode-morph-plugin](https://github.com/morphllm/opencode-morph-plugin)                         | Fast Apply editing, WarpGrep codebase search, and context compaction via Morph                     |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-mempalace-persistence](https://github.com/geco/opencode-mempalace-persistence) to the Plugins ecosystem table. The plugin persists OpenCode conversations to MemPalace (local vector DB) in real-time via chat.message and session.idle hooks. Zero cron, async mining, ~120 lines TypeScript.

Published on npm as `opencode-mempalace-persistence`.

Related: #27710 (MemPalace as session db) and #27752 (original showcase).

### How did you verify your code works?

Single-line table addition. Verified the markdown renders correctly in the existing table format.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR