### PR TITLE
feat(plugin): add freemodel.dev auth provider

### DIFF
--- a/packages/opencode/src/plugin/freemodel/index.ts
+++ b/packages/opencode/src/plugin/freemodel/index.ts
@@ -1,0 +1,139 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import { randomUUID } from "node:crypto"
+
+// freemodel.dev is a single gateway, reached with one API key, that serves two
+// request formats from the same account:
+//   - Anthropic (Claude Code) at cc.freemodel.dev      → /v1/messages
+//   - OpenAI   (Codex)        at api.freemodel.dev      → /v1/chat/completions, /v1/responses
+// Each format has a free node and a faster T1+ node. The catalog ships one
+// `freemodel` provider whose models carry their own npm + api host (Anthropic
+// vs OpenAI), so a single login exposes both model families. The free hosts are
+// the per-model api urls in the catalog; the loader never sets a provider-level
+// baseURL (that would override every model's url), and instead hands the client
+// a fetch wrapper that (a) upgrades the host to the T1+ node when that tier was
+// chosen and (b) signs + scrubs Anthropic requests so they pass the gate.
+const HOSTS = {
+  // free host -> T1+ host
+  "cc.freemodel.dev": "api-cc.freemodel.dev",
+  "api.freemodel.dev": "vip-sg.freemodel.dev",
+} as const
+
+const ANTHROPIC_HOSTS = new Set(["cc.freemodel.dev", "api-cc.freemodel.dev"])
+
+type Tier = "free" | "t1"
+
+// The gate accepts metadata.user_id only when it is a JSON string carrying a
+// session_id (the Claude Code CLI shape). Treat any other value as missing.
+function isClaudeCodeUserId(value: unknown): boolean {
+  if (typeof value !== "string") return false
+  try {
+    const parsed = JSON.parse(value)
+    return !!parsed && typeof parsed === "object" && typeof parsed.session_id === "string"
+  } catch {
+    return false
+  }
+}
+
+// opencode's system prompt advertises a `Workspace root folder:` line in its
+// <env> block. That key does not exist in the Claude Code CLI prompt, and the
+// freemodel Anthropic node fingerprints it: a body carrying that line is
+// rejected with `400 {"type":"upstream_error"}`, while the identical body with
+// the line removed is served normally. Strip it so Anthropic requests pass.
+const WORKSPACE_ROOT_LINE = /\n[ \t]*Workspace root folder:[^\n]*/g
+
+function scrubSystem(value: unknown): unknown {
+  if (typeof value === "string") return value.replace(WORKSPACE_ROOT_LINE, "")
+  if (Array.isArray(value))
+    return value.map((block) =>
+      block && typeof block === "object" && typeof (block as any).text === "string"
+        ? { ...block, text: (block as any).text.replace(WORKSPACE_ROOT_LINE, "") }
+        : block,
+    )
+  return value
+}
+
+// The Anthropic nodes gate non-CLI traffic, returning 200 with
+// {"text":"Please use Claude Code CLI"} unless the request body carries a
+// metadata.user_id that is a JSON string containing a session_id — the same
+// shape the official Claude Code CLI sends. The OpenAI nodes have no gate.
+function makeFetch(tier: Tier): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
+  const sessionID = randomUUID()
+  const userId = JSON.stringify({ device_id: "", account_uuid: "", session_id: sessionID })
+
+  return async (input, init) => {
+    let url: URL | undefined
+    const raw = typeof input === "string" ? input : input instanceof URL ? input.href : (input as Request).url
+    try {
+      url = new URL(raw)
+    } catch {}
+
+    if (url && tier === "t1") {
+      const upgraded = HOSTS[url.hostname as keyof typeof HOSTS]
+      if (upgraded) {
+        url.hostname = upgraded
+        input = typeof input === "string" || input instanceof URL ? url : new Request(url, input as Request)
+      }
+    }
+
+    // For Anthropic requests: sign with a Claude Code CLI metadata.user_id and
+    // strip the env line the gate fingerprints.
+    if (url && ANTHROPIC_HOSTS.has(url.hostname) && init?.body && typeof init.body === "string") {
+      try {
+        const body = JSON.parse(init.body)
+        if (body && typeof body === "object") {
+          let changed = false
+          if (!isClaudeCodeUserId(body.metadata?.user_id)) {
+            body.metadata = { ...body.metadata, user_id: userId }
+            changed = true
+          }
+          if (body.system !== undefined) {
+            const scrubbed = scrubSystem(body.system)
+            if (scrubbed !== body.system) {
+              body.system = scrubbed
+              changed = true
+            }
+          }
+          if (changed) init = { ...init, body: JSON.stringify(body) }
+        }
+      } catch {}
+    }
+
+    return fetch(input, init)
+  }
+}
+
+export async function FreeModelAuthPlugin(_input: PluginInput): Promise<Hooks> {
+  return {
+    auth: {
+      provider: "freemodel",
+      async loader(getAuth) {
+        const auth = await getAuth()
+        if (auth.type !== "api") return {}
+        const tier = (auth.metadata?.tier as Tier) ?? "free"
+        // No baseURL: each model keeps its own catalog api host (Anthropic vs
+        // OpenAI). The fetch wrapper handles tier upgrades and the gate.
+        return {
+          apiKey: auth.key,
+          fetch: makeFetch(tier),
+        }
+      },
+      methods: [
+        {
+          type: "api",
+          label: "API key",
+          prompts: [
+            {
+              type: "select",
+              key: "tier",
+              message: "Select FreeModel endpoint tier",
+              options: [
+                { label: "Free", value: "free", hint: "cc.freemodel.dev / api.freemodel.dev" },
+                { label: "T1+", value: "t1", hint: "api-cc.freemodel.dev / vip-sg.freemodel.dev" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  }
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -19,6 +19,7 @@ import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cl
 import { AzureAuthPlugin } from "./azure"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
 import { XaiAuthPlugin } from "./xai"
+import { FreeModelAuthPlugin } from "./freemodel"
 import { Effect, Layer, Context } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
@@ -78,6 +79,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     AzureAuthPlugin,
     DigitalOceanAuthPlugin,
     XaiAuthPlugin,
+    FreeModelAuthPlugin,
   ]
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a built-in auth provider for freemodel.dev. It's one gateway behind a single API key that speaks both the Anthropic (`/v1/messages`) and OpenAI (`/v1/chat/completions`) formats. The matching catalog entry (anomalyco/models.dev#2030) is a single `freemodel` provider whose models each carry their own `npm` + `api` host, so one login surfaces both the Claude and GPT models and each model routes to the right host.

The loader returns `{ apiKey, fetch }` and deliberately does **not** set a provider-level `baseURL`, because that would override every model's per-model host. Instead the returned `fetch` wrapper does two things:

- On the `T1+` tier it rewrites the free host to the faster node (`cc.freemodel.dev` → `api-cc.freemodel.dev`, `api.freemodel.dev` → `vip-sg.freemodel.dev`).
- On the Anthropic hosts it adds `metadata.user_id` (the gateway only serves requests whose `user_id` is a JSON string with a `session_id`, which is the shape the Claude Code CLI sends) and removes the one `Workspace root folder:` line opencode puts in its `<env>` block. That line doesn't exist in the Claude Code CLI prompt and the gateway rejects any body containing it with a `400 upstream_error`; dropping it lets the otherwise-identical request through. The OpenAI hosts have no such gate, so that branch is skipped for them.

I found the `Workspace root folder:` trigger by bisecting the system prompt against the live gateway until a one-line change flipped the response from `400` to a normal completion, so I'm confident that's the actual cause and not a coincidence.

### How did you verify your code works?

Logged in with a real key and ran a prompt against both families on both tiers (`opencode run`):

- `freemodel/claude-haiku-4-5-20251001` (Anthropic host) — replies
- `freemodel/gpt-5.4-mini` (OpenAI host) — replies

`tsgo --noEmit` is clean. Catalog tested locally via `OPENCODE_MODELS_PATH` until #2030 merges.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
