### PR TITLE
fix(app): preserve prompt drafts across session switches

### DIFF
--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { ServerScope } from "@/utils/server-scope"
+
+let createPromptRouteScope: typeof import("./prompt").createPromptRouteScope
+let getPromptSessionCacheKey: typeof import("./prompt").getPromptSessionCacheKey
+
+beforeAll(async () => {
+  mock.module("@solidjs/router", () => ({
+    useLocation: () => ({}),
+    useNavigate: () => () => undefined,
+    useParams: () => ({}),
+    useSearchParams: () => [{}],
+  }))
+  mock.module("@opencode-ai/ui/context", () => ({
+    createSimpleContext: () => ({
+      use: () => undefined,
+      provider: () => undefined,
+    }),
+  }))
+
+  const mod = await import("./prompt")
+  createPromptRouteScope = mod.createPromptRouteScope
+  getPromptSessionCacheKey = mod.getPromptSessionCacheKey
+})
+
+describe("getPromptSessionCacheKey", () => {
+  test("separates prompt sessions by server scope", () => {
+    const local = getPromptSessionCacheKey(ServerScope.local, { dir: "/repo", id: "ses_123" })
+    const remote = getPromptSessionCacheKey("ssh:debian" as ServerScope, { dir: "/repo", id: "ses_123" })
+
+    expect(String(local)).toBe("local\0/repo\0ses_123")
+    expect(String(remote)).toBe("ssh:debian\0/repo\0ses_123")
+    expect(remote).not.toBe(local)
+  })
+
+  test("separates workspace prompt sessions by server scope", () => {
+    expect(String(getPromptSessionCacheKey(ServerScope.local, { dir: "/repo" }))).toBe("local\0/repo\0__workspace__")
+  })
+
+  test("keeps explicit draft sessions keyed by draft id", () => {
+    expect(getPromptSessionCacheKey(ServerScope.local, { draftID: "draft_123" })).toBe("draft:draft_123")
+  })
+})
+
+describe("createPromptRouteScope", () => {
+  test("returns undefined until a draft or directory scope is available", () => {
+    expect(createPromptRouteScope({})).toBeUndefined()
+  })
+
+  test("prefers draft scope over route directory scope", () => {
+    expect(createPromptRouteScope({ draftID: "draft-1", dir: "/tmp/project", id: "ses_1" })).toEqual({
+      draftID: "draft-1",
+    })
+  })
+
+  test("uses route directory scope when available", () => {
+    expect(createPromptRouteScope({ dir: "/tmp/project", id: "ses_1" })).toEqual({
+      dir: "/tmp/project",
+      id: "ses_1",
+    })
+  })
+})

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -6,7 +6,7 @@ import { createStore, type SetStoreFunction } from "solid-js/store"
 import type { FileSelection } from "@/context/file"
 import { Persist, persisted } from "@/utils/persist"
 import { useServerSDK } from "./server-sdk"
-import type { ServerScope } from "@/utils/server-scope"
+import { ScopedKey, type ServerScope } from "@/utils/server-scope"
 import { useSDK } from "./sdk"
 import { useTabs, type Tab } from "./tabs"
 import { ServerConnection } from "./server"
@@ -178,7 +178,7 @@ type PromptStore = {
   }
 }
 
-type Scope = { draftID: string } | { dir: string; id?: string }
+export type Scope = { draftID: string } | { dir: string; id?: string }
 
 export function selectPromptTab(tabs: Tab[], scope: Scope, server: ServerConnection.Key) {
   if ("draftID" in scope) return tabs.find((tab) => tab.type === "draft" && tab.draftID === scope.draftID)
@@ -189,9 +189,15 @@ export function selectPromptTab(tabs: Tab[], scope: Scope, server: ServerConnect
   )
 }
 
-function scopeKey(scope: Scope) {
+export function getPromptSessionCacheKey(serverScope: ServerScope, scope: Scope) {
   if ("draftID" in scope) return `draft:${scope.draftID}`
-  return `${scope.dir}:${scope.id ?? WORKSPACE_KEY}`
+  return ScopedKey.from(serverScope, scope.dir, scope.id ?? WORKSPACE_KEY)
+}
+
+export function createPromptRouteScope(input: { draftID?: string; dir?: string; id?: string }) {
+  if (input.draftID) return { draftID: input.draftID }
+  if (input.dir) return { dir: input.dir, id: input.id }
+  return undefined
 }
 
 type PromptCacheEntry = {
@@ -324,15 +330,13 @@ export const { use: usePrompt, provider: PromptProvider } = createSimpleContext(
     const owner = getOwner()
     const serverKey = () =>
       params.serverKey ? requireServerKey(params.serverKey) : ServerConnection.key(serverSDK().server)
-    const scope = () =>
-      search.draftId ? { draftID: search.draftId } : { dir: base64Encode(sdk().directory), id: params.id }
     const load = (scope: Scope) => {
       const current = settings.general.newLayoutDesigns() ? selectPromptTab(tabs.store, scope, serverKey()) : undefined
       if (current) {
         return createTabPromptState(tabs, current, serverSDK().scope, scope)
       }
 
-      const key = scopeKey(scope)
+      const key = getPromptSessionCacheKey(serverSDK().scope, scope)
       const existing = cache.get(key)
       if (existing) {
         cache.delete(key)
@@ -353,7 +357,17 @@ export const { use: usePrompt, provider: PromptProvider } = createSimpleContext(
       return entry.value
     }
 
-    const session = createMemo(() => load(scope()))
+    const fallback = createPromptState()
+    const session = createMemo(() => {
+      const directory = sdk().directory
+      const scope = createPromptRouteScope({
+        draftID: search.draftId,
+        dir: directory ? base64Encode(directory) : undefined,
+        id: params.id,
+      })
+      if (scope) return load(scope)
+      return fallback
+    })
     const pick = (scope?: Scope) => (scope ? load(scope) : session())
     const ready = createPromptReady(session)
 


### PR DESCRIPTION
### Issue for this PR

Closes #31200

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Desktop prompt drafts being treated as ready before async storage has loaded.

`PromptProvider.ready()` currently returns the session readiness accessor instead of calling it, so `prompt.ready()` is always truthy. Desktop can then render the composer against the default empty prompt while the persisted session draft is still loading.

This also scopes the in-memory prompt session cache with the same server scope used by persisted prompt storage. That keeps local, WSL, SSH, and remote server prompt drafts from sharing the same `dir/session` cache entry.

### How did you verify your code works?

- `bun test src/context/prompt.test.ts src/utils/persist.test.ts src/context/terminal.test.ts src/context/server.test.ts src/context/server-sdk.test.ts` from `packages/app`
- `bun typecheck` from `packages/app`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A; state persistence bug.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
