### PR TITLE
fix(tui): route question replies through active workspace

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -8,11 +8,13 @@ import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../component/border"
 import { useTuiConfig } from "../../context/tui-config"
 import { useBindings, useOpencodeModeStack } from "../../keymap"
+import { useProject } from "../../context/project"
 
 const QUESTION_MODE = "question"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
+  const project = useProject()
   const { theme } = useTheme()
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
@@ -50,12 +52,14 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     void sdk.client.question.reply({
       requestID: props.request.id,
       answers,
+      workspace: project.workspace.current(),
     })
   }
 
   function reject() {
     void sdk.client.question.reject({
       requestID: props.request.id,
+      workspace: project.workspace.current(),
     })
   }
 
@@ -72,6 +76,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       void sdk.client.question.reply({
         requestID: props.request.id,
         answers: [[answer]],
+        workspace: project.workspace.current(),
       })
       return
     }

--- a/packages/opencode/test/cli/tui/question-prompt-routing.test.tsx
+++ b/packages/opencode/test/cli/tui/question-prompt-routing.test.tsx
@@ -4,8 +4,6 @@ import { testRender, useRenderer } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { Global } from "@opencode-ai/core/global"
 import { onCleanup, onMount } from "solid-js"
-import { mkdir } from "node:fs/promises"
-import path from "node:path"
 import { ProjectProvider, useProject } from "../../../src/cli/cmd/tui/context/project"
 import { SDKProvider } from "../../../src/cli/cmd/tui/context/sdk"
 import { KVProvider } from "../../../src/cli/cmd/tui/context/kv"
@@ -16,6 +14,7 @@ import {
   registerOpencodeKeymap,
 } from "../../../src/cli/cmd/tui/keymap"
 import { QuestionPrompt } from "../../../src/cli/cmd/tui/routes/session/question"
+import { tmpdir } from "../../fixture/fixture"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 import { createFetch, directory, json } from "../../fixture/tui-sdk"
 import type { QuestionRequest } from "@opencode-ai/sdk/v2"
