### PR TITLE
fix: support model variants in context limit and compaction

### DIFF
--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -11,6 +11,7 @@ type Model = {
   limit: {
     context: number
   }
+  variants?: Record<string, { limit?: { context?: number } }>
 }
 
 type Context = {
@@ -54,7 +55,7 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Metrics =>
 
   const provider = providers.find((item) => item.id === message.providerID)
   const model = provider?.models[message.modelID]
-  const limit = model?.limit.context
+  const limit = (message.variant && model?.variants?.[message.variant]?.limit?.context) || model?.limit.context
   const total = tokenTotal(message)
 
   return {

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -598,7 +598,7 @@ function makeUsageService(sdk: OpencodeClient) {
   const limits = new Map<string, Promise<number | undefined>>()
   const contextLimit: UsageService.Interface["contextLimit"] = Effect.fn("ACP.promptUsage.contextLimit")(
     function* (params) {
-      const key = `${params.directory}\u0000${params.providerID}\u0000${params.modelID}`
+      const key = `${params.directory}\u0000${params.providerID}\u0000${params.modelID}\u0000${params.variant ?? ""}`
       const current = limits.get(key)
       if (current) return yield* Effect.promise(() => current)
 
@@ -608,7 +608,7 @@ function makeUsageService(sdk: OpencodeClient) {
           const providers = Object.fromEntries(
             (response.data?.providers ?? []).map((provider) => [provider.id, provider]),
           ) as Record<ProviderV2.ID, Provider.Info>
-          return UsageService.findContextLimit(providers, params.providerID, params.modelID)
+          return UsageService.findContextLimit(providers, params.providerID, params.modelID, params.variant)
         })
         .catch((error: unknown) => {
           log.error("failed to get providers for usage context limit", { error })
@@ -648,6 +648,7 @@ function makeUsageService(sdk: OpencodeClient) {
       directory: params.directory,
       providerID: ProviderV2.ID.make(message.providerID),
       modelID: ModelV2.ID.make(message.modelID),
+      variant: message.variant,
     })
     if (!size) return
 

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -14,7 +14,7 @@ export type AssistantTokenCost = Pick<OpenCodeAssistantMessage, "cost" | "tokens
 
 export type AssistantMessage = AssistantTokenCost &
   Pick<OpenCodeAssistantMessage, "role"> &
-  Partial<Pick<OpenCodeAssistantMessage, "providerID" | "modelID">>
+  Partial<Pick<OpenCodeAssistantMessage, "providerID" | "modelID" | "variant">>
 
 export type SessionMessage = {
   readonly info: { readonly role: Message["role"] } | AssistantMessage
@@ -52,6 +52,7 @@ export interface Interface {
     readonly directory: string
     readonly providerID: ProviderV2.ID
     readonly modelID: ModelV2.ID
+    readonly variant?: string
   }) => Effect.Effect<number | undefined>
   readonly sendUpdate: (input: {
     readonly connection: UsageConnection
@@ -114,8 +115,15 @@ export function findContextLimit(
   providers: Record<ProviderV2.ID, Provider.Info>,
   providerID: ProviderV2.ID,
   modelID: ModelV2.ID,
+  variant?: string,
 ): number | undefined {
-  return providers[providerID]?.models[modelID]?.limit.context
+  const model = providers[providerID]?.models[modelID]
+  if (!model) return undefined
+  if (variant) {
+    const v = model.variants?.[variant]
+    if (v?.limit?.context) return v.limit.context
+  }
+  return model.limit.context
 }
 
 export const contextLimitLoaderLayer = Layer.effect(
@@ -146,16 +154,17 @@ export const layer = Layer.effect(
       readonly directory: string
       readonly providerID: ProviderV2.ID
       readonly modelID: ModelV2.ID
+      readonly variant?: string
     }) {
       return yield* SynchronizedRef.modifyEffect(
         limits,
         Effect.fnUntraced(function* (items) {
-          const key = `${input.directory}\u0000${input.providerID}\u0000${input.modelID}`
+          const key = `${input.directory}\u0000${input.providerID}\u0000${input.modelID}\u0000${input.variant ?? ""}`
           const current = items.get(key)
           if (current) return [current, items] as const
           const next = yield* Effect.cached(
             contextLimitLoader.providers(input.directory).pipe(
-              Effect.map((providers) => findContextLimit(providers, input.providerID, input.modelID)),
+              Effect.map((providers) => findContextLimit(providers, input.providerID, input.modelID, input.variant)),
               Effect.catch((error) =>
                 Effect.sync(() => {
                   log.error("failed to get providers for usage context limit", { error })
@@ -173,6 +182,7 @@ export const layer = Layer.effect(
       readonly directory: string
       readonly providerID: ProviderV2.ID
       readonly modelID: ModelV2.ID
+      readonly variant?: string
     }) {
       return yield* yield* cachedLimit(input)
     })
@@ -200,6 +210,7 @@ export const layer = Layer.effect(
         directory: input.directory,
         providerID: ProviderV2.ID.make(message.providerID),
         modelID: ModelV2.ID.make(message.modelID),
+        variant: message.variant,
       })
       if (!size) return
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -255,7 +255,10 @@ export function Prompt(props: PromptProps) {
     if (tokens <= 0) return
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+    type VariantConfig = { limit?: { context?: number } }
+    const modelVariants: Record<string, VariantConfig> | undefined = model?.variants
+    const limit = (last.variant && (modelVariants?.[last.variant]?.limit?.context)) || model?.limit.context
+    const pct = limit ? `${Math.round((tokens / limit) * 100)}%` : undefined
     const cost = session?.cost ?? 0
     return {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -28,9 +28,12 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
     const tokens =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    type VariantConfig = { limit?: { context?: number } }
+    const modelVariants: Record<string, VariantConfig> | undefined = model?.variants
+    const limit = (last.variant && modelVariants?.[last.variant]?.limit?.context) || model?.limit.context
     return {
       tokens,
-      percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
+      percent: limit ? Math.round((tokens / limit) * 100) : null,
     }
   })
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -40,7 +40,11 @@ export function SubagentFooter() {
     if (tokens <= 0) return
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+    type VariantConfig = { limit?: { context?: number } }
+    const modelVariants: Record<string, VariantConfig> | undefined = model?.variants
+
+    const limit = (last.variant && modelVariants?.[last.variant]?.limit?.context) || model?.limit.context
+    const pct = limit ? `${Math.round((tokens / limit) * 100)}%` : undefined
     const cost = session()?.cost ?? 0
 
     const money = new Intl.NumberFormat("en-US", {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -89,7 +89,7 @@ function completedCompactions(messages: SessionV1.WithParts[]) {
   })
 }
 
-function preserveRecentBudget(input: { cfg: ConfigV1.Info; model: Provider.Model }) {
+function preserveRecentBudget(input: { cfg: ConfigV1.Info; model: Provider.Model; variant?: string }) {
   return (
     input.cfg.compaction?.preserve_recent_tokens ??
     Math.min(MAX_PRESERVE_RECENT_TOKENS, Math.max(MIN_PRESERVE_RECENT_TOKENS, Math.floor(usable(input) * 0.25)))
@@ -143,6 +143,7 @@ export interface Interface {
   readonly isOverflow: (input: {
     tokens: SessionV1.Assistant["tokens"]
     model: Provider.Model
+    variant?: string
   }) => Effect.Effect<boolean>
   readonly prune: (input: { sessionID: SessionID }) => Effect.Effect<void>
   readonly process: (input: {
@@ -180,12 +181,14 @@ export const layer = Layer.effect(
     const isOverflow = Effect.fn("SessionCompaction.isOverflow")(function* (input: {
       tokens: SessionV1.Assistant["tokens"]
       model: Provider.Model
+      variant?: string
     }) {
       return overflow({
         cfg: yield* config.get(),
         tokens: input.tokens,
         model: input.model,
         outputTokenMax: flags.outputTokenMax,
+        variant: input.variant,
       })
     })
 
@@ -201,10 +204,11 @@ export const layer = Layer.effect(
       messages: SessionV1.WithParts[]
       cfg: ConfigV1.Info
       model: Provider.Model
+      variant?: string
     }) {
       const limit = input.cfg.compaction?.tail_turns ?? DEFAULT_TAIL_TURNS
       if (limit <= 0) return { head: input.messages, tail_start_id: undefined }
-      const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model })
+      const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model, variant: input.variant })
       const all = turns(input.messages)
       if (!all.length) return { head: input.messages, tail_start_id: undefined }
       const recent = all.slice(-limit)
@@ -348,6 +352,7 @@ export const layer = Layer.effect(
         messages: history.filter((_, index) => !hidden.has(index)),
         cfg,
         model,
+        variant: userMessage.model.variant,
       })
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -7,16 +7,27 @@ import type { MessageV2 } from "./message-v2"
 
 const COMPACTION_BUFFER = 20_000
 
-export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outputTokenMax?: number }) {
-  const context = input.model.limit.context
-  if (context === 0) return 0
+export function effectiveLimit(model: Provider.Model, variant?: string): Provider.Model["limit"] {
+  if (!variant || !model.variants) return model.limit
+  const v = model.variants[variant]
+  if (!v?.limit) return model.limit
+  return {
+    context: v.limit.context ?? model.limit.context,
+    input: v.limit.input ?? model.limit.input,
+    output: v.limit.output ?? model.limit.output,
+  }
+}
+
+export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outputTokenMax?: number; variant?: string }) {
+  const limit = effectiveLimit(input.model, input.variant)
+  if (limit.context === 0) return 0
 
   const reserved =
     input.cfg.compaction?.reserved ??
     Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
-  return input.model.limit.input
-    ? Math.max(0, input.model.limit.input - reserved)
-    : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+  return limit.input
+    ? Math.max(0, limit.input - reserved)
+    : Math.max(0, limit.context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
 }
 
 export function isOverflow(input: {
@@ -24,9 +35,10 @@ export function isOverflow(input: {
   tokens: SessionV1.Assistant["tokens"]
   model: Provider.Model
   outputTokenMax?: number
+  variant?: string
 }) {
   if (input.cfg.compaction?.auto === false) return false
-  if (input.model.limit.context === 0) return false
+  if (effectiveLimit(input.model, input.variant).context === 0) return false
 
   const count =
     input.tokens.total || input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -60,6 +60,7 @@ type Input = {
   assistantMessage: SessionV1.Assistant
   sessionID: SessionID
   model: Provider.Model
+  variant?: string
 }
 
 export interface Interface {
@@ -752,7 +753,7 @@ export const layer = Layer.effect(
               .pipe(Effect.ignore, Effect.forkIn(scope))
             if (
               !ctx.assistantMessage.summary &&
-              isOverflow({ cfg: yield* config.get(), tokens: usage.tokens, model: ctx.model })
+              isOverflow({ cfg: yield* config.get(), tokens: usage.tokens, model: ctx.model, variant: ctx.assistantMessage.variant })
             ) {
               ctx.needsCompaction = true
             }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1297,7 +1297,7 @@ export const layer = Layer.effect(
           if (
             lastFinished &&
             lastFinished.summary !== true &&
-            (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
+            (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model, variant: lastUser.model.variant }))
           ) {
             yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
             continue


### PR DESCRIPTION

### Issue for this PR

Closes #31020

### Type of change

- [x] Bug fix

### What does this PR do?

Model variants (e.g. effort tiers like "low" / "high") can declare
their own context limits that differ from the base model. Before this
patch, every context-limit consumer only inspected the base model's
limit.context, ignoring the active variant entirely.

This caused several bugs when a variant declared a tighter limit:
- The UI showed the base model's percentage instead of the variant's
- Overflow detection used the wrong threshold, delaying auto-compaction
- Compaction budget calculations (preserveRecentBudget) were wrong
- ACP usage reports sent the wrong context-limit size to the client

This patch introduces effectiveLimit() to resolve variant-aware limits
with the fallback {context, input, output} merge, then threads the
variant through findContextLimit, isOverflow, usable, and all UI
percentage calculations.

### How did you verify your code works?

- Ran `bun run typecheck` in packages/opencode — passes clean
- Manually inspected all affected call sites to confirm variant is
  threaded from the user message's `model.variant` field
- Verified that `effectiveLimit()` correctly falls back to base model
  limits when the variant has no overrides

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
