### PR TITLE
docs: add OpenCode Vim to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -69,6 +69,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk   |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI            |
+| [OpenCode Vim](https://leohenon.github.io/opencode-vim/)                                   | OpenCode fork that adds Vim motions, navigation, and editing directly to the TUI |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds OpenCode Vim to the ecosystem docs projects list in `packages/web/src/content/docs/ecosystem.mdx`.

OpenCode Vim is an OpenCode fork that adds Vim motions, navigation, and editing directly to the TUI and stays up to date with OpenCode.

Project links:
- Website: https://leohenon.github.io/opencode-vim/
- GitHub: https://github.com/leohenon/opencode-vim

### How did you verify your code works?

N/A

### Screenshots / recordings

N/A 

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR