### PR TITLE
fix(session): use parentID for latest assistant turn check

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1249,7 +1249,7 @@ export const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastAssistant.parentID === lastUser.id
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),


### PR DESCRIPTION
## Summary
- Replace lexicographic message ID ordering with explicit parentID matching when deciding whether the latest assistant message belongs to the latest user turn.
- Fixes duplicate assistant generations when user message IDs and assistant message IDs are generated by different processes/machines, such as web UI access from LAN/remote browsers.

## Root cause
The previous check used `lastUser.id < lastAssistant.id`, which assumes message IDs are globally orderable across client/server processes. That assumption can fail when the web client creates the user message ID and the server creates the assistant message ID.

## Test plan
- Verified locally by running the OpenCode web service from this branch on Windows.
- Confirmed session API and web proxy return 200 through the local OpenCode Web service.