### PR TITLE
fix(openai): preserve websocket idle state

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -362,6 +362,10 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
       for (const websocketFetch of websocketFetches) websocketFetch.close()
       websocketFetches.length = 0
     },
+    async event(input) {
+      if (input.event.type !== "session.deleted") return
+      for (const websocketFetch of websocketFetches) websocketFetch.remove(input.event.properties.info.id)
+    },
     provider: {
       id: "openai",
       async models(provider, ctx) {

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -202,7 +202,16 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     pool.clear()
   }
 
-  return Object.assign(websocketFetch, { close })
+  function remove(sessionID: string) {
+    const key = `${sessionID}:conversation`
+    const entry = pool.get(key)
+    if (!entry) return
+    log.debug("websocket pool remove", { key })
+    invalidate(entry)
+    pool.delete(key)
+  }
+
+  return Object.assign(websocketFetch, { close, remove })
 }
 
 function connectionLimitError(event: Record<string, unknown>) {

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -91,7 +91,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     }
     if (entry.busy) {
       log.debug("http fallback", { key, reason: "busy" })
-      return httpFetch(input, httpInit)
+      return fallbackFetch(input, httpInit, entry)
     }
 
     entry.busy = true
@@ -228,8 +228,15 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
           return response
         }
 
-        const reader = response.body.getReader()
-        return new Response(
+        const reader = (() => {
+          try {
+            return response.body.getReader()
+          } catch (error) {
+            release()
+            throw error
+          }
+        })()
+        const wrapped = new Response(
           new ReadableStream({
             pull(controller) {
               return reader.read().then(
@@ -254,6 +261,12 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
           }),
           response,
         )
+        Object.defineProperties(wrapped, {
+          redirected: { value: response.redirected },
+          type: { value: response.type },
+          url: { value: response.url },
+        })
+        return wrapped
       },
       (error) => {
         release()

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -78,6 +78,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     pool.set(key, entry)
 
     if (entry.fallback) {
+      entry.lastUsedAt = Date.now()
       log.debug("http fallback", { key, reason: "fallback_active" })
       return httpFetch(input, httpInit)
     }
@@ -121,6 +122,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         onConnectionInvalid: (error) => {
           log.warn("websocket invalidated", { key, error: error.message })
           entry.busy = false
+          entry.lastUsedAt = Date.now()
           if (!entry.fallback) recordStreamFailure(entry)
           invalidate(entry)
           resolveFirstEvent(false)

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -23,7 +23,6 @@ interface PoolEntry {
   lastUsedAt: number
   busy: boolean
   fallback: boolean
-  activeFallbacks: number
   streamFailures: number
 }
 
@@ -75,23 +74,16 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     }
     const key = `${sessionID}:conversation`
 
-    const entry = pool.get(key) ?? {
-      lastUsedAt: Date.now(),
-      busy: false,
-      fallback: false,
-      activeFallbacks: 0,
-      streamFailures: 0,
-    }
+    const entry = pool.get(key) ?? { lastUsedAt: Date.now(), busy: false, fallback: false, streamFailures: 0 }
     pool.set(key, entry)
 
     if (entry.fallback) {
-      entry.lastUsedAt = Date.now()
       log.debug("http fallback", { key, reason: "fallback_active" })
-      return fallbackFetch(input, httpInit, entry)
+      return httpFetch(input, httpInit)
     }
     if (entry.busy) {
       log.debug("http fallback", { key, reason: "busy" })
-      return fallbackFetch(input, httpInit, entry)
+      return httpFetch(input, httpInit)
     }
 
     entry.busy = true
@@ -159,7 +151,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
       }
       if (!entry.fallback) return response
       log.debug("http fallback", { key, reason: "websocket_retries_exhausted" })
-      return fallbackFetch(input, httpInit, entry)
+      return httpFetch(input, httpInit)
     } catch (error) {
       entry.busy = false
       entry.lastUsedAt = Date.now()
@@ -176,7 +168,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         fallback: entry.fallback ? "http" : undefined,
       })
       invalidate(entry)
-      if (entry.fallback) return fallbackFetch(input, httpInit, entry)
+      if (entry.fallback) return httpFetch(input, httpInit)
       return failedResponse(
         new ProviderError.ResponseStreamError(error instanceof Error ? error.message : String(error), {
           cause: error,
@@ -195,7 +187,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     const now = Date.now()
     for (const [key, entry] of pool) {
       if (entry.busy) continue
-      if (entry.activeFallbacks) continue
+      if (entry.fallback) continue
       if (now - entry.lastUsedAt < idleTimeout) continue
       log.debug("websocket idle prune", { key })
       invalidate(entry)
@@ -208,71 +200,6 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     clearInterval(pruneTimer)
     for (const entry of pool.values()) invalidate(entry)
     pool.clear()
-  }
-
-  function fallbackFetch(input: RequestInfo | URL, init: RequestInit | undefined, entry: PoolEntry) {
-    entry.activeFallbacks++
-    let active = true
-
-    function release() {
-      if (!active) return
-      active = false
-      entry.activeFallbacks--
-      entry.lastUsedAt = Date.now()
-    }
-
-    return httpFetch(input, init).then(
-      (response) => {
-        if (!response.body) {
-          release()
-          return response
-        }
-
-        const reader = (() => {
-          try {
-            return response.body.getReader()
-          } catch (error) {
-            release()
-            throw error
-          }
-        })()
-        const wrapped = new Response(
-          new ReadableStream({
-            pull(controller) {
-              return reader.read().then(
-                (result) => {
-                  if (!result.done) {
-                    controller.enqueue(result.value)
-                    return
-                  }
-                  release()
-                  controller.close()
-                },
-                (error) => {
-                  release()
-                  throw error
-                },
-              )
-            },
-            cancel(reason) {
-              release()
-              return reader.cancel(reason)
-            },
-          }),
-          response,
-        )
-        Object.defineProperties(wrapped, {
-          redirected: { value: response.redirected },
-          type: { value: response.type },
-          url: { value: response.url },
-        })
-        return wrapped
-      },
-      (error) => {
-        release()
-        throw error
-      },
-    )
   }
 
   return Object.assign(websocketFetch, { close })

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -23,6 +23,7 @@ interface PoolEntry {
   lastUsedAt: number
   busy: boolean
   fallback: boolean
+  activeFallbacks: number
   streamFailures: number
 }
 
@@ -74,13 +75,19 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     }
     const key = `${sessionID}:conversation`
 
-    const entry = pool.get(key) ?? { lastUsedAt: Date.now(), busy: false, fallback: false, streamFailures: 0 }
+    const entry = pool.get(key) ?? {
+      lastUsedAt: Date.now(),
+      busy: false,
+      fallback: false,
+      activeFallbacks: 0,
+      streamFailures: 0,
+    }
     pool.set(key, entry)
 
     if (entry.fallback) {
       entry.lastUsedAt = Date.now()
       log.debug("http fallback", { key, reason: "fallback_active" })
-      return httpFetch(input, httpInit)
+      return fallbackFetch(input, httpInit, entry)
     }
     if (entry.busy) {
       log.debug("http fallback", { key, reason: "busy" })
@@ -152,7 +159,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
       }
       if (!entry.fallback) return response
       log.debug("http fallback", { key, reason: "websocket_retries_exhausted" })
-      return httpFetch(input, httpInit)
+      return fallbackFetch(input, httpInit, entry)
     } catch (error) {
       entry.busy = false
       entry.lastUsedAt = Date.now()
@@ -169,7 +176,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         fallback: entry.fallback ? "http" : undefined,
       })
       invalidate(entry)
