### PR TITLE
fix(opencode): attribute task child agent on creation

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -128,6 +128,7 @@ export const TaskTool = Tool.define(
         (yield* sessions.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${next.name} subagent)`,
+          agent: next.name,
           permission: [
             ...deriveSubagentSessionPermission({
               parentSessionPermission: parent.permission ?? [],

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -412,6 +412,7 @@ describe("tool.task", () => {
 
         const child = yield* sessions.get(result.metadata.sessionId)
         expect(child.parentID).toBe(chat.id)
+        expect(child.agent).toBe("reviewer")
         expect(child.permission).toEqual([
           {
             permission: "todowrite",


### PR DESCRIPTION
## Summary

- persist the already-resolved subagent name when creating a Task-tool child session
- cover eager child-session agent attribution in the existing Task-tool test

## Why

Task-tool child sessions are created after the requested subagent has already been resolved. Passing `agent: next.name` at creation time avoids a temporary unattributed child row and prevents the row from remaining unattributed if execution stops before prompt admission.

This intentionally keeps the change narrow: prompt-time switching remains authoritative for later changes, and model attribution is unchanged.

## Testing

- `bun test test/tool/task.test.ts`