### PR TITLE
fix(tui): add Vue syntax highlighting

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -167,6 +167,16 @@ export default {
       // },
     },
     {
+      filetype: "vue",
+      wasm: "https://github.com/anomalyco/tree-sitter-vue/releases/download/v0.1.2/tree-sitter-vue.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/anomalyco/tree-sitter-vue/v0.1.2/queries/html_tags/highlights.scm",
+          "https://raw.githubusercontent.com/anomalyco/tree-sitter-vue/v0.1.2/queries/vue/highlights.scm",
+        ],
+      },
+    },
+    {
       filetype: "hcl",
       wasm: "https://github.com/tree-sitter-grammars/tree-sitter-hcl/releases/download/v1.2.0/tree-sitter-hcl.wasm",
       queries: {


### PR DESCRIPTION
## Summary

- register a Vue tree-sitter parser for TUI code and diff rendering
- source the WASM and matching highlight queries from the tagged `anomalyco/tree-sitter-vue` release
- keep the parser configuration aligned with the existing remote GitHub release pattern

## Verification

- ran OpenTUI one-shot highlighting from an empty parser cache for direct `.vue` content
- ran OpenTUI one-shot highlighting for a fenced `vue` markdown block
- ran `git diff --check origin/dev...HEAD`

Closes #6273