-      if (entry.fallback) return httpFetch(input, httpInit)
+      if (entry.fallback) return fallbackFetch(input, httpInit, entry)
       return failedResponse(
         new ProviderError.ResponseStreamError(error instanceof Error ? error.message : String(error), {
           cause: error,
@@ -188,6 +195,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     const now = Date.now()
     for (const [key, entry] of pool) {
       if (entry.busy) continue
+      if (entry.activeFallbacks) continue
       if (now - entry.lastUsedAt < idleTimeout) continue
       log.debug("websocket idle prune", { key })
       invalidate(entry)
@@ -200,6 +208,58 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     clearInterval(pruneTimer)
     for (const entry of pool.values()) invalidate(entry)
     pool.clear()
+  }
+
+  function fallbackFetch(input: RequestInfo | URL, init: RequestInit | undefined, entry: PoolEntry) {
+    entry.activeFallbacks++
+    let active = true
+
+    function release() {
+      if (!active) return
+      active = false
+      entry.activeFallbacks--
+      entry.lastUsedAt = Date.now()
+    }
+
+    return httpFetch(input, init).then(
+      (response) => {
+        if (!response.body) {
+          release()
+          return response
+        }
+
+        const reader = response.body.getReader()
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              return reader.read().then(
+                (result) => {
+                  if (!result.done) {
+                    controller.enqueue(result.value)
+                    return
+                  }
+                  release()
+                  controller.close()
+                },
+                (error) => {
+                  release()
+                  throw error
+                },
+              )
+            },
+            cancel(reason) {
+              release()
+              return reader.cancel(reason)
+            },
+          }),
+          response,
+        )
+      },
+      (error) => {
+        release()
+        throw error
+      },
+    )
   }
 
   return Object.assign(websocketFetch, { close })

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -232,6 +232,26 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
+  test("removes HTTP fallback when its session is deleted", async () => {
+    let websocketAttempts = 0
+    await using server = await createRejectingWebSocketServer(() => websocketAttempts++)
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      connectTimeout: 100,
+      streamRetries: 0,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    expect(await first.text()).toBe("http")
+    fetch.remove("session-1")
+    const second = await fetch(server.url, streamRequest())
+
+    expect(await second.text()).toBe("http")
+    expect(websocketAttempts).toBe(2)
+    expect(server.httpRequests).toHaveLength(2)
+    fetch.close()
+  })
+
   test("prunes idle websocket connections after completed responses", async () => {
     let connections = 0
     let closed = 0

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -300,6 +300,66 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
+  test("keeps HTTP fallback active while a busy-lane response body streams", async () => {
+    let connections = 0
+    let httpRequests = 0
+    let failWebSocket = () => {}
+    const http = await createHttpServer((_request, response) => {
+      httpRequests += 1
+      if (httpRequests > 1) {
+        response.writeHead(200, { "content-type": "text/plain" })
+        response.end("http")
+        return
+      }
+      response.writeHead(200, { "content-type": "text/plain" })
+      response.write("started")
+    })
+    const sockets = new WebSocketServer({ server: http.server })
+    sockets.on("connection", (socket) => {
+      connections += 1
+      socket.once("message", () => {
+        socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
+        failWebSocket = () => socket.terminate()
+      })
+    })
+    await using server = websocketServerHandle(sockets, http)
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      idleTimeout: 20,
+      streamRetries: 0,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    const firstText = first.text()
+    const second = await fetch(server.url, streamRequest())
+    failWebSocket()
+    expect((await readTextError(firstText)).message).toContain("WebSocket closed before response.completed")
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const third = await fetch(server.url, streamRequest())
+
+    expect(await third.text()).toBe("http")
+    expect(connections).toBe(1)
+    await second.body!.cancel()
+    fetch.close()
+  })
+
+  test("preserves HTTP fallback response metadata", async () => {
+    await using server = await createRejectingWebSocketServer(() => {})
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      streamRetries: 0,
+    })
+
+    const response = await fetch(server.url, streamRequest())
+
+    expect(response.url).toBe(server.url)
+    expect(response.redirected).toBe(false)
+    expect(response.type).toBe("default")
+    expect(await response.text()).toBe("http")
+    fetch.close()
+  })
+
   test("prunes idle websocket connections after completed responses", async () => {
     let connections = 0
     let closed = 0

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -493,14 +493,14 @@ describe("plugin.openai.ws-pool", () => {
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
-      idleTimeout: 200,
+      idleTimeout: 500,
       streamRetries: 1,
     })
 
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 250))
     const first = await fetch(server.url, streamRequest())
     expect((await readTextError(first.text())).message).toContain("idle timeout waiting for websocket")
-    await new Promise((resolve) => setTimeout(resolve, 130))
+    await new Promise((resolve) => setTimeout(resolve, 300))
 
     const second = await fetch(server.url, streamRequest())
 

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -232,6 +232,56 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
+  test("keeps HTTP fallback active while requests continue", async () => {
+    let websocketAttempts = 0
+    await using server = await createRejectingWebSocketServer(() => websocketAttempts++)
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      connectTimeout: 100,
+      idleTimeout: 200,
+      streamRetries: 0,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    expect(await first.text()).toBe("http")
+    await new Promise((resolve) => setTimeout(resolve, 130))
+    const second = await fetch(server.url, streamRequest())
+    expect(await second.text()).toBe("http")
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    const third = await fetch(server.url, streamRequest())
+
+    expect(await third.text()).toBe("http")
+    expect(websocketAttempts).toBe(1)
+    expect(server.httpRequests).toHaveLength(3)
+    fetch.close()
+  })
+
+  test("prunes idle websocket connections after completed responses", async () => {
+    let connections = 0
+    let closed = 0
+    await using server = await createWebSocketServer((socket) => {
+      connections += 1
+      socket.once("close", () => closed++)
+      socket.once("message", () => {
+        socket.send(JSON.stringify({ type: "response.completed", response: { id: `resp_${connections}` } }))
+      })
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      idleTimeout: 20,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    expect(await first.text()).toContain("data: [DONE]")
+    await waitFor(() => closed === 1, "idle websocket was not pruned")
+
+    const second = await fetch(server.url, streamRequest())
+
+    expect(await second.text()).toContain("data: [DONE]")
+    expect(connections).toBe(2)
+    fetch.close()
+  })
+
   test("invalidates but does not reuse a socket after terminal failure frames", async () => {
     let connections = 0
     await using server = await createWebSocketServer((socket) => {
@@ -456,6 +506,31 @@ describe("plugin.openai.ws-pool", () => {
     expect(await third.text()).toBe("http")
     expect(connections).toBe(2)
     expect(server.httpRequests).toHaveLength(2)
+    fetch.close()
+  })
+
+  test("keeps websocket retry state until the failed stream becomes idle", async () => {
+    let connections = 0
+    await using server = await createWebSocketServer((socket) => {
+      connections += 1
+      socket.once("message", () => {})
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      idleTimeout: 200,
+      streamRetries: 1,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("idle timeout waiting for websocket")
+    await new Promise((resolve) => setTimeout(resolve, 130))
+
+    const second = await fetch(server.url, streamRequest())
+
+    expect(await second.text()).toBe("http")
+    expect(connections).toBe(2)
+    expect(server.httpRequests).toHaveLength(1)
     fetch.close()
   })
 

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -252,6 +252,34 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
+  test("terminates active websocket connections when their session is deleted", async () => {
+    let connections = 0
+    await using server = await createWebSocketServer((socket) => {
+      connections += 1
+      socket.once("message", () => {
+        if (connections === 1) {
+          socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
+          return
+        }
+        socket.send(JSON.stringify({ type: "response.completed", response: { id: "resp_after_remove" } }))
+      })
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    const firstText = first.text()
+    fetch.remove("session-1")
+    expect((await readTextError(firstText)).message).toContain("WebSocket closed before response.completed")
+
+    const second = await fetch(server.url, streamRequest())
+
+    expect(await second.text()).toContain("data: [DONE]")
+    expect(connections).toBe(2)
+    fetch.close()
+  })
+
   test("prunes idle websocket connections after completed responses", async () => {
     let connections = 0
     let closed = 0

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { EventEmitter } from "node:events"
-import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http"
+import { createServer, type IncomingMessage, type Server as HttpServer } from "node:http"
 import net, { type AddressInfo, type Socket } from "node:net"
 import WebSocket, { WebSocketServer } from "ws"
 import { APICallError } from "ai"
@@ -211,7 +211,7 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
-  test("prunes HTTP fallback after its idle timeout", async () => {
+  test("keeps HTTP fallback active after its idle timeout", async () => {
     let websocketAttempts = 0
     await using server = await createRejectingWebSocketServer(() => websocketAttempts++)
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
@@ -227,136 +227,8 @@ describe("plugin.openai.ws-pool", () => {
     const second = await fetch(server.url, streamRequest())
 
     expect(await second.text()).toBe("http")
-    expect(websocketAttempts).toBe(2)
+    expect(websocketAttempts).toBe(1)
     expect(server.httpRequests).toHaveLength(2)
-    fetch.close()
-  })
-
-  test("keeps HTTP fallback active while requests continue", async () => {
-    let websocketAttempts = 0
-    await using server = await createRejectingWebSocketServer(() => websocketAttempts++)
-    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url,
-      connectTimeout: 100,
-      idleTimeout: 200,
-      streamRetries: 0,
-    })
-
-    const first = await fetch(server.url, streamRequest())
-    expect(await first.text()).toBe("http")
-    await new Promise((resolve) => setTimeout(resolve, 130))
-    const second = await fetch(server.url, streamRequest())
-    expect(await second.text()).toBe("http")
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    const third = await fetch(server.url, streamRequest())
-
-    expect(await third.text()).toBe("http")
-    expect(websocketAttempts).toBe(1)
-    expect(server.httpRequests).toHaveLength(3)
-    fetch.close()
-  })
-
-  test("keeps HTTP fallback active while a response body streams", async () => {
-    let websocketAttempts = 0
-    let httpRequests = 0
-    const http = await createHttpServer((_request, response) => {
-      httpRequests += 1
-      if (httpRequests > 1) {
-        response.writeHead(200, { "content-type": "text/plain" })
-        response.end("http")
-        return
-      }
-      response.writeHead(200, { "content-type": "text/plain" })
-      response.write("started")
-    })
-    const sockets = new WebSocketServer({
-      server: http.server,
-      verifyClient(_info, callback) {
-        websocketAttempts += 1
-        callback(false, 401, "denied")
-      },
-    })
-    await using server = websocketServerHandle(sockets, http)
-    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url,
-      connectTimeout: 100,
-      idleTimeout: 20,
-      streamRetries: 0,
-    })
-
-    const first = await fetch(server.url, streamRequest())
-    await new Promise((resolve) => setTimeout(resolve, 50))
-    const second = await fetch(server.url, streamRequest())
-
-    expect(await second.text()).toBe("http")
-    expect(websocketAttempts).toBe(1)
-    await first.body!.cancel()
-    await new Promise((resolve) => setTimeout(resolve, 50))
-
-    const third = await fetch(server.url, streamRequest())
-
-    expect(await third.text()).toBe("http")
-    expect(websocketAttempts).toBe(2)
-    fetch.close()
-  })
-
-  test("keeps HTTP fallback active while a busy-lane response body streams", async () => {
-    let connections = 0
-    let httpRequests = 0
-    let failWebSocket = () => {}
-    const http = await createHttpServer((_request, response) => {
-      httpRequests += 1
-      if (httpRequests > 1) {
-        response.writeHead(200, { "content-type": "text/plain" })
-        response.end("http")
-        return
-      }
-      response.writeHead(200, { "content-type": "text/plain" })
-      response.write("started")
-    })
-    const sockets = new WebSocketServer({ server: http.server })
-    sockets.on("connection", (socket) => {
-      connections += 1
-      socket.once("message", () => {
-        socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
-        failWebSocket = () => socket.terminate()
-      })
-    })
-    await using server = websocketServerHandle(sockets, http)
-    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url,
-      idleTimeout: 20,
-      streamRetries: 0,
-    })
-
-    const first = await fetch(server.url, streamRequest())
-    const firstText = first.text()
-    const second = await fetch(server.url, streamRequest())
-    failWebSocket()
-    expect((await readTextError(firstText)).message).toContain("WebSocket closed before response.completed")
-    await new Promise((resolve) => setTimeout(resolve, 50))
-
-    const third = await fetch(server.url, streamRequest())
-
-    expect(await third.text()).toBe("http")
-    expect(connections).toBe(1)
-    await second.body!.cancel()
-    fetch.close()
-  })
-
-  test("preserves HTTP fallback response metadata", async () => {
-    await using server = await createRejectingWebSocketServer(() => {})
-    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url,
-      streamRetries: 0,
-    })
-
-    const response = await fetch(server.url, streamRequest())
-
-    expect(response.url).toBe(server.url)
-    expect(response.redirected).toBe(false)
-    expect(response.type).toBe("default")
-    expect(await response.text()).toBe("http")
     fetch.close()
   })
 
@@ -912,16 +784,12 @@ async function createRejectingWebSocketServer(onAttempt: () => void) {
   return websocketServerHandle(server, http)
 }
 
-async function createHttpServer(
-  respond: (request: IncomingMessage, response: ServerResponse) => void = (_request, response) => {
-    response.writeHead(200, { "content-type": "text/plain" })
-    response.end("http")
-  },
-) {
+async function createHttpServer() {
   const httpRequests: IncomingMessage[] = []
   const server = createServer((request, response) => {
     httpRequests.push(request)
-    respond(request, response)
+    response.writeHead(200, { "content-type": "text/plain" })
+    response.end("http")
   })
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
   const address = server.address() as AddressInfo

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { EventEmitter } from "node:events"
-import { createServer, type IncomingMessage, type Server as HttpServer } from "node:http"
+import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http"
 import net, { type AddressInfo, type Socket } from "node:net"
 import WebSocket, { WebSocketServer } from "ws"
 import { APICallError } from "ai"
@@ -253,6 +253,50 @@ describe("plugin.openai.ws-pool", () => {
     expect(await third.text()).toBe("http")
     expect(websocketAttempts).toBe(1)
     expect(server.httpRequests).toHaveLength(3)
+    fetch.close()
+  })
+
+  test("keeps HTTP fallback active while a response body streams", async () => {
+    let websocketAttempts = 0
+    let httpRequests = 0
+    const http = await createHttpServer((_request, response) => {
+      httpRequests += 1
+      if (httpRequests > 1) {
+        response.writeHead(200, { "content-type": "text/plain" })
+        response.end("http")
+        return
+      }
+      response.writeHead(200, { "content-type": "text/plain" })
+      response.write("started")
+    })
+    const sockets = new WebSocketServer({
+      server: http.server,
+      verifyClient(_info, callback) {
+        websocketAttempts += 1
+        callback(false, 401, "denied")
+      },
+    })
+    await using server = websocketServerHandle(sockets, http)
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      connectTimeout: 100,
+      idleTimeout: 20,
+      streamRetries: 0,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const second = await fetch(server.url, streamRequest())
+
+    expect(await second.text()).toBe("http")
+    expect(websocketAttempts).toBe(1)
+    await first.body!.cancel()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const third = await fetch(server.url, streamRequest())
+
+    expect(await third.text()).toBe("http")
+    expect(websocketAttempts).toBe(2)
     fetch.close()
   })
 
@@ -808,12 +852,16 @@ async function createRejectingWebSocketServer(onAttempt: () => void) {
   return websocketServerHandle(server, http)
 }
 
-async function createHttpServer() {
+async function createHttpServer(
+  respond: (request: IncomingMessage, response: ServerResponse) => void = (_request, response) => {
+    response.writeHead(200, { "content-type": "text/plain" })
+    response.end("http")
+  },
+) {
   const httpRequests: IncomingMessage[] = []
   const server = createServer((request, response) => {
     httpRequests.push(request)
-    response.writeHead(200, { "content-type": "text/plain" })
-    response.end("http")
+    respond(request, response)
   })
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
   const address = server.address() as AddressInfo


### PR DESCRIPTION
## Summary
- refresh websocket pool inactivity state when a failed stream is released so retry metadata is not pruned immediately
- keep HTTP fallback session-sticky after websocket retries are exhausted, matching Codex CLI fallback semantics
- remove retained websocket lane state when opencode publishes `session.deleted`, matching Codex session ownership without leaking failed-session entries
- terminate active websocket lanes when their owning session is deleted
- continue pruning healthy inactive websocket entries and rotating aged sockets
- cover retry-state retention, sticky fallback, deleted-session cleanup, active socket deletion, and idle healthy socket pruning

## Testing
- `bun test test/plugin/openai-ws.test.ts test/plugin/codex.test.ts --timeout 30000`
- `bun test test/plugin/openai-ws.test.ts --timeout 30000 --rerun-each 50`
- `bun test test/plugin/openai-ws.test.ts --timeout 30000 --rerun-each 20` after session cleanup wiring
- `git diff --check origin/dev...HEAD`