### PR TITLE
feat(app): fork sessions into worktrees

### DIFF
--- a/packages/app/src/components/dialog-fork-flow.test.ts
+++ b/packages/app/src/components/dialog-fork-flow.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test"
+import {
+  ExploreForkError,
+  runExploreFork,
+  type ExploreForkClient,
+  type ExploreForkTarget,
+} from "./dialog-fork-flow"
+
+type ForkInput = { sessionID: string; messageID?: string }
+
+type Calls = {
+  clients: string[]
+  creates: Array<{ directory: string; input: { directory: string } }>
+  pending: string[]
+  waits: string[]
+  syncs: string[]
+  diffs: string[]
+  applies: Array<{ directory: string; patch: string }>
+  forks: Array<{ directory: string; input: ForkInput }>
+}
+
+function createHarness(input?: { patch?: string; createdDirectory?: string; applyFailsIn?: string }) {
+  const calls: Calls = {
+    clients: [],
+    creates: [],
+    pending: [],
+    waits: [],
+    syncs: [],
+    diffs: [],
+    applies: [],
+    forks: [],
+  }
+  const sourceDirectory = "/repo/main"
+  const patch = input?.patch ?? "diff --git a/file.txt b/file.txt"
+  const createdDirectory = input?.createdDirectory ?? "/repo/main-explore"
+
+  const clientFor = (directory: string): ExploreForkClient => ({
+    session: {
+      fork: async (value) => {
+        calls.forks.push({ directory, input: value })
+        return { data: { id: `forked:${directory}` } }
+      },
+    },
+    worktree: {
+      create: async (value) => {
+        calls.creates.push({ directory, input: value })
+        return { data: { directory: createdDirectory } }
+      },
+    },
+    vcs: {
+      diff2: {
+        raw: async () => {
+          calls.diffs.push(directory)
+          return { data: patch }
+        },
+      },
+      apply: async (value) => {
+        calls.applies.push({ directory, patch: value.patch })
+        if (directory === input?.applyFailsIn) throw new Error("apply failed")
+        return { data: { applied: true } }
+      },
+    },
+  })
+
+  const run = (target: ExploreForkTarget) =>
+    runExploreFork({
+      client: clientFor(sourceDirectory),
+      sourceDirectory,
+      sessionID: "ses_1",
+      target,
+      createClient: (directory) => {
+        calls.clients.push(directory)
+        return clientFor(directory)
+      },
+      markWorktreePending: (directory) => {
+        calls.pending.push(directory)
+      },
+      waitForWorktree: async (directory) => {
+        calls.waits.push(directory)
+        return { status: "ready" }
+      },
+      syncChild: (directory) => {
+        calls.syncs.push(directory)
+      },
+    })
+
+  return {
+    calls,
+    createdDirectory,
+    run,
+    sourceDirectory,
+  }
+}
+
+describe("runExploreFork", () => {
+  test("creates a worktree, copies the diff, forks with the target client", async () => {
+    const harness = createHarness()
+    const result = await harness.run({ type: "create" })
+
+    expect(result).toEqual({ directory: harness.createdDirectory, sessionID: `forked:${harness.createdDirectory}` })
+    expect(harness.calls.creates).toEqual([
+      { directory: harness.sourceDirectory, input: { directory: harness.sourceDirectory } },
+    ])
+    expect(harness.calls.pending).toEqual([harness.createdDirectory])
+    expect(harness.calls.waits).toEqual([harness.createdDirectory])
+    expect(harness.calls.clients).toEqual([harness.createdDirectory])
+    expect(harness.calls.syncs).toEqual([harness.createdDirectory])
+    expect(harness.calls.diffs).toEqual([harness.sourceDirectory])
+    expect(harness.calls.applies).toEqual([
+      { directory: harness.createdDirectory, patch: "diff --git a/file.txt b/file.txt" },
+    ])
+    expect(harness.calls.forks).toEqual([
+      { directory: harness.createdDirectory, input: { sessionID: "ses_1" } },
+    ])
+  })
+
+  test("uses an existing worktree without creating a new one", async () => {
+    const harness = createHarness()
+    const target = "/repo/existing"
+    const result = await harness.run({ type: "existing", directory: target })
+
+    expect(result).toEqual({ directory: target, sessionID: `forked:${target}` })
+    expect(harness.calls.creates).toEqual([])
+    expect(harness.calls.pending).toEqual([])
+    expect(harness.calls.waits).toEqual([])
+    expect(harness.calls.clients).toEqual([target])
+    expect(harness.calls.syncs).toEqual([target])
+    expect(harness.calls.applies).toEqual([{ directory: target, patch: "diff --git a/file.txt b/file.txt" }])
+    expect(harness.calls.forks).toEqual([{ directory: target, input: { sessionID: "ses_1" } }])
+  })
+
+  test("forks in the current worktree without copying changes", async () => {
+    const harness = createHarness()
+    const result = await harness.run({ type: "current", directory: harness.sourceDirectory })
+
+    expect(result).toEqual({ directory: harness.sourceDirectory, sessionID: `forked:${harness.sourceDirectory}` })
+    expect(harness.calls.clients).toEqual([])
+    expect(harness.calls.syncs).toEqual([])
+    expect(harness.calls.diffs).toEqual([])
+    expect(harness.calls.applies).toEqual([])
+    expect(harness.calls.forks).toEqual([{ directory: harness.sourceDirectory, input: { sessionID: "ses_1" } }])
+  })
+
+  test("stops before forking when applying the diff fails", async () => {
+    const target = "/repo/existing"
+    const harness = createHarness({ applyFailsIn: target })
+    const error = await harness.run({ type: "existing", directory: target }).then(
+      () => undefined,
+      (err: unknown) => err,
+    )
+
+    expect(error).toBeInstanceOf(ExploreForkError)
+    if (error instanceof ExploreForkError) expect(error.kind).toBe("copy")
+    expect(harness.calls.applies).toEqual([{ directory: target, patch: "diff --git a/file.txt b/file.txt" }])
+    expect(harness.calls.forks).toEqual([])
+  })
+})

