### PR TITLE
fix(tui): fall back to local cwd when editor spawns in attach mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -1,4 +1,5 @@
 import { defer } from "@/util/defer"
+import { existsSync } from "node:fs"
 import { rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -13,13 +14,17 @@ export async function open(opts: { value: string; renderer: CliRenderer; cwd?: s
   const filepath = join(tmpdir(), `${Date.now()}.md`)
   await using _ = defer(async () => rm(filepath, { force: true }))
 
+  // In attach mode the server's project directory may not exist locally.
+  // Fall back to the local process cwd so the editor can still spawn.
+  const cwd = opts.cwd && existsSync(opts.cwd) ? opts.cwd : process.cwd()
+
   await Filesystem.write(filepath, opts.value)
   opts.renderer.suspend()
   opts.renderer.currentRenderBuffer.clear()
   try {
     const parts = editor.split(" ")
     const proc = Process.spawn([...parts, filepath], {
-      cwd: opts.cwd,
+      cwd,
       stdin: "inherit",
       stdout: "inherit",
       stderr: "inherit",


### PR DESCRIPTION
### Issue for this PR

Closes #30582

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `opencode attach` mode, the `/editor` command (`ctrl+x e`) fails silently because the server's project directory (e.g. `/home/user/project`) does not exist on the local machine where the TUI client runs.

`Editor.open()` passes the server-reported `project.instance.path().worktree` as `cwd` to `Process.spawn()`. When that path doesn't exist locally, the spawn fails and the editor never opens.

This fix checks whether the resolved `cwd` exists on the local filesystem before using it. If it doesn't (as is always the case in remote attach mode), it falls back to `process.cwd()`.

### How did you verify your code works?

1. Started `opencode serve --port 4096` on a remote Linux machine
2. Forwarded port: `ssh -L 4096:127.0.0.1:4096 <remote>`
3. Ran `opencode attach http://localhost:4096` locally (macOS, iTerm2)
4. Pressed `ctrl+x e` — editor (`$EDITOR=nvim`) now opens correctly
5. Verified standalone mode (`opencode` directly) still works as before

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR