### PR TITLE
fix: replace Effect.die with ToolFailure in read tool TOCTOU checks

### DIFF
--- a/packages/core/src/tool/read.ts
+++ b/packages/core/src/tool/read.ts
@@ -58,7 +58,9 @@ export const layer = Layer.effectDiscard(
                 final.target.resource !== target.resource ||
                 final.target.real !== target.real
               )
-                return yield* Effect.die(new Error("Directory changed after permission approval"))
+                return yield* new ToolFailure({
+                  message: "Directory changed after permission approval. Please re-read and try again.",
+                })
               return yield* filesystem.listPageResolved(final.target, { offset, limit })
             }
             const target = resolved.target
@@ -69,7 +71,9 @@ export const layer = Layer.effectDiscard(
             })
             const final = yield* filesystem.resolveReadPath(input)
             if (final.type !== "file" || final.target.resource !== target.resource || final.target.real !== target.real)
-              return yield* Effect.die(new Error("File changed after permission approval"))
+              return yield* new ToolFailure({
+                message: "File changed after permission approval. Please re-read and try again.",
+              })
             if (
               final.target.size > FileSystem.MAX_READ_BYTES ||
               input.offset !== undefined ||
@@ -78,14 +82,16 @@ export const layer = Layer.effectDiscard(
               return yield* filesystem.readTextPageResolved(final.target, { offset: input.offset, limit: input.limit })
             return yield* filesystem.readResolved(final.target, FileSystem.MAX_READ_BYTES)
           }).pipe(
-            Effect.catchCause((cause) =>
-              Effect.fail(
+            Effect.catchCause((cause) => {
+              const errors: unknown[] = []
+              Cause.forEach(cause, (error) => errors.push(error))
+              const messages = errors.map((e) => String(e)).join("\n")
+              return Effect.fail(
                 new ToolFailure({
-                  message: `Unable to read ${"resource" in input ? input.resource : input.path}`,
-                  error: Cause.squash(cause),
+                  message: `Unable to read ${"resource" in input ? input.resource : input.path}:\n${messages}`,
                 }),
-              ),
-            ),
+              )
+            }),
           )
         },
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #30867

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `packages/core/src/tool/read.ts`, the TOCTOU (time-of-check-time-of-use) detection uses `Effect.die` for both directory and file changed scenarios. `Effect.die` creates a defect (not a failure), which is then caught by `catchCause` where `Cause.squash` may lose the meaningful error message. The AI only sees "Unable to read" with no actionable information.

Two changes:

1. Replace `Effect.die` with direct `ToolFailure` returns at L61 and L72, so the AI gets a clear "Directory/File changed after permission approval" message
2. Replace `Cause.squash` in `catchCause` with `Cause.forEach` to preserve all error details instead of only the first

### How did you verify your code works?

The change replaces defect-throwing with structured failure reporting. `ToolFailure` is already used throughout the codebase as the standard error type. No new dependencies or side effects introduced.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
