### PR TITLE
feat(tui): copy message picker modal

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-copy-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-copy-message.tsx
@@ -1,0 +1,68 @@
+import { createMemo, onMount, Show } from "solid-js"
+import { useSync } from "@tui/context/sync"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { Locale } from "@/util/locale"
+import { useDialog } from "../../ui/dialog"
+import * as Clipboard from "@tui/util/clipboard"
+import { useToast } from "../../ui/toast"
+
+export function DialogCopyMessage(props: {
+  sessionID: string
+  revertID?: string
+}) {
+  const sync = useSync()
+  const dialog = useDialog()
+  const toast = useToast()
+
+  onMount(() => {
+    dialog.setSize("large")
+  })
+
+  const options = createMemo((): DialogSelectOption<string>[] => {
+    const messages = sync.data.message[props.sessionID] ?? []
+    const result = [] as DialogSelectOption<string>[]
+    for (const message of messages) {
+      if (message.role !== "assistant") continue
+      if (props.revertID && message.id >= props.revertID) continue
+
+      const parts = sync.data.part[message.id] ?? []
+      const textParts = parts.filter((p) => p.type === "text")
+      if (textParts.length === 0) continue
+
+      const text = textParts.map((p) => p.text).join("\n").trim()
+      if (!text) continue
+
+      const preview = text.split("\n")[0].slice(0, 80)
+      result.push({
+        title: preview.length < text.split("\n")[0].length ? preview + "…" : preview,
+        value: message.id,
+        footer: Locale.time(message.time.created),
+        onSelect: async () => {
+          try {
+            await Clipboard.copy(text)
+            toast.show({ message: "Message copied to clipboard!", variant: "success" })
+          } catch {
+            toast.show({ message: "Failed to copy to clipboard", variant: "error" })
+          }
+          dialog.clear()
+        },
+      })
+    }
+    result.reverse()
+    return result
+  })
+
+  return (
+    <Show
+      when={options().length > 0}
+      fallback={
+        <>
+          {toast.show({ message: "No assistant messages found", variant: "error" })}
+          {dialog.clear()}
+        </>
+      }
+    >
+      <DialogSelect title="Copy Message" options={options()} />
+    </Show>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -61,6 +61,7 @@ import type { PromptInfo } from "../../component/prompt/history"
 import { DialogConfirm } from "@tui/ui/dialog-confirm"
 import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
+import { DialogCopyMessage } from "./dialog-copy-message"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
 import { Sidebar } from "./sidebar"
 import { SubagentFooter } from "./subagent-footer.tsx"
@@ -862,45 +863,13 @@ export function Session() {
       run: () => scrollToMessage("prev", dialog),
     },
     {
-      title: "Copy last assistant message",
+      title: "Copy message",
       value: "messages.copy",
       category: "Session",
       run: () => {
-        const revertID = session()?.revert?.messageID
-        const lastAssistantMessage = messages().findLast(
-          (msg) => msg.role === "assistant" && (!revertID || msg.id < revertID),
-        )
-        if (!lastAssistantMessage) {
-          toast.show({ message: "No assistant messages found", variant: "error" })
-          dialog.clear()
-          return
-        }
-
-        const parts = sync.data.part[lastAssistantMessage.id] ?? []
-        const textParts = parts.filter((part) => part.type === "text")
-        if (textParts.length === 0) {
-          toast.show({ message: "No text parts found in last assistant message", variant: "error" })
-          dialog.clear()
-          return
-        }
-
-        const text = textParts
-          .map((part) => part.text)
-          .join("\n")
-          .trim()
-        if (!text) {
-          toast.show({
-            message: "No text content found in last assistant message",
-            variant: "error",
-          })
-          dialog.clear()
-          return
-        }
-
-        Clipboard.copy(text)
-          .then(() => toast.show({ message: "Message copied to clipboard!", variant: "success" }))
-          .catch(() => toast.show({ message: "Failed to copy to clipboard", variant: "error" }))
-        dialog.clear()
+        dialog.replace(() => (
+          <DialogCopyMessage sessionID={route.sessionID} revertID={session()?.revert?.messageID} />
+        ))
       },
     },
     {


### PR DESCRIPTION
### Issue for this PR

Closes #30548

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`<leader>y` (`messages.copy`) currently copies only the last assistant message with no way to copy older ones.

This replaces that instant-copy behavior with a `DialogSelect` picker (same pattern as the timeline modal) that lists all assistant messages newest-first with truncated previews. Selecting one copies it to clipboard.

### How did you verify your code works?

- `bun typecheck` passes from `packages/opencode`
- Manual testing: `<leader>y` opens picker, lists messages, selecting one copies to clipboard, empty session shows error toast

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR