### PR TITLE
fix(tui): suppress diff viewer keybindings when dialog is open

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/diff-viewer.tsx
@@ -3,7 +3,7 @@ import type { TuiPlugin, TuiPluginApi, TuiRouteCurrent } from "@opencode-ai/plug
 import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
 import { TextAttributes, type BorderSides, type BoxRenderable, type ScrollBoxRenderable } from "@opentui/core"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
-import { useBindings, useCommandShortcut } from "@tui/keymap"
+import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut } from "@tui/keymap"
 import { useTheme } from "@tui/context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
 import path from "path"
@@ -649,6 +649,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
   }
 
   useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     commands,
     bindings: [
       { key: "j,down", cmd: "diff.down", desc: "Move diff viewer down" },


### PR DESCRIPTION
### Issue for this PR

Closes #30754

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opening Commands (command palette) while the Diff Viewer is open steals letter keys — q, s, d, p, E trigger diff actions instead of typing into the search input.

The cause: the diff viewer's `useBindings()` had no `mode` constraint, so its keybindings stayed active even after a dialog pushed `"modal"` onto the mode stack. The fix adds `mode: OPENCODE_BASE_MODE`, matching the pattern already used by session, permission, and question views.

Change: 2 lines in `diff-viewer.tsx` — one import, one `mode` field.

### How did you verify your code works?

1. Opened Diff Viewer, then Commands, typed q/e/p/s/d — confirmed keys triggered diff actions
2. Applied fix, repeated — keys now reach the search input
3. Confirmed no other `useBindings()` calls in the TUI have the same gap


### Screenshots / recordings

BUG
https://github.com/user-attachments/assets/33830aed-9604-4c08-b3d5-a20bd83d6175

FIX
https://github.com/user-attachments/assets/06f159cc-a06c-470e-b3d6-e6cdfe6388e6

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR