### PR TITLE
fix: bump @openrouter/ai-sdk-provider to 2.9.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -270,7 +270,7 @@
         "@opencode-ai/effect-drizzle-sqlite": "workspace:*",
         "@opencode-ai/effect-sqlite-node": "workspace:*",
         "@opencode-ai/llm": "workspace:*",
-        "@openrouter/ai-sdk-provider": "2.8.1",
+        "@openrouter/ai-sdk-provider": "2.9.0",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "2.6.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -524,7 +524,7 @@
         "@opencode-ai/sdk": "workspace:*",
         "@opencode-ai/server": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
-        "@openrouter/ai-sdk-provider": "2.8.1",
+        "@openrouter/ai-sdk-provider": "2.9.0",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "2.6.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -1754,7 +1754,7 @@
 
     "@opencode-ai/web": ["@opencode-ai/web@workspace:packages/web"],
 
-    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.8.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Y6j3yivgoEUf/kutD/k5GX/mzZfioRFoSx0gbQ+mIOzMaH/vJv1rCkztiuvlLw5xRYQil7oxHUZvmSfXqOx1NQ=="],
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.9.0", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Seva+NCa0WUQnJIUE5GzHsUv1WTIeyqwz0ELl2VtS6NP+eF+77yCXGFVOMbvoCM7QMjlnhv7931e89R+8pJdcQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -5807,6 +5807,8 @@
     "ai-gateway-provider/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.78", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-0OY12G20cUt6iU6htpEA1491Oz++NVxZxlmWGX4B7rSbeZ5pnDmOu6YtW9BKzdZlNx5Gn23i6WMxyZFoMKNcgA=="],
 
     "ai-gateway-provider/@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
+
+    "ai-gateway-provider/@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.8.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Y6j3yivgoEUf/kutD/k5GX/mzZfioRFoSx0gbQ+mIOzMaH/vJv1rCkztiuvlLw5xRYQil7oxHUZvmSfXqOx1NQ=="],
 
     "ajv-keywords/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,7 +89,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
     "@opentelemetry/sdk-trace-base": "2.6.1",
     "@parcel/watcher": "2.5.1",
-    "@openrouter/ai-sdk-provider": "2.8.1",
+    "@openrouter/ai-sdk-provider": "2.9.0",
     "ai-gateway-provider": "3.1.2",
     "bun-pty": "0.4.8",
     "cross-spawn": "catalog:",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -90,7 +90,7 @@
     "@opencode-ai/server": "workspace:*",
     "@opencode-ai/sdk": "workspace:*",
     "@opencode-ai/ui": "workspace:*",
-    "@openrouter/ai-sdk-provider": "2.8.1",
+    "@openrouter/ai-sdk-provider": "2.9.0",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/context-async-hooks": "2.6.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.214.0",


### PR DESCRIPTION
### Issue for this PR

Closes #26244

### Type of change

- [x] Bug fix

### What does this PR do?

Bumps `@openrouter/ai-sdk-provider` from `2.8.1` to `2.9.0` in `packages/opencode` and `packages/core` (+ `bun.lock`).

`2.8.1` has a streaming-parser bug: its merge-path re-emits a `tool-call` event every time the accumulated tool-call arguments are still parsable JSON, and trailing-whitespace/closing-token deltas keep them parsable. So models that emit a trailing chunk after a complete tool call get duplicate `tool-call` events with the same id. Downstream (the AI SDK `streamText` loop opencode runs on) treats them as two calls and runs the tool twice, which on reasoning+tool-call interleaving models like `moonshotai/kimi-k2.6` over OpenRouter degenerates into a silent stall / self-reinforcing duplicate loop.

`2.9.0` fixes this by gating the merge-path emit on a `sent` flag — see OpenRouterTeam/ai-sdk-provider#489 (released in https://github.com/OpenRouterTeam/ai-sdk-provider/releases/tag/2.9.0). Same peer deps (`ai ^6.0.0`), so it's a drop-in minor bump.

### How did you verify your code works?

- `bun install` resolves `2.9.0` cleanly (matching integrity), respecting the repo's `minimumReleaseAge` policy.
- `tsgo --noEmit` clean in both `packages/core` and `packages/opencode`.
- `bun test` green: `packages/opencode/test/provider/transform.test.ts` (246/246, incl. the `@openrouter/ai-sdk-provider` block) and `packages/core/test/plugin/provider-openrouter.test.ts` + `test/config/provider-options.test.ts` (24/24 — the plugin test actually instantiates `2.9.0`'s `createOpenRouter`).
- I don't have an OpenRouter key for a live kimi-through-OpenRouter run, so the runtime evidence is the upstream SDK fix (#489) + green build/tests rather than an e2e repro.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR