### PR TITLE
fix(acp): use ExperimentalHttpApiServer.context instead of Context.empty()

### DIFF
--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -1,7 +1,7 @@
 import { describeRoute, resolver, validator } from "hono-openapi"
 import { Hono } from "hono"
 import type { UpgradeWebSocket } from "hono/ws"
-import { Context, Effect } from "effect"
+import { Effect } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import z from "zod"
 import { Format } from "@/format"
@@ -44,7 +44,7 @@ import type { CorsOptions } from "@/server/cors"
 export const InstanceRoutes = (upgrade: UpgradeWebSocket, opts?: CorsOptions): Hono => {
   const app = new Hono()
   const handler = ExperimentalHttpApiServer.webHandler(opts).handler
-  const context = Context.empty() as Context.Context<unknown>
+  const context = ExperimentalHttpApiServer.context
 
   app.all("/api/*", (c) => handler(c.req.raw, context))
 


### PR DESCRIPTION
## Problem

`opencode acp` 的 `session/new` 始终返回 `-32603 Internal error: "No models available"`，阻断外部 ACP 客户端（如 cc-connect）通过 ACP 协议对接 OpenCode。

## Root Cause

`src/server/routes/instance/index.ts` 第 47 行使用 `Context.empty()` 创建 Effect context。所有 `/api/*` 请求（包括 `session/new`）都走 `ExperimentalHttpApiServer.webHandler(opts).handler`，但这个 handler 依赖的 Session、Config、Provider 等服务层在空 context 中不可用 → 502 Bad Gateway → "No models available"。

## Fix

将 `Context.empty()` 替换为 `ExperimentalHttpApiServer.context`——这是 `httpapi/server.ts` 已导出的共享 context，由所有路由层（50+ 个服务）支撑。

```diff
- const context = Context.empty() as Context.Context<unknown>
+ const context = ExperimentalHttpApiServer.context
```

同时移除不再需要的 `Context` import。

## Testing

- ✅ `opencode acp --cwd /tmp` 独立测试：`session/new` 成功返回 sessionId
- Pending: CI unit tests

## Related

- Fixes: #31076
- Unblocks: chenhg5/cc-connect#1100 (cc-connect ACP 适配器权限转发)