### PR TITLE
feat(provider): add AGIone provider

### DIFF
--- a/packages/core/src/plugin/provider.ts
+++ b/packages/core/src/plugin/provider.ts
@@ -1,3 +1,4 @@
+import { AgionePlugin } from "./provider/agione"
 import { AlibabaPlugin } from "./provider/alibaba"
 import { AmazonBedrockPlugin } from "./provider/amazon-bedrock"
 import { AnthropicPlugin } from "./provider/anthropic"
@@ -32,6 +33,7 @@ import { XAIPlugin } from "./provider/xai"
 import { ZenmuxPlugin } from "./provider/zenmux"
 
 export const ProviderPlugins = [
+  AgionePlugin,
   AlibabaPlugin,
   AmazonBedrockPlugin,
   AnthropicPlugin,

--- a/packages/core/src/plugin/provider/agione.ts
+++ b/packages/core/src/plugin/provider/agione.ts
@@ -1,0 +1,62 @@
+import { DateTime, Effect } from "effect"
+import { ModelV2 } from "../../model"
+import { PluginV2 } from "../../plugin"
+import { ProviderV2 } from "../../provider"
+
+const PROVIDER_ID = ProviderV2.ID.make("agione")
+const MODEL_ID = ModelV2.ID.make("deepseek/deepseek-v4-pro/d3462")
+const BASE_URL = "https://agione.pro/hyperone/xapi/api/v1"
+const ENV_KEY = "AGIONE_API_KEY"
+
+export const AgionePlugin = PluginV2.define({
+  id: PluginV2.ID.make("agione"),
+  effect: Effect.gen(function* () {
+    return {
+      "catalog.transform": Effect.fn(function* (evt) {
+        const apiKey = process.env[ENV_KEY]
+
+        evt.provider.update(PROVIDER_ID, (provider) => {
+          provider.name = "AGIone"
+          provider.env = [ENV_KEY]
+          provider.api = {
+            type: "aisdk",
+            package: "@ai-sdk/openai-compatible",
+            url: BASE_URL,
+          }
+          provider.request.headers["HTTP-Referer"] ??= "https://opencode.ai/"
+          provider.request.headers["X-Title"] ??= "opencode"
+
+          if (apiKey) {
+            provider.enabled = {
+              via: "env",
+              name: ENV_KEY,
+            }
+          }
+        })
+
+        evt.model.update(PROVIDER_ID, MODEL_ID, (model) => {
+          model.name = "DeepSeek V4 Pro"
+          model.family = ModelV2.Family.make("deepseek")
+          model.api = {
+            id: MODEL_ID,
+            type: "aisdk",
+            package: "@ai-sdk/openai-compatible",
+            url: BASE_URL,
+          }
+          model.capabilities = {
+            tools: true,
+            input: ["text"],
+            output: ["text"],
+          }
+          model.time.released = DateTime.makeUnsafe(Date.parse("2026-01-01"))
+          model.status = "active"
+          model.enabled = true
+          model.limit = {
+            context: 128_000,
+            output: 8_192,
+          }
+        })
+      }),
+    }
+  }),
+})

--- a/packages/core/test/plugin/provider-agione.test.ts
+++ b/packages/core/test/plugin/provider-agione.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Catalog } from "@opencode-ai/core/catalog"
+import { EventV2 } from "@opencode-ai/core/event"
+import { Location } from "@opencode-ai/core/location"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { AgionePlugin } from "@opencode-ai/core/plugin/provider/agione"
+import { ProviderPlugins } from "@opencode-ai/core/plugin/provider"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { location } from "../fixture/location"
+import { testEffect } from "../lib/effect"
+import { expectPluginRegistered, npmLayer, withEnv } from "./provider-helper"
+
+const locationLayer = Layer.succeed(
+  Location.Service,
+  Location.Service.of(location({ directory: AbsolutePath.make("test") })),
+)
+
+const it = testEffect(
+  Catalog.locationLayer.pipe(
+    Layer.provideMerge(EventV2.defaultLayer),
+    Layer.provideMerge(locationLayer),
+    Layer.provideMerge(npmLayer),
+  ),
+)
+
+describe("AgionePlugin", () => {
+  it.effect("is registered as a provider plugin", () =>
+    Effect.sync(() =>
+      expectPluginRegistered(
+        ProviderPlugins.map((item) => item.id),
+        "agione",
+      ),
+    ),
+  )
+
+  it.effect("adds the AGIone provider and default coding model", () =>
+    withEnv({ AGIONE_API_KEY: undefined }, () =>
+      Effect.gen(function* () {
+        const plugin = yield* PluginV2.Service
+        const catalog = yield* Catalog.Service
+        yield* plugin.add(AgionePlugin)
+        const transform = yield* catalog.transform()
+        yield* transform(() => {})
+
+        const provider = yield* catalog.provider.get(ProviderV2.ID.make("agione"))
+        expect(provider.name).toBe("AGIone")
+        expect(provider.env).toEqual(["AGIONE_API_KEY"])
+        expect(provider.api).toEqual({
+          type: "aisdk",
+          package: "@ai-sdk/openai-compatible",
+          url: "https://agione.pro/hyperone/xapi/api/v1",
+        })
+        expect(provider.request.headers).toEqual({
+          "HTTP-Referer": "https://opencode.ai/",
+          "X-Title": "opencode",
+        })
+        expect(provider.enabled).toBe(false)
+
+        const model = yield* catalog.model.get(
+          ProviderV2.ID.make("agione"),
+          ModelV2.ID.make("deepseek/deepseek-v4-pro/d3462"),
+        )
+        expect(model.name).toBe("DeepSeek V4 Pro")
+        expect(model.api).toEqual({
+          id: ModelV2.ID.make("deepseek/deepseek-v4-pro/d3462"),
+          type: "aisdk",
+          package: "@ai-sdk/openai-compatible",
+          url: "https://agione.pro/hyperone/xapi/api/v1",
+          settings: {},
+        })
+        expect(model.capabilities).toEqual({
+          tools: true,
+          input: ["text"],
+          output: ["text"],
+        })
+        expect(model.limit).toEqual({ context: 128_000, output: 8_192 })
+      }),
+    ),
+  )
+
+  it.effect("enables AGIone from AGIONE_API_KEY", () =>
+    withEnv({ AGIONE_API_KEY: "test-key" }, () =>
+      Effect.gen(function* () {
+        const plugin = yield* PluginV2.Service
+        const catalog = yield* Catalog.Service
+        yield* plugin.add(AgionePlugin)
+        const transform = yield* catalog.transform()
+        yield* transform(() => {})
+
+        const provider = yield* catalog.provider.get(ProviderV2.ID.make("agione"))
+        expect(provider.enabled).toEqual({ via: "env", name: "AGIONE_API_KEY" })
+      }),
+    ),
+  )
+})

