### PR TITLE
fix: include file content preview in oldString not found error

### DIFF
--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -144,9 +144,10 @@ export const layer = Layer.effectDiscard(
             const newString = convertToLineEnding(parameters.newString, ending)
             const replacements = countOccurrences(source.text, oldString)
             if (replacements === 0) {
+              const preview = source.text.length > 500 ? source.text.slice(0, 500) + "\n..." : source.text
               return yield* new ToolFailure({
                 message:
-                  "Could not find oldString in the file. It must match exactly, including whitespace and indentation.",
+                  `Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\n${preview}`,
               })
             }
             if (replacements > 1 && parameters.replaceAll !== true) {


### PR DESCRIPTION
### Issue for this PR

Closes #30863

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/core/src/tool/edit.ts` already loads the full file content into `source` (line 141) before attempting the edit. However, when `oldString` is not found, the error message only says "Could not find oldString in the file." — discarding the file-state information the AI needs to correct its edit.

**Impact:** The AI has to blindly guess the correct `oldString`, wasting multiple turns. In complex files this often cascades into hitting `MAX_STEPS` and failing the task entirely.

**Fix:** Include a preview (up to 500 characters) of the actual file content in the error message, sourced from the already-loaded `source.text`. No additional file reads or side effects — it's a simple `slice` of existing data.

### How did you verify your code works?

Verified locally by triggering an edit with a deliberately wrong `oldString` and confirming the error response now includes the file content preview. The preview is truncated at 500 chars to avoid flooding the context window.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR