### PR TITLE
fix(app): improve desktop session tabs

### DIFF
--- a/packages/app/src/components/titlebar-session-tabs.test.ts
+++ b/packages/app/src/components/titlebar-session-tabs.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { createSessionTabResolver, getRootSession } from "./titlebar-session-tabs"
+
+describe("titlebar session tabs", () => {
+  test("uses the root session for subagent routes", () => {
+    const sessions = [{ id: "root" }, { id: "child", parentID: "root" }, { id: "leaf", parentID: "child" }]
+
+    expect(getRootSession("leaf", (id) => sessions.find((session) => session.id === id))?.id).toBe("root")
+  })
+
+  test("returns the routed session when it is a root", () => {
+    const root = { id: "root" }
+
+    expect(getRootSession("root", (id) => (id === root.id ? root : undefined))).toBe(root)
+  })
+
+  test("ignores incomplete and cyclic subagent paths", () => {
+    const sessions = [
+      { id: "missing-parent", parentID: "missing" },
+      { id: "cycle-a", parentID: "cycle-b" },
+      { id: "cycle-b", parentID: "cycle-a" },
+    ]
+    const get = (id: string) => sessions.find((session) => session.id === id)
+
+    expect(getRootSession("missing-parent", get)).toBeUndefined()
+    expect(getRootSession("cycle-a", get)).toBeUndefined()
+  })
+
+  test("resolves the latest title after a session is renamed", () => {
+    const sessions = new Map([["root", { id: "root", title: "Before" }]])
+    const resolve = createSessionTabResolver({ sessionId: "root" }, (id) => sessions.get(id))
+
+    sessions.set("root", { id: "root", title: "After" })
+
+    expect(resolve()?.info.title).toBe("After")
+  })
+})

