### PR TITLE
fix(core): scope Vertex provider transforms

### DIFF
--- a/packages/core/src/plugin/provider/google-vertex.ts
+++ b/packages/core/src/plugin/provider/google-vertex.ts
@@ -63,7 +63,10 @@ export const GoogleVertexPlugin = PluginV2.define({
           if (item.provider.api.type !== "aisdk") continue
           if (
             item.provider.api.package !== "@ai-sdk/google-vertex" &&
-            !item.provider.api.package.includes("@ai-sdk/openai-compatible")
+            !(
+              item.provider.id === ProviderV2.ID.googleVertex &&
+              item.provider.api.package.includes("@ai-sdk/openai-compatible")
+            )
           )
             continue
           const project = resolveProject(item.provider.request.body)

--- a/packages/core/test/plugin/provider-google-vertex.test.ts
+++ b/packages/core/test/plugin/provider-google-vertex.test.ts
@@ -35,6 +35,27 @@ void mock.module("google-auth-library", () => ({
 }))
 
 describe("GoogleVertexPlugin", () => {
+  it.effect("ignores OpenAI-compatible providers that are not Google Vertex", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const catalog = yield* Catalog.Service
+      yield* plugin.add(GoogleVertexPlugin)
+      const transform = yield* catalog.transform()
+      yield* transform((catalog) =>
+        catalog.provider.update(ProviderV2.ID.opencode, (provider) => {
+          provider.api = {
+            type: "aisdk",
+            package: "@ai-sdk/openai-compatible",
+            url: "https://opencode.ai/zen/v1",
+          }
+        }),
+      )
+
+      const provider = yield* catalog.provider.get(ProviderV2.ID.opencode)
+      expect(provider.request.body).toEqual({})
+    }),
+  )
+
   it.effect("resolves project and location from env using legacy precedence", () =>
     withEnv(
       {


### PR DESCRIPTION
## Summary
- restrict OpenAI-compatible Vertex catalog transforms to the `google-vertex` provider
- prevent Vertex `location` and auth `fetch` options from leaking into unrelated providers such as OpenCode Zen
- add a regression for the exact cross-provider mutation

## Root cause
The Google Vertex plugin matched every provider using `@ai-sdk/openai-compatible`. It consequently added `location: "us-central1"` and a Vertex auth fetch to the `opencode` provider. A model-level override to `@ai-sdk/openai` then forwarded `location` as a raw OpenAI Responses body field, producing HTTP 400.

## Verification
- 28 focused provider and request tests
- Core typecheck
- 22-package push-hook typecheck
- Prettier check