### PR TITLE
fix(app): hide unavailable titlebar update

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -707,7 +707,9 @@ type TitlebarV2RightState = {
 function TitlebarV2Right(props: { state: TitlebarV2RightState }) {
   return (
     <div class="relative z-20 flex shrink-0 items-center justify-end gap-0 overflow-visible">
-      <TitlebarUpdateIconButton state={props.state.update} />
+      <Show when={props.state.update.visible}>
+        <TitlebarUpdateIconButton state={props.state.update} />
+      </Show>
       <div id="opencode-titlebar-right" class="flex shrink-0 items-center justify-end gap-0" />
     </div>
   )

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -89,6 +89,7 @@ import {
 } from "./layout/sidebar-workspace"
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarContent } from "./layout/sidebar-shell"
+import { runUpdateAndRestart } from "./layout/update"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
@@ -183,11 +184,7 @@ export default function Layout(props: ParentProps) {
     return updateQuery.data.version ?? ""
   }
   const installUpdate = () => {
-    if (!platform.updateAndRestart) return
-    setUpdate("installing", true)
-    void platform.updateAndRestart().catch(() => {
-      setUpdate("installing", false)
-    })
+    runUpdateAndRestart(platform.updateAndRestart, (installing) => setUpdate("installing", installing))
   }
   const titlebarUpdate: TitlebarUpdate = {
     version: updateVersion,

--- a/packages/app/src/pages/layout/update.test.ts
+++ b/packages/app/src/pages/layout/update.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { runUpdateAndRestart } from "./update"
+
+describe("runUpdateAndRestart", () => {
+  test("clears the installing state when restart resolves without exiting", async () => {
+    const states: boolean[] = []
+    await new Promise<void>((resolve) => {
+      runUpdateAndRestart(
+        async () => {},
+        (installing) => {
+          states.push(installing)
+          if (states.length === 2) resolve()
+        },
+      )
+    })
+
+    expect(states).toEqual([true, false])
+  })
+})

--- a/packages/app/src/pages/layout/update.ts
+++ b/packages/app/src/pages/layout/update.ts
@@ -1,0 +1,10 @@
+export function runUpdateAndRestart(
+  updateAndRestart: (() => Promise<void>) | undefined,
+  setInstalling: (installing: boolean) => void,
+) {
+  if (!updateAndRestart) return
+  setInstalling(true)
+  void updateAndRestart()
+    .catch(() => undefined)
+    .finally(() => setInstalling(false))
+}


### PR DESCRIPTION
## Summary
- hide the v2 titlebar update button when no update is available
- clear the titlebar installing state when a restart request resolves without exiting
- cover the resolved no-op restart path with a regression test

## Root cause
The new titlebar icon button rendered unconditionally after #30460 even though the existing update state still tracked visibility. After an update completed and the app relaunched, clicking the stale button ran an install-time update check. When the app was already current, the desktop updater resolved without restarting, leaving the renderer installing state stuck because it was only reset on rejection.

## Verification
- bun typecheck from packages/app
- bun test --preload ./happydom.ts ./src/pages/layout/update.test.ts from packages/app
- bun run test:unit from packages/app
- bun run build from packages/app
- pre-push bun turbo typecheck (21 tasks passed)
- git diff --check upstream/dev...HEAD