### PR TITLE
feat: add opencode-image-viewer to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -19,6 +19,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | [opencode-daytona](https://github.com/daytonaio/daytona/tree/main/libs/opencode-plugin)            | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews  |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                                 |
+| [opencode-image-viewer](https://www.npmjs.com/package/opencode-image-viewer)                        | Display local images in chat via local HTTP server with 50% width hero view                        |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                              |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                      |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                               |


### PR DESCRIPTION
Adds @akinopng/opencode-image-viewer to the Plugins ecosystem table.

A plugin that serves local images via an HTTP server and displays them inline in chat at 50% width with styling. Useful for image generation feedback.