### PR TITLE
fix: prevent run and shell exit hangs

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -267,17 +267,18 @@ export const make = Effect.gen(function* () {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
       let end = false
-      let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
       proc.on("error", (err) => {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
       proc.on("exit", (...args) => {
-        exit = args
+        if (end) return
+        end = true
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
       })
       proc.on("close", (...args) => {
         if (end) return
         end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
       })
       proc.on("spawn", () => {
         resume(Effect.succeed([proc, signal]))

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -284,6 +284,29 @@ describe("cross-spawn spawner", () => {
         expect(running).toBe(false)
       }),
     )
+
+    fx.live(
+      "resolves exit code before inherited stdio handles close",
+      Effect.gen(function* () {
+        const handle = yield* js(
+          [
+            'const { spawn } = require("node:child_process")',
+            'spawn(process.execPath, ["-e", "setTimeout(() => {}, 2000)"], {',
+            '  stdio: ["ignore", process.stdout, process.stderr]',
+            "})",
+            "process.exit(7)",
+          ].join("\n"),
+        )
+        const code = yield* handle.exitCode.pipe(
+          Effect.timeoutOrElse({
+            duration: "1000 millis",
+            orElse: () => Effect.fail(new Error("exit code waited for stdio close")),
+          }),
+        )
+        expect(code).toBe(ChildProcessSpawner.ExitCode(7))
+      }),
+      5_000,
+    )
   })
 
   describe("error handling", () => {

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -752,6 +752,21 @@ export const RunCommand = effectCmd({
           }
           return error
         }
+
+        async function waitForIdle(stream: Promise<string | undefined>) {
+          while (true) {
+            const next = await Promise.race([
+              stream.then((error) => ({ type: "stream" as const, error })),
+              new Promise<{ type: "poll" }>((resolve) => setTimeout(() => resolve({ type: "poll" }), 250)),
+            ])
+            if (next.type === "stream") return next.error
+
+            const state = await client.session.status().catch(() => undefined)
+            const status = state?.data?.[sessionID]
+            if (!status || status.type === "idle") return undefined
+          }
+        }
+
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)
         const client = args.attach ? attachSDK(cwd) : sdk
 
@@ -761,39 +776,50 @@ export const RunCommand = effectCmd({
         await share(client, sessionID)
 
         if (!args.interactive) {
-          const events = await client.event.subscribe()
-          loop(client, events).catch((e) => {
-            console.error(e)
+          const abort = new AbortController()
+          const events = await client.event.subscribe(undefined, { signal: abort.signal, sseMaxRetryAttempts: 1 })
+          const stream = loop(client, events).catch((error) => {
+            if (abort.signal.aborted) return undefined
+            console.error(error)
             process.exit(1)
           })
 
-          if (args.command) {
-            const result = await client.session.command({
+          try {
+            if (args.command) {
+              const result = await client.session.command({
+                sessionID,
+                agent,
+                model: args.model,
+                command: args.command,
+                arguments: message,
+                variant: args.variant,
+              })
+              if (result.error) {
+                if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+                process.exitCode = 1
+                return
+              }
+              await waitForIdle(stream)
+              return
+            }
+
+            const model = pick(args.model)
+            const result = await client.session.prompt({
               sessionID,
               agent,
-              model: args.model,
-              command: args.command,
-              arguments: message,
+              model,
               variant: args.variant,
+              parts: [...files, { type: "text", text: message }],
             })
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
               process.exitCode = 1
+              return
             }
-            return
-          }
-
-          const model = pick(args.model)
-          const result = await client.session.prompt({
-            sessionID,
-            agent,
-            model,
-            variant: args.variant,
-            parts: [...files, { type: "text", text: message }],
-          })
-          if (result.error) {
-            if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
-            process.exitCode = 1
+            await waitForIdle(stream)
+          } finally {
+            abort.abort()
+            void events.stream.return(undefined).catch(() => {})
           }
           return
         }

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -5,6 +5,7 @@
 // `OPENCODE_CONFIG_CONTENT` providing the test provider config inline.
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
+import path from "node:path"
 import { cliIt } from "../../lib/cli-process"
 
 describe("opencode run (non-interactive subprocess)", () => {
@@ -18,6 +19,35 @@ describe("opencode run (non-interactive subprocess)", () => {
         const result = yield* opencode.run("say hi")
         opencode.expectExit(result, 0)
         expect(result.stdout).toContain("hello from the test llm")
+      }),
+    60_000,
+  )
+
+  // Regression for attached `opencode run`: the prompt endpoint can return
+  // before the subscribed event stream has delivered the final tool/text output.
+  // The CLI must wait for session idle/output and close the SSE subscription
+  // before exiting, otherwise callers can see exit 0 with empty stdout.
+  cliIt.concurrent(
+    "waits for attached read/write tool output before exiting",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        const file = path.join(home, "compress.py")
+        yield* Effect.promise(() => Bun.write(file, "old algorithm\n"))
+        yield* llm.tool("read", { filePath: file })
+        yield* llm.tool("write", { filePath: file, content: "better algorithm\n" })
+        yield* llm.text("done after edit")
+        const server = yield* opencode.serve()
+        const result = yield* opencode.run(
+          "Read compress.py and rewrite it with a better algorithm. Edit the file and exit.",
+          {
+            extraArgs: ["--attach", server.url, "--dangerously-skip-permissions"],
+            timeoutMs: 20_000,
+          },
+        )
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("done after edit")
+        expect(yield* Effect.promise(() => Bun.file(file).text())).toBe("better algorithm\n")
+        expect(result.durationMs).toBeLessThan(20_000)
       }),
     60_000,
   )


### PR DESCRIPTION
### Issue for this PR

Fixes #17516

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two cases where `opencode run` could finish tool work but not complete correctly.

First, non-interactive `opencode run` now keeps the event subscription alive long enough to receive final tool/text output before closing it. This prevents attached runs from exiting 0 with missing stdout after Read/Write tools complete.

Second, shell process completion now resolves from the child `exit` event instead of waiting for stdio `close`. This prevents commands from staying busy when a child exits, but a grandchild inherited stdout or stderr.

### How did you verify your code works?

- `packages/core`: `bun test test/effect/cross-spawn-spawner.test.ts`
- `packages/core`: `bun typecheck`
- `packages/opencode`: `bun test test/cli/run/run-process.test.ts`
- `packages/opencode`: `bun typecheck`

I also built a local binary and compared it against installed `opencode` 1.16.2. The installed binary reproduced the missing final stdout in the attached run and the inherited-stdio shell timeout; the local build completed both cases.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR