### PR TITLE
fix(tui): replace @solid-primitives/scheduled with manual debounce for Node.js compatibility

### DIFF
--- a/packages/tui/src/feature-plugins/session/preview-pane.tsx
+++ b/packages/tui/src/feature-plugins/session/preview-pane.tsx
@@ -1,7 +1,7 @@
 import { createResource, Show, createMemo, createSignal, onMount, type Accessor, type JSX } from "solid-js"
 import { TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
-import { debounce, leadingAndTrailing } from "@solid-primitives/scheduled"
+
 import type { Message, Part, Session as SdkSession } from "@opencode-ai/sdk/v2"
 import { useTheme } from "../../context/theme"
 import { useSDK } from "../../context/sdk"
@@ -56,7 +56,21 @@ export function prefetchPreviews(sdk: Sdk, sync: Sync, sessionIDs: readonly stri
 export function createLeadingTrailingSignal<T>(initial: T, ms: number): [Accessor<T>, (v: T) => void, (v: T) => void] {
   const [get, set] = createSignal(initial)
   const setNow = (v: T) => set(() => v)
-  const schedule = leadingAndTrailing(debounce, setNow, ms)
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let pending: T | undefined
+  const schedule = (v: T) => {
+    if (timer) {
+      pending = v
+      return
+    }
+    set(() => v)
+    timer = setTimeout(() => {
+      timer = undefined
+      const next = pending
+      if (next !== undefined) set(() => next)
+      pending = undefined
+    }, ms)
+  }
   return [get, setNow, schedule]
 }
 

--- a/packages/tui/src/util/signal.ts
+++ b/packages/tui/src/util/signal.ts
@@ -1,9 +1,13 @@
 import { createEffect, createSignal, on, onCleanup, type Accessor } from "solid-js"
-import { debounce, type Scheduled } from "@solid-primitives/scheduled"
 
-export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, Scheduled<[value: T]>] {
+export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, (v: T) => void] {
   const [get, set] = createSignal(value)
-  return [get, debounce((v: T) => set(() => v), ms)]
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const debounced = (v: T) => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => set(() => v), ms)
+  }
+  return [get, debounced]
 }
 
 export function createFadeIn(show: Accessor<boolean>, enabled: Accessor<boolean>) {


### PR DESCRIPTION
@solid-primitives/scheduled returns a no-op when `isServer=true`. The `conditions: ["node"]` build change (commit 1e216e12d, #30873) resolves `solid-js/web` to `server.js`, setting `isServer=true`. This breaks:

- Session search in `/sessions` dialog (both basic list and experimental switcher) — search input does not filter results
- Session switcher preview pane — preview freezes after first hover

## Solution

Replace `@solid-primitives/scheduled` with manual `setTimeout`:
- `signal.ts` — `createDebouncedSignal` → manual trailing-edge debounce
- `preview-pane.tsx` — `createLeadingTrailingSignal` → manual leading + trailing edge

No build condition changes. No `skipFilter` changes. Fix isolated to two utility files.

## Tradeoffs

- Loses `clear()` method and automatic `onCleanup` (neither currently used)
- Does not fix upstream — this is a local workaround for TUI's Node.js context

Closes #31182
Supersedes #31185