### PR TITLE
fix(tui): /sessions search shows all sessions while loading results

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -43,7 +43,10 @@ export function DialogSessionList() {
   )
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
-  const sessions = createMemo(() => searchResults() ?? sync.data.session)
+  const sessions = createMemo(() => {
+    if (search()) return searchResults() ?? []
+    return sync.data.session
+  })
 
   function recover(session: NonNullable<ReturnType<typeof sessions>[number]>) {
     const workspace = project.workspace.get(session.workspaceID!)


### PR DESCRIPTION
### Issue for this PR

Closes #31182

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/sessions` search showed all sessions while waiting for API results because `searchResults() ?? sync.data.session` fell back to the full list when `searchResults()` was undefined.

Only fall back to `sync.data.session` when no search query is active. During an active search, return `[]` while loading so the UI shows "No results found" instead of everything.

**Note:** Rebased onto latest `dev`. Upstream removed `packages/tui/src/feature-plugins/session/dialog.tsx` in #31524, so this fix now only touches `packages/tui/src/component/dialog-session-list.tsx`.

### How did you verify your code works?

`bun typecheck` passes in `packages/tui`. The `/sessions` search now correctly filters results while loading.

### Screenshots / recordings

N/A — TUI change, no visual regression.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
