### PR TITLE
feat(config): discover commands from .agents/commands and .claude/commands

### DIFF
--- a/packages/core/src/v1/config/commands.ts
+++ b/packages/core/src/v1/config/commands.ts
@@ -1,0 +1,10 @@
+export * as ConfigCommandsV1 from "./commands"
+
+import { Schema } from "effect"
+
+export const Info = Schema.Struct({
+  paths: Schema.optional(Schema.Array(Schema.String)).annotate({
+    description: "Additional paths to command folders",
+  }),
+})
+export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -16,6 +16,7 @@ import { ConfigProviderV1 } from "./provider"
 import { ConfigReferenceV1 } from "./reference"
 import { ConfigServerV1 } from "./server"
 import { ConfigSkillsV1 } from "./skills"
+import { ConfigCommandsV1 } from "./commands"
 
 export type Layout = ConfigLayoutV1.Layout
 
@@ -42,6 +43,7 @@ export const Info = Schema.Struct({
     description: "Command configuration, see https://opencode.ai/docs/commands",
   }),
   skills: Schema.optional(ConfigSkillsV1.Info).annotate({ description: "Additional skill folder paths" }),
+  commands: Schema.optional(ConfigCommandsV1.Info).annotate({ description: "Additional command folder paths" }),
   reference: Schema.optional(ConfigReferenceV1.Info).annotate({
     description: "Named git or local directory references that can be mentioned as @alias or @alias/path",
   }),

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -2,8 +2,10 @@ export * as ConfigCommand from "./command"
 
 import path from "path"
 import * as Log from "@opencode-ai/core/util/log"
-import { Cause, Exit, Schema } from "effect"
+import { Cause, Effect, Exit, Schema } from "effect"
 import { Glob } from "@opencode-ai/core/util/glob"
+import { Global } from "@opencode-ai/core/global"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { ConfigCommandV1 } from "@opencode-ai/core/v1/config/command"
 import { configEntryNameFromPath } from "./entry-name"
 import { InvalidError } from "@opencode-ai/core/v1/config/error"
@@ -11,7 +13,34 @@ import * as ConfigMarkdown from "./markdown"
 
 const log = Log.create({ service: "config" })
 
+const CLAUDE_EXTERNAL_DIR = ".claude"
+const AGENTS_EXTERNAL_DIR = ".agents"
+const EXTERNAL_COMMAND_PATTERN = "{command,commands}/**/*.md"
+const CUSTOM_PATH_COMMAND_PATTERN = "**/*.md"
+
 const decodeInfo = Schema.decodeUnknownExit(ConfigCommandV1.Info)
+
+async function parseCommandFile(
+  item: string,
+  name: string,
+): Promise<{ name: string; value: ConfigCommandV1.Info } | undefined> {
+  const md = await ConfigMarkdown.parse(item).catch((err) => {
+    log.error("failed to load command", { command: item, err })
+    return undefined
+  })
+  if (!md) return undefined
+
+  const config = {
+    name,
+    ...md.data,
+    template: md.content.trim(),
+  }
+  const parsed = decodeInfo(config, { errors: "all", propertyOrder: "original" })
+  if (Exit.isSuccess(parsed)) {
+    return { name: config.name, value: parsed.value }
+  }
+  throw new InvalidError({ path: item, message: Cause.pretty(parsed.cause) }, { cause: Cause.squash(parsed.cause) })
+}
 
 export async function load(dir: string) {
   const result: Record<string, ConfigCommandV1.Info> = {}
@@ -21,25 +50,74 @@ export async function load(dir: string) {
     dot: true,
     symlink: true,
   })) {
-    const md = await ConfigMarkdown.parse(item).catch((err) => {
-      log.error("failed to load command", { command: item, err })
-      return undefined
-    })
-    if (!md) continue
-
     const name = configEntryNameFromPath(path.relative(dir, item), ["command/", "commands/"])
-
-    const config = {
-      name,
-      ...md.data,
-      template: md.content.trim(),
-    }
-    const parsed = decodeInfo(config, { errors: "all", propertyOrder: "original" })
-    if (Exit.isSuccess(parsed)) {
-      result[config.name] = parsed.value
-      continue
-    }
-    throw new InvalidError({ path: item, message: Cause.pretty(parsed.cause) }, { cause: Cause.squash(parsed.cause) })
+    const parsed = await parseCommandFile(item, name)
+    if (parsed) result[parsed.name] = parsed.value
   }
   return result
 }
