### PR TITLE
feat(opencode): add Antigravity CLI connector

### DIFF
--- a/packages/opencode/src/plugin/google-antigravity/antigravity.ts
+++ b/packages/opencode/src/plugin/google-antigravity/antigravity.ts
@@ -1,0 +1,130 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import type { Model } from "@opencode-ai/sdk/v2"
+import * as Log from "@opencode-ai/core/util/log"
+import { readSession, refresh, expiryMs } from "./keychain"
+import {
+  catalog,
+  dynamicCatalog,
+  gatedFetch,
+  loadProject,
+  translateRequest,
+  unwrapJson,
+  unwrapSse,
+  AGY_USER_AGENT,
+  PROVIDER_ID,
+} from "./models"
+
+const log = Log.create({ service: "plugin.antigravity" })
+
+// Refresh a little early so a long tool call doesn't 401 mid-flight.
+const TOKEN_SKEW_MS = 120_000
+
+// Connector for Google's Antigravity CLI (`agy`). Reuses agy's existing OS-keychain
+// sign-in (no separate login), and routes Gemini inference through the Code Assist
+// backend (cloudcode-pa v1internal) by wrapping @ai-sdk/google requests in the
+// expected envelope. See ./models for the translation and ./keychain for auth.
+export async function AntigravityAuthPlugin(_input: PluginInput): Promise<Hooks> {
+  return {
+    provider: {
+      id: PROVIDER_ID,
+      name: "Antigravity",
+      async models(_provider, ctx): Promise<Record<string, Model>> {
+        // Only expose models once the agy session has been connected.
+        if (ctx.auth?.type !== "oauth") return {}
+        try {
+          // Discover the live model list (retrieveUserQuota) using the stored token.
+          let access = ctx.auth.access
+          if (!access || Date.now() >= ctx.auth.expires - TOKEN_SKEW_MS) {
+            access = (await refresh(ctx.auth.refresh)).access
+          }
+          const project = await loadProject(access)
+          return await dynamicCatalog(access, project)
+        } catch (err) {
+          log.error("antigravity model discovery failed; using static catalog", { error: String(err) })
+          return catalog()
+        }
+      },
+    },
+    auth: {
+      provider: PROVIDER_ID,
+      async loader(getAuth) {
+        const info = await getAuth()
+        if (!info || info.type !== "oauth") return {}
+
+        const oauthInfo = info
+        let access = oauthInfo.access
+        let expires = oauthInfo.expires
+        let project: string | undefined
+
+        async function token(): Promise<string> {
+          if (!access || Date.now() >= expires - TOKEN_SKEW_MS) {
+            const next = await refresh(oauthInfo.refresh)
+            access = next.access
+            expires = next.expires
+          }
+          return access
+        }
+
+        async function ensureProject(): Promise<string> {
+          if (!project) project = await loadProject(await token())
+          return project
+        }
+
+        return {
+          apiKey: "",
+          async fetch(request: RequestInfo | URL, init?: RequestInit) {
+            const url = request instanceof URL ? request.href : typeof request === "string" ? request : request.url
+            const t = await token()
+
+            const bodyText =
+              typeof init?.body === "string" ? init.body : init?.body == null ? undefined : String(init.body)
+            const translated = translateRequest(url, bodyText, await ensureProject())
+
+            // Not a generate call (e.g. token counting) — forward with bearer auth.
+            if (!translated) {
+              const headers = new Headers(init?.headers)
+              headers.set("Authorization", `Bearer ${t}`)
+              headers.delete("x-goog-api-key")
+              return fetch(request, { ...init, headers })
+            }
+
+            const res = await gatedFetch(translated.url, {
+              method: "POST",
+              headers: { "Content-Type": "application/json", Authorization: `Bearer ${t}`, "User-Agent": AGY_USER_AGENT },
+              body: translated.body,
+            })
+            if (!res.ok) {
+              log.error("antigravity generate failed", { status: res.status })
+              return res
+            }
+            return translated.streaming ? unwrapSse(res) : await unwrapJson(res)
+          },
+        }
+      },
+      methods: [
+        {
+          type: "oauth",
+          label: "Antigravity (use existing agy sign-in)",
+          async authorize() {
+            // Import the session agy already established in the OS keychain.
+            const session = await readSession()
+            const tok = session.token
+            return {
+              url: "https://antigravity.google",
+              instructions: "Using your existing Antigravity CLI (agy) session from the system keychain.",
+              method: "auto" as const,
+              async callback() {
+                return {
+                  type: "success" as const,
+                  refresh: tok.refresh_token,
+                  access: tok.access_token,
+                  expires: expiryMs(tok),
+                }
+              },
+            }
+          },
+        },
+      ],
+    },
+  }
+}

