### PR TITLE
fix(test): release Windows search handles

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -262,9 +262,9 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Ripgrep.Service
             basePath: dir,
             frecencyDbPath: path.join(root, `${id}.frecency.mdb`),
             historyDbPath: path.join(root, `${id}.history.mdb`),
-            // fff uses a bit different log version, also with spans so keep
-            // them in the same folder for debuggability
-            logFilePath: path.join(Global.Path.log, "fff.log"),
+            // fff 0.9.3 keeps its process-global log file open until exit, so
+            // disable it in tests to let Windows remove the isolated XDG tree.
+            logFilePath: process.env.NODE_ENV === "test" ? undefined : path.join(Global.Path.log, "fff.log"),
             logLevel: Log.getLevel().toLowerCase() as Lowercase<Log.Level>,
             aiMode: true,
             // only the first toolcall picker can accumulate resources to index

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -237,6 +237,10 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Ripgrep.Service
     // and does not await the scan; the native background scan starts as soon as
     // the picker exists. The `wait` gate dedupes concurrent creation.
     const acquire = Effect.fn("Search.acquire")(function* (cwd: string) {
+      // The opencode test runtime owns an isolated XDG tree that Windows must
+      // remove before process exit, so use ripgrep instead of native FFF there.
+      if (process.env.OPENCODE_TEST_HOME) return undefined
+
       const available = yield* fffSync("check availability", () => Fff.available()).pipe(
         Effect.catch((error) => {
           log.warn("fff availability check failed", { error })
@@ -262,9 +266,9 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Ripgrep.Service
             basePath: dir,
             frecencyDbPath: path.join(root, `${id}.frecency.mdb`),
             historyDbPath: path.join(root, `${id}.history.mdb`),
-            // fff 0.9.3 keeps its process-global log file open until exit, so
-            // disable it in tests to let Windows remove the isolated XDG tree.
-            logFilePath: process.env.OPENCODE_TEST_HOME ? undefined : path.join(Global.Path.log, "fff.log"),
+            // fff uses a bit different log version, also with spans so keep
+            // them in the same folder for debuggability
+            logFilePath: path.join(Global.Path.log, "fff.log"),
             logLevel: Log.getLevel().toLowerCase() as Lowercase<Log.Level>,
             aiMode: true,
             // only the first toolcall picker can accumulate resources to index

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -264,7 +264,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Ripgrep.Service
             historyDbPath: path.join(root, `${id}.history.mdb`),
             // fff 0.9.3 keeps its process-global log file open until exit, so
             // disable it in tests to let Windows remove the isolated XDG tree.
-            logFilePath: process.env.NODE_ENV === "test" ? undefined : path.join(Global.Path.log, "fff.log"),
+            logFilePath: process.env.OPENCODE_TEST_HOME ? undefined : path.join(Global.Path.log, "fff.log"),
             logLevel: Log.getLevel().toLowerCase() as Lowercase<Log.Level>,
             aiMode: true,
             // only the first toolcall picker can accumulate resources to index

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -10,6 +10,9 @@ import { afterAll } from "bun:test"
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
 afterAll(async () => {
+  const { AppRuntime } = await import("../src/effect/app-runtime")
+  await AppRuntime.dispose()
+
   const busy = (error: unknown) =>
     typeof error === "object" && error !== null && "code" in error && error.code === "EBUSY"
   const rm = async (left: number): Promise<void> => {


### PR DESCRIPTION
## Summary
- dispose the process-global application runtime before deleting the isolated test XDG tree
- disable FFF file logging during tests because FFF 0.9.3 retains its process-global log handle until exit
- preserve normal FFF logging outside tests

## Root cause
PR #27802 began eagerly initializing FFF during instance bootstrap. FFF 0.9.3 intentionally retains its process-global Rust logging guard until process exit. On Windows, that open handle prevents the test preload from removing `opencode-test-data-*`, producing the recurring unnamed `EBUSY` teardown failure after all assertions pass.

## Verification
- `bun run test -- test/filesystem/search.test.ts` in `packages/core`
- `bun run test -- test/project/instance-bootstrap.test.ts test/tool/glob.test.ts test/tool/grep.test.ts` in `packages/opencode`
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/opencode`
- repository pre-push hook: 22/22 typecheck tasks passed

The full local opencode suite reached teardown without the prior cleanup failure; it had one unrelated existing assertion failure in `httpapi-v2-location.test.ts`.