--- a/packages/app/src/components/dialog-fork-flow.ts
+++ b/packages/app/src/components/dialog-fork-flow.ts
@@ -1,0 +1,129 @@
+type ExploreForkResponse<T> = Promise<{ data?: T; error?: unknown }>
+
+export type ExploreForkTarget =
+  | {
+      type: "create"
+    }
+  | {
+      type: "current"
+      directory: string
+    }
+  | {
+      type: "existing"
+      directory: string
+    }
+
+export type ExploreForkClient = {
+  session: {
+    fork(input: { sessionID: string; messageID?: string }): ExploreForkResponse<{ id: string }>
+  }
+  worktree: {
+    create(input: { directory: string }): ExploreForkResponse<{ directory?: string; branch?: string }>
+  }
+  vcs: {
+    diff2: {
+      raw(): ExploreForkResponse<string>
+    }
+    apply(input: { patch: string }): ExploreForkResponse<{ applied?: boolean }>
+  }
+}
+
+export type ExploreForkWorktreeState =
+  | {
+      status: "ready"
+    }
+  | {
+      status: "failed"
+      message: string
+    }
+
+export class ExploreForkError extends Error {
+  constructor(
+    readonly kind: "worktree" | "copy" | "fork",
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+export async function runExploreFork(input: {
+  client: ExploreForkClient
+  sourceDirectory: string
+  sessionID: string
+  target: ExploreForkTarget
+  createClient: (directory: string) => ExploreForkClient
+  markWorktreePending: (directory: string) => void
+  waitForWorktree: (directory: string) => Promise<ExploreForkWorktreeState>
+  syncChild: (directory: string) => void
+  copyChanges?: boolean
+}) {
+  const targetDirectory =
+    input.target.type === "create"
+      ? await input.client.worktree
+          .create({ directory: input.sourceDirectory })
+          .then((result) => {
+            if (result.error) throw new ExploreForkError("worktree", exploreForkErrorMessage(result.error))
+            if (!result.data?.directory) throw new ExploreForkError("worktree", "Failed to create worktree")
+            return result.data.directory
+          })
+          .catch((err) => {
+            if (err instanceof ExploreForkError) throw err
+            throw new ExploreForkError("worktree", exploreForkErrorMessage(err))
+          })
+      : input.target.directory
+
+  const targetClient =
+    targetDirectory === input.sourceDirectory ? input.client : input.createClient(targetDirectory)
+
+  if (input.target.type === "create") {
+    input.markWorktreePending(targetDirectory)
+    const state = await input.waitForWorktree(targetDirectory)
+    if (state.status === "failed") throw new ExploreForkError("worktree", state.message)
+  }
+
+  if (targetDirectory !== input.sourceDirectory) input.syncChild(targetDirectory)
+
+  if ((input.copyChanges ?? true) && targetDirectory !== input.sourceDirectory) {
+    const patch = await input.client.vcs.diff2
+      .raw()
+      .then((result) => {
+        if (result.error) throw new ExploreForkError("copy", exploreForkErrorMessage(result.error))
+        return result.data ?? ""
+      })
+      .catch((err) => {
+        if (err instanceof ExploreForkError) throw err
+        throw new ExploreForkError("copy", exploreForkErrorMessage(err))
+      })
+    if (patch.trim()) {
+      const applied = await targetClient.vcs.apply({ patch }).catch((err) => {
+        throw new ExploreForkError("copy", exploreForkErrorMessage(err))
+      })
+      if (applied.error) throw new ExploreForkError("copy", exploreForkErrorMessage(applied.error))
+      if (applied.data?.applied === false) throw new ExploreForkError("copy", "Patch wasn't applied")
+    }
+  }
+
+  const forked = await targetClient.session
+    .fork({
+      sessionID: input.sessionID,
+    })
+    .catch((err) => {
+      throw new ExploreForkError("fork", exploreForkErrorMessage(err))
+    })
+  if (forked.error) throw new ExploreForkError("fork", exploreForkErrorMessage(forked.error))
+  if (!forked.data?.id) throw new ExploreForkError("fork", "Failed to fork session")
+
+  return {
+    directory: targetDirectory,
+    sessionID: forked.data.id,
+  }
+}
+
+export function exploreForkErrorMessage(err: unknown) {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data?: { message?: string } }).data
+    if (data?.message) return data.message
+  }
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/packages/app/src/components/dialog-fork.tsx
+++ b/packages/app/src/components/dialog-fork.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "@solidjs/router"
 import { useSync } from "@/context/sync"
 import { useSDK } from "@/context/sdk"
 import { usePrompt } from "@/context/prompt"
