### PR TITLE
fix: strip env variable prefixes from permission pattern matching

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -120,7 +120,15 @@ function parts(node: Node) {
 }
 
 function source(node: Node) {
-  return (node.parent?.type === "redirected_statement" ? node.parent.text : node.text).trim()
+  const target = node.parent?.type === "redirected_statement" ? node.parent : node
+  const text = target.text
+  let offset = 0
+  for (let i = 0; i < target.childCount; i++) {
+    const child = target.child(i)
+    if (!child || child.type !== "variable_assignment") break
+    offset = child.endIndex - target.startIndex
+  }
+  return offset > 0 ? text.slice(offset).trim() : text.trim()
 }
 
 function commands(node: Node) {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -239,6 +239,58 @@ describe("tool.shell permissions", () => {
     }),
   )
 
+  for (const item of shells.filter((s) => !PS.has(s.label))) {
+    it.live(`strips env variable prefixes from permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        runIn(
+          projectRoot,
+          Effect.gen(function* () {
+            const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+            yield* run(
+              {
+                command: "NODE_ENV=production echo hello",
+                description: "Echo with env var",
+              },
+              capture(requests),
+            )
+            expect(requests.length).toBe(1)
+            expect(requests[0].permission).toBe("bash")
+            expect(requests[0].patterns).toContain("echo hello")
+            expect(requests[0].patterns).not.toContain("NODE_ENV=production echo hello")
+            expect(requests[0].always).toContain("echo *")
+          }),
+        ),
+      ),
+    )
+  }
+
+  for (const item of shells.filter((s) => !PS.has(s.label))) {
+    it.live(`strips multiple env variable prefixes from permission pattern [${item.label}]`, () =>
+      withShell(
+        item,
+        runIn(
+          projectRoot,
+          Effect.gen(function* () {
+            const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+            yield* run(
+              {
+                command: "NODE_ENV=production DEBUG=1 go test ./...",
+                description: "Go test with env vars",
+              },
+              capture(requests),
+            )
+            expect(requests.length).toBe(1)
+            expect(requests[0].permission).toBe("bash")
+            expect(requests[0].patterns).toContain("go test ./...")
+            expect(requests[0].patterns).not.toContain("NODE_ENV=production DEBUG=1 go test ./...")
+            expect(requests[0].always).toContain("go test *")
+          }),
+        ),
+      ),
+    )
+  }
+
   each("asks for bash permission with multiple commands", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped()


### PR DESCRIPTION
### Issue for this PR

Closes #14110

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `source()` function in `packages/opencode/src/tool/shell.ts` returns the full command text for permission pattern matching. When a command has inline environment variable prefixes (e.g., `GOFLAGS=-mod=vendor go test ./...`), the tree-sitter AST includes `variable_assignment` nodes at the start of the `command` node. `source()` returned the full text including these nodes, so the permission pattern became `GOFLAGS=-mod=vendor go test ./...` instead of `go test ./...`.

This meant permission rules like `"go *": "allow"` would not match, and users would get unnecessary permission prompts even though the command should be allowed.

Note: The `parts()` function (used for `always` auto-approval patterns) already correctly skips `variable_assignment` nodes. Only the `patterns` path via `source()` was affected.

**Fix:** Skip leading `variable_assignment` children in `source()` by finding the first non-`variable_assignment` child and slicing the text from its offset. This correctly handles:
- Single env var: `NODE_ENV=production echo hello` → `echo hello`
- Multiple env vars: `NODE_ENV=production DEBUG=1 go test ./...` → `go test ./...`
- No env vars: `go test ./...` → `go test ./...` (unchanged)
- Redirected statements: `NODE_ENV=production go test ./... > /dev/null` → `go test ./... > /dev/null`

### How did you verify your code works?

Added two new test cases in `packages/opencode/test/tool/shell.test.ts`:
1. Single env variable prefix: verifies `NODE_ENV=production echo hello` produces pattern `echo hello`
2. Multiple env variable prefixes: verifies `NODE_ENV=production DEBUG=1 go test ./...` produces pattern `go test ./...`

Both tests verify that the `always` auto-approval pattern is also correct (e.g., `echo *`, `go test *`). Tests run for bash and cmd shells (PowerShell doesn't support this syntax).

Test results: 68 pass, 1 fail (pre-existing Windows path normalization test unrelated to this change).

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR