### PR TITLE
fix(core): evict Bedrock SDK cache on expired STS credentials

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -131,9 +131,9 @@ export const layer = Layer.effect(
     const sdks = new Map<string, SDK>()
 
     function buildLanguageKey(model: ModelV2.Info) {
-      // \x00 as separator: ProviderV2.ID and ModelV2.ID are validated as branded strings
-      // from config/models.dev and cannot contain null bytes in practice, making this
-      // prefix unambiguous for eviction matching.
+      // \x00 as separator: assumes ProviderV2.ID and ModelV2.ID never contain null bytes
+      // (branded types do not enforce this at runtime). If that assumption ever breaks,
+      // the prefix match could cross model boundaries.
       return `${model.providerID}\x00${model.id}\x00${model.request.variant ?? "default"}`
     }
 

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -118,6 +118,7 @@ function initError(providerID: ProviderV2.ID) {
 
 export interface Interface {
   readonly language: (model: ModelV2.Info) => Effect.Effect<LanguageModelV3, InitError>
+  readonly evict: (model: ModelV2.Info) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/AISDK") {}
@@ -129,9 +130,23 @@ export const layer = Layer.effect(
     const languages = new Map<string, LanguageModelV3>()
     const sdks = new Map<string, SDK>()
 
+    function buildLanguageKey(model: ModelV2.Info) {
+      return `${model.providerID}/${model.id}/${model.request.variant ?? "default"}`
+    }
+
+    function buildSdkKey(model: ModelV2.Info, options: Record<string, any>) {
+      return JSON.stringify({ providerID: model.providerID, api: model.api, options })
+    }
+
     return Service.of({
+      evict: Effect.fn("AISDK.evict")(function* (model) {
+        if (model.api.type !== "aisdk") return
+        languages.delete(buildLanguageKey(model))
+        const options = prepareOptions(model, model.api.package)
+        sdks.delete(buildSdkKey(model, options))
+      }),
       language: Effect.fn("AISDK.language")(function* (model) {
-        const key = `${model.providerID}/${model.id}/${model.request.variant ?? "default"}`
+        const key = buildLanguageKey(model)
         const existing = languages.get(key)
         if (existing) return existing
         if (model.api.type !== "aisdk")
@@ -141,11 +156,7 @@ export const layer = Layer.effect(
           })
 
         const options = prepareOptions(model, model.api.package)
-        const sdkKey = JSON.stringify({
-          providerID: model.providerID,
-          api: model.api,
-          options,
-        })
+        const sdkKey = buildSdkKey(model, options)
         const sdk =
           sdks.get(sdkKey) ??
           (yield* plugin

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -118,7 +118,7 @@ function initError(providerID: ProviderV2.ID) {
 
 export interface Interface {
   readonly language: (model: ModelV2.Info) => Effect.Effect<LanguageModelV3, InitError>
-  readonly evict: (model: ModelV2.Info) => Effect.Effect<void>
+  readonly evict: (model: { providerID: ProviderV2.ID; id: string }) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/AISDK") {}
@@ -134,16 +134,15 @@ export const layer = Layer.effect(
       return `${model.providerID}/${model.id}/${model.request.variant ?? "default"}`
     }
 
-    function buildSdkKey(model: ModelV2.Info, options: Record<string, any>) {
-      return JSON.stringify({ providerID: model.providerID, api: model.api, options })
-    }
-
     return Service.of({
       evict: Effect.fn("AISDK.evict")(function* (model) {
-        if (model.api.type !== "aisdk") return
-        languages.delete(buildLanguageKey(model))
-        const options = prepareOptions(model, model.api.package)
-        sdks.delete(buildSdkKey(model, options))
+        const langKey = `${model.providerID}/${model.id}/`
+        for (const key of languages.keys()) {
+          if (key.startsWith(langKey)) languages.delete(key)
+        }
+        for (const key of sdks.keys()) {
+          if (key.includes(`"providerID":"${model.providerID}"`)) sdks.delete(key)
+        }
       }),
       language: Effect.fn("AISDK.language")(function* (model) {
         const key = buildLanguageKey(model)
@@ -156,7 +155,7 @@ export const layer = Layer.effect(
           })
 
         const options = prepareOptions(model, model.api.package)
-        const sdkKey = buildSdkKey(model, options)
+        const sdkKey = JSON.stringify({ providerID: model.providerID, api: model.api, options })
         const sdk =
           sdks.get(sdkKey) ??
           (yield* plugin

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -131,6 +131,9 @@ export const layer = Layer.effect(
     const sdks = new Map<string, SDK>()
 
     function buildLanguageKey(model: ModelV2.Info) {
+      // \x00 as separator: ProviderV2.ID and ModelV2.ID are validated as branded strings
+      // from config/models.dev and cannot contain null bytes in practice, making this
+      // prefix unambiguous for eviction matching.
       return `${model.providerID}\x00${model.id}\x00${model.request.variant ?? "default"}`
     }
 
@@ -163,7 +166,9 @@ export const layer = Layer.effect(
           })
 
         const options = prepareOptions(model, model.api.package)
-        const sdkKey = JSON.stringify({ providerID: model.providerID, api: model.api, options })
+        const sdkKey = JSON.stringify({ providerID: model.providerID, api: model.api, options }, (_, v) =>
+          typeof v === "function" ? undefined : v,
+        )
         const sdk =
           sdks.get(sdkKey) ??
           (yield* plugin

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -131,17 +131,25 @@ export const layer = Layer.effect(
     const sdks = new Map<string, SDK>()
 
     function buildLanguageKey(model: ModelV2.Info) {
-      return `${model.providerID}/${model.id}/${model.request.variant ?? "default"}`
+      return `${model.providerID}\x00${model.id}\x00${model.request.variant ?? "default"}`
     }
 
     return Service.of({
       evict: Effect.fn("AISDK.evict")(function* (model) {
-        const langKey = `${model.providerID}/${model.id}/`
-        for (const key of languages.keys()) {
-          if (key.startsWith(langKey)) languages.delete(key)
+        // Language keys are `${providerID}/${modelID}/${variant}`. Use a separator-aware
+        // prefix so a providerID containing "/" cannot extend the match into a different
+        // model's subtree.
+        const langPrefix = `${model.providerID}\x00${model.id}\x00`
+        for (const key of [...languages.keys()]) {
+          if (key.startsWith(langPrefix)) languages.delete(key)
         }
-        for (const key of sdks.keys()) {
-          if (key.includes(`"providerID":"${model.providerID}"`)) sdks.delete(key)
+        // SDK keys are JSON. Parse and compare providerID by field equality to avoid
+        // injection via crafted providerID values. All models for a provider share the
+        // same STS credentials, so provider-wide SDK eviction is correct here.
+        for (const key of [...sdks.keys()]) {
+          try {
+            if ((JSON.parse(key) as { providerID?: string }).providerID === model.providerID) sdks.delete(key)
+          } catch {}
         }
       }),
       language: Effect.fn("AISDK.language")(function* (model) {

--- a/packages/core/test/aisdk-evict.test.ts
+++ b/packages/core/test/aisdk-evict.test.ts
@@ -74,22 +74,24 @@ describe("AISDK.evict", () => {
     }),
   )
 
-  it.effect("evict does not remove entries for other models on same provider", () =>
-    Effect.gen(function* () {
-      const plugin = yield* PluginV2.Service
-      const aisdk = yield* AISDK.Service
-      const sdkCalls: string[] = []
-      yield* plugin.add(pluginWithCounter(sdkCalls))
+  it.effect(
+    "evict clears language cache for target model but not other models (language eviction is model-scoped, SDK eviction is provider-wide by design)",
+    () =>
+      Effect.gen(function* () {
+        const plugin = yield* PluginV2.Service
+        const aisdk = yield* AISDK.Service
+        const sdkCalls: string[] = []
+        yield* plugin.add(pluginWithCounter(sdkCalls))
 
-      yield* aisdk.language(modelA1)
-      yield* aisdk.language(modelA2)
-      expect(sdkCalls).toHaveLength(2)
+        yield* aisdk.language(modelA1)
+        yield* aisdk.language(modelA2)
+        expect(sdkCalls).toHaveLength(2)
 
-      yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
+        yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
 
-      yield* aisdk.language(modelA2)
-      expect(sdkCalls).toHaveLength(2)
-    }),
+        yield* aisdk.language(modelA2)
+        expect(sdkCalls).toHaveLength(2)
+      }),
   )
 
   it.effect("evict does not remove entries for different providers", () =>

--- a/packages/core/test/aisdk-evict.test.ts
+++ b/packages/core/test/aisdk-evict.test.ts
@@ -74,24 +74,39 @@ describe("AISDK.evict", () => {
     }),
   )
 
-  it.effect(
-    "evict clears language cache for target model but not other models (language eviction is model-scoped, SDK eviction is provider-wide by design)",
-    () =>
-      Effect.gen(function* () {
-        const plugin = yield* PluginV2.Service
-        const aisdk = yield* AISDK.Service
-        const sdkCalls: string[] = []
-        yield* plugin.add(pluginWithCounter(sdkCalls))
+  it.effect("language eviction is model-scoped: evicting A1 does not clear A2's language cache", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
 
-        yield* aisdk.language(modelA1)
-        yield* aisdk.language(modelA2)
-        expect(sdkCalls).toHaveLength(2)
+      yield* aisdk.language(modelA1)
+      yield* aisdk.language(modelA2)
+      expect(sdkCalls).toHaveLength(2)
 
-        yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
+      yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
 
-        yield* aisdk.language(modelA2)
-        expect(sdkCalls).toHaveLength(2)
-      }),
+      yield* aisdk.language(modelA2)
+      expect(sdkCalls).toHaveLength(2)
+    }),
+  )
+
+  it.effect("SDK eviction is provider-wide: evicting any model on a provider forces SDK rebuild for that model", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
+
+      yield* aisdk.language(modelA1)
+      expect(sdkCalls).toHaveLength(1)
+
+      yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
+
+      yield* aisdk.language(modelA1)
+      expect(sdkCalls).toHaveLength(2)
+    }),
   )
 
   it.effect("evict does not remove entries for different providers", () =>

--- a/packages/core/test/aisdk-evict.test.ts
+++ b/packages/core/test/aisdk-evict.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect } from "bun:test"
+import type { LanguageModelV3 } from "@ai-sdk/provider"
+import { Effect, Layer } from "effect"
+import { AISDK } from "@opencode-ai/core/aisdk"
+import { EventV2 } from "@opencode-ai/core/event"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { testEffect } from "./lib/effect"
+import { model } from "./plugin/provider-helper"
+
+function fakeLanguageModel(id: string): LanguageModelV3 {
+  return { specificationVersion: "v3", provider: "test", modelId: id } as unknown as LanguageModelV3
+}
+
+function pluginWithCounter(sdkCalls: string[]) {
+  return PluginV2.define({
+    id: PluginV2.ID.make("test-counter"),
+    effect: Effect.gen(function* () {
+      return {
+        "aisdk.sdk": Effect.fn(function* (evt) {
+          if (evt.package !== "test-provider") return
+          sdkCalls.push(evt.model.id)
+          evt.sdk = {
+            languageModel: (id: string) => fakeLanguageModel(id),
+          }
+        }),
+      }
+    }),
+  })
+}
+
+const layer = AISDK.layer.pipe(
+  Layer.provideMerge(PluginV2.locationLayer.pipe(Layer.provide(EventV2.defaultLayer))),
+)
+
+const it = testEffect(layer)
+
+const providerA = ProviderV2.ID.make("provider-a")
+const providerB = ProviderV2.ID.make("provider-b")
+const modelA1 = model("provider-a", "model-1")
+const modelA2 = model("provider-a", "model-2")
+const modelB1 = model("provider-b", "model-1")
+
+describe("AISDK.evict", () => {
+  it.effect("language() returns cached model on second call (baseline)", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
+
+      yield* aisdk.language(modelA1)
+      yield* aisdk.language(modelA1)
+
+      expect(sdkCalls).toHaveLength(1)
+    }),
+  )
+
+  it.effect("evict causes next language() call to re-derive (cache miss)", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
+
+      yield* aisdk.language(modelA1)
+      expect(sdkCalls).toHaveLength(1)
+
+      yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
+
+      yield* aisdk.language(modelA1)
+      expect(sdkCalls).toHaveLength(2)
+    }),
+  )
+
+  it.effect("evict does not remove entries for other models on same provider", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
+
+      yield* aisdk.language(modelA1)
+      yield* aisdk.language(modelA2)
+      expect(sdkCalls).toHaveLength(2)
+
+      yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
+
+      yield* aisdk.language(modelA2)
+      expect(sdkCalls).toHaveLength(2)
+    }),
+  )
+
+  it.effect("evict does not remove entries for different providers", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
+
+      yield* aisdk.language(modelA1)
+      yield* aisdk.language(modelB1)
+      expect(sdkCalls).toHaveLength(2)
+
+      yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
+
+      yield* aisdk.language(modelB1)
+      expect(sdkCalls).toHaveLength(2)
+    }),
+  )
+
+  it.effect("evict clears all variants for the same model", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
+
+      const modelVariantA = model("provider-a", "model-1", { request: { headers: {}, body: {}, variant: "high" } })
+      const modelVariantB = model("provider-a", "model-1", { request: { headers: {}, body: {}, variant: "low" } })
+
+      const langA1 = yield* aisdk.language(modelVariantA)
+      const langB1 = yield* aisdk.language(modelVariantB)
+      expect(langA1).not.toBe(langB1)
+
+      yield* aisdk.evict({ providerID: providerA, id: ModelV2.ID.make("model-1") })
+
+      const langA2 = yield* aisdk.language(modelVariantA)
+      const langB2 = yield* aisdk.language(modelVariantB)
+
+      expect(langA2).not.toBe(langA1)
+      expect(langB2).not.toBe(langB1)
+    }),
+  )
+
+  it.effect("evict on model that was never loaded is a no-op", () =>
+    Effect.gen(function* () {
+      const aisdk = yield* AISDK.Service
+
+      const result = yield* aisdk
+        .evict({ providerID: ProviderV2.ID.make("never-loaded"), id: ModelV2.ID.make("ghost") })
+        .pipe(Effect.exit)
+      expect(result._tag).toBe("Success")
+    }),
+  )
+})

--- a/packages/core/test/aisdk-evict.test.ts
+++ b/packages/core/test/aisdk-evict.test.ts
@@ -144,4 +144,25 @@ describe("AISDK.evict", () => {
       expect(result._tag).toBe("Success")
     }),
   )
+
+  it.effect("evict does not affect models whose providerID is a prefix of the target providerID", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const sdkCalls: string[] = []
+      yield* plugin.add(pluginWithCounter(sdkCalls))
+
+      const shortProvider = model("provider", "model-1")
+      const longProvider = model("provider-a", "model-1")
+
+      yield* aisdk.language(shortProvider)
+      yield* aisdk.language(longProvider)
+      expect(sdkCalls).toHaveLength(2)
+
+      yield* aisdk.evict({ providerID: ProviderV2.ID.make("provider-a"), id: ModelV2.ID.make("model-1") })
+
+      yield* aisdk.language(shortProvider)
+      expect(sdkCalls).toHaveLength(2)
+    }),
+  )
 })

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -197,7 +197,6 @@ export function parseAPICallError(input: { providerID: ProviderV2.ID; error: API
 // otherwise valid credential) benefits from cache eviction.
 const EXPIRED_CREDENTIAL_MESSAGE_PATTERNS = [
   /the security token included in the request is expired/i,
-  /ExpiredTokenException/,
 ]
 
 function extractAwsErrorType(responseBody: string | undefined): string | undefined {

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -185,4 +185,20 @@ export function parseAPICallError(input: { providerID: ProviderV2.ID; error: API
   }
 }
 
+// AWS STS credential expiry patterns — surfaced as 401/403 with these message signatures.
+// The security token error comes from Bedrock when STS-vended credentials have been cached
+// past their TTL by the AI SDK. The InvalidClientTokenId and ExpiredTokenException codes
+// are the canonical AWS error codes for the same condition.
+const EXPIRED_CREDENTIALS_PATTERNS = [
+  /the security token included in the request is expired/i,
+  /ExpiredTokenException/,
+  /InvalidClientTokenId/,
+]
+
+export function isExpiredCredentials(error: unknown): boolean {
+  if (!(error instanceof APICallError)) return false
+  const msg = error.message + (error.responseBody ?? "")
+  return EXPIRED_CREDENTIALS_PATTERNS.some((p) => p.test(msg))
+}
+
 export * as ProviderError from "./error"

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -185,20 +185,36 @@ export function parseAPICallError(input: { providerID: ProviderV2.ID; error: API
   }
 }
 
-// AWS STS credential expiry patterns — surfaced as 401/403 with these message signatures.
-// The security token error comes from Bedrock when STS-vended credentials have been cached
-// past their TTL by the AI SDK. The InvalidClientTokenId and ExpiredTokenException codes
-// are the canonical AWS error codes for the same condition.
-const EXPIRED_CREDENTIALS_PATTERNS = [
+// AWS STS token expiry patterns. The SDK puts the HTTP status text in error.message
+// ("Unauthorized") and the AWS error code in error.responseBody as a JSON __type field.
+// We check both, but responseBody is only checked via structured JSON field extraction —
+// not raw substring matching — so a server cannot inject arbitrary trigger strings into
+// a response body to force eviction+retry.
+//
+// InvalidClientTokenId is intentionally excluded: it signals a structurally bad or
+// unrecognized credential, not an expired one. Evicting and re-fetching won't help —
+// the same bad credential would be re-loaded. Only ExpiredTokenException (expired but
+// otherwise valid credential) benefits from cache eviction.
+const EXPIRED_CREDENTIAL_MESSAGE_PATTERNS = [
   /the security token included in the request is expired/i,
   /ExpiredTokenException/,
-  /InvalidClientTokenId/,
 ]
+
+function extractAwsErrorType(responseBody: string | undefined): string | undefined {
+  if (!responseBody) return undefined
+  try {
+    const parsed = JSON.parse(responseBody) as Record<string, unknown>
+    const type = parsed.__type ?? parsed.code
+    return typeof type === "string" ? type : undefined
+  } catch {
+    return undefined
+  }
+}
 
 export function isExpiredCredentials(error: unknown): boolean {
   if (!(error instanceof APICallError)) return false
-  const msg = error.message + (error.responseBody ?? "")
-  return EXPIRED_CREDENTIALS_PATTERNS.some((p) => p.test(msg))
+  if (EXPIRED_CREDENTIAL_MESSAGE_PATTERNS.some((p) => p.test(error.message))) return true
+  return extractAwsErrorType(error.responseBody) === "ExpiredTokenException"
 }
 
 export * as ProviderError from "./error"

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1101,6 +1101,7 @@ export interface Interface {
   readonly getProvider: (providerID: ProviderV2.ID) => Effect.Effect<Info>
   readonly getModel: (providerID: ProviderV2.ID, modelID: ModelV2.ID) => Effect.Effect<Model, ModelNotFoundError>
   readonly getLanguage: (model: Model) => Effect.Effect<LanguageModelV3, ModelNotFoundError>
+  readonly evictLanguage: (model: Model) => Effect.Effect<void>
   readonly closest: (
     providerID: ProviderV2.ID,
     query: string[],
@@ -1915,7 +1916,12 @@ export const layer = Layer.effect(
       }
     })
 
-    return Service.of({ list, getProvider, getModel, getLanguage, closest, getSmallModel, defaultModel })
+    const evictLanguage = Effect.fn("Provider.evictLanguage")(function* (model: Model) {
+      const s = yield* InstanceState.get(state)
+      s.models.delete(`${model.providerID}/${model.id}`)
+    })
+
+    return Service.of({ list, getProvider, getModel, getLanguage, evictLanguage, closest, getSmallModel, defaultModel })
   }),
 )
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -4,7 +4,7 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Provider } from "@/provider/provider"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
-import { Context, Effect, Layer } from "effect"
+import { Cause, Context, Effect, Layer } from "effect"
 import * as Stream from "effect/Stream"
 import { streamText, wrapLanguageModel, type ModelMessage, type Tool } from "ai"
 import type { LLMEvent } from "@opencode-ai/llm"
@@ -12,6 +12,7 @@ import { LLMClient, RequestExecutor, WebSocketExecutor } from "@opencode-ai/llm/
 import type { LLMClientService } from "@opencode-ai/llm/route"
 import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
 import { ProviderTransform } from "@/provider/transform"
+import { ProviderError } from "@/provider/error"
 import { Config } from "@/config/config"
 import type { Agent } from "@/agent/agent"
 import type { MessageV2 } from "./message-v2"
@@ -354,6 +355,19 @@ const live: Layer.Layer<
       }
     })
 
+    type RunResult = Effect.Success<ReturnType<typeof run>>
+
+    function toAISDKStream(result: RunResult) {
+      if (result.type === "native") return result.stream
+      const state = LLMAISDK.adapterState()
+      return Stream.fromAsyncIterable(result.result.fullStream, (e: unknown) =>
+        e instanceof Error ? e : new Error(String(e)),
+      ).pipe(
+        Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
+        Stream.flatMap((events) => Stream.fromIterable(events)),
+      )
+    }
+
     const stream: Interface["stream"] = (input) =>
       Stream.scoped(
         Stream.unwrap(
@@ -365,16 +379,18 @@ const live: Layer.Layer<
 
             const result = yield* run({ ...input, abort: ctrl.signal })
 
-            if (result.type === "native") return result.stream
-
-            // Adapter seam: both runtimes expose the same LLMEvent stream. Native
-            // already returns one; AI SDK streams are converted here.
-            const state = LLMAISDK.adapterState()
-            return Stream.fromAsyncIterable(result.result.fullStream, (e) =>
-              e instanceof Error ? e : new Error(String(e)),
-            ).pipe(
-              Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
-              Stream.flatMap((events) => Stream.fromIterable(events)),
+            return toAISDKStream(result).pipe(
+              Stream.catchCause((cause) => {
+                const err = Cause.squash(cause)
+                if (!ProviderError.isExpiredCredentials(err)) return Stream.failCause(cause)
+                return Stream.unwrap(
+                  Effect.gen(function* () {
+                    yield* provider.evictLanguage(input.model)
+                    const retried = yield* run({ ...input, abort: ctrl.signal })
+                    return toAISDKStream(retried)
+                  }),
+                )
+              }),
             )
           }),
         ),
@@ -384,7 +400,11 @@ const live: Layer.Layer<
   }),
 )
 
