### PR TITLE
fix: handle NotFound error in ensureGitignore

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -295,7 +295,7 @@ export const layer = Layer.effect(
           )
           .pipe(
             Effect.catchIf(
-              (e) => e.reason._tag === "PermissionDenied",
+              (e) => e.reason._tag === "PermissionDenied" || e.reason._tag === "NotFound",
               () => Effect.void,
             ),
           )
@@ -424,7 +424,7 @@ export const layer = Layer.effect(
             }
           }
 
-          yield* ensureGitignore(dir).pipe(Effect.orDie)
+          yield* ensureGitignore(dir).pipe(Effect.catchAll(() => Effect.void))
 
           const dep = yield* npmSvc
             .install(dir, {


### PR DESCRIPTION
### Issue for this PR

Closes #23040

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `OPENCODE_CONFIG_DIR` points to a non-existent or read-only directory, `ensureGitignore` calls `writeFileString` which raises an error. The function only catches `PermissionDenied`, so other errors (e.g., `NotFound` when the directory doesn't exist) propagate unhandled and `orDie` at the call site crashes the entire process.

**Impact:** OpenCode crashes on startup if the config directory is missing — e.g., after an update wipes `OPENCODE_CONFIG_DIR`, or in containerized environments where the directory isn't mounted. The only workaround is manually creating an empty `.gitignore` file.

**Fix (two changes):**
1. Added `NotFound` to the `catchIf` condition in `ensureGitignore` — if the directory doesn't exist, creating `.gitignore` is silently skipped
2. Replaced `Effect.orDie` with `Effect.catchAll` at the call site — as an extra safety net so any unexpected error from `ensureGitignore` doesn't crash the process

### How did you verify your code works?

Verified locally by deleting the `OPENCODE_CONFIG_DIR` directory and confirming OpenCode starts without crashing. Also tested with a read-only config directory to confirm both the `NotFound` and `PermissionDenied` paths are handled correctly.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR