### PR TITLE
fix(ui): prepare diffs off the render thread

### DIFF
--- a/packages/app/e2e/smoke/session-review-performance.spec.ts
+++ b/packages/app/e2e/smoke/session-review-performance.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Page } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+const directory = "C:/OpenCode/DiffPerformance"
+const sessionID = "ses_diff_performance"
+const lines = Number(process.env.DIFF_PERF_LINES ?? 1536)
+
+type PerfWindow = Window & {
+  __diffPerf?: {
+    frames: number[]
+    started: number
+  }
+}
+
+test("keeps the renderer responsive while preparing a pathological review diff", async ({ page }) => {
+  test.setTimeout(120_000)
+  await mockOpenCodeServer(page, {
+    directory,
+    project: { id: "proj_diff_performance", name: "Diff Performance", worktree: directory, vcs: "git" },
+    provider: { all: [], default: {} },
+    sessions: [
+      {
+        id: sessionID,
+        projectID: "proj_diff_performance",
+        directory,
+        title: "Diff performance",
+        version: "1",
+        time: { created: 1, updated: 1 },
+      },
+    ],
+    pageMessages: () => ({ items: [] }),
+    vcsDiff: [pathologicalDiff(lines)],
+  })
+  await configure(page)
+  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+  const review = page.getByRole("button", { name: "Toggle review" })
+  await expect(review).toHaveAttribute("aria-expanded", "false")
+
+  await page.evaluate(() => {
+    const state = (window as PerfWindow).__diffPerf!
+    state.frames.length = 0
+    state.started = performance.now()
+  })
+  await review.click()
+  const trigger = page.getByRole("heading", { name: /pathological\.ts/i }).locator(":scope > button")
+  await expect(trigger).toBeVisible()
+  await trigger.click()
+  await expect(page.locator('[data-component="file"][data-mode="diff"]')).toBeVisible({ timeout: 90_000 })
+
+  const metrics = await page.evaluate(() => {
+    const state = (window as PerfWindow).__diffPerf!
+    return {
+      elapsed: performance.now() - state.started,
+      frames: state.frames.length,
+      maxFrameGap: Math.max(...state.frames),
+      p95FrameGap: percentile(state.frames, 0.95),
+    }
+
+    function percentile(values: number[], ratio: number) {
+      const sorted = [...values].sort((a, b) => a - b)
+      return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * ratio))] ?? 0
+    }
+  })
+
+  console.log("session review diff performance", { linesPerSide: lines, ...metrics })
+  expect(metrics.frames).toBeGreaterThan(1)
+  expect(metrics.maxFrameGap).toBeLessThan(200)
+})
+
+function pathologicalDiff(count: number) {
+  const before = Array.from({ length: count }, (_, index) => `old:${index.toString(36).padStart(6, "0")}`)
+  const after = Array.from({ length: count }, (_, index) => `new:${index.toString(36).padStart(6, "0")}`)
+  return {
+    file: "src/pathological.ts",
+    patch: [
+      "Index: src/pathological.ts",
+      "===================================================================",
+      "--- src/pathological.ts\t",
+      "+++ src/pathological.ts\t",
+      `@@ -1,${count} +1,${count} @@`,
+      ...before.map((line) => `-${line}`),
+      ...after.map((line) => `+${line}`),
+      "",
+    ].join("\n"),
+    additions: 1,
+    deletions: 1,
+    status: "modified",
+  }
+}
+
+async function configure(page: Page) {
+  await page.addInitScript(() => {
+    const state = { frames: [] as number[], started: performance.now() }
+    ;(window as PerfWindow).__diffPerf = state
+    let previous = state.started
+    const frame = (now: number) => {
+      state.frames.push(now - previous)
+      previous = now
+      requestAnimationFrame(frame)
+    }
+    requestAnimationFrame(frame)
+  })
+  await page.addInitScript((directory) => {
+    localStorage.setItem("opencode.settings.dat:general", JSON.stringify({ layout: "stretch" }))
+    localStorage.setItem("opencode.global.dat:layout", JSON.stringify({ review: { diffStyle: "split", panelOpened: false } }))
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({ projects: { local: [{ worktree: directory, expanded: true }] }, lastProject: { local: directory } }),
+    )
+  }, directory)
+}

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -19,6 +19,7 @@ export interface MockServerConfig {
   sessions: ({ id: string } & Record<string, unknown>)[]
   pageMessages: (sessionId: string, limit: number, before?: string) => { items: unknown[]; cursor?: string }
   events?: () => unknown[]
+  vcsDiff?: unknown[]
 }
 
 export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
@@ -47,6 +48,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     if (path === "/global/event" || path === "/event") return sse(route, config.events?.())
     if (path === "/global/health") return json(route, { healthy: true })
     if (emptyObject.has(path)) return json(route, {})
+    if (path === "/vcs/diff") return json(route, config.vcsDiff ?? [])
     if (emptyList.has(path)) return json(route, [])
     if (path in staticRoutes) return json(route, staticRoutes[path])
 

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -52,7 +52,7 @@ import { showToast } from "@/utils/toast"
 import { Binary } from "@opencode-ai/core/util/binary"
 import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
-import { normalize } from "@opencode-ai/ui/session-diff"
+import { createPreparedDiff } from "@opencode-ai/ui/diff/resource"
 import { useFileComponent } from "@opencode-ai/ui/context/file"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