--- a/packages/opencode/src/plugin/agione.ts
+++ b/packages/opencode/src/plugin/agione.ts
@@ -1,0 +1,13 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const AgioneAuthPlugin: Plugin = async () => ({
+  auth: {
+    provider: "agione",
+    methods: [
+      {
+        type: "api",
+        label: "API key",
+      },
+    ],
+  },
+})

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -17,6 +17,7 @@ import { gitlabAuthPlugin as GitlabAuthPlugin } from "opencode-gitlab-auth"
 import { PoeAuthPlugin } from "opencode-poe-auth"
 import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cloudflare"
 import { AzureAuthPlugin } from "./azure"
+import { AgioneAuthPlugin } from "./agione"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
 import { XaiAuthPlugin } from "./xai"
 import { Effect, Layer, Context } from "effect"
@@ -65,6 +66,7 @@ export function experimentalWebSocketsEnabled(input: { enabled: boolean; channel
 // Built-in plugins that are directly imported (not installed from npm)
 function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
   return [
+    AgioneAuthPlugin,
     // Temporary rollout: pre-release builds use WebSockets by default; releases require explicit opt-in.
     (input) =>
       CodexAuthPlugin(input, {

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -154,6 +154,41 @@ Don't see a provider here? Submit a PR.
 
 ---
 
+### AGIone
+
+AGIone provides an OpenAI-compatible API for multiple model vendors. OpenCode includes a built-in AGIone provider with DeepSeek V4 Pro as the default coding model.
+
+1. Create an API key in the [AGIone console](https://agione.pro/).
+
+2. Run the `/connect` command and search for **AGIone**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your AGIone API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command and select `deepseek/deepseek-v4-pro/d3462`.
+
+   ```txt
+   /models
+   ```
+
+You can also use the provider with an environment variable:
+
+```bash
+AGIONE_API_KEY=<your-api-key> opencode
+```
+
+---
+
 ### Amazon Bedrock
 
 To use Amazon Bedrock with OpenCode:


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds AGIone as a built-in OpenAI-compatible provider.

AGIone uses the existing `@ai-sdk/openai-compatible` path with `https://agione.pro/hyperone/xapi/api/v1` as the base URL and `AGIONE_API_KEY` for environment-based auth. This PR adds:

- `AgionePlugin` in `packages/core`, registered before the generic OpenAI-compatible plugin
- `deepseek/deepseek-v4-pro/d3462` as the default coding model
- an internal `/connect` API-key auth plugin
- provider docs with the `/connect`, `/models`, and env-var setup paths

Submitted by the AGIone team.

### How did you verify your code works?

```text
bun install --frozen-lockfile
bun --cwd packages/core run test test/plugin/provider-agione.test.ts
bun --cwd packages/core run test test/plugin/provider-agione.test.ts test/plugin/provider-snowflake-cortex.test.ts test/plugin/provider-openai-compatible.test.ts
bun --cwd packages/core run typecheck
bunx prettier --check packages/core/src/plugin/provider/agione.ts packages/core/src/plugin/provider.ts packages/core/test/plugin/provider-agione.test.ts packages/opencode/src/plugin/agione.ts packages/opencode/src/plugin/index.ts packages/web/src/content/docs/providers.mdx
git diff --check
gitleaks protect --staged --redact --verbose
```

Live smoke test with `AGIONE_API_KEY` from the environment:

```text
POST https://agione.pro/hyperone/xapi/api/v1/chat/completions
model=deepseek/deepseek-v4-pro/d3462
status=ok
content=opencode-agione-ok
```

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
