### PR TITLE
fix(opencode): avoid shell cancel race

### DIFF
--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -78,7 +78,7 @@ export const layer = Layer.effect(
       yield* cancelBackgroundJobs(background, sessionID)
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
-      if (!existing || !existing.busy) {
+      if (!existing) {
         yield* status.set(sessionID, { type: "idle" })
         return
       }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -320,10 +320,9 @@ const useServerConfig = Effect.fn("test.useServerConfig")(function* (config: (ur
   return { dir, llm }
 })
 
-// Wait for a session's runner to enter a busy state. SessionStatus is flipped to
-// "busy" inside Runner.startShell's modifyEffect at the same moment the runner
-// is registered, so this is a deterministic readiness signal — cancel can't
-// no-op once we observe it.
+// Wait for a session's runner to enter a busy state. SessionStatus is flipped
+// inside Runner.startShell's serialized transition, so cancel can't no-op once
+// we observe it.
 const waitForBusy = (sessionID: SessionID, duration: Duration.Input = "2 seconds") =>
   pollWithTimeout(
     Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- always delegate cancellation to an existing session runner
- let the runner serialized state machine handle idle cancellation
- correct the shell cancellation readiness comment

## Tests
- `bun test test/effect/runner.test.ts`
- `bun test test/session/prompt.test.ts -t "cancel interrupts shell and resolves cleanly|cancel persists aborted shell result when shell ignores TERM|cancel interrupts loop queued behind shell|shell rejects when another shell is already running"`
- repeated `bun test test/session/prompt.test.ts -t "cancel interrupts shell and resolves cleanly"` in four isolated processes
- `bun x prettier --check src/session/run-state.ts test/session/prompt.test.ts`
- `git diff --check`