### PR TITLE
fix(session): recover when models emit tool calls as plain text

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4,6 +4,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import os from "os"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
+import { ToolCallLeak } from "./tool-call-leak"
 import { Log } from "@opencode-ai/core/util/log"
 import { SessionRevert } from "./revert"
 import { Session } from "./session"
@@ -1288,6 +1289,58 @@ export const layer = Layer.effect(
                 tool: orphan.tool,
                 callID: orphan.callID,
               })
+            }
+            // A model behind an OpenAI-compatible server sometimes emits its
+            // tool call as plain text (server-side parser miss, issue #24316).
+            // The turn looks finished ("stop", no tool parts) even though the
+            // model meant to act. Nudge it to re-issue the call through the
+            // tool-calling mechanism instead of halting; after MAX_ATTEMPTS,
+            // surface an error so the stop is explained. Compaction replays
+            // the prompt as a fresh user message, so the cap applies per
+            // compaction segment.
+            const leakedText = lastAssistantMsg?.parts.findLast((part) => part.type === "text")
+            if (
+              lastAssistant.finish === "stop" &&
+              leakedText?.type === "text" &&
+              ToolCallLeak.detect(leakedText.text)
+            ) {
+              const attempts = ToolCallLeak.countAttempts(msgs)
+              if (attempts < ToolCallLeak.MAX_ATTEMPTS) {
+                yield* slog.info("tool call leaked as text, nudging model", {
+                  messageID: lastAssistant.id,
+                  attempts,
+                })
+                const nudge: SessionV1.User = {
+                  id: MessageID.ascending(),
+                  sessionID,
+                  time: { created: Date.now() },
+                  role: "user",
+                  agent: lastUser.agent,
+                  model: lastUser.model,
+                  format: lastUser.format,
+                }
+                yield* sessions.updateMessage(nudge)
+                yield* sessions.updatePart({
+                  id: PartID.ascending(),
+                  messageID: nudge.id,
+                  sessionID,
+                  type: "text",
+                  text: ToolCallLeak.NUDGE,
+                  synthetic: true,
+                  metadata: { [ToolCallLeak.MARKER]: true },
+                } satisfies SessionV1.Part)
+                continue
+              }
+              yield* slog.warn("tool call leak recovery exhausted", { messageID: lastAssistant.id, attempts })
+              // Persist the error on the leaked assistant message so the
+              // failure survives reloads; the bus event alone is transient.
+              const leakError = new NamedError.Unknown({
+                message:
+                  "The model repeatedly wrote tool calls as plain text instead of using the tool-calling mechanism, so they were not executed. Check your inference server's tool-call parser configuration.",
+              }).toObject()
+              lastAssistant.error = leakError
+              yield* sessions.updateMessage(lastAssistant)
+              yield* events.publish(Session.Event.Error, { sessionID, error: leakError })
             }
             yield* slog.info("exiting loop")
             break

--- a/packages/opencode/src/session/tool-call-leak.ts
+++ b/packages/opencode/src/session/tool-call-leak.ts
@@ -1,0 +1,72 @@
+// Models behind OpenAI-compatible servers (vLLM, llama.cpp) sometimes emit a
+// tool call as plain text: the model drifts from its tool-call format (e.g.
+// `<function_bash>` instead of `<function=bash>`), the server's parser fails
+// to match, and the block streams back as content. The turn finishes with
+// reason "stop" and no tool calls, which would halt the session loop
+// mid-task. `detect` anchors on the end of the text, so prose that mentions
+// these tags mid-text does not fire. A message that ends with example
+// tool-call XML is an accepted false positive; it costs one extra
+// round-trip, capped at MAX_ATTEMPTS.
+// See https://github.com/anomalyco/opencode/issues/24316
+
+// Conservative on purpose: a leak cut off before any closing tag (a bare
+// `<function_x>` block mid-argument) means the stream was truncated, a
+// "length" finish rather than a parser miss. Matching bare openers would
+// fire on prose like "pass it via `<parameter=filePath>`". Both captured
+// real leaks end in a closing tag even when the server ate the opening
+// `<tool_call>`.
+const OPENING = /<tool_call>|<function[=_][\w.-]+>|<parameter=[\w.-]+>/
+const CLOSING_TAIL = /<\/(tool_call|function|parameter)>$/
+
+export const MAX_ATTEMPTS = 2
+export const MARKER = "toolCallLeakRecovery"
+
+export const NUDGE =
+  "Your previous message wrote a tool call as plain text, so it was NOT executed. " +
+  "Do not write tool-call XML or JSON inside message text. " +
+  "Re-issue the intended call now through the tool-calling mechanism with valid syntax."
+
+export function detect(text: string): boolean {
+  const trimmed = text.trimEnd()
+  if (!OPENING.test(trimmed)) return false
+  if (CLOSING_TAIL.test(trimmed)) return true
+  const open = trimmed.lastIndexOf("<tool_call>")
+  return open !== -1 && !trimmed.includes("</tool_call>", open)
+}
+
+interface PartLike {
+  type: string
+  synthetic?: boolean
+  metadata?: Record<string, any>
+}
+
+interface MessageLike {
+  info: { role: string }
+  parts: ReadonlyArray<PartLike>
+}
+
+export function isNudge(part: PartLike): boolean {
+  return part.type === "text" && part.synthetic === true && part.metadata?.[MARKER] === true
+}
+
+// Recovery attempts since the last real user prompt, derived from history so
+// the cap survives restarts. Walks backward: each trailing user message made
+// up entirely of nudge parts counts as one attempt. Any other user message
+// (real text, file attachments, or no text at all) stops the walk; real user
+// input resets the budget.
+export function countAttempts(msgs: ReadonlyArray<MessageLike>): number {
+  let count = 0
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const msg = msgs[i]
+    if (msg.info.role !== "user") continue
+    const texts = msg.parts.filter((p) => p.type === "text")
+    if (texts.length > 0 && texts.every(isNudge)) {
+      count++
+      continue
+    }
+    break
+  }
+  return count
+}
+
+export * as ToolCallLeak from "./tool-call-leak"