+import { useServerSync } from "@/context/server-sync"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { List } from "@opencode-ai/ui/list"
@@ -11,6 +12,13 @@ import { extractPromptFromParts } from "@/utils/prompt"
 import type { TextPart as SDKTextPart } from "@opencode-ai/sdk/v2/client"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { useLanguage } from "@/context/language"
+import { Worktree as WorktreeState } from "@/utils/worktree"
+import {
+  ExploreForkError,
+  exploreForkErrorMessage,
+  runExploreFork,
+  type ExploreForkTarget,
+} from "./dialog-fork-flow"
 
 interface ForkableMessage {
   id: string
@@ -22,11 +30,12 @@ function formatTime(date: Date): string {
   return date.toLocaleTimeString(undefined, { timeStyle: "short" })
 }
 
-export const DialogFork: Component = () => {
+export const DialogFork: Component<{ mode?: "message" | "worktree" }> = (props) => {
   const params = useParams()
   const navigate = useNavigate()
   const sync = useSync()
   const sdk = useSDK()
+  const serverSync = useServerSync()
   const prompt = usePrompt()
   const dialog = useDialog()
   const language = useLanguage()
@@ -55,6 +64,13 @@ export const DialogFork: Component = () => {
     return result.reverse()
   })
 
+  const targets = createMemo((): Array<ExploreForkTarget & { id: string; label: string }> => {
+    return [
+      { id: "create", type: "create", label: language.t("session.new.worktree.create") },
+      { id: "current", type: "current", directory: sdk.directory, label: language.t("dialog.fork.target.current") },
+    ]
+  })
+
   const handleSelect = (item: ForkableMessage | undefined) => {
     if (!item) return
 
@@ -80,9 +96,71 @@ export const DialogFork: Component = () => {
         navigate(`/${dir}/session/${forked.data.id}`)
       })
       .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
-        showToast({ title: language.t("common.requestFailed"), description: message })
+        showToast({ title: language.t("common.requestFailed"), description: exploreForkErrorMessage(err) })
       })
+  }
+
+  const handleExploreTarget = (target: ExploreForkTarget | undefined) => {
+    const sessionID = params.id
+    if (!sessionID || !target) return
+
+    runExploreFork({
+      client: sdk.client,
+      sourceDirectory: sdk.directory,
+      sessionID,
+      target,
+      createClient: (directory) => sdk.createClient({ directory, throwOnError: true }),
+      markWorktreePending: (directory) => WorktreeState.pending(sdk.scope, directory),
+      waitForWorktree: async (directory) => {
+        const timeoutMs = 5 * 60 * 1000
+        const timeout = new Promise<Awaited<ReturnType<typeof WorktreeState.wait>>>((resolve) => {
+          window.setTimeout(() => {
+            resolve({ status: "failed", message: language.t("workspace.error.stillPreparing") })
+          }, timeoutMs)
+        })
+        const waited = await Promise.race([WorktreeState.wait(sdk.scope, directory), timeout])
+        if (waited.status === "pending") {
+          return { status: "failed", message: language.t("workspace.error.stillPreparing") }
+        }
+        return waited
+      },
+      syncChild: (directory) => serverSync.child(directory),
+    })
+      .then((forked) => {
+        dialog.close()
+        const dir = base64Encode(forked.directory)
+        navigate(`/${dir}/session/${forked.sessionID}`)
+      })
+      .catch((err: unknown) => {
+        const title =
+          err instanceof ExploreForkError && err.kind === "worktree"
+            ? language.t("prompt.toast.worktreeCreateFailed.title")
+            : err instanceof ExploreForkError && err.kind === "copy"
+              ? language.t("toast.session.fork.copyChangesFailed.title")
+              : language.t("common.requestFailed")
+        showToast({ title, description: exploreForkErrorMessage(err), variant: "error" })
+      })
+  }
+
+  if (props.mode === "worktree") {
+    return (
+      <Dialog title={language.t("command.session.fork.worktree")}>
+        <List
+          class="flex-1 px-3 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0"
+          search={{ placeholder: language.t("common.search.placeholder"), autofocus: true }}
+          key={(x) => x.id}
+          items={targets}
+          filterKeys={["label"]}
+          onSelect={handleExploreTarget}
+        >
+          {(item) => (
+            <div class="w-full flex items-center gap-2">
+              <span class="truncate flex-1 min-w-0 text-left font-normal">{item.label}</span>
+            </div>
+          )}
+        </List>
+      </Dialog>
+    )
   }
 
   return (
@@ -99,7 +177,7 @@ export const DialogFork: Component = () => {
         {(item) => (
           <div class="w-full flex items-center gap-2">
             <span class="truncate flex-1 min-w-0 text-left font-normal">{item.text}</span>
-            <span class="text-text-weak shrink-0 font-normal">{item.time}</span>
+            {item.time && <span class="text-text-weak shrink-0 font-normal">{item.time}</span>}
           </div>
         )}
       </List>

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -86,6 +86,8 @@ export const dict = {
   "command.session.compact.description": "Summarize the session to reduce context size",
   "command.session.fork": "Fork from message",
   "command.session.fork.description": "Create a new session from a previous message",
+  "command.session.fork.worktree": "Fork into worktree",
+  "command.session.fork.worktree.description": "Fork this session into an isolated git worktree",
   "command.session.share": "Share session",
   "command.session.share.description": "Share this session and copy the URL to clipboard",
   "command.session.unshare": "Unshare session",
@@ -310,6 +312,7 @@ export const dict = {
   "mcp.auth.clickToAuthenticate": "Click to authenticate",
 
   "dialog.fork.empty": "No messages to fork from",
+  "dialog.fork.target.current": "Current worktree",
 
   "dialog.directory.search.placeholder": "Search folders",
   "dialog.directory.empty": "No folders found",
@@ -456,6 +459,7 @@ export const dict = {
   "toast.session.unshare.success.description": "Session unshared successfully!",
   "toast.session.unshare.failed.title": "Failed to unshare session",
   "toast.session.unshare.failed.description": "An error occurred while unsharing the session",
+  "toast.session.fork.copyChangesFailed.title": "Failed to copy changes",
 
   "toast.session.listFailed.title": "Failed to load sessions for {{project}}",
   "toast.project.reloadFailed.title": "Failed to reload {{project}}",

--- a/packages/app/src/pages/home-session-subtitle.test.ts
+++ b/packages/app/src/pages/home-session-subtitle.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { homeSessionSubtitle } from "./home-session-subtitle"
+
+describe("homeSessionSubtitle", () => {
+  test("uses the project name for the main worktree", () => {
+    expect(
+      homeSessionSubtitle({
+        projectName: "opencode-fork-worktree-e2e",
+        projectWorktree: "/tmp/opencode-fork-worktree-e2e",
+        sessionDirectory: "/tmp/opencode-fork-worktree-e2e",
+      }),
+    ).toBe("opencode-fork-worktree-e2e")
+  })
+
+  test("includes the branch for a fork worktree session", () => {
+    expect(
+      homeSessionSubtitle({
+        projectName: "opencode-fork-worktree-e2e",
+        projectWorktree: "/tmp/opencode-fork-worktree-e2e",
+        sessionDirectory: "/tmp/opencode-worktrees/clever-garden",
+        branch: "opencode/clever-garden",
+      }),
+    ).toBe("opencode-fork-worktree-e2e - opencode/clever-garden")
+  })
+
+  test("falls back to the directory name while worktree branch data is loading", () => {
+    expect(
+      homeSessionSubtitle({
+        projectName: "opencode-fork-worktree-e2e",
+        projectWorktree: "/tmp/opencode-fork-worktree-e2e",
+        sessionDirectory: "/tmp/opencode-worktrees/clever-garden",
+      }),
+    ).toBe("opencode-fork-worktree-e2e - clever-garden")
+  })
+})

--- a/packages/app/src/pages/home-session-subtitle.ts
+++ b/packages/app/src/pages/home-session-subtitle.ts
@@ -1,0 +1,12 @@
+import { getFilename } from "@opencode-ai/core/util/path"
+import { pathKey } from "@/utils/path-key"
+
+export function homeSessionSubtitle(input: {
+  projectName: string
+  projectWorktree: string
+  sessionDirectory: string
+  branch?: string
+}) {
+  if (pathKey(input.sessionDirectory) === pathKey(input.projectWorktree)) return input.projectName
+  return `${input.projectName} - ${input.branch ?? getFilename(input.sessionDirectory)}`
+}

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -46,6 +46,7 @@ import { useGlobal } from "@/context/global"
 import { useCommand } from "@/context/command"
 import { useSettings } from "@/context/settings"
 import { ServerHealthIndicator } from "@/components/server/server-row"
+import { homeSessionSubtitle } from "./home-session-subtitle"
 
 const HOME_SESSION_LIMIT = 15
 const HOME_ROW_LAYOUT =
@@ -59,7 +60,7 @@ const HOME_SECTION_LABEL = "text-v2-text-text-muted [font-weight:440]"
 type HomeSessionRecord = {
   session: Session
   project: LocalProject
-  projectName: string
+  subtitle: string
 }
 
 type HomeSessionSync = Pick<ReturnType<typeof useServerSync>, "child">
@@ -101,13 +102,18 @@ function buildHomeSessionRecords(input: {
       return {
         session,
         project,
-        projectName: displayName(project),
+        subtitle: homeSessionSubtitle({
+          projectName: displayName(project),
+          projectWorktree: project.worktree,
+          sessionDirectory: session.directory,
+          branch: input.sync.child(session.directory, { bootstrap: false })[0].vcs?.branch,
+        }),
       }
     })
 }
 
 function matchesHomeSessionSearch(record: HomeSessionRecord, query: string) {
-  return `${record.session.title} ${record.projectName}`.toLowerCase().includes(query)
+  return `${record.session.title} ${record.subtitle}`.toLowerCase().includes(query)
 }
 
 function createHomeSessionStatus(input: {
@@ -973,12 +979,12 @@ function HomeSessionSearchResultRow(props: {
       </Show>
       <div class="flex min-w-0 flex-1 items-center gap-1.5">
         <span
-          class={`${HOME_SEARCH_RESULT_TITLE} ${props.record.projectName ? "max-w-[min(70%,480px)] flex-[0_1_auto]" : "flex-[1_1_auto]"}`}
+          class={`${HOME_SEARCH_RESULT_TITLE} ${props.record.subtitle ? "max-w-[min(70%,480px)] flex-[0_1_auto]" : "flex-[1_1_auto]"}`}
         >
           {title()}
         </span>
-        <Show when={props.record.projectName}>
-          <span class={HOME_SEARCH_RESULT_META}>{props.record.projectName}</span>
+        <Show when={props.record.subtitle}>
+          <span class={HOME_SEARCH_RESULT_META}>{props.record.subtitle}</span>
         </Show>
       </div>
     </button>
@@ -1057,13 +1063,13 @@ function HomeSessionRow(props: {
         </div>
       </Show>
       <span
-        class={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-base [font-weight:530] ${props.record.projectName ? "max-w-[min(70%,480px)] flex-[0_1_auto]" : "flex-[1_1_auto]"}`}
+        class={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-base [font-weight:530] ${props.record.subtitle ? "max-w-[min(70%,480px)] flex-[0_1_auto]" : "flex-[1_1_auto]"}`}
       >
         {title()}
       </span>
-      <Show when={props.record.projectName}>
+      <Show when={props.record.subtitle}>
         <span class="min-w-0 flex-[1_1_auto] overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-muted [font-weight:440]">
-          {props.record.projectName}
+          {props.record.subtitle}
         </span>
       </Show>
     </button>

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -351,6 +351,11 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       dialog.show(() => <x.DialogFork />)
     })
   }
+  const forkWorktree = () => {
+    void import("@/components/dialog-fork").then((x) => {
+      dialog.show(() => <x.DialogFork mode="worktree" />)
+    })
+  }
 
   const shareCmds = () => {
     if (sync.data.config.share === "disabled") return []
@@ -415,6 +420,14 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       slash: "fork",
       disabled: !params.id || visibleUserMessages().length === 0,
       onSelect: fork,
+    }),
+    sessionCommand({
+      id: "session.fork.worktree",
+      title: language.t("command.session.fork.worktree"),
+      description: language.t("command.session.fork.worktree.description"),
+      slash: "fork-worktree",
+      disabled: !params.id,
+      onSelect: forkWorktree,
     }),
   ]
 

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -87,6 +87,18 @@ function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL
   return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
 }
 
+function hasExplicitTarget(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {
+  return (
+    url.searchParams.has("directory") ||
+    url.searchParams.has("workspace") ||
+    request.headers["x-opencode-directory"] !== undefined
+  )
+}
+
+function isForkRouteWithExplicitTarget(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {
+  return request.method === "POST" && /^\/session\/[^/]+\/fork$/.test(url.pathname) && hasExplicitTarget(request, url)
+}
+
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {
   return isLocalWorkspaceRoute(request.method, url.pathname) || url.pathname.startsWith("/console")
 }
@@ -219,7 +231,8 @@ function routeHttpApiWorkspace<E>(
 > {
   return Effect.gen(function* () {
     const request = yield* HttpServerRequest.HttpServerRequest
-    const sessionID = getWorkspaceRouteSessionID(requestURL(request))
+    const url = requestURL(request)
+    const sessionID = isForkRouteWithExplicitTarget(request, url) ? null : getWorkspaceRouteSessionID(url)
     const session = sessionID
       ? yield* Session.Service.use((svc) => svc.get(sessionID)).pipe(
           Effect.catchIf(

--- a/packages/opencode/test/server/httpapi-workspace-routing.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace-routing.test.ts
@@ -230,6 +230,11 @@ const ProbeApi = HttpApi.make("workspace-routing-probe").add(
       HttpApiEndpoint.get("get", "/probe", { query: WorkspaceRoutingQuery, success: ProbeResult }),
       HttpApiEndpoint.patch("patch", "/probe", { query: WorkspaceRoutingQuery, success: Schema.Boolean }),
       HttpApiEndpoint.get("session", "/session", { query: WorkspaceRoutingQuery, success: ProbeResult }),
+      HttpApiEndpoint.post("sessionFork", "/session/:sessionID/fork", {
+        params: { sessionID: Schema.String },
+        query: WorkspaceRoutingQuery,
+        success: ProbeResult,
+      }),
       HttpApiEndpoint.get("workspace", WorkspacePaths.list, {
         query: WorkspaceRoutingQuery,
         success: ProbeResult,
@@ -248,6 +253,7 @@ const probeHandlers = HttpApiBuilder.group(ProbeApi, "probe", (handlers) =>
     .handle("get", () => routeContextResponse)
     .handle("patch", () => Effect.succeed(false))
     .handle("session", () => routeContextResponse)
+    .handle("sessionFork", () => routeContextResponse)
     .handle("workspace", () => routeContextResponse),
 )
 
@@ -523,6 +529,22 @@ describe("HttpApi workspace routing middleware", () => {
       expect(yield* queryResponse.json).toEqual({ directory: queryDir, workspaceID: null })
       expect(headerResponse.status).toBe(200)
       expect(yield* headerResponse.json).toEqual({ directory: headerDir, workspaceID: null })
+    }),
+  )
+
+  it.live("uses explicit directory target for session fork routes", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const targetDir = path.join(dir, "fork-target")
+      yield* serveProbe
+
+      const response = yield* HttpClientRequest.post("/session/ses_123/fork").pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", targetDir),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toEqual({ directory: targetDir, workspaceID: null })
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds `/fork-worktree`, which lets users fork the current session into a separate git worktree, so they can explore a different implementation or ask the agent to try a risky direction without changing the original session or working tree.

When users use `/fork-worktree`, they can choose either:

- create a new worktree (the main addition in this PR)
- fork in the current worktree (same behavior as the existing session fork)

When creating a new worktree, the app copies the current uncommitted diff into the new worktree when possible, then creates a forked session there and navigates to it.

I thought this feature can be helpful because I often reach a point where I want to try different directions based on the current chat history, without disturbing the original session or worktree.

### How did you verify your code works?

- Ran `cd packages/app && bun typecheck`
- Ran `cd packages/app && bun test`
- Ran `cd packages/opencode && bun typecheck`
- Ran `cd packages/opencode && bun test ./test/server/httpapi-workspace-routing.test.ts`
- Manually verified with a test git repo: changed `note.txt` through the chat, ran `/fork-worktree`, selected `Create new worktree`, and confirmed the forked session opened in a new worktree with the full chat history and copied uncommitted file changes.


### Screenshots / recordings

I verified this manually with a test git repository:

1. Created a test repo and added `note.txt`.
2. Used the app chat to make changes to `note.txt`, creating both chat history and uncommitted file changes.
3. Ran `/fork-worktree` from the session and selected `Create new worktree`.
4. Confirmed that the app opened a forked session in a different worktree.
5. Confirmed that the forked session kept the full chat history and that the `note.txt` changes were copied into the new worktree.

<img width="602" height="850" alt="Screenshot 2026-06-08 at 00 00 49" src="https://github.com/user-attachments/assets/6b4588f1-93aa-4202-b8fd-413893b312fd" />



<img width="596" height="170" alt="Screenshot 2026-06-08 at 00 01 01" src="https://github.com/user-attachments/assets/6ec485f9-c259-4104-b162-efabf7b07130" />

<img width="633" height="282" alt="Screenshot 2026-06-08 at 00 01 06" src="https://github.com/user-attachments/assets/faa65307-448e-4cc1-8849-d34c38decd8f" />

Confirmed that the forked session kept the full chat history and that the note.txt changes were copied into the new worktree.the app opened a forked session in a different worktree.

<img width="613" height="859" alt="Screenshot 2026-06-08 at 00 01 18" src="https://github.com/user-attachments/assets/2d6a561d-a668-40a3-81f7-155ddcb56e9c" />

Confirmed that the new branch is created.

<img width="379" height="71" alt="Screenshot 2026-06-08 at 00 01 33" src="https://github.com/user-attachments/assets/77db6e8e-91b1-45eb-909c-62fd1e3dbd90" />

<img width="738" height="158" alt="Screenshot 2026-06-08 at 00 02 37" src="https://github.com/user-attachments/assets/0aa14fe5-b0ca-4a39-99df-c6c9f253f785" />




### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