--- a/packages/opencode/src/plugin/google-antigravity/keychain.ts
+++ b/packages/opencode/src/plugin/google-antigravity/keychain.ts
@@ -1,0 +1,189 @@
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { readFile, access } from "node:fs/promises"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+const exec = promisify(execFile)
+
+// The Antigravity CLI (`agy`, the rebranded gemini CLI) stores its OAuth session
+// in the OS-native credential manager rather than a plaintext file:
+//   macOS:   Keychain          (service "gemini", account "antigravity")
+//   Linux:   Secret Service    (libsecret / secret-tool, same attributes)
+//   Windows: Credential Manager (generic credential, target "gemini:antigravity")
+// The stored value is in zalando/go-keyring format:
+//   "go-keyring-base64:" + base64(JSON)
+// where JSON = { token: { access_token, refresh_token, expiry, token_type }, auth_method }.
+const KEYRING_SERVICE = "gemini"
+const KEYRING_ACCOUNT = "antigravity"
+const GO_KEYRING_PREFIX = "go-keyring-base64:"
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+// agy embeds its own Google OAuth client (id + secret) in its binary, exactly like
+// gemini-cli and the gcloud SDK. The antigravity backend's eligibility gate only
+// accepts tokens minted by *that* client, so refresh has to use agy's credentials,
+// not the public gemini-cli ones. Rather than re-ship Google's secrets in this repo
+// (poor hygiene; trips secret scanners), read them out of the installed agy binary at
+// runtime. Cached after first read. Overrides: AGY_BIN for the binary path, or
+// ANTIGRAVITY_OAUTH_CLIENT_ID + ANTIGRAVITY_OAUTH_CLIENT_SECRET to skip the scan
+// entirely (useful on headless/CI hosts where the binary isn't present).
+const CLIENT_ID_RE = /\d{10,}-[a-z0-9]{20,}\.apps\.googleusercontent\.com/g
+// Google client secrets are "GOCSPX-" + exactly 28 chars. Match the fixed length so we
+// don't greedily swallow an adjacent secret (the Go string table packs them together).
+const CLIENT_SECRET_RE = /GOCSPX-[A-Za-z0-9_-]{28}/g
+let cachedClient: { ids: string[]; secrets: string[] } | undefined
+
+async function findAgyBinary(): Promise<string> {
+  const candidates: string[] = []
+  if (process.env.AGY_BIN) candidates.push(process.env.AGY_BIN)
+  try {
+    const { stdout } = await exec(process.platform === "win32" ? "where" : "which", ["agy"])
+    const first = stdout.split(/\r?\n/).find((l) => l.trim())
+    if (first) candidates.push(first.trim())
+  } catch {
+    // not on PATH — fall through to well-known locations
+  }
+  candidates.push(join(homedir(), ".local", "bin", "agy"))
+  for (const p of candidates) {
+    try {
+      await access(p)
+      return p
+    } catch {
+      // try next candidate
+    }
+  }
+  throw new Error("Could not locate the `agy` binary to read its OAuth client — set AGY_BIN to its path")
+}
+
+async function loadAgyClient(): Promise<{ ids: string[]; secrets: string[] }> {
+  if (cachedClient) return cachedClient
+  // Explicit override for headless/CI environments where the binary isn't available.
+  const envId = process.env.ANTIGRAVITY_OAUTH_CLIENT_ID
+  const envSecret = process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET
+  if (envId && envSecret) {
+    cachedClient = { ids: [envId], secrets: [envSecret] }
+    return cachedClient
+  }
+  const text = (await readFile(await findAgyBinary())).toString("latin1")
+  const ids = [...new Set(text.match(CLIENT_ID_RE) ?? [])]
+  const secrets = [...new Set(text.match(CLIENT_SECRET_RE) ?? [])]
+  if (!ids.length || !secrets.length) {
+    throw new Error("Could not read agy's OAuth client id/secret from its binary")
+  }
+  cachedClient = { ids, secrets }
+  return cachedClient
+}
+
+export interface AgyToken {
+  access_token: string
+  refresh_token: string
+  expiry: string // RFC3339
+  token_type: string
+}
+
+export interface AgySession {
+  token: AgyToken
+  auth_method?: string
+}
+
+async function readRawSecret(): Promise<string> {
+  if (process.platform === "darwin") {
+    const { stdout } = await exec("security", [
+      "find-generic-password",
+      "-s",
+      KEYRING_SERVICE,
+      "-a",
+      KEYRING_ACCOUNT,
+      "-w",
+    ])
+    return stdout.trim()
+  }
+  if (process.platform === "linux") {
+    const { stdout } = await exec("secret-tool", ["lookup", "service", KEYRING_SERVICE, "username", KEYRING_ACCOUNT])
+    return stdout.trim()
+  }
+  if (process.platform === "win32") {
+    // The Windows Credential Manager stores the value under the target "service:username"
+    // (go-keyring's naming). No built-in CLI returns the blob, so read it via a CredRead
+    // P/Invoke. Passed as an encoded command to avoid PowerShell quoting issues; the blob
+    // is go-keyring's raw UTF-8 value (same JSON as Linux, no base64 wrapper).
+    const ps = windowsCredReadScript(`${KEYRING_SERVICE}:${KEYRING_ACCOUNT}`)
+    const { stdout } = await exec("powershell", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      Buffer.from(ps, "utf16le").toString("base64"),
+    ])
+    return stdout.trim()
+  }
+  throw new Error(`Antigravity keychain read not yet supported on ${process.platform}`)
+}
+
+// PowerShell that reads a generic credential's blob from the Windows Credential Manager
+// via CredRead and writes the raw UTF-8 string to stdout (empty if the target is absent).
+function windowsCredReadScript(target: string): string {
+  return `$ErrorActionPreference='Stop'
+$ProgressPreference='SilentlyContinue'
+Add-Type @"
+using System;using System.Runtime.InteropServices;using System.Text;
+public class AgyCred{
+ [StructLayout(LayoutKind.Sequential)]public struct CREDENTIAL{
+  public int Flags;public int Type;
+  [MarshalAs(UnmanagedType.LPWStr)]public string TargetName;
+  [MarshalAs(UnmanagedType.LPWStr)]public string Comment;
+  public long LastWritten;public int CredentialBlobSize;public IntPtr CredentialBlob;
+  public int Persist;public int AttributeCount;public IntPtr Attributes;
+  [MarshalAs(UnmanagedType.LPWStr)]public string TargetAlias;
+  [MarshalAs(UnmanagedType.LPWStr)]public string UserName;}
+ [DllImport("advapi32.dll",CharSet=CharSet.Unicode,SetLastError=true)]public static extern bool CredReadW(string t,int ty,int f,out IntPtr p);
+ [DllImport("advapi32.dll")]public static extern void CredFree(IntPtr p);
+ public static string Read(string target){
+  IntPtr p;if(!CredReadW(target,1,0,out p))return "";
+  try{var c=(CREDENTIAL)Marshal.PtrToStructure(p,typeof(CREDENTIAL));
+   if(c.CredentialBlobSize==0)return "";
+   byte[] b=new byte[c.CredentialBlobSize];Marshal.Copy(c.CredentialBlob,b,0,c.CredentialBlobSize);
+   return Encoding.UTF8.GetString(b);}
+  finally{CredFree(p);}}}
+"@
+[Console]::Out.Write([AgyCred]::Read("${target}"))`
+}
+
+export async function readSession(): Promise<AgySession> {
+  const raw = await readRawSecret()
+  if (!raw) throw new Error("No Antigravity session found — run `agy` and sign in first")
+  // go-keyring base64-encodes the value (with this prefix) on macOS/Windows, but stores
+  // the raw JSON directly via the Secret Service on Linux. Only decode when prefixed.
+  const json = raw.startsWith(GO_KEYRING_PREFIX)
+    ? Buffer.from(raw.slice(GO_KEYRING_PREFIX.length), "base64").toString("utf8")
+    : raw
+  return JSON.parse(json) as AgySession
+}
+
+export function expiryMs(token: AgyToken): number {
+  return new Date(token.expiry).getTime()
+}
+
+export async function refresh(refreshToken: string): Promise<{ access: string; expires: number }> {
+  const { ids, secrets } = await loadAgyClient()
+  let lastErr = ""
+  // The binary may contain more than one client id/secret; try each pairing until one
+  // mints a token (the failing combinations just 4xx and cost nothing once cached).
+  for (const client_id of ids) {
+    for (const client_secret of secrets) {
+      const res = await fetch(TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ client_id, client_secret, refresh_token: refreshToken, grant_type: "refresh_token" }),
+      })
+      if (res.ok) {
+        const data = (await res.json()) as { access_token: string; expires_in: number }
+        return { access: data.access_token, expires: Date.now() + data.expires_in * 1000 }
+      }
+      lastErr = `${res.status} ${await res.text()}`
+    }
+  }
+  throw new Error(`Antigravity token refresh failed: ${lastErr}`)
+}
+
+export * as Keychain from "./keychain"

