### PR TITLE
fix(session): inherit parent directory + workspaceID in subagent sessions

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -204,11 +204,13 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const fork = Effect.fn("SessionHttpApi.fork")(function* (ctx: {
       params: { sessionID: SessionID }
       payload?: typeof ForkPayload.Type
+      directory?: string
     }) {
       return yield* SessionError.mapStorageNotFound(
         session.fork({
           sessionID: ctx.params.sessionID,
           messageID: ctx.payload?.messageID,
+          directory: ctx.directory,
         }),
       )
     })
@@ -217,14 +219,16 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID }
       request: HttpServerRequest.HttpServerRequest
     }) {
+      const url = new URL(ctx.request.url, "http://localhost")
+      const directory = url.searchParams.get("directory") ?? undefined
       const body = yield* Effect.orDie(ctx.request.text)
-      if (body.trim().length === 0) return yield* fork({ params: ctx.params })
+      if (body.trim().length === 0) return yield* fork({ params: ctx.params, directory })
 
       const json = yield* tryParseJson(body)
       const payload = yield* Schema.decodeUnknownEffect(ForkPayload)(json).pipe(
         Effect.mapError(() => new HttpApiError.BadRequest({})),
       )
-      return yield* fork({ params: ctx.params, payload })
+      return yield* fork({ params: ctx.params, payload, directory })
     })
 
     const abort = Effect.fn("SessionHttpApi.abort")(function* (ctx: { params: { sessionID: SessionID } }) {

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -717,16 +717,39 @@ export const layer: Layer.Layer<
     }) {
       const ctx = yield* InstanceState.context
       const workspace = yield* InstanceState.workspaceID
+
+      // When this is a subagent session (parentID set), inherit the parent's
+      // workspace context — directory and workspaceID. Without this, child
+      // sessions fall back to ctx.directory (daemon process.cwd()), which is
+      // unrelated to the parent's actual project. That mismatch caused every
+      // subagent tool call to read against the wrong worktree, triggering
+      // external_directory permission asks for paths the parent's worktree
+      // fully owns. Effect.catchCause ensures a missing/race-deleted parent
+      // degrades gracefully back to ctx.directory.
+      let directory = ctx.directory
+      let resolvedWorkspaceID = input?.workspaceID ?? workspace
+      if (input?.parentID) {
+        const parent = yield* get(input.parentID).pipe(
+          Effect.catchCause(() => Effect.succeed(undefined)),
+        )
+        if (parent) {
+          directory = parent.directory
+          if (input?.workspaceID === undefined) {
+            resolvedWorkspaceID = parent.workspaceID ?? resolvedWorkspaceID
+          }
+        }
+      }
+
       return yield* createNext({
         parentID: input?.parentID,
-        directory: ctx.directory,
-        path: sessionPath(ctx.worktree, ctx.directory),
+        directory,
+        path: sessionPath(ctx.worktree, directory),
         title: input?.title,
         agent: input?.agent,
         model: input?.model,
         metadata: input?.metadata,
         permission: input?.permission,
-        workspaceID: input?.workspaceID ?? workspace,
+        workspaceID: resolvedWorkspaceID,
       })
     })
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -470,7 +470,7 @@ export interface Interface {
     permission?: PermissionV1.Ruleset
     workspaceID?: WorkspaceV2.ID
   }) => Effect.Effect<Info>
-  readonly fork: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Info, NotFound>
+  readonly fork: (input: { sessionID: SessionID; messageID?: MessageID; directory?: string }) => Effect.Effect<Info, NotFound>
   readonly touch: (sessionID: SessionID) => Effect.Effect<void>
   readonly get: (id: SessionID) => Effect.Effect<Info, NotFound>
   readonly setTitle: (input: { sessionID: SessionID; title: string }) => Effect.Effect<void>
@@ -753,13 +753,14 @@ export const layer: Layer.Layer<
       })
     })
 
-    const fork = Effect.fn("Session.fork")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {
+    const fork = Effect.fn("Session.fork")(function* (input: { sessionID: SessionID; messageID?: MessageID; directory?: string }) {
       const ctx = yield* InstanceState.context
+      const directory = input.directory ?? ctx.directory
       const original = yield* get(input.sessionID)
       const title = getForkedTitle(original.title)
       const session = yield* createNext({
-        directory: ctx.directory,
-        path: sessionPath(ctx.worktree, ctx.directory),
+        directory,
+        path: sessionPath(ctx.worktree, directory),
         workspaceID: original.workspaceID,
         title,
         metadata: structuredClone(original.metadata),

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -139,12 +139,33 @@ export const TaskTool = Tool.define(
           action: "deny" as const,
         })) ?? []),
       ]
+
+      // Hoisted above sessions.create() so model context is available at row-creation time.
+      const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(
+        Effect.provideService(Database.Service, database),
+        Effect.orDie,
+      )
+      if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
+      const variant = msg.info.variant
+
+      // Session.Model shape ({ id, providerID }) for sessions.create() row attribution.
+      // Agent config model uses { modelID }, while Session.Model uses { id } — convert here.
+      const sessionModel = next.model
+        ? { id: next.model.modelID, providerID: next.model.providerID }
+        : { id: msg.info.modelID, providerID: msg.info.providerID }
+      // Prompt-invocation shape ({ modelID, providerID }) — same as agent config model shape.
+      const model = {
+        modelID: next.model?.modelID ?? msg.info.modelID,
+        providerID: next.model?.providerID ?? msg.info.providerID,
+      }
+
       const nextSession =
         session ??
         (yield* sessions.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${next.name} subagent)`,
           agent: next.name,
+          model: sessionModel,
           permission: [
             ...childPermission,
             ...childToolDenies.filter(
@@ -156,18 +177,6 @@ export const TaskTool = Tool.define(
             ),
           ],
         }))
-
-      const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(
-        Effect.provideService(Database.Service, database),
-        Effect.orDie,
-      )
-      if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
-      const variant = msg.info.variant
-
-      const model = next.model ?? {
-        modelID: msg.info.modelID,
-        providerID: msg.info.providerID,
-      }
       const metadata = {
         parentSessionId: ctx.sessionID,
         sessionId: nextSession.id,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -381,6 +381,37 @@ describe("tool.task", () => {
     }),
   )
 
+  it.instance("execute populates agent and model on the child session row", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        { description: "test task", prompt: "hello", subagent_type: "general" },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps: stubOps() },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      const child = yield* sessions.get(result.metadata.sessionId)
+      // Test A: agent must equal the dispatched subagent name
+      expect(child.agent).toBe("general")
+      // Test B: model must be populated (falls back to parent message's ref model)
+      expect(child.model).toBeDefined()
+      expect(child.model?.id).toBe(ref.modelID)
+      expect(child.model?.providerID).toBe(ref.providerID)
+    }),
+  )
+
   it.instance(
     "execute shapes child permissions for task, todowrite, and primary tools",
     () =>
@@ -431,6 +462,7 @@ describe("tool.task", () => {
           },
         ])
         expect(seen?.tools).toBeUndefined()
+        expect(child.model).toBeDefined()
       }),
     {
       config: {


### PR DESCRIPTION
### Issue for this PR

Closes #30355

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode is run in HTTP server mode, the directory is always set to ctx.directory, which is the daemon's process.cwd(), NOT the parent session's context. For subagent sessions (parentID set), this is wrong:
they should inherit the parent's directory to maintain workspace coherence.\


### How did you verify your code works?

Local build and own developed harness

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


### Steps to reproduce

Steps to reproduce
Evidence (Session IDs from live observation, port 4096):

Parent session: ses_17cdba9cfffeC5A6FQLkMAFYtM

Created in headless client project root
Correct: directory=/path/to/headless/client/project/directory
workspaceID=wsv2_6uN7E5rF1I0rJy2qL
Child Planner session: ses_17cb08557ffe8G2ucNG1fi1F0c

Created by Brain task tool for subagent execution
Incorrect: directory=/path/to/opencode/daemon/home (daemon's $HOME)
Should have been: directory=/path/to/headless/client/project/directory (inherited from parent)
Call trace:

headless client makes HTTP POST to daemon's task endpoint with parent session context
Daemon's task.ts creates child session via Session.create({ parentID })
session.ts Session.create() previously did NOT inherit parent's directory
Result: child receives ctx.directory = daemon process.cwd() = /path/to/opencode/daemon/home

### Operating system

Linux Debian/testing

### Terminal

xterm