### PR TITLE
fix(tui): bootstrap new project copies

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/move.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/move.tsx
@@ -37,6 +37,11 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
       )
       const directory = result.data?.directory
       if (!directory) throw new Error("No project copy directory returned")
+
+      // Call a location-based route to make sure it's bootstrapped
+      // before moving on
+      await sdk.client.path.get({ directory }, { throwOnError: true })
+
       setProgress("Creating session")
       return directory
     } catch (err) {


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

New project copies created from the move flow could be used before their location was bootstrapped. After the copy endpoint returns its directory, this change awaits the `/path` SDK endpoint for that directory before creating or moving the session. The request remains within the existing “Creating copy” loading stage and uses the existing failure handling.

### How did you verify your code works?

- Full repository typecheck passed via the pre-push hook (`bun turbo typecheck`, 22 packages).
- Prettier and `git diff --check` passed.

### Screenshots / recordings

Not applicable; the existing loading UI is unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR