### PR TITLE
feat(tui): attach to configured server by default

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@dnd-kit/abstract": "0.5.0",
         "@dnd-kit/dom": "0.5.0",
@@ -92,7 +92,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -140,7 +140,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -176,7 +176,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -203,7 +203,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -225,7 +225,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -249,7 +249,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -269,7 +269,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -363,7 +363,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "effect": "catalog:",
@@ -417,7 +417,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -431,7 +431,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -443,7 +443,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -475,7 +475,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -491,7 +491,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -522,7 +522,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -541,7 +541,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -671,7 +671,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -747,7 +747,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -762,7 +762,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -777,7 +777,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -821,7 +821,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -834,7 +834,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@opencode-ai/stats-core": "workspace:*",
@@ -867,7 +867,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -886,7 +886,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -927,7 +927,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -954,7 +954,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1005,7 +1005,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.17.12",
+      "version": "1.17.13",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/v1/config/server.ts
+++ b/packages/core/src/v1/config/server.ts
@@ -15,5 +15,8 @@ export const Server = Schema.Struct({
   cors: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Additional domains to allow for CORS",
   }),
+  attach: Schema.optional(Schema.String).annotate({
+    description: "URL of a running opencode server to attach the TUI to by default",
+  }),
 }).annotate({ identifier: "ServerConfig" })
 export type Server = Schema.Schema.Type<typeof Server>

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -5,7 +5,12 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 
 export const ServeCommand = effectCmd({
   command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("shutdown-after-last-client", {
+      type: "boolean",
+      hidden: true,
+      default: false,
+    }),
   describe: "starts a headless opencode server",
   // Server loads instances per-request via x-opencode-directory header — no
   // need for an ambient project InstanceContext at startup.
@@ -16,8 +21,17 @@ export const ServeCommand = effectCmd({
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = yield* resolveNetworkOptions(args)
-    const server = yield* Effect.promise(() => Server.listen(opts))
+    const server = yield* Effect.promise(() =>
+      Server.listen({ ...opts, shutdownAfterLastClient: args["shutdown-after-last-client"] }),
+    )
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+
+    const idle = server.idle
+    if (idle) {
+      yield* Effect.promise(() => idle)
+      yield* Effect.promise(() => server.stop(true))
+      return
+    }
 
     yield* Effect.never
   }),

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -7,6 +7,7 @@ import { UI } from "@/cli/ui"
 import { errorMessage } from "@opencode-ai/tui/util/error"
 import { withTimeout } from "@/util/timeout"
 import { withNetworkOptions, resolveNetworkOptionsNoConfig, hasArg } from "@/cli/network"
+import { AppRuntime } from "@/effect/app-runtime"
 import { Filesystem } from "@/util/filesystem"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "@opencode-ai/tui/context/sdk"
@@ -20,6 +21,18 @@ declare global {
 }
 
 type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
+type AutoAttachTarget =
+  | { type: "attach"; url: string; headers?: RequestInit["headers"] }
+  | { type: "embedded" }
+  | { type: "fatal"; message: string }
+type AutoAttachFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+type AutoAttachSpawn = (input: { hostname: string; port: number; shutdownAfterLastClient: boolean }) => Promise<void> | void
+
+const AUTO_ATTACH_HEALTH_PATH = "/global/health"
+const AUTO_ATTACH_TIMEOUT_MS = 1000
+const AUTO_ATTACH_STARTUP_ATTEMPTS = 60
+const AUTO_ATTACH_STARTUP_DELAY_MS = 500
+const networkOptionNames = ["--port", "--hostname", "--mdns", "--mdns-domain", "--cors"]
 
 function createWorkerFetch(client: RpcClient): typeof fetch {
   const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -67,6 +80,145 @@ export function resolveThreadDirectory(project?: string, envPWD = process.env.PW
   const root = Filesystem.resolve(envPWD ?? cwd)
   if (project) return Filesystem.resolve(path.isAbsolute(project) ? project : path.join(root, project))
   return Filesystem.resolve(cwd)
+}
+
+export function hasExplicitNetworkOptions(argv = process.argv) {
+  return argv.some((arg) => networkOptionNames.some((name) => arg === name || arg.startsWith(`${name}=`)))
+}
+
+export async function resolveAutoAttachTarget(input: {
+  url?: string
+  headers?: RequestInit["headers"]
+  fetch?: AutoAttachFetch
+  spawn?: AutoAttachSpawn
+  timeoutMs?: number
+  startupAttempts?: number
+  startupDelayMs?: number
+  argv?: string[]
+}): Promise<AutoAttachTarget> {
+  if (hasExplicitNetworkOptions(input.argv)) return { type: "embedded" }
+  if (input.url === undefined) return { type: "embedded" }
+
+  const attach = input.url.trim()
+  if (!attach) return { type: "fatal", message: "server.attach must be a valid URL" }
+
+  let base: URL
+  try {
+    base = new URL(attach)
+  } catch {
+    return { type: "fatal", message: "server.attach must be a valid URL" }
+  }
+
+  const target = await resolveAutoAttachHealth(attach, base, input)
+  if (target.type !== "unreachable") return target
+
+  const local = localAutoAttachServer(base)
+  if (!local) return { type: "fatal", message: "server.attach target is unreachable" }
+
+  try {
+    await (input.spawn ?? spawnAutoAttachServer)({ ...local, shutdownAfterLastClient: true })
+  } catch (error) {
+    return { type: "fatal", message: `Failed to start server.attach target: ${errorMessage(error)}` }
+  }
+
+  return waitForAutoAttachHealth(attach, base, input)
+}
+
+async function resolveAutoAttachHealth(
+  attach: string,
+  base: URL,
+  input: {
+    headers?: RequestInit["headers"]
+    fetch?: AutoAttachFetch
+    timeoutMs?: number
+  },
+): Promise<AutoAttachTarget | { type: "unreachable" }> {
+  const response = await requestAutoAttachHealth(base, input).catch(() => undefined)
+  if (response === undefined) return { type: "unreachable" }
+
+  if (response.status === 401 || response.status === 403) {
+    return { type: "fatal", message: "server.attach authentication failed" }
+  }
+  if (!response.ok) {
+    return { type: "fatal", message: `server.attach health check failed with HTTP ${response.status}` }
+  }
+
+  const body = await response.json().catch(() => undefined)
+  if (typeof body !== "object" || body === null || !("healthy" in body) || body.healthy !== true) {
+    return { type: "fatal", message: "server.attach target is not a healthy opencode server" }
+  }
+
+  return { type: "attach", url: attach, headers: input.headers }
+}
+
+async function requestAutoAttachHealth(
+  base: URL,
+  input: {
+    headers?: RequestInit["headers"]
+    fetch?: AutoAttachFetch
+    timeoutMs?: number
+  },
+) {
+  return (input.fetch ?? fetch)(new URL(AUTO_ATTACH_HEALTH_PATH, base), {
+    headers: input.headers,
+    signal: AbortSignal.timeout(input.timeoutMs ?? AUTO_ATTACH_TIMEOUT_MS),
+  })
+}
+
+function localAutoAttachServer(base: URL) {
+  const hostname = base.hostname.replace(/^\[|\]$/g, "")
+  if (!["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(hostname)) return
+
+  const port = Number(base.port)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return
+
+  return { hostname, port }
+}
+
+function spawnAutoAttachServer(input: { hostname: string; port: number; shutdownAfterLastClient: boolean }) {
+  const compiled = path.basename(process.execPath).replace(/\.exe$/, "") !== "bun"
+  Bun.spawn(
+    [
+      process.execPath,
+      ...(compiled ? [] : [Bun.main]),
+      "serve",
+      "--hostname",
+      input.hostname,
+      "--port",
+      String(input.port),
+      ...(input.shutdownAfterLastClient ? ["--shutdown-after-last-client"] : []),
+    ],
+    {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    },
+  ).unref()
+}
+
+async function waitForAutoAttachHealth(
+  attach: string,
+  base: URL,
+  input: {
+    headers?: RequestInit["headers"]
+    fetch?: AutoAttachFetch
+    timeoutMs?: number
+    startupAttempts?: number
+    startupDelayMs?: number
+  },
+): Promise<AutoAttachTarget> {
+  for (const _ of Array.from({ length: input.startupAttempts ?? AUTO_ATTACH_STARTUP_ATTEMPTS })) {
+    await new Promise((resolve) => setTimeout(resolve, input.startupDelayMs ?? AUTO_ATTACH_STARTUP_DELAY_MS))
+    const target = await resolveAutoAttachHealth(attach, base, input)
+    if (target.type !== "unreachable") return target
+  }
+
+  return { type: "fatal", message: "Failed to start server.attach target" }
+}
+
+async function globalConfig() {
+  const { Config } = await import("@/config/config")
+  return AppRuntime.runPromise(Config.Service.use((cfg) => cfg.getGlobal()))
 }
 
 export const TuiThreadCommand = cmd({
@@ -198,7 +350,6 @@ export const TuiThreadCommand = cmd({
       // Resolve relative --project paths from PWD, then use the real cwd after
       // chdir so the thread and worker share the same directory key.
       const next = resolveThreadDirectory(args.project)
-      const file = await target()
       try {
         process.chdir(next)
       } catch {
@@ -206,6 +357,57 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
+      const prompt = await input(args.prompt)
+      const config = await TuiConfig.get()
+      const attach = hasExplicitNetworkOptions()
+        ? { type: "embedded" as const }
+        : await resolveAutoAttachTarget({
+            url: (await globalConfig()).server?.attach,
+            headers: ServerAuth.headers(),
+          })
+      if (attach.type === "fatal") {
+        UI.error(attach.message)
+        process.exitCode = 1
+        return
+      }
+      if (attach.type === "attach") {
+        try {
+          await validateSession({
+            url: attach.url,
+            directory: cwd,
+            headers: attach.headers,
+            sessionID: args.session,
+          })
+        } catch (error) {
+          UI.error(errorMessage(error))
+          process.exitCode = 1
+          return
+        }
+
+        const { Effect } = await import("effect")
+        const { run } = await import("../tui/layer")
+        const { createLegacyTuiPluginHost } = await import("@/plugin/tui/runtime")
+        await Effect.runPromise(
+          run({
+            url: attach.url,
+            config,
+            pluginHost: createLegacyTuiPluginHost(),
+            directory: cwd,
+            headers: attach.headers,
+            args: {
+              continue: args.continue,
+              sessionID: args.session,
+              agent: args.agent,
+              model: args.model,
+              prompt,
+              fork: args.fork,
+            },
+          }),
+        )
+        return
+      }
+
+      const file = await target()
 
       const worker = new Worker(file)
       const client = Rpc.client<typeof rpc>(worker)
@@ -222,9 +424,6 @@ export const TuiThreadCommand = cmd({
         await withTimeout(client.call("shutdown", undefined), 5000).catch(() => {})
         worker.terminate()
       }
-
-      const prompt = await input(args.prompt)
-      const config = await TuiConfig.get()
 
       const network = resolveNetworkOptionsNoConfig(args)
       const external = hasArg("--port") || hasArg("--hostname") || network.mdns === true
@@ -302,4 +501,3 @@ export const TuiThreadCommand = cmd({
     process.exit(0)
   },
 })
-// scratch

--- a/packages/opencode/src/server/routes/instance/httpapi/client-lifecycle.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/client-lifecycle.ts
@@ -1,0 +1,82 @@
+import { Context, Effect, Layer } from "effect"
+
+export type Options = {
+  initialGraceMs?: number
+  lastClientGraceMs?: number
+}
+
+export interface Interface {
+  readonly acquire: Effect.Effect<Effect.Effect<void>>
+  readonly idle: Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/HttpApiClientLifecycle") {}
+
+const noop = Service.of({
+  acquire: Effect.succeed(Effect.void),
+  idle: Effect.never,
+})
+
+export function layer(options?: boolean | Options) {
+  if (!options) return Layer.succeed(Service)(noop)
+
+  const normalized = typeof options === "boolean" ? {} : options
+  const initialGraceMs = normalized.initialGraceMs ?? 60_000
+  const lastClientGraceMs = normalized.lastClientGraceMs ?? 2_000
+
+  return Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      let active = 0
+      let closed = false
+      let timer: ReturnType<typeof setTimeout> | undefined
+      let resolveIdle!: () => void
+      const idle = new Promise<void>((resolve) => {
+        resolveIdle = resolve
+      })
+
+      const clear = () => {
+        if (!timer) return
+        clearTimeout(timer)
+        timer = undefined
+      }
+
+      const complete = () => {
+        if (closed) return
+        closed = true
+        clear()
+        resolveIdle()
+      }
+
+      const schedule = (delay: number) => {
+        clear()
+        timer = setTimeout(() => {
+          if (active === 0) complete()
+        }, delay)
+        timer.unref?.()
+      }
+
+      schedule(initialGraceMs)
+
+      yield* Effect.addFinalizer(() => Effect.sync(clear))
+
+      return Service.of({
+        acquire: Effect.sync(() => {
+          let released = false
+          if (closed) return Effect.void
+          active += 1
+          clear()
+          return Effect.sync(() => {
+            if (released || closed || active === 0) return
+            released = true
+            active -= 1
+            if (active === 0) schedule(lastClientGraceMs)
+          })
+        }),
+        idle: Effect.promise(() => idle),
+      })
+    }),
+  )
+}
+
+export * as ClientLifecycle from "./client-lifecycle"

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -5,11 +5,12 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { Installation } from "@/installation"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
-import { Effect, Queue, Schema } from "effect"
+import { Effect, Option, Queue, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
+import { ClientLifecycle } from "../client-lifecycle"
 import { RootHttpApi } from "../api"
 import { GlobalUpgradeInput } from "../groups/global"
 
@@ -30,7 +31,13 @@ function parseBody(body: string) {
   }
 }
 
-function eventResponse() {
+function releaseOnRequestClose(request: HttpServerRequest.HttpServerRequest, release: Effect.Effect<void>) {
+  const source = request.source as { once?: (event: "close", handler: () => void) => void }
+  if (typeof source.once !== "function") return
+  source.once("close", () => Effect.runFork(release))
+}
+
+function eventResponse(release: Effect.Effect<void>) {
   return Effect.gen(function* () {
     yield* Effect.logInfo("global event connected")
     const events = Stream.callback<GlobalBusEvent>((queue) => {
@@ -51,7 +58,12 @@ function eventResponse() {
         Stream.map(eventData),
         Stream.pipeThroughChannel(Sse.encode()),
         Stream.encodeText,
-        Stream.ensuring(Effect.logInfo("global event disconnected")),
+        Stream.ensuring(
+          Effect.gen(function* () {
+            yield* Effect.logInfo("global event disconnected")
+            yield* release
+          }),
+        ),
       ),
       {
         contentType: "text/event-stream",
@@ -75,8 +87,11 @@ export const globalHandlers = HttpApiBuilder.group(RootHttpApi, "global", (handl
       return { healthy: true as const, version: InstallationVersion }
     })
 
-    const event = Effect.fn("GlobalHttpApi.event")(function* () {
-      return yield* eventResponse()
+    const event = Effect.fn("GlobalHttpApi.event")(function* (ctx: { request: HttpServerRequest.HttpServerRequest }) {
+      const lifecycle = yield* Effect.serviceOption(ClientLifecycle.Service)
+      const release = Option.isSome(lifecycle) ? yield* lifecycle.value.acquire : Effect.void
+      releaseOnRequestClose(ctx.request, release)
+      return yield* eventResponse(release)
     })
 
     const configGet = Effect.fn("GlobalHttpApi.configGet")(function* () {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -8,6 +8,7 @@ import { OpenApi } from "effect/unstable/httpapi"
 import { createServer } from "node:http"
 import { MDNS } from "./mdns"
 import { HttpApiApp } from "./routes/instance/httpapi/server"
+import { ClientLifecycle } from "./routes/instance/httpapi/client-lifecycle"
 import { disposeMiddleware } from "./routes/instance/httpapi/lifecycle"
 import { WebSocketTracker } from "./routes/instance/httpapi/websocket-tracker"
 import { PublicApi } from "./routes/instance/httpapi/public"
@@ -22,6 +23,7 @@ export type Listener = {
   port: number
   url: URL
   stop: (close?: boolean) => Promise<void>
+  idle?: Promise<void>
 }
 
 type ServerApp = {
@@ -34,15 +36,18 @@ type ListenOptions = CorsOptions & {
   hostname: string
   mdns?: boolean
   mdnsDomain?: string
+  shutdownAfterLastClient?: boolean | ClientLifecycle.Options
 }
 type ListenerState = {
   scope: Scope.Scope
   server: Context.Service.Shape<typeof HttpServer.HttpServer>
   http: ListenerServer
   websockets: WebSocketTracker.Interface
+  lifecycle: ClientLifecycle.Interface
 }
-type EffectListener = Omit<Listener, "stop"> & {
+type EffectListener = Omit<Listener, "idle" | "stop"> & {
   stop: (close?: boolean) => Effect.Effect<void>
+  idle?: Effect.Effect<void>
 }
 
 interface ListenerServer {
@@ -77,6 +82,7 @@ export async function listen(opts: ListenOptions): Promise<Listener> {
     port: listener.port,
     url: listener.url,
     stop: (close?: boolean) => Effect.runPromiseExit(listener.stop(close)).then(() => undefined),
+    ...(listener.idle ? { idle: Effect.runPromise(listener.idle) } : {}),
   }
 }
 
@@ -93,6 +99,7 @@ const listenEffect: (opts: ListenOptions) => Effect.Effect<EffectListener, unkno
       port: address.port,
       url: listenerUrl,
       stop: yield* makeStop(state, unpublishMdns, listenerUrl),
+      ...(opts.shutdownAfterLastClient ? { idle: state.lifecycle.idle } : {}),
     }
   },
 )
@@ -103,6 +110,7 @@ function listenerLayer(opts: ListenOptions, port: number) {
     disableLogger: true,
     disableListenLog: true,
   }).pipe(
+    Layer.provideMerge(ClientLifecycle.layer(opts.shutdownAfterLastClient)),
     Layer.provideMerge(AppNodeBuilder.build(WebSocketTracker.node)),
     Layer.provideMerge(serverLayer({ port, hostname: opts.hostname })),
     // Install a fresh `ConfigProvider` per listener so `Config.string(...)`
@@ -132,6 +140,7 @@ function startListener(opts: ListenOptions, port: number) {
         server: Context.get(ctx, HttpServer.HttpServer),
         http: Context.get(ctx, ListenerServerService),
         websockets: Context.get(ctx, WebSocketTracker.Service),
+        lifecycle: Context.get(ctx, ClientLifecycle.Service),
       }),
     ),
   )

--- a/packages/opencode/test/cli/serve/serve-process.test.ts
+++ b/packages/opencode/test/cli/serve/serve-process.test.ts
@@ -9,6 +9,7 @@ import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { HttpClient } from "effect/unstable/http"
 import { cliIt } from "../../lib/cli-process"
+import { withTimeout } from "../../../src/util/timeout"
 
 describe("opencode serve (subprocess)", () => {
   // Smoke test: server starts, binds a port, and /global/health responds.
@@ -54,6 +55,32 @@ describe("opencode serve (subprocess)", () => {
         // Bun reports the exit code; SIGTERM-killed processes return non-null
         // (typically 143 on POSIX). We just require resolution within a sane
         // window — anything else means the kill didn't take.
+        expect(typeof code === "number" || code === null).toBe(true)
+      }),
+    60_000,
+  )
+
+  cliIt.live(
+    "exits after the last global event client disconnects when requested",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const server = yield* opencode.serve({ extraArgs: ["--shutdown-after-last-client"] })
+        const abort = new AbortController()
+        const response = yield* Effect.promise(() => fetch(`${server.url}/global/event`, { signal: abort.signal }))
+        expect(response.status).toBe(200)
+        const reader = response.body?.getReader()
+        if (!reader) throw new Error("global event response has no body")
+        const first = yield* Effect.promise(() =>
+          withTimeout(reader.read(), 5_000, "timed out waiting for global event stream"),
+        )
+        if (first.done || !first.value) throw new Error("global event stream closed before first event")
+        expect(new TextDecoder().decode(first.value)).toContain("server.connected")
+
+        yield* Effect.promise(() => reader.cancel().catch(() => undefined))
+        abort.abort()
+        const code = yield* Effect.promise(() =>
+          withTimeout(server.exited, 10_000, "timed out waiting for self-managed serve exit"),
+        )
         expect(typeof code === "number" || code === null).toBe(true)
       }),
     60_000,

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -4,7 +4,12 @@ import fs from "fs/promises"
 import path from "path"
 import yargs from "yargs"
 import { tmpdir } from "../../fixture/fixture"
-import { TuiThreadCommand, resolveThreadDirectory } from "../../../src/cli/cmd/tui"
+import {
+  hasExplicitNetworkOptions,
+  resolveAutoAttachTarget,
+  TuiThreadCommand,
+  resolveThreadDirectory,
+} from "../../../src/cli/cmd/tui"
 import { cliIt } from "../../lib/cli-process"
 
 describe("tui thread", () => {
@@ -92,4 +97,127 @@ describe("tui thread", () => {
       expect(result.stderr).toContain("--port cannot be used with --mini")
     }),
   )
+
+  test("does not probe when server.attach is not configured", async () => {
+    let called = false
+    const result = await resolveAutoAttachTarget({
+      fetch: async () => {
+        called = true
+        return Response.json({ healthy: true })
+      },
+    })
+
+    expect(result.type).toBe("embedded")
+    expect(called).toBe(false)
+  })
+
+  test("attaches when the configured server is healthy", async () => {
+    const requests: URL[] = []
+    let headers: RequestInit["headers"]
+    const result = await resolveAutoAttachTarget({
+      url: "http://localhost:4096/",
+      headers: { Authorization: "Basic test" },
+      fetch: async (input, init) => {
+        requests.push(input instanceof URL ? input : new URL(input.toString()))
+        headers = init?.headers
+        return Response.json({ healthy: true, version: "dev" })
+      },
+    })
+
+    expect(result).toEqual({
+      type: "attach",
+      url: "http://localhost:4096/",
+      headers: { Authorization: "Basic test" },
+    })
+    expect(requests.map((item) => item.toString())).toEqual(["http://localhost:4096/global/health"])
+    expect(headers).toEqual({ Authorization: "Basic test" })
+  })
+
+  test("starts a local configured server when it is unreachable", async () => {
+    const requests: URL[] = []
+    const spawns: { hostname: string; port: number; shutdownAfterLastClient: boolean }[] = []
+    let attempts = 0
+    const result = await resolveAutoAttachTarget({
+      url: "http://localhost:4096",
+      startupAttempts: 2,
+      startupDelayMs: 0,
+      fetch: async (input) => {
+        requests.push(input instanceof URL ? input : new URL(input.toString()))
+        attempts++
+        if (attempts === 1) throw new Error("ECONNREFUSED")
+        return Response.json({ healthy: true, version: "dev" })
+      },
+      spawn: (input) => {
+        spawns.push(input)
+      },
+    })
+
+    expect(result).toEqual({ type: "attach", url: "http://localhost:4096", headers: undefined })
+    expect(requests.map((item) => item.toString())).toEqual([
+      "http://localhost:4096/global/health",
+      "http://localhost:4096/global/health",
+    ])
+    expect(spawns).toEqual([{ hostname: "localhost", port: 4096, shutdownAfterLastClient: true }])
+  })
+
+  test("reports unreachable remote servers instead of falling back", async () => {
+    const result = await resolveAutoAttachTarget({
+      url: "http://192.168.1.100:4096",
+      fetch: async () => {
+        throw new Error("ECONNREFUSED")
+      },
+    })
+
+    expect(result).toEqual({ type: "fatal", message: "server.attach target is unreachable" })
+  })
+
+  test("reports local startup failures", async () => {
+    const result = await resolveAutoAttachTarget({
+      url: "http://127.0.0.1:4096",
+      fetch: async () => {
+        throw new Error("ECONNREFUSED")
+      },
+      spawn: () => {
+        throw new Error("spawn failed")
+      },
+    })
+
+    expect(result).toEqual({ type: "fatal", message: "Failed to start server.attach target: spawn failed" })
+  })
+
+  test("reports authentication failures instead of falling back", async () => {
+    const result = await resolveAutoAttachTarget({
+      url: "http://localhost:4096",
+      fetch: async () => new Response(undefined, { status: 401 }),
+    })
+
+    expect(result).toEqual({ type: "fatal", message: "server.attach authentication failed" })
+  })
+
+  test("reports invalid attach urls", async () => {
+    const result = await resolveAutoAttachTarget({
+      url: "not a url",
+    })
+
+    expect(result.type).toBe("fatal")
+  })
+
+  test("reports non-opencode health responses", async () => {
+    const result = await resolveAutoAttachTarget({
+      url: "http://localhost:4096",
+      fetch: async () => Response.json({ ok: true }),
+    })
+
+    expect(result).toEqual({
+      type: "fatal",
+      message: "server.attach target is not a healthy opencode server",
+    })
+  })
+
+  test("skips auto attach when network options are explicit", () => {
+    expect(hasExplicitNetworkOptions(["opencode", "--port", "4096"])).toBe(true)
+    expect(hasExplicitNetworkOptions(["opencode", "--hostname=0.0.0.0"])).toBe(true)
+    expect(hasExplicitNetworkOptions(["opencode", "--cors", "http://localhost:5173"])).toBe(true)
+    expect(hasExplicitNetworkOptions(["opencode"])).toBe(false)
+  })
 })

--- a/packages/opencode/test/server/httpapi-listen.test.ts
+++ b/packages/opencode/test/server/httpapi-listen.test.ts
@@ -166,6 +166,41 @@ async function openPtySocket(listener: Awaited<ReturnType<typeof startListener>>
   }
 }
 
+async function openGlobalEvent(listener: Awaited<ReturnType<typeof startListener>>) {
+  const abort = new AbortController()
+  const response = await fetch(new URL("/global/event", listener.url), {
+    headers: { authorization: authorization() },
+    signal: abort.signal,
+  })
+  expect(response.status).toBe(200)
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error("global event response has no body")
+  const first = await withTimeout(reader.read(), 5_000, "timed out waiting for global event stream")
+  if (first.done || !first.value) throw new Error("global event stream closed before first event")
+  expect(new TextDecoder().decode(first.value)).toContain("server.connected")
+
+  let closed = false
+  return {
+    close: async () => {
+      if (closed) return
+      closed = true
+      await reader.cancel().catch(() => undefined)
+      abort.abort()
+    },
+  }
+}
+
+async function expectPending(promise: Promise<void>, duration: number, label: string) {
+  let resolved = false
+  await Promise.race([
+    promise.then(() => {
+      resolved = true
+    }),
+    new Promise((resolve) => setTimeout(resolve, duration)),
+  ])
+  if (resolved) throw new Error(label)
+}
+
 describe("HttpApi Server.listen", () => {
   testPty("serves HTTP routes and upgrades PTY websocket through Server.listen", async () => {
     await using tmp = await tmpdir({ config: { formatter: false, lsp: false } })
@@ -282,6 +317,44 @@ describe("HttpApi Server.listen", () => {
     await expect(
       fetch(new URL(PtyPaths.shells, listener.url), { headers: { authorization: authorization() } }),
     ).rejects.toThrow()
+  })
+
+  test("shutdownAfterLastClient waits for the last global event client", async () => {
+    const listener = await Server.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      shutdownAfterLastClient: { initialGraceMs: 1_000, lastClientGraceMs: 80 },
+    })
+    const idle = listener.idle
+    if (!idle) throw new Error("listener did not expose idle promise")
+    const first = await openGlobalEvent(listener)
+    const second = await openGlobalEvent(listener)
+    try {
+      await expectPending(idle, 120, "listener idled while clients were connected")
+      await first.close()
+      await expectPending(idle, 120, "listener idled before the last client disconnected")
+      await second.close()
+      await withTimeout(idle, 2_000, "timed out waiting for last-client idle")
+    } finally {
+      await first.close()
+      await second.close()
+      await stop(listener, "timed out cleaning up last-client listener").catch(() => undefined)
+    }
+  })
+
+  test("shutdownAfterLastClient idles when no global event client connects", async () => {
+    const listener = await Server.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      shutdownAfterLastClient: { initialGraceMs: 50, lastClientGraceMs: 50 },
+    })
+    const idle = listener.idle
+    if (!idle) throw new Error("listener did not expose idle promise")
+    try {
+      await withTimeout(idle, 2_000, "timed out waiting for initial idle")
+    } finally {
+      await stop(listener, "timed out cleaning up initial-idle listener").catch(() => undefined)
+    }
   })
 
   test("default in-process handler does not emit Effect HTTP response logs", async () => {

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.17.12",
+  "version": "1.17.13",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #17322, About 40% of this diff is focused test coverage.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds a `server.attach` config value for the default TUI path.

 When configured, `opencode` checks the target server's `/global/health` endpoint and attaches to it instead of starting the embedded server. When unset, existing behavior is unchanged.

```jsonc
  {
    "server": {
      "attach": "http://127.0.0.1:4096"
    }
  }
```

For local attach targets, the TUI can start opencode serve when no server is already listening. That auto-started server shuts down after the last client disconnects, avoiding stale local server processes while preserving the current embedded default for users who do not opt in.

### How did you verify your code works?

Added focused tests covering the config-driven attach path, preserved embedded fallback behavior, local auto-start failures/success, and last-client shutdown for auto-started `serve` processes.

### Screenshots / recordings

This enables shared-server workflows where multiple clients connect to the same opencode session.

![bidirectional sync demo](https://github.com/sudo-tee/opencode.nvim/raw/main/docs/recipes/bidirectional-sync/bidirectional-sync.gif)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
