### PR TITLE
fix(core): expose azure openai xhigh efforts

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -782,10 +782,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
       return Object.fromEntries(
-        (GPT5_FAMILY_RE.test(id) && gpt5Version(id) === undefined
-          ? ["minimal", ...WIDELY_SUPPORTED_EFFORTS]
-          : WIDELY_SUPPORTED_EFFORTS
-        ).map((effort) => [
+        openaiReasoningEfforts(id, model.release_date).map((effort) => [
           effort,
           {
             reasoningEffort: effort,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3013,20 +3013,25 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
 
-    for (const id of ["gpt-5-4", "gpt-5-5"]) {
-      test(`${id} does not add minimal effort`, () => {
+    for (const testCase of [
+      { id: "gpt-5-1", efforts: ["none", "low", "medium", "high"] },
+      { id: "gpt-5-4", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5.4", efforts: ["none", "low", "medium", "high", "xhigh"] },
+      { id: "gpt-5-5", efforts: ["none", "low", "medium", "high", "xhigh"] },
+    ]) {
+      test(`${testCase.id} returns supported Azure reasoning efforts`, () => {
         const result = ProviderTransform.variants(
           createMockModel({
-            id,
+            id: testCase.id,
             providerID: "azure",
             api: {
-              id,
+              id: testCase.id,
               url: "https://azure.com",
               npm: "@ai-sdk/azure",
             },
           }),
         )
-        expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+        expect(Object.keys(result)).toEqual(testCase.efforts)
       })
     }
   })


### PR DESCRIPTION
## Summary
- reuse OpenAI reasoning effort mapping for Azure OpenAI models
- expose xhigh for versioned GPT-5 Azure model IDs like gpt-5-4 and gpt-5.4
- cover Azure GPT-5.1/5.4/5.5 effort variants in transform tests

Fixes #24313

## Tests
- bun test test/provider/transform.test.ts