### PR TITLE
fix(opencode): support proxied MCP OAuth callbacks

### DIFF
--- a/packages/core/src/v1/config/mcp.ts
+++ b/packages/core/src/v1/config/mcp.ts
@@ -30,7 +30,11 @@ export const OAuth = Schema.Struct({
   scope: Schema.optional(Schema.String).annotate({ description: "OAuth scopes to request during authorization" }),
   callbackPort: Schema.optional(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }))).annotate({
     description:
-      "Port for the local OAuth callback server (default: 19876). Shorthand for redirectUri when only the port needs changing. Ignored if redirectUri is set.",
+      "Port for the local OAuth callback server (default: 19876). When redirectUri is unset, also changes the generated localhost redirect URI.",
+  }),
+  callbackPath: Schema.optional(Schema.String).annotate({
+    description:
+      "Path for the local OAuth callback server (default: /mcp/oauth/callback). With a non-local redirectUri, this enables a separate local callback listener.",
   }),
   redirectUri: Schema.optional(Schema.String).annotate({
     description: "OAuth redirect URI (default: http://127.0.0.1:19876/mcp/oauth/callback).",

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -713,6 +713,8 @@ export const McpDebugCommand = effectCmd({
               clientId: oauthConfig?.clientId,
               clientSecret: oauthConfig?.clientSecret,
               scope: oauthConfig?.scope,
+              callbackPort: oauthConfig?.callbackPort,
+              callbackPath: oauthConfig?.callbackPath,
               redirectUri: oauthConfig?.redirectUri,
             },
             {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -20,7 +20,7 @@ import { NamedError } from "@opencode-ai/core/util/error"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { withTimeout } from "@/util/timeout"
 import { FSUtil } from "@opencode-ai/core/fs-util"
-import { McpOAuthProvider, OAUTH_CALLBACK_PATH } from "./oauth-provider"
+import { McpOAuthProvider, resolveCallback } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -327,6 +327,7 @@ export const layer = Layer.effect(
             clientSecret: oauthConfig?.clientSecret,
             scope: oauthConfig?.scope,
             callbackPort: oauthConfig?.callbackPort,
+            callbackPath: oauthConfig?.callbackPath,
             redirectUri: oauthConfig?.redirectUri,
           },
           {
@@ -789,13 +790,13 @@ export const layer = Layer.effect(
       // OAuth config is optional - if not provided, we'll use auto-discovery
       const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined
 
-      // Resolve effective redirect URI: explicit redirectUri > callbackPort shorthand > default
-      const effectiveRedirectUri =
-        oauthConfig?.redirectUri ??
-        (oauthConfig?.callbackPort ? `http://127.0.0.1:${oauthConfig.callbackPort}${OAUTH_CALLBACK_PATH}` : undefined)
+      const callback = resolveCallback(
+        oauthConfig?.redirectUri,
+        oauthConfig?.callbackPort,
+        oauthConfig?.callbackPath,
+      )
 
-      // Start the callback server with custom redirectUri if configured
-      yield* Effect.promise(() => McpOAuthCallback.ensureRunning(effectiveRedirectUri))
+      yield* Effect.promise(() => McpOAuthCallback.ensureRunning(callback))
 
       const oauthState = Array.from(crypto.getRandomValues(new Uint8Array(32)))
         .map((b) => b.toString(16).padStart(2, "0"))
@@ -809,7 +810,9 @@ export const layer = Layer.effect(
           clientId: oauthConfig?.clientId,
           clientSecret: oauthConfig?.clientSecret,
           scope: oauthConfig?.scope,
-          redirectUri: effectiveRedirectUri,
+          callbackPort: oauthConfig?.callbackPort,
+          callbackPath: oauthConfig?.callbackPath,
+          redirectUri: oauthConfig?.redirectUri,
         },
         {
           onRedirect: async (url) => {

--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -1,7 +1,7 @@
 import { createConnection } from "net"
 import { createServer } from "http"
 import * as Log from "@opencode-ai/core/util/log"
-import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH, parseRedirectUri } from "./oauth-provider"
+import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH, parseRedirectUri, normalizeCallbackPath } from "./oauth-provider"
 
 const log = Log.create({ service: "mcp.oauth-callback" })
 
@@ -138,9 +138,14 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
   res.end(HTML_SUCCESS)
 }
 
-export async function ensureRunning(redirectUri?: string): Promise<void> {
-  // Parse the redirect URI to get port and path (uses defaults if not provided)
-  const { port, path } = parseRedirectUri(redirectUri)
+export async function ensureRunning(options?: string | { port?: number; path?: string }): Promise<void> {
+  const { port, path } =
+    typeof options === "object"
+      ? {
+          port: options.port ?? OAUTH_CALLBACK_PORT,
+          path: normalizeCallbackPath(options.path),
+        }
+      : parseRedirectUri(options)
 
   // If server is running on a different port/path, stop it first
   if (server && (currentPort !== port || currentPath !== path)) {

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -19,6 +19,7 @@ export interface McpOAuthConfig {
   clientSecret?: string
   scope?: string
   callbackPort?: number
+  callbackPath?: string
   redirectUri?: string
 }
 
@@ -40,7 +41,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
       return this.config.redirectUri
     }
     const port = this.config.callbackPort ?? OAUTH_CALLBACK_PORT
-    return `http://127.0.0.1:${port}${OAUTH_CALLBACK_PATH}`
+    const path = normalizeCallbackPath(this.config.callbackPath)
+    return `http://127.0.0.1:${port}${path}`
   }
 
   get clientMetadata(): OAuthClientMetadata {
@@ -209,9 +211,42 @@ export function parseRedirectUri(redirectUri?: string): { port: number; path: st
   try {
     const url = new URL(redirectUri)
     const port = url.port ? parseInt(url.port, 10) : url.protocol === "https:" ? 443 : 80
-    const path = url.pathname || OAUTH_CALLBACK_PATH
+    const path = normalizeCallbackPath(url.pathname)
     return { port, path }
   } catch {
     return { port: OAUTH_CALLBACK_PORT, path: OAUTH_CALLBACK_PATH }
   }
+}
+
+export function resolveCallback(redirectUri?: string, callbackPort?: number, callbackPath?: string) {
+  const path = normalizeCallbackPath(callbackPath)
+
+  if (!redirectUri) {
+    return {
+      port: callbackPort ?? OAUTH_CALLBACK_PORT,
+      path,
+    }
+  }
+
+  try {
+    const url = new URL(redirectUri)
+    if (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "::1") {
+      return parseRedirectUri(redirectUri)
+    }
+  } catch {
+    if (callbackPath === undefined) return parseRedirectUri(redirectUri)
+    return { port: callbackPort ?? OAUTH_CALLBACK_PORT, path }
+  }
+
+  if (callbackPath === undefined) return parseRedirectUri(redirectUri)
+
+  return {
+    port: callbackPort ?? OAUTH_CALLBACK_PORT,
+    path,
+  }
+}
+
+export function normalizeCallbackPath(path?: string) {
+  if (!path) return OAUTH_CALLBACK_PATH
+  return path.startsWith("/") ? path : `/${path}`
 }

--- a/packages/opencode/test/mcp/oauth-callback.test.ts
+++ b/packages/opencode/test/mcp/oauth-callback.test.ts
@@ -31,4 +31,9 @@ describe("McpOAuthCallback.ensureRunning", () => {
     await McpOAuthCallback.ensureRunning("http://127.0.0.1:18000/custom/callback")
     expect(McpOAuthCallback.isRunning()).toBe(true)
   })
+
+  test("starts server with callback options", async () => {
+    await McpOAuthCallback.ensureRunning({ port: 18001, path: "/mcp/oauth/callback" })
+    expect(McpOAuthCallback.isRunning()).toBe(true)
+  })
 })

--- a/packages/opencode/test/mcp/oauth-provider.test.ts
+++ b/packages/opencode/test/mcp/oauth-provider.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { McpOAuthProvider, OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH } from "../../src/mcp/oauth-provider"
+import { McpOAuthProvider, OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH, resolveCallback } from "../../src/mcp/oauth-provider"
 import type { McpAuth } from "../../src/mcp/auth"
 
 // Stub auth — only synchronous getters are exercised in these tests
@@ -19,9 +19,20 @@ describe("McpOAuthProvider.redirectUrl", () => {
     expect(provider.redirectUrl).toBe(`http://127.0.0.1:6620${OAUTH_CALLBACK_PATH}`)
   })
 
+  test("uses callbackPath when set without redirectUri", () => {
+    const provider = makeProvider({ callbackPath: "/custom/callback" })
+    expect(provider.redirectUrl).toBe(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}/custom/callback`)
+  })
+
+  test("normalizes callbackPath when set without redirectUri", () => {
+    const provider = makeProvider({ callbackPath: "custom/callback" })
+    expect(provider.redirectUrl).toBe(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}/custom/callback`)
+  })
+
   test("redirectUri takes precedence over callbackPort", () => {
     const provider = makeProvider({
       callbackPort: 6620,
+      callbackPath: "/local/callback",
       redirectUri: "http://127.0.0.1:9999/custom/callback",
     })
     expect(provider.redirectUrl).toBe("http://127.0.0.1:9999/custom/callback")
@@ -37,6 +48,17 @@ describe("McpOAuthProvider.clientMetadata", () => {
   test("includes redirect_uris from redirectUrl", () => {
     const provider = makeProvider({ callbackPort: 6620 })
     expect(provider.clientMetadata.redirect_uris).toEqual([`http://127.0.0.1:6620${OAUTH_CALLBACK_PATH}`])
+  })
+
+  test("keeps public redirectUri in provider metadata", () => {
+    const provider = makeProvider({
+      callbackPort: 19876,
+      callbackPath: "/mcp/oauth/callback",
+      redirectUri: "https://jove.example.com/hub/user-redirect/proxy/19876/mcp/oauth/callback",
+    })
+    expect(provider.clientMetadata.redirect_uris).toEqual([
+      "https://jove.example.com/hub/user-redirect/proxy/19876/mcp/oauth/callback",
+    ])
   })
 
   test("includes scope when set in config", () => {
@@ -57,5 +79,50 @@ describe("McpOAuthProvider.clientMetadata", () => {
   test("sets token_endpoint_auth_method to none when no clientSecret", () => {
     const provider = makeProvider({})
     expect(provider.clientMetadata.token_endpoint_auth_method).toBe("none")
+  })
+})
+
+describe("resolveCallback", () => {
+  test("uses explicit callbackPort and callbackPath independently of public redirectUri", () => {
+    const result = resolveCallback(
+      "https://jove.example.com/hub/user-redirect/proxy/19876/mcp/oauth/callback",
+      19876,
+      "/mcp/oauth/callback",
+    )
+    expect(result).toEqual({ port: 19876, path: "/mcp/oauth/callback" })
+  })
+
+  test("preserves non-local redirectUri compatibility without callback override", () => {
+    const result = resolveCallback("https://oauth.example.com:8443/custom/callback")
+    expect(result).toEqual({ port: 8443, path: "/custom/callback" })
+  })
+
+  test("preserves non-local redirectUri when only callbackPort is also set", () => {
+    const result = resolveCallback("https://oauth.example.com:8443/custom/callback", 6620)
+    expect(result).toEqual({ port: 8443, path: "/custom/callback" })
+  })
+
+  test("uses callback override for public HTTPS redirectUri", () => {
+    const result = resolveCallback(
+      "https://jove.example.com/hub/user-redirect/proxy/19876/mcp/oauth/callback",
+      19876,
+      "mcp/oauth/callback",
+    )
+    expect(result).toEqual({ port: 19876, path: "/mcp/oauth/callback" })
+  })
+
+  test("preserves localhost redirectUri compatibility", () => {
+    const result = resolveCallback("http://127.0.0.1:8080/oauth/callback")
+    expect(result).toEqual({ port: 8080, path: "/oauth/callback" })
+  })
+
+  test("preserves localhost redirectUri when callback shorthand is also set", () => {
+    const result = resolveCallback("http://127.0.0.1:8080/oauth/callback", 6620, "/other/callback")
+    expect(result).toEqual({ port: 8080, path: "/oauth/callback" })
+  })
+
+  test("keeps callbackPort-only behavior", () => {
+    const result = resolveCallback(undefined, 6620)
+    expect(result).toEqual({ port: 6620, path: OAUTH_CALLBACK_PATH })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31014.

Related to #7377, #18955, and #23787.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes MCP OAuth for environments where the browser reaches OpenCode through a public/proxied URL, but OpenCode still needs to listen on a local callback server. One example is OpenCode running inside a JupyterHub user server or another proxied container environment, where the browser sees a public URL that forwards back to the local callback listener.

Before this change, `oauth.redirectUri` was used for both the provider-facing OAuth redirect URI and for choosing the local callback listener port/path. That works for simple localhost flows, but breaks proxied setups.

This separates the two concerns:

- `redirectUri` stays as the OAuth provider redirect URI, and is used by the MCP SDK for authorization and token exchange.
- `callbackPort` / `callbackPath` control the local callback listener when using a public/non-local redirect URI.
- Existing localhost and existing non-local `redirectUri` behavior is preserved unless `callbackPath` is set.

### How did you verify your code works?

- Ran `bun test test/mcp/oauth-provider.test.ts test/mcp/oauth-callback.test.ts test/mcp/oauth-auto-connect.test.ts --timeout 30000` from `packages/opencode`
- Ran `bun typecheck` from `packages/opencode`
- Pushed the branch, which ran the workspace pre-push `bun turbo typecheck` hook successfully
- Manually tested Slack MCP OAuth through a proxied JupyterHub environment

### Screenshots / recordings

N/A, CLI/OAuth behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
