### PR TITLE
fix(cli): pass server auth headers for embedded opencode run

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -837,6 +837,7 @@ export const RunCommand = effectCmd({
           return await runInteractiveLocalMode({
             directory: directory ?? root,
             fetch: fetchFn,
+            headers: ServerAuth.headers({ password: args.password, username: args.username }),
             resolveAgent: localAgent,
             session,
             share,
@@ -870,6 +871,7 @@ export const RunCommand = effectCmd({
         baseUrl: "http://opencode.internal",
         fetch: fetchFn,
         directory,
+        headers: ServerAuth.headers({ password: args.password, username: args.username }),
       })
       await execute(sdk)
     })

--- a/packages/opencode/src/cli/cmd/run/runtime.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.ts
@@ -60,6 +60,7 @@ type RunRuntimeInput = {
 type RunLocalInput = {
   directory: string
   fetch: typeof globalThis.fetch
+  headers?: Record<string, string>
   resolveAgent: () => Promise<string | undefined>
   session: (sdk: RunInput["sdk"]) => Promise<{ id: string; title?: string } | undefined>
   share: (sdk: RunInput["sdk"], sessionID: string) => Promise<void>
@@ -787,6 +788,7 @@ export async function runInteractiveLocalMode(input: RunLocalInput): Promise<voi
         baseUrl: "http://opencode.internal",
         fetch: input.fetch,
         directory: input.directory,
+        headers: input.headers,
       })
       let session: Promise<ResolvedSession> | undefined
 

--- a/packages/opencode/test/server/run-embedded-auth.test.ts
+++ b/packages/opencode/test/server/run-embedded-auth.test.ts
@@ -1,0 +1,46 @@
+// Set before Server modules load so ServerAuth.Config sees the password.
+process.env.OPENCODE_SERVER_PASSWORD = "secret"
+process.env.OPENCODE_SERVER_USERNAME = "opencode"
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+import { ServerAuth } from "../../src/server/auth"
+import { Server } from "../../src/server/server"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+import { resetDatabase } from "../fixture/db"
+import * as Log from "@opencode-ai/core/util/log"
+
+void Log.init({ print: false })
+
+Flag.OPENCODE_SERVER_PASSWORD = "secret"
+Flag.OPENCODE_SERVER_USERNAME = "opencode"
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+function embeddedClient(directory: string, headers?: Record<string, string>) {
+  return createOpencodeClient({
+    baseUrl: "http://opencode.internal",
+    directory,
+    headers,
+    fetch: ((req: Request) => Server.Default().app.fetch(req)) as unknown as typeof fetch,
+  })
+}
+
+describe("embedded opencode run server auth", () => {
+  test("session.create requires ServerAuth headers when OPENCODE_SERVER_PASSWORD is set", async () => {
+    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+
+    const denied = await embeddedClient(tmp.path).session.create({ title: "embedded" })
+    expect(denied.response.status).toBe(401)
+
+    const created = await embeddedClient(tmp.path, ServerAuth.headers({ password: "secret" })).session.create({
+      title: "embedded",
+    })
+    expect(created.response.status).toBe(200)
+    expect(created.data?.id).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes `Session not found` when running `opencode run` with `OPENCODE_SERVER_PASSWORD` set in the environment.
- Embedded and interactive-local modes start an in-process server that enforces basic auth, but the SDK client did not send credentials (attach mode already did).
- Pass `ServerAuth.headers()` for embedded `createOpencodeClient` and `runInteractiveLocalMode`, matching attach behavior.

## Test plan

- [x] `bun test packages/opencode/test/server/run-embedded-auth.test.ts`
- [x] `OPENCODE_SERVER_PASSWORD=… opencode run "test" --model=openai/gpt-5.5 --variant=medium` (no `Session not found`)
- [ ] `opencode auth login` + GPT-5.5 OAuth smoke test without `oc-codex-multi-auth`


Made with [Cursor](https://cursor.com)