@@ -254,11 +254,13 @@ function TimelineDiffSummaryRow(props: { diffs: SummaryDiff[] }) {
 
 function TimelineDiffView(props: { diff: SummaryDiff }) {
   const fileComponent = useFileComponent()
-  const view = normalize(props.diff)
+  const [prepared] = createPreparedDiff(() => props.diff)
 
   return (
     <div data-slot="session-turn-diff-view" data-scrollable>
-      <Dynamic component={fileComponent} mode="diff" virtualize={false} fileDiff={view.fileDiff} />
+      <Show when={prepared()}>
+        {(value) => <Dynamic component={fileComponent} mode="diff" virtualize={false} fileDiff={value().fileDiff} />}
+      </Show>
     </div>
   )
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,7 @@
     "./package.json": "./package.json",
     "./*": "./src/components/*.tsx",
     "./session-diff": "./src/components/session-diff.ts",
+    "./diff/*": "./src/diff/*.ts",
     "./i18n/*": "./src/i18n/*.ts",
     "./pierre": "./src/pierre/index.ts",
     "./pierre/*": "./src/pierre/*.ts",

--- a/packages/ui/src/components/apply-patch-file.test.ts
+++ b/packages/ui/src/components/apply-patch-file.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { patchFiles } from "./apply-patch-file"
-import { text } from "./session-diff"
 
 describe("apply patch file", () => {
-  test("parses patch metadata from the server", () => {
+  test("adapts patch metadata without preparing the diff", () => {
     const file = patchFiles([
       {
         filePath: "/tmp/a.ts",
@@ -17,10 +16,13 @@ describe("apply patch file", () => {
     ])[0]
 
     expect(file).toBeDefined()
-    expect(file?.view.fileDiff.name).toBe("a.ts")
-    expect(file?.view.fileDiff.isPartial).toBe(false)
-    expect(text(file!.view, "deletions")).toBe("one\ntwo\n")
-    expect(text(file!.view, "additions")).toBe("one\nthree\n")
+    expect(file?.source).toEqual({
+      file: "a.ts",
+      patch:
+        "Index: a.ts\n===================================================================\n--- a.ts\t\n+++ a.ts\t\n@@ -1,2 +1,2 @@\n one\n-two\n+three\n",
+      before: undefined,
+      after: undefined,
+    })
   })
 
   test("keeps legacy before and after payloads working", () => {
@@ -37,7 +39,6 @@ describe("apply patch file", () => {
     ])[0]
 
     expect(file).toBeDefined()
-    expect(text(file!.view, "deletions")).toBe("one\n")
-    expect(text(file!.view, "additions")).toBe("two\n")
+    expect(file?.source).toEqual({ file: "a.ts", patch: undefined, before: "one\n", after: "two\n" })
   })
 })

--- a/packages/ui/src/components/apply-patch-file.ts
+++ b/packages/ui/src/components/apply-patch-file.ts
@@ -1,4 +1,4 @@
-import { normalize, type ViewDiff } from "./session-diff"
+import type { DiffSource } from "./session-diff"
 
 type Kind = "add" | "update" | "delete" | "move"
 
@@ -22,17 +22,11 @@ export type ApplyPatchFile = {
   additions: number
   deletions: number
   movePath?: string
-  view: ViewDiff
+  source: DiffSource
 }
 
 function kind(value: unknown) {
   if (value === "add" || value === "update" || value === "delete" || value === "move") return value
-}
-
-function status(type: Kind): "added" | "deleted" | "modified" {
-  if (type === "add") return "added"
-  if (type === "delete") return "deleted"
-  return "modified"
 }
 
 export function patchFile(raw: unknown): ApplyPatchFile | undefined {
@@ -60,15 +54,12 @@ export function patchFile(raw: unknown): ApplyPatchFile | undefined {
     additions,
     deletions,
     movePath,
-    view: normalize({
+    source: {
       file: relativePath,
       patch,
       before,
       after,
-      additions,
-      deletions,
-      status: status(type),
-    }),
+    },
   }
 }
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -293,7 +293,26 @@ function getDirectory(path: string | undefined) {
 }
 
 import type { IconProps } from "./icon"
-import { normalize, resolveFileDiff } from "./session-diff"
+import type { DiffSource } from "./session-diff"
+import { createPreparedDiff } from "../diff/resource"
+
+function PreparedToolDiff(props: { source: DiffSource; virtualize?: boolean }) {
+  const fileComponent = useFileComponent()
+  const [prepared] = createPreparedDiff(() => props.source)
+  return (
+    <Show when={prepared()}>
+      {(value) => (
+        <Dynamic
+          component={fileComponent}
+          mode="diff"
+          virtualize={props.virtualize}
+          fileDiff={value().fileDiff}
+          hunkSeparators={value().fileDiff.isPartial ? "simple" : "line-info-basic"}
+        />
+      )}
+    </Show>
+  )
+}
 
 export type ToolInfo = {
   icon: IconProps["name"]
@@ -1936,7 +1955,6 @@ ToolRegistry.register({
   name: "edit",
   render(props) {
     const i18n = useI18n()
-    const fileComponent = useFileComponent()
     const diagnostics = createMemo(() => getDiagnostics(props.metadata.diagnostics, props.input.filePath))
     const path = createMemo(() => props.metadata?.filediff?.file || props.input.filePath || "")
     const filename = () => getFilename(props.input.filePath ?? "")
@@ -1944,7 +1962,13 @@ ToolRegistry.register({
     const diffSource = createMemo(
       () => {
         const filediff = props.metadata?.filediff
-        if (!filediff) return
+        if (!filediff) {
+          return {
+            file: props.input.filePath || "",
+            before: props.input.oldString || "",
+            after: props.input.newString || "",
+          }
+        }
         return {
           file: filediff.file || props.input.filePath || "",
           patch: typeof filediff.patch === "string" ? filediff.patch : undefined,
@@ -1958,27 +1982,6 @@ ToolRegistry.register({
           a?.file === b?.file && a?.patch === b?.patch && a?.before === b?.before && a?.after === b?.after,
       },
     )
-
-    const fileCompProps = createMemo(() => {
-      try {
-        const source = diffSource()
-        if (source) {
-          const fileDiff = resolveFileDiff(source)
-          if (fileDiff) return { fileDiff, hunkSeparators: fileDiff.isPartial ? "simple" : "line-info-basic" }
-        }
-      } catch {}
-
-      return {
-        before: {
-          name: props.metadata?.filediff?.file || props.input.filePath,
-          contents: props.metadata?.filediff?.before || props.input.oldString || "",
-        },
-        after: {
-          name: props.metadata?.filediff?.file || props.input.filePath,
-          contents: props.metadata?.filediff?.after || props.input.newString || "",
-        },
-      }
-    })
 
     return (
       <div data-component="edit-tool">
@@ -2021,7 +2024,7 @@ ToolRegistry.register({
               }
             >
               <div data-component="edit-content">
-                <Dynamic component={fileComponent} mode="diff" virtualize={props.virtualizeDiff} {...fileCompProps()} />
+                <PreparedToolDiff source={diffSource()} virtualize={props.virtualizeDiff} />
               </div>
             </ToolFileAccordion>
           </Show>
@@ -2095,7 +2098,6 @@ ToolRegistry.register({
   name: "apply_patch",
   render(props) {
     const i18n = useI18n()
-    const fileComponent = useFileComponent()
     const files = createMemo(() => patchFiles(props.metadata.files))
     const pending = createMemo(() => props.status === "pending" || props.status === "running")
     const single = createMemo(() => {
@@ -2145,19 +2147,6 @@ ToolRegistry.register({
                   <For each={files()}>
                     {(file) => {
                       const active = createMemo(() => expanded().includes(file.filePath))
-                      const [visible, setVisible] = createSignal(false)
-
-                      createEffect(() => {
-                        if (!active()) {
-                          setVisible(false)
-                          return
-                        }
-
-                        requestAnimationFrame(() => {
-                          if (!active()) return
-                          setVisible(true)
-                        })
-                      })
 
                       return (
                         <Accordion.Item value={file.filePath} data-type={file.type}>
@@ -2200,15 +2189,9 @@ ToolRegistry.register({
                             </Accordion.Trigger>
                           </StickyAccordionHeader>
                           <Accordion.Content>
-                            <Show when={props.deferContent === false || visible()}>
+                            <Show when={active()}>
                               <div data-component="apply-patch-file-diff">
-                                <Dynamic
-                                  component={fileComponent}
-                                  mode="diff"
-                                  virtualize={props.virtualizeDiff}
-                                  fileDiff={file.view.fileDiff}
-                                  hunkSeparators={file.view.fileDiff.isPartial ? "simple" : "line-info-basic"}
-                                />
+                                <PreparedToolDiff source={file.source} virtualize={props.virtualizeDiff} />
                               </div>
                             </Show>
                           </Accordion.Content>
@@ -2278,12 +2261,7 @@ ToolRegistry.register({
               }
             >
               <div data-component="apply-patch-file-diff">
-                <Dynamic
-                  component={fileComponent}
-                  mode="diff"
-                  virtualize={props.virtualizeDiff}
-                  fileDiff={single()!.view.fileDiff}
-                />
+                <PreparedToolDiff source={single()!.source} virtualize={props.virtualizeDiff} />
               </div>
             </ToolFileAccordion>
           </BasicTool>

--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -16,6 +16,12 @@ type SnapshotDiff = SnapshotFileDiff & { file: string }
 type ReviewDiff = SnapshotDiff | VcsFileDiff | LegacyDiff
 export type DiffSource = Pick<LegacyDiff, "file" | "patch" | "before" | "after">
 
+export type PreparedDiff = {
+  fileDiff: FileDiffMetadata
+  deletions: string
+  additions: string
+}
+
 export type ViewDiff = {
   file: string
   additions: number
@@ -23,9 +29,6 @@ export type ViewDiff = {
   status?: "added" | "deleted" | "modified"
   fileDiff: FileDiffMetadata
 }
-
-const diffCacheLimit = 16
-const patchFileDiffCache = new Map<string, FileDiffMetadata>()
 
 export function resolveFileDiff(diff: DiffSource) {
   if (typeof diff.patch === "string") return fileDiffFromPatch(diff.file, diff.patch)
@@ -37,12 +40,22 @@ export function resolveFileDiff(diff: DiffSource) {
 }
 
 export function normalize(diff: ReviewDiff): ViewDiff {
+  const prepared = prepareDiff(diff)
   return {
     file: diff.file,
     additions: diff.additions,
     deletions: diff.deletions,
     status: diff.status,
-    fileDiff: resolveFileDiff(diff),
+    fileDiff: prepared.fileDiff,
+  }
+}
+
+export function prepareDiff(diff: DiffSource): PreparedDiff {
+  const fileDiff = resolveFileDiff(diff)
+  return {
+    fileDiff,
+    deletions: fileDiff.deletionLines.join(""),
+    additions: fileDiff.additionLines.join(""),
   }
 }
 
@@ -52,22 +65,11 @@ export function text(diff: ViewDiff, side: "deletions" | "additions") {
 }
 
 function fileDiffFromPatch(file: string, patch: string) {
-  const key = `${file}\0${patch}`
-  const hit = patchFileDiffCache.get(key)
-  if (hit) {
-    patchFileDiffCache.delete(key)
-    patchFileDiffCache.set(key, hit)
-    return hit
-  }
-
   const contents = completePatchContents(patch)
   const input = contents ? undefined : patchInput(file, patch)
-  const value = contents
+  return contents
     ? fileDiffFromContent(file, contents.before, contents.after)
     : ((input ? parsePatchFiles(input)[0]?.files[0] : undefined) ?? emptyFileDiff(file))
-  patchFileDiffCache.set(key, value)
-  while (patchFileDiffCache.size > diffCacheLimit) patchFileDiffCache.delete(patchFileDiffCache.keys().next().value!)
-  return value
 }
 
 function completePatchContents(patch: string) {

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -23,10 +23,10 @@ import { mediaKindFromPath } from "../pierre/media"
 import { cloneSelectedLineRange, previewSelectedLines } from "../pierre/selection-bridge"
 import { createLineCommentController } from "./line-comment-annotations"
 import type { LineCommentEditorProps } from "./line-comment"
-import { normalize, text, type ViewDiff } from "./session-diff"
+import type { PreparedDiff } from "./session-diff"
+import { createPreparedDiff } from "../diff/resource"
 
 const MAX_DIFF_CHANGED_LINES = 500
-const REVIEW_MOUNT_MARGIN = 300
 
 export type SessionReviewDiffStyle = "unified" | "split"
 
@@ -68,7 +68,6 @@ type RawReviewDiff = (SnapshotFileDiff | VcsFileDiff) & {
 type ReviewDiff = ((SnapshotFileDiff & { file: string }) | VcsFileDiff) & {
   preloaded?: PreloadMultiFileDiffResult<any>
 }
-type Item = ViewDiff & { preloaded?: PreloadMultiFileDiffResult<any> }
 
 function diff(value: unknown): value is ReviewDiff {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false
@@ -164,14 +163,11 @@ type SessionReviewSelection = {
 export const SessionReview = (props: SessionReviewProps) => {
   let scroll: HTMLDivElement | undefined
   let focusToken = 0
-  let frame: number | undefined
   const i18n = useI18n()
   const fileComponent = useFileComponent()
   const anchors = new Map<string, HTMLElement>()
-  const nodes = new Map<string, HTMLDivElement>()
   const [store, setStore] = createStore({
     open: [] as string[],
-    visible: {} as Record<string, boolean>,
     force: {} as Record<string, boolean>,
     selection: null as SessionReviewSelection | null,
     commenting: null as SessionReviewSelection | null,
@@ -182,10 +178,9 @@ export const SessionReview = (props: SessionReviewProps) => {
   const opened = () => store.opened
 
   const open = () => props.open ?? store.open
-  const itemsMap = createMemo(() =>
-    Object.fromEntries(list(props.diffs).map((diff) => [diff.file, { ...normalize(diff), preloaded: diff.preloaded }])),
-  )
-  const files = createMemo(() => props.diffs.map((diff) => diff.file!))
+  const items = createMemo(() => list(props.diffs))
+  const itemsMap = createMemo(() => Object.fromEntries(items().map((diff) => [diff.file, diff])))
+  const files = createMemo(() => items().map((diff) => diff.file))
   const grouped = createMemo(() => {
     const next = new Map<string, SessionReviewComment[]>()
     for (const comment of props.comments ?? []) {
@@ -201,44 +196,7 @@ export const SessionReview = (props: SessionReviewProps) => {
   const diffStyle = () => props.diffStyle ?? (props.split ? "split" : "unified")
   const hasDiffs = () => files().length > 0
 
-  const syncVisible = () => {
-    frame = undefined
-    if (!scroll) return
-
-    const root = scroll.getBoundingClientRect()
-    const top = root.top - REVIEW_MOUNT_MARGIN
-    const bottom = root.bottom + REVIEW_MOUNT_MARGIN
-    const openSet = new Set(open())
-    const next: Record<string, boolean> = {}
-
-    for (const [file, el] of nodes) {
-      if (!openSet.has(file)) continue
-      const rect = el.getBoundingClientRect()
-      if (rect.bottom < top || rect.top > bottom) continue
-      next[file] = true
-    }
-
-    const prev = untrack(() => store.visible)
-    const prevKeys = Object.keys(prev)
-    const nextKeys = Object.keys(next)
-    if (prevKeys.length === nextKeys.length && nextKeys.every((file) => prev[file])) return
-    setStore("visible", next)
-  }
-
-  const queue = () => {
-    if (frame !== undefined) return
-    frame = requestAnimationFrame(syncVisible)
-  }
-
-  const pinned = (file: string) =>
-    props.focusedComment?.file === file ||
-    props.focusedFile === file ||
-    selection()?.file === file ||
-    commenting()?.file === file ||
-    opened()?.file === file
-
   const handleScroll: JSX.EventHandler<HTMLDivElement, Event> = (event) => {
-    queue()
     const next = props.onScroll
     if (!next) return
     if (Array.isArray(next)) {
@@ -249,21 +207,9 @@ export const SessionReview = (props: SessionReviewProps) => {
     ;(next as JSX.EventHandler<HTMLDivElement, Event>)(event)
   }
 
-  onCleanup(() => {
-    if (frame === undefined) return
-    cancelAnimationFrame(frame)
-  })
-
-  createEffect(() => {
-    props.open
-    files()
-    queue()
-  })
-
   const handleChange = (next: string[]) => {
     props.onOpenChange?.(next)
     if (props.open === undefined) setStore("open", next)
-    queue()
   }
 
   const handleExpandOrCollapseAll = () => {
@@ -275,9 +221,10 @@ export const SessionReview = (props: SessionReviewProps) => {
 
   const selectionSide = (range: SelectedLineRange) => range.endSide ?? range.side ?? "additions"
 
-  const selectionPreview = (diff: ViewDiff, range: SelectedLineRange) => {
+  const selectionPreview = (diff: PreparedDiff | undefined, range: SelectedLineRange) => {
+    if (!diff) return undefined
     const side = selectionSide(range)
-    const contents = text(diff, side)
+    const contents = diff[side]
     if (contents.length === 0) return undefined
 
     return previewSelectedLines(contents, range)
@@ -377,7 +324,6 @@ export const SessionReview = (props: SessionReviewProps) => {
         viewportRef={(el) => {
           scroll = el
           props.scrollRef?.(el)
-          queue()
         }}
         onScroll={handleScroll}
         classList={{
@@ -396,14 +342,11 @@ export const SessionReview = (props: SessionReviewProps) => {
                     const diffCanRender = () => diff().additions !== 0 || diff().deletions !== 0
 
                     const expanded = createMemo(() => open().includes(file))
-                    const mounted = createMemo(() => expanded() && (!!store.visible[file] || pinned(file)))
                     const force = () => !!store.force[file]
 
                     const comments = createMemo(() => grouped().get(file) ?? [])
                     const commentedLines = createMemo(() => comments().map((c) => c.selection))
 
-                    const beforeText = () => text(diff(), "deletions")
-                    const afterText = () => text(diff(), "additions")
                     const changedLines = () => diff().additions + diff().deletions
                     const mediaKind = createMemo(() => mediaKindFromPath(file))
 
@@ -414,10 +357,14 @@ export const SessionReview = (props: SessionReviewProps) => {
                       return changedLines() > MAX_DIFF_CHANGED_LINES
                     })
 
-                    const isAdded = () =>
-                      diff().status === "added" || (beforeText().length === 0 && afterText().length > 0)
+                    const [prepared] = createPreparedDiff(() => {
+                      if (!expanded() || tooLarge()) return
+                      return diff()
+                    })
+
+                    const isAdded = () => diff().status === "added" || (diff().deletions === 0 && diff().additions > 0)
                     const isDeleted = () =>
-                      diff().status === "deleted" || (afterText().length === 0 && beforeText().length > 0)
+                      diff().status === "deleted" || (diff().additions === 0 && diff().deletions > 0)
 
                     const selectedLines = createMemo(() => {
                       const current = selection()
@@ -455,7 +402,7 @@ export const SessionReview = (props: SessionReviewProps) => {
                           file,
                           selection,
                           comment,
-                          preview: selectionPreview(diff(), selection),
+                          preview: selectionPreview(prepared(), selection),
                         })
                       },
                       onUpdate: ({ id, comment, selection }) => {
@@ -464,7 +411,7 @@ export const SessionReview = (props: SessionReviewProps) => {
                           file,
                           selection,
                           comment,
-                          preview: selectionPreview(diff(), selection),
+                          preview: selectionPreview(prepared(), selection),
                         })
                       },
                       onDelete: (comment) => {
@@ -487,8 +434,6 @@ export const SessionReview = (props: SessionReviewProps) => {
 
                     onCleanup(() => {
                       anchors.delete(file)
-                      nodes.delete(file)
-                      queue()
                     })
 
                     const handleLineSelected = (range: SelectedLineRange | null) => {
@@ -570,23 +515,9 @@ export const SessionReview = (props: SessionReviewProps) => {
                           </Accordion.Trigger>
                         </StickyAccordionHeader>
                         <Accordion.Content data-slot="session-review-accordion-content">
-                          <div
-                            data-slot="session-review-diff-wrapper"
-                            ref={(el) => {
-                              anchors.set(file, el)
-                              nodes.set(file, el)
-                              queue()
-                            }}
-                          >
+                          <div data-slot="session-review-diff-wrapper" ref={(el) => anchors.set(file, el)}>
                             <Show when={expanded()}>
                               <Switch>
-                                <Match when={!mounted() && !tooLarge()}>
-                                  <div
-                                    data-slot="session-review-diff-placeholder"
-                                    class="rounded-lg border border-border-weak-base bg-background-stronger/40"
-                                    style={{ height: "160px" }}
-                                  />
-                                </Match>
                                 <Match when={tooLarge()}>
                                   <div data-slot="session-review-large-diff">
                                     <div data-slot="session-review-large-diff-title">
@@ -609,33 +540,35 @@ export const SessionReview = (props: SessionReviewProps) => {
                                     </div>
                                   </div>
                                 </Match>
-                                <Match when={true}>
-                                  <Dynamic
-                                    component={fileComponent}
-                                    mode="diff"
-                                    fileDiff={diff().fileDiff}
-                                    preloadedDiff={diff().preloaded}
-                                    diffStyle={diffStyle()}
-                                    onRendered={() => {
-                                      props.onDiffRendered?.()
-                                    }}
-                                    enableLineSelection={props.onLineComment != null}
-                                    enableHoverUtility={props.onLineComment != null}
-                                    onLineSelected={handleLineSelected}
-                                    onLineSelectionEnd={handleLineSelectionEnd}
-                                    onLineNumberSelectionEnd={commentsUi.onLineNumberSelectionEnd}
-                                    annotations={commentsUi.annotations()}
-                                    renderAnnotation={commentsUi.renderAnnotation}
-                                    renderHoverUtility={props.onLineComment ? commentsUi.renderHoverUtility : undefined}
-                                    selectedLines={selectedLines()}
-                                    commentedLines={commentedLines()}
-                                    media={{
-                                      mode: "auto",
-                                      path: file,
-                                      deleted: diff().status === "deleted",
-                                      readFile: diff().status === "deleted" ? undefined : props.readFile,
-                                    }}
-                                  />
+                                <Match when={prepared()}>
+                                  {(value) => (
+                                    <Dynamic
+                                      component={fileComponent}
+                                      mode="diff"
+                                      fileDiff={value().fileDiff}
+                                      preloadedDiff={diff().preloaded}
+                                      diffStyle={diffStyle()}
+                                      onRendered={() => props.onDiffRendered?.()}
+                                      enableLineSelection={props.onLineComment != null}
+                                      enableHoverUtility={props.onLineComment != null}
+                                      onLineSelected={handleLineSelected}
+                                      onLineSelectionEnd={handleLineSelectionEnd}
+                                      onLineNumberSelectionEnd={commentsUi.onLineNumberSelectionEnd}
+                                      annotations={commentsUi.annotations()}
+                                      renderAnnotation={commentsUi.renderAnnotation}
+                                      renderHoverUtility={
+                                        props.onLineComment ? commentsUi.renderHoverUtility : undefined
+                                      }
+                                      selectedLines={selectedLines()}
+                                      commentedLines={commentedLines()}
+                                      media={{
+                                        mode: "auto",
+                                        path: file,
+                                        deleted: diff().status === "deleted",
+                                        readFile: diff().status === "deleted" ? undefined : props.readFile,
+                                      }}
+                                    />
+                                  )}
                                 </Match>
                               </Switch>
                             </Show>

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -10,7 +10,7 @@ import { useFileComponent } from "../context/file"
 
 import { Binary } from "@opencode-ai/core/util/binary"
 import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
-import { createEffect, createMemo, createSignal, For, on, ParentProps, Show } from "solid-js"
+import { createMemo, For, ParentProps, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Dynamic } from "solid-js/web"
 import { AssistantParts, Message, MessageDivider, PART_MAPPING, type UserActions } from "./message-part"
@@ -24,7 +24,21 @@ import { SessionRetry } from "./session-retry"
 import { TextReveal } from "./text-reveal"
 import { createAutoScroll } from "../hooks"
 import { useI18n } from "../context/i18n"
-import { normalize } from "./session-diff"
+import { createPreparedDiff } from "../diff/resource"
+
+function SessionTurnDiffView(props: { diff: SnapshotFileDiff & { file: string } }) {
+  const fileComponent = useFileComponent()
+  const [prepared] = createPreparedDiff(() => props.diff)
+  return (
+    <Show when={prepared()}>
+      {(value) => (
+        <div data-slot="session-turn-diff-view" data-scrollable>
+          <Dynamic component={fileComponent} mode="diff" fileDiff={value().fileDiff} />
+        </div>
+      )}
+    </Show>
+  )
+}
 
 function record(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -170,7 +184,6 @@ export function SessionTurn(
 ) {
   const data = useData()
   const i18n = useI18n()
-  const fileComponent = useFileComponent()
 
   const emptyMessages: MessageType[] = []
   const emptyParts: PartType[] = []
@@ -459,27 +472,7 @@ export function SessionTurn(
                     >
                       <For each={visible()}>
                         {(diff) => {
-                          const view = normalize(diff)
                           const active = createMemo(() => expanded().includes(diff.file))
-                          const [shown, setShown] = createSignal(false)
-
-                          createEffect(
-                            on(
-                              active,
-                              (value) => {
-                                if (!value) {
-                                  setShown(false)
-                                  return
-                                }
-
-                                requestAnimationFrame(() => {
-                                  if (!active()) return
-                                  setShown(true)
-                                })
-                              },
-                              { defer: true },
-                            ),
-                          )
 
                           return (
                             <Accordion.Item value={diff.file}>
@@ -506,10 +499,8 @@ export function SessionTurn(
                                 </Accordion.Trigger>
                               </StickyAccordionHeader>
                               <Accordion.Content>
-                                <Show when={shown()}>
-                                  <div data-slot="session-turn-diff-view" data-scrollable>
-                                    <Dynamic component={fileComponent} mode="diff" fileDiff={view.fileDiff} />
-                                  </div>
+                                <Show when={active()}>
+                                  <SessionTurnDiffView diff={diff} />
                                 </Show>
                               </Accordion.Content>
                             </Accordion.Item>

--- a/packages/ui/src/diff/client-core.ts
+++ b/packages/ui/src/diff/client-core.ts
@@ -1,0 +1,80 @@
+import type { DiffSource, PreparedDiff } from "../components/session-diff"
+import type { DiffWorkerRequest, DiffWorkerResponse } from "./protocol"
+
+type WorkerLike = {
+  postMessage(message: DiffWorkerRequest): void
+  addEventListener(type: "message", listener: (event: MessageEvent<DiffWorkerResponse>) => void): void
+  addEventListener(type: "error" | "messageerror", listener: (event: Event) => void): void
+}
+
+export class DiffPreparation {
+  private static readonly cacheLimit = 16
+  private next = 0
+  private failed = false
+  private readonly cache = new Map<string, Promise<PreparedDiff>>()
+  private readonly pending = new Map<
+    number,
+    { resolve: (value: PreparedDiff) => void; reject: (error: Error) => void }
+  >()
+
+  constructor(
+    private readonly worker: WorkerLike,
+    private readonly onFailure?: () => void,
+  ) {
+    worker.addEventListener("message", (event: MessageEvent<DiffWorkerResponse>) => {
+      const pending = this.pending.get(event.data.id)
+      if (!pending) return
+      this.pending.delete(event.data.id)
+      if ("error" in event.data) {
+        pending.reject(new Error(event.data.error))
+        return
+      }
+      pending.resolve(event.data.result)
+    })
+    const fail = () => {
+      if (this.failed) return
+      this.failed = true
+      for (const pending of this.pending.values()) pending.reject(new Error("diff preparation worker failed"))
+      this.pending.clear()
+      this.cache.clear()
+      this.onFailure?.()
+    }
+    worker.addEventListener("error", fail)
+    worker.addEventListener("messageerror", fail)
+  }
+
+  prepare(source: DiffSource) {
+    const snapshot = snapshotSource(source)
+    const key = sourceKey(snapshot)
+    const hit = this.cache.get(key)
+    if (hit) {
+      this.cache.delete(key)
+      this.cache.set(key, hit)
+      return hit
+    }
+    const id = ++this.next
+    const request = new Promise<PreparedDiff>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      this.worker.postMessage({ id, source: snapshot } satisfies DiffWorkerRequest)
+    })
+    this.cache.set(key, request)
+    request.then(
+      () => {
+        while (this.cache.size > DiffPreparation.cacheLimit) this.cache.delete(this.cache.keys().next().value!)
+      },
+      () => this.cache.delete(key),
+    )
+    return request
+  }
+}
+
+export function snapshotSource(source: DiffSource): DiffSource {
+  return { file: source.file, patch: source.patch, before: source.before, after: source.after }
+}
+
+function sourceKey(source: DiffSource) {
+  if (source.patch !== undefined) return `${source.file.length}:${source.file}p${source.patch.length}:${source.patch}`
+  const before = source.before ?? ""
+  const after = source.after ?? ""
+  return `${source.file.length}:${source.file}c${before.length}:${before}${after.length}:${after}`
+}

--- a/packages/ui/src/diff/client.test.ts
+++ b/packages/ui/src/diff/client.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import { DiffPreparation } from "./client-core"
+import { prepareDiff } from "../components/session-diff"
+import type { DiffWorkerRequest, DiffWorkerResponse } from "./protocol"
+
+class FakeWorker {
+  requests: DiffWorkerRequest[] = []
+  private listener?: (event: MessageEvent<DiffWorkerResponse>) => void
+  private error?: (event: Event) => void
+
+  addEventListener(type: "message", listener: (event: MessageEvent<DiffWorkerResponse>) => void): void
+  addEventListener(type: "error" | "messageerror", listener: (event: Event) => void): void
+  addEventListener(
+    type: "message" | "error" | "messageerror",
+    listener: ((event: MessageEvent<DiffWorkerResponse>) => void) | ((event: Event) => void),
+  ) {
+    if (type === "message") this.listener = listener as (event: MessageEvent<DiffWorkerResponse>) => void
+    if (type === "error") this.error = listener as (event: Event) => void
+  }
+
+  postMessage(request: DiffWorkerRequest) {
+    this.requests.push(request)
+    queueMicrotask(() =>
+      this.listener?.({ data: { id: request.id, result: prepareDiff(request.source) } } as MessageEvent),
+    )
+  }
+
+  fail() {
+    this.error?.(new Event("error"))
+  }
+}
+
+test("deduplicates equivalent in-flight and cached preparations", async () => {
+  const worker = new FakeWorker()
+  const client = new DiffPreparation(worker)
+  const source = { file: "a.ts", before: "old\n", after: "new\n" }
+
+  const [first, second] = await Promise.all([client.prepare(source), client.prepare({ ...source })])
+  const third = await client.prepare(source)
+
+  expect(worker.requests).toHaveLength(1)
+  expect(second).toBe(first)
+  expect(third).toBe(first)
+  expect(structuredClone(first)).toEqual(first)
+})
+
+test("snapshots proxy inputs before posting them to the worker", async () => {
+  const worker = new FakeWorker()
+  const client = new DiffPreparation(worker)
+  const value = { file: "a.ts", before: "old\n", after: "new\n" }
+  const source = new Proxy(value, {})
+
+  await client.prepare(source)
+  value.after = "newer\n"
+  await client.prepare(source)
+
+  expect(worker.requests[0]?.source).toEqual({
+    file: "a.ts",
+    patch: undefined,
+    before: "old\n",
+    after: "new\n",
+  })
+  expect(worker.requests[0]?.source).not.toBe(source)
+  expect(worker.requests[1]?.source.after).toBe("newer\n")
+})
+
+test("rejects pending requests when the worker fails", async () => {
+  const worker = new FakeWorker()
+  worker.postMessage = (request) => worker.requests.push(request)
+  let failed = 0
+  const client = new DiffPreparation(worker, () => failed++)
+  const pending = client.prepare({ file: "a.ts", before: "old", after: "new" })
+
+  worker.fail()
+
+  await expect(pending).rejects.toThrow("diff preparation worker failed")
+  expect(failed).toBe(1)
+})

--- a/packages/ui/src/diff/client.ts
+++ b/packages/ui/src/diff/client.ts
@@ -1,0 +1,16 @@
+import type { DiffSource } from "../components/session-diff"
+import { DiffPreparation } from "./client-core"
+
+let client: DiffPreparation | undefined
+
+export function prepareDiff(source: DiffSource) {
+  if (!client) {
+    const worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module" })
+    const next = new DiffPreparation(worker, () => {
+      worker.terminate()
+      if (client === next) client = undefined
+    })
+    client = next
+  }
+  return client.prepare(source)
+}

--- a/packages/ui/src/diff/protocol.ts
+++ b/packages/ui/src/diff/protocol.ts
@@ -1,0 +1,8 @@
+import type { DiffSource, PreparedDiff } from "../components/session-diff"
+
+export type DiffWorkerRequest = {
+  id: number
+  source: DiffSource
+}
+
+export type DiffWorkerResponse = { id: number; result: PreparedDiff } | { id: number; error: string }

--- a/packages/ui/src/diff/render-purity.test.ts
+++ b/packages/ui/src/diff/render-purity.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+
+test("browser diff parsers are isolated from render components", async () => {
+  const root = fileURLToPath(new URL("../", import.meta.url))
+  const files: string[] = []
+  for await (const file of new Bun.Glob("**/*.{ts,tsx}").scan({ cwd: root, absolute: true })) {
+    if (file.endsWith("session-diff.ts")) continue
+    if (file.endsWith(".test.ts")) continue
+    const text = await Bun.file(file).text()
+    if (/\b(?:parseDiffFromFile|parsePatchFiles|parsePatch)\b/.test(text)) files.push(file.slice(root.length))
+  }
+  expect(files).toEqual([])
+})

--- a/packages/ui/src/diff/resource.ts
+++ b/packages/ui/src/diff/resource.ts
@@ -1,0 +1,29 @@
+import { createMemo, createResource, type Accessor } from "solid-js"
+import type { DiffSource } from "../components/session-diff"
+import { prepareDiff } from "./client"
+import { snapshotSource } from "./client-core"
+
+export function createPreparedDiff(source: Accessor<DiffSource | undefined>) {
+  const snapshot = createDiffSource(source)
+  if (typeof Worker === "undefined") return [() => undefined] as const
+  return createResource(snapshot, (value) =>
+    prepareDiff(value).catch((error) => {
+      console.error("failed to prepare diff", error)
+      return undefined
+    }),
+  )
+}
+
+export function createDiffSource(source: Accessor<DiffSource | undefined>) {
+  return createMemo(
+    () => {
+      const value = source()
+      return value ? snapshotSource(value) : undefined
+    },
+    undefined,
+    {
+      equals: (a, b) =>
+        a?.file === b?.file && a?.patch === b?.patch && a?.before === b?.before && a?.after === b?.after,
+    },
+  )
+}

--- a/packages/ui/src/diff/worker.ts
+++ b/packages/ui/src/diff/worker.ts
@@ -1,0 +1,13 @@
+import { prepareDiff } from "../components/session-diff"
+import type { DiffWorkerRequest, DiffWorkerResponse } from "./protocol"
+
+self.addEventListener("message", (event: MessageEvent<DiffWorkerRequest>) => {
+  try {
+    self.postMessage({ id: event.data.id, result: prepareDiff(event.data.source) } satisfies DiffWorkerResponse)
+  } catch (error) {
+    self.postMessage({
+      id: event.data.id,
+      error: error instanceof Error ? error.message : String(error),
+    } satisfies DiffWorkerResponse)
+  }
+})


### PR DESCRIPTION
TLDR;

- Large session-review diffs are prepared in a Web Worker instead of blocking the UI thread.
- Edit, apply-patch, turn-summary, and review components now render stable prepared state rather than running diff algorithms during reactive rendering.
- Pierre continues to own diff rendering, syntax highlighting, virtualization, and height measurement.

## Problem

Two Windows user debug exports repeatedly sampled the renderer inside this synchronous path:

```text
SessionReview
normalize
resolveFileDiff
parseDiffFromFile
structuredPatch
diffLines
execEditLength
```

Session Review eagerly parsed every file while building reactive component state, before expansion or Pierre virtualization. A sufficiently difficult line diff could therefore block the renderer for seconds while messages and parts continued streaming.

## Changelog

### Fixed
- Opening Session Review with a difficult large diff no longer freezes the renderer while the diff is calculated.
- Streaming message and tool updates no longer run diff parsing as part of component reconciliation.
- Multi-file apply-patch results no longer parse every file before its diff is opened.
- Edit and turn-summary diffs no longer calculate synchronously on the UI thread.

### Improved
- Raw patches and before/after content are prepared by one lazy renderer Web Worker and reused through a bounded cache.
- Expanded review files now rely on Pierre's virtualizer and measured heights instead of a second OpenCode viewport scanner and fixed-height placeholders.
- Components receive pending or prepared state and remain pure renderers; browser diff parser imports are isolated to one preparation module.

## Performance

A Playwright smoke test reproduces the user stack with a full-context replacement containing 1,536 unique old lines and 1,536 unique new lines. It opens the real Review panel, expands the file, samples `requestAnimationFrame`, and waits for the actual Pierre viewer.

Five isolated Chromium runs per implementation:

| Metric | `upstream/dev` median | This PR median | Change |
|---|---:|---:|---:|
| Maximum frame gap | 233.3 ms | 66.7 ms | 71% lower |
| p95 frame gap | 33.4 ms | 16.8 ms | 50% lower |
| End-to-end viewer mount | 1,330 ms | 1,208 ms | 9% lower median |

Baseline maximum frame gaps:

```text
233.2, 233.3, 250.0, 233.3, 266.7 ms
```

This PR:

```text
83.3, 33.4, 116.6, 66.7, 66.6 ms
```

The committed 200 ms responsiveness budget fails 5/5 baseline measurements and passes 5/5 worker measurements. A final repeated worker run measured `66.6, 66.6, 66.6, 66.7, 66.7 ms`.

## Verification

- UI tests: 29 passed
- App tests: 377 passed
- Desktop tests: 8 passed
- UI, app, desktop, and enterprise typechecks passed
- Desktop production build passed and emitted a separate 34 KB parser worker
- Performance smoke passed 5/5 repeated runs