### PR TITLE
chore: update web and desktop code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 # web + desktop packages
-packages/app/      @adamdotdevin
-packages/tauri/    @adamdotdevin
-packages/desktop/src-tauri/  @brendonovich
-packages/desktop/  @adamdotdevin
+packages/app/      @Hona @Brendonovich
+packages/desktop/  @Hona @Brendonovich


### PR DESCRIPTION
Replace Adam with Hona and Brendonovich as code owners for the web app and Electron desktop app, and remove obsolete Tauri ownership rules.