### PR TITLE
fix(tui): list only root sessions in session picker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -122,10 +122,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       hydratingSessions.get(sessionID)?.parts.add(partID)
     }
 
-    function sessionListQuery(): { scope?: "project"; path?: string } {
-      if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
-      if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
+    function sessionListQuery(): { scope?: "project"; path?: string; roots: true } {
+      if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project", roots: true }
+      if (!project.data.instance.path.worktree || !project.data.instance.path.directory) {
+        return { scope: "project", roots: true }
+      }
       return {
+        roots: true,
         path: path
           .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)
           .replaceAll("\\", "/"),

--- a/packages/opencode/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/opencode/test/cli/cmd/tui/sync.test.tsx
@@ -30,12 +30,16 @@ describe("tui sync", () => {
       expect(kv.get("session_directory_filter_enabled", true)).toBe(true)
       expect(session.at(-1)?.searchParams.get("scope")).toBeNull()
       expect(session.at(-1)?.searchParams.get("path")).toBe("packages/opencode")
+      expect(session.at(-1)?.searchParams.get("roots")).toBe("true")
+      expect(sync.session.query().roots).toBe(true)
 
       kv.set("session_directory_filter_enabled", false)
       await sync.session.refresh()
 
       expect(session.at(-1)?.searchParams.get("scope")).toBe("project")
       expect(session.at(-1)?.searchParams.get("path")).toBeNull()
+      expect(session.at(-1)?.searchParams.get("roots")).toBe("true")
+      expect(sync.session.query().roots).toBe(true)
     } finally {
       app.renderer.destroy()
       Global.Path.state = previous


### PR DESCRIPTION
### Issue for this PR

Closes #30606

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Requests root sessions directly in the TUI session list query so recent subagent
sessions do not fill the API limit before the client-side filter runs.

### How did you verify your code works?

- `bun test --timeout 30000 test/cli/cmd/tui/sync.test.tsx`
- `bun typecheck`

### Screenshots / recordings

Not included; this changes the session list query, not the UI rendering.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
