### PR TITLE
docs(ecosystem): add opencode-mempalace-persistence to plugins table

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -32,6 +32,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations     |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                 |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                          |
+| [opencode-mempalace-persistence](https://github.com/geco/opencode-mempalace-persistence)           | Persist conversations to MemPalace in real-time — vector DB + Knowledge Graph, zero cron           |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                            |
 | [opencode-morph-plugin](https://github.com/morphllm/opencode-morph-plugin)                         | Fast Apply editing, WarpGrep codebase search, and context compaction via Morph                     |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |


### PR DESCRIPTION
### Issue for this PR

Closes #27752
Related: #27710

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-mempalace-persistence](https://github.com/geco/opencode-mempalace-persistence) to the ecosystem plugins table. The plugin persists conversations to MemPalace (local vector DB) in real-time. Key features:

- **Auto-inject memory** — uses `experimental.chat.messages.transform` to inject identity + relevant MemPalace memories into every prompt. Zero model discipline required.
- **Real-time persistence** — saves every conversation turn via `chat.message` + `session.idle` hooks. Async mining, never blocks the UI.
- **Delta-only sync** — only processes new messages since last sync. No duplicates.
- **Knowledge Graph** — model records structured facts via MCP tools per AGENTS.md.
- **Flat export** — no hardcoded wings. Sessions mined with `--mode convos`.
- **Config** — `autoInjectContext` in `~/.mempalace/plugin-config.json`.

Published on npm as `opencode-mempalace-persistence` (~120 lines TypeScript, fully open source).

### How did you verify your code works?

Single-line table addition. Verified the markdown renders correctly in the existing table format.

### Screenshots / recordings

N/A (documentation-only change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR