### PR TITLE
fix(app): make auto-accept permissions server-global

### DIFF
--- a/packages/app/e2e/regression/auto-accept-settings-scope.spec.ts
+++ b/packages/app/e2e/regression/auto-accept-settings-scope.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { fixture, pageMessages } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+test("v2 desktop settings auto-accept applies globally", async ({ page }) => {
+  const permissionLists: string[] = []
+  page.on("request", (request) => {
+    const url = new URL(request.url())
+    if (request.method() !== "GET" || url.pathname !== "/permission") return
+    const directory = url.searchParams.get("directory")
+    if (directory) permissionLists.push(directory)
+  })
+
+  await mockOpenCodeServer(page, {
+    sessions: fixture.sessions,
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    pageMessages,
+  })
+  await page.addInitScript((directory) => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({ projects: { local: [{ worktree: directory, expanded: true }] } }),
+    )
+  }, fixture.directory)
+
+  await page.goto("/")
+  await page.getByRole("button", { name: "Settings" }).click()
+  await expect(autoAccept(page)).toBeEnabled()
+  await page.locator('[data-action="settings-auto-accept-permissions"] [data-slot="switch-control"]').click()
+  await expect(autoAccept(page)).toBeChecked()
+  await expect.poll(() => permissionState(page)).toEqual({ autoAccept: { "*": true } })
+  await expect.poll(() => permissionLists).toContain(fixture.directory)
+  await page.keyboard.press("Escape")
+
+  const first = fixture.sessions[0]
+  const second = fixture.sessions[1]
+  await page.goto(`/${base64Encode(fixture.directory)}/session/${first.id}`)
+  await openSessionSettings(page, first.title)
+  await expect(autoAccept(page)).toBeChecked()
+  await page.keyboard.press("Escape")
+
+  await page.goto(`/${base64Encode(fixture.directory)}/session/${second.id}`)
+  await openSessionSettings(page, second.title)
+  await expect(autoAccept(page)).toBeChecked()
+})
+
+async function openSessionSettings(page: import("@playwright/test").Page, title: string) {
+  await expect(page.getByRole("heading", { name: title })).toBeVisible()
+  await page.evaluate(() => document.dispatchEvent(new KeyboardEvent("keydown", { key: ",", ctrlKey: true })))
+  await expect(autoAccept(page)).toBeVisible()
+}
+
+function autoAccept(page: import("@playwright/test").Page) {
+  return page.locator('[data-action="settings-auto-accept-permissions"] input')
+}
+
+function permissionState(page: import("@playwright/test").Page) {
+  return page.evaluate(() => JSON.parse(localStorage.getItem("opencode.global.dat:permission") ?? "{}"))
+}

--- a/packages/app/e2e/regression/auto-accept-settings-scope.spec.ts
+++ b/packages/app/e2e/regression/auto-accept-settings-scope.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from "@playwright/test"
 import { base64Encode } from "@opencode-ai/core/util/encode"
+import { serverAcceptKey } from "../../src/context/permission-auto-respond"
 import { fixture, pageMessages } from "../smoke/session-timeline.fixture"
 import { mockOpenCodeServer } from "../utils/mock-server"
 