@@ -70,8 +69,10 @@ const multipleRequest: QuestionRequest = {
 }
 
 test("question prompt replies through the active workspace", async () => {
-  await mkdir(Global.Path.state, { recursive: true })
-  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+  const previous = Global.Path.state
+  await using tmp = await tmpdir()
+  Global.Path.state = tmp.path
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
 
   const replies: URL[] = []
   const calls = createFetch((url) => {
@@ -131,12 +132,15 @@ test("question prompt replies through the active workspace", async () => {
     expect(replies[0]?.searchParams.get("workspace")).toBe("ws_question")
   } finally {
     app.renderer.destroy()
+    Global.Path.state = previous
   }
 })
 
 test("multiple question prompt replies through the active workspace", async () => {
-  await mkdir(Global.Path.state, { recursive: true })
-  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+  const previous = Global.Path.state
+  await using tmp = await tmpdir()
+  Global.Path.state = tmp.path
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
 
   const replies: URL[] = []
   const calls = createFetch((url) => {
@@ -198,12 +202,15 @@ test("multiple question prompt replies through the active workspace", async () =
     expect(replies[0]?.searchParams.get("workspace")).toBe("ws_question")
   } finally {
     app.renderer.destroy()
+    Global.Path.state = previous
   }
 })
 
 test("question prompt rejects through the active workspace", async () => {
-  await mkdir(Global.Path.state, { recursive: true })
-  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+  const previous = Global.Path.state
+  await using tmp = await tmpdir()
+  Global.Path.state = tmp.path
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
 
   const rejects: URL[] = []
   const calls = createFetch((url) => {
@@ -263,5 +270,6 @@ test("question prompt rejects through the active workspace", async () => {
     expect(rejects[0]?.searchParams.get("workspace")).toBe("ws_question")
   } finally {
     app.renderer.destroy()
+    Global.Path.state = previous
   }
 })

--- a/packages/opencode/test/cli/tui/question-prompt-routing.test.tsx
+++ b/packages/opencode/test/cli/tui/question-prompt-routing.test.tsx
@@ -1,0 +1,267 @@
+/** @jsxImportSource @opentui/solid */
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { Global } from "@opencode-ai/core/global"
+import { onCleanup, onMount } from "solid-js"
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { ProjectProvider, useProject } from "../../../src/cli/cmd/tui/context/project"
+import { SDKProvider } from "../../../src/cli/cmd/tui/context/sdk"
+import { KVProvider } from "../../../src/cli/cmd/tui/context/kv"
+import { ThemeProvider } from "../../../src/cli/cmd/tui/context/theme"
+import { TuiConfigProvider } from "../../../src/cli/cmd/tui/context/tui-config"
+import {
+  OpencodeKeymapProvider,
+  registerOpencodeKeymap,
+} from "../../../src/cli/cmd/tui/keymap"
+import { QuestionPrompt } from "../../../src/cli/cmd/tui/routes/session/question"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+import { createFetch, directory, json } from "../../fixture/tui-sdk"
+import type { QuestionRequest } from "@opencode-ai/sdk/v2"
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+const request: QuestionRequest = {
+  id: "que_test",
+  sessionID: "ses_test",
+  questions: [
+    {
+      header: "Routing",
+      question: "Pick one",
+      options: [
+        {
+          label: "A",
+          description: "First option",
+        },
+      ],
+      custom: false,
+    },
+  ],
+}
+
+const multipleRequest: QuestionRequest = {
+  id: "que_test",
+  sessionID: "ses_test",
+  questions: [
+    {
+      header: "Routing",
+      question: "Pick many",
+      options: [
+        {
+          label: "A",
+          description: "First option",
+        },
+        {
+          label: "B",
+          description: "Second option",
+        },
+      ],
+      multiple: true,
+      custom: false,
+    },
+  ],
+}
+
+test("question prompt replies through the active workspace", async () => {
+  await mkdir(Global.Path.state, { recursive: true })
+  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+
+  const replies: URL[] = []
+  const calls = createFetch((url) => {
+    if (url.pathname === "/question/que_test/reply") {
+      replies.push(url)
+      return json(true)
+    }
+  })
+
+  let ready!: () => void
+  const mounted = new Promise<void>((resolve) => {
+    ready = resolve
+  })
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const off = registerOpencodeKeymap(keymap, renderer, config)
+    onCleanup(off)
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <TuiConfigProvider config={config}>
+          <KVProvider>
+            <ThemeProvider mode="dark">
+              <SDKProvider url="http://test" directory={directory} fetch={calls.fetch}>
+                <ProjectProvider>
+                  <Probe onReady={ready} />
+                  <QuestionPrompt request={request} />
+                </ProjectProvider>
+              </SDKProvider>
+            </ThemeProvider>
+          </KVProvider>
+        </TuiConfigProvider>
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  function Probe(props: { onReady: () => void }) {
+    const project = useProject()
+    onMount(async () => {
+      await project.sync()
+      project.workspace.set("ws_question")
+      props.onReady()
+    })
+    return <box />
+  }
+
+  const app = await testRender(() => <Harness />, { kittyKeyboard: true })
+  try {
+    await mounted
+
+    app.mockInput.pressEnter()
+    await wait(() => replies.length === 1)
+
+    expect(replies[0]?.searchParams.get("workspace")).toBe("ws_question")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("multiple question prompt replies through the active workspace", async () => {
+  await mkdir(Global.Path.state, { recursive: true })
+  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+
+  const replies: URL[] = []
+  const calls = createFetch((url) => {
+    if (url.pathname === "/question/que_test/reply") {
+      replies.push(url)
+      return json(true)
+    }
+  })
+
+  let ready!: () => void
+  const mounted = new Promise<void>((resolve) => {
+    ready = resolve
+  })
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const off = registerOpencodeKeymap(keymap, renderer, config)
+    onCleanup(off)
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <TuiConfigProvider config={config}>
+          <KVProvider>
+            <ThemeProvider mode="dark">
+              <SDKProvider url="http://test" directory={directory} fetch={calls.fetch}>
+                <ProjectProvider>
+                  <Probe onReady={ready} />
+                  <QuestionPrompt request={multipleRequest} />
+                </ProjectProvider>
+              </SDKProvider>
+            </ThemeProvider>
+          </KVProvider>
+        </TuiConfigProvider>
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  function Probe(props: { onReady: () => void }) {
+    const project = useProject()
+    onMount(async () => {
+      await project.sync()
+      project.workspace.set("ws_question")
+      props.onReady()
+    })
+    return <box />
+  }
+
+  const app = await testRender(() => <Harness />, { kittyKeyboard: true })
+  try {
+    await mounted
+
+    app.mockInput.pressEnter()
+    app.mockInput.pressKey("l")
+    app.mockInput.pressEnter()
+    await wait(() => replies.length === 1)
+
+    expect(replies[0]?.searchParams.get("workspace")).toBe("ws_question")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("question prompt rejects through the active workspace", async () => {
+  await mkdir(Global.Path.state, { recursive: true })
+  await Bun.write(path.join(Global.Path.state, "kv.json"), "{}")
+
+  const rejects: URL[] = []
+  const calls = createFetch((url) => {
+    if (url.pathname === "/question/que_test/reject") {
+      rejects.push(url)
+      return json(true)
+    }
+  })
+
+  let ready!: () => void
+  const mounted = new Promise<void>((resolve) => {
+    ready = resolve
+  })
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const off = registerOpencodeKeymap(keymap, renderer, config)
+    onCleanup(off)
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <TuiConfigProvider config={config}>
+          <KVProvider>
+            <ThemeProvider mode="dark">
+              <SDKProvider url="http://test" directory={directory} fetch={calls.fetch}>
+                <ProjectProvider>
+                  <Probe onReady={ready} />
+                  <QuestionPrompt request={request} />
+                </ProjectProvider>
+              </SDKProvider>
+            </ThemeProvider>
+          </KVProvider>
+        </TuiConfigProvider>
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  function Probe(props: { onReady: () => void }) {
+    const project = useProject()
+    onMount(async () => {
+      await project.sync()
+      project.workspace.set("ws_question")
+      props.onReady()
+    })
+    return <box />
+  }
+
+  const app = await testRender(() => <Harness />, { kittyKeyboard: true })
+  try {
+    await mounted
+
+    app.mockInput.pressEscape()
+    await wait(() => rejects.length === 1)
+
+    expect(rejects[0]?.searchParams.get("workspace")).toBe("ws_question")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #30523

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

QuestionPrompt sent `question.reply` and `question.reject` without a workspace, so continuing a session from another cwd could route the response to the wrong instance.

This passes the active workspace for:
- single-choice replies
- multiple-choice submit
- Esc reject

This complements #30281, which routes question events to the TUI; this routes the TUI's question responses back to the active workspace.

### How did you verify your code works?

From `packages/opencode`:

```sh
bun test test/cli/tui/question-prompt-routing.test.tsx test/cli/tui/use-event.test.tsx test/cli/cmd/tui/sync.test.tsx
bun typecheck
git diff --check
```

Also manually verified the fixed binary in the container for single-choice submit, multiple-choice submit, and Esc reject.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