-export const layer = live.pipe(Layer.provide(Permission.defaultLayer), Layer.provide(EventV2Bridge.defaultLayer))
+export const layer = live.pipe(
+  Layer.provide(Permission.defaultLayer),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(AISDK.defaultLayer),
+)
 
 export const defaultLayer = Layer.suspend(() =>
   layer.pipe(

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -28,6 +28,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import * as Option from "effect/Option"
 import * as OtelTracer from "@effect/opentelemetry/Tracer"
 import { LLMAISDK } from "./llm/ai-sdk"
+import { AISDK } from "@opencode-ai/core/aisdk"
 import { LLMNativeRuntime } from "./llm/native-runtime"
 import { LLMRequestPrep } from "./llm/request"
 
@@ -71,6 +72,7 @@ const live: Layer.Layer<
   | EventV2Bridge.Service
   | LLMClientService
   | RuntimeFlags.Service
+  | AISDK.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -82,6 +84,7 @@ const live: Layer.Layer<
     const events = yield* EventV2Bridge.Service
     const llmClient = yield* LLMClient.Service
     const flags = yield* RuntimeFlags.Service
+    const aisdk = yield* AISDK.Service
 
     const run = Effect.fn("LLM.run")(function* (input: StreamRequest) {
       yield* Effect.logInfo("stream", {
@@ -383,9 +386,12 @@ const live: Layer.Layer<
               Stream.catchCause((cause) => {
                 const err = Cause.squash(cause)
                 if (!ProviderError.isExpiredCredentials(err)) return Stream.failCause(cause)
+                if (ctrl.signal.aborted) return Stream.failCause(cause)
                 return Stream.unwrap(
                   Effect.gen(function* () {
-                    yield* provider.evictLanguage(input.model)
+                    yield* Effect.all([provider.evictLanguage(input.model), aisdk.evict(input.model)], {
+                      concurrency: "unbounded",
+                    })
                     const retried = yield* run({ ...input, abort: ctrl.signal })
                     return toAISDKStream(retried)
                   }),
@@ -416,6 +422,7 @@ export const defaultLayer = Layer.suspend(() =>
       LLMClient.layer.pipe(Layer.provide(Layer.mergeAll(RequestExecutor.defaultLayer, WebSocketExecutor.layer))),
     ),
     Layer.provide(RuntimeFlags.defaultLayer),
+    Layer.provide(AISDK.defaultLayer),
   ),
 )
 

--- a/packages/opencode/test/fake/provider.ts
+++ b/packages/opencode/test/fake/provider.ts
@@ -47,9 +47,11 @@ export namespace ProviderTest {
   export function fake(override: Partial<Provider.Interface> & { model?: Provider.Model; info?: Provider.Info } = {}) {
     const mdl = override.model ?? model()
     const row = override.info ?? info({}, mdl)
+    const evictions = { count: 0 }
     return {
       model: mdl,
       info: row,
+      evictions,
       layer: Layer.succeed(
         Provider.Service,
         Provider.Service.of({
@@ -65,7 +67,11 @@ export namespace ProviderTest {
           getLanguage: Effect.fn("TestProvider.getLanguage")(() =>
             Effect.die(new Error("ProviderTest.getLanguage not configured")),
           ),
-          evictLanguage: Effect.fn("TestProvider.evictLanguage")(() => Effect.void),
+          evictLanguage: Effect.fn("TestProvider.evictLanguage")(() =>
+            Effect.sync(() => {
+              evictions.count++
+            }),
+          ),
           closest: Effect.fn("TestProvider.closest")((providerID) =>
             Effect.succeed(providerID === row.id ? { providerID: row.id, modelID: mdl.id } : undefined),
           ),

--- a/packages/opencode/test/fake/provider.ts
+++ b/packages/opencode/test/fake/provider.ts
@@ -65,6 +65,7 @@ export namespace ProviderTest {
           getLanguage: Effect.fn("TestProvider.getLanguage")(() =>
             Effect.die(new Error("ProviderTest.getLanguage not configured")),
           ),
+          evictLanguage: Effect.fn("TestProvider.evictLanguage")(() => Effect.void),
           closest: Effect.fn("TestProvider.closest")((providerID) =>
             Effect.succeed(providerID === row.id ? { providerID: row.id, modelID: mdl.id } : undefined),
           ),

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { APICallError } from "ai"
+import { ProviderError } from "../../src/provider/error"
+
+function expiredError(opts: { message?: string; responseBody?: string; statusCode?: number } = {}) {
+  return new APICallError({
+    message: opts.message ?? "Request failed",
+    url: "https://bedrock.us-east-1.amazonaws.com/model/invoke",
+    requestBodyValues: {},
+    statusCode: opts.statusCode ?? 401,
+    responseBody: opts.responseBody,
+    isRetryable: false,
+  })
+}
+
+describe("ProviderError.isExpiredCredentials", () => {
+  test("matches STS security token message in error message", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "The security token included in the request is expired" }),
+      ),
+    ).toBe(true)
+  })
+
+  test("matches STS security token message case-insensitively", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "THE SECURITY TOKEN INCLUDED IN THE REQUEST IS EXPIRED" }),
+      ),
+    ).toBe(true)
+  })
+
+  test("matches ExpiredTokenException in response body", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({
+          message: "401",
+          responseBody: JSON.stringify({ __type: "ExpiredTokenException", message: "Token has expired" }),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  test("matches InvalidClientTokenId in response body", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({
+          message: "403",
+          responseBody: JSON.stringify({ code: "InvalidClientTokenId", message: "The security token is invalid" }),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  test("does not match a generic 401 without STS signals", () => {
+    expect(
+      ProviderError.isExpiredCredentials(expiredError({ message: "Unauthorized", statusCode: 401 })),
+    ).toBe(false)
+  })
+
+  test("does not match a rate-limit error", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "Too many requests", statusCode: 429 }),
+      ),
+    ).toBe(false)
+  })
+
+  test("does not match a context overflow error", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "prompt is too long", statusCode: 400 }),
+      ),
+    ).toBe(false)
+  })
+
+  test("returns false for non-APICallError values", () => {
+    expect(ProviderError.isExpiredCredentials(new Error("The security token included in the request is expired"))).toBe(
+      false,
+    )
+    expect(ProviderError.isExpiredCredentials(null)).toBe(false)
+    expect(ProviderError.isExpiredCredentials("ExpiredTokenException")).toBe(false)
+  })
+})

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -30,20 +30,12 @@ describe("ProviderError.isExpiredCredentials", () => {
     ).toBe(true)
   })
 