--- a/packages/opencode/test/session/tool-call-leak.test.ts
+++ b/packages/opencode/test/session/tool-call-leak.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test"
+import { ToolCallLeak } from "../../src/session/tool-call-leak"
+
+describe("ToolCallLeak.detect", () => {
+  test("fires on the captured malformed Qwen3 sample (issue #24316)", () => {
+    // Real leak captured from vLLM + Qwen3.6-27B-NVFP4: model drifted to
+    // `<function_bash>`, vLLM's parser consumed the opening <tool_call> and
+    // flushed the rest as text.
+    const text =
+      "\n\n<function_bash>\n<parameter=command>\nfind lib -name \"*.dart\" | head -20\n</parameter>\n</function>\n</tool_call>"
+    expect(ToolCallLeak.detect(text)).toBe(true)
+  })
+
+  test("fires on a well-formed Qwen3 XML block", () => {
+    const text =
+      "<tool_call>\n<function=read>\n<parameter=filePath>\n/tmp/index.js\n</parameter>\n</function>\n</tool_call>"
+    expect(ToolCallLeak.detect(text)).toBe(true)
+  })
+
+  test("fires on a closed hermes JSON block", () => {
+    const text = '<tool_call>\n{"name": "read", "arguments": {"filePath": "/tmp/a"}}\n</tool_call>'
+    expect(ToolCallLeak.detect(text)).toBe(true)
+  })
+
+  test("fires on a truncated hermes block with trailing whitespace", () => {
+    const text = 'Let me check that file.\n<tool_call>\n{"name": "read"\n  '
+    expect(ToolCallLeak.detect(text)).toBe(true)
+  })
+
+  test("fires on an unclosed tool_call block in XML style", () => {
+    const text = "<tool_call>\n<function=read>\n<parameter=filePath>\n/tmp/a"
+    expect(ToolCallLeak.detect(text)).toBe(true)
+  })
+
+  test("ignores a bare opener truncated before any closing tag (documented limitation)", () => {
+    const text = "<function_bash>\n<parameter=command>\nfind . -name '*.dart'"
+    expect(ToolCallLeak.detect(text)).toBe(false)
+  })
+
+  test("fires when prose precedes the leaked block", () => {
+    const text =
+      "I'll search the codebase for the handler.\n\n<function=grep>\n<parameter=pattern>\nhandler\n</parameter>\n</function>"
+    expect(ToolCallLeak.detect(text)).toBe(true)
+  })
+
+  test("ignores plain prose", () => {
+    expect(ToolCallLeak.detect("The refactor is complete. All tests pass.")).toBe(false)
+  })
+
+  test("ignores mid-text tag mentions that end in prose", () => {
+    const text = "Use `<parameter=filePath>` to pass the path. The closing `</parameter>` tag is required."
+    expect(ToolCallLeak.detect(text)).toBe(false)
+  })
+
+  test("ignores closing tags without any opening signature", () => {
+    expect(ToolCallLeak.detect("In XML, elements end with tags like </function>")).toBe(false)
+  })
+
+  test("ignores empty text", () => {
+    expect(ToolCallLeak.detect("")).toBe(false)
+  })
+
+  test("exports the integration contract", () => {
+    expect(ToolCallLeak.MAX_ATTEMPTS).toBeGreaterThan(0)
+    expect(ToolCallLeak.MARKER).toBe("toolCallLeakRecovery")
+    expect(ToolCallLeak.NUDGE.length).toBeGreaterThan(0)
+  })
+})
+
+const nudgePart = {
+  type: "text",
+  synthetic: true,
+  metadata: { [ToolCallLeak.MARKER]: true },
+}
+const user = (...parts: any[]) => ({ info: { role: "user" }, parts })
+const assistant = (...parts: any[]) => ({ info: { role: "assistant" }, parts })
+const textPart = (text: string) => ({ type: "text", text })
+
+describe("ToolCallLeak.countAttempts", () => {
+  test("zero when the last user message is a real prompt", () => {
+    const msgs = [user(textPart("fix the bug")), assistant(textPart("ok"))]
+    expect(ToolCallLeak.countAttempts(msgs)).toBe(0)
+  })
+
+  test("counts trailing nudge messages", () => {
+    const msgs = [
+      user(textPart("fix the bug")),
+      assistant(textPart("<tool_call>")),
+      user(nudgePart),
+      assistant(textPart("<tool_call>")),
+      user(nudgePart),
+      assistant(textPart("<tool_call>")),
+    ]
+    expect(ToolCallLeak.countAttempts(msgs)).toBe(2)
+  })
+
+  test("resets after a real user prompt", () => {
+    const msgs = [
+      user(textPart("fix the bug")),
+      assistant(textPart("<tool_call>")),
+      user(nudgePart),
+      assistant(textPart("done")),
+      user(textPart("now add tests")),
+      assistant(textPart("<tool_call>")),
+    ]
+    expect(ToolCallLeak.countAttempts(msgs)).toBe(0)
+  })
+
+  test("a synthetic part without the marker is not a nudge", () => {
+    const msgs = [user({ type: "text", synthetic: true })]
+    expect(ToolCallLeak.countAttempts(msgs)).toBe(0)
+  })
+
+  test("a file-only user message is real input and resets the count", () => {
+    const msgs = [
+      user(textPart("fix the bug")),
+      assistant(textPart("<tool_call>")),
+      user(nudgePart),
+      assistant(textPart("<tool_call>")),
+      user({ type: "file", url: "data:image/png;base64,x" }),
+      assistant(textPart("<tool_call>")),
+    ]
+    expect(ToolCallLeak.countAttempts(msgs)).toBe(0)
+  })
+
+  test("a message mixing a nudge part with real text is real input", () => {
+    const msgs = [user(nudgePart, textPart("also, look at this"))]
+    expect(ToolCallLeak.countAttempts(msgs)).toBe(0)
+  })
+
+  test("empty history", () => {
+    expect(ToolCallLeak.countAttempts([])).toBe(0)
+  })
+})
+
+describe("ToolCallLeak.isNudge", () => {
+  test("accepts the exact nudge shape", () => {
+    expect(ToolCallLeak.isNudge(nudgePart)).toBe(true)
+  })
+
+  test("rejects parts missing any of type/synthetic/marker", () => {
+    expect(ToolCallLeak.isNudge({ type: "file", synthetic: true, metadata: { [ToolCallLeak.MARKER]: true } })).toBe(false)
+    expect(ToolCallLeak.isNudge({ type: "text", metadata: { [ToolCallLeak.MARKER]: true } })).toBe(false)
+    expect(ToolCallLeak.isNudge({ type: "text", synthetic: true })).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #24316

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Models served through vLLM/llama.cpp sometimes write their tool call as plain text instead of a structured call. I captured this live with Qwen3.6 27B: about 50K tokens into a session the model emitted `<function_bash>` instead of `<function=bash>`, the server-side parser couldn't match it, the whole call leaked into the message text, and the turn finished `stop` with zero tool calls. The session loop saw a "finished" turn and halted mid-task.

I first tested the tag-stripping approach from #27984, but it didn't hold up. It patches `packages/llm`, which the CLI doesn't import (OpenAI-compatible providers go through the AI SDK path), and stripping text can't un-halt the session anyway since there's still no tool call to execute.

This PR adds a small detector (`tool-call-leak.ts`) that recognizes a leaked tool-call block at the end of the assistant text (Qwen XML, drifted variants, hermes JSON). When the session loop is about to exit on such a turn, it instead injects a hidden corrective message and lets the model retry, capped at 2 attempts per user prompt. Past the cap it stops with a visible error instead of a silent halt. Nothing is ever parsed or executed from the leaked text; the retry goes through the normal tool-calling path, so permissions and tool resolution are untouched. This works because the leak is intermittent format drift: given a correction, the model re-issues the call properly on the next try.

### How did you verify your code works?
- 21 unit tests for the detector and attempt counting; the captured real-world leak is one of the test cases
- `bun test` in `packages/opencode`: 3000 pass, 0 fail; `bun run typecheck` clean
- End-to-end against a scripted OpenAI-compatible mock server: leak -> hidden retry -> tool executes -> session completes; permanent leak -> stops after 2 attempts with a persisted error
- Smoke test against live vLLM + Qwen3.6 27B: healthy turns never trigger the detector

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
