### PR TITLE
fix(opencode): mark errored compaction summaries as terminal

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -561,7 +561,13 @@ export const layer = Layer.effect(
         }
       }
 
-      if (processor.message.error) return "stop"
+      if (processor.message.error) {
+        if (!processor.message.finish) {
+          processor.message.finish = "error"
+          yield* session.updateMessage(processor.message)
+        }
+        return "stop"
+      }
       if (result === "continue") {
         const summary = summaryText(
           (yield* session.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -907,6 +907,56 @@ describe("session.compaction.process", () => {
     }).pipe(withCompaction({ result: "compact" })),
   )
 
+  itCompaction.instance(
+    "sets finish=error when processor reports summary error without terminal finish",
+    () => {
+      const failing = Layer.mock(SessionProcessorModule.SessionProcessor.Service)({
+        create: (input) =>
+          Effect.succeed({
+            get message() {
+              return input.assistantMessage
+            },
+            updateToolCall: Effect.fn("TestSessionProcessor.updateToolCall")(() => Effect.succeed(undefined)),
+            completeToolCall: Effect.fn("TestSessionProcessor.completeToolCall")(() => Effect.void),
+            process: Effect.fn("TestSessionProcessor.process")(() =>
+              Effect.sync(() => {
+                input.assistantMessage.error = new SessionV1.APIError({
+                  message: "summary failed",
+                  isRetryable: false,
+                }).toObject()
+                return "continue" as const
+              }),
+            ),
+          }),
+      })
+
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const msg = yield* createUserMessage(session.id, "hello")
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+
+        const result = yield* SessionCompaction.use.process({
+          parentID: msg.id,
+          messages: msgs,
+          sessionID: session.id,
+          auto: false,
+        })
+
+        const summary = (yield* ssn.messages({ sessionID: session.id })).find(
+          (item) => item.info.role === "assistant" && item.info.summary,
+        )
+
+        expect(result).toBe("stop")
+        expect(summary?.info.role).toBe("assistant")
+        if (summary?.info.role === "assistant") {
+          expect(summary.info.error).toBeTruthy()
+          expect(summary.info.finish).toBe("error")
+        }
+      }).pipe(withCompaction({ plugin: Plugin.defaultLayer, llm: LLM.defaultLayer }), Effect.provide(failing))
+    },
+  )
+
   it.instance(
     "adds synthetic continue prompt when auto is enabled",
     Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #30834

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a compaction terminal-state gap.

In `SessionCompaction.process`, if the processor sets `assistantMessage.error` but leaves `finish` unset, the code previously returned `"stop"` immediately and left the summary message non-terminal.

That can make an errored compaction summary look like pending work in later loops.

Now, when `processor.message.error` is present and `finish` is missing, we set `finish: "error"`, persist the message, and then return `"stop"`.

I also added a regression test that simulates this exact path (error set, no finish set) and verifies the summary is persisted with `finish="error"`.

### How did you verify your code works?

- `bun typecheck` (from `packages/opencode`)
- `bun test test/session/compaction.test.ts -t "sets finish=error when processor reports summary error without terminal finish"` (from `packages/opencode`)
- `bun test test/session/compaction.test.ts` (from `packages/opencode`)

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
