### PR TITLE
fix(plugin): fall back when live transport is unauthorized

### DIFF
--- a/packages/opencode/src/plugin/client.ts
+++ b/packages/opencode/src/plugin/client.ts
@@ -1,0 +1,79 @@
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { ServerAuth } from "@/server/auth"
+
+const liveServerReachable = new Map<string, boolean>()
+type ClientFetch = (request: Request) => Promise<Response>
+
+function normalizeServerUrl(serverUrl: URL) {
+  return serverUrl.toString()
+}
+
+async function probeServerReachable(serverUrl: URL, timeoutMs = 1500) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await globalThis.fetch(new URL("/session", serverUrl), {
+      method: "GET",
+      headers: ServerAuth.headers(),
+      signal: controller.signal,
+    })
+    return response.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function useLiveServer(serverUrl: URL) {
+  const key = normalizeServerUrl(serverUrl)
+  const cached = liveServerReachable.get(key)
+  if (cached !== undefined) return cached
+  const reachable = await probeServerReachable(serverUrl)
+  liveServerReachable.set(key, reachable)
+  return reachable
+}
+
+function rewriteRequest(request: Request, serverUrl: URL) {
+  const url = new URL(request.url)
+  return new Request(new URL(`${url.pathname}${url.search}`, serverUrl), request)
+}
+
+export function createPluginClient(input: {
+  directory: string
+  getServerUrl: () => URL
+  fallbackFetch: ClientFetch
+}) {
+  return createOpencodeClient({
+    baseUrl: "http://localhost",
+    directory: input.directory,
+    headers: ServerAuth.headers(),
+    fetch: createPluginFetch(input),
+  })
+}
+
+export function createPluginFetch(input: { getServerUrl: () => URL; fallbackFetch: ClientFetch }): ClientFetch {
+  return async (request: Request) => {
+    const serverUrl = input.getServerUrl()
+    if (await useLiveServer(serverUrl)) {
+      const key = normalizeServerUrl(serverUrl)
+      const fallbackRequest = request.clone()
+      try {
+        const response = await globalThis.fetch(rewriteRequest(request, serverUrl))
+        if (response.status === 401 || response.status === 403) {
+          liveServerReachable.set(key, false)
+          return input.fallbackFetch(fallbackRequest)
+        }
+        return response
+      } catch {
+        liveServerReachable.set(key, false)
+        return input.fallbackFetch(fallbackRequest)
+      }
+    }
+    return input.fallbackFetch(request)
+  }
+}
+
+export function resetPluginClientReachabilityForTests() {
+  liveServerReachable.clear()
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -30,6 +30,7 @@ import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
+import { createPluginClient } from "./client"
 
 const log = Log.create({ service: "plugin" })
 
@@ -138,11 +139,11 @@ export const layer = Layer.effect(
 
         const { Server } = yield* Effect.promise(() => import("../server/server"))
 
-        const client = createOpencodeClient({
-          baseUrl: "http://localhost:4096",
+        const getServerUrl = () => Server.url ?? new URL("http://localhost:4096")
+        const client = createPluginClient({
           directory: ctx.directory,
-          headers: ServerAuth.headers(),
-          fetch: async (...args) => Server.Default().app.fetch(...args),
+          getServerUrl,
+          fallbackFetch: async (request) => Server.Default().app.fetch(request),
         })
         const cfg = yield* config.get()
         const input: PluginInput = {
@@ -156,7 +157,7 @@ export const layer = Layer.effect(
             },
           },
           get serverUrl(): URL {
-            return Server.url ?? new URL("http://localhost:4096")
+            return getServerUrl()
           },
           // @ts-expect-error
           $: typeof Bun === "undefined" ? undefined : Bun.$,

--- a/packages/opencode/test/plugin/client.test.ts
+++ b/packages/opencode/test/plugin/client.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { createPluginFetch, resetPluginClientReachabilityForTests } from "@/plugin/client"
+
+function asFetch(fn: (request: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  return Object.assign(fn, { preconnect: globalThis.fetch.preconnect }) as unknown as typeof globalThis.fetch
+}
+
+afterEach(() => {
+  resetPluginClientReachabilityForTests()
+  mock.restore()
+})
+
+describe("plugin client transport", () => {
+  test("uses live listener when probe succeeds", async () => {
+    const liveFetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (new URL(request.url).pathname === "/session") return new Response("[]", { status: 200 })
+      return new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } })
+    })
+    const liveFetch = asFetch(liveFetchMock)
+    const fallbackFetchMock = mock(async () => new Response("fallback", { status: 200 }))
+    const fallbackFetch = asFetch(fallbackFetchMock)
+    const previousFetch = globalThis.fetch
+    globalThis.fetch = liveFetch
+
+    try {
+      const fetch = createPluginFetch({
+        getServerUrl: () => new URL("http://127.0.0.1:7777"),
+        fallbackFetch,
+      })
+
+      const result = await fetch(new Request("http://localhost/session"))
+      expect(result.status).toBe(200)
+      expect(fallbackFetchMock).not.toHaveBeenCalled()
+      expect(liveFetchMock).toHaveBeenCalledTimes(2)
+      const request = liveFetchMock.mock.calls[1]?.[0]
+      const finalUrl = request instanceof Request ? request.url : String(request)
+      expect(finalUrl.startsWith("http://127.0.0.1:7777/")).toBe(true)
+    } finally {
+      globalThis.fetch = previousFetch
+    }
+  })
+
+  test("probe 401 falls back without second live request", async () => {
+    const liveFetchMock = mock(async () => new Response("unauthorized", { status: 401 }))
+    const liveFetch = asFetch(liveFetchMock)
+    const fallbackFetchMock = mock(
+      async () => new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } }),
+    )
+    const fallbackFetch = asFetch(fallbackFetchMock)
+    const previousFetch = globalThis.fetch
+    globalThis.fetch = liveFetch
+
+    try {
+      const fetch = createPluginFetch({
+        getServerUrl: () => new URL("http://127.0.0.1:7778"),
+        fallbackFetch,
+      })
+
+      const result = await fetch(new Request("http://localhost/session"))
+      expect(result.status).toBe(200)
+      expect(liveFetchMock).toHaveBeenCalledTimes(1)
+      expect(fallbackFetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      globalThis.fetch = previousFetch
+    }
+  })
+
+  test("live 401 demotes cache and retries fallback", async () => {
+    const liveFetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (new URL(request.url).pathname === "/session") return new Response("[]", { status: 200 })
+      return new Response("unauthorized", { status: 401 })
+    })
+    const liveFetch = asFetch(liveFetchMock)
+    const fallbackFetchMock = mock(async () => new Response("fallback", { status: 200 }))
+    const fallbackFetch = asFetch(fallbackFetchMock)
+    const previousFetch = globalThis.fetch
+    globalThis.fetch = liveFetch
+
+    try {
+      const fetch = createPluginFetch({
+        getServerUrl: () => new URL("http://127.0.0.1:7779"),
+        fallbackFetch,
+      })
+
+      const first = await fetch(new Request("http://localhost/app"))
+      const second = await fetch(new Request("http://localhost/app"))
+
+      expect(first.status).toBe(200)
+      expect(second.status).toBe(200)
+      expect(liveFetchMock).toHaveBeenCalledTimes(2)
+      expect(fallbackFetchMock).toHaveBeenCalledTimes(2)
+    } finally {
+      globalThis.fetch = previousFetch
+    }
+  })
+
+  test("POST body survives fallback retry after live 401", async () => {
+    const liveFetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (new URL(request.url).pathname === "/session") return new Response("[]", { status: 200 })
+      return new Response("unauthorized", { status: 401 })
+    })
+    const liveFetch = asFetch(liveFetchMock)
+    const fallbackBodies: string[] = []
+    const fallbackFetchMock = mock(async (request: Request) => {
+      fallbackBodies.push(await request.text())
+      return new Response("fallback", { status: 200 })
+    })
+    const fallbackFetch = asFetch(fallbackFetchMock as unknown as typeof globalThis.fetch)
+    const previousFetch = globalThis.fetch
+    globalThis.fetch = liveFetch
+
+    try {
+      const fetch = createPluginFetch({
+        getServerUrl: () => new URL("http://127.0.0.1:7780"),
+        fallbackFetch: fallbackFetch as unknown as (request: Request) => Promise<Response>,
+      })
+
+      const result = await fetch(
+        new Request("http://localhost/messages", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ hello: "world" }),
+        }),
+      )
+
+      expect(result.status).toBe(200)
+      expect(fallbackBodies).toEqual([JSON.stringify({ hello: "world" })])
+    } finally {
+      globalThis.fetch = previousFetch
+    }
+  })
+
+  test("rewrite preserves auth and directory headers on live success", async () => {
+    const liveRequests: Request[] = []
+    const liveFetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (new URL(request.url).pathname === "/session") return new Response("[]", { status: 200 })
+      liveRequests.push(request)
+      return new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } })
+    })
+    const liveFetch = asFetch(liveFetchMock)
+    const fallbackFetchMock = mock(async () => new Response("fallback", { status: 200 }))
+    const fallbackFetch = asFetch(fallbackFetchMock)
+    const previousFetch = globalThis.fetch
+    globalThis.fetch = liveFetch
+
+    try {
+      const fetch = createPluginFetch({
+        getServerUrl: () => new URL("http://127.0.0.1:7781"),
+        fallbackFetch,
+      })
+
+      const result = await fetch(
+        new Request("http://localhost/chat?foo=bar", {
+          headers: {
+            Authorization: "Bearer token",
+            "x-opencode-directory": "/tmp/project",
+          },
+        }),
+      )
+
+      expect(result.status).toBe(200)
+      expect(liveRequests).toHaveLength(1)
+      expect(liveRequests[0]?.url).toBe("http://127.0.0.1:7781/chat?foo=bar")
+      expect(liveRequests[0]?.headers.get("Authorization")).toBe("Bearer token")
+      expect(liveRequests[0]?.headers.get("x-opencode-directory")).toBe("/tmp/project")
+    } finally {
+      globalThis.fetch = previousFetch
+    }
+  })
+
+  test("falls back to in-process fetch when live listener probe fails", async () => {
+    const liveFetchMock = mock(async () => new Response("missing", { status: 404 }))
+    const liveFetch = asFetch(liveFetchMock)
+    const fallbackFetchMock = mock(
+      async () => new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } }),
+    )
+    const fallbackFetch = asFetch(fallbackFetchMock)
+    const previousFetch = globalThis.fetch
+    globalThis.fetch = liveFetch
+
+    try {
+      const fetch = createPluginFetch({
+        getServerUrl: () => new URL("http://127.0.0.1:8888"),
+        fallbackFetch,
+      })
+
+      const result = await fetch(new Request("http://localhost/session"))
+      expect(result.status).toBe(200)
+      expect(liveFetchMock).toHaveBeenCalledTimes(1)
+      expect(fallbackFetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      globalThis.fetch = previousFetch
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31237

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugin clients can use the live HTTP listener when available, but a 401/403 response means that transport is not usable by the plugin client. This PR moves plugin client setup into a small transport wrapper that:

- only treats the live listener as usable when the probe returns OK
- demotes the live transport when a request returns 401/403 or fetch fails
- retries the original request through the in-process fallback
- clones requests before live attempts so POST bodies survive fallback retry

This keeps plugin API calls from getting stuck on an unauthorized live listener when the in-process path is available.

### How did you verify your code works?

- `bun install --frozen-lockfile`
- `bun test test/plugin/client.test.ts`
- `bun run typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
