### PR TITLE
fix(desktop): stabilize snapshot sidecar lifecycle

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -424,7 +424,7 @@ export const make = Effect.gen(function* () {
                 yield* Effect.ignore(input.settle)
                 return ExitCode(code)
               }
-              yield* input.settle
+              yield* Effect.ignore(input.settle)
               return yield* Effect.fail(
                 toPlatformError(
                   "exitCode",

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -5,6 +5,7 @@ import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as FileSystem from "effect/FileSystem"
+import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import * as PlatformError from "effect/PlatformError"
@@ -26,6 +27,16 @@ import { PassThrough } from "node:stream"
 import launch from "cross-spawn"
 
 const toError = (err: unknown): Error => (err instanceof globalThis.Error ? err : new globalThis.Error(String(err)))
+
+const settleFiber = <A, E>(fiber: Fiber.Fiber<A, E>) =>
+  Effect.suspend(() => {
+    const exit = fiber.pollUnsafe()
+    if (!exit) return Fiber.interrupt(fiber)
+    return Exit.match(exit, {
+      onFailure: Effect.failCause,
+      onSuccess: () => Effect.void,
+    })
+  })
 
 const toTag = (err: NodeJS.ErrnoException): PlatformError.SystemErrorTag => {
   switch (err.code) {
@@ -233,8 +244,11 @@ export const make = Effect.gen(function* () {
           encoding: cfg.encoding,
         })
       }
-      if (Stream.isStream(cfg.stream)) return Effect.as(Effect.forkScoped(Stream.run(cfg.stream, sink)), sink)
-      return Effect.succeed(sink)
+      if (!Stream.isStream(cfg.stream)) return Effect.succeed({ sink, settle: Effect.void })
+      return Effect.map(Effect.forkScoped(Stream.run(cfg.stream, sink)), (fiber) => ({
+        sink,
+        settle: settleFiber(fiber),
+      }))
     })
 
   const setupOutput = (
@@ -402,26 +416,36 @@ export const make = Effect.gen(function* () {
 
           const fd = yield* setupFds(command, proc, extra)
           const out = setupOutput(command, proc, sout, serr)
+          const input = yield* setupStdin(command, proc, sin)
+          const exitCode = yield* Effect.cached(
+            Effect.gen(function* () {
+              const [code, exitSignal] = yield* Deferred.await(signal)
+              if (Predicate.isNotNull(code) && code !== 0) {
+                yield* Effect.ignore(input.settle)
+                return ExitCode(code)
+              }
+              yield* input.settle
+              if (Predicate.isNotNull(code)) return ExitCode(code)
+              return yield* Effect.fail(
+                toPlatformError(
+                  "exitCode",
+                  new Error(`Process interrupted due to receipt of signal: '${exitSignal}'`),
+                  command,
+                ),
+              )
+            }),
+          )
           let ref = true
           return makeHandle({
             pid: ProcessId(proc.pid!),
-            stdin: yield* setupStdin(command, proc, sin),
+            stdin: input.sink,
             stdout: out.stdout,
             stderr: out.stderr,
             all: out.all,
             getInputFd: fd.getInputFd,
             getOutputFd: fd.getOutputFd,
             isRunning: Effect.map(Deferred.isDone(signal), (done) => !done),
-            exitCode: Effect.flatMap(Deferred.await(signal), ([code, signal]) => {
-              if (Predicate.isNotNull(code)) return Effect.succeed(ExitCode(code))
-              return Effect.fail(
-                toPlatformError(
-                  "exitCode",
-                  new Error(`Process interrupted due to receipt of signal: '${signal}'`),
-                  command,
-                ),
-              )
-            }),
+            exitCode,
             kill: (opts?: ChildProcess.KillOptions) => {
               const sig = opts?.killSignal ?? "SIGTERM"
               const send = (s: NodeJS.Signals) =>

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -420,12 +420,11 @@ export const make = Effect.gen(function* () {
           const exitCode = yield* Effect.cached(
             Effect.gen(function* () {
               const [code, exitSignal] = yield* Deferred.await(signal)
-              if (Predicate.isNotNull(code) && code !== 0) {
+              if (Predicate.isNotNull(code)) {
                 yield* Effect.ignore(input.settle)
                 return ExitCode(code)
               }
               yield* input.settle
-              if (Predicate.isNotNull(code)) return ExitCode(code)
               return yield* Effect.fail(
                 toPlatformError(
                   "exitCode",

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -240,6 +240,16 @@ describe("cross-spawn spawner", () => {
         expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(0))
       }),
     )
+
+    fx.effect(
+      "preserves a successful exit when the child stops reading stdin",
+      Effect.gen(function* () {
+        const stdin = Stream.make(Buffer.alloc(4 * 1024 * 1024))
+        const handle = yield* js('process.stdin.once("data", () => process.exit(0)); process.stdin.resume()', { stdin })
+
+        expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+    )
   })
 
   describe("process control", () => {

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from "bun:test"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { Effect, Exit, Stream } from "effect"
+import { Deferred, Effect, Exit, Option, Stream } from "effect"
 import type * as PlatformError from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -223,6 +223,21 @@ describe("cross-spawn spawner", () => {
         const out = yield* decodeByteStream(handle.stdout)
         yield* handle.exitCode
         expect(out).toBe("a b c")
+      }),
+    )
+
+    fx.effect(
+      "settles configured stdin before exposing process exit",
+      Effect.gen(function* () {
+        const settled = yield* Deferred.make<void>()
+        const stdin = Stream.concat(Stream.make(Buffer.from("input", "utf-8")), Stream.never).pipe(
+          Stream.ensuring(Deferred.succeed(settled, undefined)),
+        )
+        const handle = yield* js('process.stdin.once("data", () => process.exit(0)); process.stdin.resume()', { stdin })
+
+        expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(0))
+        expect(Option.isSome(yield* Deferred.poll(settled))).toBe(true)
+        expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(0))
       }),
     )
   })

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -250,6 +250,23 @@ describe("cross-spawn spawner", () => {
         expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(0))
       }),
     )
+
+    fx.effect(
+      "preserves signal termination when stdin stops accepting input",
+      Effect.gen(function* () {
+        if (process.platform === "win32") return
+        const stdin = Stream.make(Buffer.alloc(4 * 1024 * 1024))
+        const handle = yield* js('process.stdin.once("data", () => process.kill(process.pid, "SIGTERM")); process.stdin.resume()', {
+          stdin,
+        })
+
+        const exit = yield* Effect.exit(handle.exitCode)
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isSuccess(exit)) return
+        expect(String(exit.cause)).toContain("SIGTERM")
+      }),
+    )
   })
 
   describe("process control", () => {

--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -196,6 +196,43 @@ describe("AppProcess", () => {
         expect(Array.from(out)).toEqual(["a", "b"])
       }),
     )
+
+    it.effect(
+      "preserves a child failure when it closes stdin early",
+      Effect.acquireUseRelease(
+        Effect.promise(() => fs.mkdtemp(path.join(tmpdir(), "opencode-locked-git-"))),
+        (dir) =>
+          Effect.gen(function* () {
+            const svc = yield* AppProcess.Service
+            const gitdir = path.join(dir, "snapshot.git")
+            const worktree = path.join(dir, "worktree")
+            yield* Effect.promise(() => fs.mkdir(worktree))
+            yield* svc
+              .run(ChildProcess.make("git", ["init", "--bare", gitdir]))
+              .pipe(Effect.flatMap(AppProcess.requireSuccess))
+            yield* Effect.promise(() => fs.writeFile(path.join(gitdir, "index.lock"), ""))
+            const input = Array.from({ length: 30_000 }, (_, index) => `path-${index}`).join("\0") + "\0"
+
+            const result = yield* svc.run(
+              ChildProcess.make("git", [
+                "--git-dir",
+                gitdir,
+                "--work-tree",
+                worktree,
+                "add",
+                "--all",
+                "--pathspec-from-file=-",
+                "--pathspec-file-nul",
+              ]),
+              { stdin: input },
+            )
+
+            expect(result.exitCode).toBe(128)
+            expect(result.stderr.toString("utf8")).toContain("index.lock")
+          }),
+        (dir) => Effect.promise(() => fs.rm(dir, { recursive: true, force: true })),
+      ),
+    )
   })
 
   describe("run with stdin option", () => {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -38,6 +38,7 @@ import { createWslServersController } from "./wsl/servers"
 import { registerWslIpcHandlers } from "./wsl/ipc"
 import { spawnWslSidecar } from "./wsl/sidecar"
 import { migrate } from "./migrate"
+import { isUnexpectedCurrentSidecar } from "./sidecar-lifecycle"
 
 const APP_NAMES: Record<string, string> = {
   dev: "OpenCode Dev",
@@ -321,6 +322,11 @@ const main = Effect.gen(function* () {
       }),
     )
     server = listener
+    void listener.exit.then((settlement) => {
+      if (!isUnexpectedCurrentSidecar(server, listener, settlement)) return
+      server = null
+      writeLog("utility", "sidecar terminated unexpectedly", { code: settlement.code }, "error")
+    })
     yield* Deferred.succeed(serverReady, {
       url,
       username: "opencode",

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -5,6 +5,7 @@ import type { Details } from "electron"
 import { DEFAULT_SERVER_URL_KEY } from "./constants"
 import { getUserShell, loadShellEnv } from "./shell-env"
 import { getStore } from "./store"
+import { createSidecarLifecycle, type SidecarSettlement } from "./sidecar-lifecycle"
 
 export type HealthCheck = { wait: Promise<void> }
 
@@ -13,7 +14,10 @@ type SidecarMessage =
   | { type: "stopped" }
   | { type: "error"; error: { message: string; stack?: string } }
 
-export type SidecarListener = { stop: () => Promise<void> }
+export type SidecarListener = {
+  stop: () => Promise<void>
+  readonly exit: Promise<SidecarSettlement>
+}
 
 const SIDECAR_SERVICE_NAME = "opencode server"
 const SIDECAR_START_STALL_TIMEOUT = 60_000
@@ -66,6 +70,7 @@ export async function spawnLocalServer(
   })
   let exited = false
   const exit = defer<number>()
+  const lifecycle = createSidecarLifecycle()
 
   const onProcessGone = (_event: unknown, details: Details) => {
     if (details.type !== "Utility" || details.name !== SIDECAR_SERVICE_NAME) return
@@ -78,6 +83,7 @@ export async function spawnLocalServer(
     app.off("child-process-gone", onProcessGone)
     options.onExit?.(code)
     exit.resolve(code)
+    lifecycle.exited(code)
   })
   child.on("error", (error) => options.onStderr?.(`utility process error: ${serializeError(error).message}`))
 
@@ -159,21 +165,23 @@ export async function spawnLocalServer(
     await Promise.race([ready(), gone])
   })()
 
-  let stopping: Promise<void> | undefined
+  let stop: Promise<void> | undefined
 
   return {
     listener: {
+      exit: lifecycle.exit,
       stop: () => {
-        if (stopping) return stopping
+        if (stop) return stop
         if (exited) return Promise.resolve()
+        lifecycle.stopping()
         child.postMessage({ type: "stop" })
-        stopping = Promise.race([
+        stop = Promise.race([
           exit.promise.then(() => undefined),
           delay(SIDECAR_STOP_TIMEOUT).then(() => {
             if (!exited) child.kill()
           }),
         ])
-        return stopping
+        return stop
       },
     },
     health: { wait },

--- a/packages/desktop/src/main/sidecar-lifecycle.test.ts
+++ b/packages/desktop/src/main/sidecar-lifecycle.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { createSidecarLifecycle, isUnexpectedCurrentSidecar } from "./sidecar-lifecycle"
+
+test("classifies an unrequested sidecar exit as unexpected", async () => {
+  const lifecycle = createSidecarLifecycle()
+
+  lifecycle.exited(1)
+
+  expect(await lifecycle.exit).toEqual({ code: 1, expected: false })
+})
+
+test("classifies an exit after stop begins as expected", async () => {
+  const lifecycle = createSidecarLifecycle()
+
+  lifecycle.stopping()
+  lifecycle.exited(0)
+
+  expect(await lifecycle.exit).toEqual({ code: 0, expected: true })
+})
+
+test("ignores an unexpected exit from a replaced sidecar", () => {
+  const exited = {}
+  const replacement = {}
+
+  expect(isUnexpectedCurrentSidecar(exited, exited, { code: 1, expected: false })).toBe(true)
+  expect(isUnexpectedCurrentSidecar(replacement, exited, { code: 1, expected: false })).toBe(false)
+  expect(isUnexpectedCurrentSidecar(exited, exited, { code: 0, expected: true })).toBe(false)
+})

--- a/packages/desktop/src/main/sidecar-lifecycle.ts
+++ b/packages/desktop/src/main/sidecar-lifecycle.ts
@@ -1,0 +1,20 @@
+export type SidecarSettlement = { code: number; expected: boolean }
+
+export function createSidecarLifecycle() {
+  let expected = false
+  let resolve!: (settlement: SidecarSettlement) => void
+  const exit = new Promise<SidecarSettlement>((done) => {
+    resolve = done
+  })
+  return {
+    exit,
+    stopping: () => {
+      expected = true
+    },
+    exited: (code: number) => resolve({ code, expected }),
+  }
+}
+
+export function isUnexpectedCurrentSidecar<T>(current: T | null, exited: T, settlement: SidecarSettlement) {
+  return current === exited && !settlement.expected
+}

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -31,6 +31,7 @@ export type FileDiff = typeof FileDiff.Type
 const log = Log.create({ service: "snapshot" })
 const prune = "7.days"
 const limit = 2 * 1024 * 1024
+const baseline = "refs/opencode/snapshot-index"
 const core = ["-c", "core.longpaths=true", "-c", "core.symlinks=true"]
 const cfg = ["-c", "core.autocrlf=false", ...core]
 const quote = [...cfg, "-c", "core.quotepath=false"]
@@ -131,7 +132,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
         const drop = Effect.fnUntraced(function* (files: string[], env?: Record<string, string>) {
           if (!files.length) return
-          const result = yield* git(
+          yield* git(
             [
               ...cfg,
               ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
@@ -142,8 +143,6 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               stdin: feed(files),
             },
           )
-          if (result.code === 0) return
-          return yield* Effect.die(new Error(result.stderr))
         })
 
         const stage = Effect.fnUntraced(function* (files: string[], env?: Record<string, string>) {
@@ -157,7 +156,10 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             },
           )
           if (result.code === 0) return
-          return yield* Effect.die(new Error(result.stderr))
+          log.warn("failed to add snapshot files", {
+            exitCode: result.code,
+            stderr: result.stderr,
+          })
         })
 
         const exists = (file: string) => fs.exists(file).pipe(Effect.orDie)
@@ -199,9 +201,11 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             [
               git([...quote, ...args(["diff-files", "--name-only", "-z", "--", "."])], {
                 cwd: state.directory,
+                env,
               }),
               git([...quote, ...args(["ls-files", "--others", "--exclude-standard", "-z", "--", "."])], {
                 cwd: state.directory,
+                env,
               }),
             ],
             { concurrency: 2 },
@@ -261,24 +265,37 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           )
         })
 
+        const seed = Effect.fnUntraced(function* (previous: GitResult, env: Record<string, string>) {
+          if (previous.code === 0) {
+            return yield* git([...cfg, ...args(["read-tree", previous.text.trim()])], { cwd: state.directory, env })
+          }
+          const initialized = yield* git([...cfg, ...args(["read-tree", "--empty"])], { cwd: state.directory, env })
+          if (initialized.code !== 0) return initialized
+          if (!(yield* exists(path.join(state.gitdir, "index")))) return initialized
+          const legacy = yield* git([...quote, ...args(["ls-files", "--stage", "-z"])], { cwd: state.directory })
+          if (legacy.code !== 0) return legacy
+          return yield* git([...cfg, ...args(["update-index", "-z", "--index-info"])], {
+            cwd: state.directory,
+            env,
+            stdin: legacy.text,
+          })
+        })
+
         const capture = Effect.fnUntraced(function* () {
           const root = path.join(state.gitdir, "tmp")
           yield* fs.ensureDir(root).pipe(Effect.orDie)
           const dir = yield* fs.makeTempDirectoryScoped({ directory: root, prefix: "index-" }).pipe(Effect.orDie)
           const env = { GIT_INDEX_FILE: path.join(dir, "index") }
-          const index = path.join(state.gitdir, "index")
-          const seed = yield* Effect.gen(function* () {
-            if (!(yield* exists(index))) return ["read-tree", "--empty"]
-            const result = yield* git(args(["write-tree"]), { cwd: state.directory })
-            if (result.code !== 0) return yield* Effect.die(new Error(result.stderr))
-            return ["read-tree", result.text.trim()]
-          })
-          const initialized = yield* git([...cfg, ...args(seed)], { cwd: state.directory, env })
+          const previous = yield* git(args(["rev-parse", "--verify", `${baseline}^{tree}`]), { cwd: state.directory })
+          const initialized = yield* seed(previous, env)
           if (initialized.code !== 0) return yield* Effect.die(new Error(initialized.stderr))
           yield* add(env)
           const result = yield* git(args(["write-tree"]), { cwd: state.directory, env })
           if (result.code !== 0) return yield* Effect.die(new Error(result.stderr))
-          return result.text.trim()
+          const hash = result.text.trim()
+          const published = yield* git(args(["update-ref", baseline, hash]), { cwd: state.directory })
+          if (published.code !== 0) return yield* Effect.die(new Error(published.stderr))
+          return hash
         }, Effect.scoped)
 
         const cleanup = Effect.fnUntraced(function* () {

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -129,34 +129,35 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           return new Set(check.text.split("\0").filter(Boolean))
         })
 
-        const drop = Effect.fnUntraced(function* (files: string[]) {
+        const drop = Effect.fnUntraced(function* (files: string[], env?: Record<string, string>) {
           if (!files.length) return
-          yield* git(
+          const result = yield* git(
             [
               ...cfg,
               ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
             ],
             {
               cwd: state.directory,
+              env,
               stdin: feed(files),
             },
           )
+          if (result.code === 0) return
+          return yield* Effect.die(new Error(result.stderr))
         })
 
-        const stage = Effect.fnUntraced(function* (files: string[]) {
+        const stage = Effect.fnUntraced(function* (files: string[], env?: Record<string, string>) {
           if (!files.length) return
           const result = yield* git(
             [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
             {
               cwd: state.directory,
+              env,
               stdin: feed(files),
             },
           )
           if (result.code === 0) return
-          log.warn("failed to add snapshot files", {
-            exitCode: result.code,
-            stderr: result.stderr,
-          })
+          return yield* Effect.die(new Error(result.stderr))
         })
 
         const exists = (file: string) => fs.exists(file).pipe(Effect.orDie)
@@ -192,7 +193,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.orDie)
         })
 
-        const add = Effect.fnUntraced(function* () {
+        const add = Effect.fnUntraced(function* (env?: Record<string, string>) {
           yield* sync()
           const [diff, other] = yield* Effect.all(
             [
@@ -228,7 +229,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           if (ignored.size > 0) {
             const ignoredFiles = Array.from(ignored)
             log.info("removing gitignored files from snapshot", { count: ignoredFiles.length })
-            yield* drop(ignoredFiles)
+            yield* drop(ignoredFiles, env)
           }
 
           const allow = all.filter((item) => !ignored.has(item))
@@ -254,8 +255,31 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           const block = new Set(untracked.filter((item) => large.has(item)))
           yield* sync(Array.from(block))
           // Stage only the allowed candidate paths so snapshot updates stay scoped.
-          yield* stage(allow.filter((item) => !block.has(item)))
+          yield* stage(
+            allow.filter((item) => !block.has(item)),
+            env,
+          )
         })
+
+        const capture = Effect.fnUntraced(function* () {
+          const root = path.join(state.gitdir, "tmp")
+          yield* fs.ensureDir(root).pipe(Effect.orDie)
+          const dir = yield* fs.makeTempDirectoryScoped({ directory: root, prefix: "index-" }).pipe(Effect.orDie)
+          const env = { GIT_INDEX_FILE: path.join(dir, "index") }
+          const index = path.join(state.gitdir, "index")
+          const seed = yield* Effect.gen(function* () {
+            if (!(yield* exists(index))) return ["read-tree", "--empty"]
+            const result = yield* git(args(["write-tree"]), { cwd: state.directory })
+            if (result.code !== 0) return yield* Effect.die(new Error(result.stderr))
+            return ["read-tree", result.text.trim()]
+          })
+          const initialized = yield* git([...cfg, ...args(seed)], { cwd: state.directory, env })
+          if (initialized.code !== 0) return yield* Effect.die(new Error(initialized.stderr))
+          yield* add(env)
+          const result = yield* git(args(["write-tree"]), { cwd: state.directory, env })
+          if (result.code !== 0) return yield* Effect.die(new Error(result.stderr))
+          return result.text.trim()
+        }, Effect.scoped)
 
         const cleanup = Effect.fnUntraced(function* () {
           return yield* locked(
@@ -291,9 +315,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
                 yield* git(["--git-dir", state.gitdir, "config", "core.fsmonitor", "false"])
                 log.info("initialized")
               }
-              yield* add()
-              const result = yield* git(args(["write-tree"]), { cwd: state.directory })
-              const hash = result.text.trim()
+              const hash = yield* capture()
               log.info("tracking", { hash, cwd: state.directory, git: state.gitdir })
               return hash
             }),
@@ -303,9 +325,9 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
         const patch = Effect.fnUntraced(function* (hash: string) {
           return yield* locked(
             Effect.gen(function* () {
-              yield* add()
+              const current = yield* capture()
               const result = yield* git(
-                [...quote, ...args(["diff", "--cached", "--no-ext-diff", "--name-only", hash, "--", "."])],
+                [...quote, ...args(["diff", "--no-ext-diff", "--name-only", hash, current, "--", "."])],
                 {
                   cwd: state.directory,
                 },
@@ -477,8 +499,8 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
         const diff = Effect.fnUntraced(function* (hash: string) {
           return yield* locked(
             Effect.gen(function* () {
-              yield* add()
-              const result = yield* git([...quote, ...args(["diff", "--cached", "--no-ext-diff", hash, "--", "."])], {
+              const current = yield* capture()
+              const result = yield* git([...quote, ...args(["diff", "--no-ext-diff", hash, current, "--", "."])], {
                 cwd: state.worktree,
               })
               if (result.code !== 0) {

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -220,6 +220,25 @@ it.instance(
 )
 
 it.instance(
+  "files captured while small remain tracked after growing past the size limit",
+  withTrackedSnapshot(({ tmp, snapshot, before }) =>
+    Effect.gen(function* () {
+      yield* write(`${tmp.path}/growing.txt`, "small")
+      const tracked = yield* snapshot.track()
+      expect(tracked).toBeTruthy()
+      yield* write(`${tmp.path}/growing.txt`, new Uint8Array(2 * 1024 * 1024 + 1))
+
+      const after = yield* snapshot.track()
+      const diff = yield* snapshot.diffFull(tracked!, after!)
+
+      expect(after).not.toBe(before)
+      expect(diff.find((item) => item.file === "growing.txt")?.status).toBe("modified")
+    }),
+  ),
+  { git: true },
+)
+
+it.instance(
   "nested directory revert",
   withTrackedSnapshot(({ tmp, snapshot, before }) =>
     Effect.gen(function* () {
@@ -700,14 +719,19 @@ it.instance(
         }
         throw new Error("snapshot git directory not found")
       })
+      yield* exec(tmp.path, ["git", "--git-dir", gitdir, "update-ref", "-d", "refs/opencode/snapshot-index"])
+      yield* exec(tmp.path, ["git", "--git-dir", gitdir, "--work-tree", tmp.path, "read-tree", before])
       yield* write(path.join(gitdir, "index.lock"), "")
+      yield* write(`${tmp.path}/a.txt`, new Uint8Array(2 * 1024 * 1024 + 1))
       yield* write(`${tmp.path}/new.txt`, "new content")
 
       const after = yield* snapshot.track()
+      const diff = yield* snapshot.diffFull(before, after!)
 
       expect(after).toBeTruthy()
       expect(after).not.toBe(before)
       expect(yield* snapshot.diff(before)).toContain("new.txt")
+      expect(diff.find((item) => item.file === "a.txt")?.status).toBe("modified")
       expect(yield* Effect.promise(() => fs.readdir(path.join(gitdir, "tmp")))).toEqual([])
     }),
   ),

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -2,6 +2,8 @@ import { afterEach, expect } from "bun:test"
 import { $ } from "bun"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import { Hash } from "@opencode-ai/core/util/hash"
 import fs from "fs/promises"
 import path from "path"
 import { Effect, Fiber, Layer } from "effect"
@@ -675,6 +677,38 @@ it.instance(
     Effect.gen(function* () {
       expect(yield* snapshot.track()).toBe(before)
       expect(yield* snapshot.track()).toBe(before)
+    }),
+  ),
+  { git: true },
+)
+
+it.instance(
+  "stale shared index lock cannot block snapshot capture",
+  withTrackedSnapshot(({ tmp, snapshot, before }) =>
+    Effect.gen(function* () {
+      const projects = yield* Effect.promise(() => fs.readdir(path.join(Global.Path.data, "snapshot")))
+      const gitdir = yield* Effect.promise(async () => {
+        for (const project of projects) {
+          const candidate = path.join(Global.Path.data, "snapshot", project, Hash.fast(tmp.path))
+          if (
+            await fs.stat(candidate).then(
+              () => true,
+              () => false,
+            )
+          )
+            return candidate
+        }
+        throw new Error("snapshot git directory not found")
+      })
+      yield* write(path.join(gitdir, "index.lock"), "")
+      yield* write(`${tmp.path}/new.txt`, "new content")
+
+      const after = yield* snapshot.track()
+
+      expect(after).toBeTruthy()
+      expect(after).not.toBe(before)
+      expect(yield* snapshot.diff(before)).toContain("new.txt")
+      expect(yield* Effect.promise(() => fs.readdir(path.join(gitdir, "tmp")))).toEqual([])
     }),
   ),
   { git: true },


### PR DESCRIPTION
TLDR;

- Snapshot capture no longer gets stuck behind a stale internal Git index lock.
- Early Git failures no longer leave a late pipe error that can terminate the local Desktop server.
- Desktop no longer keeps a terminated local server marked as active.

## Problem

OpenCode snapshots use Git with a NUL-delimited path list written to child-process stdin. If the snapshot repository contains a stale `index.lock`, Git exits before consuming that input. On Windows, the outstanding overlapped pipe write can then complete as `write EOF`; if stdin lifecycle finishes after process completion, that late socket error can terminate the Desktop sidecar instead of preserving Git's real exit status and lock diagnostic.

The shared snapshot index also means the stale lock continues blocking later captures. This change isolates each capture in a scoped alternate index, persists its baseline as an immutable Git tree ref, and settles child stdin before exposing process completion.

## Headless repro

Run with Node 24 and Git for Windows. This uses the same `git add --pathspec-from-file=- --pathspec-file-nul` shape as snapshot capture:

```js
// repro.mjs
import { spawn, spawnSync } from "node:child_process"
import { mkdirSync, rmSync, writeFileSync } from "node:fs"
import { join } from "node:path"

const root = join(import.meta.dirname, "snapshot-eof-repro")
const worktree = join(root, "worktree")
const gitdir = join(root, "snapshot.git")
rmSync(root, { recursive: true, force: true })
mkdirSync(worktree, { recursive: true })
spawnSync("git", ["init", "--bare", gitdir])
writeFileSync(join(gitdir, "index.lock"), "")

const input = Buffer.alloc(4 * 1024 * 1024, 0x61)
for (let i = 255; i < input.length; i += 256) input[i] = 0

const child = spawn("git", [
  "--git-dir", gitdir,
  "--work-tree", worktree,
  "add", "--all",
  "--pathspec-from-file=-",
  "--pathspec-file-nul",
], { stdio: ["overlapped", "pipe", "pipe"], windowsHide: true })

child.stdin.end(input)
```

```powershell
node repro.mjs
```

Before this change, the process terminates with the same failure observed in Desktop diagnostics:

```text
Error: write EOF
    at WriteWrap.onWriteComplete [as oncomplete]
Emitted 'error' event on Socket instance
code: 'EOF'
syscall: 'write'
```

## Changelog

### Fixed
- OpenCode Desktop no longer loses snapshot capture when an old internal snapshot lock remains on disk.
- Files already tracked by snapshots remain tracked after migration, including files that later grow beyond the new-file size limit.
- The local Desktop server no longer terminates from a delayed input-pipe error after Git exits early.
- Git failures retain their original exit status and diagnostic output instead of being replaced by a secondary pipe error.
- Successful commands remain successful when they intentionally stop reading input before it is exhausted.
- An unexpectedly terminated local server is no longer kept as the current Desktop server connection.
- A previous local server process exiting after replacement no longer clears the newer active server.

### Improved
- Snapshot capture now uses a temporary scoped Git index and a Git-managed baseline ref while preserving existing snapshot retention, pruning, serialization, restore, and revert behavior.
- Intentional Desktop shutdown is distinguished from an unexpected local server exit in diagnostics.