### PR TITLE
fix(workflows): serialize desktop release uploads

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -334,9 +334,9 @@ jobs:
           VITE_SENTRY_ENVIRONMENT: ${{ (github.ref_name == 'beta' && 'beta') || 'production' }}
           VITE_SENTRY_RELEASE: desktop@${{ needs.version.outputs.version }}
 
-      - name: Package and publish
+      - name: Package
         if: needs.version.outputs.release
-        run: npx electron-builder ${{ matrix.settings.platform_flag }} --publish always --config electron-builder.config.ts
+        run: npx electron-builder ${{ matrix.settings.platform_flag }} --publish never --config electron-builder.config.ts
         working-directory: packages/desktop
         timeout-minutes: 60
         env:
@@ -356,11 +356,9 @@ jobs:
         env:
           OPENCODE_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
 
-      - name: Create and upload macOS .app.tar.gz
+      - name: Create macOS .app.tar.gz
         if: runner.os == 'macOS' && needs.version.outputs.release
         working-directory: packages/desktop/dist
-        env:
-          GH_TOKEN: ${{ steps.committer.outputs.token }}
         run: |
           if [[ "${{ matrix.settings.target }}" == "x86_64-apple-darwin" ]]; then
             APP_DIR="mac"
@@ -378,7 +376,6 @@ jobs:
             exit 1
           fi
           tar -czf "$OUT_NAME" -C "$(dirname "$APP_PATH")" "$(basename "$APP_PATH")"
-          gh release upload "v${{ needs.version.outputs.version }}" "$OUT_NAME" --clobber --repo "${{ needs.version.outputs.repo }}"
 
       - name: Verify signed Windows Electron artifacts
         if: runner.os == 'Windows'
@@ -464,6 +461,13 @@ jobs:
           pattern: latest-yml-*
           path: /tmp/latest-yml
 
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        if: needs.version.outputs.release
+        with:
+          pattern: opencode-desktop-*
+          path: /tmp/desktop
+          merge-multiple: true
+
       - name: Setup git committer
         id: committer
         uses: ./.github/actions/setup-git-committer
@@ -489,6 +493,19 @@ jobs:
           git config --global user.email "opencode@sst.dev"
           git config --global user.name "opencode"
           ssh-keyscan -H aur.archlinux.org >> ~/.ssh/known_hosts || true
+
+      - name: Upload desktop release assets
+        if: needs.version.outputs.release
+        env:
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
+        run: |
+          shopt -s nullglob
+          files=(/tmp/desktop/*.{exe,blockmap,dmg,zip,AppImage,deb,rpm} /tmp/desktop/*.app.tar.gz)
+          if (( ${#files[@]} == 0 )); then
+            echo "No desktop release assets found"
+            exit 1
+          fi
+          gh release upload "v${{ needs.version.outputs.version }}" "${files[@]}" --clobber --repo "${{ needs.version.outputs.repo }}"
 
       - run: ./script/publish.ts
         env:


### PR DESCRIPTION
## Summary
- package desktop matrix outputs without publishing from each runner
- download all desktop artifacts in the publish job
- upload desktop assets to the single draft release before updater finalization

## Why
Concurrent electron-builder publishers can create multiple drafts for the same version and split release assets across them.

## Validation
- `actionlint .github/workflows/publish.yml`
- `git diff --check`