### PR TITLE
fix(core): filter chatcmpl-dummy SSE frames from Responses API stream

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -6,6 +6,7 @@ import { ModelV2 } from "./model"
 import { EventV2 } from "./event"
 import { PluginV2 } from "./plugin"
 import { ProviderV2 } from "./provider"
+import { filterResponseFrame } from "./util/sse"
 
 type SDK = any
 
@@ -67,7 +68,9 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
 
   const customFetch = options.fetch
   const chunkTimeout = options.chunkTimeout
+  const filterSseFrame: string[] | undefined = options.filterSseFrame
   delete options.chunkTimeout
+  delete options.filterSseFrame
   options.fetch = async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
     const opts = { ...(init ?? {}) }
     const signals = [
@@ -100,6 +103,18 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
       ...opts,
       timeout: false,
     })
+
+    if (filterSseFrame?.length) {
+      const url = typeof input === "string" ? input : input instanceof Request ? input.url : ""
+      if (url.includes("/responses")) {
+        const filtered = filterResponseFrame(res, filterSseFrame)
+        if (filtered) {
+          if (!chunkAbortCtl || typeof chunkTimeout !== "number") return filtered
+          return wrapSSE(filtered, chunkTimeout, chunkAbortCtl)
+        }
+      }
+    }
+
     if (!chunkAbortCtl || typeof chunkTimeout !== "number") return res
     return wrapSSE(res, chunkTimeout, chunkAbortCtl)
   }

--- a/packages/core/src/util/sse.ts
+++ b/packages/core/src/util/sse.ts
@@ -1,0 +1,31 @@
+export function filterResponseFrame(res: Response, ids: string[]): Response | undefined {
+  if (!res.ok || !res.body || !ids.length) return
+  if (!res.headers.get("content-type")?.includes("text/event-stream")) return
+
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ""
+
+  const filtered = res.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        buffer += decoder.decode(chunk, { stream: true })
+        const parts = buffer.split("\n\n")
+        buffer = parts.pop() ?? ""
+        for (const part of parts) {
+          const dataLine = part.split("\n").find((line) => line.startsWith("data:"))?.slice(5).trim() ?? ""
+          const skip = dataLine && (() => {
+            try { return ids.includes(JSON.parse(dataLine)?.id) }
+            catch { return false }
+          })()
+          if (!skip) controller.enqueue(encoder.encode(part + "\n\n"))
+        }
+      },
+      flush(controller) {
+        buffer += decoder.decode()
+        if (buffer) controller.enqueue(encoder.encode(buffer))
+      },
+    }),
+  )
+  return new Response(filtered, res)
+}

--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -112,6 +112,12 @@ export const Info = Schema.Struct({
           description:
             "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
         }),
+        filterSseFrame: Schema.optional(
+          Schema.mutable(Schema.Array(Schema.String)),
+        ).annotate({
+          description:
+            "List of SSE event id values to filter out from streaming responses. Used to skip synthetic frames from OpenAI-compatible proxies.",
+        }),
       }),
       [Schema.Record(Schema.String, Schema.Any)],
     ),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1735,6 +1735,40 @@ export const layer = Layer.effect(
             timeout: false,
           }).finally(() => headerTimeoutCtl?.clear())
 
+          // Filter out synthetic `chatcmpl-dummy` SSE frames that some
+          // OpenAI-compatible proxies emit before the real Responses API events.
+          if (res.ok && res.body) {
+            const url = typeof input === "string" ? input : input instanceof Request ? input.url : ""
+            if (url.includes("/responses") && res.headers.get("content-type")?.includes("text/event-stream")) {
+              const filtered = res.body.pipeThrough(
+                new TransformStream({
+                  decoder: new TextDecoder(),
+                  encoder: new TextEncoder(),
+                  buffer: "",
+                  transform(chunk, controller) {
+                    this.buffer += this.decoder.decode(chunk, { stream: true })
+                    const parts = this.buffer.split("\n\n")
+                    this.buffer = parts.pop() ?? ""
+                    for (const part of parts) {
+                      const dataLine = part.startsWith("data:") ? part.slice(5).trim() : ""
+                      const skip = dataLine && (() => {
+                        try { return JSON.parse(dataLine)?.id === "chatcmpl-dummy" }
+                        catch { return false }
+                      })()
+                      if (!skip) controller.enqueue(this.encoder.encode(part + "\n\n"))
+                    }
+                  },
+                  flush(controller) {
+                    if (this.buffer) controller.enqueue(this.encoder.encode(this.buffer))
+                  },
+                }),
+              )
+              const filteredRes = new Response(filtered, res)
+              if (!chunkAbortCtl) return filteredRes
+              return wrapSSE(filteredRes, chunkTimeout, chunkAbortCtl)
+            }
+          }
+
           if (!chunkAbortCtl) return res
           return wrapSSE(res, chunkTimeout, chunkAbortCtl)
         }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -31,6 +31,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { filterResponseFrame } from "@opencode-ai/core/util/sse"
 
 const log = Log.create({ service: "provider" })
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
@@ -1689,8 +1690,10 @@ export const layer = Layer.effect(
         const customFetch = options["fetch"]
         const chunkTimeout = options["chunkTimeout"]
         const headerTimeout = options["headerTimeout"]
+        const filterSseFrame: string[] | undefined = options["filterSseFrame"]
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
+        delete options["filterSseFrame"]
 
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const fetchFn = customFetch ?? fetch
@@ -1735,37 +1738,16 @@ export const layer = Layer.effect(
             timeout: false,
           }).finally(() => headerTimeoutCtl?.clear())
 
