### PR TITLE
fix: add --no-orphans to compiled binary execArgv

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -180,7 +180,7 @@ for (const item of targets) {
       autoloadPackageJson: true,
       target: name.replace(pkg.name, "bun") as any,
       outfile: `dist/${name}/bin/opencode`,
-      execArgv: [`--user-agent=opencode/${Script.version}`, "--use-system-ca", "--"],
+      execArgv: [`--user-agent=opencode/${Script.version}`, "--use-system-ca", "--no-orphans", "--"],
       windows: {},
     },
     files: embeddedFileMap ? { "opencode-web-ui.gen.ts": embeddedFileMap } : {},


### PR DESCRIPTION
### Issue for this PR

Closes #30123

For context: existing issues #30073, #30123, and #26714 all discuss the same MCP orphan problem. This PR takes the simplest approach — enabling Bun's built-in `--no-orphans` mode in the compiled binary — rather than adding a `process.on('exit')` handler or modifying MCP lifecycle logic.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `--no-orphans` to the compiled binary's `execArgv` in the build script. When opencode exits, Bun now automatically kills all descendant processes (including MCP stdio servers spawned via `StdioClientTransport`).

Before this change, MCP child processes became orphans reparented to init/launchd on abnormal exit (SIGKILL/crash) or the `process.exit()` fallback. Bun's `--no-orphans` handles both clean and unclean exits (Linux `prctl` / macOS kqueue descendant reaper).

### How did you verify your code works?

The change is a single flag addition to the Bun build config (`execArgv`). The flag is documented and maintained by Bun — verified its behavior matches the implementation described in Bun's `ParentDeathWatchdog` (Linux `prctl`, macOS kqueue, clean-exit tree walk with SIGSTOP+verify SIGKILL). No runtime test was added because the behavior depends on Bun's runtime internals, not opencode logic.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally (verified build script syntax, confirmed flag is accepted)
- [x] I have not included unrelated changes in this PR