### PR TITLE
fix(acp): classify task as think

### DIFF
--- a/packages/opencode/src/acp/tool.ts
+++ b/packages/opencode/src/acp/tool.ts
@@ -61,6 +61,9 @@ export function toToolKind(toolName: string): ToolKind {
     case "read":
       return "read"
 
+    case "task":
+      return "think"
+
     default:
       return "other"
   }

--- a/packages/opencode/test/acp/tool.test.ts
+++ b/packages/opencode/test/acp/tool.test.ts
@@ -23,6 +23,7 @@ describe("acp tool conversion", () => {
     expect(toToolKind("context7_resolve_library_id")).toBe("search")
     expect(toToolKind("context7_get_library_docs")).toBe("search")
     expect(toToolKind("read")).toBe("read")
+    expect(toToolKind("task")).toBe("think")
     expect(toToolKind("custom_tool")).toBe("other")
   })
 


### PR DESCRIPTION
- map ACP `task` tool updates to the `think` tool kind
- add coverage for the `task` ACP tool kind mapping

Closes #30557