### PR TITLE
fix: migration

### DIFF
--- a/packages/core/src/database/migration/20260603040000_session_message_projection_order.ts
+++ b/packages/core/src/database/migration/20260603040000_session_message_projection_order.ts
@@ -9,12 +9,30 @@ export default {
       yield* tx.run(
         `UPDATE \`session_message\` SET \`seq\` = COALESCE((SELECT \`seq\` + 1 FROM \`event\` WHERE \`event\`.\`id\` = \`session_message\`.\`id\`), 0);`,
       )
-      const unmatched = yield* tx.get<{ count: number }>(
-        `SELECT COUNT(*) AS \`count\` FROM \`session_message\` WHERE \`seq\` = 0;`,
-      )
-      if ((unmatched?.count ?? 0) > 0)
-        return yield* Effect.die("Cannot migrate session_message projections without matching durable events")
+      yield* tx.run(`
+        WITH \`unmatched\` AS (
+          SELECT
+            \`session_message\`.\`id\`,
+            COALESCE(MAX(\`event\`.\`seq\`), -1) + ROW_NUMBER() OVER (
+              PARTITION BY \`session_message\`.\`session_id\`
+              ORDER BY \`session_message\`.\`time_created\`, \`session_message\`.\`id\`
+            ) + 1 AS \`seq\`
+          FROM \`session_message\`
+          LEFT JOIN \`event\` ON \`event\`.\`aggregate_id\` = \`session_message\`.\`session_id\`
+          WHERE NOT EXISTS (SELECT 1 FROM \`event\` AS \`source\` WHERE \`source\`.\`id\` = \`session_message\`.\`id\`)
+          GROUP BY \`session_message\`.\`id\`
+        )
+        UPDATE \`session_message\`
+        SET \`seq\` = (SELECT \`unmatched\`.\`seq\` FROM \`unmatched\` WHERE \`unmatched\`.\`id\` = \`session_message\`.\`id\`)
+        WHERE \`session_message\`.\`id\` IN (SELECT \`id\` FROM \`unmatched\`);
+      `)
       yield* tx.run(`UPDATE \`session_message\` SET \`seq\` = \`seq\` - 1;`)
+      yield* tx.run(
+        `INSERT INTO \`event_sequence\` (\`aggregate_id\`, \`seq\`)
+        SELECT \`session_id\`, MAX(\`seq\`) FROM \`session_message\`
+        GROUP BY \`session_id\`
+        ON CONFLICT(\`aggregate_id\`) DO UPDATE SET \`seq\` = MAX(\`event_sequence\`.\`seq\`, excluded.\`seq\`);`,
+      )
       yield* tx.run(`DROP INDEX IF EXISTS \`session_message_session_type_time_created_id_idx\`;`)
       yield* tx.run(`CREATE INDEX \`session_message_session_seq_idx\` ON \`session_message\` (\`session_id\`,\`seq\`);`)
       yield* tx.run(

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -83,7 +83,8 @@ describe("DatabaseMigration", () => {
     await run(
       Effect.gen(function* () {
         const db = yield* makeDb
-        yield* db.run(sql`CREATE TABLE event (id text PRIMARY KEY, seq integer NOT NULL)`)
+        yield* db.run(sql`CREATE TABLE event_sequence (aggregate_id text PRIMARY KEY, seq integer NOT NULL)`)
+        yield* db.run(sql`CREATE TABLE event (id text PRIMARY KEY, aggregate_id text NOT NULL, seq integer NOT NULL)`)
         yield* db.run(
           sql`CREATE TABLE session_message (id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, time_created integer NOT NULL, data text NOT NULL)`,
         )
@@ -93,7 +94,9 @@ describe("DatabaseMigration", () => {
         yield* db.run(
           sql`CREATE INDEX session_message_session_type_time_created_id_idx ON session_message (session_id, type, time_created, id)`,
         )
-        yield* db.run(sql`INSERT INTO event (id, seq) VALUES ('evt_z', 0), ('evt_a', 1)`)
+        yield* db.run(
+          sql`INSERT INTO event (id, aggregate_id, seq) VALUES ('evt_z', 'session', 0), ('evt_a', 'session', 1)`,
+        )
         yield* db.run(
           sql`INSERT INTO session_message (id, session_id, type, time_created, data) VALUES ('evt_z', 'session', 'user', 0, '{}'), ('evt_a', 'session', 'user', 0, '{}')`,
         )
@@ -108,23 +111,61 @@ describe("DatabaseMigration", () => {
     )
   })
 
-  test("fails projected Session message order backfill without a durable event", async () => {
-    await expect(
-      run(
-        Effect.gen(function* () {
-          const db = yield* makeDb
-          yield* db.run(sql`CREATE TABLE event (id text PRIMARY KEY, seq integer NOT NULL)`)
-          yield* db.run(
-            sql`CREATE TABLE session_message (id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, time_created integer NOT NULL, data text NOT NULL)`,
-          )
-          yield* db.run(
-            sql`INSERT INTO session_message (id, session_id, type, time_created, data) VALUES ('evt_missing', 'session', 'user', 0, '{}')`,
-          )
+  test("falls back to stable projected order without durable events", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`CREATE TABLE event_sequence (aggregate_id text PRIMARY KEY, seq integer NOT NULL)`)
+        yield* db.run(sql`CREATE TABLE event (id text PRIMARY KEY, aggregate_id text NOT NULL, seq integer NOT NULL)`)
+        yield* db.run(
+          sql`CREATE TABLE session_message (id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, time_created integer NOT NULL, data text NOT NULL)`,
+        )
+        yield* db.run(
+          sql`INSERT INTO session_message (id, session_id, type, time_created, data) VALUES ('evt_model', 'session', 'model-switched', 0, '{}'), ('evt_agent', 'session', 'agent-switched', 0, '{}')`,
+        )
 
-          yield* DatabaseMigration.applyOnly(db, [sessionMessageProjectionOrderMigration])
-        }),
-      ),
-    ).rejects.toThrow("Cannot migrate session_message projections without matching durable events")
+        yield* DatabaseMigration.applyOnly(db, [sessionMessageProjectionOrderMigration])
+
+        expect(yield* db.all(sql`SELECT id, seq FROM session_message ORDER BY seq`)).toEqual([
+          { id: "evt_agent", seq: 0 },
+          { id: "evt_model", seq: 1 },
+        ])
+        expect(yield* db.get(sql`SELECT aggregate_id, seq FROM event_sequence WHERE aggregate_id = 'session'`)).toEqual({
+          aggregate_id: "session",
+          seq: 1,
+        })
+      }),
+    )
+  })
+
+  test("advances durable event sequence past fallback projected messages", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`CREATE TABLE event_sequence (aggregate_id text PRIMARY KEY, seq integer NOT NULL)`)
+        yield* db.run(sql`CREATE TABLE event (id text PRIMARY KEY, aggregate_id text NOT NULL, seq integer NOT NULL)`)
+        yield* db.run(
+          sql`CREATE TABLE session_message (id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, time_created integer NOT NULL, data text NOT NULL)`,
+        )
+        yield* db.run(sql`INSERT INTO event_sequence (aggregate_id, seq) VALUES ('session', 0)`)
+        yield* db.run(sql`INSERT INTO event (id, aggregate_id, seq) VALUES ('evt_prompt', 'session', 0)`)
+        yield* db.run(
+          sql`INSERT INTO session_message (id, session_id, type, time_created, data) VALUES ('evt_prompt', 'session', 'user', 0, '{}'), ('evt_agent', 'session', 'agent-switched', 1, '{}'), ('evt_model', 'session', 'model-switched', 1, '{}')`,
+        )
+
+        yield* DatabaseMigration.applyOnly(db, [sessionMessageProjectionOrderMigration])
+
+        expect(yield* db.all(sql`SELECT id, seq FROM session_message ORDER BY seq`)).toEqual([
+          { id: "evt_prompt", seq: 0 },
+          { id: "evt_agent", seq: 1 },
+          { id: "evt_model", seq: 2 },
+        ])
+        expect(yield* db.get(sql`SELECT aggregate_id, seq FROM event_sequence WHERE aggregate_id = 'session'`)).toEqual({
+          aggregate_id: "session",
+          seq: 2,
+        })
+      }),
+    )
   })
 
   test("runs session usage backfill in order with schema changes", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes migration regression introduced in #30632

Previously, `20260603040000_session_message_projection_order` assumed every existing session_message projection had a matching durable event row. Getting error `Cannot migrate session_message projections without matching durable events`

Now the migration does this:

1. Adds `session_message.seq`.
2. Uses durable `event.seq` when the matching event exists.
3. For projection-only rows, assigns a stable fallback order per session using `time_created`, `id`.
4. Normalizes the staged `seq` values back to zero-based order.
5. Updates `event_sequence.seq` to at least the max projected message seq, so future durable events do not reuse a sequence number.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
