### PR TITLE
fix(opencode): optimize snapshots & add loading ui for clarity

### DIFF
--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -121,19 +121,16 @@ export const ReasoningPart = Schema.Struct({
 }).annotate({ identifier: "ReasoningPart" })
 export type ReasoningPart = Types.DeepMutable<Schema.Schema.Type<typeof ReasoningPart>>
 
-// Records the snapshot index sync that runs before the LLM stream on
-// first track per worktree, and on sessions where source HEAD has
-// moved since last sync. Same shape as ReasoningPart so the TUI can
-// render a spinner then a final state line in chat.
-export const IndexingPart = Schema.Struct({
+// Records snapshot preparation before the LLM stream starts.
+export const PreparingSnapshotsPart = Schema.Struct({
   ...partBase,
-  type: Schema.Literal("indexing"),
+  type: Schema.Literal("preparing-snapshots"),
   time: Schema.Struct({
     start: NonNegativeInt,
     end: Schema.optional(NonNegativeInt),
   }),
-}).annotate({ identifier: "IndexingPart" })
-export type IndexingPart = Types.DeepMutable<Schema.Schema.Type<typeof IndexingPart>>
+}).annotate({ identifier: "PreparingSnapshotsPart" })
+export type PreparingSnapshotsPart = Types.DeepMutable<Schema.Schema.Type<typeof PreparingSnapshotsPart>>
 
 const filePartSourceBase = {
   text: Schema.Struct({
@@ -374,7 +371,7 @@ export const Part = Schema.Union([
   TextPart,
   SubtaskPart,
   ReasoningPart,
-  IndexingPart,
+  PreparingSnapshotsPart,
   FilePart,
   ToolPart,
   StepStartPart,
@@ -389,7 +386,7 @@ export type Part =
   | TextPart
   | SubtaskPart
   | ReasoningPart
-  | IndexingPart
+  | PreparingSnapshotsPart
   | FilePart
   | ToolPart
   | StepStartPart

--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -121,6 +121,20 @@ export const ReasoningPart = Schema.Struct({
 }).annotate({ identifier: "ReasoningPart" })
 export type ReasoningPart = Types.DeepMutable<Schema.Schema.Type<typeof ReasoningPart>>
 
+// Records the snapshot index sync that runs before the LLM stream on
+// first track per worktree, and on sessions where source HEAD has
+// moved since last sync. Same shape as ReasoningPart so the TUI can
+// render a spinner then a final state line in chat.
+export const IndexingPart = Schema.Struct({
+  ...partBase,
+  type: Schema.Literal("indexing"),
+  time: Schema.Struct({
+    start: NonNegativeInt,
+    end: Schema.optional(NonNegativeInt),
+  }),
+}).annotate({ identifier: "IndexingPart" })
+export type IndexingPart = Types.DeepMutable<Schema.Schema.Type<typeof IndexingPart>>
+
 const filePartSourceBase = {
   text: Schema.Struct({
     value: Schema.String,
@@ -360,6 +374,7 @@ export const Part = Schema.Union([
   TextPart,
   SubtaskPart,
   ReasoningPart,
+  IndexingPart,
   FilePart,
   ToolPart,
   StepStartPart,
@@ -374,6 +389,7 @@ export type Part =
   | TextPart
   | SubtaskPart
   | ReasoningPart
+  | IndexingPart
   | FilePart
   | ToolPart
   | StepStartPart

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -108,38 +108,31 @@ export const layer = Layer.effect(
     const database = yield* Database.Service
 
     const create = Effect.fn("SessionProcessor.create")(function* (input: Input) {
-      // Pre-capture snapshot before the LLM stream starts. The AI SDK may
-      // execute tools internally before emitting start-step events, so
-      // capturing inside the event handler can be too late.
-      //
-      // The snapshot service invokes onIndexingStart when about to sync
-      // the index to a new source HEAD. We use it to insert an IndexingPart
-      // into the chat so the user sees a spinner during the wait. Skipped
-      // when the index is already synced, so steady-state prompts add no
-      // part.
-      //
-      // Array wraps the part because TS narrows `let foo: T | undefined` to
-      // `never` when only mutated inside a closure.
-      const indexingPartHolder: [SessionV1.IndexingPart | undefined] = [undefined]
-      const initialSnapshot = yield* snapshot.track({
-        onIndexingStart: () =>
-          Effect.gen(function* () {
-            const next: SessionV1.IndexingPart = {
-              id: PartID.ascending(),
-              messageID: input.assistantMessage.id,
-              sessionID: input.assistantMessage.sessionID,
-              type: "indexing",
-              time: { start: Date.now() },
-            }
-            indexingPartHolder[0] = next
-            yield* session.updatePart(next).pipe(Effect.ignore)
-          }),
+      // Capture before streaming; some providers execute tools before
+      // emitting step-start events.
+      const preparingSnapshotsPartHolder: [SessionV1.PreparingSnapshotsPart | undefined] = [undefined]
+      const finishPreparingSnapshotsPart = Effect.gen(function* () {
+        const preparingSnapshotsPart = preparingSnapshotsPartHolder[0]
+        if (!preparingSnapshotsPart || preparingSnapshotsPart.time.end !== undefined) return
+        preparingSnapshotsPart.time.end = Date.now()
+        yield* session.updatePart(preparingSnapshotsPart).pipe(Effect.ignore)
       })
-      const indexingPart = indexingPartHolder[0]
-      if (indexingPart) {
-        indexingPart.time.end = Date.now()
-        yield* session.updatePart(indexingPart).pipe(Effect.ignore)
-      }
+      const initialSnapshot = yield* snapshot
+        .track({
+          onPreparingSnapshotsStart: () =>
+            Effect.gen(function* () {
+              const next: SessionV1.PreparingSnapshotsPart = {
+                id: PartID.ascending(),
+                messageID: input.assistantMessage.id,
+                sessionID: input.assistantMessage.sessionID,
+                type: "preparing-snapshots",
+                time: { start: Date.now() },
+              }
+              preparingSnapshotsPartHolder[0] = next
+              yield* session.updatePart(next).pipe(Effect.ignore)
+            }),
+        })
+        .pipe(Effect.onExit(() => finishPreparingSnapshotsPart))
       const ctx: ProcessorContext = {
         assistantMessage: input.assistantMessage,
         sessionID: input.sessionID,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -108,10 +108,38 @@ export const layer = Layer.effect(
     const database = yield* Database.Service
 
     const create = Effect.fn("SessionProcessor.create")(function* (input: Input) {
-      // Pre-capture snapshot before the LLM stream starts. The AI SDK
-      // may execute tools internally before emitting start-step events,
-      // so capturing inside the event handler can be too late.
-      const initialSnapshot = yield* snapshot.track()
+      // Pre-capture snapshot before the LLM stream starts. The AI SDK may
+      // execute tools internally before emitting start-step events, so
+      // capturing inside the event handler can be too late.
+      //
+      // The snapshot service invokes onIndexingStart when about to sync
+      // the index to a new source HEAD. We use it to insert an IndexingPart
+      // into the chat so the user sees a spinner during the wait. Skipped
+      // when the index is already synced, so steady-state prompts add no
+      // part.
+      //
+      // Array wraps the part because TS narrows `let foo: T | undefined` to
+      // `never` when only mutated inside a closure.
+      const indexingPartHolder: [SessionV1.IndexingPart | undefined] = [undefined]
+      const initialSnapshot = yield* snapshot.track({
+        onIndexingStart: () =>
+          Effect.gen(function* () {
+            const next: SessionV1.IndexingPart = {
+              id: PartID.ascending(),
+              messageID: input.assistantMessage.id,
+              sessionID: input.assistantMessage.sessionID,
+              type: "indexing",
+              time: { start: Date.now() },
+            }
+            indexingPartHolder[0] = next
+            yield* session.updatePart(next).pipe(Effect.ignore)
+          }),
+      })
+      const indexingPart = indexingPartHolder[0]
+      if (indexingPart) {
+        indexingPart.time.end = Date.now()
+        yield* session.updatePart(indexingPart).pipe(Effect.ignore)
+      }
       const ctx: ProcessorContext = {
         assistantMessage: input.assistantMessage,
         sessionID: input.sessionID,

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -41,13 +41,10 @@ interface GitResult {
 
 type State = Omit<Interface, "init">
 
-// Fired immediately before a fresh source-HEAD sync. The session processor
-// uses this to add an Indexing part to the chat. Not invoked when the
-// index is already in sync.
-export type IndexingStartHook = () => Effect.Effect<void>
+export type PreparingSnapshotsStartHook = () => Effect.Effect<void>
 
 export interface TrackOptions {
-  readonly onIndexingStart?: IndexingStartHook
+  readonly onPreparingSnapshotsStart?: PreparingSnapshotsStartHook
 }
 
 export interface Interface {
@@ -116,23 +113,10 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
         const ignore = Effect.fnUntraced(function* (files: string[]) {
           if (!files.length) return new Set<string>()
-          const check = yield* git(
-            [
-              ...quote,
-              "--git-dir",
-              path.join(state.worktree, ".git"),
-              "--work-tree",
-              state.worktree,
-              "check-ignore",
-              "--no-index",
-              "--stdin",
-              "-z",
-            ],
-            {
-              cwd: state.directory,
-              stdin: feed(files),
-            },
-          )
+          const check = yield* git([...quote, "check-ignore", "--no-index", "--stdin", "-z"], {
+            cwd: state.worktree,
+            stdin: feed(files),
+          })
           if (check.code !== 0 && check.code !== 1) return new Set<string>()
           return new Set(check.text.split("\0").filter(Boolean))
         })
@@ -145,7 +129,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
             ],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -156,7 +140,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           const result = yield* git(
             [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -219,7 +203,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           return true
         })
 
-        const syncedHeadPath = path.join(state.gitdir, "info", "synced-head")
+        const syncedHeadPath = path.join(state.gitdir, "info", "synced-head-worktree-v1")
         const readSyncedHead = Effect.fnUntraced(function* () {
           const text = (yield* read(syncedHeadPath)).trim()
           return text || undefined
@@ -230,19 +214,30 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             yield* fs.writeFileString(syncedHeadPath, hash + "\n").pipe(Effect.orDie)
           })
 
+        const trackedIgnoredFiles = Effect.fnUntraced(function* () {
+          const result = yield* sourceGit([...quote, "ls-files", "-ci", "--exclude-standard", "-z"])
+          if (result.code !== 0) return []
+          return result.text.split("\0").filter(Boolean)
+        })
+
         // Import the source HEAD tree into the snapshot index. Cheap because
         // alternates makes every blob already resolvable.
         const importHead = Effect.fnUntraced(function* (head: string) {
           const read = yield* git([...core, ...args(["read-tree", head])], { cwd: state.worktree })
           if (read.code !== 0) {
-            log.warn("failed to read-tree source HEAD", { head, exitCode: read.code, stderr: read.stderr })
+            yield* Effect.logWarning("failed to read-tree source HEAD", {
+              head,
+              exitCode: read.code,
+              stderr: read.stderr,
+            })
             return false
           }
           // Without --refresh, diff-files reports every entry as potentially
           // modified and the next git add re-hashes everything. Use -q, not
           // --quiet: the latter is not a valid flag for update-index and
           // silently disables the refresh.
-          yield* git([...core, ...args(["update-index", "--refresh", "-q"])], { cwd: state.directory })
+          yield* git([...core, ...args(["update-index", "--refresh", "-q"])], { cwd: state.worktree })
+          yield* drop(yield* trackedIgnoredFiles())
           return true
         })
 
@@ -258,12 +253,8 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             syncedHead = head
             return // synced (matched persisted state)
           }
-          // Index isn't synced. About to run read-tree + update-index
-          // --refresh. Fire the indexing hook unconditionally so the
-          // caller can show a spinner; even on small repos the wait is
-          // short, but the user always sees what's happening.
-          if (options?.onIndexingStart) {
-            yield* options.onIndexingStart().pipe(Effect.catch(() => Effect.void))
+          if (options?.onPreparingSnapshotsStart) {
+            yield* options.onPreparingSnapshotsStart().pipe(Effect.catch(() => Effect.void))
           }
           const alternates = yield* setupAlternates()
           if (!alternates) return // couldn't sync: alternates setup failed
@@ -342,10 +333,10 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           const [diff, other] = yield* Effect.all(
             [
               git([...quote, ...args(["diff-files", "--name-only", "-z", "--", "."])], {
-                cwd: state.directory,
+                cwd: state.worktree,
               }),
               git([...quote, ...args(["ls-files", "--others", "--exclude-standard", "-z", "--", "."])], {
-                cwd: state.directory,
+                cwd: state.worktree,
               }),
             ],
             { concurrency: 2 },
@@ -383,7 +374,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             (yield* Effect.all(
               allow.map((item) =>
                 fs
-                  .stat(path.join(state.directory, item))
+                  .stat(path.join(state.worktree, item))
                   .pipe(Effect.catch(() => Effect.void))
                   .pipe(
                     Effect.map((stat) => {
@@ -398,7 +389,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           )
           const block = new Set(untracked.filter((item) => large.has(item)))
           yield* sync(Array.from(block))
-          // Stage only the allowed candidate paths so snapshot updates stay scoped.
+          // Stage only changed/untracked candidate paths so clean HEAD entries stay cheap.
           yield* stage(allow.filter((item) => !block.has(item)))
         })
 
@@ -407,7 +398,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             Effect.gen(function* () {
               if (!(yield* enabled())) return
               if (!(yield* exists(state.gitdir))) return
-              const result = yield* git(args(["gc", `--prune=${prune}`]), { cwd: state.directory })
+              const result = yield* git(args(["gc", `--prune=${prune}`]), { cwd: state.worktree })
               if (result.code !== 0) {
                 yield* Effect.logWarning("cleanup failed", {
                   exitCode: result.code,
@@ -424,9 +415,9 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           return yield* locked(
             Effect.gen(function* () {
               if (!(yield* enabled())) return
-              const existed = yield* exists(state.gitdir)
+              const initialized = yield* exists(path.join(state.gitdir, "HEAD"))
               yield* fs.ensureDir(state.gitdir).pipe(Effect.orDie)
-              if (!existed) {
+              if (!initialized) {
                 yield* git(["init"], {
                   env: { GIT_DIR: state.gitdir, GIT_WORK_TREE: state.worktree },
                 })
@@ -446,10 +437,10 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               // large repos this is the difference between a sub-second
               // track() and a +10min git add storm. When sync can't happen
               // (e.g. fresh git init with no commits), add() falls through
-              // to the bulk-add path; such repos are small.
+              // to the bulk-add path
               yield* ensureHeadSynced(options)
               yield* add()
-              const result = yield* git(args(["write-tree"]), { cwd: state.directory })
+              const result = yield* git(args(["write-tree"]), { cwd: state.worktree })
               const hash = result.text.trim()
               yield* Effect.logInfo("tracking", { hash, cwd: state.directory, git: state.gitdir })
               return hash
@@ -464,7 +455,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               const result = yield* git(
                 [...quote, ...args(["diff", "--cached", "--no-ext-diff", "--name-only", hash, "--", "."])],
                 {
-                  cwd: state.directory,
+                  cwd: state.worktree,
                 },
               )
               if (result.code !== 0) {
@@ -714,7 +705,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
                   const batch = yield* appProcess.run(
                     ChildProcess.make("git", [...cfg, ...args(["cat-file", "--batch"])], {
-                      cwd: state.directory,
+                      cwd: state.worktree,
                       extendEnv: true,
                     }),
                     { stdin: refs.map((item) => item.ref).join("\n") + "\n" },
@@ -797,7 +788,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
               const statuses = yield* git(
                 [...quote, ...args(["diff", "--no-ext-diff", "--name-status", "--no-renames", from, to, "--", "."])],
-                { cwd: state.directory },
+                { cwd: state.worktree },
               )
 
               for (const line of statuses.text.trim().split("\n")) {
@@ -810,7 +801,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               const numstat = yield* git(
                 [...quote, ...args(["diff", "--no-ext-diff", "--no-renames", "--numstat", from, to, "--", "."])],
                 {
-                  cwd: state.directory,
+                  cwd: state.worktree,
                 },
               )
 

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -41,10 +41,19 @@ interface GitResult {
 
 type State = Omit<Interface, "init">
 
+// Fired immediately before a fresh source-HEAD sync. The session processor
+// uses this to add an Indexing part to the chat. Not invoked when the
+// index is already in sync.
+export type IndexingStartHook = () => Effect.Effect<void>
+
+export interface TrackOptions {
+  readonly onIndexingStart?: IndexingStartHook
+}
+
 export interface Interface {
   readonly init: () => Effect.Effect<void>
   readonly cleanup: () => Effect.Effect<void>
-  readonly track: () => Effect.Effect<string | undefined>
+  readonly track: (options?: TrackOptions) => Effect.Effect<string | undefined>
   readonly patch: (hash: string) => Effect.Effect<Patch>
   readonly restore: (snapshot: string) => Effect.Effect<void>
   readonly revert: (patches: Patch[]) => Effect.Effect<void>
@@ -163,9 +172,106 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
         const remove = (file: string) => fs.remove(file).pipe(Effect.catch(() => Effect.void))
         const locked = <A, E, R>(fx: Effect.Effect<A, E, R>) => lock(state.gitdir).withPermits(1)(fx)
 
+        // In-memory cache of the source HEAD we last synced to. Lets repeat
+        // track() calls in the same session skip the sync work.
+        let syncedHead: string | undefined = undefined
+
         const enabled = Effect.fnUntraced(function* () {
           if (state.vcs !== "git") return false
           return (yield* config.get()).snapshot !== false
+        })
+
+        // Run git against the source repo, not the snapshot. Used to read
+        // HEAD and resolve git paths for alternates setup.
+        const sourceGit = Effect.fnUntraced(function* (cmd: string[]) {
+          return yield* git(cmd, { cwd: state.worktree })
+        })
+
+        const sourceHead = Effect.fnUntraced(function* () {
+          const result = yield* sourceGit(["rev-parse", "--verify", "HEAD"])
+          if (result.code !== 0) return undefined
+          const hash = result.text.trim()
+          return hash || undefined
+        })
+
+        // `--git-path objects` resolves through linked-worktree pointer
+        // files to the actual shared object store.
+        const sourceObjectsPath = Effect.fnUntraced(function* () {
+          const result = yield* sourceGit(["rev-parse", "--path-format=absolute", "--git-path", "objects"])
+          if (result.code !== 0) return undefined
+          const dir = result.text.trim()
+          if (!dir) return undefined
+          if (!(yield* exists(dir))) return undefined
+          return dir
+        })
+
+        // Point the snapshot at the source's object store so read-tree
+        // resolves blobs without re-hashing the worktree. Idempotent.
+        const setupAlternates = Effect.fnUntraced(function* () {
+          const objects = yield* sourceObjectsPath()
+          if (!objects) return false
+          const target = path.join(state.gitdir, "objects", "info", "alternates")
+          yield* fs.ensureDir(path.dirname(target)).pipe(Effect.orDie)
+          const desired = objects + "\n"
+          const current = yield* read(target)
+          if (current === desired) return true
+          yield* fs.writeFileString(target, desired).pipe(Effect.orDie)
+          return true
+        })
+
+        const syncedHeadPath = path.join(state.gitdir, "info", "synced-head")
+        const readSyncedHead = Effect.fnUntraced(function* () {
+          const text = (yield* read(syncedHeadPath)).trim()
+          return text || undefined
+        })
+        const writeSyncedHead = (hash: string) =>
+          Effect.gen(function* () {
+            yield* fs.ensureDir(path.dirname(syncedHeadPath)).pipe(Effect.orDie)
+            yield* fs.writeFileString(syncedHeadPath, hash + "\n").pipe(Effect.orDie)
+          })
+
+        // Import the source HEAD tree into the snapshot index. Cheap because
+        // alternates makes every blob already resolvable.
+        const importHead = Effect.fnUntraced(function* (head: string) {
+          const read = yield* git([...core, ...args(["read-tree", head])], { cwd: state.worktree })
+          if (read.code !== 0) {
+            log.warn("failed to read-tree source HEAD", { head, exitCode: read.code, stderr: read.stderr })
+            return false
+          }
+          // Without --refresh, diff-files reports every entry as potentially
+          // modified and the next git add re-hashes everything. Use -q, not
+          // --quiet: the latter is not a valid flag for update-index and
+          // silently disables the refresh.
+          yield* git([...core, ...args(["update-index", "--refresh", "-q"])], { cwd: state.directory })
+          return true
+        })
+
+        // Make sure the snapshot index is in sync with source HEAD before
+        // add() runs. Idempotent: a no-op when the in-memory cache or the
+        // persisted info/synced-head file already matches.
+        const ensureHeadSynced = Effect.fnUntraced(function* (options?: TrackOptions) {
+          const head = yield* sourceHead()
+          if (!head) return // couldn't sync: source has no HEAD
+          if (syncedHead === head) return // already synced
+          const stored = yield* readSyncedHead()
+          if (stored === head) {
+            syncedHead = head
+            return // synced (matched persisted state)
+          }
+          // Index isn't synced. About to run read-tree + update-index
+          // --refresh. Fire the indexing hook unconditionally so the
+          // caller can show a spinner; even on small repos the wait is
+          // short, but the user always sees what's happening.
+          if (options?.onIndexingStart) {
+            yield* options.onIndexingStart().pipe(Effect.catch(() => Effect.void))
+          }
+          const alternates = yield* setupAlternates()
+          if (!alternates) return // couldn't sync: alternates setup failed
+          const ok = yield* importHead(head)
+          if (!ok) return // couldn't sync: read-tree failed
+          yield* writeSyncedHead(head)
+          syncedHead = head
+          // synced
         })
 
         const excludes = Effect.fnUntraced(function* () {
@@ -314,7 +420,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           )
         })
 
-        const track = Effect.fnUntraced(function* () {
+        const track = Effect.fnUntraced(function* (options?: TrackOptions) {
           return yield* locked(
             Effect.gen(function* () {
               if (!(yield* enabled())) return
@@ -336,6 +442,12 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
                 yield* seed()
                 yield* Effect.logInfo("initialized")
               }
+              // Sync the snapshot index to source HEAD when available. On
+              // large repos this is the difference between a sub-second
+              // track() and a +10min git add storm. When sync can't happen
+              // (e.g. fresh git init with no commits), add() falls through
+              // to the bulk-add path; such repos are small.
+              yield* ensureHeadSynced(options)
               yield* add()
               const result = yield* git(args(["write-tree"]), { cwd: state.directory })
               const hash = result.text.trim()
@@ -775,8 +887,8 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
       cleanup: Effect.fn("Snapshot.cleanup")(function* () {
         return yield* InstanceState.useEffect(state, (s) => s.cleanup())
       }),
-      track: Effect.fn("Snapshot.track")(function* () {
-        return yield* InstanceState.useEffect(state, (s) => s.track())
+      track: Effect.fn("Snapshot.track")(function* (options?: TrackOptions) {
+        return yield* InstanceState.useEffect(state, (s) => s.track(options))
       }),
       patch: Effect.fn("Snapshot.patch")(function* (hash: string) {
         return yield* InstanceState.useEffect(state, (s) => s.patch(hash))

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -17,6 +17,7 @@ import { SessionProcessor } from "../../src/session/processor"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
+import { Snapshot } from "../../src/snapshot"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -235,6 +236,18 @@ const boot = Effect.fn("test.boot")(function* () {
   return { processors, session, provider }
 })
 
+const failingSnapshot = Layer.mock(Snapshot.Service)({
+  track: (options?: Snapshot.TrackOptions) =>
+    Effect.gen(function* () {
+      if (options?.onPreparingSnapshotsStart) yield* options.onPreparingSnapshotsStart()
+      return yield* Effect.die(new Error("simulated snapshot failure"))
+    }),
+})
+const failingSnapshotEnv = LayerNode.buildLayer(root, {
+  replacements: [...replacements, LayerNode.replace(Snapshot.node, failingSnapshot)],
+})
+const failingSnapshotIt = testEffect(failingSnapshotEnv)
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -284,6 +297,35 @@ it.live("session.processor effect tests capture llm input cleanly", () =>
         expect(parts.some((part) => part.type === "text" && part.text === "hello")).toBe(true)
       }),
     { config: (url) => providerCfg(url) },
+  ),
+)
+
+failingSnapshotIt.live("session.processor finalizes preparing snapshots part when initial snapshot fails", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "hi")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const exit = yield* processors
+          .create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+          .pipe(Effect.exit)
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        const parts = yield* MessageV2.parts(msg.id)
+        const preparing = parts.find(
+          (part): part is SessionV1.PreparingSnapshotsPart => part.type === "preparing-snapshots",
+        )
+        expect(preparing).toBeDefined()
+        expect(preparing?.time.end).toBeDefined()
+      }),
+    { config: cfg },
   ),
 )
 

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -2,6 +2,8 @@ import { afterEach, expect } from "bun:test"
 import { $ } from "bun"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import { Hash } from "@opencode-ai/core/util/hash"
 import fs from "fs/promises"
 import path from "path"
 import { Effect, Fiber, Layer } from "effect"
@@ -9,6 +11,7 @@ import { Snapshot } from "../../src/snapshot"
 import {
   disposeAllInstances,
   provideInstance,
+  requireInstance,
   testInstanceStoreLayer,
   TestInstance,
   tmpdirScoped,
@@ -1151,27 +1154,115 @@ it.instance(
   Effect.gen(function* () {
     const tmp = yield* bootstrap()
     const snapshot = yield* Snapshot.Service
-    // First commit, first track. Snapshot is synced to commit A.
+    // The preparing-snapshots hook only fires when a sync actually runs,
+    // so counting it distinguishes re-sync from the bulk-add fallback
+    // (which would also capture new files and pass revert assertions).
+    let syncs = 0
+    const options = {
+      onPreparingSnapshotsStart: () =>
+        Effect.sync(() => {
+          syncs++
+        }),
+    }
+    // First commit, first track. Snapshot syncs to commit A.
     yield* write(`${tmp.path}/staged.txt`, "v1")
     yield* exec(tmp.path, ["git", "add", "staged.txt"])
     yield* exec(tmp.path, ["git", "commit", "-m", "v1"])
-    const first = yield* snapshot.track()
+    const first = yield* snapshot.track(options)
     expect(first).toBeTruthy()
+    expect(syncs).toBe(1)
 
-    // New commit B introduces a new file. Snapshot must re-sync so the
-    // new file is captured for revert.
+    // New commit B. The changed HEAD must trigger a second sync.
     yield* write(`${tmp.path}/staged-v2.txt`, "v2")
     yield* exec(tmp.path, ["git", "add", "staged-v2.txt"])
     yield* exec(tmp.path, ["git", "commit", "-m", "v2"])
-    const second = yield* snapshot.track()
+    const second = yield* snapshot.track(options)
     expect(second).toBeTruthy()
+    expect(syncs).toBe(2)
 
-    // Delete the v2 file and verify the new snapshot can restore it.
+    // Delete the v2 file and verify the re-synced snapshot restores it.
     yield* rm(`${tmp.path}/staged-v2.txt`)
     const patch = yield* snapshot.patch(second!)
     expect(patch.files).toContain(fwd(tmp.path, "staged-v2.txt"))
     yield* snapshot.revert([patch])
     expect(yield* readText(`${tmp.path}/staged-v2.txt`)).toBe("v2")
+  }),
+  { git: true },
+)
+
+it.live(
+  "tracks the whole worktree when opened from a subdirectory",
+  Effect.gen(function* () {
+    const dir = yield* scopedGitTmpdir()
+    yield* mkdirp(`${dir}/subdir`)
+    yield* write(`${dir}/root-tracked.txt`, "root-original")
+    yield* exec(dir, ["git", "add", "root-tracked.txt"])
+    yield* exec(dir, ["git", "commit", "-m", "add root-tracked.txt"])
+
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+
+      yield* write(`${dir}/root-tracked.txt`, "root-modified")
+      yield* write(`${dir}/root-untracked.txt`, "root-untracked")
+      const patch = yield* snapshot.patch(before!)
+      expect(patch.files).toContain(fwd(dir, "root-tracked.txt"))
+      expect(patch.files).toContain(fwd(dir, "root-untracked.txt"))
+
+      yield* snapshot.revert([patch])
+      expect(yield* readText(`${dir}/root-tracked.txt`)).toBe("root-original")
+      expect(yield* exists(`${dir}/root-untracked.txt`)).toBe(false)
+    }).pipe(provideInstance(`${dir}/subdir`))
+  }),
+)
+
+it.instance(
+  "does not restore tracked files that match source ignore rules",
+  Effect.gen(function* () {
+    const tmp = yield* TestInstance
+    const snapshot = yield* Snapshot.Service
+    yield* write(`${tmp.directory}/.gitignore`, "ignored-tracked.txt\n")
+    yield* write(`${tmp.directory}/ignored-tracked.txt`, "ignored content")
+    yield* exec(tmp.directory, ["git", "add", ".gitignore"])
+    yield* exec(tmp.directory, ["git", "add", "-f", "ignored-tracked.txt"])
+    yield* exec(tmp.directory, ["git", "commit", "-m", "add ignored tracked file"])
+
+    const before = yield* snapshot.track()
+    expect(before).toBeTruthy()
+    yield* rm(`${tmp.directory}/ignored-tracked.txt`)
+    yield* snapshot.restore(before!)
+    expect(yield* exists(`${tmp.directory}/ignored-tracked.txt`)).toBe(false)
+  }),
+  { git: true },
+)
+
+it.instance(
+  "does not recreate borrowed files when source alternates are unavailable",
+  Effect.gen(function* () {
+    const tmp = yield* TestInstance
+    const snapshot = yield* Snapshot.Service
+    yield* write(`${tmp.directory}/borrowed.txt`, "borrowed content")
+    yield* exec(tmp.directory, ["git", "add", "borrowed.txt"])
+    yield* exec(tmp.directory, ["git", "commit", "-m", "add borrowed.txt"])
+
+    const before = yield* snapshot.track()
+    expect(before).toBeTruthy()
+    const instance = yield* requireInstance
+    yield* rm(
+      path.join(
+        Global.Path.data,
+        "snapshot",
+        instance.project.id,
+        Hash.fast(instance.worktree),
+        "objects",
+        "info",
+        "alternates",
+      ),
+    )
+    yield* rm(`${tmp.directory}/borrowed.txt`)
+    yield* snapshot.restore(before!)
+    expect(yield* exists(`${tmp.directory}/borrowed.txt`)).toBe(false)
   }),
   { git: true },
 )
@@ -1185,15 +1276,52 @@ it.instance(
     // must fall back to the bulk-add path.
     yield* Effect.promise(() => fs.rm(path.join(tmp.directory, ".git", "refs", "heads", "main"), { force: true }))
     yield* Effect.promise(() => fs.rm(path.join(tmp.directory, ".git", "refs", "heads", "master"), { force: true }))
-    yield* Effect.promise(() =>
-      fs.writeFile(path.join(tmp.directory, ".git", "HEAD"), "ref: refs/heads/main\n"),
-    )
+    yield* Effect.promise(() => fs.writeFile(path.join(tmp.directory, ".git", "HEAD"), "ref: refs/heads/main\n"))
     yield* write(`${tmp.directory}/lonely.txt`, "still snapshots")
     const result = yield* snapshot.track()
     expect(result).toBeTruthy()
     yield* rm(`${tmp.directory}/lonely.txt`)
     const patch = yield* snapshot.patch(result!)
     expect(patch.files).toContain(fwd(tmp.directory, "lonely.txt"))
+    yield* snapshot.revert([patch])
+    expect(yield* readText(`${tmp.directory}/lonely.txt`)).toBe("still snapshots")
+  }),
+  { git: true },
+)
+
+it.instance(
+  "heals a partial gitdir that was never fully initialized",
+  Effect.gen(function* () {
+    const snapshot = yield* Snapshot.Service
+    const instance = yield* requireInstance
+    const gitdir = path.join(Global.Path.data, "snapshot", instance.project.id, Hash.fast(instance.worktree))
+
+    // Simulate the partial state observed in the wild: an earlier session
+    // crashed before git init populated HEAD/config/refs, but left the
+    // subdirectories that setupAlternates and sync create. The fix should
+    // detect the missing HEAD and re-init instead of failing every track.
+    yield* Effect.promise(() => fs.mkdir(path.join(gitdir, "info"), { recursive: true }))
+    yield* Effect.promise(() => fs.mkdir(path.join(gitdir, "objects", "info"), { recursive: true }))
+    yield* Effect.promise(() => fs.writeFile(path.join(gitdir, "info", "exclude"), ""))
+
+    let hookCount = 0
+    const result = yield* snapshot.track({
+      onPreparingSnapshotsStart: () =>
+        Effect.sync(() => {
+          hookCount++
+        }),
+    })
+    expect(result).toBeTruthy()
+
+    // A subsequent track() reuses the in-memory cache, so the hook does
+    // not refire even though the previous call had to repair the gitdir.
+    yield* snapshot.track({
+      onPreparingSnapshotsStart: () =>
+        Effect.sync(() => {
+          hookCount++
+        }),
+    })
+    expect(hookCount).toBe(1)
   }),
   { git: true },
 )

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1119,3 +1119,81 @@ it.instance(
   }),
   { git: true },
 )
+
+// --- Tests for source-HEAD sync fast path ---
+
+it.instance(
+  "captures content of files committed in the source repo so they can be reverted",
+  Effect.gen(function* () {
+    const tmp = yield* bootstrap()
+    const snapshot = yield* Snapshot.Service
+    // Commit a file in the source before the snapshot exists. Initial
+    // track must capture its content for revert to work.
+    yield* write(`${tmp.path}/committed.txt`, "committed-original")
+    yield* exec(tmp.path, ["git", "add", "committed.txt"])
+    yield* exec(tmp.path, ["git", "commit", "-m", "add committed.txt"])
+    const before = yield* snapshot.track()
+    expect(before).toBeTruthy()
+
+    yield* rm(`${tmp.path}/committed.txt`)
+    const patch = yield* snapshot.patch(before!)
+    expect(patch.files).toContain(fwd(tmp.path, "committed.txt"))
+
+    yield* snapshot.revert([patch])
+    expect(yield* exists(`${tmp.path}/committed.txt`)).toBe(true)
+    expect(yield* readText(`${tmp.path}/committed.txt`)).toBe("committed-original")
+  }),
+  { git: true },
+)
+
+it.instance(
+  "re-syncs when the source HEAD changes between tracks",
+  Effect.gen(function* () {
+    const tmp = yield* bootstrap()
+    const snapshot = yield* Snapshot.Service
+    // First commit, first track. Snapshot is synced to commit A.
+    yield* write(`${tmp.path}/staged.txt`, "v1")
+    yield* exec(tmp.path, ["git", "add", "staged.txt"])
+    yield* exec(tmp.path, ["git", "commit", "-m", "v1"])
+    const first = yield* snapshot.track()
+    expect(first).toBeTruthy()
+
+    // New commit B introduces a new file. Snapshot must re-sync so the
+    // new file is captured for revert.
+    yield* write(`${tmp.path}/staged-v2.txt`, "v2")
+    yield* exec(tmp.path, ["git", "add", "staged-v2.txt"])
+    yield* exec(tmp.path, ["git", "commit", "-m", "v2"])
+    const second = yield* snapshot.track()
+    expect(second).toBeTruthy()
+
+    // Delete the v2 file and verify the new snapshot can restore it.
+    yield* rm(`${tmp.path}/staged-v2.txt`)
+    const patch = yield* snapshot.patch(second!)
+    expect(patch.files).toContain(fwd(tmp.path, "staged-v2.txt"))
+    yield* snapshot.revert([patch])
+    expect(yield* readText(`${tmp.path}/staged-v2.txt`)).toBe("v2")
+  }),
+  { git: true },
+)
+
+it.instance(
+  "falls back gracefully when source repo has no HEAD",
+  Effect.gen(function* () {
+    const tmp = yield* TestInstance
+    const snapshot = yield* Snapshot.Service
+    // Remove the root commit so source HEAD doesn't resolve. Snapshot
+    // must fall back to the bulk-add path.
+    yield* Effect.promise(() => fs.rm(path.join(tmp.directory, ".git", "refs", "heads", "main"), { force: true }))
+    yield* Effect.promise(() => fs.rm(path.join(tmp.directory, ".git", "refs", "heads", "master"), { force: true }))
+    yield* Effect.promise(() =>
+      fs.writeFile(path.join(tmp.directory, ".git", "HEAD"), "ref: refs/heads/main\n"),
+    )
+    yield* write(`${tmp.directory}/lonely.txt`, "still snapshots")
+    const result = yield* snapshot.track()
+    expect(result).toBeTruthy()
+    yield* rm(`${tmp.directory}/lonely.txt`)
+    const patch = yield* snapshot.patch(result!)
+    expect(patch.files).toContain(fwd(tmp.directory, "lonely.txt"))
+  }),
+  { git: true },
+)

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -189,6 +189,17 @@ export type ReasoningPart = {
   }
 }
 
+export type PreparingSnapshotsPart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "preparing-snapshots"
+  time: {
+    start: number
+    end?: number
+  }
+}
+
 export type FilePartSourceText = {
   value: string
   start: number
@@ -393,6 +404,7 @@ export type Part =
       agent: string
     }
   | ReasoningPart
+  | PreparingSnapshotsPart
   | FilePart
   | ToolPart
   | StepStartPart

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -420,11 +420,11 @@ export type ReasoningPart = {
   }
 }
 
-export type IndexingPart = {
+export type PreparingSnapshotsPart = {
   id: string
   sessionID: string
   messageID: string
-  type: "indexing"
+  type: "preparing-snapshots"
   time: {
     start: number
     end?: number
@@ -637,7 +637,7 @@ export type Part =
   | TextPart
   | SubtaskPart
   | ReasoningPart
-  | IndexingPart
+  | PreparingSnapshotsPart
   | FilePart
   | ToolPart
   | StepStartPart

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -420,6 +420,17 @@ export type ReasoningPart = {
   }
 }
 
+export type IndexingPart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "indexing"
+  time: {
+    start: number
+    end?: number
+  }
+}
+
 export type FilePartSourceText = {
   value: string
   start: number
@@ -626,6 +637,7 @@ export type Part =
   | TextPart
   | SubtaskPart
   | ReasoningPart
+  | IndexingPart
   | FilePart
   | ToolPart
   | StepStartPart

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14936,6 +14936,44 @@
         "required": ["id", "sessionID", "messageID", "type", "text", "time"],
         "additionalProperties": false
       },
+      "PreparingSnapshotsPart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^prt"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses"
+          },
+          "messageID": {
+            "type": "string",
+            "pattern": "^msg"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["preparing-snapshots"]
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "end": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": ["start"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "sessionID", "messageID", "type", "time"],
+        "additionalProperties": false
+      },
       "FilePartSourceText": {
         "type": "object",
         "properties": {
@@ -15559,6 +15597,9 @@
           },
           {
             "$ref": "#/components/schemas/ReasoningPart"
+          },
+          {
+            "$ref": "#/components/schemas/PreparingSnapshotsPart"
           },
           {
             "$ref": "#/components/schemas/FilePart"

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -35,6 +35,7 @@ import type {
   UserMessage,
   TextPart,
   ReasoningPart,
+  IndexingPart,
   SessionStatus,
 } from "@opencode-ai/sdk/v2"
 import { useLocal } from "../../context/local"
@@ -1574,6 +1575,7 @@ const PART_MAPPING = {
   text: TextPart,
   tool: ToolPart,
   reasoning: ReasoningPart,
+  indexing: IndexingPart,
 }
 
 const INLINE_TOOL_ICON_WIDTH = 2
@@ -1682,6 +1684,35 @@ function ReasoningHeader(props: {
         </text>
       </Match>
     </Switch>
+  )
+}
+
+function IndexingPart(props: { last: boolean; part: IndexingPart; message: AssistantMessage }) {
+  const { theme } = useTheme()
+  // time.end is undefined while track() runs, set when it returns.
+  const isDone = createMemo(() => props.part.time.end !== undefined)
+  const duration = createMemo(() => {
+    const end = props.part.time.end
+    return end === undefined ? 0 : Math.max(0, end - props.part.time.start)
+  })
+  // Muted style matching ReasoningHeader: warning hue with thinkingOpacity.
+  const fg = () => RGBA.fromValues(theme.warning.r, theme.warning.g, theme.warning.b, theme.thinkingOpacity)
+
+  return (
+    <box id={"indexing-" + props.part.id} paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
+      <Switch>
+        <Match when={!isDone()}>
+          <box flexDirection="row">
+            <Spinner color={fg()}>Preparing snapshots for first-time repo setup</Spinner>
+          </box>
+        </Match>
+        <Match when={true}>
+          <text fg={fg()} wrapMode="none">
+            <span>Prepared snapshots for first-time repo setup · {Locale.duration(duration())}</span>
+          </text>
+        </Match>
+      </Switch>
+    </box>
   )
 }
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -35,7 +35,7 @@ import type {
   UserMessage,
   TextPart,
   ReasoningPart,
-  IndexingPart,
+  PreparingSnapshotsPart,
   SessionStatus,
 } from "@opencode-ai/sdk/v2"
 import { useLocal } from "../../context/local"
@@ -1575,7 +1575,7 @@ const PART_MAPPING = {
   text: TextPart,
   tool: ToolPart,
   reasoning: ReasoningPart,
-  indexing: IndexingPart,
+  "preparing-snapshots": PreparingSnapshotsPart,
 }
 
 const INLINE_TOOL_ICON_WIDTH = 2
@@ -1687,28 +1687,32 @@ function ReasoningHeader(props: {
   )
 }
 
-function IndexingPart(props: { last: boolean; part: IndexingPart; message: AssistantMessage }) {
+function PreparingSnapshotsPart(props: { last: boolean; part: PreparingSnapshotsPart; message: AssistantMessage }) {
   const { theme } = useTheme()
-  // time.end is undefined while track() runs, set when it returns.
   const isDone = createMemo(() => props.part.time.end !== undefined)
   const duration = createMemo(() => {
     const end = props.part.time.end
     return end === undefined ? 0 : Math.max(0, end - props.part.time.start)
   })
-  // Muted style matching ReasoningHeader: warning hue with thinkingOpacity.
   const fg = () => RGBA.fromValues(theme.warning.r, theme.warning.g, theme.warning.b, theme.thinkingOpacity)
 
   return (
-    <box id={"indexing-" + props.part.id} paddingLeft={3} marginTop={1} flexDirection="column" flexShrink={0}>
+    <box
+      id={"preparing-snapshots-" + props.part.id}
+      paddingLeft={3}
+      marginTop={1}
+      flexDirection="column"
+      flexShrink={0}
+    >
       <Switch>
         <Match when={!isDone()}>
           <box flexDirection="row">
-            <Spinner color={fg()}>Preparing snapshots for first-time repo setup</Spinner>
+            <Spinner color={fg()}>Preparing snapshots</Spinner>
           </box>
         </Match>
         <Match when={true}>
           <text fg={fg()} wrapMode="none">
-            <span>Prepared snapshots for first-time repo setup · {Locale.duration(duration())}</span>
+            <span>Prepared snapshots · {Locale.duration(duration())}</span>
           </text>
         </Match>
       </Switch>


### PR DESCRIPTION
### Issue for this PR

Closes #3176
Closes #30386

Addresses #12437
Addresses #18072
- theses issues are already closed but i'm still referencing it here since it is related

Mitigates #9290
- `alternates` eliminates the per-blob duplication that contributed to snapshot dir bloat

*May* mitigate #29413 
- shrinks the window for orphaned-lock creation

### Type of change

- [x] Bug fix
- [x] New feature
  - A loading spinner for when snapshot preparation is occurring 
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

this pr speeds up first-time snapshot preparation for large git repos ~

before this, a fresh snapshot index had to discover and hash nearly every non-ignored file through `git add --all`, which could take minutes on very large repos and make opencode look hung before the llm stream started

the new path reuses the source repo's existing git object store through `objects/info/alternates` ^^

```bash
printf "%s\n" "$source_objects" > "$snapshot/objects/info/alternates"
```

after that, opencode imports the source `HEAD` tree into the snapshot index

```bash
git --git-dir="$snapshot" --work-tree="$source" read-tree HEAD
```

then opencode refreshes index stat info

```bash
git --git-dir="$snapshot" --work-tree="$source" update-index --refresh -q
```

before this change, an empty snapshot index roughly behaved like this:

- `diff-files`: nothing useful, because there was no baseline index
- `ls-files --others --exclude-standard`: almost every non-ignored file appeared as untracked, scaling with repo size

after this change:

- `diff-files`: reports files where the worktree differs from the snapshot index
- `ls-files --others --exclude-standard`: reports files not present in the imported `HEAD` tree, such as user-created untracked files

this pr also adds a "preparing snapshots" spinner so the tui can show progress while snapshot preparation runs ^^

ignored files remain excluded from snapshots, including tracked files that match source ignore rules after the initial `read-tree` import

**tradeoff:** snapshots now borrow source git objects through alternates. if source history is rewritten and git later prunes objects that an older snapshot still references, restoring that old snapshot may not be able to recreate the missing files

i think this tradeoff is ok for recent session undo, especially with git's default prune window, but we can revisit it if snapshots need stronger archival guarantees

### How did you verify your code works?

i've been using this binary as my standalone opencode since making this PR. i've also attached a recording below so you can see the bug being reproduced (and subsequently fixed + the new UI elements) (˶ᵔ ᵕ ᵔ˶)

as for tests, coverage includes:
- captures content of files committed in the source repo so they can be reverted
- re-syncs when the source HEAD changes between tracks
- tracks the whole worktree when opened from a subdirectory
- does not restore tracked files that match source ignore rules
- does not recreate borrowed files when source alternates are unavailable
- falls back gracefully when source repo has no HEAD
- session.processor finalizes preparing snapshots part when initial snapshot fails
- heals a partial gitdir that was never fully initialized

i've also personally self-reviewed this PR a couple times & had gpt5.5 make a thorough examination for any holes

### Screenshots / recordings

here is the user experience prior to this PR, on a fresh chromium repo: 

https://github.com/user-attachments/assets/92cc7972-ed69-419b-b249-b4398ff3e0da

and here is the user experience on this PR's binary:

https://github.com/user-attachments/assets/81ff1c16-5868-4b60-b04a-5e9dd8585f80


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
