### PR TITLE
fix(provider): respect configured small_model and add opencode handling to smallOptions

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1869,7 +1869,15 @@ export const layer = Layer.effect(
       if (cfg.small_model) {
         const parsed = parseModel(cfg.small_model)
         return yield* getModel(parsed.providerID, parsed.modelID).pipe(
-          Effect.catchTag("ProviderModelNotFoundError", () => Effect.succeed(undefined)),
+          Effect.catchTag("ProviderModelNotFoundError", (err) => {
+            log.warn("configured small_model not found, falling back to main model", {
+              configured: cfg.small_model,
+              providerID: parsed.providerID,
+              modelID: parsed.modelID,
+              error: err.message,
+            })
+            return Effect.succeed(undefined)
+          }),
         )
       }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1178,6 +1178,13 @@ export function smallOptions(model: Provider.Model) {
     return { veniceParameters: { disableThinking: true } }
   }
 
+  if (model.providerID.startsWith("opencode")) {
+    return mergeDeep(
+      { include: INCLUDE_ENCRYPTED_REASONING, reasoningSummary: "auto" },
+      small,
+    )
+  }
+
   return small
 }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3900,6 +3900,38 @@ describe("ProviderTransform.smallOptions - google thinking controls", () => {
   })
 })
 
+describe("ProviderTransform.smallOptions - opencode provider", () => {
+  const createOpencodeModel = (id: string) =>
+    ({
+      id: `opencode/${id}`,
+      providerID: "opencode",
+      api: {
+        id: id,
+        url: "https://api.opencode.ai/zen/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: { reasoning: true },
+      limit: { output: 64_000 },
+      release_date: "2026-01-01",
+      variants: {},
+    }) as any
+
+  test("returns include and reasoningSummary for opencode reasoning models", () => {
+    expect(ProviderTransform.smallOptions(createOpencodeModel("big-pickle"))).toEqual({
+      include: ["reasoning.encrypted_content"],
+      reasoningSummary: "auto",
+    })
+  })
+
+  test("returns base options when opencode model has no reasoning", () => {
+    const model = { ...createOpencodeModel("non-reasoning"), capabilities: { reasoning: false } }
+    expect(ProviderTransform.smallOptions(model)).toEqual({
+      include: ["reasoning.encrypted_content"],
+      reasoningSummary: "auto",
+    })
+  })
+})
+
 describe("ProviderTransform.providerOptions - ai-gateway-provider", () => {
   const createModel = (overrides: Partial<any> = {}) =>
     ({


### PR DESCRIPTION
### Issue for this PR

Closes #31042

### Type of change

- [x] Bug fix

### What does this PR do?

Two bugs cause the symptoms in #31042:

**Bug 1 — silent fallback in `getSmallModel`.** When `small_model` is configured but the model isn't in the provider catalog, the function returns `undefined` and the title agent silently uses the main model. The fallback behavior is correct (per the documented design and the changelog: *"Invalid small_model config no longer poisons fallback paths"*), but the user has no way to know their config was ignored. The fix adds a `WARN` log inside the `catchTag` handler so users see why.

**Bug 2 — `smallOptions` missing opencode handling.** When the title agent calls the LLM with `small: true` for an opencode provider model, `smallOptions` returned `{}` because it only handled `openai`, `openrouter`/`llmgateway`, and `venice`. The opencode API call was missing the `include` and `reasoningSummary` options that `options()` already sets for opencode, so the request would fail/behave unexpectedly, and the LLM runtime would retry — that's the ~90s delay users reported. The fix adds the same opencode options to `smallOptions`, scoped to the small-model call path.

Related: #8609 (misleading docs), #14807 (silent failure), #30662 (smallOptions missing opencode).

### How did you verify your code works?

```
cd packages/opencode
bun typecheck                                          # passes
bun test ./test/provider/provider.test.ts              # 88/88 pass
bun test ./test/provider/transform.test.ts             # 250/250 pass (was 248, +2 new for opencode)
bun test ./test/session/prompt.test.ts -t "loop calls LLM"  # passes
```

To verify the warning manually: set `small_model: "opencode/some-invalid-model"` in your config, start a session, and you should see a `WARN` line `configured small_model not found, falling back to main model` in the logs.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR