### PR TITLE
fix(openai): disable header timeout for websockets

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -358,6 +358,13 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
   const websocketFetches: Array<ReturnType<typeof OpenAIWebSocketPool.createWebSocketFetch>> = []
 
   return {
+    async config(config) {
+      if (!options.experimentalWebSockets) return
+      config.provider ??= {}
+      config.provider.openai ??= {}
+      config.provider.openai.options ??= {}
+      config.provider.openai.options.headerTimeout ??= false
+    },
     async dispose() {
       for (const websocketFetch of websocketFetches) websocketFetch.close()
       websocketFetches.length = 0

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -358,13 +358,6 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
   const websocketFetches: Array<ReturnType<typeof OpenAIWebSocketPool.createWebSocketFetch>> = []
 
   return {
-    async config(config) {
-      if (!options.experimentalWebSockets) return
-      config.provider ??= {}
-      config.provider.openai ??= {}
-      config.provider.openai.options ??= {}
-      config.provider.openai.options.headerTimeout ??= false
-    },
     async dispose() {
       for (const websocketFetch of websocketFetches) websocketFetch.close()
       websocketFetches.length = 0
@@ -417,7 +410,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
           websocketFetches.push(websocketFetch)
           websocketFetchInstalled = true
         }
-        if (auth.type !== "oauth") return websocketFetch ? { fetch: websocketFetch } : {}
+        if (auth.type !== "oauth") return websocketFetch ? { fetch: websocketFetch, headerTimeout: false } : {}
 
         let refreshPromise:
           | Promise<{
@@ -428,6 +421,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
 
         return {
           apiKey: OAUTH_DUMMY_KEY,
+          ...(websocketFetch ? { headerTimeout: false } : {}),
           async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
             if (init?.headers) {
               if (init.headers instanceof Headers) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1425,7 +1425,7 @@ export const layer = Layer.effect(
             log.error("Provider does not exist in model list " + providerID)
             continue
           }
-          const result = yield* fn(data)
+          const result = yield* fn(providers[providerID] ?? data)
           if (result && (result.autoload || providers[providerID])) {
             if (result.getModel) modelLoaders[providerID] = result.getModel
             if (result.vars) varsLoaders[providerID] = result.vars

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -190,13 +190,13 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         options: ok ? {} : { apiKey: "public" },
       }
     }),
-    openai: () =>
+    openai: (input) =>
       Effect.succeed({
         autoload: false,
         async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
           return sdk.responses(modelID)
         },
-        options: { headerTimeout: OPENAI_HEADER_TIMEOUT_DEFAULT },
+        options: { headerTimeout: input.options.headerTimeout ?? OPENAI_HEADER_TIMEOUT_DEFAULT },
       }),
     xai: () =>
       Effect.succeed({

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -140,6 +140,30 @@ describe("plugin.codex", () => {
     await enabled.dispose?.()
   })
 
+  test("disables the HTTP header timeout when websocket transport is enabled", async () => {
+    const disabled = await CodexAuthPlugin({} as never)
+    const hooks = await CodexAuthPlugin({} as never, { experimentalWebSockets: true })
+    const disabledConfig = {} as Parameters<NonNullable<typeof hooks.config>>[0]
+    const config = {} as Parameters<NonNullable<typeof hooks.config>>[0]
+
+    await disabled.config!(disabledConfig)
+    await hooks.config!(config)
+
+    expect(disabledConfig.provider).toBeUndefined()
+    expect(config.provider?.openai?.options?.headerTimeout).toBe(false)
+  })
+
+  test("preserves explicit header timeout configuration when websocket transport is enabled", async () => {
+    const hooks = await CodexAuthPlugin({} as never, { experimentalWebSockets: true })
+    const config = { provider: { openai: { options: { headerTimeout: 30_000 } } } } as Parameters<
+      NonNullable<typeof hooks.config>
+    >[0]
+
+    await hooks.config!(config)
+
+    expect(config.provider.openai.options.headerTimeout).toBe(30_000)
+  })
+
   test("deduplicates concurrent Codex token refreshes", async () => {
     let auth = {
       type: "oauth" as const,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -137,31 +137,21 @@ describe("plugin.codex", () => {
 
     expect(disabledOptions.fetch).toBeUndefined()
     expect(enabledOptions.fetch).toBeFunction()
+    expect(disabledOptions.headerTimeout).toBeUndefined()
+    expect(enabledOptions.headerTimeout).toBe(false)
     await enabled.dispose?.()
   })
 
-  test("disables the HTTP header timeout when websocket transport is enabled", async () => {
-    const disabled = await CodexAuthPlugin({} as never)
+  test("disables the HTTP header timeout for websocket OAuth transport", async () => {
     const hooks = await CodexAuthPlugin({} as never, { experimentalWebSockets: true })
-    const disabledConfig = {} as Parameters<NonNullable<typeof hooks.config>>[0]
-    const config = {} as Parameters<NonNullable<typeof hooks.config>>[0]
+    const options = await hooks.auth!.loader!(
+      async () => ({ type: "oauth", refresh: "refresh", access: "access", expires: Date.now() + 60_000 }) as never,
+      {} as never,
+    )
 
-    await disabled.config!(disabledConfig)
-    await hooks.config!(config)
-
-    expect(disabledConfig.provider).toBeUndefined()
-    expect(config.provider?.openai?.options?.headerTimeout).toBe(false)
-  })
-
-  test("preserves explicit header timeout configuration when websocket transport is enabled", async () => {
-    const hooks = await CodexAuthPlugin({} as never, { experimentalWebSockets: true })
-    const config = { provider: { openai: { options: { headerTimeout: 30_000 } } } } as Parameters<
-      NonNullable<typeof hooks.config>
-    >[0]
-
-    await hooks.config!(config)
-
-    expect(config.provider.openai.options.headerTimeout).toBe(30_000)
+    expect(options.fetch).toBeFunction()
+    expect(options.headerTimeout).toBe(false)
+    await hooks.dispose?.()
   })
 
   test("deduplicates concurrent Codex token refreshes", async () => {

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -11,7 +11,6 @@ import { Env } from "@/env"
 import { Plugin } from "@/plugin"
 import { Provider } from "@/provider/provider"
 import { ProviderError } from "@/provider/error"
-import { RuntimeFlags } from "@/effect/runtime-flags"
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -168,42 +167,6 @@ it.live("OpenAI API auth gets default headerTimeout", () =>
       { openai: { type: "api", key: "sk-test" } },
     )
   }),
-)
-
-it.live("OpenAI Codex websocket transport disables default headerTimeout", () =>
-  Effect.gen(function* () {
-    yield* withAuthContent(
-      Effect.gen(function* () {
-        yield* provideTmpdirInstance(() =>
-          Effect.gen(function* () {
-            const provider = yield* Provider.Service
-            const openai = yield* provider.getProvider(ProviderV2.ID.openai)
-            expect(openai.options.headerTimeout).toBe(false)
-          }),
-        )
-      }),
-      { openai: { type: "api", key: "sk-test" } },
-    )
-  }).pipe(Effect.provide(RuntimeFlags.layer({ experimentalWebSockets: true }))),
-)
-
-it.live("OpenAI Codex websocket transport preserves configured headerTimeout", () =>
-  Effect.gen(function* () {
-    yield* withAuthContent(
-      Effect.gen(function* () {
-        yield* provideTmpdirInstance(
-          () =>
-            Effect.gen(function* () {
-              const provider = yield* Provider.Service
-              const openai = yield* provider.getProvider(ProviderV2.ID.openai)
-              expect(openai.options.headerTimeout).toBe(30_000)
-            }),
-          { config: { provider: { openai: { options: { headerTimeout: 30_000 } } } } },
-        )
-      }),
-      { openai: { type: "api", key: "sk-test" } },
-    )
-  }).pipe(Effect.provide(RuntimeFlags.layer({ experimentalWebSockets: true }))),
 )
 
 function providerConfig(url: string, options: Record<string, unknown> = {}) {

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -11,6 +11,12 @@ import { Env } from "@/env"
 import { Plugin } from "@/plugin"
 import { Provider } from "@/provider/provider"
 import { ProviderError } from "@/provider/error"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Config } from "@/config/config"
+import { Auth } from "@/auth"
+import { ModelsDev } from "@opencode-ai/core/models-dev"
+import { EventV2Bridge } from "@/event-v2-bridge"
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -19,6 +25,8 @@ afterEach(async () => {
 const it = testEffect(
   Layer.mergeAll(Provider.defaultLayer, Env.defaultLayer, Plugin.defaultLayer, CrossSpawnSpawner.defaultLayer),
 )
+const httpOnly = testEffect(providerLayer({ disableDefaultPlugins: true }))
+const websockets = testEffect(providerLayer({ experimentalWebSockets: true }))
 
 it.live("headerTimeout does not abort delayed SSE body after headers arrive", () =>
   Effect.gen(function* () {
@@ -152,7 +160,7 @@ it.live("OpenAI Codex headerTimeout default can be disabled by config", () =>
   }),
 )
 
-it.live("OpenAI API auth gets default headerTimeout", () =>
+httpOnly.live("OpenAI API auth gets default headerTimeout", () =>
   Effect.gen(function* () {
     yield* withAuthContent(
       Effect.gen(function* () {
@@ -168,6 +176,65 @@ it.live("OpenAI API auth gets default headerTimeout", () =>
     )
   }),
 )
+
+websockets.live("OpenAI Codex websocket transport disables default headerTimeout", () =>
+  Effect.gen(function* () {
+    yield* withAuthContent(
+      Effect.gen(function* () {
+        yield* provideTmpdirInstance(() =>
+          Effect.gen(function* () {
+            const provider = yield* Provider.Service
+            const openai = yield* provider.getProvider(ProviderV2.ID.openai)
+            expect(openai.options.headerTimeout).toBe(false)
+          }),
+        )
+      }),
+      { openai: { type: "api", key: "sk-test" } },
+    )
+  }),
+)
+
+websockets.live("OpenAI Codex websocket transport preserves configured headerTimeout", () =>
+  Effect.gen(function* () {
+    yield* withAuthContent(
+      Effect.gen(function* () {
+        yield* provideTmpdirInstance(
+          () =>
+            Effect.gen(function* () {
+              const provider = yield* Provider.Service
+              const openai = yield* provider.getProvider(ProviderV2.ID.openai)
+              expect(openai.options.headerTimeout).toBe(30_000)
+            }),
+          { config: { provider: { openai: { options: { headerTimeout: 30_000 } } } } },
+        )
+      }),
+      { openai: { type: "api", key: "sk-test" } },
+    )
+  }),
+)
+
+function providerLayer(flags: Partial<RuntimeFlags.Info>) {
+  const runtime = RuntimeFlags.layer(flags)
+  const plugin = Plugin.layer.pipe(
+    Layer.provide(EventV2Bridge.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(runtime),
+  )
+  return Layer.mergeAll(
+    Provider.layer.pipe(
+      Layer.provide(FSUtil.defaultLayer),
+      Layer.provide(Env.defaultLayer),
+      Layer.provide(Config.defaultLayer),
+      Layer.provide(Auth.defaultLayer),
+      Layer.provide(plugin),
+      Layer.provide(ModelsDev.defaultLayer),
+      Layer.provide(runtime),
+    ),
+    Env.defaultLayer,
+    plugin,
+    CrossSpawnSpawner.defaultLayer,
+  )
+}
 
 function providerConfig(url: string, options: Record<string, unknown> = {}) {
   const config = testProviderConfig(url)

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -11,6 +11,7 @@ import { Env } from "@/env"
 import { Plugin } from "@/plugin"
 import { Provider } from "@/provider/provider"
 import { ProviderError } from "@/provider/error"
+import { RuntimeFlags } from "@/effect/runtime-flags"
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -167,6 +168,42 @@ it.live("OpenAI API auth gets default headerTimeout", () =>
       { openai: { type: "api", key: "sk-test" } },
     )
   }),
+)
+
+it.live("OpenAI Codex websocket transport disables default headerTimeout", () =>
+  Effect.gen(function* () {
+    yield* withAuthContent(
+      Effect.gen(function* () {
+        yield* provideTmpdirInstance(() =>
+          Effect.gen(function* () {
+            const provider = yield* Provider.Service
+            const openai = yield* provider.getProvider(ProviderV2.ID.openai)
+            expect(openai.options.headerTimeout).toBe(false)
+          }),
+        )
+      }),
+      { openai: { type: "api", key: "sk-test" } },
+    )
+  }).pipe(Effect.provide(RuntimeFlags.layer({ experimentalWebSockets: true }))),
+)
+
+it.live("OpenAI Codex websocket transport preserves configured headerTimeout", () =>
+  Effect.gen(function* () {
+    yield* withAuthContent(
+      Effect.gen(function* () {
+        yield* provideTmpdirInstance(
+          () =>
+            Effect.gen(function* () {
+              const provider = yield* Provider.Service
+              const openai = yield* provider.getProvider(ProviderV2.ID.openai)
+              expect(openai.options.headerTimeout).toBe(30_000)
+            }),
+          { config: { provider: { openai: { options: { headerTimeout: 30_000 } } } } },
+        )
+      }),
+      { openai: { type: "api", key: "sk-test" } },
+    )
+  }).pipe(Effect.provide(RuntimeFlags.layer({ experimentalWebSockets: true }))),
 )
 
 function providerConfig(url: string, options: Record<string, unknown> = {}) {


### PR DESCRIPTION
## Summary
- disable the HTTP-oriented OpenAI response-header timeout only when the Codex auth loader actually installs a websocket adapter
- preserve the 10 second OpenAI header timeout for HTTP-only providers without a loader-installed websocket adapter
- preserve explicit user-configured `headerTimeout` values
- pass custom provider loaders the active merged provider state so loader-installed options survive built-in defaults
- let websocket transport use its own Codex-aligned controls: 15 second connect timeout and 5 minute idle timeout between events

## Testing
- `bun test test/plugin/codex.test.ts test/plugin/openai-ws.test.ts --timeout 30000`
- `bun test test/plugin/codex.test.ts test/plugin/openai-ws.test.ts --timeout 30000 --rerun-each 20`
- `git diff --check origin/dev...HEAD`

## Notes
- added provider integration fixtures that assert HTTP-only default timeout, websocket timeout disablement, and explicit websocket timeout override after the full provider loader chain
- local collection of `test/provider/header-timeout.test.ts` and `bun typecheck` is blocked in the temporary worktree because its linked dependencies resolve workspace modules against the unrelated original checkout; CI runs against a coherent full checkout