--- a/packages/opencode/src/plugin/google-antigravity/models.ts
+++ b/packages/opencode/src/plugin/google-antigravity/models.ts
@@ -1,0 +1,322 @@
+import type { Model } from "@opencode-ai/sdk/v2"
+
+export const PROVIDER_ID = "google-antigravity"
+export const CLOUDCODE_BASE = "https://cloudcode-pa.googleapis.com"
+// Placeholder base handed to @ai-sdk/google; the auth fetch rewrites every request
+// to CLOUDCODE_BASE/v1internal, so only the URL *shape* (.../models/<id>:<method>)
+// matters here.
+export const AISDK_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+// The Code Assist backend gates its richer endpoints (notably fetchAvailableModels)
+// on this exact User-Agent — without it they return 403. agy sends it on every call.
+export const AGY_USER_AGENT = "antigravity"
+
+export function agyHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+    "User-Agent": AGY_USER_AGENT,
+  }
+}
+
+// Static fallback only — the live catalog comes from fetchAvailableModels (see below).
+// This small set is used if that call fails (offline / transient error) so the picker
+// isn't empty. ids/names mirror fetchAvailableModels and are verified against
+// v1internal:generateContent across all three upstream providers.
+interface Spec {
+  id: string
+  name: string
+  context: number
+  output: number
+  reasoning?: boolean
+  image?: boolean
+  status?: Model["status"]
+  family?: string
+}
+
+const SPECS: Spec[] = [
+  { id: "gemini-3-flash", name: "Gemini 3 Flash", context: 1_048_576, output: 65_536, reasoning: true, image: true },
+  { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)", context: 1_048_576, output: 65_536, reasoning: true, image: true },
+  { id: "gemini-pro-agent", name: "Gemini 3.1 Pro (High)", context: 1_048_576, output: 65_536, reasoning: true, image: true },
+  { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", context: 1_048_576, output: 65_536, reasoning: true, image: true },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Thinking)", context: 250_000, output: 64_000, reasoning: true, image: true, family: "claude" },
+  { id: "gpt-oss-120b-medium", name: "GPT-OSS 120B (Medium)", context: 131_072, output: 32_768, reasoning: true, family: "gpt-oss" },
+]
+
+function buildModel(spec: Spec): Model {
+  return {
+    id: spec.id,
+    providerID: PROVIDER_ID,
+    api: { id: spec.id, url: AISDK_BASE, npm: "@ai-sdk/google" },
+    name: spec.name,
+    family: spec.family ?? "gemini",
+    capabilities: {
+      temperature: true,
+      reasoning: spec.reasoning ?? false,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: spec.image ?? false, video: false, pdf: spec.image ?? false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    // Access is via the user's Antigravity subscription, not metered per token.
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: spec.context, output: spec.output },
+    status: spec.status ?? "active",
+    options: {},
+    headers: {},
+    release_date: "2026-01-01",
+  }
+}
+
+// Static fallback catalog (used if the live fetchAvailableModels call fails).
+export function catalog(): Record<string, Model> {
+  return Object.fromEntries(SPECS.map((s) => [s.id, buildModel(s)]))
+}
+
+// ---- dynamic model discovery ----------------------------------------------
+//
+// agy's `fetchAvailableModels` is the authoritative catalog: it carries the real
+// display names, context/output limits, image + thinking support, and crucially
+// the non-derivable id->name mapping (e.g. id `gemini-3-flash-agent` is shown as
+// "Gemini 3.5 Flash (High)"). It's gated on the `antigravity` User-Agent — without
+// it the endpoint 403s, which is why naive callers fall back to the thinner
+// retrieveUserQuota list (gemini-only, wrong names). With the right UA we get the
+// full set: Gemini + Claude + GPT-OSS, all reachable through generateContent.
+interface FamModel {
+  displayName?: string
+  supportsImages?: boolean
+  supportsThinking?: boolean
+  maxTokens?: number
+  maxOutputTokens?: number
+  recommended?: boolean
+  modelProvider?: string
+}
+
+// Internal/utility models agy never surfaces (tab-completion, checkpointers), plus
+// ids verified to 400 on generateContent even though they're listed (the broken
+// `-high` pro variant; its twin `gemini-pro-agent` renders the same name and works).
+const SKIP_ID = /^(tab_|chat_)/
+const BROKEN_IDS = new Set(["gemini-3.1-pro-high"])
+
+function familyOf(modelProvider: string | undefined): string {
+  if (modelProvider === "MODEL_PROVIDER_ANTHROPIC") return "claude"
+  if (modelProvider === "MODEL_PROVIDER_OPENAI") return "gpt-oss"
+  return "gemini"
+}
+
+// @ai-sdk/google is the transport for every model (Claude/GPT-OSS included): the
+// Code Assist envelope is Gemini-shaped and the backend translates, so responses
+// come back as standard GenerateContentResponses regardless of upstream provider.
+function buildFamModel(id: string, m: FamModel): Model {
+  return buildModel({
+    id,
+    name: m.displayName ?? id,
+    family: familyOf(m.modelProvider),
+    context: m.maxTokens ?? 1_048_576,
+    output: m.maxOutputTokens ?? 65_536,
+    reasoning: m.supportsThinking ?? false,
+    image: m.supportsImages ?? false,
+    status: "active",
+  })
+}
+
+// Fetch agy's full catalog. Dedupes by display name (several internal ids share a
+// name, e.g. four ids all show "Gemini 3.1 Flash Lite") preferring the recommended
+// one so the picker reads like agy's own.
+export async function fetchAvailableModels(accessToken: string, project: string): Promise<Record<string, Model>> {
+  const res = await fetch(`${CLOUDCODE_BASE}/v1internal:fetchAvailableModels`, {
+    method: "POST",
+    headers: agyHeaders(accessToken),
+    body: JSON.stringify({ project }),
+  })
+  if (!res.ok) throw new Error(`fetchAvailableModels failed: ${res.status}`)
+  const json = (await res.json()) as { models?: Record<string, FamModel> }
+  const entries = Object.entries(json.models ?? {}).filter(
+    ([id, m]) => m.displayName && !SKIP_ID.test(id) && !BROKEN_IDS.has(id),
+  )
+
+  // Keep one id per display name, preferring recommended.
+  const byName = new Map<string, { id: string; m: FamModel }>()
+  for (const [id, m] of entries) {
+    const name = m.displayName!
+    const existing = byName.get(name)
+    if (!existing || (m.recommended && !existing.m.recommended)) byName.set(name, { id, m })
+  }
+
+  const out: Record<string, Model> = {}
+  for (const { id, m } of byName.values()) out[id] = buildFamModel(id, m)
+  return out
+}
+
+// Build the catalog live from agy's catalog, falling back to the static list.
+export async function dynamicCatalog(accessToken: string, project: string): Promise<Record<string, Model>> {
+  const models = await fetchAvailableModels(accessToken, project)
+  if (Object.keys(models).length === 0) return catalog()
+  return models
+}
+
+// ---- Code Assist handshake -------------------------------------------------
+
+// loadCodeAssist returns the (Google-managed) project the account is provisioned
+// against; v1internal:generateContent requires it in the request envelope.
+export async function loadProject(accessToken: string): Promise<string> {
+  const res = await fetch(`${CLOUDCODE_BASE}/v1internal:loadCodeAssist`, {
+    method: "POST",
+    headers: agyHeaders(accessToken),
+    body: JSON.stringify({
+      metadata: { ideType: "IDE_UNSPECIFIED", platform: "PLATFORM_UNSPECIFIED", pluginType: "GEMINI" },
+    }),
+  })
+  if (!res.ok) throw new Error(`loadCodeAssist failed: ${res.status} ${await res.text()}`)
+  const json = (await res.json()) as { cloudaicompanionProject?: string }
+  if (!json.cloudaicompanionProject) throw new Error("loadCodeAssist returned no project")
+  return json.cloudaicompanionProject
+}
+
+// ---- request/response envelope translation ---------------------------------
+
+const URL_RE = /\/models\/([^:/]+):(streamGenerateContent|generateContent)/
+
+interface GeminiPart {
+  functionCall?: { name?: string; id?: string; args?: unknown }
+  functionResponse?: { name?: string; id?: string; response?: unknown }
+}
+interface GeminiContent {
+  parts?: GeminiPart[]
+}
+
+// @ai-sdk/google drops the tool-call id from functionCall/functionResponse parts for
+// regular function tools (it only sets it for server tools). Gemini tolerates that —
+// it pairs calls to responses positionally — but the Code Assist backend translates
+// these to Anthropic tool_use / OpenAI tool_calls, which *require* a matching id, so
+// Claude and GPT-OSS reject the request ("tool_use.id: Field required"). Synthesize
+// stable ids and pair them via a FIFO queue per tool name, mirroring the order Gemini
+// emits parallel calls and their responses. Harmless for Gemini (id is a valid field).
+function injectToolCallIds(request: { contents?: GeminiContent[] }): void {
+  const pending = new Map<string, string[]>() // tool name -> queued call ids awaiting a response
+  let seq = 0
+  for (const content of request.contents ?? []) {
+    for (const part of content.parts ?? []) {
+      const call = part.functionCall
+      if (call) {
+        // Synthesize an id only when missing; queue it (native or synthesized) so the
+        // matching response below can pick up the same id regardless.
+        if (!call.id) call.id = `call_${seq++}`
+        const name = call.name ?? ""
+        const queue = pending.get(name) ?? (pending.set(name, []), pending.get(name)!)
+        queue.push(call.id)
+      }
+      const resp = part.functionResponse
+      if (resp && !resp.id) {
+        resp.id = pending.get(resp.name ?? "")?.shift() ?? `call_${seq++}`
+      }
+    }
+  }
+}
+
+// Rewrite an @ai-sdk/google request into the cloudcode-pa v1internal envelope.
+// Returns the new URL + body, or null if the request isn't a generate call.
+export function translateRequest(
+  url: string,
+  bodyText: string | undefined,
+  project: string,
+): { url: string; body: string; streaming: boolean } | null {
+  const m = URL_RE.exec(url)
+  if (!m) return null
+  const [, model, method] = m
+  const streaming = method === "streamGenerateContent"
+  const inner = bodyText ? JSON.parse(bodyText) : {}
+  injectToolCallIds(inner)
+  const target = `${CLOUDCODE_BASE}/v1internal:${method}${streaming ? "?alt=sse" : ""}`
+  return { url: target, body: JSON.stringify({ model, project, request: inner }), streaming }
+}
+
+// cloudcode wraps every GenerateContentResponse as { response: <resp> }. The AI SDK
+// expects the bare resp, so unwrap it (non-streaming).
+export async function unwrapJson(res: Response): Promise<Response> {
+  const json = (await res.json()) as { response?: unknown }
+  const unwrapped = json && typeof json === "object" && "response" in json ? json.response : json
+  return new Response(JSON.stringify(unwrapped), {
+    status: res.status,
+    statusText: res.statusText,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+// Streaming: cloudcode emits SSE `data: {"response": {...}}` lines; unwrap each
+// `.response` so the AI SDK's Gemini stream parser sees bare GenerateContentResponses.
+export function unwrapSse(res: Response): Response {
+  if (!res.body) return res
+  const dec = new TextDecoder()
+  const enc = new TextEncoder()
+  let buf = ""
+  const transform = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      buf += dec.decode(chunk, { stream: true })
+      const lines = buf.split("\n")
+      buf = lines.pop() ?? ""
+      for (const line of lines) {
+        if (!line.startsWith("data:")) {
+          controller.enqueue(enc.encode(line + "\n"))
+          continue
+        }
+        const payload = line.slice(5).trim()
+        if (!payload || payload === "[DONE]") {
+          controller.enqueue(enc.encode(line + "\n"))
+          continue
+        }
+        try {
+          const obj = JSON.parse(payload) as { response?: unknown }
+          const inner = obj && typeof obj === "object" && "response" in obj ? obj.response : obj
+          controller.enqueue(enc.encode(`data: ${JSON.stringify(inner)}\n`))
+        } catch {
+          controller.enqueue(enc.encode(line + "\n"))
+        }
+      }
+    },
+    flush(controller) {
+      if (buf) controller.enqueue(enc.encode(buf))
+    },
+  })
+  return new Response(res.body.pipeThrough(transform), {
+    status: res.status,
+    statusText: res.statusText,
+    headers: { "content-type": "text/event-stream" },
+  })
+}
+
+// Antigravity enforces a tight per-minute request throttle (the same one `agy` itself
+// hits). opencode can fire two near-simultaneous requests at the start of a session —
+// the main turn plus a title-generation request that getSmallModel routes back here —
+// which trips the throttle and makes the AI SDK dogpile retries. Serialize the *start*
+// of generate calls through one chain (fetch resolves on headers, so streaming bodies
+// still overlap) and back off once on a 429 so we stop amplifying the limit.
+let gate: Promise<unknown> = Promise.resolve()
+
+function parseRetryMs(res: Response, body: string): number {
+  const header = res.headers.get("retry-after")
+  if (header) {
+    const secs = Number(header)
+    if (Number.isFinite(secs)) return Math.min(secs * 1000, 60_000)
+  }
+  // Cloudcode returns the throttle window in the error text ("...reset after 49s").
+  const m = /reset[a-z]*(?:\s+(?:after|in))?\s*(\d+)\s*s/i.exec(body)
+  if (m) return Math.min(Number(m[1]) * 1000 + 500, 60_000)
+  return 5_000
+}
+
+export async function gatedFetch(url: string, init: RequestInit): Promise<Response> {
+  const run = async (): Promise<Response> => {
+    const res = await fetch(url, init)
+    if (res.status !== 429) return res
+    const body = await res.clone().text().catch(() => "")
+    await new Promise((r) => setTimeout(r, parseRetryMs(res, body)))
+    return fetch(url, init)
+  }
+  const result = gate.then(run, run)
+  gate = result.catch(() => {})
+  return result
+}
+
+export * as AntigravityModels from "./models"

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -13,6 +13,7 @@ import { CodexAuthPlugin } from "./openai/codex"
 import { Session } from "@/session/session"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { CopilotAuthPlugin } from "./github-copilot/copilot"
