### PR TITLE
test(opencode): remove shell timeout output race

### DIFF
--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1077,11 +1077,10 @@ describe("tool.shell abort", () => {
         projectRoot,
         Effect.gen(function* () {
           const result = yield* run({
-            command: `echo started && sleep 60`,
+            command: `sleep 60`,
             description: "Timeout test",
             timeout: 500,
           })
-          expect(result.output).toContain("started")
           expect(result.output).toContain("shell tool terminated command after exceeding timeout")
           expect(result.output).toContain("retry with a larger timeout value in milliseconds")
         }),
@@ -1099,12 +1098,11 @@ describe("tool.shell abort", () => {
           expect(tool.description).toContain("commands will time out after 500ms")
           const result = yield* tool.execute(
             {
-              command: `echo started && sleep 60`,
+              command: `sleep 60`,
               description: "Default timeout test",
             },
             ctx,
           )
-          expect(result.output).toContain("started")
           expect(result.output).toContain("exceeding timeout 500 ms")
         }),
       ).pipe(Effect.provide(RuntimeFlags.layer({ bashDefaultTimeoutMs: 500 }))),


### PR DESCRIPTION
## Summary
- remove timeout-test assertions that depend on the shell producing output within 500 ms
- keep timeout coverage focused on termination metadata and configured default behavior
- retain output-preservation coverage in the readiness-synchronized abort test

## Testing
- `bun test test/tool/shell.test.ts --test-name-pattern "terminates command on timeout|uses RuntimeFlags bashDefaultTimeoutMs"` (3 consecutive runs)