### PR TITLE
fix(desktop): validate openExternal URLs by protocol

### DIFF
--- a/packages/desktop/src/main/external-link.test.ts
+++ b/packages/desktop/src/main/external-link.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+
+import { isSafeExternalLink } from "./external-link"
+
+describe("external link", () => {
+  test("allows http and https links", () => {
+    expect(isSafeExternalLink("https://opencode.ai")).toBe(true)
+    expect(isSafeExternalLink("http://localhost:3000")).toBe(true)
+  })
+
+  test("blocks non-http protocols", () => {
+    expect(isSafeExternalLink("file:///tmp/demo.txt")).toBe(false)
+    expect(isSafeExternalLink("javascript:alert(1)")).toBe(false)
+    expect(isSafeExternalLink("smb://attacker/share")).toBe(false)
+    expect(isSafeExternalLink("ms-msdt:/id PCWDiagnostic")).toBe(false)
+  })
+
+  test("blocks malformed links", () => {
+    expect(isSafeExternalLink("not a url")).toBe(false)
+    expect(isSafeExternalLink("/relative/path")).toBe(false)
+    expect(isSafeExternalLink("")).toBe(false)
+  })
+})

--- a/packages/desktop/src/main/external-link.ts
+++ b/packages/desktop/src/main/external-link.ts
@@ -1,0 +1,10 @@
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"])
+
+export function isSafeExternalLink(url: string) {
+  try {
+    const parsed = new URL(url)
+    return ALLOWED_PROTOCOLS.has(parsed.protocol)
+  } catch {
+    return false
+  }
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -8,6 +8,7 @@ import type { DesktopMenuAction } from "@opencode-ai/app/desktop-menu"
 import type { FatalRendererError, ServerReadyData, TitlebarTheme } from "../preload/types"
 import { runDesktopMenuAction } from "./desktop-menu-actions"
 import { assertAttachmentBudget, createPickedFileAuthorizations } from "./attachment-picker"
+import { isSafeExternalLink } from "./external-link"
 import { getStore } from "./store"
 import { getPinchZoomEnabled, setPinchZoomEnabled, setTitlebar, updateTitlebar } from "./windows"
 import type { UpdaterController } from "./updater-controller"
@@ -164,6 +165,7 @@ export function registerIpcHandlers(deps: Deps) {
   )
 
   ipcMain.on("open-link", (_event: IpcMainEvent, url: string) => {
+    if (!isSafeExternalLink(url)) return
     void shell.openExternal(url)
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #30613

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop `open-link` IPC handler called `shell.openExternal(url)` without validating the URL scheme.

This PR adds a protocol allowlist guard and blocks non-web protocols before opening links externally.

Allowed protocols:
- `http:`
- `https:`

Blocked examples:
- `file:`
- `javascript:`
- `smb:`
- `ms-msdt:`
- malformed strings

### How did you verify your code works?

- Added focused tests in `packages/desktop/src/main/external-link.test.ts`:
  - allows `http` / `https`
  - blocks unsafe protocols
  - blocks malformed/relative inputs
- Ran:
  - `bun test src/main/external-link.test.ts` (from `packages/desktop`)
  - `bun typecheck` (from `packages/desktop`)

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