-          // Filter out synthetic `chatcmpl-dummy` SSE frames that some
+          // Filter out synthetic SSE frames that some
           // OpenAI-compatible proxies emit before the real Responses API events.
-          if (res.ok && res.body) {
+          if (filterSseFrame?.length) {
             const url = typeof input === "string" ? input : input instanceof Request ? input.url : ""
-            if (url.includes("/responses") && res.headers.get("content-type")?.includes("text/event-stream")) {
-              const filtered = res.body.pipeThrough(
-                new TransformStream({
-                  decoder: new TextDecoder(),
-                  encoder: new TextEncoder(),
-                  buffer: "",
-                  transform(chunk, controller) {
-                    this.buffer += this.decoder.decode(chunk, { stream: true })
-                    const parts = this.buffer.split("\n\n")
-                    this.buffer = parts.pop() ?? ""
-                    for (const part of parts) {
-                      const dataLine = part.startsWith("data:") ? part.slice(5).trim() : ""
-                      const skip = dataLine && (() => {
-                        try { return JSON.parse(dataLine)?.id === "chatcmpl-dummy" }
-                        catch { return false }
-                      })()
-                      if (!skip) controller.enqueue(this.encoder.encode(part + "\n\n"))
-                    }
-                  },
-                  flush(controller) {
-                    if (this.buffer) controller.enqueue(this.encoder.encode(this.buffer))
-                  },
-                }),
-              )
-              const filteredRes = new Response(filtered, res)
-              if (!chunkAbortCtl) return filteredRes
-              return wrapSSE(filteredRes, chunkTimeout, chunkAbortCtl)
+            if (url.includes("/responses")) {
+              const filtered = filterResponseFrame(res, filterSseFrame)
+              if (filtered) {
+                if (!chunkAbortCtl) return filtered
+                return wrapSSE(filtered, chunkTimeout, chunkAbortCtl)
+              }
             }
           }
 


### PR DESCRIPTION
### Issue for this PR

Closes #30916

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some OpenAI-compatible gateways serving the Responses API (`/v1/responses`) emit a synthetic SSE frame at the start of the stream with `id: "chatcmpl-dummy"` and `object: "chat.completion.chunk"` before the real Responses API events. This frame has empty content (`"content":""`) and no `event:` prefix, so it is not a valid Responses API event.

When the AI SDK receives this frame, it tries to validate it against the Responses API event schema union, which fails with a `TypeValidationError` that terminates the agent turn immediately. All subsequent real events are lost.

The fix pipes the SSE response body through a `TransformStream` in the custom `fetch` wrapper inside `resolveSDK()`. Each chunk is split into SSE frames; if a `data:` line parses as JSON and has `id === "chatcmpl-dummy"`, that frame is dropped. All other frames pass through unchanged.

The filter is scoped to Responses API calls only (URL contains `/responses` and content-type is `text/event-stream`), so it does not affect Chat Completions streams or other providers.

### How did you verify your code works?

- Built a standalone binary and tested against the proxy that reproduces the issue: `opencode run "say hi" --model openai/gpt-5.5` no longer errors.
- Confirmed the same binary works with deepseek/deepseek-v4-pro (no regression).
- Confirmed the official release v1.15.13 exhibits the same bug and the fix resolves it.
- Confirmed non-streaming Responses API (no `chatcmpl-dummy` frame) continues to work.
- Typechecked with `tsgo --noEmit` in `packages/opencode`.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---
Update: the filtering is now configurable through `opencode.json` via provider options, for example `provider.openai.options.filterSseFrame`.
By default, no SSE frames are filtered. The filter only runs when `filterSseFrame` is explicitly configured, so existing users are unaffected.
