### PR TITLE
docs: fix MCP header interpolation example to {env:VAR}

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -303,7 +303,7 @@ Special object-shaped (not callbacks): `tool: { my_tool: { ... } }`,
       "type": "remote",
       "url": "https://...",
       "enabled": true,
-      "headers": { "Authorization": "Bearer ${GITHUB_TOKEN}" }
+      "headers": { "Authorization": "Bearer {env:GITHUB_TOKEN}" }
     },
     "old-server": { "enabled": false }
   }
@@ -311,7 +311,9 @@ Special object-shaped (not callbacks): `tool: { my_tool: { ... } }`,
 ```
 
 `command` is an array of strings. `type` is required. Use `enabled: false` to
-disable a server inherited from a parent config.
+disable a server inherited from a parent config. String values such as header
+tokens support `{env:VAR}` interpolation (and `{file:path}`); the shell-style
+`${VAR}` is not substituted.
 
 ## Permissions
 


### PR DESCRIPTION
### Issue for this PR

Closes #29611

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The MCP remote-header example in `customize-opencode.md` used `Bearer ${GITHUB_TOKEN}`, but opencode's config string interpolation only supports `{env:VAR}` and `{file:path}` — there is no `${VAR}` form, so the documented example silently resolves to an empty token and breaks auth. This fixes the example to `Bearer {env:GITHUB_TOKEN}` and adds a one-line note documenting the supported interpolation syntax.

### How did you verify your code works?

I traced the interpolation in `packages/opencode/src/config/variable.ts` (`ConfigVariable.substitute`), which only substitutes `{env:VAR}` / `{file:path}`, and confirmed the whole config text runs through it at load (`config.ts`). So `${GITHUB_TOKEN}` would never be substituted, while `{env:GITHUB_TOKEN}` is. Docs-only change.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
