### PR TITLE
fix(tui): route question responses by session directory

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1256,7 +1256,10 @@ export function Session() {
                   <PermissionPrompt request={permissions()[0]} />
                 </Show>
                 <Show when={permissions().length === 0 && questions().length > 0}>
-                  <QuestionPrompt request={questions()[0]} />
+                  <QuestionPrompt
+                    request={questions()[0]}
+                    directory={sync.session.get(questions()[0].sessionID)?.directory}
+                  />
                 </Show>
                 <Show when={session()?.parentID}>
                   <SubagentFooter />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -11,7 +11,7 @@ import { useBindings, useOpencodeModeStack } from "../../keymap"
 
 const QUESTION_MODE = "question"
 
-export function QuestionPrompt(props: { request: QuestionRequest }) {
+export function QuestionPrompt(props: { request: QuestionRequest; directory?: string }) {
   const sdk = useSDK()
   const { theme } = useTheme()
   const renderer = useRenderer()
@@ -49,6 +49,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     const answers = questions().map((_, i) => store.answers[i] ?? [])
     void sdk.client.question.reply({
       requestID: props.request.id,
+      directory: props.directory,
       answers,
     })
   }
@@ -56,6 +57,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
   function reject() {
     void sdk.client.question.reject({
       requestID: props.request.id,
+      directory: props.directory,
     })
   }
 
@@ -71,6 +73,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     if (single()) {
       void sdk.client.question.reply({
         requestID: props.request.id,
+        directory: props.directory,
         answers: [[answer]],
       })
       return


### PR DESCRIPTION
### Issue for this PR

Closes #30523

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a local session is continued from another cwd, question replies and rejects were sent without the session directory. That routed them to the TUI startup-directory instance instead of the directory-scoped instance holding the pending question, leaving the prompt stuck.

Pass the owning question session directory into `QuestionPrompt` and include it in every `question.reply` and `question.reject` request. The directory is looked up from `request.sessionID` so questions surfaced from child sessions route to their actual owner.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode`
- `bun test test/cli/tui` from `packages/opencode`
- `bun x prettier --check src/cli/cmd/tui/routes/session/index.tsx src/cli/cmd/tui/routes/session/question.tsx` from `packages/opencode`
- `git diff --check`
- Pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

Not applicable. This changes request routing without changing the rendered UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR