### PR TITLE
fix(acp): `ACP.resumeSession` should not replay messages

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -320,7 +320,6 @@ export function make(input: {
 
     yield* registerMcpServers(input.sdk, registeredMcp, params.cwd, state.id, params.mcpServers ?? [])
     yield* sendAvailableCommands(input.connection, state.id, snapshot)
-    yield* replayMessages(events, messages)
 
     return {
       configOptions: configOptions(snapshot, {

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -411,6 +411,45 @@ describe("ACP service sessions", () => {
     expect(select(updated, "effort")?.currentValue).toBe("default")
   })
 
+  it("resumes a session without replaying historical transcript chunks", async () => {
+    const { service, updates } = makeService([
+      {
+        info: {
+          id: "msg_user",
+          sessionID: "ses_resume",
+          role: "user",
+          model: { providerID: "test", modelID: "test-model", variant: "high" },
+          agent: "plan",
+        },
+        parts: [{ id: "part_user", sessionID: "ses_resume", messageID: "msg_user", type: "text", text: "hello" }],
+      },
+      {
+        info: { id: "msg_assistant", sessionID: "ses_resume", role: "assistant" },
+        parts: [
+          {
+            id: "part_assistant",
+            sessionID: "ses_resume",
+            messageID: "msg_assistant",
+            type: "text",
+            text: "hi there",
+          },
+        ],
+      },
+    ])
+
+    const resumed = await Effect.runPromise(
+      service.resumeSession({ cwd: "/workspace", sessionId: "ses_resume", mcpServers: [] }),
+    )
+
+    expect(select(resumed, "effort")?.currentValue).toBe("high")
+    expect(select(resumed, "mode")?.currentValue).toBe("plan")
+    expect(
+      updates
+        .map((item) => item.update)
+        .filter((item) => item.sessionUpdate === "user_message_chunk" || item.sessionUpdate === "agent_message_chunk"),
+    ).toEqual([])
+  })
+
   it("closes local ACP state and aborts the backing session best-effort", async () => {
     const { service, aborts } = makeService()
     const created = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))


### PR DESCRIPTION
### Issue for this PR

Closes #30756

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a violation of ACP and adds a test. See #30756 for details.

### How did you verify your code works?

I have run tests locally and tried to connect to my revised version of OpenCode from Zed.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
