### PR TITLE
feat: JSON output mode (experimental)

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, createResource, onMount, type JSX } from "solid-js"
+import { Component, Show, createEffect, createMemo, createResource, createSignal, onMount, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -207,6 +207,22 @@ export const SettingsGeneral: Component = () => {
 
   const autoOption = { id: "auto", value: "", label: language.t("settings.general.row.shell.autoDefault") }
   const currentShell = createMemo(() => serverSync.data.config.shell ?? "")
+  const jsonResponse = createMemo(() => serverSync.data.config.json_response ?? {})
+  const [jsonRequiredInput, setJsonRequiredInput] = createSignal("")
+
+  createEffect(() => {
+    setJsonRequiredInput((jsonResponse().required ?? []).join(", "))
+  })
+
+  const jsonRequiredKeys = (value: string) =>
+    value
+      .split(",")
+      .map((key) => key.trim())
+      .filter((key) => key.length > 0)
+
+  const updateJsonResponse = (patch: { enabled?: boolean; required?: string[] }) =>
+    serverSync.updateConfig({ json_response: { ...jsonResponse(), ...patch } })
+  const commitJsonRequiredInput = () => void updateJsonResponse({ required: jsonRequiredKeys(jsonRequiredInput()) })
 
   const shellOptions = createMemo<ShellSelectOption[]>(() => {
     const list = shells.latest
@@ -352,6 +368,41 @@ export const SettingsGeneral: Component = () => {
             triggerVariant="settings"
             triggerStyle={{ "min-width": "180px" }}
           />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.jsonResponse.title")}
+          description={language.t("settings.general.row.jsonResponse.description")}
+        >
+          <div data-action="settings-json-response">
+            <Switch
+              checked={jsonResponse().enabled === true}
+              onChange={(checked) => void updateJsonResponse({ enabled: checked })}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.jsonResponseKeys.title")}
+          description={language.t("settings.general.row.jsonResponseKeys.description")}
+        >
+          <div class="w-full sm:w-[220px]">
+            <TextField
+              data-action="settings-json-response-keys"
+              label={language.t("settings.general.row.jsonResponseKeys.title")}
+              hideLabel
+              type="text"
+              value={jsonRequiredInput()}
+              onChange={setJsonRequiredInput}
+              onBlur={commitJsonRequiredInput}
+              placeholder="summary, actions, done"
+              spellcheck={false}
+              autocorrect="off"
+              autocomplete="off"
+              autocapitalize="off"
+              class="text-12-regular"
+            />
+          </div>
         </SettingsRow>
 
         <SettingsRow

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, createResource, onMount } from "solid-js"
+import { Component, Show, createEffect, createMemo, createResource, createSignal, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -209,6 +209,22 @@ export const SettingsGeneralV2: Component = () => {
 
   const autoOption = { id: "auto", value: "", label: language.t("settings.general.row.shell.autoDefault") }
   const currentShell = createMemo(() => globalSync.data.config.shell ?? "")
+  const jsonResponse = createMemo(() => globalSync.data.config.json_response ?? {})
+  const [jsonRequiredInput, setJsonRequiredInput] = createSignal("")
+
+  createEffect(() => {
+    setJsonRequiredInput((jsonResponse().required ?? []).join(", "))
+  })
+
+  const jsonRequiredKeys = (value: string) =>
+    value
+      .split(",")
+      .map((key) => key.trim())
+      .filter((key) => key.length > 0)
+
+  const updateJsonResponse = (patch: { enabled?: boolean; required?: string[] }) =>
+    globalSync.updateConfig({ json_response: { ...jsonResponse(), ...patch } })
+  const commitJsonRequiredInput = () => void updateJsonResponse({ required: jsonRequiredKeys(jsonRequiredInput()) })
 
   const shellOptions = createMemo<ShellSelectOption[]>(() => {
     const list = shells.latest
@@ -350,6 +366,42 @@ export const SettingsGeneralV2: Component = () => {
               globalSync.updateConfig({ shell: option.value })
             }}
           />
+        </SettingsRowV2>
+
+        <SettingsRowV2
+          title={language.t("settings.general.row.jsonResponse.title")}
+          description={language.t("settings.general.row.jsonResponse.description")}
+        >
+          <div data-action="settings-json-response">
+            <Switch
+              checked={jsonResponse().enabled === true}
+              onChange={(checked) => void updateJsonResponse({ enabled: checked })}
+            />
+          </div>
+        </SettingsRowV2>
+
+        <SettingsRowV2
+          title={language.t("settings.general.row.jsonResponseKeys.title")}
+          description={language.t("settings.general.row.jsonResponseKeys.description")}
+        >
+          <div class="w-full sm:w-[220px]">
+            <TextInputV2
+              data-action="settings-json-response-keys"
+              type="text"
+              appearance="base"
+              value={jsonRequiredInput()}
+              onInput={(event) => {
+                setJsonRequiredInput(event.currentTarget.value)
+              }}
+              onBlur={commitJsonRequiredInput}
+              placeholder="summary, actions, done"
+              spellcheck={false}
+              autocorrect="off"
+              autocomplete="off"
+              autocapitalize="off"
+              aria-label={language.t("settings.general.row.jsonResponseKeys.title")}
+            />
+          </div>
         </SettingsRowV2>
 
         <SettingsRowV2

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -754,6 +754,12 @@ export const dict = {
     "Choose the shell used for your terminal. Compatible shells are also used for agent tool calls.",
   "settings.general.row.shell.autoDefault": "Auto (Default)",
   "settings.general.row.shell.terminalOnly": "terminal only",
+  "settings.general.row.jsonResponse.title": "JSON output mode",
+  "settings.general.row.jsonResponse.description":
+    "Require final assistant messages to be valid JSON objects without surrounding prose or Markdown",
+  "settings.general.row.jsonResponseKeys.title": "Required JSON keys",
+  "settings.general.row.jsonResponseKeys.description":
+    "Comma-separated top-level keys that must be present when JSON output mode is enabled",
   "settings.general.row.appearance.title": "Appearance",
   "settings.general.row.appearance.description": "Customise how OpenCode looks on your device",
   "settings.general.row.colorScheme.title": "Color scheme",

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -124,6 +124,19 @@ export const Info = Schema.Struct({
   attachment: Schema.optional(ConfigAttachmentV1.Info).annotate({
     description: "Attachment processing configuration, including image size limits and resizing behavior",
   }),
+  json_response: Schema.optional(
+    Schema.Struct({
+      enabled: Schema.optional(Schema.Boolean).annotate({
+        description: "Require final assistant responses to be valid JSON objects",
+      }),
+      required: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+        description: "Top-level JSON keys that must be present in final assistant responses",
+      }),
+    }),
+  ).annotate({
+    description:
+      "JSON response mode. When enabled, OpenCode instructs models to return only JSON and rejects malformed final responses.",
+  }),
   enterprise: Schema.optional(
     Schema.Struct({ url: Schema.optional(Schema.String).annotate({ description: "Enterprise URL" }) }),
   ),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -79,6 +79,52 @@ IMPORTANT:
 
 const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema.`
 
+type JsonResponseConfig = {
+  readonly required?: readonly string[]
+}
+
+const jsonResponseRequiredKeys = (input: JsonResponseConfig | undefined) =>
+  (input?.required ?? []).map((key) => key.trim()).filter((key) => key.length > 0)
+
+const jsonResponseSystemPrompt = (required: string[]) =>
+  [
+    "IMPORTANT: JSON response mode is enabled.",
+    "Your final assistant response MUST be exactly one valid JSON object.",
+    "Do not include Markdown, code fences, comments, prose before or after the JSON, or multiple JSON values.",
+    ...(required.length ? [`The object MUST include these top-level keys: ${required.join(", ")}.`] : []),
+    `Example final response: ${JSON.stringify(
+      Object.fromEntries((required.length ? required : ["response"]).map((key) => [key, ""])),
+    )}`,
+  ].join("\n")
+
+function isJsonObject(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input)
+}
+
+function jsonResponseText(parts: SessionV1.Part[]) {
+  return parts
+    .flatMap((part) => (part.type === "text" ? [part.text] : []))
+    .join("")
+    .trim()
+}
+
+function jsonResponseError(text: string, required: string[]) {
+  if (!text) return "JSON response mode expected a final JSON object, but the assistant response was empty."
+  if (!text.startsWith("{") || !text.endsWith("}"))
+    return "JSON response mode expected exactly one JSON object with no surrounding text or code fences."
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return `JSON response mode expected valid JSON, but parsing failed: ${message}`
+  }
+  if (!isJsonObject(parsed)) return "JSON response mode expected a JSON object, not an array or primitive value."
+  const missing = required.filter((key) => !(key in parsed))
+  if (missing.length) return `JSON response mode expected required top-level key(s): ${missing.join(", ")}.`
+  return undefined
+}
+
 const log = Log.create({ service: "session.prompt" })
 const elog = EffectLogger.create({ service: "session.prompt" })
 
@@ -1435,7 +1481,8 @@ export const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, modelMsgs] = yield* Effect.all([
+            const [cfg, skills, env, instructions, modelMsgs] = yield* Effect.all([
+              config.get(),
               sys.skills(agent),
               sys.environment(model),
               instruction.system().pipe(Effect.orDie),
@@ -1443,6 +1490,9 @@ export const layer = Layer.effect(
             ])
             const system = [...env, ...instructions, ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
+            const jsonResponseRequired = jsonResponseRequiredKeys(cfg.json_response)
+            const jsonResponseEnabled = cfg.json_response?.enabled === true && format.type === "text"
+            if (jsonResponseEnabled) system.push(jsonResponseSystemPrompt(jsonResponseRequired))
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({
               user: lastUser,
@@ -1473,6 +1523,22 @@ export const layer = Layer.effect(
                 }).toObject()
                 yield* sessions.updateMessage(handle.message)
                 return "break" as const
+              }
+              if (jsonResponseEnabled) {
+                const parts = yield* MessageV2.parts(handle.message.id).pipe(
+                  Effect.provideService(Database.Service, database),
+                )
+                if (!parts.some((part) => part.type === "tool")) {
+                  const error = jsonResponseError(jsonResponseText(parts), jsonResponseRequired)
+                  if (error) {
+                    handle.message.error = new SessionV1.StructuredOutputError({
+                      message: error,
+                      retries: 0,
+                    }).toObject()
+                    yield* sessions.updateMessage(handle.message)
+                    return "break" as const
+                  }
+                }
               }
             }
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -296,6 +296,16 @@ function providerCfg(url: string) {
   }
 }
 
+function providerJsonResponseCfg(url: string, required: string[]) {
+  return {
+    ...providerCfg(url),
+    json_response: {
+      enabled: true,
+      required,
+    },
+  }
+}
+
 const writeText = Effect.fn("test.writeText")(function* (file: string, text: string) {
   const fs = yield* FSUtil.Service
   yield* fs.writeWithDirs(file, text)
@@ -510,6 +520,113 @@ it.instance("loop calls LLM and returns assistant message", () =>
     const parts = result.parts.filter((p) => p.type === "text")
     expect(parts.some((p) => p.type === "text" && p.text === "world")).toBe(true)
     expect(yield* llm.hits).toHaveLength(1)
+  }),
+)
+
+it.instance("json response mode injects instructions and accepts valid JSON", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => providerJsonResponseCfg(url, ["summary", "actions"]))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "JSON response mode",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.text('{"summary":"world","actions":[]}')
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role === "assistant") expect(result.info.error).toBeUndefined()
+    expect(result.parts.some((part) => part.type === "text" && part.text === '{"summary":"world","actions":[]}')).toBe(
+      true,
+    )
+    const hits = yield* llm.hits
+    expect(hits).toHaveLength(1)
+    expect(JSON.stringify(hits[0].body)).toContain("JSON response mode is enabled")
+    expect(JSON.stringify(hits[0].body)).toContain("summary, actions")
+  }),
+)
+
+it.instance("json response mode rejects malformed final JSON", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => providerJsonResponseCfg(url, ["summary"]))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "JSON response mode invalid",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.text("summary: world")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role !== "assistant") return
+    expect(result.info.error?.name).toBe("StructuredOutputError")
+    expect(JSON.stringify(result.info.error)).toContain("expected exactly one JSON object")
+  }),
+)
+
+it.instance("json response mode allows tool calls before final JSON", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => providerJsonResponseCfg(url, ["summary"]))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "JSON response mode tools",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.push(reply().tool("first", { value: "first" }).stop())
+    yield* llm.text('{"summary":"second"}')
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(yield* llm.calls).toBe(2)
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role !== "assistant") return
+    expect(result.info.error).toBeUndefined()
+    expect(result.parts.some((part) => part.type === "text" && part.text === '{"summary":"second"}')).toBe(true)
+  }),
+)
+
+it.instance("json response mode rejects missing required keys", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => providerJsonResponseCfg(url, ["summary", "actions"]))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({
+      title: "JSON response mode keys",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.text('{"summary":"world"}')
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role !== "assistant") return
+    expect(result.info.error?.name).toBe("StructuredOutputError")
+    expect(JSON.stringify(result.info.error)).toContain("actions")
   }),
 )
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1337,6 +1337,19 @@ export type Config = {
   tools?: {
     [key: string]: boolean
   }
+  /**
+   * JSON response mode. When enabled, OpenCode instructs models to return only JSON and rejects malformed final responses.
+   */
+  json_response?: {
+    /**
+     * Require final assistant responses to be valid JSON objects
+     */
+    enabled?: boolean
+    /**
+     * Top-level JSON keys that must be present in final assistant responses
+     */
+    required?: Array<string>
+  }
   enterprise?: {
     /**
      * Enterprise URL

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1892,6 +1892,19 @@ export type Config = {
     [key: string]: boolean
   }
   attachment?: AttachmentConfig
+  /**
+   * JSON response mode. When enabled, OpenCode instructs models to return only JSON and rejects malformed final responses.
+   */
+  json_response?: {
+    /**
+     * Require final assistant responses to be valid JSON objects
+     */
+    enabled?: boolean
+    /**
+     * Top-level JSON keys that must be present in final assistant responses
+     */
+    required?: Array<string>
+  }
   enterprise?: {
     url?: string
   }


### PR DESCRIPTION
### Issue for this PR

None available

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

My pull request introduces an experimental JSON response mode that encourages the model to return valid JSON with schema which is checked for malformed results, that can be rejected.

This improves reliability of some models with brainworms like GLM-5.x which had repeating outputs and corrupted context windows. Those requests are reliably rejected by this mechanism.

### How did you verify your code works?

I used `bun dev` to source-run the local modifications and verify it is functional.

I didn't record my screen at that time because I was unaware of the requirement.

### Screenshots / recordings

Not available yet. I'll update this PR later with one (currently assigned on other tasks).


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- _If you do not follow this template your PR will be automatically rejected._ -->
