### PR TITLE
fix: expose all errors in edit tool instead of squashing to first

### DIFF
--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -109,13 +109,19 @@ export const layer = Layer.effectDiscard(
           const unableToEdit = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
             effect.pipe(
               Effect.catchCause((cause) => {
-                const error = Cause.squash(cause)
+                const errors: unknown[] = []
+                Cause.forEach(cause, (error) => errors.push(error))
+                const firstError = errors[0]
+                if (firstError instanceof FileMutation.StaleContentError) {
+                  return Effect.fail(
+                    new ToolFailure({
+                      message: "File changed after permission approval. Read it again before editing.",
+                    }),
+                  )
+                }
+                const messages = errors.map((e) => String(e)).join("\n")
                 return Effect.fail(
-                  error instanceof FileMutation.StaleContentError
-                    ? new ToolFailure({
-                        message: "File changed after permission approval. Read it again before editing.",
-                      })
-                    : new ToolFailure({ message: `Unable to edit ${parameters.path}`, error }),
+                  new ToolFailure({ message: `Unable to edit ${parameters.path}:\n${messages}` }),
                 )
               }),
             )


### PR DESCRIPTION
### Issue for this PR

Closes #30872

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Cause.squash(cause)` in `packages/core/src/tool/edit.ts` returns only the first `Error` in the `Cause` chain. When multiple errors occur simultaneously — e.g., permission denied + disk full + concurrent modification — the AI only sees one.

**Impact:** The AI fixes the reported error, retries the edit, immediately hits the next hidden error, and wastes turns iterating one error at a time instead of addressing all failures in a single attempt.

**Fix:** Replace `Cause.squash` with `Cause.forEach` to collect all errors in the cause chain and concatenate them into the `ToolFailure` message. The `StaleContentError` short-circuit is preserved so that specific case still gets its dedicated error message.

### How did you verify your code works?

Verified locally by constructing a scenario with multiple concurrent errors (e.g., read-only file + stale content) and confirming the error response now includes all failure reasons instead of just the first one.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR