### PR TITLE
fix(session): respect directory filter with workspaces

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -1013,7 +1013,7 @@ function listByProject(
           : or(...conds)!,
       )
     }
-  } else if (input.scope !== "project" && !input.experimentalWorkspaces) {
+  } else if (input.scope !== "project") {
     if (input.directory) {
       conditions.push(eq(SessionTable.directory, input.directory))
     }

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -16,7 +16,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { BackgroundJob } from "@/background/job"
 
 void Log.init({ print: false })
-const it = testEffect(
+const layer = (experimentalWorkspaces: boolean) =>
   Layer.mergeAll(
     Database.defaultLayer,
     SessionNs.layer.pipe(
@@ -25,11 +25,12 @@ const it = testEffect(
       Layer.provide(Database.defaultLayer),
       Layer.provide(EventV2Bridge.defaultLayer),
       Layer.provide(SessionProjector.defaultLayer),
-      Layer.provide(RuntimeFlags.layer({ experimentalWorkspaces: false })),
+      Layer.provide(RuntimeFlags.layer({ experimentalWorkspaces })),
       Layer.provide(BackgroundJob.defaultLayer),
     ),
-  ),
-)
+  )
+const it = testEffect(layer(false))
+const itWorkspaces = testEffect(layer(true))
 
 const withSession = (input?: Parameters<SessionNs.Interface["create"]>[0]) =>
   Effect.acquireRelease(SessionNs.use.create(input), (created) =>
@@ -93,6 +94,30 @@ describe("session.list", () => {
         )).map((session) => session.id)
         expect(ids).not.toContain(root.id)
         expect(ids).not.toContain(parent.id)
+        expect(ids).toContain(current.id)
+        expect(ids).not.toContain(sibling.id)
+      }),
+    { git: true },
+  )
+
+  itWorkspaces.instance(
+    "filters by directory when experimental workspaces are enabled",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => mkdir(path.join(test.directory, "packages", "opencode"), { recursive: true }))
+        yield* Effect.promise(() => mkdir(path.join(test.directory, "packages", "app"), { recursive: true }))
+
+        const current = yield* withSession({ title: "current" }).pipe(
+          provideInstance(path.join(test.directory, "packages", "opencode")),
+        )
+        const sibling = yield* withSession({ title: "sibling" }).pipe(
+          provideInstance(path.join(test.directory, "packages", "app")),
+        )
+
+        const ids = (yield* SessionNs.Service.use((session) =>
+          session.list({ directory: path.join(test.directory, "packages", "opencode") }),
+        )).map((session) => session.id)
         expect(ids).toContain(current.id)
         expect(ids).not.toContain(sibling.id)
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #30801

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes directory-scoped session lists when experimental workspaces are enabled.

Before this change, `Session.list({ directory })` ignored `directory` in that mode unless callers also passed a `path`. The web sidebar could then receive project-wide results, filter them client-side by exact directory, and render only `New session` + `Load more` even though sessions existed.

This makes `directory` apply whenever `scope: "project"` was not explicitly requested, and adds regression coverage for two sibling directories in the same git project.

### How did you verify your code works?

- `cd packages/opencode && bun test test/server/session-list.test.ts`
- `cd packages/opencode && bun typecheck`
- Built a patched release-channel binary and verified the web UI now shows the existing sessions for the affected worktree.

### Screenshots / recordings

**Before**

https://github.com/user-attachments/assets/d97831d0-ebef-4c5e-a0c1-8b5eeb124a14

**After**

<img width="372" height="514" alt="Fixed session sidebar showing existing sessions" src="https://github.com/user-attachments/assets/f14592d2-2b42-4eed-ba86-51efa9bc822a" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR