### PR TITLE
fix(opencode): sanitize OpenAI schema patterns

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1305,6 +1305,32 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
   }
   */
 
+  // The OpenAI Responses/Chat function-schema validator rejects requests whose
+  // tool parameter schemas carry a `pattern` (regex) keyword. A handful are
+  // tolerated, but a tool set heavy with `pattern` constraints (e.g. MCP servers
+  // that validate entity refs) trips the validator and the request fails
+  // mid-stream with a generic server_error. Anthropic and Bedrock accept
+  // `pattern`, so scope the strip to the OpenAI provider. `pattern` is advisory
+  // for function-calling anyway — the model never enforces it — so dropping it
+  // is lossless for tool behavior.
+  if (model.api.npm === "@ai-sdk/openai") {
+    const schemaMapKeys = new Set(["$defs", "definitions", "dependentSchemas", "patternProperties", "properties"])
+    const stripPattern = (obj: unknown, parentKey?: string): unknown => {
+      if (obj === null || typeof obj !== "object") return obj
+      if (Array.isArray(obj)) return obj.map((item) => stripPattern(item, parentKey))
+      return Object.fromEntries(
+        Object.entries(obj as Record<string, unknown>)
+          .filter(([key]) => key !== "pattern" || schemaMapKeys.has(parentKey ?? ""))
+          .map(([key, value]) => [key, stripPattern(value, key)]),
+      )
+    }
+
+    const sanitized = stripPattern(schema)
+    if (typeof sanitized === "object" && sanitized !== null && !Array.isArray(sanitized)) {
+      schema = sanitized as JSONSchema7
+    }
+  }
+
   if (model.providerID === "moonshotai" || model.api.id.toLowerCase().includes("kimi")) {
     const sanitizeMoonshot = (obj: unknown): unknown => {
       if (obj === null || typeof obj !== "object") return obj

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -720,6 +720,71 @@ describe("ProviderTransform.providerOptions", () => {
   })
 })
 
+describe("ProviderTransform.schema - OpenAI pattern sanitization", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      entityRef: {
+        type: "string",
+        pattern: "^(component|system):default/[a-z0-9-]+$",
+      },
+      pattern: {
+        type: "string",
+        pattern: "^literal-pattern-property$",
+      },
+      filters: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            value: {
+              type: "string",
+              pattern: "^[a-z]+$",
+            },
+          },
+        },
+      },
+    },
+    required: ["entityRef", "pattern"],
+  } as any
+
+  test("removes nested pattern constraints for OpenAI models", () => {
+    const result = ProviderTransform.schema(
+      {
+        providerID: "openai",
+        api: {
+          id: "gpt-5.5",
+          npm: "@ai-sdk/openai",
+        },
+      } as any,
+      schema,
+    ) as any
+
+    expect(result.properties.entityRef.pattern).toBeUndefined()
+    expect(result.properties.pattern).toEqual({ type: "string" })
+    expect(result.properties.filters.items.properties.value.pattern).toBeUndefined()
+    expect(result.required).toEqual(["entityRef", "pattern"])
+  })
+
+  test("preserves pattern constraints for Anthropic models", () => {
+    const result = ProviderTransform.schema(
+      {
+        providerID: "anthropic",
+        api: {
+          id: "claude-sonnet-4-5",
+          npm: "@ai-sdk/anthropic",
+        },
+      } as any,
+      schema,
+    ) as any
+
+    expect(result.properties.entityRef.pattern).toBe("^(component|system):default/[a-z0-9-]+$")
+    expect(result.properties.pattern.pattern).toBe("^literal-pattern-property$")
+    expect(result.properties.filters.items.properties.value.pattern).toBe("^[a-z]+$")
+    expect(result.required).toEqual(["entityRef", "pattern"])
+  })
+})
+
 describe("ProviderTransform.schema - gemini array items", () => {
   test("adds missing items for array properties", () => {
     const geminiModel = {
@@ -957,11 +1022,15 @@ describe("ProviderTransform.schema - gemini combiner nodes", () => {
       return
     }
     if (Array.isArray(node)) {
-      node.forEach((item, i) => walk(item, cb, [...path, i]))
+      node.forEach((item, i) => {
+        walk(item, cb, [...path, i])
+      })
       return
     }
     cb(node, path)
-    Object.entries(node).forEach(([key, value]) => walk(value, cb, [...path, key]))
+    Object.entries(node).forEach(([key, value]) => {
+      walk(value, cb, [...path, key])
+    })
   }
 
   test("keeps edits.items.anyOf without adding type", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #30553

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI rejects some tool parameter schemas containing regex `pattern` constraints, which can surface as a generic `server_error` during tool calls. This strips those `pattern` constraints only for `@ai-sdk/openai` models while preserving non-OpenAI schemas and legitimate properties named `pattern`.

### Repro / context

With Backstage MCP enabled and an OpenAI-backed GPT-5.5 model, requests could fail before tool execution with a generic `server_error` / `response.failed`.

The trigger was MCP tool schemas containing many JSON Schema `pattern` regex constraints, such as Backstage entity refs and catalog filters. OpenAI's tool schema validator rejects that shape in practice, while Anthropic/Bedrock accept it.

Validated locally against the real opencode config with Backstage enabled:

- before: GPT-5.5 + Backstage MCP crashed with `server_error` / `response.failed`
- after: GPT-5.5 successfully routed to `backstage_auth_who-am-i`
- the resulting `NotAllowedError` was expected Backstage auth behavior, which confirmed the model request/tool-routing path no longer crashed
- we also reran a live session after the patch and the original issue no longer reproduced

### How did you verify your code works?

- `bun test test/provider/transform.test.ts`
- `bun typecheck`
- pre-push `bun turbo typecheck`
- live GPT-5.5 session with Backstage MCP enabled completed tool routing without the previous crash

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
