### PR TITLE
fix(tui): inject reminder after moving session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/move.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/move.tsx
@@ -10,6 +10,10 @@ import { DialogMoveSession, type MoveSessionSelection } from "../dialog-move-ses
 import { DialogWorkspaceFileChanges } from "../dialog-workspace-file-changes"
 import { useHomeSessionDestination } from "../../routes/home/session-destination"
 
+function moveReminderText(directory: string) {
+  return `<system-reminder>The user has changed the current working directory to "${directory}". This is still the same project but at a possibly new location; take this into account when working with any files from now on.</system-reminder>`
+}
+
 export function usePromptMove(input: { projectID: () => string | undefined; sessionID: () => string | undefined }) {
   const dialog = useDialog()
   const sdk = useSDK()
@@ -93,8 +97,8 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
       return
     }
     setProgress("Moving session")
-    await sdk.client.experimental.controlPlane
-      .moveSession(
+    try {
+      await sdk.client.experimental.controlPlane.moveSession(
         {
           sessionID,
           destination: { directory },
@@ -102,15 +106,28 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
         },
         { throwOnError: true },
       )
-      .then(() => dialog.clear())
-      .catch((error) => {
-        toast.error(error)
-        dialog.clear()
-      })
-      .finally(() => {
-        setProgress(undefined)
-        setCreating(false)
-      })
+      await sdk.client.session
+        .promptAsync({
+          sessionID,
+          directory,
+          noReply: true,
+          parts: [
+            {
+              type: "text",
+              text: moveReminderText(directory),
+              synthetic: true,
+            },
+          ],
+        })
+        .catch(() => undefined)
+      dialog.clear()
+    } catch (error) {
+      toast.error(error)
+      dialog.clear()
+    } finally {
+      setProgress(undefined)
+      setCreating(false)
+    }
   }
 
   const pending = createMemo(() => Boolean(homeDestination?.destination()))

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
@@ -31,5 +31,7 @@ function message(error: MoveSession.Error) {
   if (error instanceof SessionV2.NotFoundError) return `Session not found: ${error.sessionID}`
   if (error instanceof MoveSession.DestinationProjectMismatchError)
     return "Destination directory belongs to another project"
+  if (error instanceof MoveSession.ApplyChangesError)
+    return `Unable to apply your changes in the destination directory. The files may conflict with existing changes.`
   return error.message
 }


### PR DESCRIPTION
### Issue for this PR

Closes #31026

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a synthetic no-reply directory-change reminder after `/move` relocates an existing session so subsequent prompts use the destination filesystem context. It also gives patch application failures a clear explanation instead of only raw Git output.

### How did you verify your code works?

- Ran the repository pre-push typecheck across all 22 applicable packages.
- Ran `git diff --check`.
- Verified the reminder targets the destination directory and is only added after a successful move.

### Screenshots / recordings

Not applicable; this changes session context and error text rather than layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR