### PR TITLE
fix(desktop): validate URL protocol before shell.openExternal

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -136,6 +136,7 @@ export function registerIpcHandlers(deps: Deps) {
   )
 
   ipcMain.on("open-link", (_event: IpcMainEvent, url: string) => {
+    if (!isSafeExternalUrl(url)) return
     void shell.openExternal(url)
   })
 
@@ -209,4 +210,14 @@ export function sendMenuCommand(win: BrowserWindow, id: string) {
 
 export function sendDeepLinks(win: BrowserWindow, urls: string[]) {
   win.webContents.send("deep-link", urls)
+}
+
+const SAFE_PROTOCOLS = new Set(["http:", "https:", "mailto:"])
+
+function isSafeExternalUrl(url: string): boolean {
+  try {
+    return SAFE_PROTOCOLS.has(new URL(url).protocol)
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #30613

### Type of change

- [x] Bug fix

### What does this PR do?

The `open-link` IPC handler called `shell.openExternal(url)` without validating the URL protocol. This allowed arbitrary protocols (`file:`, `javascript:`, `smb:`, `ms-msdt:`, etc.) to be opened via the OS default handler.

The main attack vector is the terminal component where `getHoveredLinkText()` reads URLs from xterm.js and passes them to `openLink()`. LLM output could contain malicious URLs that get opened via Shift+Click.

Added a `isSafeExternalUrl()` check that only allows `http:`, `https:`, and `mailto:` protocols.

### How did you verify your code works?

Verified the `isSafeExternalUrl` function correctly:
- Accepts `https://example.com`, `http://localhost`, `mailto:user@test.com`
- Rejects `file:///etc/passwd`, `javascript:alert(1)`, `smb://attacker/share`, invalid strings

### Screenshots / recordings

N/A - This is a backend/IPC change with no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
