### PR TITLE
fix(app): show stopping state on the prompt stop button

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1111,7 +1111,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return permission.isAutoAccepting(id, sdk.directory)
   })
 
-  const { abort, handleSubmit } = createPromptSubmit({
+  const { abort, aborting, handleSubmit } = createPromptSubmit({
     info,
     imageAttachments,
     commentCount,
@@ -1616,6 +1616,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     disabled={!working() && blank()}
                     tabIndex={store.mode === "normal" ? undefined : -1}
                     icon={stopping() ? "stop" : store.mode === "shell" ? "arrow-undo-down" : "arrow-up"}
+                    loading={aborting()}
                     variant="primary"
                     class="size-7 rounded-md p-[6px] text-v2-icon-icon-muted shadow-[var(--v2-elevation-button-contrast)] disabled:opacity-50"
                     style={{
@@ -1759,6 +1760,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       disabled={!working() && blank()}
                       tabIndex={store.mode === "normal" ? undefined : -1}
                       icon={stopping() ? "stop" : store.mode === "shell" ? "arrow-undo-down" : "arrow-up"}
+                      loading={aborting()}
                       variant="primary"
                       class="size-8"
                       aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -3,7 +3,7 @@ import { showToast } from "@/utils/toast"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { Binary } from "@opencode-ai/core/util/binary"
 import { useNavigate, useParams } from "@solidjs/router"
-import { batch, type Accessor } from "solid-js"
+import { batch, createEffect, createSignal, type Accessor } from "solid-js"
 import type { FileSelection } from "@/context/file"
 import { useServerSync } from "@/context/server-sync"
 import { useLanguage } from "@/context/language"
@@ -222,6 +222,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     return language.t("common.requestFailed")
   }
 
+  const [aborting, setAborting] = createSignal(false)
+  createEffect(() => {
+    if (!input.working()) setAborting(false)
+  })
+
   const abort = async () => {
     const sessionID = params.id
     if (!sessionID) return Promise.resolve()
@@ -239,6 +244,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       pending.delete(sessionID)
       return Promise.resolve()
     }
+
+    setAborting(true)
     return sdk.client.session
       .abort({
         sessionID,
@@ -579,6 +586,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
   return {
     abort,
+    aborting,
     handleSubmit,
   }
 }

--- a/packages/ui/src/components/icon-button.css
+++ b/packages/ui/src/components/icon-button.css
@@ -179,3 +179,19 @@
 [data-component="icon-button"].titlebar-icon[data-variant="ghost"][aria-expanded="true"]:hover:not(:disabled) {
   background-color: var(--surface-raised-base-active);
 }
+
+[data-component="icon-button"] [data-component="spinner"] {
+  width: 16px;
+}
+[data-component="icon-button"][data-size="large"] [data-component="spinner"] {
+  width: 20px;
+}
+[data-component="icon-button"][data-variant="primary"] [data-component="spinner"] {
+  color: var(--icon-invert-base);
+}
+[data-component="icon-button"][data-variant="secondary"] [data-component="spinner"] {
+  color: var(--icon-strong-base);
+}
+[data-component="icon-button"][data-variant="ghost"] [data-component="spinner"] {
+  color: var(--icon-base);
+}

--- a/packages/ui/src/components/icon-button.tsx
+++ b/packages/ui/src/components/icon-button.tsx
@@ -1,19 +1,23 @@
 import { Button as Kobalte } from "@kobalte/core/button"
-import { type ComponentProps, splitProps } from "solid-js"
+import { type ComponentProps, Show, splitProps } from "solid-js"
 import { Icon, IconProps } from "./icon"
+import { Spinner } from "./spinner"
 
 export interface IconButtonProps extends ComponentProps<typeof Kobalte> {
   icon: IconProps["name"]
   size?: "small" | "normal" | "large"
   iconSize?: IconProps["size"]
   variant?: "primary" | "secondary" | "ghost"
+  loading?: boolean
 }
 
 export function IconButton(props: ComponentProps<"button"> & IconButtonProps) {
-  const [split, rest] = splitProps(props, ["variant", "size", "iconSize", "class", "classList"])
+  const [split, rest] = splitProps(props, ["variant", "size", "iconSize", "class", "classList", "loading"])
   return (
     <Kobalte
       {...rest}
+      disabled={rest.disabled || split.loading}
+      aria-busy={split.loading || undefined}
       data-component="icon-button"
       data-icon={props.icon}
       data-size={split.size || "normal"}
@@ -23,7 +27,12 @@ export function IconButton(props: ComponentProps<"button"> & IconButtonProps) {
         [split.class ?? ""]: !!split.class,
       }}
     >
-      <Icon name={props.icon} size={split.iconSize ?? (split.size === "large" ? "normal" : "small")} />
+      <Show
+        when={split.loading}
+        fallback={<Icon name={props.icon} size={split.iconSize ?? (split.size === "large" ? "normal" : "small")} />}
+      >
+        <Spinner />
+      </Show>
     </Kobalte>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #30695

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the web UI the prompt stop button is driven only by the server `working()` state, so when you interrupt a prompt nothing changes on the button for the 1-2s it takes the session to actually abort. It looks like the click didn't register, so you end up clicking again.

This tracks an optimistic `aborting` signal in `createPromptSubmit`, set as soon as the abort request is sent and cleared once the session reports not-working (the source of truth, so a new prompt starts clean). While aborting, the stop button shows the existing `Spinner` and is disabled, via a new `loading` prop on the shared `IconButton`.

### How did you verify your code works?

Tested directly in the local web UI (`opencode serve` + `packages/app` dev): the stop button shows the spinner immediately on click and returns to the send icon once the session goes idle. Also ran `bun typecheck` in `packages/app` and `packages/ui`.

### Screenshots / recordings

![stop button shows a spinner while aborting](https://github.com/user-attachments/assets/dddc501a-35e9-4a37-b16a-8cad501e5dc6)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