--- a/packages/app/src/components/titlebar-session-tabs.test.ts
+++ b/packages/app/src/components/titlebar-session-tabs.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { createSessionTabResolver, getRootSession, removeDeletedSessionTabs } from "./titlebar-session-tabs"
+import {
+  createSessionTabResolver,
+  findSessionTab,
+  getRootSession,
+  removeDeletedSessionTabs,
+} from "./titlebar-session-tabs"
 
 describe("titlebar session tabs", () => {
   test("uses the root session for subagent routes", () => {
@@ -42,6 +47,25 @@ describe("titlebar session tabs", () => {
     sessions.set("root", { id: "root", title: "After" })
 
     expect(resolve()?.info.title).toBe("After")
+  })
+
+  test("keeps the last root tab metadata after a remote archive", () => {
+    const sessions = new Map([["root", { id: "root", title: "Root" }]])
+    const resolve = createSessionTabResolver({ sessionId: "root" }, (id) => sessions.get(id))
+
+    expect(resolve()?.info.title).toBe("Root")
+    sessions.delete("root")
+    expect(resolve()?.info.title).toBe("Root")
+  })
+
+  test("finds an existing root tab after its metadata is removed", () => {
+    const tabs = [{ sessionId: "root" }]
+    const sessions = new Map([
+      ["leaf", { parentID: "child" }],
+      ["child", { parentID: "root" }],
+    ])
+
+    expect(findSessionTab(tabs, "leaf", (id) => sessions.get(id))).toBe(tabs[0])
   })
 
   test("navigates after removing the active root tab from a subagent route", () => {

--- a/packages/app/src/components/titlebar-session-tabs.test.ts
+++ b/packages/app/src/components/titlebar-session-tabs.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import {
-  createSessionTabResolver,
-  findSessionTab,
-  getRootSession,
-  removeDeletedSessionTabs,
-} from "./titlebar-session-tabs"
+import { createSessionTabResolver, getRootSession, removeUnavailableSessionTabs } from "./titlebar-session-tabs"
 
 describe("titlebar session tabs", () => {
   test("uses the root session for subagent routes", () => {
@@ -58,16 +53,6 @@ describe("titlebar session tabs", () => {
     expect(resolve()?.info.title).toBe("Root")
   })
 
-  test("finds an existing root tab after its metadata is removed", () => {
-    const tabs = [{ sessionId: "root" }]
-    const sessions = new Map([
-      ["leaf", { parentID: "child" }],
-      ["child", { parentID: "root" }],
-    ])
-
-    expect(findSessionTab(tabs, "leaf", (id) => sessions.get(id))).toBe(tabs[0])
-  })
-
   test("navigates after removing the active root tab from a subagent route", () => {
     const tabs = [
       { dir: "/workspace", sessionId: "root", href: "/workspace/session/root" },
@@ -75,7 +60,7 @@ describe("titlebar session tabs", () => {
     ]
 
     expect(
-      removeDeletedSessionTabs(
+      removeUnavailableSessionTabs(
         tabs,
         { directory: "/workspace", sessionIDs: ["root", "child"] },
         {
@@ -85,5 +70,33 @@ describe("titlebar session tabs", () => {
       ),
     ).toBe("/workspace/session/next")
     expect(tabs).toEqual([{ dir: "/workspace", sessionId: "next", href: "/workspace/session/next" }])
+  })
+
+  test("navigates after child-first remote deletion events", () => {
+    const tabs = [
+      { dir: "/workspace", sessionId: "root", href: "/workspace/session/root" },
+      { dir: "/workspace", sessionId: "next", href: "/workspace/session/next" },
+    ]
+
+    expect(
+      removeUnavailableSessionTabs(
+        tabs,
+        { directory: "/workspace", sessionIDs: ["leaf"] },
+        {
+          href: "/workspace/session/root",
+          sessionId: "leaf",
+        },
+      ),
+    ).toBe("/workspace/session/root")
+    expect(
+      removeUnavailableSessionTabs(
+        tabs,
+        { directory: "/workspace", sessionIDs: ["root"] },
+        {
+          href: "/workspace/session/root",
+          sessionId: "leaf",
+        },
+      ),
+    ).toBe("/workspace/session/next")
   })
 })

--- a/packages/app/src/components/titlebar-session-tabs.test.ts
+++ b/packages/app/src/components/titlebar-session-tabs.test.ts
@@ -14,6 +14,15 @@ describe("titlebar session tabs", () => {
     expect(getRootSession("root", (id) => (id === root.id ? root : undefined))).toBe(root)
   })
 
+  test("waits for delayed lineage rather than opening a subagent tab", () => {
+    const sessions: { id: string; parentID?: string }[] = [{ id: "child", parentID: "root" }]
+    const get = (id: string) => sessions.find((session) => session.id === id)
+
+    expect(getRootSession("child", get)).toBeUndefined()
+    sessions.push({ id: "root" })
+    expect(getRootSession("child", get)?.id).toBe("root")
+  })
+
   test("ignores incomplete and cyclic subagent paths", () => {
     const sessions = [
       { id: "missing-parent", parentID: "missing" },

--- a/packages/app/src/components/titlebar-session-tabs.test.ts
+++ b/packages/app/src/components/titlebar-session-tabs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { createSessionTabResolver, getRootSession } from "./titlebar-session-tabs"
+import { createSessionTabResolver, getRootSession, removeDeletedSessionTabs } from "./titlebar-session-tabs"
 
 describe("titlebar session tabs", () => {
   test("uses the root session for subagent routes", () => {
@@ -33,5 +33,24 @@ describe("titlebar session tabs", () => {
     sessions.set("root", { id: "root", title: "After" })
 
     expect(resolve()?.info.title).toBe("After")
+  })
+
+  test("navigates after removing the active root tab from a subagent route", () => {
+    const tabs = [
+      { dir: "/workspace", sessionId: "root", href: "/workspace/session/root" },
+      { dir: "/workspace", sessionId: "next", href: "/workspace/session/next" },
+    ]
+
+    expect(
+      removeDeletedSessionTabs(
+        tabs,
+        { directory: "/workspace", sessionIDs: ["root", "child"] },
+        {
+          href: "/workspace/session/child",
+          sessionId: "child",
+        },
+      ),
+    ).toBe("/workspace/session/next")
+    expect(tabs).toEqual([{ dir: "/workspace", sessionId: "next", href: "/workspace/session/next" }])
   })
 })

--- a/packages/app/src/components/titlebar-session-tabs.ts
+++ b/packages/app/src/components/titlebar-session-tabs.ts
@@ -22,3 +22,33 @@ export function createSessionTabResolver<T extends { sessionId: string }, U>(
     return info ? { ...tab, info } : undefined
   }
 }
+
+export function removeDeletedSessionTabs<T extends { dir: string; sessionId: string; href: string }>(
+  tabs: T[],
+  input: { directory: string; sessionIDs: string[] },
+  current?: { href: string; sessionId: string },
+) {
+  const sessionIDs = new Set(input.sessionIDs)
+  const currentIndex = current
+    ? tabs.findIndex(
+        (tab) =>
+          tab.href === current.href ||
+          (sessionIDs.has(current.sessionId) && tab.dir === input.directory && sessionIDs.has(tab.sessionId)),
+      )
+    : -1
+  const removedCurrent =
+    currentIndex !== -1 &&
+    tabs[currentIndex]?.dir === input.directory &&
+    sessionIDs.has(tabs[currentIndex]?.sessionId ?? "")
+
+  for (let i = tabs.length - 1; i >= 0; i--) {
+    const tab = tabs[i]
+    if (!tab) continue
+    if (tab.dir !== input.directory) continue
+    if (!sessionIDs.has(tab.sessionId)) continue
+    tabs.splice(i, 1)
+  }
+
+  if (!removedCurrent) return
+  return tabs[currentIndex]?.href ?? tabs[tabs.length - 1]?.href ?? "/"
+}

--- a/packages/app/src/components/titlebar-session-tabs.ts
+++ b/packages/app/src/components/titlebar-session-tabs.ts
@@ -24,24 +24,7 @@ export function createSessionTabResolver<T extends { sessionId: string }, U>(
   }
 }
 
-export function findSessionTab<T extends { sessionId: string }>(
-  tabs: T[],
-  id: string,
-  get: (id: string) => { parentID?: string } | undefined,
-) {
-  const seen = new Set<string>()
-  let currentID: string | undefined = id
-
-  while (currentID) {
-    if (seen.has(currentID)) return
-    seen.add(currentID)
-    const tab = tabs.find((tab) => tab.sessionId === currentID)
-    if (tab) return tab
-    currentID = get(currentID)?.parentID
-  }
-}
-
-export function removeDeletedSessionTabs<T extends { dir: string; sessionId: string; href: string }>(
+export function removeUnavailableSessionTabs<T extends { dir: string; sessionId: string; href: string }>(
   tabs: T[],
   input: { directory: string; sessionIDs: string[] },
   current?: { href: string; sessionId: string },
@@ -67,6 +50,6 @@ export function removeDeletedSessionTabs<T extends { dir: string; sessionId: str
     tabs.splice(i, 1)
   }
 
-  if (!removedCurrent) return
-  return tabs[currentIndex]?.href ?? tabs[tabs.length - 1]?.href ?? "/"
+  if (removedCurrent) return tabs[currentIndex]?.href ?? tabs[tabs.length - 1]?.href ?? "/"
+  if (current && sessionIDs.has(current.sessionId)) return tabs[currentIndex]?.href ?? "/"
 }

--- a/packages/app/src/components/titlebar-session-tabs.ts
+++ b/packages/app/src/components/titlebar-session-tabs.ts
@@ -1,0 +1,24 @@
+export function getRootSession<T extends { id: string; parentID?: string }>(
+  id: string,
+  get: (id: string) => T | undefined,
+) {
+  const seen = new Set<string>()
+  let session = get(id)
+
+  while (session) {
+    if (seen.has(session.id)) return
+    seen.add(session.id)
+    if (!session.parentID) return session
+    session = get(session.parentID)
+  }
+}
+
+export function createSessionTabResolver<T extends { sessionId: string }, U>(
+  tab: T,
+  get: (id: string) => U | undefined,
+) {
+  return () => {
+    const info = get(tab.sessionId)
+    return info ? { ...tab, info } : undefined
+  }
+}

--- a/packages/app/src/components/titlebar-session-tabs.ts
+++ b/packages/app/src/components/titlebar-session-tabs.ts
@@ -17,9 +17,27 @@ export function createSessionTabResolver<T extends { sessionId: string }, U>(
   tab: T,
   get: (id: string) => U | undefined,
 ) {
+  let cached: U | undefined
   return () => {
-    const info = get(tab.sessionId)
-    return info ? { ...tab, info } : undefined
+    cached = get(tab.sessionId) ?? cached
+    return cached ? { ...tab, info: cached } : undefined
+  }
+}
+
+export function findSessionTab<T extends { sessionId: string }>(
+  tabs: T[],
+  id: string,
+  get: (id: string) => { parentID?: string } | undefined,
+) {
+  const seen = new Set<string>()
+  let currentID: string | undefined = id
+
+  while (currentID) {
+    if (seen.has(currentID)) return
+    seen.add(currentID)
+    const tab = tabs.find((tab) => tab.sessionId === currentID)
+    if (tab) return tab
+    currentID = get(currentID)?.parentID
   }
 }
 

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -29,7 +29,7 @@ import {
   SESSION_TABS_REMOVED_EVENT,
   type SessionTabsRemovedDetail,
 } from "@/components/titlebar-session-events"
-import { createSessionTabResolver, getRootSession } from "@/components/titlebar-session-tabs"
+import { createSessionTabResolver, getRootSession, removeDeletedSessionTabs } from "@/components/titlebar-session-tabs"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -301,26 +301,14 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                   void startTransition(() => {
                     setStore(
                       produce((tabs) => {
-                        const sessionIDs = new Set(input.sessionIDs)
-                        const currentHref = params.dir && params.id ? makeSessionHref(params.dir, params.id) : undefined
-                        const currentIndex = currentHref ? tabs.findIndex((tab) => tab.href === currentHref) : -1
-                        const removedCurrent =
-                          currentIndex !== -1 &&
-                          tabs[currentIndex]?.dir === input.directory &&
-                          sessionIDs.has(tabs[currentIndex]?.sessionId ?? "")
-
-                        for (let i = tabs.length - 1; i >= 0; i--) {
-                          const tab = tabs[i]
-                          if (!tab) continue
-                          if (tab.dir !== input.directory) continue
-                          if (!sessionIDs.has(tab.sessionId)) continue
-                          tabs.splice(i, 1)
-                        }
-
-                        if (!removedCurrent) return
-                        const nextTab = tabs[currentIndex] ?? tabs[tabs.length - 1]
-                        if (nextTab) navigate(nextTab.href)
-                        else navigate("/")
+                        const next = removeDeletedSessionTabs(
+                          tabs,
+                          input,
+                          params.dir && params.id
+                            ? { href: makeSessionHref(params.dir, params.id), sessionId: params.id }
+                            : undefined,
+                        )
+                        if (next) navigate(next)
                       }),
                     )
                   })

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -268,7 +268,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
             const tabForSession = (b64Dir: string, sessionId: string) => {
               const dir = decodeDirectory(b64Dir)
               if (!dir) return
-              const [store] = serverSync.child(dir)
+              const [store] = serverSync.peek(dir, { bootstrap: false })
               const session = getRootSession(sessionId, (id) => store.session.find((session) => session.id === id))
               if (!session) return
               const href = makeSessionHref(b64Dir, session.id)

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -31,9 +31,8 @@ import {
 } from "@/components/titlebar-session-events"
 import {
   createSessionTabResolver,
-  findSessionTab,
   getRootSession,
-  removeDeletedSessionTabs,
+  removeUnavailableSessionTabs,
 } from "@/components/titlebar-session-tabs"
 
 type TauriDesktopWindow = {
@@ -260,13 +259,21 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
             }
 
             type Tab = { dir: string; sessionId: string; href: string }
+            const routeTabs = new Map<string, string>()
+            const clearRoutesForTab = (href: string) => {
+              for (const [route, tab] of routeTabs) {
+                if (tab === href) routeTabs.delete(route)
+              }
+            }
             const tabForSession = (b64Dir: string, sessionId: string) => {
               const dir = decodeDirectory(b64Dir)
               if (!dir) return
               const [store] = serverSync.child(dir)
               const session = getRootSession(sessionId, (id) => store.session.find((session) => session.id === id))
               if (!session) return
-              return { dir, sessionId: session.id, href: makeSessionHref(b64Dir, session.id) }
+              const href = makeSessionHref(b64Dir, session.id)
+              routeTabs.set(makeSessionHref(b64Dir, sessionId), href)
+              return { dir, sessionId: session.id, href }
             }
 
             const [tabsStore, tabsStoreActions] = iife(() => {
@@ -294,6 +301,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                       produce((tabs) => {
                         const index = tabs.findIndex((t) => t.href === href)
                         if (index === -1) return
+                        clearRoutesForTab(href)
                         tabs.splice(index, 1)
                         const nextTab = tabs[index] ?? tabs[tabs.length - 1]
                         if (nextTab) navigate(nextTab.href)
@@ -306,13 +314,23 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                   void startTransition(() => {
                     setStore(
                       produce((tabs) => {
-                        const next = removeDeletedSessionTabs(
+                        const hrefs = new Set(tabs.map((tab) => tab.href))
+                        const next = removeUnavailableSessionTabs(
                           tabs,
                           input,
                           params.dir && params.id
-                            ? { href: makeSessionHref(params.dir, params.id), sessionId: params.id }
+                            ? {
+                                href:
+                                  currentSessionTab()?.href ??
+                                  routeTabs.get(makeSessionHref(params.dir, params.id)) ??
+                                  makeSessionHref(params.dir, params.id),
+                                sessionId: params.id,
+                              }
                             : undefined,
                         )
+                        for (const href of hrefs) {
+                          if (!tabs.some((tab) => tab.href === href)) clearRoutesForTab(href)
+                        }
                         if (next) navigate(next)
                       }),
                     )
@@ -346,11 +364,9 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
             const currentSessionTab = () => {
               if (!params.dir || !params.id) return
               const tab = tabForSession(params.dir, params.id)
-              if (tab) return tabsStore.find((item) => item.href === tab.href)
-              const dir = decodeDirectory(params.dir)
-              if (!dir) return
-              const [store] = serverSync.child(dir)
-              return findSessionTab(tabsStore, params.id, (id) => store.session.find((session) => session.id === id))
+              const href = tab?.href ?? routeTabs.get(makeSessionHref(params.dir, params.id))
+              if (!href) return
+              return tabsStore.find((item) => item.href === href)
             }
 
             const closeCurrentSessionTab = () => {

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -29,6 +29,7 @@ import {
   SESSION_TABS_REMOVED_EVENT,
   type SessionTabsRemovedDetail,
 } from "@/components/titlebar-session-events"
+import { createSessionTabResolver, getRootSession } from "@/components/titlebar-session-tabs"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -254,18 +255,21 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
             }
 
             type Tab = { dir: string; sessionId: string; href: string }
+            const tabForSession = (b64Dir: string, sessionId: string) => {
+              const dir = decodeDirectory(b64Dir)
+              if (!dir) return
+              const [store] = serverSync.child(dir)
+              const session = getRootSession(sessionId, (id) => store.session.find((session) => session.id === id))
+              if (!session) return
+              return { dir, sessionId: session.id, href: makeSessionHref(b64Dir, session.id) }
+            }
 
             const [tabsStore, tabsStoreActions] = iife(() => {
               const [store, setStore] = createStore<Tab[]>(
                 iife(() => {
                   if (!params.dir || !params.id) return []
-                  return [
-                    {
-                      dir: decodeDirectory(params.dir) ?? "",
-                      sessionId: params.id,
-                      href: makeSessionHref(params.dir, params.id),
-                    },
-                  ]
+                  const tab = tabForSession(params.dir, params.id)
+                  return tab ? [tab] : []
                 }),
               )
 
@@ -336,11 +340,9 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
               const params = useParams()
               if (!(params.dir && params.id)) return
 
-              tabsStoreActions.addTab({
-                dir: decodeDirectory(params.dir) ?? "",
-                sessionId: params.id,
-                href: makeSessionHref(params.dir, params.id),
-              })
+              const tab = tabForSession(params.dir, params.id)
+              if (!tab) return
+              tabsStoreActions.addTab(tab)
             })
 
             const projects = createMemo(() => layout.projects.list())
@@ -350,8 +352,9 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
 
             const currentSessionTab = () => {
               if (!params.dir || !params.id) return
-              const href = makeSessionHref(params.dir, params.id)
-              return tabsStore.find((tab) => tab.href === href)
+              const tab = tabForSession(params.dir, params.id)
+              if (!tab) return
+              return tabsStore.find((item) => item.href === tab.href)
             }
 
             const closeCurrentSessionTab = () => {
@@ -451,12 +454,11 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                 () => tabsStore,
                 (tab) => {
                   const sync = serverSync.createDirSyncContext(tab.dir)
-                  const session = sync.session.get(tab.sessionId)
-                  return session ? { ...tab, info: session } : null
+                  return createSessionTabResolver(tab, sync.session.get)
                 },
               )
 
-              return () => base().flatMap((s) => (s ? [s] : []))
+              return () => base().flatMap((resolve) => resolve() ?? [])
             })
 
             return (
@@ -495,6 +497,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                             project={projectForSession(tab.info, projects(), projectByID())}
                             directory={tab.dir}
                             sessionId={tab.info.id}
+                            active={tab.href === currentSessionTab()?.href}
                             onClose={() => tabsStoreActions.removeTab(tab.href)}
                           />
                         </>
@@ -750,11 +753,10 @@ function TabNavItem(props: {
   project?: LocalProject
   directory: string
   sessionId: string
+  active: boolean
   hideClose?: boolean
   onClose: () => void
 }) {
-  const match = useMatch(() => props.href)
-  const isActive = () => !!match()
   const closeTab = (event: MouseEvent) => {
     event.preventDefault()
     event.stopPropagation()
@@ -762,8 +764,8 @@ function TabNavItem(props: {
   }
   return (
     <div
-      class="group relative flex h-7 min-w-24 max-w-60 flex-row items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-[6px] bg-[var(--tab-bg)] px-1.5 [--tab-bg:var(--v2-background-bg-deep)] hover:[--tab-bg:var(--v2-background-bg-layer-02)] data-[active='true']:[--tab-bg:var(--v2-background-bg-layer-02)]"
-      data-active={isActive()}
+      class="group relative flex h-7 min-w-24 max-w-60 flex-row items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-[6px] bg-[var(--tab-bg)] pl-1.5 pr-8 [--tab-bg:var(--v2-background-bg-deep)] hover:[--tab-bg:var(--v2-background-bg-layer-02)] data-[active='true']:[--tab-bg:var(--v2-background-bg-layer-02)]"
+      data-active={props.active}
       onMouseDown={(event) => {
         if (event.button !== 1) return
         closeTab(event)

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -776,7 +776,7 @@ function TabNavItem(props: {
   }
   return (
     <div
-      class="group relative flex h-7 min-w-24 max-w-60 flex-row items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-[6px] bg-[var(--tab-bg)] pl-1.5 pr-8 [--tab-bg:var(--v2-background-bg-deep)] hover:[--tab-bg:var(--v2-background-bg-layer-02)] data-[active='true']:[--tab-bg:var(--v2-background-bg-layer-02)]"
+      class="group relative flex h-7 min-w-24 max-w-60 flex-row items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-[6px] bg-[var(--tab-bg)] px-1.5 [--tab-bg:var(--v2-background-bg-deep)] hover:[--tab-bg:var(--v2-background-bg-layer-02)] data-[active='true']:[--tab-bg:var(--v2-background-bg-layer-02)]"
       data-active={props.active}
       onMouseDown={(event) => {
         if (event.button !== 1) return

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -29,7 +29,12 @@ import {
   SESSION_TABS_REMOVED_EVENT,
   type SessionTabsRemovedDetail,
 } from "@/components/titlebar-session-events"
-import { createSessionTabResolver, getRootSession, removeDeletedSessionTabs } from "@/components/titlebar-session-tabs"
+import {
+  createSessionTabResolver,
+  findSessionTab,
+  getRootSession,
+  removeDeletedSessionTabs,
+} from "@/components/titlebar-session-tabs"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -341,8 +346,11 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
             const currentSessionTab = () => {
               if (!params.dir || !params.id) return
               const tab = tabForSession(params.dir, params.id)
-              if (!tab) return
-              return tabsStore.find((item) => item.href === tab.href)
+              if (tab) return tabsStore.find((item) => item.href === tab.href)
+              const dir = decodeDirectory(params.dir)
+              if (!dir) return
+              const [store] = serverSync.child(dir)
+              return findSessionTab(tabsStore, params.id, (id) => store.session.find((session) => session.id === id))
             }
 
             const closeCurrentSessionTab = () => {

--- a/packages/app/src/context/directory-sync.ts
+++ b/packages/app/src/context/directory-sync.ts
@@ -13,6 +13,7 @@ import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { SESSION_CACHE_LIMIT, dropSessionCaches, pickSessionCacheEvictions } from "./global-sync/session-cache"
 import { diffs as list, message as clean } from "@/utils/diffs"
 import { useServerSDK } from "./server-sdk"
+import { hydrateSessionLineage } from "./session-lineage"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -462,7 +463,29 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
 
           const hasSession = Binary.search(store.session, sessionID, (s) => s.id).found
           const cached = store.message[sessionID] !== undefined && meta.limit[key] !== undefined
-          if (cached && hasSession && !opts?.force) return
+          const syncLineage = async () => {
+            const session = getSession(sessionID)
+            if (!session) return
+            await hydrateSessionLineage(session, getSession, async (ancestorID) => {
+              const response = await retry(() => client.session.get({ sessionID: ancestorID }))
+              if (!tracked(directory, sessionID)) return
+              const data = response.data
+              if (!data) return
+              setStore(
+                "session",
+                produce((draft) => {
+                  const match = Binary.search(draft, ancestorID, (session) => session.id)
+                  if (match.found) {
+                    draft[match.index] = data
+                    return
+                  }
+                  draft.splice(match.index, 0, data)
+                }),
+              )
+              return data
+            })
+          }
+          if (cached && hasSession && !opts?.force) return syncLineage()
 
           const limit = meta.limit[key] ?? initialMessagePageSize
           const sessionReq =
@@ -502,6 +525,7 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
                 })
 
           await Promise.all([sessionReq, messagesReq])
+          await syncLineage()
         })
       },
       async diff(sessionID: string, opts?: { force?: boolean }) {

--- a/packages/app/src/context/directory-sync.ts
+++ b/packages/app/src/context/directory-sync.ts
@@ -467,9 +467,12 @@ export const createDirSyncContext = (directory: string, serverSync: ReturnType<t
             const session = getSession(sessionID)
             if (!session) return
             await hydrateSessionLineage(session, getSession, async (ancestorID) => {
-              const response = await retry(() => client.session.get({ sessionID: ancestorID }))
+              const response = await retry(() => client.session.get({ sessionID: ancestorID })).catch((error) => {
+                if (isNotFound(error)) return
+                throw error
+              })
               if (!tracked(directory, sessionID)) return
-              const data = response.data
+              const data = response?.data
               if (!data) return
               setStore(
                 "session",

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -268,12 +268,35 @@ describe("applyDirectoryEvent", () => {
       push() {},
       directory: "/tmp",
       loadLsp() {},
-      onSessionDeleted(sessionIDs) {
+      onSessionRemoved(sessionIDs) {
         deleted.push(sessionIDs)
       },
     })
 
     expect(deleted).toEqual([["root", "child", "leaf"]])
+  })
+
+  test("reports an archived root session tree before removing metadata", () => {
+    const removed: string[][] = []
+    const [store, setStore] = createStore(
+      baseState({
+        session: [rootSession({ id: "root" }), rootSession({ id: "child", parentID: "root" })],
+      }),
+    )
+
+    applyDirectoryEvent({
+      event: { type: "session.updated", properties: { info: rootSession({ id: "root", archived: 10 }) } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+      onSessionRemoved(sessionIDs) {
+        removed.push(sessionIDs)
+      },
+    })
+
+    expect(removed).toEqual([["root", "child"]])
   })
 
   test("cleans caches for trimmed sessions on session.created", () => {

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -249,6 +249,33 @@ describe("applyDirectoryEvent", () => {
     }
   })
 
+  test("reports a deleted root session tree before removing metadata", () => {
+    const deleted: string[][] = []
+    const [store, setStore] = createStore(
+      baseState({
+        session: [
+          rootSession({ id: "root" }),
+          rootSession({ id: "child", parentID: "root" }),
+          rootSession({ id: "leaf", parentID: "child" }),
+        ],
+      }),
+    )
+
+    applyDirectoryEvent({
+      event: { type: "session.deleted", properties: { info: rootSession({ id: "root" }) } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+      onSessionDeleted(sessionIDs) {
+        deleted.push(sessionIDs)
+      },
+    })
+
+    expect(deleted).toEqual([["root", "child", "leaf"]])
+  })
+
   test("cleans caches for trimmed sessions on session.created", () => {
     const dropped = rootSession({ id: "ses_b" })
     const kept = rootSession({ id: "ses_a" })

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -15,6 +15,7 @@ import type { State, VcsCache } from "./types"
 import { trimSessions } from "./session-trim"
 import { dropSessionCaches } from "./session-cache"
 import { diffs as list, message as clean } from "@/utils/diffs"
+import { sessionTreeIDs } from "@/context/session-lineage"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -99,6 +100,7 @@ export function applyDirectoryEvent(input: {
   loadLsp: () => void
   vcsCache?: VcsCache
   setSessionTodo?: (sessionID: string, todos: Todo[] | undefined) => void
+  onSessionDeleted?: (sessionIDs: string[]) => void
 }) {
   const event = input.event
   switch (event.type) {
@@ -152,6 +154,7 @@ export function applyDirectoryEvent(input: {
     }
     case "session.deleted": {
       const info = (event.properties as { info: Session }).info
+      const deleted = [...sessionTreeIDs(input.store.session, info.id)]
       const result = Binary.search(input.store.session, info.id, (s) => s.id)
       if (result.found) {
         input.setStore(
@@ -162,6 +165,7 @@ export function applyDirectoryEvent(input: {
         )
       }
       cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
+      input.onSessionDeleted?.(deleted)
       if (info.parentID) break
       input.setStore("sessionTotal", (value) => Math.max(0, value - 1))
       break

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -100,7 +100,7 @@ export function applyDirectoryEvent(input: {
   loadLsp: () => void
   vcsCache?: VcsCache
   setSessionTodo?: (sessionID: string, todos: Todo[] | undefined) => void
-  onSessionDeleted?: (sessionIDs: string[]) => void
+  onSessionRemoved?: (sessionIDs: string[]) => void
 }) {
   const event = input.event
   switch (event.type) {
@@ -127,7 +127,8 @@ export function applyDirectoryEvent(input: {
       const info = (event.properties as { info: Session }).info
       const result = Binary.search(input.store.session, info.id, (s) => s.id)
       if (info.time.archived) {
-        if (input.store.session[result.index]!.time.archived === info.time.archived) break
+        const removed = [...sessionTreeIDs(input.store.session, info.id)]
+        if (result.found && input.store.session[result.index]?.time.archived === info.time.archived) break
         if (result.found) {
           input.setStore(
             "session",
@@ -137,6 +138,7 @@ export function applyDirectoryEvent(input: {
           )
         }
         cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
+        input.onSessionRemoved?.(removed)
         if (info.parentID) break
         input.setStore("sessionTotal", (value) => Math.max(0, value - 1))
         break
@@ -165,7 +167,7 @@ export function applyDirectoryEvent(input: {
         )
       }
       cleanupSessionCaches(input.setStore, info.id, input.setSessionTodo)
-      input.onSessionDeleted?.(deleted)
+      input.onSessionRemoved?.(deleted)
       if (info.parentID) break
       input.setStore("sessionTotal", (value) => Math.max(0, value - 1))
       break

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -400,7 +400,7 @@ export function createServerSyncContext(_serverSDK?: ServerSDK) {
       setStore,
       push: queue.push,
       setSessionTodo,
-      onSessionDeleted: (sessionIDs) => notifySessionTabsRemoved({ directory, sessionIDs }),
+      onSessionRemoved: (sessionIDs) => notifySessionTabsRemoved({ directory, sessionIDs }),
       vcsCache: children.vcsCache.get(key),
       loadLsp: () => {
         void queryClient.fetchQuery(queryOptionsApi.lsp(key))

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -41,6 +41,7 @@ import { PathKey } from "@/utils/path-key"
 import { createDirSyncContext } from "./directory-sync"
 import { createSimpleContext, NormalizedProviderListResponse } from "@opencode-ai/ui/context"
 import { createRefCountMap } from "@/utils/refcount"
+import { notifySessionTabsRemoved } from "@/components/titlebar-session-events"
 import { useGlobal } from "./global"
 import { ServerConnection, useServer } from "./server"
 import { retry } from "@opencode-ai/core/util/retry"
@@ -399,6 +400,7 @@ export function createServerSyncContext(_serverSDK?: ServerSDK) {
       setStore,
       push: queue.push,
       setSessionTodo,
+      onSessionDeleted: (sessionIDs) => notifySessionTabsRemoved({ directory, sessionIDs }),
       vcsCache: children.vcsCache.get(key),
       loadLsp: () => {
         void queryClient.fetchQuery(queryOptionsApi.lsp(key))

--- a/packages/app/src/context/session-lineage.test.ts
+++ b/packages/app/src/context/session-lineage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { hydrateSessionLineage } from "./session-lineage"
+import { hydrateSessionLineage, sessionTreeIDs } from "./session-lineage"
 
 describe("session lineage", () => {
   test("hydrates missing ancestors for a routed subagent", async () => {
@@ -39,5 +39,11 @@ describe("session lineage", () => {
     )
 
     expect(loaded).toEqual([])
+  })
+
+  test("collects a root session tree", () => {
+    expect([
+      ...sessionTreeIDs([{ id: "root" }, { id: "child", parentID: "root" }, { id: "leaf", parentID: "child" }], "root"),
+    ]).toEqual(["root", "child", "leaf"])
   })
 })

--- a/packages/app/src/context/session-lineage.test.ts
+++ b/packages/app/src/context/session-lineage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { hydrateSessionLineage } from "./session-lineage"
+
+describe("session lineage", () => {
+  test("hydrates missing ancestors for a routed subagent", async () => {
+    const sessions = new Map<string, { id: string; parentID?: string }>([["leaf", { id: "leaf", parentID: "child" }]])
+    const available = new Map<string, { id: string; parentID?: string }>([
+      ["child", { id: "child", parentID: "root" }],
+      ["root", { id: "root" }],
+    ])
+
+    await hydrateSessionLineage(
+      sessions.get("leaf")!,
+      (id) => sessions.get(id),
+      async (id) => {
+        const session = available.get(id)
+        if (session) sessions.set(id, session)
+        return session
+      },
+    )
+
+    expect([...sessions.keys()]).toEqual(["leaf", "child", "root"])
+  })
+
+  test("stops hydrating cyclic lineages", async () => {
+    const sessions = new Map([
+      ["child", { id: "child", parentID: "root" }],
+      ["root", { id: "root", parentID: "child" }],
+    ])
+    const loaded: string[] = []
+
+    await hydrateSessionLineage(
+      sessions.get("child")!,
+      (id) => sessions.get(id),
+      async (id) => {
+        loaded.push(id)
+        return sessions.get(id)
+      },
+    )
+
+    expect(loaded).toEqual([])
+  })
+})

--- a/packages/app/src/context/session-lineage.ts
+++ b/packages/app/src/context/session-lineage.ts
@@ -14,3 +14,27 @@ export async function hydrateSessionLineage<T extends { id: string; parentID?: s
     current = parent
   }
 }
+
+export function sessionTreeIDs(sessions: { id: string; parentID?: string }[], rootID: string) {
+  const result = new Set([rootID])
+  const byParent = sessions.reduce((acc, session) => {
+    if (!session.parentID) return acc
+    const children = acc.get(session.parentID)
+    if (children) children.push(session.id)
+    if (!children) acc.set(session.parentID, [session.id])
+    return acc
+  }, new Map<string, string[]>())
+  const stack = [rootID]
+
+  while (stack.length) {
+    const parentID = stack.pop()
+    if (!parentID) continue
+    for (const child of byParent.get(parentID) ?? []) {
+      if (result.has(child)) continue
+      result.add(child)
+      stack.push(child)
+    }
+  }
+
+  return result
+}

--- a/packages/app/src/context/session-lineage.ts
+++ b/packages/app/src/context/session-lineage.ts
@@ -1,0 +1,16 @@
+export async function hydrateSessionLineage<T extends { id: string; parentID?: string }>(
+  session: T,
+  get: (id: string) => T | undefined,
+  load: (id: string) => Promise<T | undefined>,
+) {
+  const seen = new Set([session.id])
+  let current = session
+
+  while (current.parentID) {
+    if (seen.has(current.parentID)) return
+    seen.add(current.parentID)
+    const parent = get(current.parentID) ?? (await load(current.parentID))
+    if (!parent) return
+    current = parent
+  }
+}

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -64,6 +64,7 @@ import { useCommand, type CommandOption } from "@/context/command"
 import { ConstrainDragXAxis, getDraggableId } from "@/utils/solid-dnd"
 import { DebugBar } from "@/components/debug-bar"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { notifySessionTabsRemoved } from "@/components/titlebar-session-events"
 import { useServer } from "@/context/server"
 import { useLanguage, type Locale } from "@/context/language"
 import { pathKey } from "@/utils/path-key"
@@ -90,6 +91,7 @@ import {
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarContent } from "./layout/sidebar-shell"
 import { runUpdateAndRestart } from "./layout/update"
+import { sessionTreeIDs } from "@/context/session-lineage"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
@@ -973,8 +975,10 @@ export default function Layout(props: ParentProps) {
   async function archiveSession(session: Session) {
     const [store, setStore] = serverSync.child(session.directory)
     const sessions = store.session ?? []
-    const index = sessions.findIndex((s) => s.id === session.id)
-    const nextSession = sessions[index + 1] ?? sessions[index - 1]
+    const roots = sessions.filter((item) => !item.parentID)
+    const index = roots.findIndex((item) => item.id === session.id)
+    const nextSession = roots[index + 1] ?? roots[index - 1]
+    const archived = sessionTreeIDs(sessions, session.id)
 
     await serverSDK.client.session.update({
       directory: session.directory,
@@ -987,13 +991,14 @@ export default function Layout(props: ParentProps) {
         if (match.found) draft.session.splice(match.index, 1)
       }),
     )
-    if (session.id === params.id) {
+    if (params.id && archived.has(params.id)) {
       if (nextSession) {
         navigate(`/${params.dir}/session/${nextSession.id}`)
       } else {
         navigate(`/${params.dir}/session`)
       }
     }
+    notifySessionTabsRemoved({ directory: session.directory, sessionIDs: [...archived] })
   }
 
   command.register("layout", () => {

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -66,6 +66,7 @@ import { useSettings } from "@/context/settings"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { notifySessionTabsRemoved } from "@/components/titlebar-session-events"
+import { sessionTreeIDs } from "@/context/session-lineage"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionTitle } from "@/utils/session-title"
 import { makeTimer } from "@solid-primitives/timer"
@@ -895,33 +896,7 @@ export function MessageTimeline(props: {
 
     if (!result) return false
 
-    const removed = new Set<string>([sessionID])
-    const byParent = new Map<string, string[]>()
-    for (const item of sync.data.session) {
-      const parentID = item.parentID
-      if (!parentID) continue
-      const existing = byParent.get(parentID)
-      if (existing) {
-        existing.push(item.id)
-        continue
-      }
-      byParent.set(parentID, [item.id])
-    }
-
-    const stack = [sessionID]
-    while (stack.length) {
-      const parentID = stack.pop()
-      if (!parentID) continue
-
-      const children = byParent.get(parentID)
-      if (!children) continue
-
-      for (const child of children) {
-        if (removed.has(child)) continue
-        removed.add(child)
-        stack.push(child)
-      }
-    }
+    const removed = sessionTreeIDs(sync.data.session, sessionID)
 
     navigateAfterSessionRemoval(sessionID, session.parentID, nextSession?.id)
 


### PR DESCRIPTION
## Summary
- reserve close-button width so active desktop tabs do not cover their titles
- keep subagent routes attached to their root session tab
- resolve session tab metadata reactively so renamed sessions update immediately

## Testing
- bun test --preload ./happydom.ts ./src/components/titlebar-history.test.ts ./src/components/titlebar-session-events.test.ts ./src/components/titlebar-session-tabs.test.ts
- bun typecheck (packages/app)
- bun turbo typecheck (push hook)