### PR TITLE
fix(acp): classify apply_patch as edit

### DIFF
--- a/packages/opencode/src/acp/tool.ts
+++ b/packages/opencode/src/acp/tool.ts
@@ -46,6 +46,7 @@ export function toToolKind(toolName: string): ToolKind {
       return "fetch"
 
     case "edit":
+    case "apply_patch":
     case "patch":
     case "write":
       return "edit"

--- a/packages/opencode/test/acp/tool.test.ts
+++ b/packages/opencode/test/acp/tool.test.ts
@@ -15,6 +15,7 @@ describe("acp tool conversion", () => {
     expect(toToolKind("shell")).toBe("execute")
     expect(toToolKind("webfetch")).toBe("fetch")
     expect(toToolKind("edit")).toBe("edit")
+    expect(toToolKind("apply_patch")).toBe("edit")
     expect(toToolKind("patch")).toBe("edit")
     expect(toToolKind("write")).toBe("edit")
     expect(toToolKind("grep")).toBe("search")


### PR DESCRIPTION
- map ACP `apply_patch` tool updates to the `edit` tool kind
- add coverage for the `apply_patch` ACP tool kind mapping

Closes #30558