### PR TITLE
fix(core): repair poisoned session metadata migration

### DIFF
--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -23,6 +23,7 @@ export function applyOnly(db: Database, input: Migration[]) {
     yield* db.run(
       sql`CREATE TABLE IF NOT EXISTS ${sql.identifier("migration")} (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL)`,
     )
+    const skipMigrations = !!process.env.OPENCODE_SKIP_MIGRATIONS
     let completed = new Set(
       (yield* db.all<{ id: string }>(sql`SELECT id FROM ${sql.identifier("migration")}`)).map((row) => row.id),
     )
@@ -43,17 +44,31 @@ export function applyOnly(db: Database, input: Migration[]) {
         )
       }
     }
+    if (!skipMigrations) yield* repairKnownSchemaDrift(db, input, completed)
 
     for (const migration of input) {
       if (completed.has(migration.id)) continue
+      if (skipMigrations) continue
       yield* db.transaction((tx) =>
         Effect.gen(function* () {
-          if (!process.env.OPENCODE_SKIP_MIGRATIONS) yield* migration.up(tx)
+          yield* migration.up(tx)
           yield* tx.run(
             sql`INSERT INTO ${sql.identifier("migration")} (id, time_completed) VALUES (${migration.id}, ${Date.now()})`,
           )
         }),
       )
     }
+  })
+}
+
+function repairKnownSchemaDrift(db: Database, input: Migration[], completed: Set<string>) {
+  return Effect.gen(function* () {
+    const sessionMetadata = input.find((migration) => migration.id === "20260511173437_session-metadata")
+    if (!sessionMetadata) return
+    if (!completed.has(sessionMetadata.id)) return
+    if (!(yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${"session"}`))) return
+
+    // Older Drizzle skip-migration runs could record this id without applying its SQL.
+    yield* db.transaction((tx) => sessionMetadata.up(tx))
   })
 }

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -426,6 +426,88 @@ describe("DatabaseMigration", () => {
     )
   })
 
+  test("runs session metadata migration after importing older drizzle state", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`CREATE TABLE session (id text PRIMARY KEY)`)
+        yield* db.run(
+          sql`CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash text NOT NULL, created_at numeric, name text, applied_at TEXT)`,
+        )
+        yield* db.run(sql`
+          INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
+          VALUES ('hash', 1, '20260511000411_data_migration_state', ${new Date().toISOString()})
+        `)
+
+        yield* DatabaseMigration.applyOnly(db, [sessionMetadataMigration])
+
+        expect(
+          (yield* db.all<{ name: string }>(sql`PRAGMA table_info(session)`)).map((column) => column.name),
+        ).toContain("metadata")
+        expect(yield* db.all(sql`SELECT id FROM migration ORDER BY id`)).toEqual([
+          { id: "20260511000411_data_migration_state" },
+          { id: "20260511173437_session-metadata" },
+        ])
+      }),
+    )
+  })
+
+  test("repairs imported session metadata migration state when the column is missing", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`CREATE TABLE session (id text PRIMARY KEY)`)
+        yield* db.run(
+          sql`CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash text NOT NULL, created_at numeric, name text, applied_at TEXT)`,
+        )
+        yield* db.run(sql`
+          INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
+          VALUES ('hash', 1, '20260511173437_session-metadata', ${new Date().toISOString()})
+        `)
+
+        yield* DatabaseMigration.applyOnly(db, [sessionMetadataMigration])
+
+        expect(
+          (yield* db.all<{ name: string }>(sql`PRAGMA table_info(session)`)).map((column) => column.name),
+        ).toContain("metadata")
+        expect(yield* db.all(sql`SELECT id FROM migration ORDER BY id`)).toEqual([
+          { id: "20260511173437_session-metadata" },
+        ])
+      }),
+    )
+  })
+
+  test("does not record migrations as complete when migrations are skipped", async () => {
+    const previous = process.env.OPENCODE_SKIP_MIGRATIONS
+    try {
+      await run(
+        Effect.gen(function* () {
+          const db = yield* makeDb
+          yield* db.run(sql`CREATE TABLE session (id text PRIMARY KEY)`)
+
+          process.env.OPENCODE_SKIP_MIGRATIONS = "true"
+          yield* DatabaseMigration.applyOnly(db, [sessionMetadataMigration])
+
+          expect(yield* db.all(sql`SELECT id FROM migration`)).toEqual([])
+          expect(
+            (yield* db.all<{ name: string }>(sql`PRAGMA table_info(session)`)).map((column) => column.name),
+          ).not.toContain("metadata")
+
+          delete process.env.OPENCODE_SKIP_MIGRATIONS
+          yield* DatabaseMigration.applyOnly(db, [sessionMetadataMigration])
+
+          expect(yield* db.all(sql`SELECT id FROM migration`)).toEqual([{ id: "20260511173437_session-metadata" }])
+          expect(
+            (yield* db.all<{ name: string }>(sql`PRAGMA table_info(session)`)).map((column) => column.name),
+          ).toContain("metadata")
+        }),
+      )
+    } finally {
+      if (previous === undefined) delete process.env.OPENCODE_SKIP_MIGRATIONS
+      else process.env.OPENCODE_SKIP_MIGRATIONS = previous
+    }
+  })
+
   test("does not replay a migrated session metadata column", async () => {
     await run(
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- Repair core migration startup when legacy Drizzle state says `20260511173437_session-metadata` is complete but the actual `session` table is missing `metadata`.
- Stop `OPENCODE_SKIP_MIGRATIONS` from recording migrations as complete when their SQL was not run.
- Add regression coverage for clean older Drizzle state, poisoned metadata state, and skip-migration poisoning.

## Problem
`session list` uses the current `SessionTable` projection, which always selects `session.metadata`. Some databases can contain migration state that says `20260511173437_session-metadata` completed while the table does not actually have the column. The v1.16 core runner imports that legacy Drizzle state into the new `migration` table and then trusts completed ids, so it skips the idempotent metadata migration forever.

```mermaid
sequenceDiagram
  participant Old as v1.15.x Drizzle runner
  participant Journal as __drizzle_migrations
  participant Schema as session table
  participant Core as v1.16 core runner
  participant List as session list

  Old->>Journal: record 20260511173437_session-metadata
  Old--xSchema: metadata column not added
  Core->>Journal: import completed ids
  Core->>Core: skip completed metadata migration
  List->>Schema: select session.metadata
  Schema-->>List: no such column: metadata
```

## Why this shows up at v1.16
A clean `v1.15.3`-only database should migrate correctly on v1.16 because `v1.15.3` predates the metadata migration and should not have the metadata migration id recorded. Running `v1.15.3` successfully mainly proves that older code did not select `session.metadata`.

The reproduced failing state requires the metadata migration id to be present while the column is absent. One concrete path is the old skip-migration behavior, which replaced migration SQL with `select 1` but still let Drizzle record the migration as applied. v1.16 then made the stale state visible because it imports the legacy journal and selects the newer session schema.

## Fix
```mermaid
flowchart TD
  A[Core DB startup] --> B[Create migration table]
  B --> C[Import legacy Drizzle ids when needed]
  C --> D{OPENCODE_SKIP_MIGRATIONS?}
  D -->|yes| E[Skip SQL and do not record new completion ids]
  D -->|no| F{metadata id complete and session table exists?}
  F -->|yes| G[Run idempotent metadata migration as schema repair]
  F -->|no| H[Continue]
  G --> H
  H --> I[Apply pending migrations normally]
```

The repair is deliberately narrow: it only targets `20260511173437_session-metadata`, only when that migration id is already complete, only when `session` exists, and it reuses the existing idempotent migration implementation.

## Why I am confident
- I reproduced the exact poisoned state in the core migration seam: `__drizzle_migrations` contains `20260511173437_session-metadata`, `session.metadata` is absent, and selecting `SessionTable` fails with the reported query shape.
- I verified the clean older-state path separately: an older Drizzle journal without the metadata id runs the metadata migration and adds the column.
- The regression test fails on current dev before the fix and passes after the fix.
- The exact `SessionTable` select repro now succeeds after migration repair and returns a row with `metadata` present.

## Verification
- `bunx prettier --write packages/core/src/database/migration.ts packages/core/test/database-migration.test.ts`
- `bunx oxlint packages/core/src/database/migration.ts packages/core/test/database-migration.test.ts`
- `bun typecheck` from `packages/core`
- `bun test --timeout 5000 test/database-migration.test.ts` from `packages/core`
- Exact poisoned-state `SessionTable` select repro
- Push hook ran `bun turbo typecheck` successfully
