### PR TITLE
fix(opencode): respect disabled auto compaction on overflow

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -909,6 +909,13 @@ export const layer = Layer.effect(
         const error = parse(e)
         yield* flushV2Fragments()
         if (SessionV1.ContextOverflowError.isInstance(error)) {
+          if ((yield* config.get()).compaction?.auto === false && !ctx.assistantMessage.summary) {
+            ctx.assistantMessage.error = error
+            ctx.assistantMessage.finish = "error"
+            yield* events.publish(Session.Event.Error, { sessionID: ctx.sessionID, error })
+            yield* status.set(ctx.sessionID, { type: "idle" })
+            return
+          }
           ctx.needsCompaction = true
           yield* events.publish(Session.Event.Error, { sessionID: ctx.sessionID, error })
           return

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -513,6 +513,36 @@ it.instance("loop calls LLM and returns assistant message", () =>
   }),
 )
 
+it.instance("loop stops provider overflow instead of auto-compacting when disabled", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      compaction: { auto: false },
+    }))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+
+    yield* llm.error(413, { error: { message: "request entity too large" } })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    const messages = yield* sessions.messages({ sessionID: chat.id })
+
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role === "assistant") {
+      expect(result.info.error?.name).toBe("ContextOverflowError")
+      expect(result.info.finish).toBe("error")
+    }
+    expect(messages.some((message) => message.parts.some((part) => part.type === "compaction"))).toBe(false)
+  }),
+)
+
 noLLMServer.instance.skip(
   "prompt emits v2 prompted and synthetic events (v2 projector disabled)",
   () =>


### PR DESCRIPTION
## Summary

- stop provider/request overflow recovery from enqueueing automatic compaction when `compaction.auto` is `false`
- persist the provider overflow as a `ContextOverflowError` assistant error instead, so users can manually compact, switch models, or reduce attachments
- add prompt-loop regression coverage that verifies no compaction marker is created for provider overflow with auto compaction disabled

## Root Cause

The proactive token-threshold path already respected `compaction.auto === false`, but provider overflow errors were converted into `ContextOverflowError`, then `SessionProcessor` returned `"compact"`. `SessionPrompt.runLoop` treated that result as an unconditional automatic compaction request and created a `compaction` part with `auto: true`, bypassing the config.

This keeps compaction-agent overflow behavior unchanged by only applying the guard to normal assistant messages, not summary compaction messages.

## V2 Note

I checked the `packages/core` V2 path while making this. The active V2 runner still lists compaction continuation as a TODO, and `V2Session.compact` currently returns `OperationUnavailableError`, so there is no equivalent V2 auto-compaction recovery path to patch yet. When compaction continuation moves into `packages/core`, it should carry this invariant: `compaction.auto: false` disables every automatic compaction trigger, including provider/request-size overflow recovery.

Fixes #30664.

## Checks

- `/Users/nxl/.bun/bin/bun test test/session/prompt.test.ts --timeout 30000`
- `/Users/nxl/.bun/bin/bun test test/session/processor-effect.test.ts test/session/compaction.test.ts --timeout 30000`
- `/Users/nxl/.bun/bin/bun typecheck`
- pre-push hook: `bun turbo typecheck`