-  test("matches ExpiredTokenException in error message", () => {
+  test("does not match ExpiredTokenException in message only — must be in structured __type field", () => {
     expect(
       ProviderError.isExpiredCredentials(
         expiredError({ message: "ExpiredTokenException: Token has expired" }),
       ),
-    ).toBe(true)
-  })
-
-  test("matches ExpiredTokenException on 403", () => {
-    expect(
-      ProviderError.isExpiredCredentials(
-        expiredError({ message: "ExpiredTokenException", statusCode: 403 }),
-      ),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   test("matches ExpiredTokenException as structured __type field in responseBody (real SDK behavior)", () => {

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -30,26 +30,83 @@ describe("ProviderError.isExpiredCredentials", () => {
     ).toBe(true)
   })
 
-  test("matches ExpiredTokenException in response body", () => {
+  test("matches ExpiredTokenException in error message", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "ExpiredTokenException: Token has expired" }),
+      ),
+    ).toBe(true)
+  })
+
+  test("matches ExpiredTokenException on 403", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "ExpiredTokenException", statusCode: 403 }),
+      ),
+    ).toBe(true)
+  })
+
+  test("matches ExpiredTokenException as structured __type field in responseBody (real SDK behavior)", () => {
     expect(
       ProviderError.isExpiredCredentials(
         expiredError({
-          message: "401",
+          message: "Unauthorized",
           responseBody: JSON.stringify({ __type: "ExpiredTokenException", message: "Token has expired" }),
+          statusCode: 401,
         }),
       ),
     ).toBe(true)
   })
 
-  test("matches InvalidClientTokenId in response body", () => {
+  test("matches ExpiredTokenException as structured __type field on 403", () => {
     expect(
       ProviderError.isExpiredCredentials(
         expiredError({
-          message: "403",
-          responseBody: JSON.stringify({ code: "InvalidClientTokenId", message: "The security token is invalid" }),
+          message: "Forbidden",
+          responseBody: JSON.stringify({ __type: "ExpiredTokenException", message: "Token has expired" }),
+          statusCode: 403,
         }),
       ),
     ).toBe(true)
+  })
+
+  test("does not match InvalidClientTokenId — structurally invalid credential, retry won't help", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "InvalidClientTokenId: The security token is invalid", statusCode: 403 }),
+      ),
+    ).toBe(false)
+  })
+
+  test("does not match InvalidClientTokenId in responseBody __type field", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({
+          message: "Forbidden",
+          responseBody: JSON.stringify({ __type: "InvalidClientTokenId" }),
+          statusCode: 403,
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  test("does not match raw ExpiredTokenException string anywhere in responseBody — injection protection", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({
+          message: "Unauthorized",
+          responseBody: '{"error":"something about ExpiredTokenException in a message field"}',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  test("does not throw on malformed JSON in responseBody", () => {
+    expect(
+      ProviderError.isExpiredCredentials(
+        expiredError({ message: "Unauthorized", responseBody: "not json {{{{" }),
+      ),
+    ).toBe(false)
   })
 
   test("does not match a generic 401 without STS signals", () => {

--- a/packages/opencode/test/session/llm-native-recorded.test.ts
+++ b/packages/opencode/test/session/llm-native-recorded.test.ts
@@ -10,6 +10,7 @@ import { Effect, Layer, Option, Schema, Stream } from "effect"
 import path from "node:path"
 import z from "zod"
 import { Auth } from "@/auth"
+import { AISDK } from "@opencode-ai/core/aisdk"
 import { Config } from "@/config/config"
 import { Plugin } from "@/plugin"
 import { Provider } from "@/provider/provider"
@@ -303,6 +304,7 @@ function recordedNativeLLMLayer(scenario: RecordedScenario) {
       Layer.provide(Plugin.defaultLayer),
       Layer.provide(recordedClient),
       Layer.provide(RuntimeFlags.layer({ experimentalNativeLlm: true })),
+      Layer.provide(AISDK.defaultLayer),
     ),
   )
 }

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -3,7 +3,7 @@ import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import path from "path"
-import { tool, type ModelMessage } from "ai"
+import { tool, type ModelMessage, APICallError } from "ai"
 import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
@@ -14,6 +14,7 @@ import { Auth } from "@/auth"
 import { Config } from "@/config/config"
 import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
+import { ProviderError } from "@/provider/error"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { Plugin } from "@/plugin"
 
@@ -24,6 +25,7 @@ import { SessionID, MessageID } from "../../src/session/schema"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Permission } from "@/permission"
 import { LLMAISDK } from "@/session/llm/ai-sdk"
+import { AISDK } from "@opencode-ai/core/aisdk"
 import { Session as SessionNs } from "@/session/session"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -83,6 +85,7 @@ function llmLayerWithExecutor(executor: Layer.Layer<RequestExecutor.Service>, fl
     Layer.provide(Plugin.defaultLayer),
     Layer.provide(LLMClient.layer.pipe(Layer.provide(Layer.mergeAll(executor, WebSocketExecutor.layer)))),
     Layer.provide(RuntimeFlags.layer(flags)),
+    Layer.provide(AISDK.defaultLayer),
   )
 }
 
@@ -1136,6 +1139,7 @@ describe("session.llm.stream", () => {
             Layer.provide(Plugin.defaultLayer),
             Layer.provide(failingNativeClient),
             Layer.provide(RuntimeFlags.layer({ experimentalNativeLlm: false })),
+            Layer.provide(AISDK.defaultLayer),
           ),
           {
             user: {
@@ -1928,5 +1932,140 @@ describe("session.llm.stream", () => {
         },
       }),
     },
+  )
+})
+
+describe("session.llm.expired-credentials-retry", () => {
+  const openaiFixture = { providerID: "openai", modelID: "gpt-5.2" }
+  const openaiConfig = () =>
+    openAIConfig(loadFixture(openaiFixture.providerID, openaiFixture.modelID).model, `${state.server!.url.origin}/v1`)
+
+  function expiredTokenResponse() {
+    return new Response(JSON.stringify({ __type: "ExpiredTokenException", message: "Token has expired" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    })
+  }
+
+  const modelID = ModelV2.ID.make(loadFixture(openaiFixture.providerID, openaiFixture.modelID).model.id)
+
+  function makeStreamInput(resolved: Provider.Model): LLM.StreamInput {
+    const sessionID = SessionID.make("session-expired-creds")
+    const agent: Agent.Info = {
+      name: "test",
+      mode: "primary",
+      options: {},
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    }
+    return {
+      user: {
+        id: MessageID.make("msg_user-expired-creds"),
+        sessionID,
+        role: "user",
+        time: { created: Date.now() },
+        agent: agent.name,
+        model: { providerID: ProviderV2.ID.make(openaiFixture.providerID), modelID: resolved.id },
+      },
+      sessionID,
+      model: resolved,
+      agent,
+      system: ["You are a helpful assistant."],
+      messages: [{ role: "user", content: "Hello" }],
+      tools: {},
+    }
+  }
+
+  it.instance(
+    "retries once on expired STS credentials and succeeds",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* Provider.use.getModel(ProviderV2.ID.make(openaiFixture.providerID), modelID)
+        const apiPath = resolved.api.id.startsWith("gpt-") ? "/responses" : "/chat/completions"
+
+        const retrySuccessChunks = [
+          {
+            type: "response.created",
+            response: { id: "resp-retry", created_at: Math.floor(Date.now() / 1000), model: resolved.api.id, service_tier: null },
+          },
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { type: "message", id: "item-retry", status: "in_progress", role: "assistant", content: [] },
+          },
+          {
+            type: "response.content_part.added",
+            item_id: "item-retry",
+            output_index: 0,
+            content_index: 0,
+            part: { type: "output_text", text: "", annotations: [] },
+          },
+          {
+            type: "response.output_text.delta",
+            item_id: "item-retry",
+            delta: "Hello from retry",
+            logprobs: null,
+          },
+          {
+            type: "response.completed",
+            response: {
+              incomplete_details: null,
+              usage: { input_tokens: 1, input_tokens_details: null, output_tokens: 4, output_tokens_details: null },
+              service_tier: null,
+            },
+          },
+        ]
+
+        const firstRequest = waitRequest(apiPath, expiredTokenResponse())
+        const secondRequest = waitRequest(apiPath, createEventResponse(retrySuccessChunks, true))
+
+        yield* drain(makeStreamInput(resolved))
+
+        const first = yield* Effect.promise(() => Promise.race([firstRequest, timeout(5000)]))
+        const second = yield* Effect.promise(() => Promise.race([secondRequest, timeout(5000)]))
+
+        expect(first.url.pathname).toContain(apiPath)
+        expect(second.url.pathname).toContain(apiPath)
+      }),
+    { config: openaiConfig },
+  )
+
+  it.instance(
+    "does not retry on non-expired-credential errors",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* Provider.use.getModel(ProviderV2.ID.make(openaiFixture.providerID), modelID)
+        const apiPath = resolved.api.id.startsWith("gpt-") ? "/responses" : "/chat/completions"
+
+        waitRequest(
+          apiPath,
+          new Response(JSON.stringify({ error: { message: "Not Found", type: "not_found" } }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          }),
+        )
+
+        const result = yield* drain(makeStreamInput(resolved)).pipe(Effect.exit)
+
+        expect(result._tag).toBe("Failure")
+        expect(state.queue.length).toBe(0)
+      }),
+    { config: openaiConfig },
+  )
+
+  it.instance(
+    "propagates error without looping when retry also gets expired credentials",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* Provider.use.getModel(ProviderV2.ID.make(openaiFixture.providerID), modelID)
+        const apiPath = resolved.api.id.startsWith("gpt-") ? "/responses" : "/chat/completions"
+
+        waitRequest(apiPath, expiredTokenResponse())
+        waitRequest(apiPath, expiredTokenResponse())
+
+        const result = yield* drain(makeStreamInput(resolved)).pipe(Effect.exit)
+
+        expect(result._tag).toBe("Failure")
+      }),
+    { config: openaiConfig },
   )
 })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1935,6 +1935,36 @@ describe("session.llm.stream", () => {
   )
 })
 
+function llmLayerWithProviderSpy(evictionSpy: { count: number }) {
+  const spyLayer = Layer.effect(
+    Provider.Service,
+    Effect.gen(function* () {
+      const inner = yield* Provider.Service
+      return Provider.Service.of({
+        ...inner,
+        evictLanguage: Effect.fn("SpyProvider.evictLanguage")((model) =>
+          Effect.gen(function* () {
+            evictionSpy.count++
+            yield* inner.evictLanguage(model)
+          }),
+        ),
+      })
+    }),
+  ).pipe(Layer.provide(Provider.defaultLayer))
+
+  return LLM.layer.pipe(
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(spyLayer),
+    Layer.provide(Plugin.defaultLayer),
+    Layer.provide(
+      LLMClient.layer.pipe(Layer.provide(Layer.mergeAll(RequestExecutor.defaultLayer, WebSocketExecutor.layer))),
+    ),
+    Layer.provide(RuntimeFlags.defaultLayer),
+    Layer.provide(AISDK.defaultLayer),
+  )
+}
+
 describe("session.llm.expired-credentials-retry", () => {
   const openaiFixture = { providerID: "openai", modelID: "gpt-5.2" }
   const openaiConfig = () =>
@@ -1948,6 +1978,41 @@ describe("session.llm.expired-credentials-retry", () => {
   }
 
   const modelID = ModelV2.ID.make(loadFixture(openaiFixture.providerID, openaiFixture.modelID).model.id)
+
+  function retrySuccessChunks(modelApiId: string) {
+    return [
+      {
+        type: "response.created",
+        response: { id: "resp-retry", created_at: Math.floor(Date.now() / 1000), model: modelApiId, service_tier: null },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { type: "message", id: "item-retry", status: "in_progress", role: "assistant", content: [] },
+      },
+      {
+        type: "response.content_part.added",
+        item_id: "item-retry",
+        output_index: 0,
+        content_index: 0,
+        part: { type: "output_text", text: "", annotations: [] },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "item-retry",
+        delta: "Hello from retry",
+        logprobs: null,
+      },
+      {
+        type: "response.completed",
+        response: {
+          incomplete_details: null,
+          usage: { input_tokens: 1, input_tokens_details: null, output_tokens: 4, output_tokens_details: null },
+          service_tier: null,
+        },
+      },
+    ]
+  }
 
   function makeStreamInput(resolved: Provider.Model): LLM.StreamInput {
     const sessionID = SessionID.make("session-expired-creds")
@@ -1982,41 +2047,8 @@ describe("session.llm.expired-credentials-retry", () => {
         const resolved = yield* Provider.use.getModel(ProviderV2.ID.make(openaiFixture.providerID), modelID)
         const apiPath = resolved.api.id.startsWith("gpt-") ? "/responses" : "/chat/completions"
 
-        const retrySuccessChunks = [
-          {
-            type: "response.created",
-            response: { id: "resp-retry", created_at: Math.floor(Date.now() / 1000), model: resolved.api.id, service_tier: null },
-          },
-          {
-            type: "response.output_item.added",
-            output_index: 0,
-            item: { type: "message", id: "item-retry", status: "in_progress", role: "assistant", content: [] },
-          },
-          {
-            type: "response.content_part.added",
-            item_id: "item-retry",
-            output_index: 0,
-            content_index: 0,
-            part: { type: "output_text", text: "", annotations: [] },
-          },
-          {
-            type: "response.output_text.delta",
-            item_id: "item-retry",
-            delta: "Hello from retry",
-            logprobs: null,
-          },
-          {
-            type: "response.completed",
-            response: {
-              incomplete_details: null,
-              usage: { input_tokens: 1, input_tokens_details: null, output_tokens: 4, output_tokens_details: null },
-              service_tier: null,
-            },
-          },
-        ]
-
         const firstRequest = waitRequest(apiPath, expiredTokenResponse())
-        const secondRequest = waitRequest(apiPath, createEventResponse(retrySuccessChunks, true))
+        const secondRequest = waitRequest(apiPath, createEventResponse(retrySuccessChunks(resolved.api.id), true))
 
         yield* drain(makeStreamInput(resolved))
 
@@ -2067,6 +2099,68 @@ describe("session.llm.expired-credentials-retry", () => {
 
         expect(result._tag).toBe("Failure")
         expect(state.queue.length).toBe(0)
+      }),
+    { config: openaiConfig },
+  )
+
+  it.instance(
+    "calls evictLanguage exactly once on expired credential error (eviction-retry coupling)",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* Provider.use.getModel(ProviderV2.ID.make(openaiFixture.providerID), modelID)
+        const apiPath = resolved.api.id.startsWith("gpt-") ? "/responses" : "/chat/completions"
+
+        const evictionSpy = { count: 0 }
+
+        waitRequest(apiPath, expiredTokenResponse())
+        waitRequest(apiPath, createEventResponse(retrySuccessChunks(resolved.api.id), true))
+
+        yield* drainWith(llmLayerWithProviderSpy(evictionSpy), makeStreamInput(resolved))
+
+        expect(evictionSpy.count).toBe(1)
+      }),
+    { config: openaiConfig },
+  )
+
+  it.instance(
+    "does not call evictLanguage on non-expired-credential errors",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* Provider.use.getModel(ProviderV2.ID.make(openaiFixture.providerID), modelID)
+        const apiPath = resolved.api.id.startsWith("gpt-") ? "/responses" : "/chat/completions"
+
+        const evictionSpy = { count: 0 }
+
+        waitRequest(
+          apiPath,
+          new Response(JSON.stringify({ error: { message: "Not Found", type: "not_found" } }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          }),
+        )
+
+        yield* drainWith(llmLayerWithProviderSpy(evictionSpy), makeStreamInput(resolved)).pipe(Effect.exit)
+
+        expect(evictionSpy.count).toBe(0)
+      }),
+    { config: openaiConfig },
+  )
+
+  it.instance(
+    "calls evictLanguage exactly once even when retry also fails with expired credentials",
+    () =>
+      Effect.gen(function* () {
+        const resolved = yield* Provider.use.getModel(ProviderV2.ID.make(openaiFixture.providerID), modelID)
+        const apiPath = resolved.api.id.startsWith("gpt-") ? "/responses" : "/chat/completions"
+
+        const evictionSpy = { count: 0 }
+
+        waitRequest(apiPath, expiredTokenResponse())
+        waitRequest(apiPath, expiredTokenResponse())
+
+        yield* drainWith(llmLayerWithProviderSpy(evictionSpy), makeStreamInput(resolved)).pipe(Effect.exit)
+
+        expect(evictionSpy.count).toBe(1)
       }),
     { config: openaiConfig },
   )

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -2025,6 +2025,7 @@ describe("session.llm.expired-credentials-retry", () => {
 
         expect(first.url.pathname).toContain(apiPath)
         expect(second.url.pathname).toContain(apiPath)
+        expect(state.queue.length).toBe(0)
       }),
     { config: openaiConfig },
   )
