### PR TITLE
docs(ecosystem): add @ulthon/ul-opencode-event plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| @ulthon/ul-opencode-event (https://github.com/ulthon/ul-opencode-event)                            | Multi-channel notifications (SMTP, DingTalk, Feishu) and multi-level token usage analytics for session lifecycle events |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Add [@ulthon/ul-opencode-event](https://gitee.com/ulthon/ul-opencode-event) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

This is a community notification plugin for OpenCode that provides:

- **Multi-channel notifications** — SMTP email, DingTalk bot, Feishu bot alerts on session lifecycle events (idle, error, permission, question, etc.)
- **Multi-level token analytics** — tracks token usage at message / session / total / project levels, with automatic session cache and DB preload for recovery across restarts
- Global + project-level config merge, i18n templates (zh/en), built-in CLI test tool

npm: https://www.npmjs.com/package/@ulthon/ul-opencode-event

### How did you verify your code works?

Verified the Markdown table row renders correctly. The plugin is published on npm (`npm view @ulthon/ul-opencode-event`) and the Gitee repo is publicly accessible.

### Screenshots / recordings

N/A (documentation change only)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR