### PR TITLE
docs: add Persian (fa) README translation

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.bn.md
+++ b/README.bn.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.br.md
+++ b/README.br.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.bs.md
+++ b/README.bs.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.da.md
+++ b/README.da.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.de.md
+++ b/README.de.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.es.md
+++ b/README.es.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.fa.md
+++ b/README.fa.md
@@ -50,12 +50,12 @@
 # سریع و ساده
 curl -fsSL https://opencode.ai/install | bash
 
-# پکیج منیجرها
+# پکیج منیجر ها
 npm i -g opencode-ai@latest        # یا bun/pnpm/yarn
-scoop install opencode             # ویندوز
-choco install opencode             # ویندوز
+scoop install opencode             # Windows
+choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS و لینوکس (پیشنهادی، همیشه به‌روز)
-brew install opencode              # macOS و لینوکس (فرمول رسمی brew، به‌روزرسانی کمتر)
+brew install opencode              # macOS and Linux (official brew formula, updated less)
 sudo pacman -S opencode            # Arch Linux (نسخه پایدار)
 paru -S opencode-bin               # Arch Linux (آخرین نسخه از AUR)
 mise use -g opencode               # هر سیستم‌عاملی

--- a/README.fa.md
+++ b/README.fa.md
@@ -44,37 +44,39 @@
 
 ---
 
+<div dir="rtl">
+
 ### نصب
 
 ```bash
 # سریع و ساده
 curl -fsSL https://opencode.ai/install | bash
 
-# پکیج منیجر ها
+# پکیج منیجرها
 npm i -g opencode-ai@latest        # یا bun/pnpm/yarn
-scoop install opencode             # Windows
-choco install opencode             # Windows
+scoop install opencode             # ویندوز
+choco install opencode             # ویندوز
 brew install anomalyco/tap/opencode # macOS و لینوکس (پیشنهادی، همیشه به‌روز)
-brew install opencode              # macOS and Linux (official brew formula, updated less)
-sudo pacman -S opencode            # Arch Linux (نسخه پایدار)
+brew install opencode              # macOS و لینوکس (فرمول رسمی brew، به‌روزرسانی کمتر)
+sudo pacman -S opencode            # Arch Linux (پایدار)
 paru -S opencode-bin               # Arch Linux (آخرین نسخه از AUR)
 mise use -g opencode               # هر سیستم‌عاملی
 nix run nixpkgs#opencode           # یا github:anomalyco/opencode برای آخرین نسخه dev
 ```
 
 > [!TIP]
-> قبل از نصب، نسخه‌های قدیمی‌تر از ۰.۱.x را حذف کنید.
+> قبل از نصب، نسخه‌های قدیمی‌تر از 0.1.x را حذف کنید.
 
 ### اپلیکیشن دسکتاپ (بتا)
 
 OpenCode به‌صورت اپلیکیشن دسکتاپ هم در دسترس است. می‌توانید آن را مستقیماً از [صفحه releases](https://github.com/anomalyco/opencode/releases) یا [opencode.ai/download](https://opencode.ai/download) دانلود کنید.
 
-| پلتفرم                    | دانلود                             |
-| ------------------------- | ---------------------------------- |
-| macOS (Apple Silicon)     | `opencode-desktop-mac-arm64.dmg`   |
-| macOS (Intel)             | `opencode-desktop-mac-x64.dmg`     |
-| ویندوز                    | `opencode-desktop-windows-x64.exe` |
-| لینوکس                    | `.deb`، `.rpm` یا `.AppImage`      |
+| پلتفرم                | دانلود                             |
+| --------------------- | ---------------------------------- |
+| macOS (Apple Silicon) | `opencode-desktop-mac-arm64.dmg`   |
+| macOS (Intel)         | `opencode-desktop-mac-x64.dmg`     |
+| ویندوز                | `opencode-desktop-windows-x64.exe` |
+| لینوکس                | `.deb` یا `.rpm` یا `.AppImage`    |
 
 ```bash
 # macOS (Homebrew)
@@ -87,10 +89,10 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 
 اسکریپت نصب برای انتخاب مسیر نصب، ترتیب اولویت زیر را رعایت می‌کند:
 
-1. `$OPENCODE_INSTALL_DIR` — مسیر سفارشی
-2. `$XDG_BIN_DIR` — مسیر سازگار با مشخصات XDG Base Directory
-3. `$HOME/bin` — مسیر استاندارد باینری کاربر (اگر وجود داشته باشد یا قابل ساخت باشد)
-4. `$HOME/.opencode/bin` — مسیر پیش‌فرض
+1. `$OPENCODE_INSTALL_DIR` - مسیر نصب سفارشی
+2. `$XDG_BIN_DIR` - مسیر سازگار با مشخصات XDG Base Directory
+3. `$HOME/bin` - مسیر استاندارد باینری کاربر (اگر وجود داشته باشد یا قابل ساخت باشد)
+4. `$HOME/.opencode/bin` - مسیر پیش‌فرض
 
 ```bash
 # نمونه‌ها
@@ -100,15 +102,16 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ### ایجنت‌ها
 
-OpenCode دو ایجنت توکار دارد که می‌توانید با کلید `Tab` بین آن‌ها جابه‌جا شوید:
+OpenCode دو ایجنت توکار دارد که می‌توانید با کلید `Tab` بین آن‌ها جابه‌جا شوید.
 
-- **build** — ایجنت پیش‌فرض با دسترسی کامل، مناسب برای توسعه
-- **plan** — ایجنت فقط‌خواندنی برای تحلیل و بررسی کد
+- **build** - ایجنت پیش‌فرض با دسترسی کامل، مناسب برای توسعه
+- **plan** - ایجنت فقط‌خواندنی برای تحلیل و بررسی کد
   - به‌صورت پیش‌فرض ویرایش فایل را رد می‌کند
   - قبل از اجرای دستورات bash اجازه می‌گیرد
   - ایده‌آل برای بررسی کدبیس‌های ناآشنا یا برنامه‌ریزی تغییرات
 
-همچنین یک ساب‌ایجنت **general** برای جست‌وجوهای پیچیده و وظایف چندمرحله‌ای وجود دارد که به‌صورت داخلی استفاده می‌شود و می‌توانید با `@general` در پیام‌ها آن را فراخوانی کنید.
+همچنین یک ساب‌ایجنت **general** برای جست‌وجوهای پیچیده و وظایف چندمرحله‌ای وجود دارد.
+این ایجنت به‌صورت داخلی استفاده می‌شود و می‌توان با `@general` در پیام‌ها آن را فراخوانی کرد.
 
 برای اطلاعات بیشتر درباره [ایجنت‌ها](https://opencode.ai/docs/agents) مستندات را بخوانید.
 
@@ -126,4 +129,6 @@ OpenCode دو ایجنت توکار دارد که می‌توانید با کل�
 
 ---
 
-**به جامعه ما بپیوندید:** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**به جامعه ما بپیوندید** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+
+</div>

--- a/README.fa.md
+++ b/README.fa.md
@@ -1,0 +1,129 @@
+<p align="center">
+  <a href="https://opencode.ai">
+    <picture>
+      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="لوگوی OpenCode">
+    </picture>
+  </a>
+</p>
+<p align="center">ایجنت کدنویسی هوش مصنوعی متن‌باز.</p>
+<p align="center">
+  <a href="https://opencode.ai/discord"><img alt="Discord" src="https://img.shields.io/discord/1391832426048651334?style=flat-square&label=discord" /></a>
+  <a href="https://www.npmjs.com/package/opencode-ai"><img alt="npm" src="https://img.shields.io/npm/v/opencode-ai?style=flat-square" /></a>
+  <a href="https://github.com/anomalyco/opencode/actions/workflows/publish.yml"><img alt="وضعیت بیلد" src="https://img.shields.io/github/actions/workflow/status/anomalyco/opencode/publish.yml?style=flat-square&branch=dev" /></a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh.md">简体中文</a> |
+  <a href="README.zht.md">繁體中文</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.de.md">Deutsch</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.it.md">Italiano</a> |
+  <a href="README.da.md">Dansk</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.pl.md">Polski</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.bs.md">Bosanski</a> |
+  <a href="README.ar.md">العربية</a> |
+  <a href="README.no.md">Norsk</a> |
+  <a href="README.br.md">Português (Brasil)</a> |
+  <a href="README.th.md">ไทย</a> |
+  <a href="README.tr.md">Türkçe</a> |
+  <a href="README.uk.md">Українська</a> |
+  <a href="README.bn.md">বাংলা</a> |
+  <a href="README.gr.md">Ελληνικά</a> |
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
+</p>
+
+[![رابط کاربری ترمینال OpenCode](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+
+---
+
+### نصب
+
+```bash
+# سریع و ساده
+curl -fsSL https://opencode.ai/install | bash
+
+# پکیج منیجرها
+npm i -g opencode-ai@latest        # یا bun/pnpm/yarn
+scoop install opencode             # ویندوز
+choco install opencode             # ویندوز
+brew install anomalyco/tap/opencode # macOS و لینوکس (پیشنهادی، همیشه به‌روز)
+brew install opencode              # macOS و لینوکس (فرمول رسمی brew، به‌روزرسانی کمتر)
+sudo pacman -S opencode            # Arch Linux (نسخه پایدار)
+paru -S opencode-bin               # Arch Linux (آخرین نسخه از AUR)
+mise use -g opencode               # هر سیستم‌عاملی
+nix run nixpkgs#opencode           # یا github:anomalyco/opencode برای آخرین نسخه dev
+```
+
+> [!TIP]
+> قبل از نصب، نسخه‌های قدیمی‌تر از ۰.۱.x را حذف کنید.
+
+### اپلیکیشن دسکتاپ (بتا)
+
+OpenCode به‌صورت اپلیکیشن دسکتاپ هم در دسترس است. می‌توانید آن را مستقیماً از [صفحه releases](https://github.com/anomalyco/opencode/releases) یا [opencode.ai/download](https://opencode.ai/download) دانلود کنید.
+
+| پلتفرم                    | دانلود                             |
+| ------------------------- | ---------------------------------- |
+| macOS (Apple Silicon)     | `opencode-desktop-mac-arm64.dmg`   |
+| macOS (Intel)             | `opencode-desktop-mac-x64.dmg`     |
+| ویندوز                    | `opencode-desktop-windows-x64.exe` |
+| لینوکس                    | `.deb`، `.rpm` یا `.AppImage`      |
+
+```bash
+# macOS (Homebrew)
+brew install --cask opencode-desktop
+# ویندوز (Scoop)
+scoop bucket add extras; scoop install extras/opencode-desktop
+```
+
+#### مسیر نصب
+
+اسکریپت نصب برای انتخاب مسیر نصب، ترتیب اولویت زیر را رعایت می‌کند:
+
+1. `$OPENCODE_INSTALL_DIR` — مسیر سفارشی
+2. `$XDG_BIN_DIR` — مسیر سازگار با مشخصات XDG Base Directory
+3. `$HOME/bin` — مسیر استاندارد باینری کاربر (اگر وجود داشته باشد یا قابل ساخت باشد)
+4. `$HOME/.opencode/bin` — مسیر پیش‌فرض
+
+```bash
+# نمونه‌ها
+OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
+XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
+```
+
+### ایجنت‌ها
+
+OpenCode دو ایجنت توکار دارد که می‌توانید با کلید `Tab` بین آن‌ها جابه‌جا شوید:
+
+- **build** — ایجنت پیش‌فرض با دسترسی کامل، مناسب برای توسعه
+- **plan** — ایجنت فقط‌خواندنی برای تحلیل و بررسی کد
+  - به‌صورت پیش‌فرض ویرایش فایل را رد می‌کند
+  - قبل از اجرای دستورات bash اجازه می‌گیرد
+  - ایده‌آل برای بررسی کدبیس‌های ناآشنا یا برنامه‌ریزی تغییرات
+
+همچنین یک ساب‌ایجنت **general** برای جست‌وجوهای پیچیده و وظایف چندمرحله‌ای وجود دارد که به‌صورت داخلی استفاده می‌شود و می‌توانید با `@general` در پیام‌ها آن را فراخوانی کنید.
+
+برای اطلاعات بیشتر درباره [ایجنت‌ها](https://opencode.ai/docs/agents) مستندات را بخوانید.
+
+### مستندات
+
+برای آشنایی با نحوه پیکربندی OpenCode، [**به مستندات ما مراجعه کنید**](https://opencode.ai/docs).
+
+### مشارکت در توسعه
+
+اگر علاقه‌مند به مشارکت در OpenCode هستید، لطفاً قبل از ارسال pull request، [راهنمای مشارکت](./CONTRIBUTING.md) را بخوانید.
+
+### ساخت روی OpenCode
+
+اگر روی پروژه‌ای کار می‌کنید که با OpenCode مرتبط است و از کلمه «opencode» در نامش استفاده می‌کند — مثلاً «opencode-dashboard» یا «opencode-mobile» — لطفاً در README خود توضیح دهید که این پروژه توسط تیم OpenCode ساخته نشده و هیچ وابستگی‌ای به ما ندارد.
+
+---
+
+**به جامعه ما بپیوندید:** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)

--- a/README.fa.md
+++ b/README.fa.md
@@ -7,11 +7,11 @@
     </picture>
   </a>
 </p>
-<p align="center">ایجنت کدنویسی هوش مصنوعی متن‌باز.</p>
+<p align="center">یک ایجنت کدنویسی متن‌باز مبتنی بر هوش مصنوعی.</p>
 <p align="center">
   <a href="https://opencode.ai/discord"><img alt="Discord" src="https://img.shields.io/discord/1391832426048651334?style=flat-square&label=discord" /></a>
   <a href="https://www.npmjs.com/package/opencode-ai"><img alt="npm" src="https://img.shields.io/npm/v/opencode-ai?style=flat-square" /></a>
-  <a href="https://github.com/anomalyco/opencode/actions/workflows/publish.yml"><img alt="وضعیت بیلد" src="https://img.shields.io/github/actions/workflow/status/anomalyco/opencode/publish.yml?style=flat-square&branch=dev" /></a>
+  <a href="https://github.com/anomalyco/opencode/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/anomalyco/opencode/publish.yml?style=flat-square&branch=dev" /></a>
 </p>
 
 <p align="center">
@@ -40,95 +40,91 @@
   <a href="README.fa.md">فارسی</a>
 </p>
 
-[![رابط کاربری ترمینال OpenCode](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
-
-<div dir="rtl">
 
 ### نصب
 
 ```bash
-# سریع و ساده
+# YOLO
 curl -fsSL https://opencode.ai/install | bash
 
-# پکیج منیجرها
+# مدیران پکیج
 npm i -g opencode-ai@latest        # یا bun/pnpm/yarn
-scoop install opencode             # ویندوز
-choco install opencode             # ویندوز
-brew install anomalyco/tap/opencode # macOS و لینوکس (پیشنهادی، همیشه به‌روز)
-brew install opencode              # macOS و لینوکس (فرمول رسمی brew، به‌روزرسانی کمتر)
-sudo pacman -S opencode            # Arch Linux (پایدار)
+scoop install opencode             # Windows
+choco install opencode             # Windows
+brew install anomalyco/tap/opencode # macOS و Linux (توصیه‌شده، همیشه به‌روز)
+brew install opencode              # macOS و Linux (فرمول رسمی brew، به‌روزرسانی کمتر)
+sudo pacman -S opencode            # Arch Linux (Stable)
 paru -S opencode-bin               # Arch Linux (آخرین نسخه از AUR)
-mise use -g opencode               # هر سیستم‌عاملی
-nix run nixpkgs#opencode           # یا github:anomalyco/opencode برای آخرین نسخه dev
+mise use -g opencode               # هر سیستمی
+nix run nixpkgs#opencode           # یا github:anomalyco/opencode برای آخرین شاخه dev
 ```
 
 > [!TIP]
 > قبل از نصب، نسخه‌های قدیمی‌تر از 0.1.x را حذف کنید.
 
-### اپلیکیشن دسکتاپ (بتا)
+### اپلیکیشن دسکتاپ (BETA)
 
-OpenCode به‌صورت اپلیکیشن دسکتاپ هم در دسترس است. می‌توانید آن را مستقیماً از [صفحه releases](https://github.com/anomalyco/opencode/releases) یا [opencode.ai/download](https://opencode.ai/download) دانلود کنید.
+OpenCode به صورت اپلیکیشن دسکتاپ نیز در دسترس است. مستقیماً از [صفحه Releases](https://github.com/anomalyco/opencode/releases) یا از [opencode.ai/download](https://opencode.ai/download) دانلود کنید.
 
 | پلتفرم                | دانلود                             |
 | --------------------- | ---------------------------------- |
 | macOS (Apple Silicon) | `opencode-desktop-mac-arm64.dmg`   |
 | macOS (Intel)         | `opencode-desktop-mac-x64.dmg`     |
-| ویندوز                | `opencode-desktop-windows-x64.exe` |
-| لینوکس                | `.deb` یا `.rpm` یا `.AppImage`    |
+| Windows               | `opencode-desktop-windows-x64.exe` |
+| Linux                 | `.deb` یا `.rpm` یا AppImage       |
 
 ```bash
 # macOS (Homebrew)
 brew install --cask opencode-desktop
-# ویندوز (Scoop)
+# Windows (Scoop)
 scoop bucket add extras; scoop install extras/opencode-desktop
 ```
 
 #### مسیر نصب
 
-اسکریپت نصب برای انتخاب مسیر نصب، ترتیب اولویت زیر را رعایت می‌کند:
+اسکریپت نصب ترتیب اولویت زیر را برای مسیر نصب رعایت می‌کند:
 
 1. `$OPENCODE_INSTALL_DIR` - مسیر نصب سفارشی
 2. `$XDG_BIN_DIR` - مسیر سازگار با مشخصات XDG Base Directory
-3. `$HOME/bin` - مسیر استاندارد باینری کاربر (اگر وجود داشته باشد یا قابل ساخت باشد)
-4. `$HOME/.opencode/bin` - مسیر پیش‌فرض
+3. `$HOME/bin` - پوشه باینری استاندارد کاربر (در صورت وجود یا امکان ساخت)
+4. `$HOME/.opencode/bin` - مسیر پیش‌فرض جایگزین
 
 ```bash
-# نمونه‌ها
+# مثال‌ها
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
 XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
-### ایجنت‌ها
+### Agents
 
-OpenCode دو ایجنت توکار دارد که می‌توانید با کلید `Tab` بین آن‌ها جابه‌جا شوید.
+OpenCode دارای دو ایجنت داخلی است که می‌توانید با دکمه `Tab` بین آن‌ها جابه‌جا شوید.
 
-- **build** - ایجنت پیش‌فرض با دسترسی کامل، مناسب برای توسعه
+- **build** - پیش‌فرض، ایجنت با دسترسی کامل برای کارهای توسعه
 - **plan** - ایجنت فقط‌خواندنی برای تحلیل و بررسی کد
-  - به‌صورت پیش‌فرض ویرایش فایل را رد می‌کند
-  - قبل از اجرای دستورات bash اجازه می‌گیرد
-  - ایده‌آل برای بررسی کدبیس‌های ناآشنا یا برنامه‌ریزی تغییرات
+  - به صورت پیش‌فرض از ویرایش فایل‌ها خودداری می‌کند
+  - قبل از اجرای دستورات bash اجازه می‌خواهد
+  - مناسب برای بررسی پایگاه‌های کد ناآشنا یا برنامه‌ریزی تغییرات
 
-همچنین یک ساب‌ایجنت **general** برای جست‌وجوهای پیچیده و وظایف چندمرحله‌ای وجود دارد.
-این ایجنت به‌صورت داخلی استفاده می‌شود و می‌توان با `@general` در پیام‌ها آن را فراخوانی کرد.
+علاوه بر این، یک ایجنت فرعی **general** برای جستجوهای پیچیده و وظایف چندمرحله‌ای وجود دارد.
+به صورت داخلی استفاده می‌شود و با نوشتن `@general` در پیام‌ها قابل فراخوانی است.
 
-برای اطلاعات بیشتر درباره [ایجنت‌ها](https://opencode.ai/docs/agents) مستندات را بخوانید.
+برای اطلاعات بیشتر، [agents](https://opencode.ai/docs/agents) را مطالعه کنید.
 
 ### مستندات
 
-برای آشنایی با نحوه پیکربندی OpenCode، [**به مستندات ما مراجعه کنید**](https://opencode.ai/docs).
+برای اطلاعات بیشتر درباره نحوه تنظیم OpenCode، [**به مستندات مراجعه کنید**](https://opencode.ai/docs).
 
-### مشارکت در توسعه
+### مشارکت
 
-اگر علاقه‌مند به مشارکت در OpenCode هستید، لطفاً قبل از ارسال pull request، [راهنمای مشارکت](./CONTRIBUTING.md) را بخوانید.
+اگر علاقه‌مند به مشارکت در OpenCode هستید، لطفاً قبل از ارسال pull request، [مستندات مشارکت](./CONTRIBUTING.md) را مطالعه کنید.
 
-### ساخت روی OpenCode
+### ساخت بر روی OpenCode
 
-اگر روی پروژه‌ای کار می‌کنید که با OpenCode مرتبط است و از کلمه «opencode» در نامش استفاده می‌کند — مثلاً «opencode-dashboard» یا «opencode-mobile» — لطفاً در README خود توضیح دهید که این پروژه توسط تیم OpenCode ساخته نشده و هیچ وابستگی‌ای به ما ندارد.
+اگر روی پروژه‌ای مرتبط با OpenCode کار می‌کنید که از "opencode" در نامش استفاده می‌کند (مانند "opencode-dashboard" یا "opencode-mobile")، لطفاً یک یادداشت در README اضافه کنید که توضیح دهد این پروژه توسط تیم OpenCode ساخته نشده و هیچ وابستگی‌ای به ما ندارد.
 
 ---
 
 **به جامعه ما بپیوندید** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
-
-</div>

--- a/README.fr.md
+++ b/README.fr.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.gr.md
+++ b/README.gr.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.it.md
+++ b/README.it.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.no.md
+++ b/README.no.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.pl.md
+++ b/README.pl.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.ru.md
+++ b/README.ru.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.th.md
+++ b/README.th.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.tr.md
+++ b/README.tr.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.uk.md
+++ b/README.uk.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.vi.md
+++ b/README.vi.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.zh.md
+++ b/README.zh.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/README.zht.md
+++ b/README.zht.md
@@ -36,7 +36,8 @@
   <a href="README.uk.md">Українська</a> |
   <a href="README.bn.md">বাংলা</a> |
   <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.vi.md">Tiếng Việt</a> |
+  <a href="README.fa.md">فارسی</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)


### PR DESCRIPTION
### Issue for this PR
Closes #

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds a Persian (Farsi) translation of the README as `README.fa.md`. Persian is spoken by over 100 million people worldwide and was one of the few major languages missing from the project's documentation. The translation follows the same RTL (right-to-left) structure used in the existing Arabic README (`README.ar.md`), using a `<div dir="rtl">` wrapper for proper text direction. A link to the Persian README has also been added to the language list in all existing README files.

### How did you verify your code works?
I reviewed the rendered output to confirm the RTL layout displays correctly and that all links, code blocks, and formatting match the structure of the other translated READMEs.

### Screenshots / recordings
_N/A — this is a documentation-only change with no UI impact._

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR