### PR TITLE
feat(app): v2 thinking level selector

### DIFF
--- a/packages/app/e2e/regression/prompt-thinking-level.spec.ts
+++ b/packages/app/e2e/regression/prompt-thinking-level.spec.ts
@@ -64,12 +64,18 @@ test("shows the V2 thinking level control while relevant", async ({ page }) => {
   await composer.hover()
   await expect(control).toBeVisible()
 
+  await control.locator('[data-action="prompt-model-variant"]').click()
+  const high = page.getByRole("option", { name: "high" })
+  await expect(high).toBeVisible()
+  await page.mouse.move(0, 0)
+  await expect(control).toBeVisible()
+  await expect(high).toBeVisible()
+  await high.click()
+
   await idleComposer(page)
   await input.focus()
   await expect(control).toBeVisible()
 
-  await control.locator('[data-action="prompt-model-variant"]').click()
-  await page.getByRole("option", { name: "high" }).click()
   await idleComposer(page)
   await expect(control).toBeVisible()
 })

--- a/packages/app/e2e/regression/prompt-thinking-level.spec.ts
+++ b/packages/app/e2e/regression/prompt-thinking-level.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test, type Page } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+const directory = "C:/OpenCode/PromptThinkingLevelRegression"
+const projectID = "proj_prompt_thinking_level_regression"
+const sessionID = "ses_prompt_thinking_level_regression"
+
+test("shows the V2 thinking level control while relevant", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: projectID,
+      worktree: directory,
+      vcs: "git",
+      name: "prompt-thinking-level-regression",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: {
+      all: [
+        {
+          id: "opencode",
+          name: "OpenCode",
+          models: {
+            "thinking-model": {
+              id: "thinking-model",
+              name: "Thinking Model",
+              limit: { context: 200_000 },
+              variants: { high: {} },
+            },
+          },
+        },
+      ],
+      connected: ["opencode"],
+      default: { providerID: "opencode", modelID: "thinking-model" },
+    },
+    sessions: [
+      {
+        id: sessionID,
+        slug: "prompt-thinking-level-regression",
+        projectID,
+        directory,
+        title: "Prompt thinking level regression",
+        version: "dev",
+        time: { created: 1700000000000, updated: 1700000000000 },
+      },
+    ],
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+  })
+
+  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+  const composer = page.locator('[data-component="session-composer"]')
+  const input = composer.locator('[data-component="prompt-input"]')
+  const control = composer.locator('[data-component="prompt-variant-control"]')
+  await expect(composer).toBeVisible()
+
+  await idleComposer(page)
+  await expect(control).toBeHidden()
+
+  await composer.hover()
+  await expect(control).toBeVisible()
+
+  await idleComposer(page)
+  await input.focus()
+  await expect(control).toBeVisible()
+
+  await control.locator('[data-action="prompt-model-variant"]').click()
+  await page.getByRole("option", { name: "high" }).click()
+  await idleComposer(page)
+  await expect(control).toBeVisible()
+})
+
+async function idleComposer(page: Page) {
+  await page.mouse.move(0, 0)
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1101,6 +1101,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   )
 
   const variants = createMemo(() => ["default", ...local.model.variant.list()])
+  // Check provider variants directly: `variants` also includes the UI-only default option.
+  const showVariantControl = createMemo(() => local.model.variant.list().length > 0)
   const accepting = createMemo(() => {
     const id = params.id
     if (!id) return permission.isAutoAcceptingDirectory(sdk.directory)
@@ -1571,6 +1573,38 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     <ComposerPickerTrigger state={newProjectTriggerState()} />
                   </Show>
                   <ComposerModelControl state={modelControlState()} />
+                  <Show when={store.mode !== "shell" && showVariantControl()}>
+                    <div
+                      data-component="prompt-variant-control"
+                      classList={{
+                        "hidden group-hover/prompt-input:block group-focus-within/prompt-input:block":
+                          !local.model.variant.current(),
+                      }}
+                    >
+                      <TooltipKeybind
+                        placement="top"
+                        gutter={4}
+                        title={language.t("command.model.variant.cycle")}
+                        keybind={command.keybind("model.variant.cycle")}
+                      >
+                        <Select
+                          size="normal"
+                          options={variants()}
+                          current={local.model.variant.current() ?? "default"}
+                          label={(x) => (x === "default" ? language.t("common.default") : x)}
+                          onSelect={(value) => {
+                            local.model.variant.set(value === "default" ? undefined : value)
+                            restoreFocus()
+                          }}
+                          class="capitalize max-w-[160px] justify-start text-v2-text-text-faint"
+                          valueClass="truncate text-[13px] font-[440] leading-5 text-v2-text-text-faint"
+                          triggerStyle={control()}
+                          triggerProps={{ "data-action": "prompt-model-variant" }}
+                          variant="ghost"
+                        />
+                      </TooltipKeybind>
+                    </div>
+                  </Show>
                 </div>
                 <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
                   <IconButton
@@ -1890,7 +1924,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                             </TooltipKeybind>
                           </Show>
                         </div>
-                        <Show when={variants().length > 2}>
+                        <Show when={showVariantControl()}>
                           <div
                             data-component="prompt-variant-control"
                             style={providersShouldFadeIn() ? { animation: "fade-in 0.3s" } : undefined}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -277,6 +277,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     draggingType: "image" | "@mention" | null
     mode: "normal" | "shell"
     applyingHistory: boolean
+    variantOpen: boolean
   }>({
     popover: null,
     historyIndex: -1,
@@ -285,6 +286,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     draggingType: null,
     mode: "normal",
     applyingHistory: false,
+    variantOpen: false,
   })
   const [picker, setPicker] = createStore({
     projectOpen: false,
@@ -1578,7 +1580,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       data-component="prompt-variant-control"
                       classList={{
                         "hidden group-hover/prompt-input:block group-focus-within/prompt-input:block":
-                          !local.model.variant.current(),
+                          !local.model.variant.current() && !store.variantOpen,
                       }}
                     >
                       <TooltipKeybind
@@ -1592,6 +1594,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                           options={variants()}
                           current={local.model.variant.current() ?? "default"}
                           label={(x) => (x === "default" ? language.t("common.default") : x)}
+                          onOpenChange={(open) => setStore("variantOpen", open)}
                           onSelect={(value) => {
                             local.model.variant.set(value === "default" ? undefined : value)
                             restoreFocus()


### PR DESCRIPTION
## Summary
- restore the thinking-level selector in the V2 composer
- show it on composer hover or focus while defaulted, and keep it visible for non-default selections
- use the provider variant list directly for capability detection, matching the TUI behavior

## Test plan
- bun run test:e2e -- e2e/regression/prompt-thinking-level.spec.ts
- bun run test:unit
- bun typecheck
- bun turbo typecheck (push hook)