### PR TITLE
feat(provider): support Bedrock OpenAI model URLs

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -341,6 +341,9 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       return {
         autoload: true,
         options: providerOptions,
+        vars(options) {
+          return { AWS_REGION: typeof options.region === "string" ? options.region : defaultRegion }
+        },
         async getModel(sdk: any, modelID: string, options?: Record<string, any>, model?: Model) {
           if (model?.api.npm === "@ai-sdk/amazon-bedrock/mantle") return selectBedrockMantleLanguageModel(sdk, modelID)
 

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -138,6 +138,41 @@ it.instance(
 )
 
 it.instance(
+  "Bedrock Mantle: OpenAI model URL uses configured region",
+  () =>
+    Effect.gen(function* () {
+      yield* set("AWS_BEARER_TOKEN_BEDROCK", "test-bearer-token")
+      const model = yield* Provider.use.getModel(ProviderV2.ID.amazonBedrock, ModelV2.ID.make("openai.gpt-5.4"))
+      const language = yield* Provider.use.getLanguage(model)
+      expect((language as { provider: string }).provider).toBe("bedrock-mantle.responses")
+      expect(
+        (language as unknown as { config: { url: (input: { path: string; modelId: string }) => string } }).config.url({
+          path: "/responses",
+          modelId: "openai.gpt-5.4",
+        }),
+      ).toBe("https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses")
+    }),
+  {
+    config: {
+      provider: {
+        "amazon-bedrock": {
+          options: { region: "us-west-2" },
+          models: {
+            "openai.gpt-5.4": {
+              ...mantleModelConfig,
+              provider: {
+                npm: "@ai-sdk/amazon-bedrock/mantle",
+                api: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
   "Bedrock Mantle: GPT OSS safeguard uses Chat Completions and Mantle base path",
   () =>
     Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #30819

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Amazon Bedrock provider URL variable substitution so Bedrock Mantle OpenAI model entries can use the documented endpoint format:

```text
https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1
```

This keeps model catalog data in models.dev, per the contributing guidelines, while making opencode resolve the configured Bedrock region correctly at runtime.

The test covers a config-defined `openai.gpt-5.4` Bedrock Mantle model and verifies it uses the Responses API with the configured region.

### How did you verify your code works?

- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/opencode`
- `bun test test/provider/amazon-bedrock.test.ts` in `packages/opencode`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