-test("v2 desktop settings auto-accept applies globally", async ({ page }) => {
+test("v2 desktop settings auto-accept applies across the active server", async ({ page }) => {
   const permissionLists: string[] = []
   page.on("request", (request) => {
     const url = new URL(request.url())
@@ -32,7 +33,7 @@ test("v2 desktop settings auto-accept applies globally", async ({ page }) => {
   await expect(autoAccept(page)).toBeEnabled()
   await page.locator('[data-action="settings-auto-accept-permissions"] [data-slot="switch-control"]').click()
   await expect(autoAccept(page)).toBeChecked()
-  await expect.poll(() => permissionState(page)).toEqual({ autoAccept: { "*": true } })
+  await expect.poll(() => permissionState(page)).toEqual({ autoAccept: { [serverAcceptKey("http://127.0.0.1:4096")]: true } })
   await expect.poll(() => permissionLists).toContain(fixture.directory)
   await page.keyboard.press("Escape")
 

--- a/packages/app/e2e/regression/auto-accept-settings-scope.spec.ts
+++ b/packages/app/e2e/regression/auto-accept-settings-scope.spec.ts
@@ -49,6 +49,52 @@ test("v2 desktop settings auto-accept applies across the active server", async (
   await expect(autoAccept(page)).toBeChecked()
 })
 
+test("server auto-accept waits for inherited session overrides", async ({ page }) => {
+  const parent = { ...fixture.sessions[0], id: "ses_parent" }
+  const child = { ...fixture.sessions[1], id: "ses_child", parentID: parent.id }
+  const responses: unknown[] = []
+  let permissionLists = 0
+  page.on("request", (request) => {
+    if (request.method() === "GET" && new URL(request.url()).pathname === "/permission") permissionLists++
+  })
+  await mockOpenCodeServer(page, {
+    sessions: [parent, child],
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    pageMessages: () => ({ items: [] }),
+    permissions: [
+      {
+        id: "per_child",
+        sessionID: child.id,
+        permission: "bash",
+        patterns: ["*"],
+        metadata: {},
+        always: [],
+      },
+    ],
+    onPermissionRespond: (input) => responses.push(input),
+  })
+  await page.addInitScript((input) => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({ projects: { local: [{ worktree: input.directory, expanded: true }] } }),
+    )
+    localStorage.setItem(
+      "opencode.global.dat:permission",
+      JSON.stringify({ autoAccept: { [`${base64Encode(input.directory)}/${input.parentID}`]: false } }),
+    )
+  }, { directory: fixture.directory, parentID: parent.id })
+
+  await page.goto("/")
+  await page.getByRole("button", { name: "Settings" }).click()
+  await page.locator('[data-action="settings-auto-accept-permissions"] [data-slot="switch-control"]').click()
+  await expect.poll(() => permissionLists).toBeGreaterThan(0)
+  await page.waitForTimeout(500)
+  expect(responses).toEqual([])
+})
+
 async function openSessionSettings(page: import("@playwright/test").Page, title: string) {
   await expect(page.getByRole("heading", { name: title })).toBeVisible()
   await page.evaluate(() => document.dispatchEvent(new KeyboardEvent("keydown", { key: ",", ctrlKey: true })))

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -19,6 +19,8 @@ export interface MockServerConfig {
   sessions: ({ id: string } & Record<string, unknown>)[]
   pageMessages: (sessionId: string, limit: number, before?: string) => { items: unknown[]; cursor?: string }
   events?: () => unknown[]
+  permissions?: unknown[]
+  onPermissionRespond?: (input: { sessionID: string; permissionID: string; response: unknown }) => void
 }
 
 export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
@@ -47,6 +49,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     if (path === "/global/event" || path === "/event") return sse(route, config.events?.())
     if (path === "/global/health") return json(route, { healthy: true })
     if (emptyObject.has(path)) return json(route, {})
+    if (path === "/permission") return json(route, config.permissions ?? [])
     if (emptyList.has(path)) return json(route, [])
     if (path in staticRoutes) return json(route, staticRoutes[path])
 
@@ -57,6 +60,16 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     }
 
     if (/^\/session\/[^/]+\/(children|todo|diff)$/.test(path)) return json(route, [])
+
+    const permissionMatch = path.match(/^\/session\/([^/]+)\/permissions\/([^/]+)$/)
+    if (permissionMatch) {
+      config.onPermissionRespond?.({
+        sessionID: permissionMatch[1],
+        permissionID: permissionMatch[2],
+        response: route.request().postDataJSON(),
+      })
+      return json(route, {})
+    }
 
     const messagesMatch = path.match(/^\/session\/([^/]+)\/message$/)
     if (messagesMatch) {

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -300,7 +300,7 @@ export const SettingsGeneral: Component = () => {
           description={language.t("toast.permissions.autoaccept.on.description")}
         >
           <div data-action="settings-auto-accept-permissions">
-            <Switch checked={permission.isAutoAcceptingGlobal()} onChange={permission.setAutoAcceptGlobal} />
+            <Switch checked={permission.isAutoAcceptingServer()} onChange={permission.setAutoAcceptServer} />
           </div>
         </SettingsRow>
 

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -9,7 +9,6 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { showToast } from "@/utils/toast"
-import { useParams } from "@solidjs/router"
 import { useLanguage } from "@/context/language"
 import { usePermission } from "@/context/permission"
 import { usePlatform, type DisplayBackend } from "@/context/platform"
@@ -27,7 +26,6 @@ import {
   terminalInput,
   useSettings,
 } from "@/context/settings"
-import { decode64 } from "@/utils/base64"
 import { playSoundById, SOUND_OPTIONS } from "@/utils/sound"
 import { Link } from "./link"
 import { SettingsList } from "./settings-list"
@@ -88,7 +86,6 @@ export const SettingsGeneral: Component = () => {
   const permission = usePermission()
   const platform = usePlatform()
   const dialog = useDialog()
-  const params = useParams()
   const settings = useSettings()
 
   const [store, setStore] = createStore({
@@ -96,31 +93,6 @@ export const SettingsGeneral: Component = () => {
   })
 
   const linux = createMemo(() => platform.platform === "desktop" && platform.os === "linux")
-  const dir = createMemo(() => decode64(params.dir))
-  const accepting = createMemo(() => {
-    const value = dir()
-    if (!value) return false
-    if (!params.id) return permission.isAutoAcceptingDirectory(value)
-    return permission.isAutoAccepting(params.id, value)
-  })
-
-  const toggleAccept = (checked: boolean) => {
-    const value = dir()
-    if (!value) return
-
-    if (!params.id) {
-      if (permission.isAutoAcceptingDirectory(value) === checked) return
-      permission.toggleAutoAcceptDirectory(value)
-      return
-    }
-
-    if (checked) {
-      permission.enableAutoAccept(params.id, value)
-      return
-    }
-
-    permission.disableAutoAccept(params.id, value)
-  }
   const desktop = createMemo(() => platform.platform === "desktop")
 
   const check = () => {
@@ -328,7 +300,7 @@ export const SettingsGeneral: Component = () => {
           description={language.t("toast.permissions.autoaccept.on.description")}
         >
           <div data-action="settings-auto-accept-permissions">
-            <Switch checked={accepting()} disabled={!dir()} onChange={toggleAccept} />
+            <Switch checked={permission.isAutoAcceptingGlobal()} onChange={permission.setAutoAcceptGlobal} />
           </div>
         </SettingsRow>
 

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -299,7 +299,7 @@ export const SettingsGeneralV2: Component = () => {
           description={language.t("toast.permissions.autoaccept.on.description")}
         >
           <div data-action="settings-auto-accept-permissions">
-            <Switch checked={permission.isAutoAcceptingGlobal()} onChange={permission.setAutoAcceptGlobal} />
+            <Switch checked={permission.isAutoAcceptingServer()} onChange={permission.setAutoAcceptServer} />
           </div>
         </SettingsRowV2>
 

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -9,7 +9,6 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { showToast } from "@/utils/toast"
-import { useParams } from "@solidjs/router"
 import { useLanguage } from "@/context/language"
 import { usePermission } from "@/context/permission"
 import { usePlatform, type DisplayBackend } from "@/context/platform"
@@ -27,7 +26,6 @@ import {
   terminalInput,
   useSettings,
 } from "@/context/settings"
-import { decode64 } from "@/utils/base64"
 import { playSoundById, SOUND_OPTIONS } from "@/utils/sound"
 import { Link } from "../link"
 import { SettingsListV2 } from "./parts/list"
@@ -90,7 +88,6 @@ export const SettingsGeneralV2: Component = () => {
   const permission = usePermission()
   const platform = usePlatform()
   const dialog = useDialog()
-  const params = useParams()
   const settings = useSettings()
 
   const [store, setStore] = createStore({
@@ -98,31 +95,6 @@ export const SettingsGeneralV2: Component = () => {
   })
 
   const linux = createMemo(() => platform.platform === "desktop" && platform.os === "linux")
-  const dir = createMemo(() => decode64(params.dir))
-  const accepting = createMemo(() => {
-    const value = dir()
-    if (!value) return false
-    if (!params.id) return permission.isAutoAcceptingDirectory(value)
-    return permission.isAutoAccepting(params.id, value)
-  })
-
-  const toggleAccept = (checked: boolean) => {
-    const value = dir()
-    if (!value) return
-
-    if (!params.id) {
-      if (permission.isAutoAcceptingDirectory(value) === checked) return
-      permission.toggleAutoAcceptDirectory(value)
-      return
-    }
-
-    if (checked) {
-      permission.enableAutoAccept(params.id, value)
-      return
-    }
-
-    permission.disableAutoAccept(params.id, value)
-  }
   const desktop = createMemo(() => platform.platform === "desktop")
 
   const check = () => {
@@ -327,7 +299,7 @@ export const SettingsGeneralV2: Component = () => {
           description={language.t("toast.permissions.autoaccept.on.description")}
         >
           <div data-action="settings-auto-accept-permissions">
-            <Switch checked={accepting()} disabled={!dir()} onChange={toggleAccept} />
+            <Switch checked={permission.isAutoAcceptingGlobal()} onChange={permission.setAutoAcceptGlobal} />
           </div>
         </SettingsRowV2>
 

--- a/packages/app/src/context/permission-auto-respond.test.ts
+++ b/packages/app/src/context/permission-auto-respond.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { PermissionRequest, Session } from "@opencode-ai/sdk/v2/client"
 import { base64Encode } from "@opencode-ai/core/util/encode"
-import { autoRespondsPermission, isDirectoryAutoAccepting } from "./permission-auto-respond"
+import { autoRespondsPermission, isDirectoryAutoAccepting, isGlobalAutoAccepting } from "./permission-auto-respond"
 
 const session = (input: { id: string; parentID?: string }) =>
   ({
@@ -81,6 +81,22 @@ describe("autoRespondsPermission", () => {
 
     expect(autoRespondsPermission(autoAccept, sessions, permission("root"), directory)).toBe(false)
   })
+
+  test("falls back to global auto-accept", () => {
+    expect(autoRespondsPermission({ "*": true }, [session({ id: "root" })], permission("root"), "/tmp/project")).toBe(
+      true,
+    )
+  })
+
+  test("session-level override takes precedence over global auto-accept", () => {
+    const directory = "/tmp/project"
+    const autoAccept = {
+      "*": true,
+      [`${base64Encode(directory)}/root`]: false,
+    }
+
+    expect(autoRespondsPermission(autoAccept, [session({ id: "root" })], permission("root"), directory)).toBe(false)
+  })
 })
 
 describe("isDirectoryAutoAccepting", () => {
@@ -98,5 +114,24 @@ describe("isDirectoryAutoAccepting", () => {
     const directory = "/tmp/project"
     const autoAccept = { [`${base64Encode(directory)}/*`]: false }
     expect(isDirectoryAutoAccepting(autoAccept, directory)).toBe(false)
+  })
+
+  test("falls back to global auto-accept", () => {
+    expect(isDirectoryAutoAccepting({ "*": true }, "/tmp/project")).toBe(true)
+  })
+
+  test("prefers a directory override over global auto-accept", () => {
+    const directory = "/tmp/project"
+    expect(isDirectoryAutoAccepting({ "*": true, [`${base64Encode(directory)}/*`]: false }, directory)).toBe(false)
+  })
+})
+
+describe("isGlobalAutoAccepting", () => {
+  test("returns the global wildcard value", () => {
+    expect(isGlobalAutoAccepting({ "*": true })).toBe(true)
+  })
+
+  test("ignores narrower auto-accept entries", () => {
+    expect(isGlobalAutoAccepting({ [`${base64Encode("/tmp/project")}/*`]: true })).toBe(false)
   })
 })

--- a/packages/app/src/context/permission-auto-respond.test.ts
+++ b/packages/app/src/context/permission-auto-respond.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { PermissionRequest, Session } from "@opencode-ai/sdk/v2/client"
 import { base64Encode } from "@opencode-ai/core/util/encode"
-import { autoRespondsPermission, isDirectoryAutoAccepting, isGlobalAutoAccepting } from "./permission-auto-respond"
+import { autoRespondsPermission, isDirectoryAutoAccepting, isServerAutoAccepting, serverAcceptKey } from "./permission-auto-respond"
 
 const session = (input: { id: string; parentID?: string }) =>
   ({
@@ -82,20 +82,34 @@ describe("autoRespondsPermission", () => {
     expect(autoRespondsPermission(autoAccept, sessions, permission("root"), directory)).toBe(false)
   })
 
-  test("falls back to global auto-accept", () => {
-    expect(autoRespondsPermission({ "*": true }, [session({ id: "root" })], permission("root"), "/tmp/project")).toBe(
-      true,
-    )
+  test("falls back to server-level auto-accept", () => {
+    const server = "http://localhost:4096"
+    expect(
+      autoRespondsPermission({ [serverAcceptKey(server)]: true }, [session({ id: "root" })], permission("root"), "/tmp/project", server),
+    ).toBe(true)
   })
 
-  test("session-level override takes precedence over global auto-accept", () => {
+  test("does not apply another server's auto-accept", () => {
+    expect(
+      autoRespondsPermission(
+        { [serverAcceptKey("http://localhost:4096")]: true },
+        [session({ id: "root" })],
+        permission("root"),
+        "/tmp/project",
+        "http://localhost:4097",
+      ),
+    ).toBe(false)
+  })
+
+  test("session-level override takes precedence over server-level auto-accept", () => {
     const directory = "/tmp/project"
+    const server = "http://localhost:4096"
     const autoAccept = {
-      "*": true,
+      [serverAcceptKey(server)]: true,
       [`${base64Encode(directory)}/root`]: false,
     }
 
-    expect(autoRespondsPermission(autoAccept, [session({ id: "root" })], permission("root"), directory)).toBe(false)
+    expect(autoRespondsPermission(autoAccept, [session({ id: "root" })], permission("root"), directory, server)).toBe(false)
   })
 })
 
@@ -116,22 +130,25 @@ describe("isDirectoryAutoAccepting", () => {
     expect(isDirectoryAutoAccepting(autoAccept, directory)).toBe(false)
   })
 
-  test("falls back to global auto-accept", () => {
-    expect(isDirectoryAutoAccepting({ "*": true }, "/tmp/project")).toBe(true)
+  test("falls back to server-level auto-accept", () => {
+    const server = "http://localhost:4096"
+    expect(isDirectoryAutoAccepting({ [serverAcceptKey(server)]: true }, "/tmp/project", server)).toBe(true)
   })
 
-  test("prefers a directory override over global auto-accept", () => {
+  test("prefers a directory override over server-level auto-accept", () => {
     const directory = "/tmp/project"
-    expect(isDirectoryAutoAccepting({ "*": true, [`${base64Encode(directory)}/*`]: false }, directory)).toBe(false)
+    const server = "http://localhost:4096"
+    expect(isDirectoryAutoAccepting({ [serverAcceptKey(server)]: true, [`${base64Encode(directory)}/*`]: false }, directory, server)).toBe(false)
   })
 })
 
-describe("isGlobalAutoAccepting", () => {
-  test("returns the global wildcard value", () => {
-    expect(isGlobalAutoAccepting({ "*": true })).toBe(true)
+describe("isServerAutoAccepting", () => {
+  test("returns the server wildcard value", () => {
+    const server = "http://localhost:4096"
+    expect(isServerAutoAccepting({ [serverAcceptKey(server)]: true }, server)).toBe(true)
   })
 
   test("ignores narrower auto-accept entries", () => {
-    expect(isGlobalAutoAccepting({ [`${base64Encode("/tmp/project")}/*`]: true })).toBe(false)
+    expect(isServerAutoAccepting({ [`${base64Encode("/tmp/project")}/*`]: true }, "http://localhost:4096")).toBe(false)
   })
 })

--- a/packages/app/src/context/permission-auto-respond.ts
+++ b/packages/app/src/context/permission-auto-respond.ts
@@ -1,7 +1,5 @@
 import { base64Encode } from "@opencode-ai/core/util/encode"
 
-export const GLOBAL_ACCEPT_KEY = "*"
-
 export function acceptKey(sessionID: string, directory?: string) {
   if (!directory) return sessionID
   return `${base64Encode(directory)}/${sessionID}`
@@ -11,19 +9,23 @@ export function directoryAcceptKey(directory: string) {
   return `${base64Encode(directory)}/*`
 }
 
+export function serverAcceptKey(server: string) {
+  return `server:${base64Encode(server)}/*`
+}
+
 function accepted(autoAccept: Record<string, boolean>, sessionID: string, directory?: string) {
   const key = acceptKey(sessionID, directory)
   const directoryKey = directory ? directoryAcceptKey(directory) : undefined
   return autoAccept[key] ?? autoAccept[sessionID] ?? (directoryKey ? autoAccept[directoryKey] : undefined)
 }
 
-export function isDirectoryAutoAccepting(autoAccept: Record<string, boolean>, directory: string) {
+export function isDirectoryAutoAccepting(autoAccept: Record<string, boolean>, directory: string, server?: string) {
   const key = directoryAcceptKey(directory)
-  return autoAccept[key] ?? isGlobalAutoAccepting(autoAccept)
+  return autoAccept[key] ?? (server ? isServerAutoAccepting(autoAccept, server) : false)
 }
 
-export function isGlobalAutoAccepting(autoAccept: Record<string, boolean>) {
-  return autoAccept[GLOBAL_ACCEPT_KEY] ?? false
+export function isServerAutoAccepting(autoAccept: Record<string, boolean>, server: string) {
+  return autoAccept[serverAcceptKey(server)] ?? false
 }
 
 function sessionLineage(session: { id: string; parentID?: string }[], sessionID: string) {
@@ -49,9 +51,10 @@ export function autoRespondsPermission(
   session: { id: string; parentID?: string }[],
   permission: { sessionID: string },
   directory?: string,
+  server?: string,
 ) {
   const value = sessionLineage(session, permission.sessionID)
     .map((id) => accepted(autoAccept, id, directory))
     .find((item): item is boolean => item !== undefined)
-  return value ?? isGlobalAutoAccepting(autoAccept)
+  return value ?? (server ? isServerAutoAccepting(autoAccept, server) : false)
 }

--- a/packages/app/src/context/permission-auto-respond.ts
+++ b/packages/app/src/context/permission-auto-respond.ts
@@ -1,5 +1,7 @@
 import { base64Encode } from "@opencode-ai/core/util/encode"
 
+export const GLOBAL_ACCEPT_KEY = "*"
+
 export function acceptKey(sessionID: string, directory?: string) {
   if (!directory) return sessionID
   return `${base64Encode(directory)}/${sessionID}`
@@ -17,7 +19,11 @@ function accepted(autoAccept: Record<string, boolean>, sessionID: string, direct
 
 export function isDirectoryAutoAccepting(autoAccept: Record<string, boolean>, directory: string) {
   const key = directoryAcceptKey(directory)
-  return autoAccept[key] ?? false
+  return autoAccept[key] ?? isGlobalAutoAccepting(autoAccept)
+}
+
+export function isGlobalAutoAccepting(autoAccept: Record<string, boolean>) {
+  return autoAccept[GLOBAL_ACCEPT_KEY] ?? false
 }
 
 function sessionLineage(session: { id: string; parentID?: string }[], sessionID: string) {
@@ -47,5 +53,5 @@ export function autoRespondsPermission(
   const value = sessionLineage(session, permission.sessionID)
     .map((id) => accepted(autoAccept, id, directory))
     .find((item): item is boolean => item !== undefined)
-  return value ?? false
+  return value ?? isGlobalAutoAccepting(autoAccept)
 }

--- a/packages/app/src/context/permission.tsx
+++ b/packages/app/src/context/permission.tsx
@@ -196,6 +196,8 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
 
     function flushServer() {
       for (const directory of serverDirectories()) {
+        const [childStore] = serverSync.child(directory)
+        if (childStore.status !== "complete") continue
         flushPending(directory, isAutoAcceptingServer)
       }
     }

--- a/packages/app/src/context/permission.tsx
+++ b/packages/app/src/context/permission.tsx
@@ -2,15 +2,19 @@ import { createEffect, createMemo, onCleanup } from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2/client"
+import { queryOptions, useQueryClient } from "@tanstack/solid-query"
 import { Persist, persisted } from "@/utils/persist"
 import { useServerSDK } from "@/context/server-sdk"
 import { useServerSync } from "./server-sync"
+import { useServer } from "./server"
 import { useParams } from "@solidjs/router"
 import { decode64 } from "@/utils/base64"
 import {
   acceptKey,
   directoryAcceptKey,
+  GLOBAL_ACCEPT_KEY,
   isDirectoryAutoAccepting,
+  isGlobalAutoAccepting,
   autoRespondsPermission,
 } from "./permission-auto-respond"
 
@@ -48,8 +52,10 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
   name: "Permission",
   init: () => {
     const params = useParams()
+    const server = useServer()
     const serverSDK = useServerSDK()
     const serverSync = useServerSync()
+    const queryClient = useQueryClient()
 
     const permissionsEnabled = createMemo(() => {
       const directory = decode64(params.dir)
@@ -147,10 +153,58 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       return isDirectoryAutoAccepting(store.autoAccept, directory)
     }
 
+    function isAutoAcceptingGlobal() {
+      return isGlobalAutoAccepting(store.autoAccept)
+    }
+
     function shouldAutoRespond(permission: PermissionRequest, directory?: string) {
       const session = directory ? serverSync.child(directory, { bootstrap: false })[0].session : []
       return autoRespondsPermission(store.autoAccept, session, permission, directory)
     }
+
+    function pendingPermissionsQuery(directory: string) {
+      return queryOptions({
+        queryKey: [directory, "permission"] as const,
+        queryFn: () => serverSDK.client.permission.list({ directory }).then((x) => x.data ?? []),
+      })
+    }
+
+    function autoRespondPending(directory: string, permissions: PermissionRequest[], enabled: () => boolean) {
+      if (!enabled()) return
+      for (const perm of permissions) {
+        if (!perm?.id) continue
+        if (!shouldAutoRespond(perm, directory)) continue
+        respondOnce(perm, directory)
+      }
+    }
+
+    function flushPending(directory: string, enabled: () => boolean) {
+      queryClient
+        .fetchQuery(pendingPermissionsQuery(directory))
+        .then((permissions) => autoRespondPending(directory, permissions, enabled))
+        .catch(() => undefined)
+    }
+
+    const globalDirectories = createMemo(() => {
+      const routeDirectory = decode64(params.dir)
+      const directories = [
+        ...server.projects.list().map((project) => project.worktree),
+        ...serverSync.data.project.flatMap((project) => [project.worktree, ...(project.sandboxes ?? [])]),
+      ]
+      return [...new Set(routeDirectory ? [routeDirectory, ...directories] : directories)]
+    })
+
+    function flushGlobal() {
+      for (const directory of globalDirectories()) {
+        flushPending(directory, isAutoAcceptingGlobal)
+      }
+    }
+
+    createEffect(() => {
+      if (!ready()) return
+      if (!isAutoAcceptingGlobal()) return
+      flushGlobal()
+    })
 
     function bumpEnableVersion(sessionID: string, directory?: string) {
       const key = acceptKey(sessionID, directory)
@@ -178,17 +232,7 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
         }),
       )
 
-      serverSDK.client.permission
-        .list({ directory })
-        .then((x) => {
-          if (!isAutoAcceptingDirectory(directory)) return
-          for (const perm of x.data ?? []) {
-            if (!perm?.id) continue
-            if (!shouldAutoRespond(perm, directory)) continue
-            respondOnce(perm, directory)
-          }
-        })
-        .catch(() => undefined)
+      flushPending(directory, () => isAutoAcceptingDirectory(directory))
     }
 
     function disableDirectory(directory: string) {
@@ -196,6 +240,23 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       setStore(
         produce((draft) => {
           draft.autoAccept[key] = false
+        }),
+      )
+    }
+
+    function enableGlobal() {
+      setStore(
+        produce((draft) => {
+          draft.autoAccept[GLOBAL_ACCEPT_KEY] = true
+        }),
+      )
+      flushGlobal()
+    }
+
+    function disableGlobal() {
+      setStore(
+        produce((draft) => {
+          draft.autoAccept[GLOBAL_ACCEPT_KEY] = false
         }),
       )
     }
@@ -210,18 +271,10 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
         }),
       )
 
-      serverSDK.client.permission
-        .list({ directory })
-        .then((x) => {
-          if (enableVersion.get(key) !== version) return
-          if (!isAutoAccepting(sessionID, directory)) return
-          for (const perm of x.data ?? []) {
-            if (!perm?.id) continue
-            if (!shouldAutoRespond(perm, directory)) continue
-            respondOnce(perm, directory)
-          }
-        })
-        .catch(() => undefined)
+      flushPending(directory, () => {
+        if (enableVersion.get(key) !== version) return false
+        return isAutoAccepting(sessionID, directory)
+      })
     }
 
     function disable(sessionID: string, directory?: string) {
@@ -244,6 +297,7 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       },
       isAutoAccepting,
       isAutoAcceptingDirectory,
+      isAutoAcceptingGlobal,
       toggleAutoAccept(sessionID: string, directory: string) {
         if (isAutoAccepting(sessionID, directory)) {
           disable(sessionID, directory)
@@ -258,6 +312,14 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
           return
         }
         enableDirectory(directory)
+      },
+      setAutoAcceptGlobal(value: boolean) {
+        if (isAutoAcceptingGlobal() === value) return
+        if (value) {
+          enableGlobal()
+          return
+        }
+        disableGlobal()
       },
       enableAutoAccept(sessionID: string, directory: string) {
         if (isAutoAccepting(sessionID, directory)) return

--- a/packages/app/src/context/permission.tsx
+++ b/packages/app/src/context/permission.tsx
@@ -12,9 +12,9 @@ import { decode64 } from "@/utils/base64"
 import {
   acceptKey,
   directoryAcceptKey,
-  GLOBAL_ACCEPT_KEY,
   isDirectoryAutoAccepting,
-  isGlobalAutoAccepting,
+  isServerAutoAccepting,
+  serverAcceptKey,
   autoRespondsPermission,
 } from "./permission-auto-respond"
 
@@ -146,25 +146,25 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
 
     function isAutoAccepting(sessionID: string, directory?: string) {
       const session = directory ? serverSync.child(directory, { bootstrap: false })[0].session : []
-      return autoRespondsPermission(store.autoAccept, session, { sessionID }, directory)
+      return autoRespondsPermission(store.autoAccept, session, { sessionID }, directory, server.key)
     }
 
     function isAutoAcceptingDirectory(directory: string) {
-      return isDirectoryAutoAccepting(store.autoAccept, directory)
+      return isDirectoryAutoAccepting(store.autoAccept, directory, server.key)
     }
 
-    function isAutoAcceptingGlobal() {
-      return isGlobalAutoAccepting(store.autoAccept)
+    function isAutoAcceptingServer() {
+      return isServerAutoAccepting(store.autoAccept, server.key)
     }
 
     function shouldAutoRespond(permission: PermissionRequest, directory?: string) {
       const session = directory ? serverSync.child(directory, { bootstrap: false })[0].session : []
-      return autoRespondsPermission(store.autoAccept, session, permission, directory)
+      return autoRespondsPermission(store.autoAccept, session, permission, directory, server.key)
     }
 
     function pendingPermissionsQuery(directory: string) {
       return queryOptions({
-        queryKey: [directory, "permission"] as const,
+        queryKey: [server.key, directory, "permission"] as const,
         queryFn: () => serverSDK.client.permission.list({ directory }).then((x) => x.data ?? []),
       })
     }
@@ -185,7 +185,7 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
         .catch(() => undefined)
     }
 
-    const globalDirectories = createMemo(() => {
+    const serverDirectories = createMemo(() => {
       const routeDirectory = decode64(params.dir)
       const directories = [
         ...server.projects.list().map((project) => project.worktree),
@@ -194,16 +194,16 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       return [...new Set(routeDirectory ? [routeDirectory, ...directories] : directories)]
     })
 
-    function flushGlobal() {
-      for (const directory of globalDirectories()) {
-        flushPending(directory, isAutoAcceptingGlobal)
+    function flushServer() {
+      for (const directory of serverDirectories()) {
+        flushPending(directory, isAutoAcceptingServer)
       }
     }
 
     createEffect(() => {
       if (!ready()) return
-      if (!isAutoAcceptingGlobal()) return
-      flushGlobal()
+      if (!isAutoAcceptingServer()) return
+      flushServer()
     })
 
     function bumpEnableVersion(sessionID: string, directory?: string) {
@@ -244,19 +244,19 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       )
     }
 
-    function enableGlobal() {
+    function enableServer() {
       setStore(
         produce((draft) => {
-          draft.autoAccept[GLOBAL_ACCEPT_KEY] = true
+          draft.autoAccept[serverAcceptKey(server.key)] = true
         }),
       )
-      flushGlobal()
+      flushServer()
     }
 
-    function disableGlobal() {
+    function disableServer() {
       setStore(
         produce((draft) => {
-          draft.autoAccept[GLOBAL_ACCEPT_KEY] = false
+          draft.autoAccept[serverAcceptKey(server.key)] = false
         }),
       )
     }
@@ -297,7 +297,7 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       },
       isAutoAccepting,
       isAutoAcceptingDirectory,
-      isAutoAcceptingGlobal,
+      isAutoAcceptingServer,
       toggleAutoAccept(sessionID: string, directory: string) {
         if (isAutoAccepting(sessionID, directory)) {
           disable(sessionID, directory)
@@ -313,13 +313,13 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
         }
         enableDirectory(directory)
       },
-      setAutoAcceptGlobal(value: boolean) {
-        if (isAutoAcceptingGlobal() === value) return
+      setAutoAcceptServer(value: boolean) {
+        if (isAutoAcceptingServer() === value) return
         if (value) {
-          enableGlobal()
+          enableServer()
           return
         }
-        disableGlobal()
+        disableServer()
       },
       enableAutoAccept(sessionID: string, directory: string) {
         if (isAutoAccepting(sessionID, directory)) return


### PR DESCRIPTION
## Summary
- make the desktop settings auto-accept toggle apply across sessions, directories, worktrees, and sandboxes for the active server
- persist a server-scoped wildcard so switching servers shows that server own auto-accept preference
- preserve narrower session and directory overrides for contextual auto-accept commands
- reconcile existing pending permissions through TanStack Query when server-level auto-accept is enabled or known directories change
- wait for directory bootstrap before server-wide reconciliation so inherited session overrides are available
- add unit coverage for server wildcard precedence and headless v2 settings regressions

## Scope
- changes are limited to packages/app
- does not modify packages/opencode, the TUI, desktop main-process code, or generated SDK code

## Test plan
- bun typecheck from packages/app
- bun run test:unit from packages/app
- bun run test:e2e e2e/regression/auto-accept-settings-scope.spec.ts from packages/app
- git diff --check
- pre-push hook: bun turbo typecheck