### PR TITLE
fix(opencode): write error message to stderr in CLI fail handler

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -143,6 +143,7 @@ const cli = yargs(args)
     ) {
       if (err) throw err
       cli.showHelp(show)
+      if (msg) UI.error(msg)
     }
     if (err) throw err
     process.exit(1)


### PR DESCRIPTION
The `.fail()` handler showed the help text on unknown arguments but never printed the actual error message, so `opencode --bad-flag` produced output identical to `opencode --help` — the user had no way to tell their argument was wrong.

This outputs `msg` via `UI.error` right after the help text.

**How I verified:** ran `bun dev --unkown-flag` — it now prints `Error: Unknown arguments: unkown-flag, unkownFlag` after the help and exits 1. `--help` itself is unchanged. Typecheck (opencode package) and oxlint pass.

Fixes #29390