+import { AntigravityAuthPlugin } from "./google-antigravity/antigravity"
 import { gitlabAuthPlugin as GitlabAuthPlugin } from "opencode-gitlab-auth"
 import { PoeAuthPlugin } from "opencode-poe-auth"
 import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cloudflare"
@@ -71,6 +72,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
         experimentalWebSockets: experimentalWebSocketsEnabled({ enabled: flags.experimentalWebSockets }),
       }),
     CopilotAuthPlugin,
+    AntigravityAuthPlugin,
     GitlabAuthPlugin,
     PoeAuthPlugin,
     CloudflareWorkersAuthPlugin,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1361,8 +1361,22 @@ export const layer = Layer.effect(
           const providerID = ProviderV2.ID.make(p.id)
           if (disabled.has(providerID)) continue
 
-          const provider = database[providerID]
-          if (!provider) continue
+          // A plugin can define a provider that models.dev (and config) doesn't know
+          // about. Synthesize a minimal catalog record so it self-registers, instead
+          // of requiring a models.dev entry or a hand-written config block that a
+          // catalog refresh would wipe. The models() hook below fills in the models.
+          let provider = database[providerID]
+          if (!provider) {
+            provider = {
+              id: providerID,
+              name: p.name ?? p.id,
+              source: "custom",
+              env: [],
+              options: {},
+              models: {},
+            }
+            database[providerID] = provider
+          }
           const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
 
           provider.models = yield* Effect.promise(async () => {
@@ -1510,10 +1524,16 @@ export const layer = Layer.effect(
           if (!stored) continue
           if (!plugin.auth.loader) continue
 
+          // A credential can be stored for a provider that isn't in the catalog
+          // (e.g. installed via models.dev later, or a stale entry). Skip rather
+          // than crash in toPublicInfo when there's no catalog record yet.
+          const record = database[plugin.auth.provider]
+          if (!record) continue
+
           const options = yield* Effect.promise(() =>
             plugin.auth!.loader!(
               () => bridge.promise(auth.get(providerID).pipe(Effect.orDie)) as any,
-              toPublicInfo(database[plugin.auth!.provider]),
+              toPublicInfo(record),
             ),
           )
           const opts = options ?? {}

--- a/packages/opencode/test/plugin/google-antigravity.test.ts
+++ b/packages/opencode/test/plugin/google-antigravity.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { AntigravityAuthPlugin } from "../../src/plugin/google-antigravity/antigravity"
+import { expiryMs } from "../../src/plugin/google-antigravity/keychain"
+import {
+  catalog,
+  translateRequest,
+  unwrapJson,
+  unwrapSse,
+  PROVIDER_ID,
+  CLOUDCODE_BASE,
+} from "../../src/plugin/google-antigravity/models"
+import { OAUTH_DUMMY_KEY } from "../../src/auth"
+
+describe("plugin.google-antigravity", () => {
+  describe("keychain.expiryMs", () => {
+    test("correctly parses RFC3339 expiry string to milliseconds", () => {
+      const token = {
+        access_token: "access",
+        refresh_token: "refresh",
+        expiry: "2026-06-05T21:00:00Z",
+        token_type: "Bearer",
+      }
+      expect(expiryMs(token)).toBe(new Date("2026-06-05T21:00:00Z").getTime())
+    })
+  })
+
+  describe("models.catalog", () => {
+    test("returns a static fallback catalog across providers", () => {
+      const cat = catalog()
+      expect(cat["gemini-3-flash"]).toBeDefined()
+      expect(cat["gemini-3-flash"].providerID).toBe(PROVIDER_ID)
+      expect(cat["gemini-3-flash"].family).toBe("gemini")
+      // fallback spans all three upstream providers agy proxies
+      expect(cat["claude-sonnet-4-6"].family).toBe("claude")
+      expect(cat["gpt-oss-120b-medium"].family).toBe("gpt-oss")
+    })
+  })
+
+  describe("models.translateRequest", () => {
+    test("returns null for non-generate URLs", () => {
+      expect(translateRequest("https://example.com/api/test", undefined, "my-proj")).toBeNull()
+    })
+
+    test("translates generateContent calls to cloudcode-pa v1internal envelope", () => {
+      const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+      const body = JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hello" }] }] })
+      const res = translateRequest(url, body, "my-proj")
+
+      expect(res).not.toBeNull()
+      expect(res!.url).toBe(`${CLOUDCODE_BASE}/v1internal:generateContent`)
+      expect(res!.streaming).toBe(false)
+      const parsedBody = JSON.parse(res!.body)
+      expect(parsedBody.model).toBe("gemini-2.5-flash")
+      expect(parsedBody.project).toBe("my-proj")
+      expect(parsedBody.request.contents).toEqual([{ role: "user", parts: [{ text: "hello" }] }])
+    })
+
+    test("translates streamGenerateContent calls to cloudcode-pa v1internal envelope with sse query param", () => {
+      const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:streamGenerateContent"
+      const body = JSON.stringify({ contents: [{ role: "user", parts: [{ text: "stream this" }] }] })
+      const res = translateRequest(url, body, "my-proj")
+
+      expect(res).not.toBeNull()
+      expect(res!.url).toBe(`${CLOUDCODE_BASE}/v1internal:streamGenerateContent?alt=sse`)
+      expect(res!.streaming).toBe(true)
+      const parsedBody = JSON.parse(res!.body)
+      expect(parsedBody.model).toBe("gemini-3-flash")
+      expect(parsedBody.project).toBe("my-proj")
+    })
+
+    test("injects matched ids onto functionCall/functionResponse parts for Claude/GPT-OSS", () => {
+      const url = "https://generativelanguage.googleapis.com/v1beta/models/claude-sonnet-4-6:generateContent"
+      const body = JSON.stringify({
+        contents: [
+          { role: "user", parts: [{ text: "weather in Paris and Tokyo?" }] },
+          { role: "model", parts: [{ functionCall: { name: "wx", args: { c: "Paris" } } }, { functionCall: { name: "wx", args: { c: "Tokyo" } } }] },
+          { role: "user", parts: [{ functionResponse: { name: "wx", response: { v: "20C" } } }, { functionResponse: { name: "wx", response: { v: "14C" } } }] },
+        ],
+      })
+      const contents = JSON.parse(translateRequest(url, body, "p")!.body).request.contents
+      const callIds = contents[1].parts.map((p: any) => p.functionCall.id)
+      const respIds = contents[2].parts.map((p: any) => p.functionResponse.id)
+      // every part gets an id, and parallel calls pair to their responses in order
+      expect(callIds.every(Boolean)).toBe(true)
+      expect(callIds).toEqual(respIds)
+      expect(new Set(callIds).size).toBe(2) // distinct ids for distinct calls
+    })
+
+    test("preserves an id already present on a functionCall", () => {
+      const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent"
+      const body = JSON.stringify({
+        contents: [{ role: "model", parts: [{ functionCall: { name: "wx", id: "native-xyz", args: {} } }] }],
+      })
+      const contents = JSON.parse(translateRequest(url, body, "p")!.body).request.contents
+      expect(contents[0].parts[0].functionCall.id).toBe("native-xyz")
+    })
+  })
+
+  describe("models.unwrapJson", () => {
+    test("unwraps the response wrapper from cloudcode json responses", async () => {
+      const wrappedResponse = new Response(JSON.stringify({ response: { candidates: [{ content: { parts: [{ text: "hi" }] } }] } }))
+      const unwrapped = await unwrapJson(wrappedResponse)
+      const data = await unwrapped.json()
+      expect(data).toEqual({ candidates: [{ content: { parts: [{ text: "hi" }] } }] })
+    })
+
+    test("returns original json if response field is not present", async () => {
+      const plainResponse = new Response(JSON.stringify({ other: "data" }))
+      const unwrapped = await unwrapJson(plainResponse)
+      const data = await unwrapped.json()
+      expect(data).toEqual({ other: "data" })
+    })
+  })
+
+  describe("models.unwrapSse", () => {
+    test("transforms SSE lines to unwrap the response payload", async () => {
+      const mockStream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const encoder = new TextEncoder()
+          controller.enqueue(encoder.encode('data: {"response": {"candidates": [{"content": {"parts": [{"text": "hello"}]}}]}}\n\n'))
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"))
+          controller.close()
+        }
+      })
+      const wrappedResponse = new Response(mockStream)
+      const unwrapped = unwrapSse(wrappedResponse)
+      const reader = unwrapped.body!.getReader()
+      const decoder = new TextDecoder()
+
+      let text = ""
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        text += decoder.decode(value)
+      }
+
+      expect(text).toContain('data: {"candidates":[{"content":{"parts":[{"text":"hello"}]}}]}')
+      expect(text).toContain("data: [DONE]")
+    })
+  })
+
+  describe("AntigravityAuthPlugin", () => {
+    test("loader returns empty object if stored credentials are not oauth", async () => {
+      const hooks = await AntigravityAuthPlugin({} as any)
+      const getAuthApi = async () => ({ type: "api" as const, key: "my-key" })
+      const loaderRes = await hooks.auth!.loader!(getAuthApi, {} as any)
+      expect(loaderRes).toEqual({})
+    })
+
+    test("loader proxies requests and rewrites generateContent calls", async () => {
+      const hooks = await AntigravityAuthPlugin({} as any)
+      const getAuthOauth = async () => ({
+        type: "oauth" as const,
+        access: "my-access-token",
+        refresh: "my-refresh-token",
+        expires: Date.now() + 3600_000,
+      })
+
+      // Spy on global fetch
+      const fetchSpy = spyOn(global, "fetch").mockImplementation(async (request, init) => {
+        const urlStr = request instanceof URL ? request.href : typeof request === "string" ? request : request.url
+        if (urlStr.includes("loadCodeAssist")) {
+          return new Response(JSON.stringify({ cloudaicompanionProject: "my-proj" }))
+        }
+        if (urlStr.includes("generateContent")) {
+          // Verify request envelope was wrapped
+          const body = JSON.parse(init?.body as string)
+          expect(body.project).toBe("my-proj")
+          expect(body.model).toBe("gemini-2.5-flash")
+          return new Response(JSON.stringify({ response: { text: "mocked reply" } }))
+        }
+        return new Response("not found", { status: 404 })
+      })
+
+      try {
+        const loaderRes = await hooks.auth!.loader!(getAuthOauth, {} as any)
+        expect(loaderRes.fetch).toBeDefined()
+
+        const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+        const response = await loaderRes.fetch!(url, {
+          method: "POST",
+          body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hi" }] }] }),
+        })
+
+        expect(response.status).toBe(200)
+        const json = await response.json()
+        expect(json).toEqual({ text: "mocked reply" })
+        expect(fetchSpy).toHaveBeenCalledTimes(2) // loadCodeAssist + generateContent
+      } finally {
+        fetchSpy.mockRestore()
+      }
+    })
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -213,6 +213,11 @@ export type ProviderHookContext = {
 
 export type ProviderHook = {
   id: string
+  /**
+   * Display name for the provider. Used when the provider is not present in the
+   * models.dev catalog or user config, so the plugin can register it standalone.
+   */
+  name?: string
   models?: (provider: ProviderV2, ctx: ProviderHookContext) => Promise<Record<string, ModelV2>>
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #28889

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a provider that reuses an existing Antigravity CLI (`agy`) sign-in — Gemini, Claude, and GPT-OSS with no extra login or API key.

- read agy's OAuth token from the OS keychain (macOS Keychain / Linux Secret Service); refresh with agy's own client, read from the agy binary at runtime rather than hardcoded
- list models from Code Assist `fetchAvailableModels` (only responds with the `antigravity` User-Agent); rewrite `@ai-sdk/google` requests into the `v1internal` envelope; unwrap responses (JSON + SSE)
- synthesize and pair the tool-call ids `@ai-sdk/google` omits for regular tools — Gemini pairs by position, but the backend maps them to Anthropic `tool_use` / OpenAI `tool_calls`, which need a matching id, so Claude/GPT-OSS otherwise fail
- self-register the provider when models.dev doesn't have it: synthesize a minimal catalog record from the plugin's `provider` hook (adds optional `name` to `ProviderHook`), so it needs no config entry and survives catalog refreshes
- keychain read works on all three OSes: macOS Keychain (`security`), Linux Secret Service (`secret-tool`), Windows Credential Manager (`CredRead` via PowerShell) — handling go-keyring's base64-on-macOS vs raw-JSON-on-Linux/Windows value formats

### How did you verify your code works?

- exercised end-to-end on macOS, Linux (Fedora), and Windows 11: keychain read → token refresh → model list → `generateContent` with tool calls, across Gemini, Claude Sonnet/Opus, and GPT-OSS
- `bun test test/plugin/google-antigravity.test.ts` (12 pass — envelope translation, SSE unwrap, fallback catalog, auth loader, tool-call id pairing)
- `bunx tsc --noEmit -p tsconfig.json` in `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
