### PR TITLE
fix(mcp): use localhost instead of 127.0.0.1 for OAuth redirect URI

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -183,7 +183,7 @@ export namespace McpOAuthCallback {
 
   export async function isPortInUse(): Promise<boolean> {
     return new Promise((resolve) => {
-      const socket = createConnection(OAUTH_CALLBACK_PORT, "127.0.0.1")
+      const socket = createConnection(OAUTH_CALLBACK_PORT, "localhost")
       socket.on("connect", () => {
         socket.destroy()
         resolve(true)

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -32,7 +32,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   ) {}
 
   get redirectUrl(): string {
-    return `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`
+    return `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`
   }
 
   get clientMetadata(): OAuthClientMetadata {


### PR DESCRIPTION
## Summary

Use `localhost` instead of `127.0.0.1` for the MCP OAuth callback redirect URI and port probe, fixing authentication failures against servers protected by AWS WAF.

## Problem

The OAuth redirect URI is currently `http://127.0.0.1:19876/mcp/oauth/callback`. AWS WAF's `GenericRFI_BODY` and `GenericRFI_QUERYARGUMENTS` rules (from `AWSManagedRulesCommonRuleSet`) flag `http://127.0.0.1` URLs as potential Remote File Inclusion attacks and return **403 Forbidden**, blocking:

1. **Dynamic Client Registration** (`POST /oauth2/register`) — the `redirect_uris` field in the JSON body contains the IP-form URL
2. **Authorization** (`GET /oauth2/authorize?redirect_uri=...`) — the query parameter contains it

This makes `opencode mcp auth <name>` fail with:
```
Connection error: HTTP 403: {"message":"Forbidden"}
```

Other MCP clients (e.g. Claude CLI) use `http://localhost:...` and work fine because `localhost` doesn't trigger the WAF pattern.

## Fix

- **`oauth-provider.ts`**: Change `redirectUrl` getter from `http://127.0.0.1:...` to `http://localhost:...`
- **`oauth-callback.ts`**: Change `isPortInUse()` probe from `127.0.0.1` to `localhost` for consistency

The callback server (`Bun.serve`) already listens on `0.0.0.0` (all interfaces), so it accepts connections on both `localhost` and `127.0.0.1`. No behavioral change for the server — only the URI sent to the remote authorization server changes.

## References

- [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) — recommends `localhost` for loopback redirect URIs in native OAuth apps
- [AWS GenericRFI rules](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html) — inspect request bodies and query strings for URLs containing IP addresses