### PR TITLE
fix(app): inject OPENCODE_VERSION into web UI bundle at build time

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -121,7 +121,7 @@ const clearAuthToken = () => {
 
 const platform: Platform = {
   platform: "web",
-  version: pkg.version,
+  version: import.meta.env.VITE_OPENCODE_VERSION || pkg.version,
   openLink,
   back,
   forward,

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -2,6 +2,7 @@ interface ImportMetaEnv {
   readonly VITE_OPENCODE_SERVER_HOST: string
   readonly VITE_OPENCODE_SERVER_PORT: string
   readonly VITE_OPENCODE_CHANNEL?: "dev" | "beta" | "prod"
+  readonly VITE_OPENCODE_VERSION: string
 
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_SENTRY_ENVIRONMENT?: string

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -12,6 +12,8 @@ const channel = (() => {
   return "dev"
 })()
 
+const version = process.env.OPENCODE_VERSION ?? ""
+
 /**
  * @type {import("vite").PluginOption}
  */
@@ -27,6 +29,7 @@ export default [
         },
         define: {
           "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
+          "import.meta.env.VITE_OPENCODE_VERSION": JSON.stringify(version),
         },
         worker: {
           format: "es",


### PR DESCRIPTION
### Issue for this PR

Closes #24286

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After upgrading OpenCode via CLI, the web UI served by `opencode web` shows a stale/older version while the CLI binary reports the correct version. This happens because the web UI bundle embeds `package.json`'s version at build time, which lags behind when `OPENCODE_VERSION` is injected differently into the CLI binary.

This fix:
- Reads `OPENCODE_VERSION` from the environment at app bundle build time (matching how `OPENCODE_CHANNEL` is already handled)
- Injects it as `VITE_OPENCODE_VERSION` via Vite's `define` option
- Falls back to `package.json` version when the env var is not set (e.g. local dev)

### How did you verify your code works?

- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app test:unit`
- For manual verification: build with a known version via `OPENCODE_VERSION=1.14.24 bun run --cwd packages/app build` and confirm the version string appears in the JS bundle.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
