### PR TITLE
fix(opencode): resolve Bedrock hang by using node build conditions

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -165,7 +165,7 @@ for (const item of targets) {
   const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
 
   await Bun.build({
-    conditions: ["browser"],
+    conditions: ["node"],
     tsconfig: "./tsconfig.json",
     plugins: [plugin],
     external: ["node-gyp"],


### PR DESCRIPTION
Fixes #30858

### Issue for this PR

Closes #30858

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The AWS Bedrock provider hangs indefinitely when using the AI SDK path. The root cause is that the build uses `conditions: ['browser']`, which causes the bundler to resolve AWS SDK browser polyfills. The `@smithy/core` `browser`/`react-native` exports export `fromArrayBuffer` as a stubbed Symbol instead of a real `Buffer.from` function, so the Bedrock event stream decoder silently fails and hangs.

Changed `conditions: ['browser']` to `conditions: ['node']` in `packages/opencode/script/build.ts` so the bundler resolves the real Node.js AWS SDK exports.

### How did you verify your code works?

- Built the patched binary: `bun run --cwd packages/opencode build --single`
- Ran `opencode run --model amazon-bedrock/us.anthropic.claude-opus-4-6-v1 'hello'` — responds in ~2.8s instead of hanging indefinitely
- Verified all models work: haiku-4-5, sonnet-4-5, and inference profiles

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
