### PR TITLE
fix(worktree): harden Windows workspace lifecycle

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -605,6 +605,15 @@ export default function Layout(props: ParentProps) {
     return layout.sidebar.workspaces(project.worktree)()
   })
 
+  const currentSandboxWorkspace = createMemo(() => {
+    const project = currentProject()
+    const directory = currentDir()
+    if (!project) return
+    if (!directory) return
+    if (pathKey(directory) === pathKey(project.worktree)) return
+    return { root: project.worktree, directory }
+  })
+
   const visibleSessionDirs = createMemo(() => {
     const project = currentProject()
     if (!project) return [] as string[]
@@ -1109,6 +1118,28 @@ export default function Layout(props: ParentProps) {
           const project = currentProject()
           if (!project) return
           return createWorkspace(project)
+        },
+      },
+      {
+        id: "workspace.reset",
+        title: language.t("workspace.reset.title"),
+        category: language.t("command.category.workspace"),
+        disabled: !currentSandboxWorkspace() || isBusy(currentSandboxWorkspace()?.directory ?? ""),
+        onSelect: () => {
+          const target = currentSandboxWorkspace()
+          if (!target) return
+          dialog.show(() => <DialogResetWorkspace root={target.root} directory={target.directory} />)
+        },
+      },
+      {
+        id: "workspace.delete",
+        title: language.t("workspace.delete.title"),
+        category: language.t("command.category.workspace"),
+        disabled: !currentSandboxWorkspace() || isBusy(currentSandboxWorkspace()?.directory ?? ""),
+        onSelect: () => {
+          const target = currentSandboxWorkspace()
+          if (!target) return
+          dialog.show(() => <DialogDeleteWorkspace root={target.root} directory={target.directory} />)
         },
       },
       {

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -114,6 +114,7 @@ describe("layout workspace helpers", () => {
     expect(String(pathKey("C:\\"))).toBe("C:/")
     expect(String(pathKey("C://"))).toBe("C:/")
     expect(String(pathKey("C:///"))).toBe("C:/")
+    expect(String(pathKey("d:/"))).toBe("D:/")
   })
 
   test("keeps local first while preserving known order", () => {

--- a/packages/app/src/utils/path-key.ts
+++ b/packages/app/src/utils/path-key.ts
@@ -15,10 +15,16 @@ const trimTrailingSlashes = (value: string) => {
 
 const isWindowsPath = (value: string) => value[1] === ":" || value.startsWith("\\\\")
 
+const normalizeWindowsDrive = (value: string) => {
+  if (!isDrive(value.slice(0, 2))) return value
+  return value[0]!.toUpperCase() + value.slice(1)
+}
+
 export const pathKey = (path: string) => {
   const value = isWindowsPath(path) ? path.replaceAll("\\", "/") : path
   const trimmed = trimTrailingSlashes(value)
   if (!trimmed && value.startsWith("/")) return "/" as PathKey
-  if (isDrive(trimmed)) return `${trimmed}/` as PathKey
-  return trimmed as PathKey
+  const normalized = normalizeWindowsDrive(trimmed)
+  if (isDrive(normalized)) return `${normalized}/` as PathKey
+  return normalized as PathKey
 }

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, FiberMap, Iterable, Layer, Schema, Stream } from "effect"
+import { Cause, Context, Effect, FiberMap, Iterable, Layer, Schema, Stream } from "effect"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { FetchHttpClient, HttpBody, HttpClient, HttpClientError, HttpClientRequest } from "effect/unstable/http"
 import { Database } from "@opencode-ai/core/database/database"
@@ -76,6 +76,10 @@ function fromRow(row: typeof WorkspaceTable.$inferSelect): Info {
 
 const log = Log.create({ service: "workspace-sync" })
 
+function isUnknownWorkspaceAdapterError(error: unknown) {
+  return error instanceof globalThis.Error && error.message.startsWith("Unknown workspace adapter:")
+}
+
 export const CreateInput = Schema.Struct({
   id: Schema.optional(WorkspaceV2.ID),
   type: Info.fields.type,
@@ -144,6 +148,7 @@ type SessionWarpError =
   | HttpClientError.HttpClientError
 type WaitForSyncError = SyncTimeoutError | SyncAbortedError
 type SyncLoopError = SyncHttpError | HttpClientError.HttpClientError
+type RemoveError = globalThis.Error
 
 export interface Interface {
   readonly create: (input: CreateInput) => Effect.Effect<Info, CreateError>
@@ -151,7 +156,7 @@ export interface Interface {
   readonly list: (project: Project.Info) => Effect.Effect<Info[]>
   readonly syncList: (project: Project.Info) => Effect.Effect<void>
   readonly get: (id: WorkspaceV2.ID) => Effect.Effect<Info | undefined>
-  readonly remove: (id: WorkspaceV2.ID) => Effect.Effect<Info | undefined>
+  readonly remove: (id: WorkspaceV2.ID) => Effect.Effect<Info | undefined, RemoveError>
   readonly status: () => Effect.Effect<ConnectionStatus[]>
   readonly isSyncing: (workspaceID: WorkspaceV2.ID) => Effect.Effect<boolean>
   readonly waitForSync: (
@@ -478,8 +483,6 @@ export const layer = Layer.effect(
     })
 
     const startSync = Effect.fn("Workspace.startSync")(function* (space: Info) {
-      if (!flags.experimentalWorkspaces) return
-
       const target = yield* WorkspaceAdapterRuntime.target(space).pipe(
         Effect.catch((error) =>
           Effect.sync(() => {
@@ -498,6 +501,8 @@ export const layer = Layer.effect(
         setStatus(space.id, (yield* fs.existsSafe(target.directory)) ? "connected" : "error")
         return
       }
+
+      if (!flags.experimentalWorkspaces) return
 
       const exists = yield* FiberMap.has(syncFibers, space.id)
       if (exists && connections.get(space.id)?.status !== "error") return
@@ -575,22 +580,24 @@ export const layer = Layer.effect(
       }
 
       yield* WorkspaceAdapterRuntime.create(adapter, config, env)
-      yield* Effect.all(
-        [
-          waitEvent({
-            timeout: TIMEOUT,
-            fn(event) {
-              if (event.workspace === info.id && event.payload.type === Event.Status.type) {
-                const { status } = event.payload.properties
-                return status === "error" || status === "connected"
-              }
-              return false
-            },
-          }),
-          startSync(info),
-        ],
-        { concurrency: 2, discard: true },
-      )
+
+      const statusReady = () => {
+        const status = connections.get(info.id)?.status
+        return status === "error" || status === "connected"
+      }
+      yield* startSync(info)
+      if (!statusReady()) {
+        yield* waitEvent({
+          timeout: TIMEOUT,
+          fn(event) {
+            if (event.workspace === info.id && event.payload.type === Event.Status.type) {
+              const { status } = event.payload.properties
+              return status === "error" || status === "connected"
+            }
+            return false
+          },
+        })
+      }
 
       return info
     })
@@ -910,14 +917,16 @@ export const layer = Layer.effect(
       yield* stopSync(id)
 
       const info = fromRow(row)
-      yield* Effect.catchCause(
-        Effect.gen(function* () {
-          yield* WorkspaceAdapterRuntime.remove(info)
+      yield* WorkspaceAdapterRuntime.remove(info).pipe(
+        Effect.catchCause((cause) => {
+          const error = Cause.squash(cause)
+          if (isUnknownWorkspaceAdapterError(error)) {
+            return Effect.sync(() => {
+              log.error("adapter not available when removing workspace", { type: row.type })
+            })
+          }
+          return Effect.fail(error instanceof globalThis.Error ? error : new globalThis.Error(String(error)))
         }),
-        () =>
-          Effect.sync(() => {
-            log.error("adapter not available when removing workspace", { type: row.type })
-          }),
       )
 
       yield* db.delete(WorkspaceTable).where(eq(WorkspaceTable.id, id)).run().pipe(Effect.orDie)

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -143,13 +143,14 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
     }
 
     const dispose = Effect.fn("InstanceStore.dispose")(function* (ctx: InstanceContext) {
-      const entry = cache.get(ctx.directory)
-      if (!entry) return yield* disposeContext(ctx)
+      const directory = FSUtil.resolve(ctx.directory)
+      const entry = cache.get(directory)
+      if (!entry) return yield* disposeContext({ ...ctx, directory })
 
       const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
-      if (Exit.isFailure(exit)) return yield* removeEntry(ctx.directory, entry).pipe(Effect.asVoid)
-      if (exit.value !== ctx) return
-      yield* disposeEntry(ctx.directory, entry, ctx).pipe(Effect.asVoid)
+      if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry).pipe(Effect.asVoid)
+      if (exit.value !== ctx && exit.value.directory !== directory) return
+      yield* disposeEntry(directory, entry, exit.value).pipe(Effect.asVoid)
     })
 
     const disposeDirectory = Effect.fn("InstanceStore.disposeDirectory")(function* (input: string) {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
@@ -3,7 +3,7 @@ import { Workspace } from "@/control-plane/workspace"
 import * as InstanceState from "@/effect/instance-state"
 import { Vcs } from "@/project/vcs"
 import { Cause, Effect } from "effect"
-import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { notFound } from "../errors"
 import { ApiVcsApplyError } from "../groups/instance"
@@ -58,7 +58,7 @@ export const workspaceHandlers = HttpApiBuilder.group(InstanceHttpApi, "workspac
     })
 
     const remove = Effect.fn("WorkspaceHttpApi.remove")(function* (ctx: { params: { id: Workspace.Info["id"] } }) {
-      return yield* workspace.remove(ctx.params.id)
+      return yield* workspace.remove(ctx.params.id).pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
     })
 
     const warp = Effect.fn("WorkspaceHttpApi.warp")(function* (ctx: { payload: typeof WarpPayload.Type }) {

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -12,7 +12,7 @@ import { errorMessage } from "../util/error"
 import { EventV2 } from "@opencode-ai/core/event"
 import { GlobalBus } from "@/bus/global"
 import { Git } from "@/git"
-import { Effect, Layer, Path, Schema, Scope, Context } from "effect"
+import { Cause, Effect, Layer, Path, Schema, Scope, Context } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { NodePath } from "@effect/platform-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -56,6 +56,13 @@ export const RemoveInput = Schema.Struct({
   directory: Schema.String,
 }).annotate({ identifier: "WorktreeRemoveInput" })
 export type RemoveInput = Schema.Schema.Type<typeof RemoveInput>
+
+export const RemoveResult = Schema.Struct({
+  removed: Schema.Literal(true),
+  cleanupDeferred: Schema.Boolean,
+  warning: Schema.optional(Schema.String),
+}).annotate({ identifier: "WorktreeRemoveResult" })
+export type RemoveResult = Schema.Schema.Type<typeof RemoveResult>
 
 export const ResetInput = Schema.Struct({
   directory: Schema.String,
@@ -138,13 +145,67 @@ export interface Interface {
   readonly createFromInfo: (info: Info, startCommand?: string) => Effect.Effect<void, Error>
   readonly create: (input?: CreateInput) => Effect.Effect<Info, Error>
   readonly list: () => Effect.Effect<(Omit<Info, "branch"> & { branch?: string })[], Error>
-  readonly remove: (input: RemoveInput) => Effect.Effect<boolean, Error>
+  readonly remove: (input: RemoveInput) => Effect.Effect<RemoveResult, Error>
   readonly reset: (input: ResetInput) => Effect.Effect<boolean, Error>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Worktree") {}
 
 type GitResult = { code: number; text: string; stderr: string }
+type DirectoryCleanupResult = { cleanupDeferred: false } | { cleanupDeferred: true; warning: string }
+
+const cleanupDeferredCodes = new Set(["EBUSY", "EPERM", "ENOTEMPTY"])
+
+export function isCleanupDeferredError(error: unknown, platform = process.platform) {
+  if (platform !== "win32") return false
+  const code = (error as { code?: unknown } | undefined)?.code
+  return typeof code === "string" && cleanupDeferredCodes.has(code)
+}
+
+function scheduleDeferredDirectoryCleanup(target: string) {
+  const delays = [1_000, 3_000, 10_000]
+  const retry = (attempt: number) => {
+    const timer = setTimeout(() => {
+      import("fs/promises")
+        .then((fsp) => fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }))
+        .catch((error) => {
+          if (!isCleanupDeferredError(error) || attempt >= delays.length - 1) {
+            log.warn("worktree deferred directory cleanup failed", { directory: target, message: errorMessage(error) })
+            return
+          }
+          retry(attempt + 1)
+        })
+    }, delays[attempt])
+    timer.unref?.()
+  }
+  retry(0)
+}
+
+export function removePhysicalDirectory(
+  target: string,
+  rm: () => Promise<void> = () =>
+    import("fs/promises").then((fsp) =>
+      fsp.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }),
+    ),
+) {
+  return Effect.tryPromise({
+    try: rm,
+    catch: (error) => error,
+  }).pipe(
+    Effect.as({ cleanupDeferred: false } satisfies DirectoryCleanupResult),
+    Effect.catch((error) => {
+      if (isCleanupDeferredError(error)) {
+        const warning = errorMessage(error) || "Worktree directory cleanup deferred"
+        log.warn("worktree directory cleanup deferred", { directory: target, message: warning })
+        scheduleDeferredDirectoryCleanup(target)
+        return Effect.succeed({ cleanupDeferred: true, warning } satisfies DirectoryCleanupResult)
+      }
+      return Effect.fail(
+        new RemoveFailedError({ message: errorMessage(error) || "Failed to remove git worktree directory" }),
+      )
+    }),
+  )
+}
 
 export const layer: Layer.Layer<
   Service,
@@ -242,7 +303,17 @@ export const layer: Layer.Layer<
         })
       }
 
-      yield* project.addSandbox(ctx.project.id, info.directory).pipe(Effect.catch(() => Effect.void))
+      yield* project.addSandbox(ctx.project.id, info.directory).pipe(
+        Effect.catchCause((cause) =>
+          Effect.gen(function* () {
+            yield* git(["worktree", "remove", "--force", info.directory], { cwd: ctx.worktree }).pipe(Effect.ignore)
+            if (info.branch) yield* git(["branch", "-D", info.branch], { cwd: ctx.worktree }).pipe(Effect.ignore)
+            return yield* new CreateFailedError({
+              message: `Failed to record worktree sandbox: ${Cause.pretty(cause)}`,
+            })
+          }),
+        ),
+      )
     })
 
     const boot = Effect.fnUntraced(function* (info: Info, startCommand?: string) {
@@ -313,7 +384,7 @@ export const layer: Layer.Layer<
       const abs = pathSvc.resolve(input)
       const real = yield* fs.realPath(abs).pipe(Effect.catch(() => Effect.succeed(abs)))
       const normalized = pathSvc.normalize(real)
-      return process.platform === "win32" ? normalized.toLowerCase() : normalized
+      return process.platform === "win32" ? normalized.replaceAll("/", "\\").toLowerCase() : normalized
     })
 
     function parseWorktreeList(text: string) {
@@ -347,6 +418,19 @@ export const layer: Layer.Layer<
       return undefined
     })
 
+    function locateWorktreeByBranch(entries: { path?: string; branch?: string }[], branch?: string) {
+      if (!branch) return undefined
+      return entries.find((item) => item.branch?.replace(/^refs\/heads\//, "") === branch)
+    }
+
+    const gitTopLevel = Effect.fnUntraced(function* (directory: string) {
+      const result = yield* git(["rev-parse", "--show-toplevel"], { cwd: directory })
+      if (result.code !== 0) return
+      const top = result.text.trim()
+      if (!top) return
+      return yield* canonical(top)
+    })
+
     const list = Effect.fn("Worktree.list")(function* () {
       const ctx = yield* InstanceState.context
       if (ctx.project.vcs !== "git") {
@@ -377,30 +461,108 @@ export const layer: Layer.Layer<
 
     function stopFsmonitor(target: string) {
       return fs.exists(target).pipe(
-        Effect.orDie,
+        Effect.catch(() => Effect.succeed(false)),
         Effect.flatMap((exists) => (exists ? git(["fsmonitor--daemon", "stop"], { cwd: target }) : Effect.void)),
+        Effect.ignore,
       )
     }
 
     function cleanDirectory(target: string) {
-      return Effect.tryPromise({
-        try: async () => {
-          const fsp = await import("fs/promises")
-          const attempts = process.platform === "win32" ? 50 : 5
-          for (const attempt of Array.from({ length: attempts }, (_, i) => i)) {
-            try {
-              await fsp.rm(target, { recursive: true, force: true })
-              return
-            } catch (error) {
-              if (attempt === attempts - 1) throw error
-              await new Promise((resolve) => setTimeout(resolve, 100))
-            }
-          }
-        },
-        catch: (error) =>
-          new RemoveFailedError({ message: errorMessage(error) || "Failed to remove git worktree directory" }),
-      })
+      return removePhysicalDirectory(target)
     }
+
+    function removed(cleanup: DirectoryCleanupResult = { cleanupDeferred: false }): RemoveResult {
+      return {
+        removed: true,
+        cleanupDeferred: cleanup.cleanupDeferred,
+        ...(cleanup.cleanupDeferred ? { warning: cleanup.warning } : {}),
+      }
+    }
+
+    function successMessage(result: GitResult, fallback: string) {
+      return result.stderr || result.text || fallback
+    }
+
+    function hasWindowsProjectWorktreeShape(target: string, projectID: string) {
+      if (process.platform !== "win32") return false
+      const projectRoot = pathSvc.dirname(target)
+      const worktreeRoot = pathSvc.dirname(projectRoot)
+      const opencodeRoot = pathSvc.dirname(worktreeRoot)
+      const dataRoot = pathSvc.dirname(opencodeRoot)
+      return (
+        pathSvc.basename(projectRoot).toLowerCase() === projectID.toLowerCase() &&
+        pathSvc.basename(worktreeRoot).toLowerCase() === "worktree" &&
+        pathSvc.basename(opencodeRoot).toLowerCase() === "opencode" &&
+        pathSvc.basename(dataRoot).toLowerCase() === "data"
+      )
+    }
+
+    function ensureSandboxTarget(target: string, root: string, primary: string, projectID: string) {
+      if (target === primary) {
+        return new RemoveFailedError({ message: "Cannot remove the primary workspace" })
+      }
+      if (target === root || (!target.startsWith(`${root}${pathSvc.sep}`) && !hasWindowsProjectWorktreeShape(target, projectID))) {
+        return new RemoveFailedError({ message: "Worktree path is outside the OpenCode worktree root" })
+      }
+      return undefined
+    }
+
+    function isSandboxTarget(target: string, root: string, primary: string, projectID: string) {
+      return (
+        target !== primary &&
+        target !== root &&
+        (target.startsWith(`${root}${pathSvc.sep}`) || hasWindowsProjectWorktreeShape(target, projectID))
+      )
+    }
+
+    const removeSandboxRecords = Effect.fnUntraced(function* (directories: string[]) {
+      const ctx = yield* InstanceState.context
+      yield* Effect.forEach(
+        [...new Set(directories)],
+        (directory) => project.removeSandbox(ctx.project.id, directory).pipe(Effect.catch(() => Effect.void)),
+        { discard: true },
+      )
+    })
+
+    const deleteBranch = Effect.fnUntraced(function* (branchRef?: string) {
+      const ctx = yield* InstanceState.context
+      const branch = branchRef?.replace(/^refs\/heads\//, "")
+      if (!branch) return
+      if (!branch.startsWith("opencode/")) {
+        return yield* new RemoveFailedError({ message: `Refusing to delete non-opencode worktree branch: ${branch}` })
+      }
+
+      const ref = `refs/heads/${branch}`
+      const before = yield* git(["show-ref", "--verify", "--quiet", ref], { cwd: ctx.worktree })
+      if (before.code !== 0) return
+
+      const deleted = yield* git(["branch", "-D", branch], { cwd: ctx.worktree })
+      if (deleted.code === 0) return
+
+      const after = yield* git(["show-ref", "--verify", "--quiet", ref], { cwd: ctx.worktree })
+      if (after.code !== 0) return
+
+      return yield* new RemoveFailedError({
+        message: successMessage(deleted, "Failed to delete worktree branch"),
+      })
+    })
+
+    const worktreeBranch = Effect.fnUntraced(function* (target: string, branchRef?: string) {
+      const branch = branchRef?.replace(/^refs\/heads\//, "")
+      if (branch) return branch
+      const result = yield* git(["symbolic-ref", "--quiet", "--short", "HEAD"], { cwd: target })
+      if (result.code !== 0) return `opencode/${pathSvc.basename(target)}`
+      const current = result.text.trim()
+      if (current) return current
+      return `opencode/${pathSvc.basename(target)}`
+    })
+
+    const currentBranch = Effect.fnUntraced(function* (target: string) {
+      const result = yield* git(["symbolic-ref", "--quiet", "--short", "HEAD"], { cwd: target })
+      if (result.code !== 0) return
+      const current = result.text.trim()
+      return current || undefined
+    })
 
     const remove = Effect.fn("Worktree.remove")(function* (input: RemoveInput) {
       const ctx = yield* InstanceState.context
@@ -409,6 +571,12 @@ export const layer: Layer.Layer<
       }
 
       const directory = yield* canonical(input.directory)
+      const lookupDirectory = (yield* gitTopLevel(input.directory)) ?? directory
+      const root = yield* canonical(pathSvc.join(Global.Path.data, "worktree", ctx.project.id))
+      const primary = yield* canonical(ctx.project.worktree)
+      const safetyDirectory = isSandboxTarget(lookupDirectory, root, primary, ctx.project.id) ? lookupDirectory : directory
+      const unsafe = ensureSandboxTarget(safetyDirectory, root, primary, ctx.project.id)
+      if (unsafe) return yield* unsafe
 
       // Preserve the loaded path casing for the store cache; `directory` is lowercased on Windows.
       if (directory !== (yield* canonical(ctx.worktree))) yield* store.disposeDirectory(input.directory)
@@ -419,50 +587,79 @@ export const layer: Layer.Layer<
       }
 
       const entries = parseWorktreeList(list.text)
-      const entry = yield* locateWorktree(entries, directory)
+      let entry = yield* locateWorktree(entries, lookupDirectory)
+      const inputBranch = entry?.path ? undefined : yield* currentBranch(input.directory)
+      entry = entry ?? locateWorktreeByBranch(entries, inputBranch)
 
       if (!entry?.path) {
         const directoryExists = yield* fs.exists(directory).pipe(Effect.orDie)
         if (directoryExists) {
+          if (inputBranch && !inputBranch.startsWith("opencode/")) {
+            return yield* new RemoveFailedError({
+              message: `Refusing to remove worktree with non-opencode branch: ${inputBranch}`,
+            })
+          }
+          if (inputBranch?.startsWith("opencode/")) {
+            return yield* new RemoveFailedError({
+              message: "Worktree is still checked out but was not found in the git worktree registry",
+            })
+          }
           yield* stopFsmonitor(directory)
-          yield* cleanDirectory(directory)
+          const cleanup = yield* cleanDirectory(directory)
+          yield* removeSandboxRecords([input.directory, directory])
+          return removed(cleanup)
         }
-        return true
+        yield* removeSandboxRecords([input.directory, directory])
+        return removed()
       }
 
-      // Git may return the original casing when a caller supplied a normalized Windows path.
-      yield* store.disposeDirectory(entry.path)
+      const branch = yield* worktreeBranch(entry.path, entry.branch)
+      if (branch && !branch.startsWith("opencode/")) {
+        return yield* new RemoveFailedError({
+          message: `Refusing to remove worktree with non-opencode branch: ${branch}`,
+        })
+      }
+
+      yield* store
+        .dispose({ directory: entry.path, worktree: entry.path, project: ctx.project })
+        .pipe(Effect.catchCause(() => Effect.void))
       yield* stopFsmonitor(entry.path)
-      const removed = yield* git(["worktree", "remove", "--force", entry.path], { cwd: ctx.worktree })
-      if (removed.code !== 0) {
+      const gitRemoved = yield* git(["worktree", "remove", "--force", entry.path], { cwd: ctx.worktree })
+      if (gitRemoved.code !== 0) {
         const next = yield* git(["worktree", "list", "--porcelain"], { cwd: ctx.worktree })
         if (next.code !== 0) {
           return yield* new RemoveFailedError({
-            message: removed.stderr || removed.text || next.stderr || next.text || "Failed to remove git worktree",
+            message: successMessage(gitRemoved, successMessage(next, "Failed to remove git worktree")),
           })
         }
 
-        const stale = yield* locateWorktree(parseWorktreeList(next.text), directory)
+        const nextEntries = parseWorktreeList(next.text)
+        const stale =
+          (yield* locateWorktree(nextEntries, lookupDirectory)) ?? locateWorktreeByBranch(nextEntries, branch)
         if (stale?.path) {
           return yield* new RemoveFailedError({
-            message: removed.stderr || removed.text || "Failed to remove git worktree",
+            message: successMessage(gitRemoved, "Failed to remove git worktree"),
           })
         }
       }
 
-      yield* cleanDirectory(entry.path)
-
-      const branch = entry.branch?.replace(/^refs\/heads\//, "")
-      if (branch) {
-        const deleted = yield* git(["branch", "-D", branch], { cwd: ctx.worktree })
-        if (deleted.code !== 0) {
-          return yield* new RemoveFailedError({
-            message: deleted.stderr || deleted.text || "Failed to delete worktree branch",
-          })
-        }
+      const next = yield* git(["worktree", "list", "--porcelain"], { cwd: ctx.worktree })
+      if (next.code !== 0) {
+        return yield* new RemoveFailedError({
+          message: successMessage(next, "Failed to verify git worktree removal"),
+        })
+      }
+      const nextEntries = parseWorktreeList(next.text)
+      const stale = (yield* locateWorktree(nextEntries, lookupDirectory)) ?? locateWorktreeByBranch(nextEntries, branch)
+      if (stale?.path) {
+        return yield* new RemoveFailedError({ message: "Git worktree remains registered after removal" })
       }
 
-      return true
+      yield* deleteBranch(branch)
+
+      const cleanup = yield* cleanDirectory(entry.path)
+      yield* removeSandboxRecords([input.directory, directory, entry.path])
+      return removed(cleanup)
     })
 
     const gitExpect = Effect.fnUntraced(function* (
@@ -545,7 +742,8 @@ export const layer: Layer.Layer<
         return yield* new NotGitError({ message: "Worktrees are only supported for git projects" })
       }
 
-      const directory = yield* canonical(input.directory)
+      const inputDirectory = yield* canonical(input.directory)
+      const directory = (yield* gitTopLevel(input.directory)) ?? inputDirectory
       const primary = yield* canonical(ctx.worktree)
       if (directory === primary) {
         return yield* new ResetFailedError({ message: "Cannot reset the primary workspace" })

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -706,6 +706,21 @@ describe("Project.addSandbox and Project.removeSandbox", () => {
     }),
   )
 
+  it.live("removeSandbox is idempotent when the sandbox is absent", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      const result = yield* project.fromDirectory(tmp)
+      const sandboxDir = path.join(tmp, "missing-sandbox")
+
+      yield* project.removeSandbox(result.project.id, sandboxDir)
+      yield* project.removeSandbox(result.project.id, sandboxDir)
+
+      const found = yield* project.get(result.project.id)
+      expect(found?.sandboxes).not.toContain(sandboxDir)
+    }),
+  )
+
   it.live("addSandbox emits GlobalBus event", () =>
     Effect.gen(function* () {
       const project = yield* Project.Service

--- a/packages/opencode/test/project/worktree-remove.test.ts
+++ b/packages/opencode/test/project/worktree-remove.test.ts
@@ -2,125 +2,265 @@ import { $ } from "bun"
 import { describe, expect } from "bun:test"
 import * as fs from "fs/promises"
 import path from "path"
-import { Effect, Layer } from "effect"
+import { Cause, Effect, Exit, Layer } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Worktree } from "../../src/worktree"
-import { TestInstance } from "../fixture/fixture"
+import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(Worktree.defaultLayer, CrossSpawnSpawner.defaultLayer))
-const wintest = process.platform === "win32" ? it.instance : it.instance.skip
+const wintest = process.platform === "win32" ? it.live : it.live.skip
+const nonWindowsTest = process.platform === "win32" ? it.live.skip : it.live
+const gitShimName = process.platform === "win32" ? "git.cmd" : "git"
+
+function gitShim(real: string, mode: "remove-detaches" | "remove-stays") {
+  if (process.platform === "win32") {
+    const runReal = mode === "remove-detaches" ? `"${real}" %* >nul 2>nul` : ""
+    return [
+      "@echo off",
+      'if "%1"=="worktree" if "%2"=="remove" (',
+      ...(runReal ? [`  ${runReal}`] : []),
+      mode === "remove-detaches"
+        ? '  echo fatal: failed to remove worktree: Directory not empty 1>&2'
+        : '  echo fatal: simulated worktree remove failure 1>&2',
+      "  exit /b 1",
+      ")",
+      `"${real}" %*`,
+      "exit /b %ERRORLEVEL%",
+    ].join("\r\n")
+  }
+  return [
+    "#!/bin/bash",
+    `REAL_GIT=${JSON.stringify(real)}`,
+    'if [ "$1" = "worktree" ] && [ "$2" = "remove" ]; then',
+    ...(mode === "remove-detaches" ? ['  "$REAL_GIT" "$@" >/dev/null 2>&1'] : []),
+    mode === "remove-detaches"
+      ? '  echo "fatal: failed to remove worktree: Directory not empty" >&2'
+      : '  echo "fatal: simulated worktree remove failure" >&2',
+    "  exit 1",
+    "fi",
+    'exec "$REAL_GIT" "$@"',
+  ].join("\n")
+}
 
 describe("Worktree.remove", () => {
-  it.instance(
-    "continues when git remove exits non-zero after detaching",
-    () =>
-      Effect.gen(function* () {
-        const root = (yield* TestInstance).directory
-        const svc = yield* Worktree.Service
-        const name = `remove-regression-${Date.now().toString(36)}`
-        const branch = `opencode/${name}`
-        const dir = path.join(root, "..", name)
+  it.effect("classifies Windows EBUSY cleanup as deferred success", () =>
+    Effect.gen(function* () {
+      const result = yield* Worktree.removePhysicalDirectory("locked", () =>
+        Promise.reject(Object.assign(new Error("busy"), { code: "EBUSY" })),
+      )
 
-        yield* Effect.promise(() => $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(root).quiet())
-        yield* Effect.promise(() => $`git reset --hard`.cwd(dir).quiet())
-
-        const real = (yield* Effect.promise(() => $`which git`.quiet().text())).trim()
-        expect(real).toBeTruthy()
-
-        const bin = path.join(root, "bin")
-        const shim = path.join(bin, "git")
-        yield* Effect.promise(() => fs.mkdir(bin, { recursive: true }))
-        yield* Effect.promise(() =>
-          Bun.write(
-            shim,
-            [
-              "#!/bin/bash",
-              `REAL_GIT=${JSON.stringify(real)}`,
-              'if [ "$1" = "worktree" ] && [ "$2" = "remove" ]; then',
-              '  "$REAL_GIT" "$@" >/dev/null 2>&1',
-              '  echo "fatal: failed to remove worktree: Directory not empty" >&2',
-              "  exit 1",
-              "fi",
-              'exec "$REAL_GIT" "$@"',
-            ].join("\n"),
-          ),
-        )
-        yield* Effect.promise(() => fs.chmod(shim, 0o755))
-
-        const prev = yield* Effect.acquireRelease(
-          Effect.sync(() => {
-            const prev = process.env.PATH ?? ""
-            process.env.PATH = `${bin}${path.delimiter}${prev}`
-            return prev
-          }),
-          (prev) =>
-            Effect.sync(() => {
-              process.env.PATH = prev
-            }),
-        )
-        void prev
-
-        const ok = yield* svc.remove({ directory: dir })
-
-        expect(ok).toBe(true)
-        expect(
-          yield* Effect.promise(() =>
-            fs
-              .stat(dir)
-              .then(() => true)
-              .catch(() => false),
-          ),
-        ).toBe(false)
-
-        const list = yield* Effect.promise(() => $`git worktree list --porcelain`.cwd(root).quiet().text())
-        expect(list).not.toContain(`worktree ${dir}`)
-
-        const ref = yield* Effect.promise(() =>
-          $`git show-ref --verify --quiet refs/heads/${branch}`.cwd(root).quiet().nothrow(),
-        )
-        expect(ref.exitCode).not.toBe(0)
-      }),
-    { git: true },
+      expect(result.cleanupDeferred).toBe(process.platform === "win32")
+    }),
   )
 
-  wintest(
-    "stops fsmonitor before removing a worktree",
-    () =>
-      Effect.gen(function* () {
-        const root = (yield* TestInstance).directory
-        const svc = yield* Worktree.Service
-        const name = `remove-fsmonitor-${Date.now().toString(36)}`
-        const branch = `opencode/${name}`
-        const dir = path.join(root, "..", name)
+  it.effect("treats unknown cleanup errors as hard remove failures", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        Worktree.removePhysicalDirectory("unknown", () =>
+          Promise.reject(Object.assign(new Error("surprise"), { code: "ENOUGH" })),
+        ),
+      )
 
-        yield* Effect.promise(() => $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(root).quiet())
-        yield* Effect.promise(() => $`git reset --hard`.cwd(dir).quiet())
-        yield* Effect.promise(() => $`git config core.fsmonitor true`.cwd(dir).quiet())
-        yield* Effect.promise(() => $`git fsmonitor--daemon stop`.cwd(dir).quiet().nothrow())
-        yield* Effect.promise(() => Bun.write(path.join(dir, "tracked.txt"), "next\n"))
-        yield* Effect.promise(() => $`git diff`.cwd(dir).quiet())
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Worktree.RemoveFailedError)
+    }),
+  )
 
-        const before = yield* Effect.promise(() => $`git fsmonitor--daemon status`.cwd(dir).quiet().nothrow())
-        expect(before.exitCode).toBe(0)
+  it.live("continues when git remove exits non-zero after detaching", () =>
+    provideTmpdirInstance(
+      (root) =>
+        Effect.gen(function* () {
+          const svc = yield* Worktree.Service
+          const name = `remove-regression-${Date.now().toString(36)}`
+          const info = yield* svc.makeWorktreeInfo({ name })
+          const branch = info.branch!
+          const dir = info.directory
 
-        const ok = yield* svc.remove({ directory: dir })
+          yield* Effect.promise(() => $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(root).quiet())
+          yield* Effect.promise(() => $`git reset --hard`.cwd(dir).quiet())
 
-        expect(ok).toBe(true)
-        expect(
-          yield* Effect.promise(() =>
-            fs
-              .stat(dir)
-              .then(() => true)
-              .catch(() => false),
-          ),
-        ).toBe(false)
+          const real = (yield* Effect.promise(() => $`which git`.quiet().text())).trim()
+          expect(real).toBeTruthy()
 
-        const ref = yield* Effect.promise(() =>
-          $`git show-ref --verify --quiet refs/heads/${branch}`.cwd(root).quiet().nothrow(),
-        )
-        expect(ref.exitCode).not.toBe(0)
-      }),
-    { git: true },
+          const bin = path.join(root, "bin")
+          const shim = path.join(bin, gitShimName)
+          yield* Effect.promise(() => fs.mkdir(bin, { recursive: true }))
+          yield* Effect.promise(() => Bun.write(shim, gitShim(real, "remove-detaches")))
+          yield* Effect.promise(() => fs.chmod(shim, 0o755))
+
+          const prev = yield* Effect.acquireRelease(
+            Effect.sync(() => {
+              const prev = process.env.PATH ?? ""
+              process.env.PATH = `${bin}${path.delimiter}${prev}`
+              return prev
+            }),
+            (prev) =>
+              Effect.sync(() => {
+                process.env.PATH = prev
+              }),
+          )
+          void prev
+
+          const ok = yield* svc.remove({ directory: dir })
+
+          expect(ok).toEqual({ removed: true, cleanupDeferred: false })
+          expect(
+            yield* Effect.promise(() =>
+              fs
+                .stat(dir)
+                .then(() => true)
+                .catch(() => false),
+            ),
+          ).toBe(false)
+
+          const list = yield* Effect.promise(() => $`git worktree list --porcelain`.cwd(root).quiet().text())
+          expect(list).not.toContain(`worktree ${dir}`)
+
+          const ref = yield* Effect.promise(() =>
+            $`git show-ref --verify --quiet refs/heads/${branch}`.cwd(root).quiet().nothrow(),
+          )
+          expect(ref.exitCode).not.toBe(0)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("does not let async bootstrap recreate a removed worktree directory", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const svc = yield* Worktree.Service
+          const info = yield* svc.create({ name: `remove-boot-race-${Date.now().toString(36)}` })
+
+          const removed = yield* svc.remove({ directory: info.directory })
+          expect(removed).toEqual({ removed: true, cleanupDeferred: false })
+
+          yield* Effect.sleep("2 seconds")
+          expect(
+            yield* Effect.promise(() =>
+              fs
+                .stat(info.directory)
+                .then(() => true)
+                .catch(() => false),
+            ),
+          ).toBe(false)
+        }),
+      { git: true },
+    ),
+  )
+
+  nonWindowsTest("fails when git remove exits non-zero and worktree remains registered", () =>
+    provideTmpdirInstance(
+      (root) =>
+        Effect.gen(function* () {
+          const svc = yield* Worktree.Service
+          const name = `remove-hard-${Date.now().toString(36)}`
+          const info = yield* svc.makeWorktreeInfo({ name })
+          const branch = info.branch!
+          const dir = info.directory
+
+          yield* Effect.promise(() => $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(root).quiet())
+          yield* Effect.promise(() => $`git reset --hard`.cwd(dir).quiet())
+
+          const real = (yield* Effect.promise(() => $`which git`.quiet().text())).trim()
+          const bin = path.join(root, "bin-hard")
+          const shim = path.join(bin, gitShimName)
+          yield* Effect.promise(() => fs.mkdir(bin, { recursive: true }))
+          yield* Effect.promise(() => Bun.write(shim, gitShim(real, "remove-stays")))
+          yield* Effect.promise(() => fs.chmod(shim, 0o755))
+
+          const prev = yield* Effect.acquireRelease(
+            Effect.sync(() => {
+              const prev = process.env.PATH ?? ""
+              process.env.PATH = `${bin}${path.delimiter}${prev}`
+              return prev
+            }),
+            (prev) =>
+              Effect.sync(() => {
+                process.env.PATH = prev
+              }),
+          )
+          void prev
+
+          const exit = yield* Effect.exit(svc.remove({ directory: dir }))
+
+          expect(Exit.isFailure(exit)).toBe(true)
+          if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Worktree.RemoveFailedError)
+
+          const list = yield* Effect.promise(() => $`git worktree list --porcelain`.cwd(root).quiet().text())
+          expect(list).toContain(`worktree ${dir}`)
+
+          yield* Effect.promise(() => $`git worktree remove --force ${dir}`.cwd(root).quiet())
+          yield* Effect.promise(() => $`git branch -D ${branch}`.cwd(root).quiet())
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("refuses to remove a worktree on a non-opencode branch", () =>
+    provideTmpdirInstance(
+      (root) =>
+        Effect.gen(function* () {
+          const svc = yield* Worktree.Service
+          const name = `remove-branch-safety-${Date.now().toString(36)}`
+          const info = yield* svc.makeWorktreeInfo({ name, detached: true })
+          const branch = `danger/${info.name}`
+
+          yield* Effect.promise(() => $`git worktree add --no-checkout -b ${branch} ${info.directory}`.cwd(root).quiet())
+          yield* Effect.promise(() => $`git reset --hard`.cwd(info.directory).quiet())
+          expect(yield* svc.list()).toContainEqual(expect.objectContaining({ branch }))
+
+          const exit = yield* Effect.exit(svc.remove({ directory: info.directory }))
+
+          expect(Exit.isFailure(exit)).toBe(true)
+          if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Worktree.RemoveFailedError)
+
+          yield* Effect.promise(() => $`git worktree remove --force ${info.directory}`.cwd(root).quiet())
+          yield* Effect.promise(() => $`git branch -D ${branch}`.cwd(root).quiet())
+        }),
+      { git: true },
+    ),
+  )
+
+  wintest("stops fsmonitor before removing a worktree", () =>
+    provideTmpdirInstance(
+      (root) =>
+        Effect.gen(function* () {
+          const svc = yield* Worktree.Service
+          const name = `remove-fsmonitor-${Date.now().toString(36)}`
+          const info = yield* svc.makeWorktreeInfo({ name })
+          const branch = info.branch!
+          const dir = info.directory
+
+          yield* Effect.promise(() => $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(root).quiet())
+          yield* Effect.promise(() => $`git reset --hard`.cwd(dir).quiet())
+          yield* Effect.promise(() => $`git config core.fsmonitor true`.cwd(dir).quiet())
+          yield* Effect.promise(() => $`git fsmonitor--daemon stop`.cwd(dir).quiet().nothrow())
+          yield* Effect.promise(() => Bun.write(path.join(dir, "tracked.txt"), "next\n"))
+          yield* Effect.promise(() => $`git diff`.cwd(dir).quiet())
+
+          const before = yield* Effect.promise(() => $`git fsmonitor--daemon status`.cwd(dir).quiet().nothrow())
+          expect(before.exitCode).toBe(0)
+
+          const ok = yield* svc.remove({ directory: dir })
+
+          expect(ok).toEqual({ removed: true, cleanupDeferred: false })
+          expect(
+            yield* Effect.promise(() =>
+              fs
+                .stat(dir)
+                .then(() => true)
+                .catch(() => false),
+            ),
+          ).toBe(false)
+
+          const ref = yield* Effect.promise(() =>
+            $`git show-ref --verify --quiet refs/heads/${branch}`.cwd(root).quiet().nothrow(),
+          )
+          expect(ref.exitCode).not.toBe(0)
+        }),
+      { git: true },
+    ),
   )
 })

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -5,12 +5,22 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import { GlobalBus, type GlobalEvent } from "../../src/bus/global"
 import { Git } from "../../src/git"
+import { InstanceRef } from "../../src/effect/instance-ref"
+import { Database } from "@opencode-ai/core/database/database"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { Worktree } from "../../src/worktree"
 import { disposeAllInstances, provideInstance, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { eq } from "drizzle-orm"
 
 const it = testEffect(
-  Layer.mergeAll(Worktree.defaultLayer, FSUtil.defaultLayer, CrossSpawnSpawner.defaultLayer, Git.defaultLayer),
+  Layer.mergeAll(
+    Worktree.defaultLayer,
+    FSUtil.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Git.defaultLayer,
+    Database.defaultLayer,
+  ),
 )
 const wintest = process.platform !== "win32" ? it.instance : it.instance.skip
 
@@ -40,7 +50,7 @@ const removeCreatedWorktree = (directory: string) =>
   Effect.gen(function* () {
     const svc = yield* Worktree.Service
     const ok = yield* svc.remove({ directory })
-    if (!ok) return yield* Effect.fail(new Error(`failed to remove worktree ${directory}`))
+    if (!ok.removed) return yield* Effect.fail(new Error(`failed to remove worktree ${directory}`))
   })
 
 const withCreatedWorktree = <A, E, R>(
@@ -167,7 +177,8 @@ describe("Worktree", () => {
           expect(props.name).toBe(info.name)
           expect(props.branch).toBeUndefined()
 
-          yield* svc.remove({ directory: info.directory })
+          const removed = yield* svc.remove({ directory: info.directory })
+          expect(removed.removed).toBe(true)
         }),
       { git: true },
     )
@@ -234,6 +245,33 @@ describe("Worktree", () => {
         ),
       { git: true },
     )
+
+    it.instance(
+      "fails and rolls back the git worktree when sandbox persistence fails",
+      () =>
+        Effect.gen(function* () {
+          const test = yield* TestInstance
+          const ctx = yield* InstanceRef
+          const svc = yield* Worktree.Service
+          const info = yield* svc.makeWorktreeInfo({ name: `sandbox-fail-${Date.now().toString(36)}` })
+
+          if (!ctx) return yield* Effect.die(new Error("missing test instance"))
+          const { db } = yield* Database.Service
+          yield* db.delete(ProjectTable).where(eq(ProjectTable.id, ctx.project.id)).run().pipe(Effect.orDie)
+
+          const exit = yield* Effect.exit(svc.createFromInfo(info))
+
+          expect(Exit.isFailure(exit)).toBe(true)
+          if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Worktree.CreateFailedError)
+
+          const list = yield* git(test.directory, ["worktree", "list", "--porcelain"])
+          expect(normalize(list)).not.toContain(normalize(info.directory))
+
+          const branch = yield* gitResult(test.directory, ["show-ref", "--verify", "--quiet", `refs/heads/${info.branch}`])
+          expect(branch.exitCode).not.toBe(0)
+        }),
+      { git: true },
+    )
   })
 
   describe("createFromInfo", () => {
@@ -283,7 +321,8 @@ describe("Worktree", () => {
             directory: normalize(directory),
           })
 
-          yield* svc.remove({ directory: target })
+          yield* git(test.directory, ["worktree", "remove", "--force", target])
+          yield* git(test.directory, ["branch", "-D", branch])
         }),
       { git: true },
     )
@@ -296,8 +335,43 @@ describe("Worktree", () => {
         Effect.gen(function* () {
           const test = yield* TestInstance
           const svc = yield* Worktree.Service
-          const ok = yield* svc.remove({ directory: path.join(test.directory, "does-not-exist") })
-          expect(ok).toBe(true)
+          const info = yield* svc.makeWorktreeInfo({ name: "does-not-exist" })
+          const ok = yield* svc.remove({ directory: info.directory })
+          expect(ok).toEqual({ removed: true, cleanupDeferred: false })
+        }),
+      { git: true },
+    )
+
+    it.instance(
+      "rejects a path outside the OpenCode worktree root",
+      () =>
+        Effect.gen(function* () {
+          const test = yield* TestInstance
+          const svc = yield* Worktree.Service
+          const exit = yield* Effect.exit(svc.remove({ directory: path.join(test.directory, "unsafe") }))
+
+          expect(Exit.isFailure(exit)).toBe(true)
+          if (Exit.isFailure(exit)) {
+            const error = Cause.squash(exit.cause)
+            expect(error).toBeInstanceOf(Worktree.RemoveFailedError)
+          }
+        }),
+      { git: true },
+    )
+
+    it.instance(
+      "rejects removing the primary workspace",
+      () =>
+        Effect.gen(function* () {
+          const test = yield* TestInstance
+          const svc = yield* Worktree.Service
+          const exit = yield* Effect.exit(svc.remove({ directory: test.directory }))
+
+          expect(Exit.isFailure(exit)).toBe(true)
+          if (Exit.isFailure(exit)) {
+            const error = Cause.squash(exit.cause)
+            expect(error).toBeInstanceOf(Worktree.RemoveFailedError)
+          }
         }),
       { git: true },
     )

--- a/packages/opencode/test/server/httpapi-workspace.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace.test.ts
@@ -108,6 +108,32 @@ function listedAdapter(directory: string, type: string): WorkspaceAdapter {
   }
 }
 
+function removeFailingAdapter(directory: string): WorkspaceAdapter {
+  return {
+    name: "Remove Failing Test",
+    description: "Fail when removing a local test workspace",
+    configure(info) {
+      return {
+        ...info,
+        name: "remove-failing-test",
+        directory,
+      }
+    },
+    async create() {
+      await mkdir(directory, { recursive: true })
+    },
+    async remove() {
+      throw new Error("simulated remove failure")
+    },
+    target() {
+      return {
+        type: "local" as const,
+        directory,
+      }
+    },
+  }
+}
+
 function missingAdapterContext(): never {
   throw new Error("missing workspace adapter context")
 }
@@ -240,6 +266,30 @@ describe("workspace HttpApi", () => {
       const listed = yield* request(WorkspacePaths.list, dir)
       expect(listed.status).toBe(200)
       expect(yield* listed.json).toEqual([])
+    }),
+  )
+
+  it.live("keeps workspace record when adapter remove fails", () =>
+    Effect.gen(function* () {
+      Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.use.fromDirectory(dir)
+      registerAdapter(project.project.id, "remove-failing-test", removeFailingAdapter(path.join(dir, ".workspace")))
+
+      const created = yield* request(WorkspacePaths.list, dir, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "remove-failing-test", branch: null }),
+      })
+      expect(created.status).toBe(200)
+      const workspace = (yield* created.json) as Workspace.Info
+
+      const removed = yield* request(WorkspacePaths.remove.replace(":id", workspace.id), dir, { method: "DELETE" })
+      expect(removed.status).toBe(400)
+
+      const listed = yield* request(WorkspacePaths.list, dir)
+      expect(listed.status).toBe(200)
+      expect((yield* listed.json) as Workspace.Info[]).toEqual([expect.objectContaining({ id: workspace.id })])
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Fixes part of #29033

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR hardens part of the Windows New Workspace / git worktree lifecycle described in #29033.

It does not claim to fix the native `STATUS_STACK_BUFFER_OVERRUN` crash itself. Instead, it reduces the worktree lifecycle failure cascade around stale workspace records, ghost branches, leftover directories, reset/delete failures, and path canonicalization mismatches.

Main changes:

- Dispose the target instance before removing a worktree.
- Treat Windows `EBUSY` / `EPERM` / `ENOTEMPTY` cleanup failures as deferred physical cleanup after git registry removal.
- Preserve workspace records when adapter removal fails instead of pretending the workspace was removed.
- Roll back created worktrees/branches when sandbox persistence fails.
- Reject unsafe remove targets such as the primary worktree, external paths, and non-`opencode/*` branches.
- Canonicalize reset paths through git top-level resolution, including Windows drive-letter and 8.3 path handling.
- Map workspace remove domain errors to HTTP 400.
- Expose existing reset/delete workspace actions for the active sandbox in the command palette.

### How did you verify your code works?

Tested locally on Windows.

- `bun test test/project/worktree.test.ts test/project/worktree-remove.test.ts test/project/project.test.ts test/server/httpapi-workspace.test.ts --timeout 30000`
  - 68 pass / 3 skip / 0 fail

- `bun test src/pages/layout/helpers.test.ts`
  - 20 pass / 0 fail

- `bun turbo typecheck`
  - 21 packages / 0 fail

### Screenshots / recordings

N/A. The UI-facing change only exposes existing workspace reset/delete actions in the command palette; there is no visual redesign.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR