### PR TITLE
fix(tui): enable client-side filtering for session search dialogs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -229,7 +229,6 @@ export function DialogSessionList() {
     <DialogSelect
       title="Sessions"
       options={options()}
-      skipFilter={true}
       current={currentSessionID()}
       onFilter={setSearch}
       onMove={() => {

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/session/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/session/dialog.tsx
@@ -252,7 +252,6 @@ export function SessionSwitcherDialog() {
       ref={(value) => (select = value)}
       title="Sessions"
       options={options()}
-      skipFilter={true}
       current={currentSessionID()}
       onFilter={setSearch}
       onMove={(option) => {


### PR DESCRIPTION
### Issue for this PR

Closes #31182

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Issue:** The `/sessions` command search appears broken - typing in the filter box does not filter sessions. All sessions continue to display regardless of search term. This affects both the basic session list dialog and the experimental session switcher plugin.

**Root cause:** Both dialogs used `skipFilter={true}` on the `DialogSelect` component, which disabled client-side filtering. They relied entirely on server-side API calls to filter results via `sdk.client.session.list({ search: query })`. When the API returned empty results or encountered errors, the fallback behavior showed ALL unfiltered sessions instead of "No results found" or properly filtered results.

**Fix:** Removed `skipFilter={true}` from both `DialogSessionList` and `SessionSwitcherDialog`. This enables `DialogSelect`'s built-in client-side fuzzysort filtering as a fallback layer.

**Why this works:**
- Server-side API search still fires via `onFilter={setSearch}`, so the backend still gets search queries
- DialogSelect now applies client-side fuzzysort on top of whatever options are provided
- If API returns empty array → `options()` builds from empty result → fuzzysort filters nothing → displays nothing → "No results found" shown
- If API fails/doesn't update → `sync.data.session` provides all sessions → client-side fuzzysort handles the filtering
- Provides redundant filtering layers (server + client) ensuring search always works

**Files changed:**
- `packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx` - removed line 232
- `packages/opencode/src/cli/cmd/tui/feature-plugins/session/dialog.tsx` - removed line 255

### How did you verify your code works?

- Built v1.16.2 with the fix applied (version 1.16.2-oc)
- Tested basic `/sessions` search - confirmed filter input properly narrows session list
- Enabled experimental session switcher (`OPENCODE_EXPERIMENTAL_SESSION_SWITCHER=1 opencode`)
- Tested experimental `/sessions` search - confirmed filter works identically to basic dialog
- Verified in both modes that typing search terms correctly filters results, and empty searches show all sessions as expected

### Screenshots / recordings

N/A - simple text-based UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
