### PR TITLE
fix(core): avoid recursive scan when browsing directories in Open Project

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -298,8 +298,8 @@ export const layer = Layer.effect(
       })
     })
 
-    const scan = Effect.fnUntraced(function* () {
-      if (location.directory === Global.Path.home && location.project.id === "global") {
+    const scan = Effect.fnUntraced(function* (options?: { shallow?: boolean }) {
+      if (options?.shallow || (location.directory === Global.Path.home && location.project.id === "global")) {
         const protectedNames = Protected.names()
         const nested = new Set(["node_modules", "dist", "build", "target", "vendor"])
         return (yield* Effect.forEach(
@@ -601,7 +601,8 @@ export const layer = Layer.effect(
       }),
       listPageResolved,
       find: Effect.fn("FileSystem.find")(function* (input) {
-        const items = (yield* scan()).filter((item) => input.type !== "file" || !item.endsWith("/"))
+        const shallow = input.type === "directory" && location.project.id === "global"
+        const items = (yield* scan({ shallow })).filter((item) => input.type !== "file" || !item.endsWith("/"))
         const filtered = items.filter((item) => input.type !== "directory" || item.endsWith("/"))
         const sorted = input.query.trim()
           ? fuzzysort.go(input.query.trim(), filtered, { limit: input.limit ?? 100 }).map((item) => item.target)

--- a/packages/core/test/location-search.test.ts
+++ b/packages/core/test/location-search.test.ts
@@ -44,6 +44,29 @@ function withTmp<A, E, R>(f: (directory: string) => Effect.Effect<A, E, R>) {
   ).pipe(Effect.flatMap((tmp) => f(tmp.path)))
 }
 
+describe("FileSystem.find", () => {
+  it.live("uses shallow search for global directory finds", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(async () => {
+          await fs.mkdir(path.join(directory, "alpha", "nested", "deep"), { recursive: true })
+          await fs.mkdir(path.join(directory, "beta"))
+          await fs.writeFile(path.join(directory, "alpha", "nested", "deep", "file.txt"), "deep\n")
+        })
+        const filesystem = yield* FileSystem.Service
+        const paths = (yield* filesystem.find({ query: "", type: "directory" }))
+          .map((item) => item.path)
+          .sort()
+
+        expect(paths).toContain(RelativePath.make("alpha"))
+        expect(paths).toContain(RelativePath.make("alpha/nested"))
+        expect(paths).toContain(RelativePath.make("beta"))
+        expect(paths).not.toContain(RelativePath.make("alpha/nested/deep"))
+      }).pipe(provide(directory)),
+    ),
+  )
+})
+
 describe("LocationSearch", () => {
   it.live("greps an absolute managed tool-output file", () =>
     withTmp((directory) => {


### PR DESCRIPTION
### Issue for this PR

Closes #15334 (exact root cause; was folded into the memory megathread #20695). Related: #22655.

### Type of change

- [x] Bug fix

### What does this PR do?

The Open Project picker can browse any location the server can see, including non-project roots like `/`, `/usr`, `/var`, or a deep `~/projects/org/repo`. For those, `FileSystem.find` fell through to a full recursive `rg --files` scan of the entire tree. That spawns many ripgrep processes, spikes CPU/memory (the linked issue saw 12 `rg` processes and a 350MB→7.9GB jump while "scanning entire /var" and "/usr"), and leaves the web "Open Project" modal stuck on **Loading**.

There was already a bounded, shallow (2-level) directory scan, but it only triggered for the *exact* home directory. This PR uses that same shallow listing for **directory-type finds in non-project (global) locations**. The picker only needs immediate folder names to let you browse, so nothing is lost. File search (`@`-mentions) inside real git projects is unchanged — it still uses the full recursive scan.

The change is two lines in `packages/core/src/filesystem.ts`: `scan()` gains a `shallow` flag, and `find()` sets it when `type === "directory"` and the location is global.

### How did you verify your code works?

- Added a regression test in `packages/core/test/location-search.test.ts`: it creates `alpha/nested/deep` + `beta`, then asserts a global `type: "directory"` find returns `alpha`, `alpha/nested`, and `beta` but **not** the third-level `alpha/nested/deep` (proving it stays shallow rather than recursing).
- `bun test test/location-search.test.ts` from `packages/core` → 12 pass.
- `bun typecheck` from `packages/core` → clean.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

_Note: this code was written with GPT-5.5._
