### PR TITLE
fix(opencode): respect MCP server capabilities

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -126,15 +126,6 @@ function isOutputSchemaValidationError(error: Error) {
   )
 }
 
-function isMethodNotFound(error: unknown) {
-  if (typeof error === "object" && error !== null && "code" in error && error.code === -32601) return true
-  return error instanceof Error && /(?:-32601|method (?:not found|not available)|not supported)/i.test(error.message)
-}
-
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error)
-}
-
 function listTools(key: string, client: MCPClient, timeout: number) {
   return Effect.tryPromise({
     try: () => client.listTools(undefined, { timeout }),
@@ -212,11 +203,9 @@ function fetchFromClient<T extends { name: string }>(
 ) {
   return Effect.tryPromise({
     try: () => listFn(client),
-    catch: (error) => {
-      const message = errorMessage(error)
-      if (isMethodNotFound(error)) log.warn(`MCP server does not support ${label}`, { clientName, error: message })
-      else log.error(`failed to get ${label}`, { clientName, error: message })
-      return error
+    catch: (e: any) => {
+      log.warn(`failed to get ${label}`, { clientName, error: e.message })
+      return e
     },
   }).pipe(
     Effect.map((items) => {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -472,7 +472,7 @@ export const layer = Layer.effect(
         return { status } satisfies CreateResult
       }
 
-      const listed = yield* defs(key, mcpClient, mcp.timeout)
+      const listed = mcpClient.getServerCapabilities()?.tools ? yield* defs(key, mcpClient, mcp.timeout) : []
       if (!listed) {
         yield* Effect.tryPromise(() => mcpClient.close()).pipe(Effect.ignore)
         return { status: { status: "failed", error: "Failed to get tools" } } satisfies CreateResult
@@ -508,6 +508,7 @@ export const layer = Layer.effect(
     )
 
     function watch(s: State, name: string, client: MCPClient, bridge: EffectBridge.Shape, timeout?: number) {
+      if (!client.getServerCapabilities()?.tools) return
       client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
         log.info("tools list changed notification received", { server: name })
         if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
@@ -718,12 +719,21 @@ export const layer = Layer.effect(
 
     const prompts = Effect.fn("MCP.prompts")(function* () {
       const s = yield* InstanceState.get(state)
-      return yield* collectFromConnected(s, (c) => c.listPrompts().then((r) => r.prompts), "prompts")
+      return yield* collectFromConnected(
+        s,
+        (c) => (c.getServerCapabilities()?.prompts ? c.listPrompts().then((r) => r.prompts) : Promise.resolve([])),
+        "prompts",
+      )
     })
 
     const resources = Effect.fn("MCP.resources")(function* () {
       const s = yield* InstanceState.get(state)
-      return yield* collectFromConnected(s, (c) => c.listResources().then((r) => r.resources), "resources")
+      return yield* collectFromConnected(
+        s,
+        (c) =>
+          c.getServerCapabilities()?.resources ? c.listResources().then((r) => r.resources) : Promise.resolve([]),
+        "resources",
+      )
     })
 
     const withClient = Effect.fnUntraced(function* <A>(

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -858,7 +858,11 @@ export const layer = Layer.effect(
           Effect.tapError(() => Effect.tryPromise(() => client?.close() ?? Promise.resolve()).pipe(Effect.ignore)),
         )
 
-        const listed = client ? yield* defs(mcpName, client, mcpConfig.timeout) : undefined
+        const listed = client
+          ? client.getServerCapabilities()?.tools
+            ? yield* defs(mcpName, client, mcpConfig.timeout)
+            : []
+          : undefined
         if (!client || !listed) {
           yield* Effect.tryPromise(() => client?.close() ?? Promise.resolve()).pipe(Effect.ignore)
           return { status: "failed", error: "Failed to get tools" } as Status

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -126,6 +126,15 @@ function isOutputSchemaValidationError(error: Error) {
   )
 }
 
+function isMethodNotFound(error: unknown) {
+  if (typeof error === "object" && error !== null && "code" in error && error.code === -32601) return true
+  return error instanceof Error && /(?:-32601|method (?:not found|not available)|not supported)/i.test(error.message)
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
 function listTools(key: string, client: MCPClient, timeout: number) {
   return Effect.tryPromise({
     try: () => client.listTools(undefined, { timeout }),
@@ -203,9 +212,11 @@ function fetchFromClient<T extends { name: string }>(
 ) {
   return Effect.tryPromise({
     try: () => listFn(client),
-    catch: (e: any) => {
-      log.error(`failed to get ${label}`, { clientName, error: e.message })
-      return e
+    catch: (error) => {
+      const message = errorMessage(error)
+      if (isMethodNotFound(error)) log.warn(`MCP server does not support ${label}`, { clientName, error: message })
+      else log.error(`failed to get ${label}`, { clientName, error: message })
+      return error
     },
   }).pipe(
     Effect.map((items) => {

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -7,8 +7,11 @@ import { testEffect } from "../lib/effect"
 
 // Per-client state for controlling mock behavior
 interface MockClientState {
+  capabilities: { tools?: object; prompts?: object; resources?: object }
   tools: Array<{ name: string; description?: string; inputSchema: object; outputSchema?: object }>
   listToolsCalls: number
+  listPromptsCalls: number
+  listResourcesCalls: number
   requestCalls: number
   listToolsShouldFail: boolean
   listToolsError: string
@@ -35,8 +38,11 @@ function getOrCreateClientState(name?: string): MockClientState {
   let state = clientStates.get(key)
   if (!state) {
     state = {
+      capabilities: { tools: {}, prompts: {}, resources: {} },
       tools: [{ name: "test_tool", description: "A test tool", inputSchema: { type: "object", properties: {} } }],
       listToolsCalls: 0,
+      listPromptsCalls: 0,
+      listResourcesCalls: 0,
       requestCalls: 0,
       listToolsShouldFail: false,
       listToolsError: "listTools failed",
@@ -133,6 +139,10 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       this._state?.notificationHandlers.set(schema, handler)
     }
 
+    getServerCapabilities() {
+      return this._state?.capabilities
+    }
+
     async listTools() {
       if (this._state) this._state.listToolsCalls++
       if (this._state?.listToolsShouldFail) {
@@ -148,6 +158,7 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     }
 
     async listPrompts() {
+      if (this._state) this._state.listPromptsCalls++
       if (this._state?.listPromptsShouldFail) {
         throw new Error("listPrompts failed")
       }
@@ -155,6 +166,7 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     }
 
     async listResources() {
+      if (this._state) this._state.listResourcesCalls++
       if (this._state?.listResourcesShouldFail) {
         throw new Error("listResources failed")
       }
@@ -596,6 +608,84 @@ it.instance(
       },
     },
   },
+)
+
+it.instance(
+  "resource-only servers connect without listing tools",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "resource-only-server"
+        const serverState = getOrCreateClientState("resource-only-server")
+        serverState.capabilities = { resources: {} }
+        serverState.resources = [{ name: "docs", uri: "docs://readme" }]
+
+        const result = yield* mcp.add("resource-only-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        expect(statusName(result.status, "resource-only-server")).toBe("connected")
+        expect(serverState.listToolsCalls).toBe(0)
+        expect(Object.keys(yield* mcp.tools())).toHaveLength(0)
+        expect(Object.keys(yield* mcp.resources())).toEqual(["resource-only-server:docs"])
+        expect(serverState.listResourcesCalls).toBe(1)
+        expect(serverState.listPromptsCalls).toBe(0)
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "prompt-only servers connect without listing tools",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "prompt-only-server"
+        const serverState = getOrCreateClientState("prompt-only-server")
+        serverState.capabilities = { prompts: {} }
+        serverState.prompts = [{ name: "review" }]
+
+        const result = yield* mcp.add("prompt-only-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        expect(statusName(result.status, "prompt-only-server")).toBe("connected")
+        expect(serverState.listToolsCalls).toBe(0)
+        expect(Object.keys(yield* mcp.tools())).toHaveLength(0)
+        expect(Object.keys(yield* mcp.prompts())).toEqual(["prompt-only-server:review"])
+        expect(serverState.listPromptsCalls).toBe(1)
+        expect(serverState.listResourcesCalls).toBe(0)
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "tools-only servers skip optional prompt and resource discovery",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "tools-only-server"
+        const serverState = getOrCreateClientState("tools-only-server")
+        serverState.capabilities = { tools: {} }
+
+        const result = yield* mcp.add("tools-only-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        expect(statusName(result.status, "tools-only-server")).toBe("connected")
+        expect(serverState.listToolsCalls).toBe(1)
+        expect(Object.keys(yield* mcp.tools())).toEqual(["tools-only-server_test_tool"])
+        expect(yield* mcp.prompts()).toEqual({})
+        expect(yield* mcp.resources()).toEqual({})
+        expect(serverState.listPromptsCalls).toBe(0)
+        expect(serverState.listResourcesCalls).toBe(0)
+      }),
+    ),
+  { config: { mcp: {} } },
 )
 
 it.instance(

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,7 +1,8 @@
-import { expect, mock, beforeEach } from "bun:test"
+import { expect, mock, beforeEach, spyOn } from "bun:test"
 import { Cause, Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { testEffect } from "../lib/effect"
+import { Log } from "@opencode-ai/core/util/log"
 
 // --- Mock infrastructure ---
 
@@ -13,7 +14,9 @@ interface MockClientState {
   listToolsShouldFail: boolean
   listToolsError: string
   listPromptsShouldFail: boolean
+  listPromptsError: Error
   listResourcesShouldFail: boolean
+  listResourcesError: Error
   prompts: Array<{ name: string; description?: string }>
   resources: Array<{ name: string; uri: string; description?: string }>
   closed: boolean
@@ -41,7 +44,9 @@ function getOrCreateClientState(name?: string): MockClientState {
       listToolsShouldFail: false,
       listToolsError: "listTools failed",
       listPromptsShouldFail: false,
+      listPromptsError: new Error("listPrompts failed"),
       listResourcesShouldFail: false,
+      listResourcesError: new Error("listResources failed"),
       prompts: [],
       resources: [],
       closed: false,
@@ -149,14 +154,14 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
 
     async listPrompts() {
       if (this._state?.listPromptsShouldFail) {
-        throw new Error("listPrompts failed")
+        throw this._state.listPromptsError
       }
       return { prompts: this._state?.prompts ?? [] }
     }
 
     async listResources() {
       if (this._state?.listResourcesShouldFail) {
-        throw new Error("listResources failed")
+        throw this._state.listResourcesError
       }
       return { resources: this._state?.resources ?? [] }
     }
@@ -596,6 +601,64 @@ it.instance(
       },
     },
   },
+)
+
+it.instance(
+  "optional discovery logs unsupported methods as warnings",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "tools-only-server"
+        const serverState = getOrCreateClientState("tools-only-server")
+        serverState.listPromptsShouldFail = true
+        serverState.listPromptsError = Object.assign(new Error("MCP error -32601: Method not found"), { code: -32601 })
+        serverState.listResourcesShouldFail = true
+        serverState.listResourcesError = new Error("resources not supported")
+        const logger = Log.create({ service: "mcp" })
+        const warn = spyOn(logger, "warn").mockImplementation(() => {})
+        const error = spyOn(logger, "error").mockImplementation(() => {})
+
+        yield* mcp.add("tools-only-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        expect(yield* mcp.prompts()).toEqual({})
+        expect(yield* mcp.resources()).toEqual({})
+        expect(warn).toHaveBeenCalledTimes(2)
+        expect(error).not.toHaveBeenCalled()
+        warn.mockRestore()
+        error.mockRestore()
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "optional discovery keeps unexpected failures at error level",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "broken-prompt-server"
+        const serverState = getOrCreateClientState("broken-prompt-server")
+        serverState.listPromptsShouldFail = true
+        const logger = Log.create({ service: "mcp" })
+        const warn = spyOn(logger, "warn").mockImplementation(() => {})
+        const error = spyOn(logger, "error").mockImplementation(() => {})
+
+        yield* mcp.add("broken-prompt-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        expect(yield* mcp.prompts()).toEqual({})
+        expect(warn).not.toHaveBeenCalled()
+        expect(error).toHaveBeenCalledTimes(1)
+        warn.mockRestore()
+        error.mockRestore()
+      }),
+    ),
+  { config: { mcp: {} } },
 )
 
 it.instance(

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,8 +1,7 @@
-import { expect, mock, beforeEach, spyOn } from "bun:test"
+import { expect, mock, beforeEach } from "bun:test"
 import { Cause, Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { testEffect } from "../lib/effect"
-import { Log } from "@opencode-ai/core/util/log"
 
 // --- Mock infrastructure ---
 
@@ -14,9 +13,7 @@ interface MockClientState {
   listToolsShouldFail: boolean
   listToolsError: string
   listPromptsShouldFail: boolean
-  listPromptsError: Error
   listResourcesShouldFail: boolean
-  listResourcesError: Error
   prompts: Array<{ name: string; description?: string }>
   resources: Array<{ name: string; uri: string; description?: string }>
   closed: boolean
@@ -44,9 +41,7 @@ function getOrCreateClientState(name?: string): MockClientState {
       listToolsShouldFail: false,
       listToolsError: "listTools failed",
       listPromptsShouldFail: false,
-      listPromptsError: new Error("listPrompts failed"),
       listResourcesShouldFail: false,
-      listResourcesError: new Error("listResources failed"),
       prompts: [],
       resources: [],
       closed: false,
@@ -154,14 +149,14 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
 
     async listPrompts() {
       if (this._state?.listPromptsShouldFail) {
-        throw this._state.listPromptsError
+        throw new Error("listPrompts failed")
       }
       return { prompts: this._state?.prompts ?? [] }
     }
 
     async listResources() {
       if (this._state?.listResourcesShouldFail) {
-        throw this._state.listResourcesError
+        throw new Error("listResources failed")
       }
       return { resources: this._state?.resources ?? [] }
     }
@@ -601,64 +596,6 @@ it.instance(
       },
     },
   },
-)
-
-it.instance(
-  "optional discovery logs unsupported methods as warnings",
-  () =>
-    MCP.Service.use((mcp: MCPNS.Interface) =>
-      Effect.gen(function* () {
-        lastCreatedClientName = "tools-only-server"
-        const serverState = getOrCreateClientState("tools-only-server")
-        serverState.listPromptsShouldFail = true
-        serverState.listPromptsError = Object.assign(new Error("MCP error -32601: Method not found"), { code: -32601 })
-        serverState.listResourcesShouldFail = true
-        serverState.listResourcesError = new Error("resources not supported")
-        const logger = Log.create({ service: "mcp" })
-        const warn = spyOn(logger, "warn").mockImplementation(() => {})
-        const error = spyOn(logger, "error").mockImplementation(() => {})
-
-        yield* mcp.add("tools-only-server", {
-          type: "local",
-          command: ["echo", "test"],
-        })
-
-        expect(yield* mcp.prompts()).toEqual({})
-        expect(yield* mcp.resources()).toEqual({})
-        expect(warn).toHaveBeenCalledTimes(2)
-        expect(error).not.toHaveBeenCalled()
-        warn.mockRestore()
-        error.mockRestore()
-      }),
-    ),
-  { config: { mcp: {} } },
-)
-
-it.instance(
-  "optional discovery keeps unexpected failures at error level",
-  () =>
-    MCP.Service.use((mcp: MCPNS.Interface) =>
-      Effect.gen(function* () {
-        lastCreatedClientName = "broken-prompt-server"
-        const serverState = getOrCreateClientState("broken-prompt-server")
-        serverState.listPromptsShouldFail = true
-        const logger = Log.create({ service: "mcp" })
-        const warn = spyOn(logger, "warn").mockImplementation(() => {})
-        const error = spyOn(logger, "error").mockImplementation(() => {})
-
-        yield* mcp.add("broken-prompt-server", {
-          type: "local",
-          command: ["echo", "test"],
-        })
-
-        expect(yield* mcp.prompts()).toEqual({})
-        expect(warn).not.toHaveBeenCalled()
-        expect(error).toHaveBeenCalledTimes(1)
-        warn.mockRestore()
-        error.mockRestore()
-      }),
-    ),
-  { config: { mcp: {} } },
 )
 
 it.instance(

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -91,6 +91,10 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
 
     setNotificationHandler() {}
 
+    getServerCapabilities() {
+      return { tools: {} }
+    }
+
     async listTools() {
       return { tools: [{ name: "test_tool", inputSchema: { type: "object", properties: {} } }] }
     }

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -21,6 +21,8 @@ const transportCalls: Array<{
 // auth flow (which calls provider.state()) or a simple UnauthorizedError.
 let simulateAuthFlow = true
 let connectSucceedsImmediately = false
+let serverCapabilities: { tools?: object; resources?: object } = { tools: {} }
+let listToolsCalls = 0
 
 // Mock the transport constructors to simulate OAuth auto-auth on 401
 void mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
@@ -92,11 +94,16 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     setNotificationHandler() {}
 
     getServerCapabilities() {
-      return { tools: {} }
+      return serverCapabilities
     }
 
     async listTools() {
+      listToolsCalls++
       return { tools: [{ name: "test_tool", inputSchema: { type: "object", properties: {} } }] }
+    }
+
+    async listResources() {
+      return { resources: [{ name: "docs", uri: "docs://readme" }] }
     }
 
     async close() {}
@@ -112,6 +119,8 @@ beforeEach(() => {
   transportCalls.length = 0
   simulateAuthFlow = true
   connectSucceedsImmediately = false
+  serverCapabilities = { tools: {} }
+  listToolsCalls = 0
 })
 
 // Import modules after mocking
@@ -237,4 +246,29 @@ mcpTest.instance(
       }),
     ),
   { config: config("test-oauth-connect") },
+)
+
+mcpTest.instance(
+  "authenticate() connects a resource-only server without listing tools",
+  () =>
+    MCP.Service.use((mcp) =>
+      Effect.gen(function* () {
+        const added = yield* mcp.add("test-oauth-resources", {
+          type: "remote",
+          url: "https://example.com/mcp",
+        })
+        const before = added.status as Record<string, { status: string }>
+        expect(before["test-oauth-resources"]?.status).toBe("needs_auth")
+
+        simulateAuthFlow = false
+        connectSucceedsImmediately = true
+        serverCapabilities = { resources: {} }
+
+        const result = yield* mcp.authenticate("test-oauth-resources")
+        expect(result.status).toBe("connected")
+        expect(listToolsCalls).toBe(0)
+        expect(Object.keys(yield* mcp.resources())).toEqual(["test-oauth-resources:docs"])
+      }),
+    ),
+  { config: config("test-oauth-resources") },
 )

--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -89,6 +89,10 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     async connect(transport: { start: () => Promise<void> }) {
       await transport.start()
     }
+
+    getServerCapabilities() {
+      return { tools: {} }
+    }
   },
 }))
 


### PR DESCRIPTION
## Summary

- keep prompt-only and resource-only MCP servers connected without requiring `tools/list`
- only discover tools, prompts, and resources when the server advertises the corresponding capability
- only register tool-list change handling for tool-capable servers
- log handled MCP discovery failures as warnings instead of errors
- cover tools-only, prompt-only, and resource-only servers

## Verification

- `bun typecheck` in `packages/opencode`
- complete MCP suite: 48 passed
- broader MCP integration suite: 71 passed
- confirmed `getServerCapabilities()` exists in both SDK 1.27.1 and 1.29.0

Fixes #26048

Related to #20174 and #30476.