### PR TITLE
fix(opencode): limit generated project copy names

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/project-copy.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/project-copy.ts
@@ -77,7 +77,7 @@ export const projectCopyHandlers = HttpApiBuilder.group(InstanceHttpApi, "projec
           messages: [
             {
               role: "user",
-              content: `Generate a short filesystem-safe name for a project working copy based on this context:\n${text}`,
+              content: `Generate a short 3-4 word name that describes this task:\n${text}`,
             },
           ],
         })
@@ -86,7 +86,8 @@ export const projectCopyHandlers = HttpApiBuilder.group(InstanceHttpApi, "projec
           Stream.map((event) => event.text),
           Stream.mkString,
         )
-      return slugify(result) || Slug.create()
+      const output = result.trim()
+      return output ? slugify(output.split(/\s+/).slice(0, 4).join(" ")) : Slug.create()
     })
 
     const create = Effect.fn("ProjectCopyHttpApi.create")(function* (ctx: {


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Generated project copy names could be longer than intended because their length depended entirely on the title model following a general request for a short name.

This change asks the model for a descriptive 3-4 word task name and enforces a maximum of four whitespace-separated words before slugifying the result. Empty model output continues to use the existing random slug fallback.

### How did you verify your code works?

- Full workspace typecheck passed through the pre-push hook (`bun turbo typecheck`, 22 executed package tasks).
- Prettier and `git diff --check` passed.

### Screenshots / recordings

Not applicable; this changes generated project copy directory names only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR