### PR TITLE
fix(core): use static tool type imports

### DIFF
--- a/packages/core/src/public/opencode.ts
+++ b/packages/core/src/public/opencode.ts
@@ -13,11 +13,11 @@ import { SessionProjector } from "../session/projector"
 import { SessionStore } from "../session/store"
 import { ApplicationTools } from "../tool/application-tools"
 import { Session } from "./session"
-import type { ToolService } from "./tool"
+import { Tool } from "./tool"
 
 export interface Interface {
   readonly sessions: Session.Interface
-  readonly tools: ToolService
+  readonly tools: Tool.Interface
 }
 
 /** Intentional public native API for Effect applications embedding OpenCode. */

--- a/packages/core/src/public/opencode.ts
+++ b/packages/core/src/public/opencode.ts
@@ -13,10 +13,11 @@ import { SessionProjector } from "../session/projector"
 import { SessionStore } from "../session/store"
 import { ApplicationTools } from "../tool/application-tools"
 import { Session } from "./session"
+import type { ToolService } from "./tool"
 
 export interface Interface {
   readonly sessions: Session.Interface
-  readonly tools: import("./tool").Service
+  readonly tools: ToolService
 }
 
 /** Intentional public native API for Effect applications embedding OpenCode. */

--- a/packages/core/src/public/tool.ts
+++ b/packages/core/src/public/tool.ts
@@ -1,9 +1,10 @@
 import { Effect, Scope } from "effect"
+import type { Tool } from "../tool/tool"
 
 export { Failure, RegistrationError, make } from "../tool/tool"
 export type { AnyTool, Content, Context, Tool } from "../tool/tool"
 
-export interface Service {
+export interface ToolService {
   /**
    * Register same-process tools on this OpenCode instance for the current Scope.
    * Location tools with the same name take precedence where they are installed.
@@ -11,6 +12,6 @@ export interface Service {
    * started settling may fail because the tool is no longer available.
    */
   readonly register: (
-    tools: Readonly<Record<string, import("../tool/tool").AnyTool>>,
-  ) => Effect.Effect<void, import("../tool/tool").RegistrationError, Scope.Scope>
+    tools: Readonly<Record<string, Tool.AnyTool>>,
+  ) => Effect.Effect<void, Tool.RegistrationError, Scope.Scope>
 }

--- a/packages/core/src/public/tool.ts
+++ b/packages/core/src/public/tool.ts
@@ -1,17 +1,17 @@
+export * as Tool from "./tool"
+
 import { Effect, Scope } from "effect"
-import type { Tool } from "../tool/tool"
+import type { AnyTool, RegistrationError } from "../tool/tool"
 
 export { Failure, RegistrationError, make } from "../tool/tool"
-export type { AnyTool, Content, Context, Tool } from "../tool/tool"
+export type { AnyTool, Content, Context } from "../tool/tool"
 
-export interface ToolService {
+export interface Interface {
   /**
    * Register same-process tools on this OpenCode instance for the current Scope.
    * Location tools with the same name take precedence where they are installed.
    * Closing the Scope removes the tools immediately, so calls that have not
    * started settling may fail because the tool is no longer available.
    */
-  readonly register: (
-    tools: Readonly<Record<string, Tool.AnyTool>>,
-  ) => Effect.Effect<void, Tool.RegistrationError, Scope.Scope>
+  readonly register: (tools: Readonly<Record<string, AnyTool>>) => Effect.Effect<void, RegistrationError, Scope.Scope>
 }


### PR DESCRIPTION
## Summary

- replace inline import types in the public Tool API with ordinary static type imports
- name the registration facade `ToolService` to distinguish it from the opaque `Tool<Input, Output>` carrier

## Verification

- `bun typecheck` in `packages/core`
- repository-wide pre-push `bun turbo typecheck` (22 packages)
- `git diff --check`