### PR TITLE
fix(tui): load OpenTUI from Windows sidecar DLL

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -141,6 +141,24 @@ if (!skipInstall) {
   await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
   await $`bun install --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
 }
+
+function resolveOpenTuiDll(item: { os: string; arch: "arm64" | "x64" }) {
+  if (item.os !== "win32") return
+
+  const packagePath = `@opentui/core-win32-${item.arch}/opentui.dll`
+  const candidates = [
+    path.resolve(dir, `node_modules/${packagePath}`),
+    path.resolve(dir, `node_modules/.bun/node_modules/${packagePath}`),
+    path.resolve(dir, `../../node_modules/${packagePath}`),
+    path.resolve(dir, `../../node_modules/.bun/node_modules/${packagePath}`),
+  ]
+  const dllPath = candidates.find((candidate) => fs.existsSync(candidate))
+  if (!dllPath) {
+    throw new Error(`OpenTUI Windows native library not found. Checked: ${candidates.join(", ")}`)
+  }
+  return fs.realpathSync(dllPath)
+}
+
 for (const item of targets) {
   const name = [
     pkg.name,
@@ -194,6 +212,11 @@ for (const item of targets) {
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },
   })
+
+  const openTuiDll = resolveOpenTuiDll(item)
+  if (openTuiDll) {
+    await $`cp ${openTuiDll} dist/${name}/bin/opentui.dll`
+  }
 
   // Smoke test: only run if binary is for current platform
   if (item.os === process.platform && item.arch === process.arch && !item.abi) {

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -27,6 +27,8 @@ const arch = archMap[os.arch()] ?? os.arch()
 const base = `opencode-${platform}-${arch}`
 const sourceBinary = platform === "windows" ? "opencode.exe" : "opencode"
 const targetBinary = path.join(__dirname, "bin", "opencode.exe")
+const sourceOpenTuiDll = "opentui.dll"
+const targetOpenTuiDll = path.join(__dirname, "bin", sourceOpenTuiDll)
 
 function supportsAvx2() {
   if (arch !== "x64") return false
@@ -120,7 +122,10 @@ function resolveBinary(name) {
   const packageJsonPath = require.resolve(`${name}/package.json`)
   const binaryPath = path.join(path.dirname(packageJsonPath), "bin", sourceBinary)
   if (!fs.existsSync(binaryPath)) throw new Error(`Binary not found at ${binaryPath}`)
-  return binaryPath
+  return {
+    binaryPath,
+    packageDir: path.dirname(packageJsonPath),
+  }
 }
 
 function installPackage(name) {
@@ -136,15 +141,31 @@ function installPackage(name) {
     )
     if (result.status !== 0) return
     const packageDir = path.join(temp, "node_modules", name)
-    copyBinary(path.join(packageDir, "bin", sourceBinary), targetBinary)
+    copyPackageFiles({
+      binaryPath: path.join(packageDir, "bin", sourceBinary),
+      packageDir,
+    })
     return true
   } finally {
     fs.rmSync(temp, { recursive: true, force: true })
   }
 }
 
-function copyBinary(source, target) {
-  if (!fs.existsSync(source)) throw new Error(`Binary not found at ${source}`)
+function copyPackageFiles(resolved) {
+  copyFile(resolved.binaryPath, targetBinary, { executable: true })
+  copyOpenTuiDll(resolved.packageDir)
+}
+
+function copyOpenTuiDll(packageDir) {
+  if (platform !== "windows") return
+
+  const source = path.join(packageDir, "bin", sourceOpenTuiDll)
+  if (!fs.existsSync(source)) return
+  copyFile(source, targetOpenTuiDll)
+}
+
+function copyFile(source, target, options = {}) {
+  if (!fs.existsSync(source)) throw new Error(`File not found at ${source}`)
   fs.mkdirSync(path.dirname(target), { recursive: true })
   if (fs.existsSync(target)) fs.unlinkSync(target)
   try {
@@ -152,7 +173,7 @@ function copyBinary(source, target) {
   } catch {
     fs.copyFileSync(source, target)
   }
-  fs.chmodSync(target, 0o755)
+  if (options.executable) fs.chmodSync(target, 0o755)
 }
 
 function verifyBinary() {
@@ -167,7 +188,7 @@ function verifyBinary() {
 function main() {
   for (const name of packageNames()) {
     try {
-      copyBinary(resolveBinary(name), targetBinary)
+      copyPackageFiles(resolveBinary(name))
       if (verifyBinary()) return
     } catch {
       if (installPackage(name) && verifyBinary()) return

--- a/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
@@ -12,6 +12,7 @@ import { CliRenderEvents, createCliRenderer, type CliRenderer, type ScrollbackWr
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { Session as SessionApi } from "@/session/session"
 import { registerOpencodeKeymap } from "@/cli/cmd/tui/keymap"
+import { configureOpenTuiNativeLibrary } from "@/cli/opentui-native"
 import * as Locale from "@/util/locale"
 import { withRunSpan } from "./otel"
 import { resolveInteractiveStdin } from "./runtime.stdin"
@@ -174,6 +175,7 @@ export async function createRuntimeLifecycle(input: LifecycleInput): Promise<Lif
       let unregisterKeymap: (() => void) | undefined
 
       try {
+        await configureOpenTuiNativeLibrary()
         const renderer = await createCliRenderer({
           stdin: source.stdin,
           targetFps: 30,

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -4,6 +4,7 @@ import * as Clipboard from "@tui/util/clipboard"
 import * as Selection from "@tui/util/selection"
 import * as TuiAudio from "@tui/util/audio"
 import { createCliRenderer, MouseButton, type CliRenderer, type CliRendererConfig } from "@opentui/core"
+import { configureOpenTuiNativeLibrary } from "@/cli/opentui-native"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import {
   Switch,
@@ -151,7 +152,8 @@ export function tuiRendererConfig(_config: TuiConfig.Resolved): CliRendererConfi
   }
 }
 
-export function createTuiRenderer(config: TuiConfig.Resolved) {
+export async function createTuiRenderer(config: TuiConfig.Resolved) {
+  await configureOpenTuiNativeLibrary()
   return createCliRenderer(tuiRendererConfig(config))
 }
 

--- a/packages/opencode/src/cli/opentui-native.ts
+++ b/packages/opencode/src/cli/opentui-native.ts
@@ -1,0 +1,20 @@
+import fs from "fs"
+import path from "path"
+
+const OPENTUI_DLL = "opentui.dll"
+
+export function resolveOpenTuiSidecarPath(execPath = process.execPath, platform = process.platform) {
+  if (platform !== "win32") return
+
+  const candidate = path.join(path.dirname(execPath), OPENTUI_DLL)
+  if (!fs.existsSync(candidate)) return
+  return candidate
+}
+
+export async function configureOpenTuiNativeLibrary() {
+  const libPath = resolveOpenTuiSidecarPath()
+  if (!libPath) return
+
+  const { setRenderLibPath } = await import("@opentui/core")
+  setRenderLibPath(libPath)
+}

--- a/packages/opencode/test/cli/opentui-native.test.ts
+++ b/packages/opencode/test/cli/opentui-native.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { resolveOpenTuiSidecarPath } from "@/cli/opentui-native"
+
+describe("resolveOpenTuiSidecarPath", () => {
+  test("uses opencode.exe-adjacent opentui.dll on Windows", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-opentui-"))
+    try {
+      const exe = path.join(dir, "opencode.exe")
+      const dll = path.join(dir, "opentui.dll")
+      fs.writeFileSync(exe, "")
+      fs.writeFileSync(dll, "")
+
+      expect(resolveOpenTuiSidecarPath(exe, "win32")).toBe(dll)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("ignores non-Windows platforms", () => {
+    expect(resolveOpenTuiSidecarPath("/usr/bin/opencode", "linux")).toBeUndefined()
+  })
+
+  test("does not return a missing sidecar", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-opentui-"))
+    try {
+      expect(resolveOpenTuiSidecarPath(path.join(dir, "opencode.exe"), "win32")).toBeUndefined()
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #22543

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Windows TUI startup can fail because the compiled Bun executable exposes OpenTUI's native DLL through a virtual `B:/~BUN/root/...` path. The Windows loader needs a real native DLL path, so renderer startup can fail with error 126.

This PR copies `opentui.dll` from `@opentui/core-win32-*` into Windows package `bin/`, copies that sidecar beside the installed `opencode.exe`, and calls `setRenderLibPath()` before creating the normal TUI renderer or the `opencode run` footer renderer.

### How did you verify your code works?

- `bun --cwd packages/opencode test --timeout 30000 test/cli/opentui-native.test.ts` passed: 3 tests, 0 failures.
- `bun --cwd packages/opencode script/build.ts --single --skip-install --skip-embed-web-ui` passed.
- Confirmed the build produced `packages/opencode/dist/opencode-windows-x64/bin/opentui.dll` and the build smoke `--version` passed.
- Ran the built Windows TUI without the local `B:` workaround: `dist/opencode-windows-x64/bin/opencode.exe . --print-logs --log-level DEBUG`. It rendered and did not hit error 126.
- Note: full `bun --cwd packages/opencode typecheck` failed in my checkout due to current `dev` workspace errors outside this PR (`@opencode-ai/llm` resolution and existing Effect typing errors in core/server files).

### Screenshots / recordings

Not included. This is a native library startup fix, not a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR