### PR TITLE
fix(tui): prioritize models slash autocomplete

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -633,6 +633,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         suggested: true,
         category: "Agent",
         slashName: "models",
+        // Bias /mo toward /models over /move without changing global fuzzy scoring.
+        slashAliases: ["mo"],
         run: () => {
           dialog.replace(() => <DialogModel />)
         },


### PR DESCRIPTION
## Summary\n- add a targeted /mo slash alias for /models\n- document why the alias exists to avoid changing global fuzzy ranking\n\n## Testing\n- Not run (metadata-only autocomplete weighting change)