### PR TITLE
feat(tui): add backup models array

### DIFF
--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -12,6 +12,9 @@ const Color = Schema.Union([
 const AgentSchema = Schema.StructWithRest(
   Schema.Struct({
     model: Schema.optional(Schema.String),
+    backupModel: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+      description: "Backup models (provider/model) tried in order when the primary model fails.",
+    }),
     variant: Schema.optional(Schema.String).annotate({
       description: "Default model variant for this agent (applies only when using the agent's configured model).",
     }),
@@ -43,6 +46,7 @@ const AgentSchema = Schema.StructWithRest(
 const KNOWN_KEYS = new Set([
   "name",
   "model",
+  "backupModel",
   "variant",
   "prompt",
   "description",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -43,6 +43,14 @@ export const Info = Schema.Struct({
       providerID: ProviderV2.ID,
     }),
   ),
+  backupModel: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        modelID: ModelV2.ID,
+        providerID: ProviderV2.ID,
+      }),
+    ),
+  ),
   variant: Schema.optional(Schema.String),
   prompt: Schema.optional(Schema.String),
   options: Schema.Record(Schema.String, Schema.Unknown),
@@ -263,6 +271,7 @@ export const layer = Layer.effect(
               native: false,
             }
           if (value.model) item.model = Provider.parseModel(value.model)
+          if (value.backupModel) item.backupModel = value.backupModel.map(Provider.parseModel)
           item.variant = value.variant ?? item.variant
           item.prompt = value.prompt ?? item.prompt
           item.description = value.description ?? item.description

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1635,17 +1635,18 @@ function ReasoningHeader(props: {
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const muted = createMemo(() => Boolean(props.part.metadata?.muted))
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <markdown
-          syntaxStyle={syntax()}
+          syntaxStyle={muted() ? generateSubtleSyntax(theme) : syntax()}
           streaming={true}
           internalBlockMode="top-level"
           content={props.part.text.trim()}
           tableOptions={{ style: "grid" }}
           conceal={ctx.conceal()}
-          fg={theme.markdownText}
+          fg={muted() ? theme.textMuted : theme.markdownText}
           bg={theme.background}
         />
       </box>

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -387,6 +387,19 @@ export const layer = Layer.effect(
       const model = agent.model
         ? yield* provider.getModel(agent.model.providerID, agent.model.modelID).pipe(Effect.orDie)
         : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID).pipe(Effect.orDie)
+
+      // Resolve backup models from the user's agent so compaction falls back
+      // to a working model when the primary has exceeded usage limits.
+      const userAgent = yield* agents.get(userMessage.agent)
+      const backupModels: Provider.Model[] | undefined = userAgent?.backupModel?.length
+        ? (yield* Effect.all(
+            userAgent.backupModel.map((bm) =>
+              provider.getModel(bm.providerID, bm.modelID).pipe(
+                Effect.orElseSucceed(() => undefined),
+              ),
+            ),
+          )).filter((m: Provider.Model | undefined): m is Provider.Model => m !== undefined)
+        : undefined
       const cfg = yield* config.get()
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
       const prior = completedCompactions(history)
@@ -442,6 +455,7 @@ export const layer = Layer.effect(
         assistantMessage: msg,
         sessionID: input.sessionID,
         model,
+        backupModels: backupModels?.length ? backupModels : undefined,
       })
       const result = yield* processor.process({
         user: userMessage,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -60,6 +60,7 @@ type Input = {
   assistantMessage: SessionV1.Assistant
   sessionID: SessionID
   model: Provider.Model
+  backupModels?: Provider.Model[]
 }
 
 export interface Interface {
@@ -960,13 +961,47 @@ export const layer = Layer.effect(
         ctx.needsCompaction = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
 
-        return yield* Effect.gen(function* () {
-          yield* Effect.gen(function* () {
+        const retrySet = (info: {
+          attempt: number
+          message: string
+          action?: SessionRetry.Retryable["action"]
+          next: number
+        }) => {
+          // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
+          const event = mirrorAssistant
+            ? events.publish(SessionEvent.Retried, {
+                sessionID: ctx.sessionID,
+                attempt: info.attempt,
+                error: {
+                  message: info.message,
+                  isRetryable: true,
+                },
+                timestamp: DateTime.makeUnsafe(Date.now()),
+              })
+            : Effect.void
+          return flushV2Fragments().pipe(
+            Effect.andThen(event),
+            Effect.andThen(
+              status.set(ctx.sessionID, {
+                type: "retry",
+                attempt: info.attempt,
+                message: info.message,
+                action: info.action,
+                next: info.next,
+              }),
+            ),
+          )
+        }
+
+        // Inherits tracing from SessionProcessor.process (inner Effect.fn overhead not needed here).
+        const runStream = (si: LLM.StreamInput, providerID: string, maxRetries?: number) =>
+          Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.currentTextID = undefined
             ctx.reasoningMap = {}
+            ctx.needsCompaction = false
             yield* status.set(ctx.sessionID, { type: "busy" })
-            const stream = llm.stream(streamInput)
+            const stream = llm.stream(si)
 
             yield* stream.pipe(
               Stream.tap((event) => handleEvent(event)),
@@ -988,44 +1023,109 @@ export const layer = Layer.effect(
             ),
             Effect.retry(
               SessionRetry.policy({
-                provider: input.model.providerID,
+                provider: providerID,
+                maxRetries,
                 parse,
-                set: (info) => {
-                  // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
-                  const event = mirrorAssistant
-                    ? events.publish(SessionEvent.Retried, {
-                        sessionID: ctx.sessionID,
-                        attempt: info.attempt,
-                        error: {
-                          message: info.message,
-                          isRetryable: true,
-                        },
-                        timestamp: DateTime.makeUnsafe(Date.now()),
-                      })
-                    : Effect.void
-                  return flushV2Fragments().pipe(
-                    Effect.andThen(event),
-                    Effect.andThen(
-                      status.set(ctx.sessionID, {
-                        type: "retry",
-                        attempt: info.attempt,
-                        message: info.message,
-                        action: info.action,
-                        next: info.next,
-                      }),
-                    ),
-                  )
-                },
+                set: retrySet,
               }),
             ),
-            Effect.catch(halt),
-            Effect.ensuring(cleanup()),
           )
 
+        // backupModels are already filtered for undefined upstream in prompt.ts
+        const backupModels = input.backupModels ?? []
+
+        return yield* Effect.gen(function* () {
+          if (backupModels.length > 0) {
+            // When backup models are configured, individual model retries are
+            // disabled (maxRetries: 0) in favor of falling through to the next
+            // backup model immediately.
+            const primaryResult = yield* runStream(streamInput, input.model.providerID, 0).pipe(Effect.exit)
+
+            // Track whether ANY model hit overflow so we only compact as a
+            // last resort when no model can handle the full context.
+            let needsCompaction = ctx.needsCompaction
+
+            // Check if the primary model failed due to context overflow before
+            // attempting backup models — propagation through halt() is bypassed
+            // when using Effect.exit, so we handle it explicitly here.
+            if (Exit.isFailure(primaryResult)) {
+              const parsedError = Exit.match(primaryResult, {
+                onSuccess: () => undefined,
+                onFailure: (cause) => parse(Cause.squash(cause)),
+              })
+              if (SessionV1.ContextOverflowError.isInstance(parsedError)) {
+                needsCompaction = true
+                yield* events.publish(Session.Event.Error, { sessionID: ctx.sessionID, error: parsedError })
+              }
+            }
+
+            // Primary model succeeded without overflow.
+            // If it failed or needs compaction, try backup models before compacting.
+            let modelSucceeded = Exit.isSuccess(primaryResult) && !ctx.needsCompaction
+
+            if (!modelSucceeded) {
+              // Track the last model that streamed successfully (even with
+              // overflow) — used to select the right model for compaction
+              // when all backups hit overflow but none failed outright.
+              let effectiveModel: Provider.Model | undefined
+
+              for (const bm of backupModels) {
+                ctx.assistantMessage.error = undefined
+                ctx.assistantMessage.modelID = bm.id
+                ctx.assistantMessage.providerID = bm.providerID
+                yield* session.updateMessage(ctx.assistantMessage)
+                const backupInput = { ...streamInput, model: bm }
+                const result = yield* runStream(backupInput, bm.providerID, 0).pipe(Effect.exit)
+                if (Exit.isSuccess(result)) effectiveModel = bm
+                if (Exit.isSuccess(result) && !ctx.needsCompaction) {
+                  yield* session.updatePart({
+                    id: PartID.ascending(),
+                    messageID: ctx.assistantMessage.id,
+                    sessionID: ctx.assistantMessage.sessionID,
+                    type: "text",
+                    text: `Used backup model: ${bm.providerID}/${bm.id}\n`,
+                    synthetic: true,
+                    metadata: { muted: true },
+                  } satisfies SessionV1.TextPart)
+                  modelSucceeded = true
+                  needsCompaction = false
+                  break
+                }
+                if (ctx.needsCompaction) needsCompaction = true
+                if (Exit.isFailure(result)) {
+                  const parsedError = Exit.match(result, {
+                    onSuccess: () => undefined,
+                    onFailure: (cause) => parse(Cause.squash(cause)),
+                  })
+                  if (SessionV1.ContextOverflowError.isInstance(parsedError)) {
+                    needsCompaction = true
+                  }
+                }
+              }
+
+              // Revert modelID to the effective model so prompt.ts picks
+              // the right model for compaction instead of a failed backup.
+              if (!modelSucceeded && effectiveModel) {
+                ctx.assistantMessage.modelID = effectiveModel.id
+                ctx.assistantMessage.providerID = effectiveModel.providerID
+                yield* session.updateMessage(ctx.assistantMessage)
+              }
+            }
+
+            if (!modelSucceeded) {
+              if (needsCompaction) return "compact" as const
+              yield* halt(new Error("All configured models failed"))
+              return "stop" as const
+            }
+
+            if (ctx.blocked || ctx.assistantMessage.error) return "stop" as const
+            return "continue" as const
+          }
+          yield* runStream(streamInput, input.model.providerID).pipe(Effect.catch(halt))
           if (ctx.needsCompaction) return "compact"
           if (ctx.blocked || ctx.assistantMessage.error) return "stop"
           return "continue"
-        })
+        }).pipe(Effect.ensuring(cleanup()))
       })
 
       return {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1255,6 +1255,7 @@ export const layer = Layer.effect(
         const slog = elog.with({ sessionID })
         let structured: unknown
         let step = 0
+        let modelOverride: Provider.Model | undefined
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1309,7 +1310,7 @@ export const layer = Layer.effect(
               history: msgs,
             }).pipe(Effect.ignore, Effect.forkIn(scope))
 
-          const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
+          const model = modelOverride ?? (yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID))
           const task = tasks.pop()
 
           if (task?.type === "subtask") {
@@ -1348,6 +1349,27 @@ export const layer = Layer.effect(
           }
           const maxSteps = agent.steps ?? Infinity
           const isLastStep = step >= maxSteps
+          const backupModels = agent.backupModel?.length
+            ? yield* Effect.all(
+                agent.backupModel.map((bm) =>
+                  provider.getModel(bm.providerID, bm.modelID).pipe(
+                    Effect.orElseSucceed(() => undefined),
+                    Effect.tap((m) =>
+                      m
+                        ? Effect.void
+                        : Effect.sync(() =>
+                            slog.warn("backup model not found", {
+                              providerID: bm.providerID,
+                              modelID: bm.modelID,
+                            }),
+                          ),
+                    ),
+                  ),
+                ),
+              ).pipe(
+                Effect.map((arr) => arr.filter((m) => m !== undefined)),
+              )
+            : undefined
           msgs = yield* SessionReminders.apply({ messages: msgs, agent, session }).pipe(
             Effect.provideService(RuntimeFlags.Service, flags),
             Effect.provideService(FSUtil.Service, fsys),
@@ -1386,6 +1408,7 @@ export const layer = Layer.effect(
               assistantMessage: msg,
               sessionID,
               model,
+              backupModels,
             })
             .pipe(Effect.onInterrupt(() => finalizeInterruptedAssistant))
 
@@ -1483,12 +1506,29 @@ export const layer = Layer.effect(
               }
             }
 
+            // If a backup model was selected, switch to it for subsequent
+            // loop iterations so the "Switching to backup model" status
+            // only appears once per prompt rather than on every message.
+            if (handle.message.providerID !== model.providerID || handle.message.modelID !== model.id) {
+              modelOverride = yield* getModel(
+                handle.message.providerID as ProviderV2.ID,
+                handle.message.modelID as ModelV2.ID,
+                sessionID,
+              )
+            }
+
             if (result === "stop") return "break" as const
             if (result === "compact") {
+              // When a backup model was used (even if it overflowed),
+              // prefer it for compaction over the primary which may have
+              // exceeded its usage limit.
+              const compactionModel = modelOverride
+                ? { providerID: modelOverride.providerID as ProviderV2.ID, modelID: modelOverride.id as ModelV2.ID }
+                : lastUser.model
               yield* compaction.create({
                 sessionID,
                 agent: lastUser.agent,
-                model: lastUser.model,
+                model: compactionModel,
                 auto: true,
                 overflow: !handle.message.finish,
               })

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -175,6 +175,7 @@ function parseJSON(value: unknown) {
 
 export function policy(opts: {
   provider: string
+  maxRetries?: number
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
 }) {
@@ -183,6 +184,7 @@ export function policy(opts: {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
+      if (opts.maxRetries !== undefined && meta.attempt > opts.maxRetries) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1704,6 +1704,7 @@ export type PermissionConfig =
 
 export type AgentConfig = {
   model?: string
+  backupModel?: Array<string>
   variant?: string
   temperature?: number
   top_p?: number
@@ -1728,6 +1729,7 @@ export type AgentConfig = {
   [key: string]:
     | unknown
     | string
+    | Array<string>
     | number
     | {
         [key: string]: boolean
@@ -2365,6 +2367,10 @@ export type Agent = {
     modelID: string
     providerID: string
   }
+  backupModel?: Array<{
+    modelID: string
+    providerID: string
+  }>
   variant?: string
   prompt?: string
   options: {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -250,6 +250,24 @@
   }
 }
 
+[data-component="text-part"][data-muted] {
+  color: var(--text-weak);
+  font-size: 13px;
+
+  [data-component="markdown"] {
+    color: var(--text-weak);
+    font-size: 13px;
+  }
+
+  [data-slot="text-part-meta"] {
+    display: none;
+  }
+
+  [data-slot="text-part-copy-wrapper"] {
+    display: none;
+  }
+}
+
 [data-component="compaction-part"] {
   width: 100%;
   display: flex;

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1544,7 +1544,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
 
   return (
     <Show when={text()}>
-      <div data-component="text-part" data-timeline-part-id={part().id}>
+      <div data-component="text-part" data-timeline-part-id={part().id} data-muted={Boolean(part().metadata?.muted) ? "" : undefined}>
         <div data-slot="text-part-body">
           <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} />}>
             <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />


### PR DESCRIPTION
### Issue for this PR

Closes #25150 
Closes #7602 
Closes #20100
Closes #16868

### Type of change

- [x] New feature

### What does this PR do?

- Adds a way to add backup models (array format) 
- It goes through the array until it can complete successfully. If not, it will try the last model on the retry loop (current behavior using selected model)
- Shows 'Used backup model: provider/model' at the end of prompt completion so user knows it switched to the backup and which one it used
- No backup model defined, standard retry logic is used

This improves the user experience, especially for those who like to use the free models. It sucks when the session breaks when the rate limit is hit, and it continues to retry or shows "Retrying in 4h 31m...". This way it will continue on error, switching to the backup when the provider is down, or usage is hit.

Format for backup model is an array with "model/provider", same as model. Example:

```
backupModel: ["opencode/big-pickle", "opencode-go/deepseek-v4-flash"]
```

### How did you verify your code works?

- Ran `bun test` inside the packages/opencode directory
- Ran `bun typecheck`
- User testing (sending prompts and trying out the feature) works on compaction and standard prompts sent by user

<img width="346" height="111" alt="image" src="https://github.com/user-attachments/assets/6ab6e0ed-f7eb-49da-a49f-15abfc35c6a4" />

### Screenshots / recordings

<img width="702" height="658" alt="image" src="https://github.com/user-attachments/assets/3d4c72ac-036c-42eb-ae28-f6013e6b6333" />

---

How it looks in my commit-storyteller.md agent file in .config/opencode/agents directory:

<img width="669" height="78" alt="image" src="https://github.com/user-attachments/assets/3daac6a3-fa5c-49ff-8bc7-9bfad8fee9df" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Any feedback would be greatly appreciated!
