### PR TITLE
fix(prompt): soften absolute no-comments rule into a nuanced policy

### DIFF
--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -65,7 +65,7 @@ When making changes to files, first understand the file's code conventions. Mimi
 - Always follow security best practices. Never introduce code that exposes or logs secrets and keys. Never commit secrets or keys to the repository.
 
 # Code style
-- IMPORTANT: DO NOT ADD ***ANY*** COMMENTS unless asked
+- Do not add comments that merely restate the code. Add a comment only to explain WHY (a non-obvious decision or workaround) or to give context for a genuinely complex block; otherwise prefer self-explanatory code.
 
 # Doing tasks
 The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:

--- a/packages/opencode/src/session/prompt/trinity.txt
+++ b/packages/opencode/src/session/prompt/trinity.txt
@@ -67,7 +67,7 @@ When making changes to files, first understand the file's code conventions. Mimi
 - Always follow security best practices. Never introduce code that exposes or logs secrets and keys. Never commit secrets or keys to the repository.
 
 # Code style
-- IMPORTANT: DO NOT ADD ***ANY*** COMMENTS unless asked
+- Do not add comments that merely restate the code. Add a comment only to explain WHY (a non-obvious decision or workaround) or to give context for a genuinely complex block; otherwise prefer self-explanatory code.
 
 # Doing tasks
 The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:


### PR DESCRIPTION
### Issue for this PR

Closes #29508

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `# Code style` section of `default.txt` and `trinity.txt` had an absolute rule: `DO NOT ADD ***ANY*** COMMENTS unless asked`. That is stricter than opencode's other prompt presets — `codex.txt`, `gpt.txt` and `gemini.txt` all allow sparing comments that explain non-obvious logic. This replaces the blanket ban with the same nuanced rule those presets use: no comments by default, but allow one to explain *why* (a non-obvious decision or workaround) or to give context for a genuinely complex block.

Both files get the identical replacement line so the two presets stay consistent.

### How did you verify your code works?

These are prompt text files imported as raw strings; no tests or snapshots assert on them. I confirmed the old line is gone from both files, the replacement is byte-identical across the two, and `grep` finds no remaining `DO NOT ADD` reference.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