+
+const scanDir = Effect.fnUntraced(function* (state: Map<string, string>, root: string, pattern: string) {
+  const matches = yield* Effect.tryPromise({
+    try: () =>
+      Glob.scan(pattern, {
+        cwd: root,
+        absolute: true,
+        dot: true,
+        symlink: true,
+      }),
+    catch: () => [] as string[],
+  })
+  for (const match of matches) {
+    state.set(match, root)
+  }
+})
+
+export const loadExternal = Effect.fnUntraced(function* (
+  fsys: FSUtil.Interface,
+  directory: string,
+  worktree: string,
+  extraPaths: string[] = [],
+) {
+  const matches = new Map<string, string>()
+  const externalDirs = [CLAUDE_EXTERNAL_DIR, AGENTS_EXTERNAL_DIR]
+
+  for (const dir of externalDirs) {
+    const root = path.join(Global.Path.home, dir)
+    if (!(yield* fsys.isDir(root))) continue
+    yield* scanDir(matches, root, EXTERNAL_COMMAND_PATTERN)
+  }
+
+  const upDirs = yield* fsys
+    .up({ targets: externalDirs, start: directory, stop: worktree })
+    .pipe(Effect.catch(() => Effect.succeed([] as string[])))
+  for (const root of upDirs) {
+    yield* scanDir(matches, root, EXTERNAL_COMMAND_PATTERN)
+  }
+
+  for (const item of extraPaths) {
+    const expanded = item.startsWith("~/") ? path.join(Global.Path.home, item.slice(2)) : item
+    const dir = path.isAbsolute(expanded) ? expanded : path.join(directory, expanded)
+    if (!(yield* fsys.isDir(dir))) {
+      log.warn("command path not found", { path: dir })
+      continue
+    }
+    yield* scanDir(matches, dir, CUSTOM_PATH_COMMAND_PATTERN)
+  }
+
+  const result: Record<string, ConfigCommandV1.Info> = {}
+  for (const [item, baseDir] of matches) {
+    const name = configEntryNameFromPath(path.relative(baseDir, item), ["command/", "commands/"])
+    const parsed = yield* Effect.tryPromise({
+      try: () => parseCommandFile(item, name),
+      catch: (err) => {
+        log.error("failed to load external command", { command: item, err })
+        return undefined
+      },
+    })
+    if (parsed) result[parsed.name] = parsed.value
+  }
+
+  log.info("loaded external commands", { count: Object.keys(result).length })
+  return result
+})

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -458,6 +458,10 @@ export const layer = Layer.effect(
           yield* mergePluginOrigins(dir, list)
         }
 
+        const extraCommandPaths = result.commands?.paths ?? []
+        const external = yield* ConfigCommand.loadExternal(fs, ctx.directory, ctx.worktree, extraCommandPaths)
+        result.command = mergeDeep(external, result.command ?? {})
+
         if (process.env.OPENCODE_CONFIG_CONTENT) {
           const source = "OPENCODE_CONFIG_CONTENT"
           const next = yield* loadConfig(process.env.OPENCODE_CONFIG_CONTENT, {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -868,6 +868,103 @@ Nested command template`,
   }),
 )
 
+it.instance("loads commands from .agents/commands", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, ".agents", "commands", "external.md"),
+      `---
+description: External command
+---
+Hello from .agents/commands`,
+    )
+
+    const config = yield* Config.use.get()
+
+    expect(config.command?.["external"]).toEqual({
+      description: "External command",
+      template: "Hello from .agents/commands",
+    })
+  }),
+)
+
+it.instance("loads commands from .claude/commands", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, ".claude", "commands", "claude-cmd.md"),
+      `---
+description: Claude command
+---
+Hello from .claude/commands`,
+    )
+
+    const config = yield* Config.use.get()
+
+    expect(config.command?.["claude-cmd"]).toEqual({
+      description: "Claude command",
+      template: "Hello from .claude/commands",
+    })
+  }),
+)
+
+it.instance(".opencode/command overrides .agents/commands", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, ".agents", "commands", "override.md"),
+      `---
+description: External version
+---
+External template`,
+    )
+
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, ".opencode", "command", "override.md"),
+      `---
+description: Local version
+---
+Local template`,
+    )
+
+    const config = yield* Config.use.get()
+
+    expect(config.command?.["override"]).toEqual({
+      description: "Local version",
+      template: "Local template",
+    })
+  }),
+)
+
+it.instance("loads commands from config.commands.paths", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const customDir = path.join(test.directory, "custom-commands")
+    yield* FSUtil.use.writeWithDirs(
+      path.join(customDir, "custom.md"),
+      `---
+description: Custom path command
+---
+Custom path template`,
+    )
+
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, "opencode.json"),
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        commands: { paths: ["custom-commands"] },
+      }),
+    )
+
+    const config = yield* Config.use.get()
+
+    expect(config.command?.["custom"]).toEqual({
+      description: "Custom path command",
+      template: "Custom path template",
+    })
+  }),
+)
+
 it.instance("updates config and writes to file", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #27972
Closes #14240

### Type of change

- [x] New feature

### What does this PR do?

Discovers slash commands from external directories (`.agents/commands/`, `.claude/commands/`) in addition to the existing `.opencode/command(s)/` paths. Brings command discovery to parity with how skills are already discovered from multiple paths.

Commands placed in `.agents/commands/` or `.claude/commands/` are automatically discovered:

```
.agents/commands/deploy.md   → /deploy
.claude/commands/review.md   → /review
```

Custom paths via `opencode.json`:

```json
{ "commands": { "paths": ["my-team/commands"] } }
```

Discovery precedence (lowest → highest): global `~/.agents/commands/` and `~/.claude/commands/`, then project `.agents/commands/` and `.claude/commands/` (walking up), then `commands.paths` custom folders, then `.opencode/command(s)/` (existing, wins).

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — no errors from changed files
- `bun test test/config/config.test.ts` — 96/96 pass including 4 new tests:
  - `loads commands from .agents/commands`
  - `loads commands from .claude/commands`
  - `.opencode/command overrides .agents/commands`
  - `loads commands from config.commands.paths`
- `bun test test/skill/skill.test.ts` — 16/16 pass, no regression
- Full turbo typecheck passed on push (27 packages, 21/21 successful)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR