### PR TITLE
docs: clarify LSP config vs experimental lsp tool

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -51,6 +51,10 @@ OpenCode comes with several built-in LSP servers for popular languages:
 LSP is disabled by default. When enabled, servers start when one of the above file extensions is detected and the requirements are met.
 
 :::note
+Enabling `lsp` in config turns on LSP server integration and diagnostics. The separate [`lsp` tool](/docs/tools#lsp-experimental) is still experimental and also requires `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` (or `OPENCODE_EXPERIMENTAL=true`).
+:::
+
+:::note
 You can disable automatic LSP server downloads by setting the `OPENCODE_DISABLE_LSP_DOWNLOAD` environment variable to `true`.
 :::
 


### PR DESCRIPTION
Fixes #30954

Clarifies that enabling `lsp` in config turns on LSP server integration and diagnostics, while the separate `lsp` tool still requires the experimental env flag.

Verification: docs-only change; checked the affected `/docs/lsp` and `/docs/tools#lsp-experimental` pages in source.