### PR TITLE
fix(app): prevent nested scroll in unpaid model dialog

### DIFF
--- a/packages/app/src/components/dialog-select-model-unpaid.tsx
+++ b/packages/app/src/components/dialog-select-model-unpaid.tsx
@@ -90,7 +90,7 @@ export const DialogSelectModelUnpaid: Component<{ model?: ModelState }> = (props
             <div class="px-2 text-14-medium text-text-base">{language.t("dialog.model.unpaid.addMore.title")}</div>
             <div class="w-full">
               <List
-                class="w-full px-3"
+                class="w-full px-3 [&_[data-slot=list-scroll]]:overflow-visible"
                 key={(p) => p.id}
                 items={providers.popular}
                 activeIcon="plus-small"


### PR DESCRIPTION
### Issue for this PR

Closes #30717

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

fixes nested scroll in the select model dialog. "Add more models" provider list had its own scroll container, so hovering it and scrolling moved only that inner list, the dialog itself wouldn't scroll, leaving the content below unreachable

### How did you verify your code works?

opened the select model dialog and scrolled with the cursor over the provider list, the whole dialog now scrolls instead of getting stuck.

### Screenshots / recordings

| state | preview |
| -------|------|
| before | <img src="https://github.com/user-attachments/assets/b4ab4e19-2c6d-4f74-a522-0471401a23d9" /> |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
