### PR TITLE
fix(llm): add stream timeout to prevent OMO harness deadlock

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -6,7 +6,7 @@ import { Log } from "@opencode-ai/core/util/log"
 import { Context, Effect, Layer } from "effect"
 import * as Stream from "effect/Stream"
 import { streamText, wrapLanguageModel, type ModelMessage, type Tool } from "ai"
-import type { LLMEvent } from "@opencode-ai/llm"
+import { LLMEvent } from "@opencode-ai/llm"
 import { LLMClient, RequestExecutor, WebSocketExecutor } from "@opencode-ai/llm/route"
 import type { LLMClientService } from "@opencode-ai/llm/route"
 import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
@@ -373,6 +373,14 @@ const live: Layer.Layer<
             ).pipe(
               Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
               Stream.flatMap((events) => Stream.fromIterable(events)),
+              Stream.timeout("5 minutes"),
+              Stream.catchCause(() =>
+                Stream.fromIterable([
+                  LLMEvent.providerError({
+                    message: "Stream timeout: no events received for 5 minutes",
+                  }),
+                ]),
+              ),
             )
           }),
         ),


### PR DESCRIPTION
## Summary

Fixes stream consumer deadlock in OMO harness when LLM provider stops emitting events but never closes the stream.

## Problem

The AI SDK `fullStream` is converted to an Effect Stream without any timeout between events:

```typescript
return Stream.fromAsyncIterable(result.result.fullStream, ...).pipe(
  Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
  Stream.flatMap((events) => Stream.fromIterable(events)),
  // No timeout here - hangs forever if provider stops emitting
)
```

This causes indefinite hangs (observed 36 minutes with Kimi K2.6 thinking mode) where the consumer waits for events that never arrive.

## Solution

Add `Stream.timeout` and `Stream.catchCause` to handle inactivity gracefully:

```typescript
Stream.timeout("5 minutes"),
Stream.catchCause(() =>
  Stream.fromIterable([
    LLMEvent.providerError({
      message: "Stream timeout: no events received for 5 minutes",
    }),
  ]),
),
```

Also changed `LLMEvent` import from `type` to value import to access the constructor.

## Changes

- `packages/opencode/src/session/llm.ts`
  - Added `Stream.timeout("5 minutes")` to detect stalled streams
  - Added `Stream.catchCause` to emit `providerError` on timeout
  - Changed `import type { LLMEvent }` to `import { LLMEvent }` for constructor access

## Testing

- TypeScript typecheck passes
- The fix converts an indefinite hang into a graceful error with a clear message

## Related Issues

Fixes #31122