### PR TITLE
fix(task): persist agent name on subagent sessions

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -146,6 +146,12 @@ export const TaskTool = Tool.define(
         session ??
         (yield* sessions.create({
           parentID: ctx.sessionID,
+          // Invariant: every subagent session row carries its agent name.
+          // `deriveSubagentSessionPermission` resolves the parent's agent
+          // from this column when a subagent spawns its own subagent, and
+          // a missing value silently drops the parent agent's edit denies
+          // (e.g. Plan mode) on the grandchild.
+          agent: next.name,
           title: params.description + ` (@${next.name} subagent)`,
           permission: [
             ...deriveSubagentSessionPermission({

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -480,6 +480,55 @@ describe("tool.task", () => {
     }),
   )
 
+  // Regression: subagent sessions must persist their `agent` field so that
+  // when this subagent later spawns a nested subagent via `task.ts`, the
+  // grandchild can resolve `parentAgent` and inherit the parent agent's
+  // restrictions (e.g. Plan mode edit denies) via
+  // `deriveSubagentSessionPermission`. Before this was set, `parent.agent`
+  // was undefined for any spawned subagent and the inheritance silently
+  // bypassed.
+  it.instance(
+    "execute persists the subagent's agent name on the created session",
+    () =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        const promptOps = stubOps()
+
+        const result = yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "reviewer",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const child = yield* sessions.get(result.metadata.sessionId)
+        expect(child.agent).toBe("reviewer")
+      }),
+    {
+      config: {
+        agent: {
+          reviewer: {
+            mode: "subagent",
+          },
+        },
+      },
+    },
+  )
+
   background.instance("execute launches background tasks without waiting for completion", () =>
     Effect.gen(function* () {
       const jobs = yield* BackgroundJob.Service


### PR DESCRIPTION
### Issue for this PR

Closes #30610

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The task tool created subagent session rows without setting `agent`. When a subagent spawned its own subagent, `deriveSubagentSessionPermission` could not read `parent.agent` and dropped the parent agent's edit denies on the grandchild, so a Plan-mode chain leaked edit access to the deepest subagent. This sets the agent name at session creation so the restrictions carry down.

### How did you verify your code works?

Added a regression test that runs the task tool and asserts the created subagent session stores its agent name (`child.agent` is `"reviewer"`). That is the value `deriveSubagentSessionPermission` reads as `parent.agent` when this subagent later spawns its own subagent. The assertion fails before the change, since `agent` was never written, and passes after. `bun typecheck` passes.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
