### PR TITLE
test(opencode): remove disposal event wait race

### DIFF
--- a/packages/opencode/test/project/instance-bootstrap.test.ts
+++ b/packages/opencode/test/project/instance-bootstrap.test.ts
@@ -86,7 +86,7 @@ it.live("CLI bootstrap runs InstanceBootstrap before callback", () =>
 it.live("CLI bootstrap disposes the instance when the callback rejects", () =>
   Effect.gen(function* () {
     const tmp = yield* bootstrapFixture
-    const disposed = yield* waitDisposed(tmp.directory).pipe(Effect.forkScoped)
+    const disposed = yield* waitDisposed(tmp.directory).pipe(Effect.forkScoped({ startImmediately: true }))
 
     const exit = yield* Effect.promise(() =>
       cliBootstrap(tmp.directory, async () => Promise.reject(new Error("boom"))),

--- a/packages/opencode/test/server/httpapi-config.test.ts
+++ b/packages/opencode/test/server/httpapi-config.test.ts
@@ -37,7 +37,7 @@ describe("config HttpApi", () => {
     "serves config update through the default server app",
     Effect.gen(function* () {
       const tmp = yield* tmpdirEffect({ config: { formatter: false, lsp: false } })
-      const disposed = yield* waitDisposed(tmp.path).pipe(Effect.forkScoped)
+      const disposed = yield* waitDisposed(tmp.path).pipe(Effect.forkScoped({ startImmediately: true }))
 
       const response = yield* Effect.promise(() =>
         Promise.resolve(

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -333,7 +333,7 @@ describe("HttpApi instance context middleware", () => {
         directory: workspaceDir,
       })
       yield* serveDisposeProbe()
-      const disposed = yield* waitDisposedEvent.pipe(Effect.forkScoped)
+      const disposed = yield* waitDisposedEvent.pipe(Effect.forkScoped({ startImmediately: true }))
 
       const response = yield* HttpClientRequest.post(`/dispose-probe?workspace=${workspace.id}`).pipe(
         HttpClient.execute,


### PR DESCRIPTION
## Summary
- start disposal event wait fibers immediately before triggering one-shot bus events
- cover config, instance context, and CLI bootstrap disposal tests

## Testing
- bun test --timeout 30000 test/server/httpapi-config.test.ts test/server/httpapi-instance-context.test.ts test/project/instance-bootstrap.test.ts