### PR TITLE
refactor(core): separate v2 message identity

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,23 @@
+# Core database migrations
+
+## V2 beta reset boundary
+
+During the pre-launch V2 beta period, these unreleased tables may be truncated
+by an ordinary compatibility migration:
+
+- `session_message`: disposable V2 timeline projection.
+- `session_input`: disposable V2 prompt-admission inbox. Truncating it may drop
+  accepted but unpromoted beta prompts, so call that out explicitly.
+- `event`: unreleased workspace synchronization history.
+- `event_sequence`: unreleased workspace synchronization cursor and owner state.
+
+Resetting `event` and `event_sequence` intentionally makes existing Sessions
+non-warpable until new replayable history is recorded. Call that out explicitly.
+
+Do not truncate these tables as part of a V2 compatibility migration:
+
+- `session`, `message`, `part`: canonical V1 Session history.
+
+If a proposed V2 schema change appears to require resetting anything outside
+the wipeable beta tables, stop and design an explicit compatibility or
+fresh-database cutover plan instead.

--- a/packages/core/migration/20260604153000_session_message_identity/migration.sql
+++ b/packages/core/migration/20260604153000_session_message_identity/migration.sql
@@ -1,0 +1,4 @@
+DELETE FROM `session_input`;--> statement-breakpoint
+DELETE FROM `session_message`;--> statement-breakpoint
+DELETE FROM `event`;--> statement-breakpoint
+DELETE FROM `event_sequence`;

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -31,5 +31,6 @@ export const migrations = (
     import("./migration/20260603040000_session_message_projection_order"),
     import("./migration/20260603141458_session_input_inbox"),
     import("./migration/20260603160727_jittery_ezekiel_stane"),
+    import("./migration/20260604153000_session_message_identity"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260604153000_session_message_identity.ts
+++ b/packages/core/src/database/migration/20260604153000_session_message_identity.ts
@@ -1,0 +1,16 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260604153000_session_message_identity",
+  up(tx) {
+    return Effect.gen(function* () {
+      // These tables remain disposable until workspace sync and V2 Sessions launch.
+      // Preserve canonical V1 session, message, and part rows.
+      yield* tx.run(`DELETE FROM \`session_input\`;`)
+      yield* tx.run(`DELETE FROM \`session_message\`;`)
+      yield* tx.run(`DELETE FROM \`event\`;`)
+      yield* tx.run(`DELETE FROM \`event_sequence\`;`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -8,7 +8,7 @@ import { Location } from "./location"
 import { externalID, type ExternalID, NonNegativeInt, withStatics } from "./schema"
 import { Identifier } from "./util/identifier"
 
-export const ID = Schema.String.pipe(
+export const ID = Schema.String.check(Schema.isStartsWith("evt_")).pipe(
   Schema.brand("Event.ID"),
   withStatics((schema) => ({
     create: () => schema.make("evt_" + Identifier.ascending()),

--- a/packages/core/src/session/input.ts
+++ b/packages/core/src/session/input.ts
@@ -3,7 +3,7 @@ export * as SessionInput from "./input"
 import { and, asc, eq, inArray, isNull } from "drizzle-orm"
 import { DateTime, Effect, Schema } from "effect"
 import type { Database } from "../database/database"
-import type { EventV2 } from "../event"
+import { EventV2 } from "../event"
 import { EventTable } from "../event/sql"
 import { NonNegativeInt, PositiveInt } from "../schema"
 import { V2Schema } from "../v2-schema"
@@ -66,7 +66,7 @@ export const admit = Effect.fn("SessionInput.admit")(function* (
           const event = yield* db
             .select({ id: EventTable.id })
             .from(EventTable)
-            .where(eq(EventTable.id, input.id))
+            .where(eq(EventTable.id, SessionMessage.ID.toEvent(input.id)))
             .get()
             .pipe(Effect.orDie)
           const message = yield* db
@@ -133,7 +133,7 @@ export const guardReservedID = Effect.fn("SessionInput.guardReservedID")(functio
   db: DatabaseService,
   event: EventV2.Payload,
 ) {
-  const admitted = yield* find(db, event.id)
+  const admitted = yield* find(db, SessionMessage.ID.fromEvent(event.id))
   if (admitted === undefined) return
   if (!Schema.is(SessionEvent.Prompted)(event))
     return yield* Effect.die("Durable event conflicts with admitted prompt input")
@@ -225,7 +225,7 @@ const publish = Effect.fn("SessionInput.publish")(function* (
         prompt: decodePrompt(row.prompt),
         delivery: row.delivery,
       },
-      { id: SessionMessage.ID.make(row.id) },
+      { id: SessionMessage.ID.toEvent(SessionMessage.ID.make(row.id)) },
     )
   }
   return rows.length

--- a/packages/core/src/session/message-id.ts
+++ b/packages/core/src/session/message-id.ts
@@ -1,0 +1,16 @@
+export * as SessionMessageID from "./message-id"
+
+import { Schema } from "effect"
+import { EventV2 } from "../event"
+import { withStatics } from "../schema"
+import { Identifier } from "../util/identifier"
+
+export const ID = Schema.String.check(Schema.isStartsWith("msg_")).pipe(
+  Schema.brand("Session.Message.ID"),
+  withStatics((schema) => ({
+    create: () => schema.make("msg_" + Identifier.ascending()),
+    fromEvent: (id: EventV2.ID) => schema.make("msg" + id.slice(3)),
+    toEvent: (id: ID) => EventV2.ID.make("evt" + id.slice(3)),
+  })),
+)
+export type ID = typeof ID.Type

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -1,5 +1,6 @@
 import { castDraft, produce, type WritableDraft } from "immer"
 import { Effect } from "effect"
+import type { EventV2 } from "../event"
 import { SessionEvent } from "./event"
 import { SessionMessage } from "./message"
 
@@ -112,9 +113,9 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
   const latestReasoning = (assistant: DraftAssistant | undefined, reasoningID: string) =>
     assistant?.content.findLast((item): item is DraftReasoning => item.type === "reasoning" && item.id === reasoningID)
 
-  const updateOwnedAssistant = (messageID: SessionMessage.ID, recipe: (draft: DraftAssistant) => void) =>
+  const updateOwnedAssistant = (messageID: EventV2.ID, recipe: (draft: DraftAssistant) => void) =>
     Effect.gen(function* () {
-      const assistant = yield* adapter.getAssistant(messageID)
+      const assistant = yield* adapter.getAssistant(SessionMessage.ID.fromEvent(messageID))
       if (assistant) yield* adapter.updateAssistant(produce(assistant, recipe))
     })
 
@@ -123,7 +124,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
       "session.next.agent.switched": (event) => {
         return adapter.appendMessage(
           new SessionMessage.AgentSwitched({
-            id: event.id,
+            id: SessionMessage.ID.fromEvent(event.id),
             type: "agent-switched",
             metadata: event.metadata,
             agent: event.data.agent,
@@ -134,7 +135,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
       "session.next.model.switched": (event) => {
         return adapter.appendMessage(
           new SessionMessage.ModelSwitched({
-            id: event.id,
+            id: SessionMessage.ID.fromEvent(event.id),
             type: "model-switched",
             metadata: event.metadata,
             model: event.data.model,
@@ -145,7 +146,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
       "session.next.prompted": (event) => {
         return adapter.appendMessage(
           new SessionMessage.User({
-            id: event.id,
+            id: SessionMessage.ID.fromEvent(event.id),
             type: "user",
             metadata: event.metadata,
             text: event.data.prompt.text,
@@ -161,7 +162,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
           new SessionMessage.Synthetic({
             sessionID: event.data.sessionID,
             text: event.data.text,
-            id: event.id,
+            id: SessionMessage.ID.fromEvent(event.id),
             type: "synthetic",
             time: { created: event.data.timestamp },
           }),
@@ -170,7 +171,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
       "session.next.shell.started": (event) => {
         return adapter.appendMessage(
           new SessionMessage.Shell({
-            id: event.id,
+            id: SessionMessage.ID.fromEvent(event.id),
             type: "shell",
             metadata: event.metadata,
             callID: event.data.callID,
@@ -205,7 +206,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
           }
           yield* adapter.appendMessage(
             new SessionMessage.Assistant({
-              id: event.id,
+              id: SessionMessage.ID.fromEvent(event.id),
               type: "assistant",
               agent: event.data.agent,
               model: event.data.model,
@@ -419,7 +420,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
       "session.next.compaction.started": (event) => {
         return adapter.appendMessage(
           new SessionMessage.Compaction({
-            id: event.id,
+            id: SessionMessage.ID.fromEvent(event.id),
             type: "compaction",
             metadata: event.metadata,
             reason: event.data.reason,

--- a/packages/core/src/session/message.ts
+++ b/packages/core/src/session/message.ts
@@ -2,14 +2,14 @@ export * as SessionMessage from "./message"
 
 import { Schema } from "effect"
 import { ProviderMetadata } from "@opencode-ai/llm"
-import { EventV2 } from "../event"
 import { ModelV2 } from "../model"
 import { ToolOutput } from "../tool-output"
 import { V2Schema } from "../v2-schema"
 import { SessionEvent } from "./event"
+import { SessionMessageID } from "./message-id"
 import { Prompt } from "./prompt"
 
-export const ID = EventV2.ID
+export const ID = SessionMessageID.ID
 export type ID = Schema.Schema.Type<typeof ID>
 
 const Base = {

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -335,10 +335,11 @@ export const layer = Layer.effectDiscard(
     )
     yield* events.project(SessionEvent.Prompted, (event) =>
       Effect.gen(function* () {
+        const messageID = SessionMessage.ID.fromEvent(event.id)
         const existing = yield* db
           .select({ id: SessionMessageTable.id })
           .from(SessionMessageTable)
-          .where(eq(SessionMessageTable.id, event.id))
+          .where(eq(SessionMessageTable.id, messageID))
           .get()
           .pipe(Effect.orDie)
         if (existing) return yield* Effect.die(new PromptAlreadyProjected())
@@ -346,7 +347,7 @@ export const layer = Layer.effectDiscard(
         const row = yield* db
           .select()
           .from(SessionMessageTable)
-          .where(eq(SessionMessageTable.id, event.id))
+          .where(eq(SessionMessageTable.id, messageID))
           .get()
           .pipe(Effect.orDie)
         if (!row) return yield* Effect.die("Prompt projection was not stored")
@@ -355,7 +356,7 @@ export const layer = Layer.effectDiscard(
         if (event.seq === undefined)
           return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
         yield* SessionInput.project(db, {
-          id: SessionMessage.ID.make(event.id),
+          id: messageID,
           sessionID: event.data.sessionID,
           prompt: event.data.prompt,
           delivery: event.data.delivery,

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -13,6 +13,7 @@ import { ToolRegistry } from "../../tool-registry"
 import { SessionRunnerModel } from "./model"
 import { Database } from "../../database/database"
 import { SessionInput } from "../input"
+import { SessionMessage } from "../message"
 import { QuestionV2 } from "../../question"
 
 /**
@@ -106,7 +107,7 @@ export const layer = Layer.effect(
           yield* events.publish(SessionEvent.Tool.Failed, {
             sessionID,
             timestamp: yield* DateTime.now,
-            assistantMessageID: message.id,
+            assistantMessageID: SessionMessage.ID.toEvent(message.id),
             callID: tool.id,
             error: { type: "unknown", message: "Tool execution interrupted" },
             provider: {

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -7,9 +7,11 @@ import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 import { Effect, Layer } from "effect"
 import { eq, inArray, sql } from "drizzle-orm"
 import { DatabaseMigration } from "@opencode-ai/core/database/migration"
+import { migrations } from "@opencode-ai/core/database/migration.gen"
 import sessionUsageMigration from "@opencode-ai/core/database/migration/20260510033149_session_usage"
 import normalizeStoragePathsMigration from "@opencode-ai/core/database/migration/20260601010001_normalize_storage_paths"
 import sessionMessageProjectionOrderMigration from "@opencode-ai/core/database/migration/20260603040000_session_message_projection_order"
+import sessionMessageIdentityMigration from "@opencode-ai/core/database/migration/20260604153000_session_message_identity"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -62,7 +64,7 @@ describe("DatabaseMigration", () => {
         expect(
           yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_input'`),
         ).toEqual({ name: "session_input" })
-        expect(yield* db.get(sql`SELECT count(*) as count FROM migration`)).toEqual({ count: 29 })
+        expect(yield* db.get(sql`SELECT count(*) as count FROM migration`)).toEqual({ count: 30 })
         expect(
           yield* db.all(
             sql`SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('event_aggregate_seq_idx', 'event_aggregate_type_seq_idx', 'session_input_session_pending_seq_idx', 'session_input_session_pending_delivery_seq_idx', 'session_message_session_idx', 'session_message_session_type_idx', 'session_message_session_seq_idx', 'session_message_session_type_seq_idx', 'session_message_session_time_created_id_idx') ORDER BY name`,
@@ -131,6 +133,100 @@ describe("DatabaseMigration", () => {
         )
         expect(yield* db.get(sql`SELECT id, seq FROM session_message`)).toEqual({ id: "fresh_projection", seq: 7 })
       }),
+    )
+  })
+
+  test("resets unreleased EventV2 state without deleting canonical Session history", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`CREATE TABLE session (id text PRIMARY KEY)`)
+        yield* db.run(sql`CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL)`)
+        yield* db.run(sql`CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL)`)
+        yield* db.run(sql`CREATE TABLE session_message (id text PRIMARY KEY)`)
+        yield* db.run(sql`CREATE TABLE session_input (id text PRIMARY KEY)`)
+        yield* db.run(
+          sql`CREATE TABLE event_sequence (aggregate_id text PRIMARY KEY, seq integer NOT NULL, owner_id text)`,
+        )
+        yield* db.run(sql`CREATE TABLE event (id text PRIMARY KEY, aggregate_id text NOT NULL, seq integer NOT NULL)`)
+        yield* db.run(sql`INSERT INTO session (id) VALUES ('session')`)
+        yield* db.run(sql`INSERT INTO message (id, session_id) VALUES ('legacy_message', 'session')`)
+        yield* db.run(
+          sql`INSERT INTO part (id, message_id, session_id) VALUES ('legacy_part', 'legacy_message', 'session')`,
+        )
+        yield* db.run(sql`INSERT INTO session_message (id) VALUES ('experimental_message')`)
+        yield* db.run(sql`INSERT INTO session_input (id) VALUES ('experimental_input')`)
+        yield* db.run(sql`INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES ('session', 1, 'workspace')`)
+        yield* db.run(sql`INSERT INTO event (id, aggregate_id, seq) VALUES ('experimental_event', 'session', 1)`)
+
+        yield* DatabaseMigration.applyOnly(db, [sessionMessageIdentityMigration])
+
+        expect(yield* db.all(sql`SELECT id FROM session`)).toEqual([{ id: "session" }])
+        expect(yield* db.all(sql`SELECT id FROM message`)).toEqual([{ id: "legacy_message" }])
+        expect(yield* db.all(sql`SELECT id FROM part`)).toEqual([{ id: "legacy_part" }])
+        expect(yield* db.all(sql`SELECT id FROM session_message`)).toEqual([])
+        expect(yield* db.all(sql`SELECT id FROM session_input`)).toEqual([])
+        expect(yield* db.all(sql`SELECT id FROM event`)).toEqual([])
+        expect(yield* db.all(sql`SELECT aggregate_id FROM event_sequence`)).toEqual([])
+      }),
+    )
+  })
+
+  test("applies the Session-message identity reset through normal database startup", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "identity-reset.sqlite")
+    const before = migrations.filter((migration) => migration.id !== sessionMessageIdentityMigration.id)
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`PRAGMA foreign_keys = ON`)
+        yield* DatabaseMigration.applyOnly(db, before)
+        yield* db.run(
+          sql`INSERT INTO project (id, worktree, sandboxes, time_created, time_updated) VALUES ('project', '/project', '[]', 1, 1)`,
+        )
+        yield* db.run(
+          sql`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated) VALUES ('session', 'project', 'session', '/project', 'Session', 'test', 1, 1)`,
+        )
+        yield* db.run(
+          sql`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('legacy_message', 'session', 1, 1, '{}')`,
+        )
+        yield* db.run(
+          sql`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES ('legacy_part', 'legacy_message', 'session', 1, 1, '{}')`,
+        )
+        yield* db.run(
+          sql`INSERT INTO todo (session_id, content, status, priority, position, time_created, time_updated) VALUES ('session', 'keep', 'pending', 'low', 0, 1, 1)`,
+        )
+        yield* db.run(
+          sql`INSERT INTO session_message (id, session_id, type, seq, time_created, time_updated, data) VALUES ('evt_message', 'session', 'user', 1, 1, 1, '{}')`,
+        )
+        yield* db.run(
+          sql`INSERT INTO session_input (id, session_id, prompt, delivery, time_created) VALUES ('evt_input', 'session', '{}', 'queue', 1)`,
+        )
+        yield* db.run(sql`INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES ('session', 1, 'workspace')`)
+        yield* db.run(
+          sql`INSERT INTO event (id, aggregate_id, seq, type, data) VALUES ('evt_event', 'session', 1, 'session.created.1', '{}')`,
+        )
+      }).pipe(Effect.provide(SqliteClient.layer({ filename, disableWAL: true })), Effect.scoped),
+    )
+
+    await Effect.runPromise(Effect.scoped(Layer.build(Database.layerFromPath(filename))))
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        expect(yield* db.all(sql`SELECT id FROM session`)).toEqual([{ id: "session" }])
+        expect(yield* db.all(sql`SELECT id FROM message`)).toEqual([{ id: "legacy_message" }])
+        expect(yield* db.all(sql`SELECT id FROM part`)).toEqual([{ id: "legacy_part" }])
+        expect(yield* db.all(sql`SELECT content FROM todo`)).toEqual([{ content: "keep" }])
+        expect(yield* db.all(sql`SELECT id FROM session_message`)).toEqual([])
+        expect(yield* db.all(sql`SELECT id FROM session_input`)).toEqual([])
+        expect(yield* db.all(sql`SELECT id FROM event`)).toEqual([])
+        expect(yield* db.all(sql`SELECT aggregate_id FROM event_sequence`)).toEqual([])
+        expect(yield* db.get(sql`SELECT id FROM migration WHERE id = ${sessionMessageIdentityMigration.id}`)).toEqual({
+          id: sessionMessageIdentityMigration.id,
+        })
+      }).pipe(Effect.provide(SqliteClient.layer({ filename, disableWAL: true })), Effect.scoped),
     )
   })
 

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -7,6 +7,7 @@ import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import { V2Schema } from "@opencode-ai/core/v2-schema"
+import { SessionMessage } from "@opencode-ai/core/session/message"
 import { eq } from "drizzle-orm"
 import { location } from "./fixture/location"
 import { testEffect } from "./lib/effect"
@@ -84,6 +85,21 @@ const SyncTimestamp = EventV2.define({
 })
 
 describe("EventV2", () => {
+  it.effect("keeps event IDs in the evt namespace", () =>
+    Effect.sync(() => {
+      expect(EventV2.ID.create()).toMatch(/^evt_/)
+      expect(() => EventV2.ID.make("msg_wrong_namespace")).toThrow()
+      expect(() => EventV2.ID.make("evtx")).toThrow()
+    }),
+  )
+
+  it.effect("round-trips Session message IDs through creator event IDs", () =>
+    Effect.sync(() => {
+      expect(String(SessionMessage.ID.fromEvent(EventV2.ID.make("evt_custom")))).toBe("msg_custom")
+      expect(String(SessionMessage.ID.toEvent(SessionMessage.ID.make("msg_custom")))).toBe("evt_custom")
+    }),
+  )
+
   it.effect("derives stable namespaced external IDs", () =>
     Effect.sync(() => {
       const input = { namespace: "opencord.agent-input", key: "input-1" }

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -67,13 +67,23 @@ describe("SessionProjector", () => {
 
       yield* events.publish(
         SessionEvent.Prompted,
-        { sessionID, timestamp: created, prompt: new Prompt({ text: "first" }), delivery: "steer" },
-        { id: SessionMessage.ID.make("evt_z") },
+        {
+          sessionID,
+          timestamp: created,
+          prompt: new Prompt({ text: "first" }),
+          delivery: "steer",
+        },
+        { id: EventV2.ID.make("evt_z") },
       )
       yield* events.publish(
         SessionEvent.Prompted,
-        { sessionID, timestamp: created, prompt: new Prompt({ text: "second" }), delivery: "steer" },
-        { id: SessionMessage.ID.make("evt_a") },
+        {
+          sessionID,
+          timestamp: created,
+          prompt: new Prompt({ text: "second" }),
+          delivery: "steer",
+        },
+        { id: EventV2.ID.make("evt_a") },
       )
 
       const sessions = yield* SessionV2.Service
@@ -131,13 +141,13 @@ describe("SessionProjector", () => {
         .run()
         .pipe(Effect.orDie)
       const events = yield* EventV2.Service
-      const id = SessionMessage.ID.make("evt_admitted")
+      const id = SessionMessage.ID.make("msg_admitted")
       yield* SessionInput.admit(db, { id, sessionID, prompt: new Prompt({ text: "promote me" }), delivery: "steer" })
 
       const event = yield* events.publish(
         SessionEvent.Prompted,
         { sessionID, timestamp: created, prompt: new Prompt({ text: "promote me" }), delivery: "steer" },
-        { id },
+        { id: SessionMessage.ID.toEvent(id) },
       )
 
       expect(
@@ -168,9 +178,21 @@ describe("SessionProjector", () => {
         .pipe(Effect.orDie)
       const events = yield* EventV2.Service
 
-      yield* events.publish(SessionEvent.AgentSwitched, { sessionID, timestamp: created, agent: "build" })
-      yield* events.publish(SessionEvent.ModelSwitched, { sessionID, timestamp: created, model })
-      yield* events.publish(SessionEvent.Synthetic, { sessionID, timestamp: created, text: "synthetic context" })
+      yield* events.publish(SessionEvent.AgentSwitched, {
+        sessionID,
+        timestamp: created,
+        agent: "build",
+      })
+      yield* events.publish(SessionEvent.ModelSwitched, {
+        sessionID,
+        timestamp: created,
+        model,
+      })
+      yield* events.publish(SessionEvent.Synthetic, {
+        sessionID,
+        timestamp: created,
+        text: "synthetic context",
+      })
       yield* events.publish(SessionEvent.Shell.Started, {
         sessionID,
         timestamp: created,
@@ -183,7 +205,11 @@ describe("SessionProjector", () => {
         callID: "shell-1",
         output: "/project",
       })
-      yield* events.publish(SessionEvent.Compaction.Started, { sessionID, timestamp: created, reason: "manual" })
+      yield* events.publish(SessionEvent.Compaction.Started, {
+        sessionID,
+        timestamp: created,
+        reason: "manual",
+      })
       yield* events.publish(SessionEvent.Compaction.Delta, { sessionID, timestamp: created, text: "partial" })
       yield* events.publish(SessionEvent.Compaction.Ended, {
         sessionID,
@@ -228,6 +254,53 @@ describe("SessionProjector", () => {
     }),
   )
 
+  it.effect("rejects a creator event that reuses an existing projected message ID", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "test",
+          directory: "/project",
+          title: "test",
+          version: "test",
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const events = yield* EventV2.Service
+      yield* events.publish(
+        SessionEvent.Synthetic,
+        { sessionID, timestamp: created, text: "first" },
+        { id: EventV2.ID.make("evt_same") },
+      )
+
+      const duplicate = yield* events
+        .publish(
+          SessionEvent.Synthetic,
+          { sessionID, timestamp: created, text: "second" },
+          { id: EventV2.ID.make("evt_same") },
+        )
+        .pipe(Effect.exit)
+
+      expect(duplicate._tag).toBe("Failure")
+      expect(
+        yield* db
+          .select()
+          .from(SessionMessageTable)
+          .where(eq(SessionMessageTable.id, SessionMessage.ID.make("msg_same")))
+          .get()
+          .pipe(Effect.orDie),
+      ).toMatchObject({ data: { text: "first" } })
+    }),
+  )
+
   it.effect("rejects a Prompted event that conflicts with an admitted inbox row", () =>
     Effect.gen(function* () {
       const { db } = yield* Database.Service
@@ -249,14 +322,14 @@ describe("SessionProjector", () => {
         .run()
         .pipe(Effect.orDie)
       const events = yield* EventV2.Service
-      const id = SessionMessage.ID.make("evt_conflict")
+      const id = SessionMessage.ID.make("msg_conflict")
       yield* SessionInput.admit(db, { id, sessionID, prompt: new Prompt({ text: "admitted" }), delivery: "steer" })
 
       const exit = yield* events
         .publish(
           SessionEvent.Prompted,
           { sessionID, timestamp: created, prompt: new Prompt({ text: "different" }), delivery: "steer" },
-          { id },
+          { id: SessionMessage.ID.toEvent(id) },
         )
         .pipe(Effect.exit)
 
@@ -288,12 +361,16 @@ describe("SessionProjector", () => {
         .run()
         .pipe(Effect.orDie)
       const events = yield* EventV2.Service
-      const id = SessionMessage.ID.make("evt_delivery_conflict")
+      const id = SessionMessage.ID.make("msg_delivery_conflict")
       const prompt = new Prompt({ text: "admitted" })
       yield* SessionInput.admit(db, { id, sessionID, prompt, delivery: "queue" })
 
       const exit = yield* events
-        .publish(SessionEvent.Prompted, { sessionID, timestamp: created, prompt, delivery: "steer" }, { id })
+        .publish(
+          SessionEvent.Prompted,
+          { sessionID, timestamp: created, prompt, delivery: "steer" },
+          { id: SessionMessage.ID.toEvent(id) },
+        )
         .pipe(Effect.exit)
 
       expect(String(exit)).toContain("Prompt projection conflicts with admitted input")
@@ -306,7 +383,7 @@ describe("SessionProjector", () => {
   it.effect("does not revive a stale incomplete in-memory assistant projection", () =>
     Effect.gen(function* () {
       const stale = new SessionMessage.Assistant({
-        id: SessionMessage.ID.make("evt_assistant_stale"),
+        id: SessionMessage.ID.make("msg_assistant_stale"),
         type: "assistant",
         agent: "build",
         model,
@@ -314,7 +391,7 @@ describe("SessionProjector", () => {
         time: { created },
       })
       const completed = new SessionMessage.Assistant({
-        id: SessionMessage.ID.make("evt_assistant_completed"),
+        id: SessionMessage.ID.make("msg_assistant_completed"),
         type: "assistant",
         agent: "build",
         model,
@@ -351,8 +428,8 @@ describe("SessionProjector", () => {
       yield* db
         .insert(SessionMessageTable)
         .values([
-          assistantRow(SessionMessage.ID.make("evt_assistant_1"), 0),
-          assistantRow(SessionMessage.ID.make("evt_assistant_2"), 1),
+          assistantRow(SessionMessage.ID.make("msg_assistant_1"), 0),
+          assistantRow(SessionMessage.ID.make("msg_assistant_2"), 1),
         ])
         .run()
         .pipe(Effect.orDie)
@@ -361,7 +438,7 @@ describe("SessionProjector", () => {
       yield* service.publish(SessionEvent.Step.Ended, {
         sessionID,
         timestamp: DateTime.makeUnsafe(1),
-        assistantMessageID: SessionMessage.ID.make("evt_assistant_2"),
+        assistantMessageID: EventV2.ID.make("evt_assistant_2"),
         finish: "stop",
         cost: 0,
         tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
@@ -409,8 +486,8 @@ describe("SessionProjector", () => {
       yield* db
         .insert(SessionMessageTable)
         .values([
-          assistantRow(SessionMessage.ID.make("evt_assistant_stale"), 0),
-          assistantRow(SessionMessage.ID.make("evt_assistant_completed"), 1, {
+          assistantRow(SessionMessage.ID.make("msg_assistant_stale"), 0),
+          assistantRow(SessionMessage.ID.make("msg_assistant_completed"), 1, {
             created: DateTime.makeUnsafe(1),
             completed: DateTime.makeUnsafe(2),
           }),
@@ -437,7 +514,7 @@ describe("SessionProjector", () => {
       )
       expect(messages).toEqual([
         new SessionMessage.Assistant({
-          id: SessionMessage.ID.make("evt_assistant_completed"),
+          id: SessionMessage.ID.make("msg_assistant_completed"),
           type: "assistant",
           agent: "build",
           model,
@@ -445,7 +522,7 @@ describe("SessionProjector", () => {
           time: { created: DateTime.makeUnsafe(1), completed: DateTime.makeUnsafe(2) },
         }),
         new SessionMessage.Assistant({
-          id: SessionMessage.ID.make("evt_assistant_stale"),
+          id: SessionMessage.ID.make("msg_assistant_stale"),
           type: "assistant",
           agent: "build",
           model,

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -310,7 +310,7 @@ describe("SessionV2.prompt", () => {
       yield* events.publish(
         SessionEvent.Prompted,
         { sessionID, timestamp: yield* DateTime.now, prompt, delivery: "steer" },
-        { id: messageID },
+        { id: SessionMessage.ID.toEvent(messageID) },
       )
 
       const retried = yield* session.prompt({ id: messageID, sessionID, prompt, resume: false })
@@ -329,7 +329,7 @@ describe("SessionV2.prompt", () => {
       yield* events.publish(
         SessionEvent.Prompted,
         { sessionID, timestamp: yield* DateTime.now, prompt, delivery: "queue" },
-        { id: messageID },
+        { id: SessionMessage.ID.toEvent(messageID) },
       )
 
       const retried = yield* session.prompt({ id: messageID, sessionID, prompt, delivery: "queue", resume: false })
@@ -339,7 +339,7 @@ describe("SessionV2.prompt", () => {
     }),
   )
 
-  it.effect("rejects an input ID already used by a durable non-prompt event", () =>
+  it.effect("rejects an input ID already used by a projected non-prompt message", () =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -347,7 +347,7 @@ describe("SessionV2.prompt", () => {
       yield* events.publish(
         SessionEvent.Synthetic,
         { sessionID, timestamp: yield* DateTime.now, text: "Collision" },
-        { id: messageID },
+        { id: SessionMessage.ID.toEvent(messageID) },
       )
 
       const failure = yield* session
@@ -359,10 +359,44 @@ describe("SessionV2.prompt", () => {
     }),
   )
 
-  it.effect("rejects a durable event ID reserved by an admitted prompt without poisoning promotion", () =>
+  it.effect("keeps event envelope IDs separate from admitted message IDs", () =>
     Effect.gen(function* () {
       yield* setup
       const { db } = yield* Database.Service
+      const session = yield* SessionV2.Service
+      const events = yield* EventV2.Service
+      const prompt = new Prompt({ text: "Reserved prompt" })
+      yield* session.prompt({ id: messageID, sessionID, prompt, resume: false })
+
+      yield* events.publish(
+        SessionEvent.Synthetic,
+        { sessionID, timestamp: yield* DateTime.now, text: "Synthetic" },
+        { id: EventV2.ID.make("evt_reserved_prompt") },
+      )
+
+      expect(yield* admitted(messageID)).not.toHaveProperty("promotedSeq")
+
+      yield* SessionInput.promoteSteers(db, events, sessionID)
+
+      expect(yield* admitted(messageID)).toMatchObject({ promotedSeq: 1 })
+      expect(yield* session.messages({ sessionID })).toMatchObject([
+        { id: messageID, type: "user", text: "Reserved prompt" },
+        { type: "synthetic", text: "Synthetic" },
+      ])
+    }),
+  )
+
+  it.effect("keeps Session message IDs in the msg namespace", () =>
+    Effect.sync(() => {
+      expect(SessionMessage.ID.create()).toMatch(/^msg_/)
+      expect(() => SessionMessage.ID.make("evt_wrong_namespace")).toThrow()
+      expect(() => SessionMessage.ID.make("msgx")).toThrow()
+    }),
+  )
+
+  it.effect("rejects a non-prompt event that reuses an admitted message ID", () =>
+    Effect.gen(function* () {
+      yield* setup
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       const prompt = new Prompt({ text: "Reserved prompt" })
@@ -372,20 +406,13 @@ describe("SessionV2.prompt", () => {
         .publish(
           SessionEvent.Synthetic,
           { sessionID, timestamp: yield* DateTime.now, text: "Conflicting synthetic" },
-          { id: messageID },
+          { id: SessionMessage.ID.toEvent(messageID) },
         )
         .pipe(Effect.catchDefect(Effect.succeed))
 
       expect(failure).toBe("Durable event conflicts with admitted prompt input")
       expect(yield* admitted(messageID)).not.toHaveProperty("promotedSeq")
       expect(yield* session.messages({ sessionID })).toEqual([])
-
-      yield* SessionInput.promoteSteers(db, events, sessionID)
-
-      expect(yield* admitted(messageID)).toMatchObject({ promotedSeq: 0 })
-      expect(yield* session.messages({ sessionID })).toMatchObject([
-        { id: messageID, type: "user", text: "Reserved prompt" },
-      ])
     }),
   )
 

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Message, Model } from "@opencode-ai/llm"
 import * as OpenAIChat from "@opencode-ai/llm/protocols/openai-chat"
-import { EventV2 } from "@opencode-ai/core/event"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { SessionMessage } from "@opencode-ai/core/session/message"
@@ -12,7 +11,7 @@ import { ToolOutput } from "@opencode-ai/core/tool-output"
 import { DateTime } from "effect"
 
 const created = DateTime.makeUnsafe(0)
-const id = (value: string) => EventV2.ID.make(`evt_${value}`)
+const id = (value: string) => SessionMessage.ID.make(`msg_${value}`)
 const model = Model.make({ id: "model", provider: "provider", route: OpenAIChat.route })
 
 describe("toLLMMessages", () => {

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1218,30 +1218,30 @@ describe("SessionRunnerLLM", () => {
       const events = yield* EventV2.Service
       yield* session.prompt({ sessionID, prompt: new Prompt({ text: "Recover interrupted tool" }), resume: false })
       yield* SessionInput.promoteSteers((yield* Database.Service).db, events, sessionID)
-      const assistant = yield* events.publish(SessionEvent.Step.Started, {
+      const assistantMessageID = (yield* events.publish(SessionEvent.Step.Started, {
         sessionID,
         timestamp: yield* DateTime.now,
         agent: "build",
         model: { id: ModelV2.ID.make("fake-model"), providerID: ProviderV2.ID.make("fake") },
-      })
+      })).id
       yield* events.publish(SessionEvent.Tool.Input.Started, {
         sessionID,
         timestamp: yield* DateTime.now,
-        assistantMessageID: assistant.id,
+        assistantMessageID,
         callID: "call-interrupted",
         name: "echo",
       })
       yield* events.publish(SessionEvent.Tool.Input.Ended, {
         sessionID,
         timestamp: yield* DateTime.now,
-        assistantMessageID: assistant.id,
+        assistantMessageID,
         callID: "call-interrupted",
         text: '{"text":"stale"}',
       })
       yield* events.publish(SessionEvent.Tool.Called, {
         sessionID,
         timestamp: yield* DateTime.now,
-        assistantMessageID: assistant.id,
+        assistantMessageID,
         callID: "call-interrupted",
         tool: "echo",
         input: { text: "stale" },
@@ -1280,30 +1280,30 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
       yield* SessionInput.promoteSteers((yield* Database.Service).db, events, sessionID)
-      const assistant = yield* events.publish(SessionEvent.Step.Started, {
+      const assistantMessageID = (yield* events.publish(SessionEvent.Step.Started, {
         sessionID,
         timestamp: yield* DateTime.now,
         agent: "build",
         model: { id: ModelV2.ID.make("fake-model"), providerID: ProviderV2.ID.make("fake") },
-      })
+      })).id
       yield* events.publish(SessionEvent.Tool.Input.Started, {
         sessionID,
         timestamp: yield* DateTime.now,
-        assistantMessageID: assistant.id,
+        assistantMessageID,
         callID: "call-hosted-interrupted",
         name: "web_search",
       })
       yield* events.publish(SessionEvent.Tool.Input.Ended, {
         sessionID,
         timestamp: yield* DateTime.now,
-        assistantMessageID: assistant.id,
+        assistantMessageID,
         callID: "call-hosted-interrupted",
         text: '{"query":"stale"}',
       })
       yield* events.publish(SessionEvent.Tool.Called, {
         sessionID,
         timestamp: yield* DateTime.now,
-        assistantMessageID: assistant.id,
+        assistantMessageID,
         callID: "call-hosted-interrupted",
         tool: "web_search",
         input: { query: "stale" },
@@ -1338,16 +1338,16 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
       yield* SessionInput.promoteSteers((yield* Database.Service).db, events, sessionID)
-      const assistant = yield* events.publish(SessionEvent.Step.Started, {
+      const assistantMessageID = (yield* events.publish(SessionEvent.Step.Started, {
         sessionID,
         timestamp: yield* DateTime.now,
         agent: "build",
         model: { id: ModelV2.ID.make("fake-model"), providerID: ProviderV2.ID.make("fake") },
-      })
+      })).id
       yield* events.publish(SessionEvent.Tool.Input.Started, {
         sessionID,
         timestamp: yield* DateTime.now,
-        assistantMessageID: assistant.id,
+        assistantMessageID,
         callID: "call-pending-interrupted",
         name: "echo",
       })

--- a/packages/core/test/session-tool-progress.test.ts
+++ b/packages/core/test/session-tool-progress.test.ts
@@ -60,7 +60,7 @@ describe("Tool.Progress", () => {
         const row = yield* db
           .select()
           .from(SessionMessageTable)
-          .where(eq(SessionMessageTable.id, assistantMessageID))
+          .where(eq(SessionMessageTable.id, SessionMessage.ID.fromEvent(assistantMessageID)))
           .get()
           .pipe(Effect.orDie)
         if (!row) return yield* Effect.die("Missing projected assistant")

--- a/packages/opencode/src/cli/cmd/tui/context/sync-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync-v2.tsx
@@ -1,4 +1,5 @@
 import { useEvent } from "@tui/context/event"
+import { EventV2 } from "@opencode-ai/core/event"
 import type {
   SessionMessage,
   SessionMessageAssistant,
@@ -9,6 +10,9 @@ import type {
 import { createStore, produce, reconcile } from "solid-js/store"
 import { createSimpleContext } from "./helper"
 import { useSDK } from "./sdk"
+import { SessionMessageID } from "@opencode-ai/core/session/message-id"
+
+const messageID = (eventID: string) => SessionMessageID.ID.fromEvent(EventV2.ID.make(eventID))
 
 function activeAssistant(messages: SessionMessage[]) {
   const index = messages.findIndex((message) => message.type === "assistant" && !message.time.completed)
@@ -82,7 +86,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.agent.switched":
           update(event.properties.sessionID, (draft) => {
             draft.unshift({
-              id: event.id,
+              id: messageID(event.id),
               type: "agent-switched",
               agent: event.properties.agent,
               time: { created: event.properties.timestamp },
@@ -92,7 +96,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.model.switched":
           update(event.properties.sessionID, (draft) => {
             draft.unshift({
-              id: event.id,
+              id: messageID(event.id),
               type: "model-switched",
               model: event.properties.model,
               time: { created: event.properties.timestamp },
@@ -102,7 +106,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.prompted": {
           update(event.properties.sessionID, (draft) => {
             draft.unshift({
-              id: event.id,
+              id: messageID(event.id),
               type: "user",
               text: event.properties.prompt.text,
               files: event.properties.prompt.files,
@@ -116,7 +120,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.synthetic":
           update(event.properties.sessionID, (draft) => {
             draft.unshift({
-              id: event.id,
+              id: messageID(event.id),
               type: "synthetic",
               sessionID: event.properties.sessionID,
               text: event.properties.text,
@@ -127,7 +131,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.shell.started":
           update(event.properties.sessionID, (draft) => {
             draft.unshift({
-              id: event.id,
+              id: messageID(event.id),
               type: "shell",
               callID: event.properties.callID,
               command: event.properties.command,
@@ -149,7 +153,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
             const currentAssistant = activeAssistant(draft)
             if (currentAssistant) currentAssistant.time.completed = event.properties.timestamp
             draft.unshift({
-              id: event.id,
+              id: messageID(event.id),
               type: "assistant",
               agent: event.properties.agent,
               model: event.properties.model,
@@ -161,7 +165,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
           break
         case "session.next.step.ended":
           update(event.properties.sessionID, (draft) => {
-            const currentAssistant = ownedAssistant(draft, event.properties.assistantMessageID)
+            const currentAssistant = ownedAssistant(draft, messageID(event.properties.assistantMessageID))
             if (!currentAssistant) return
             currentAssistant.time.completed = event.properties.timestamp
             currentAssistant.finish = event.properties.finish
@@ -173,7 +177,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
           break
         case "session.next.step.failed":
           update(event.properties.sessionID, (draft) => {
-            const currentAssistant = ownedAssistant(draft, event.properties.assistantMessageID)
+            const currentAssistant = ownedAssistant(draft, messageID(event.properties.assistantMessageID))
             if (!currentAssistant) return
             currentAssistant.time.completed = event.properties.timestamp
             currentAssistant.finish = "error"
@@ -199,7 +203,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
           break
         case "session.next.tool.input.started":
           update(event.properties.sessionID, (draft) => {
-            ownedAssistant(draft, event.properties.assistantMessageID)?.content.push({
+            ownedAssistant(draft, messageID(event.properties.assistantMessageID))?.content.push({
               type: "tool",
               id: event.properties.callID,
               name: event.properties.name,
@@ -211,7 +215,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.tool.input.delta":
           update(event.properties.sessionID, (draft) => {
             const match = latestTool(
-              ownedAssistant(draft, event.properties.assistantMessageID),
+              ownedAssistant(draft, messageID(event.properties.assistantMessageID)),
               event.properties.callID,
             )
             if (match?.state.status === "pending") match.state.input += event.properties.delta
@@ -220,7 +224,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.tool.input.ended":
           update(event.properties.sessionID, (draft) => {
             const match = latestTool(
-              ownedAssistant(draft, event.properties.assistantMessageID),
+              ownedAssistant(draft, messageID(event.properties.assistantMessageID)),
               event.properties.callID,
             )
             if (match?.state.status === "pending") match.state.input = event.properties.text
@@ -229,7 +233,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.tool.called":
           update(event.properties.sessionID, (draft) => {
             const match = latestTool(
-              ownedAssistant(draft, event.properties.assistantMessageID),
+              ownedAssistant(draft, messageID(event.properties.assistantMessageID)),
               event.properties.callID,
             )
             if (!match) return
@@ -241,7 +245,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.tool.progress":
           update(event.properties.sessionID, (draft) => {
             const match = latestTool(
-              ownedAssistant(draft, event.properties.assistantMessageID),
+              ownedAssistant(draft, messageID(event.properties.assistantMessageID)),
               event.properties.callID,
             )
             if (match?.state.status !== "running") return
@@ -252,7 +256,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.tool.success":
           update(event.properties.sessionID, (draft) => {
             const match = latestTool(
-              ownedAssistant(draft, event.properties.assistantMessageID),
+              ownedAssistant(draft, messageID(event.properties.assistantMessageID)),
               event.properties.callID,
             )
             if (match?.state.status !== "running") return
@@ -270,7 +274,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.tool.failed":
           update(event.properties.sessionID, (draft) => {
             const match = latestTool(
-              ownedAssistant(draft, event.properties.assistantMessageID),
+              ownedAssistant(draft, messageID(event.properties.assistantMessageID)),
               event.properties.callID,
             )
             if (!match || (match.state.status !== "pending" && match.state.status !== "running")) return
@@ -317,7 +321,7 @@ export const { use: useSyncV2, provider: SyncProviderV2 } = createSimpleContext(
         case "session.next.compaction.started":
           update(event.properties.sessionID, (draft) => {
             draft.unshift({
-              id: event.id,
+              id: messageID(event.id),
               type: "compaction",
               reason: event.properties.reason,
               summary: "",

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
@@ -1,4 +1,3 @@
-import { Config } from "@/config/config"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { EventV2 } from "@opencode-ai/core/event"
 import { InstanceDisposed } from "@/server/event"
@@ -20,10 +19,10 @@ const SyncEventSchemas = EventV2.registry
     return [
       Schema.Struct({
         type: Schema.Literal("sync"),
-        id: Schema.String,
+        id: EventV2.ID,
         syncEvent: Schema.Struct({
           type: Schema.Literal(EventV2.versionedType(definition.type, definition.sync.version)),
-          id: Schema.String,
+          id: EventV2.ID,
           seq: Schema.Finite,
           aggregateID: Schema.String,
           data: definition.data,
@@ -41,7 +40,7 @@ const GlobalEventSchema = Schema.Struct({
     ...EventV2.registry
       .values()
       .map((definition) =>
-        Schema.Struct({ id: Schema.String, type: Schema.Literal(definition.type), properties: definition.data }),
+        Schema.Struct({ id: EventV2.ID, type: Schema.Literal(definition.type), properties: definition.data }),
       )
       .toArray(),
     InstanceDisposed,

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/sync.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/sync.ts
@@ -1,4 +1,5 @@
 import { NonNegativeInt } from "@opencode-ai/core/schema"
+import { EventV2 } from "@opencode-ai/core/event"
 import { SessionID } from "@/session/schema"
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
@@ -9,7 +10,7 @@ import { described } from "./metadata"
 
 const root = "/sync"
 export const ReplayEvent = Schema.Struct({
-  id: Schema.String,
+  id: EventV2.ID,
   aggregateID: Schema.String,
   seq: NonNegativeInt,
   type: Schema.String,
@@ -27,7 +28,7 @@ export const SessionPayload = Schema.Struct({
 })
 export const HistoryPayload = Schema.Record(Schema.String, NonNegativeInt)
 export const HistoryEvent = Schema.Struct({
-  id: Schema.String,
+  id: EventV2.ID,
   aggregate_id: Schema.String,
   seq: NonNegativeInt,
   type: Schema.String,

--- a/packages/opencode/test/cli/tui/sync-v2.test.tsx
+++ b/packages/opencode/test/cli/tui/sync-v2.test.tsx
@@ -49,14 +49,14 @@ test("sync v2 settles pending tools when a live failure arrives", async () => {
     await mounted
     events.emit(
       global({
-        id: "agent-1",
+        id: "evt_agent_1",
         type: "session.next.agent.switched",
         properties: { sessionID: "session-1", timestamp: 0, agent: "build" },
       }),
     )
     events.emit(
       global({
-        id: "model-1",
+        id: "evt_model_1",
         type: "session.next.model.switched",
         properties: {
           sessionID: "session-1",
@@ -67,7 +67,7 @@ test("sync v2 settles pending tools when a live failure arrives", async () => {
     )
     events.emit(
       global({
-        id: "assistant-1",
+        id: "evt_assistant_1",
         type: "session.next.step.started",
         properties: {
           sessionID: "session-1",
@@ -79,12 +79,12 @@ test("sync v2 settles pending tools when a live failure arrives", async () => {
     )
     events.emit(
       global({
-        id: "input-1",
+        id: "evt_input_1",
         type: "session.next.tool.input.started",
         properties: {
           sessionID: "session-1",
           timestamp: 2,
-          assistantMessageID: "assistant-1",
+          assistantMessageID: "evt_assistant_1",
           callID: "call-1",
           name: "bash",
         },
@@ -92,12 +92,12 @@ test("sync v2 settles pending tools when a live failure arrives", async () => {
     )
     events.emit(
       global({
-        id: "failed-1",
+        id: "evt_failed_1",
         type: "session.next.tool.failed",
         properties: {
           sessionID: "session-1",
           timestamp: 3,
-          assistantMessageID: "assistant-1",
+          assistantMessageID: "evt_assistant_1",
           callID: "call-1",
           error: { type: "unknown", message: "aborted" },
           provider: { executed: false },
@@ -117,6 +117,7 @@ test("sync v2 settles pending tools when a live failure arrives", async () => {
     const assistant = sync.session.message.fromSession("session-1")[0]
     expect(assistant?.type).toBe("assistant")
     if (assistant?.type !== "assistant") return
+    expect(assistant.id).toBe("msg_assistant_1")
     const tool = assistant.content[0]
     expect(tool?.type).toBe("tool")
     if (tool?.type !== "tool") return

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -22,7 +22,6 @@ import * as HttpSessionError from "../../src/server/routes/instance/httpapi/hand
 import { SessionPaths } from "../../src/server/routes/instance/httpapi/groups/session"
 import { Session } from "@/session/session"
 import { MessageID, PartID, SessionID, type SessionID as SessionIDType } from "../../src/session/schema"
-import { MessageV2 } from "../../src/session/message-v2"
 import { Database } from "@opencode-ai/core/database/database"
 import { SessionInputTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionMessage } from "@opencode-ai/core/session/message"
@@ -584,7 +583,7 @@ describe("session HttpApi", () => {
           request(`/api/session/${session.id}/prompt`, {
             method: "POST",
             headers: { ...headers, "content-type": "application/json" },
-            body: JSON.stringify({ id: "evt_http_prompt", prompt: { text: "hello" } }),
+            body: JSON.stringify({ id: "msg_http_prompt", prompt: { text: "hello" } }),
           })
         const first = yield* recordPrompt()
         const retried = yield* recordPrompt()
@@ -604,12 +603,12 @@ describe("session HttpApi", () => {
           db
             .select()
             .from(SessionInputTable)
-            .where(eq(SessionInputTable.id, SessionMessage.ID.make("evt_http_prompt")))
+            .where(eq(SessionInputTable.id, SessionMessage.ID.make("msg_http_prompt")))
             .get()
             .pipe(Effect.orDie),
         )
         expect(admitted).toMatchObject({
-          id: "evt_http_prompt",
+          id: "msg_http_prompt",
           session_id: session.id,
           delivery: "steer",
           promoted_seq: null,
@@ -618,13 +617,13 @@ describe("session HttpApi", () => {
         const conflict = yield* request(`/api/session/${session.id}/prompt`, {
           method: "POST",
           headers: { ...headers, "content-type": "application/json" },
-          body: JSON.stringify({ id: "evt_http_prompt", prompt: { text: "goodbye" } }),
+          body: JSON.stringify({ id: "msg_http_prompt", prompt: { text: "goodbye" } }),
         })
         expect(conflict.status).toBe(409)
         expect(yield* responseJson(conflict)).toEqual({
           _tag: "ConflictError",
-          message: "Prompt message ID conflicts with an existing durable record: evt_http_prompt",
-          resource: "evt_http_prompt",
+          message: "Prompt message ID conflicts with an existing durable record: msg_http_prompt",
+          resource: "msg_http_prompt",
         })
       }),
     { git: true, config: { formatter: false, lsp: false } },

--- a/packages/opencode/test/v2/session-message-updater.test.ts
+++ b/packages/opencode/test/v2/session-message-updater.test.ts
@@ -7,6 +7,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionMessageUpdater } from "@opencode-ai/core/session/message-updater"
+import { SessionMessage } from "@opencode-ai/core/session/message"
 import { ToolOutput } from "@opencode-ai/core/tool-output"
 
 test.skip("step snapshots carry over to assistant messages", () => {
@@ -62,10 +63,11 @@ test.skip("step snapshots carry over to assistant messages", () => {
 test.skip("text ended populates assistant text content", () => {
   const state: SessionMessageUpdater.MemoryState = { messages: [] }
   const sessionID = SessionID.make("session")
+  const assistantMessageID = EventV2.ID.create()
 
   Effect.runSync(
     SessionMessageUpdater.update(SessionMessageUpdater.memory(state), {
-      id: EventV2.ID.create(),
+      id: assistantMessageID,
       type: "session.next.step.started",
       data: {
         sessionID,
@@ -243,7 +245,7 @@ test.skip("compaction events reduce to compaction message", () => {
 
   expect(state.messages).toHaveLength(1)
   expect(state.messages[0]).toMatchObject({
-    id,
+    id: SessionMessage.ID.fromEvent(id),
     type: "compaction",
     reason: "auto",
     summary: "final summary",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8175,7 +8175,8 @@
                       "type": "object",
                       "properties": {
                         "id": {
-                          "type": "string"
+                          "type": "string",
+                          "pattern": "^evt_"
                         },
                         "aggregateID": {
                           "type": "string"
@@ -8330,7 +8331,8 @@
                     "type": "object",
                     "properties": {
                       "id": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "aggregate_id": {
                         "type": "string"
@@ -10123,7 +10125,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^msg_"
                   },
                   "prompt": {
                     "$ref": "#/components/schemas/Prompt"
@@ -14014,7 +14017,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14032,7 +14036,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14056,7 +14061,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14080,7 +14086,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14108,7 +14115,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14136,7 +14144,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14164,7 +14173,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14192,7 +14202,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14221,7 +14232,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14252,7 +14264,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14285,7 +14298,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14316,7 +14330,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14360,7 +14375,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14395,7 +14411,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14426,7 +14443,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14460,7 +14478,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14494,7 +14513,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14544,7 +14564,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14561,7 +14582,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "finish": {
                         "type": "string"
@@ -14613,7 +14635,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14630,7 +14653,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "error": {
                         "$ref": "#/components/schemas/SessionErrorUnknown"
@@ -14647,7 +14671,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14678,7 +14703,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14712,7 +14738,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14746,7 +14773,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14783,7 +14811,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14817,7 +14846,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14857,7 +14887,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14874,7 +14905,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "callID": {
                         "type": "string"
@@ -14894,7 +14926,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14911,7 +14944,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "callID": {
                         "type": "string"
@@ -14931,7 +14965,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14948,7 +14983,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "callID": {
                         "type": "string"
@@ -14968,7 +15004,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -14985,7 +15022,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "callID": {
                         "type": "string"
@@ -15024,7 +15062,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15041,7 +15080,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "callID": {
                         "type": "string"
@@ -15074,7 +15114,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15091,7 +15132,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "callID": {
                         "type": "string"
@@ -15149,7 +15191,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15166,7 +15209,8 @@
                         "pattern": "^ses"
                       },
                       "assistantMessageID": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^evt_"
                       },
                       "callID": {
                         "type": "string"
@@ -15203,7 +15247,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15237,7 +15282,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15269,7 +15315,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15300,7 +15347,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15334,7 +15382,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15373,7 +15422,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15404,7 +15454,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15453,7 +15504,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15477,7 +15529,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15501,7 +15554,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15525,7 +15579,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15549,7 +15604,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15573,7 +15629,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15603,7 +15660,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15653,7 +15711,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15685,7 +15744,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15713,7 +15773,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15737,7 +15798,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15761,7 +15823,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15790,7 +15853,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15815,7 +15879,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15854,7 +15919,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15889,7 +15955,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15918,7 +15985,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15949,7 +16017,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -15967,7 +16036,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16027,7 +16097,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16060,7 +16131,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16084,7 +16156,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16133,7 +16206,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16168,7 +16242,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16194,7 +16269,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16218,7 +16294,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16245,7 +16322,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16280,7 +16358,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16304,7 +16383,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16388,7 +16468,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16427,7 +16508,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16462,7 +16544,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16491,7 +16574,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16519,7 +16603,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16544,7 +16629,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16569,7 +16655,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16592,7 +16679,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16619,7 +16707,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16643,7 +16732,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16667,7 +16757,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16691,7 +16782,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16720,7 +16812,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -16738,7 +16831,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "type": {
                     "type": "string",
@@ -20748,7 +20842,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -20758,7 +20853,8 @@
                 "enum": ["session.created.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -20796,7 +20892,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -20806,7 +20903,8 @@
                 "enum": ["session.updated.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -20844,7 +20942,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -20854,7 +20953,8 @@
                 "enum": ["session.deleted.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -20892,7 +20992,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -20902,7 +21003,8 @@
                 "enum": ["message.updated.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -20940,7 +21042,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -20950,7 +21053,8 @@
                 "enum": ["message.removed.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -20989,7 +21093,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -20999,7 +21104,8 @@
                 "enum": ["message.part.updated.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21040,7 +21146,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21050,7 +21157,8 @@
                 "enum": ["message.part.removed.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21093,7 +21201,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21103,7 +21212,8 @@
                 "enum": ["session.next.agent.switched.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21144,7 +21254,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21154,7 +21265,8 @@
                 "enum": ["session.next.model.switched.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21208,7 +21320,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21218,7 +21331,8 @@
                 "enum": ["session.next.prompted.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21263,7 +21377,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21273,7 +21388,8 @@
                 "enum": ["session.next.synthetic.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21314,7 +21430,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21324,7 +21441,8 @@
                 "enum": ["session.next.shell.started.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21368,7 +21486,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21378,7 +21497,8 @@
                 "enum": ["session.next.shell.ended.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21422,7 +21542,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21432,7 +21553,8 @@
                 "enum": ["session.next.step.started.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21492,7 +21614,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21502,7 +21625,8 @@
                 "enum": ["session.next.step.ended.2"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21521,7 +21645,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "finish": {
                     "type": "string"
@@ -21581,7 +21706,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21591,7 +21717,8 @@
                 "enum": ["session.next.step.failed.2"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21610,7 +21737,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "error": {
                     "$ref": "#/components/schemas/SessionErrorUnknown"
@@ -21635,7 +21763,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21645,7 +21774,8 @@
                 "enum": ["session.next.text.started.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21686,7 +21816,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21696,7 +21827,8 @@
                 "enum": ["session.next.text.ended.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21740,7 +21872,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21750,7 +21883,8 @@
                 "enum": ["session.next.reasoning.started.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21797,7 +21931,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21807,7 +21942,8 @@
                 "enum": ["session.next.reasoning.ended.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21857,7 +21993,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21867,7 +22004,8 @@
                 "enum": ["session.next.tool.input.started.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21886,7 +22024,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "callID": {
                     "type": "string"
@@ -21914,7 +22053,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21924,7 +22064,8 @@
                 "enum": ["session.next.tool.input.ended.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -21943,7 +22084,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "callID": {
                     "type": "string"
@@ -21971,7 +22113,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -21981,7 +22124,8 @@
                 "enum": ["session.next.tool.called.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22000,7 +22144,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "callID": {
                     "type": "string"
@@ -22047,7 +22192,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -22057,7 +22203,8 @@
                 "enum": ["session.next.tool.progress.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22076,7 +22223,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "callID": {
                     "type": "string"
@@ -22117,7 +22265,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -22127,7 +22276,8 @@
                 "enum": ["session.next.tool.success.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22146,7 +22296,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "callID": {
                     "type": "string"
@@ -22212,7 +22363,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -22222,7 +22374,8 @@
                 "enum": ["session.next.tool.failed.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22241,7 +22394,8 @@
                     "pattern": "^ses"
                   },
                   "assistantMessageID": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^evt_"
                   },
                   "callID": {
                     "type": "string"
@@ -22286,7 +22440,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -22296,7 +22451,8 @@
                 "enum": ["session.next.retried.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22340,7 +22496,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -22350,7 +22507,8 @@
                 "enum": ["session.next.compaction.started.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22392,7 +22550,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -22402,7 +22561,8 @@
                 "enum": ["session.next.compaction.delta.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22443,7 +22603,8 @@
             "enum": ["sync"]
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^evt_"
           },
           "syncEvent": {
             "type": "object",
@@ -22453,7 +22614,8 @@
                 "enum": ["session.next.compaction.ended.1"]
               },
               "id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "seq": {
                 "type": "number"
@@ -22765,7 +22927,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^msg_"
           },
           "metadata": {
             "type": "object"
@@ -22813,7 +22976,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^msg_"
           },
           "metadata": {
             "type": "object"
@@ -22843,7 +23007,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^msg_"
           },
           "metadata": {
             "type": "object"
@@ -22886,7 +23051,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^msg_"
           },
           "metadata": {
             "type": "object"
@@ -22920,7 +23086,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^msg_"
           },
           "metadata": {
             "type": "object"
@@ -23188,7 +23355,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^msg_"
           },
           "metadata": {
             "type": "object"
@@ -23317,7 +23485,8 @@
             "type": "string"
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^msg_"
           },
           "metadata": {
             "type": "object"
@@ -24484,7 +24653,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "finish": {
                 "type": "string"
@@ -24553,7 +24723,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "error": {
                 "$ref": "#/components/schemas/SessionErrorUnknown"
@@ -24797,7 +24968,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "callID": {
                 "type": "string"
@@ -24834,7 +25006,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "callID": {
                 "type": "string"
@@ -24871,7 +25044,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "callID": {
                 "type": "string"
@@ -24908,7 +25082,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "callID": {
                 "type": "string"
@@ -24964,7 +25139,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "callID": {
                 "type": "string"
@@ -25014,7 +25190,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "callID": {
                 "type": "string"
@@ -25081,7 +25258,8 @@
                 "pattern": "^ses"
               },
               "assistantMessageID": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^evt_"
               },
               "callID": {
                 "type": "string"

--- a/specs/v2/schema-changelog.md
+++ b/specs/v2/schema-changelog.md
@@ -6,6 +6,27 @@ This document covers meaningful contract changes introduced on the `feat/opencod
 
 ## Earlier Branch History
 
+### Independent Session Message Identity
+
+Affected schema:
+
+- V2 Session-message IDs and pre-launch `session_input` and `session_message` rows.
+
+Change:
+
+- Separate mutable Session-message identity (`msg_*`) from immutable event-envelope identity (`evt_*`).
+- Derive projected `msg_*` IDs reversibly from creator `evt_*` IDs without changing synchronized event payloads.
+
+Reason:
+
+- Event IDs identify immutable facts. Message IDs identify mutable timeline rows. Reusing one ID hid that boundary and leaked `evt_*` IDs into projected messages.
+- Clients can generate user-message IDs before prompt admission for optimistic rendering and exact retry. Promotion reverses that ID into the creator event ID, and projection derives the original message ID again.
+
+Compatibility:
+
+- The migration resets unreleased workspace-sync events, sequence state, V2 inbox rows, and V2 timeline projections. Canonical V1 `session`, `message`, and `part` history remains untouched.
+- Existing Sessions intentionally lose workspace-warp replayability across this pre-launch cutover until new replayable history is recorded.
+
 ### Replayable Session Event Refinement And Cursor Stream
 
 Affected schema:


### PR DESCRIPTION
## Summary

- separate projected Session timeline IDs (`msg_*`) from durable event envelope IDs (`evt_*`) with reversible derivation
- keep synchronized Session event payloads unchanged while translating ownership references at projection and TUI boundaries
- tighten HTTP sync/global event schemas and regenerated OpenAPI prefix constraints
- reset disposable pre-launch V2 projection, inbox, event, and event-sequence state during upgrade

## Beta reset boundary

This intentionally truncates unreleased beta state in `session_input`, `session_message`, `event`, and `event_sequence`. Canonical V1 `session`, `message`, and `part` rows remain intact. Accepted but unpromoted beta prompts may be dropped, and existing Sessions temporarily lose workspace-warp replayability until new replayable history is recorded.

## Verification

- `bun run test -- test/database-migration.test.ts test/event.test.ts test/session-projector.test.ts test/session-prompt.test.ts test/session-runner.test.ts test/session-tool-progress.test.ts test/session-runner-message.test.ts` from `packages/core`
- `bun run test -- test/v2/session-message-updater.test.ts test/session/processor-effect.test.ts test/cli/tui/sync-v2.test.tsx test/server/httpapi-session.test.ts` from `packages/opencode`
- `bun script/migration.ts --check` from `packages/core`
- `bun turbo typecheck`
- `bunx prettier --check ...` for changed source files
- file-scoped `bunx oxlint ...`
- `git diff --check`