@@ -2065,6 +2066,7 @@ describe("session.llm.expired-credentials-retry", () => {
         const result = yield* drain(makeStreamInput(resolved)).pipe(Effect.exit)
 
         expect(result._tag).toBe("Failure")
+        expect(state.queue.length).toBe(0)
       }),
     { config: openaiConfig },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #30940

### Type of change

- [x] Bug fix

### What does this PR do?

Bedrock + STS credentials (SAML/SSO) expire after ~60 minutes. The AI SDK caches `LanguageModelV3` instances indefinitely — `fromNodeProviderChain` is called once at construction, baked in, and that object gets returned forever even after on-disk credentials have rotated. Fresh creds are sitting right there; OpenCode just never goes back to read them.

Fix: on any stream error matching AWS expired-credential signatures (`ExpiredTokenException` in the structured `__type` response field, or the security-token-expiry phrase in the error message), evict the cached language model and SDK entries for that provider and retry the request once. The retry has no catch wrapper, so a second failure surfaces as a plain error — no retry loop.

Two eviction points:
- `AISDK.Service.evict()` in `aisdk.ts` clears the `languages` and `sdks` Maps
- `Provider.Service.evictLanguage()` in `provider.ts` clears `s.models`

### How did you verify your code works?

Ran active Bedrock sessions with `aws sso login` keeping credentials fresh on disk — confirmed sessions run past 60 minutes without the expiry error.

Tests added:
- `packages/opencode/test/provider/error.test.ts` — 13 unit tests for the detection function: structured `__type` field matching, injection protection, malformed JSON safe, `InvalidClientTokenId` excluded (wrong error class — bad credential, not expired one)
- `packages/core/test/aisdk-evict.test.ts` — 8 unit tests for `AISDK.evict`: cache miss after eviction, variant coverage, cross-model and cross-provider isolation
- `packages/opencode/test/session/llm.test.ts` — 6 integration tests: retry fires and succeeds, no retry on unrelated errors, no retry loop on double-expiry; 3 spy tests confirming `evictLanguage` is called exactly once on retry and zero times on non-expired errors

### Screenshots / recordings

_N/A — not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR