### PR TITLE
fix(tui): replace @solid-primitives/scheduled with manual debounce for Node.js compatibility

### DIFF
--- a/packages/tui/src/feature-plugins/session/preview-pane.tsx
+++ b/packages/tui/src/feature-plugins/session/preview-pane.tsx
@@ -1,7 +1,7 @@
 import { createResource, Show, createMemo, createSignal, onMount, type Accessor, type JSX } from "solid-js"
 import { TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
-import { debounce, leadingAndTrailing } from "@solid-primitives/scheduled"
+
 import type { Message, Part, Session as SdkSession } from "@opencode-ai/sdk/v2"
 import { useTheme } from "../../context/theme"
 import { useSDK } from "../../context/sdk"
@@ -56,7 +56,21 @@ export function prefetchPreviews(sdk: Sdk, sync: Sync, sessionIDs: readonly stri
 export function createLeadingTrailingSignal<T>(initial: T, ms: number): [Accessor<T>, (v: T) => void, (v: T) => void] {
   const [get, set] = createSignal(initial)
   const setNow = (v: T) => set(() => v)
-  const schedule = leadingAndTrailing(debounce, setNow, ms)
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let pending: T | undefined
+  const schedule = (v: T) => {
+    if (timer) {
+      pending = v
+      return
+    }
+    set(() => v)
+    timer = setTimeout(() => {
+      timer = undefined
+      const next = pending
+      if (next !== undefined) set(() => next)
+      pending = undefined
+    }, ms)
+  }
   return [get, setNow, schedule]
 }
 

--- a/packages/tui/src/util/signal.ts
+++ b/packages/tui/src/util/signal.ts
@@ -1,9 +1,13 @@
 import { createEffect, createSignal, on, onCleanup, type Accessor } from "solid-js"
-import { debounce, type Scheduled } from "@solid-primitives/scheduled"
 
-export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, Scheduled<[value: T]>] {
+export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, (v: T) => void] {
   const [get, set] = createSignal(value)
-  return [get, debounce((v: T) => set(() => v), ms)]
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const debounced = (v: T) => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => set(() => v), ms)
+  }
+  return [get, debounced]
 }
 
 export function createFadeIn(show: Accessor<boolean>, enabled: Accessor<boolean>) {


### PR DESCRIPTION
### Issue for this PR

Closes #31182

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`@solid-primitives/scheduled` returns a no-op when `isServer=true`. The `conditions: ["node"]` build change (commit 1e5216e12d, #30873) resolves `solid-js/web` to `server.js`, setting `isServer=true`. This breaks:

- Session search in `/sessions` dialog — search input does not filter results
- Session switcher preview pane — preview freezes after first hover

Replace `@solid-primitives/scheduled` with manual `setTimeout` debounce in two files:
- `signal.ts` — `createDebouncedSignal` → manual trailing-edge debounce
- `preview-pane.tsx` — `createLeadingTrailingSignal` → manual leading + trailing edge

No build condition changes. No `skipFilter` changes. Fix isolated to two utility files. Supersedes #31185.

### How did you verify your code works?

Tested locally with a local build — session search in `/sessions` dialog filters results correctly, preview pane updates on hover.

### Screenshots / recordings

_N/A - not a visual UI change, behavioral fix for search filtering._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
