### PR TITLE
fix(opencode): show CLI failure message before help

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -142,6 +142,10 @@ const cli = yargs(args)
       msg?.startsWith("Invalid values:")
     ) {
       if (err) throw err
+      if (msg) {
+        UI.error(msg)
+        process.stderr.write(EOL)
+      }
       cli.showHelp(show)
     }
     if (err) throw err

--- a/packages/opencode/test/cli/fail-help.test.ts
+++ b/packages/opencode/test/cli/fail-help.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import stripAnsi from "strip-ansi"
+import { cliIt } from "../lib/cli-process"
+import { stripCrlf } from "../lib/snapshot"
+
+describe("opencode CLI failure help", () => {
+  cliIt.live("prints the yargs failure message before help text", ({ opencode }) =>
+    Effect.gen(function* () {
+      const result = yield* opencode.spawn(["--unkown-flag"])
+      const stderr = stripCrlf(stripAnsi(result.stderr))
+
+      opencode.expectExit(result, 1)
+      expect(stderr).toContain("Error: Unknown arguments: unkown-flag")
+      expect(stderr.indexOf("Unknown arguments: unkown-flag")).toBeLessThan(stderr.indexOf("Commands:"))
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29390

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When yargs reports an invalid CLI argument, the top-level `.fail()` handler showed the full help text but did not print the failure message. That made `opencode --unkown-flag` look the same as `opencode --help`.

This change prints the yargs failure message with the existing CLI error formatter before rendering help. It keeps the existing help behavior while making invalid arguments visible to the user. A subprocess regression test covers the invalid-argument path and checks that the error appears before the help command list.

### How did you verify your code works?

- `bun test test/cli/fail-help.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `npm run lint` fallback at repo root: 3537 warnings, 0 errors
- pre-push hook: `bun turbo typecheck` passed

### Screenshots / recordings

Not applicable. This is CLI stderr output.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
