### PR TITLE
fix(opencode): auto-reconnect MCP clients on unexpected transport close

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -509,6 +509,32 @@ export const layer = Layer.effect(
 
     function watch(s: State, name: string, client: MCPClient, bridge: EffectBridge.Shape, timeout?: number) {
       if (!client.getServerCapabilities()?.tools) return
+
+      client.onclose = () => {
+        if (s.clients[name] !== client) return
+
+        log.warn("MCP transport closed unexpectedly", { server: name })
+        s.status[name] = { status: "failed", error: "Transport closed unexpectedly" }
+        delete s.defs[name]
+
+        bridge
+          .promise(
+            Effect.gen(function* () {
+              const mcpConfig = yield* getMcpConfig(name)
+              if (!mcpConfig) {
+                log.error("MCP config not found, cannot reconnect", { name })
+                return
+              }
+              yield* createAndStore(name, mcpConfig)
+              yield* events.publish(ToolsChanged, { server: name }).pipe(Effect.ignore)
+              log.info("MCP reconnected after transport close", { server: name })
+            }),
+          )
+          .catch((error) => {
+            log.error("MCP reconnect failed after transport close", { server: name, error: String(error) })
+          })
+      }
+
       client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
         log.info("tools list changed notification received", { server: name })
         if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
@@ -563,9 +589,12 @@ export const layer = Layer.effect(
 
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
+            const clientsToClose = Object.entries(s.clients)
+            s.clients = {}
+            s.defs = {}
             yield* Effect.forEach(
-              Object.values(s.clients),
-              (client) =>
+              clientsToClose,
+              ([, client]) =>
                 Effect.gen(function* () {
                   const pid = client.transport instanceof StdioClientTransport ? client.transport.pid : null
                   if (typeof pid === "number") {
@@ -591,6 +620,7 @@ export const layer = Layer.effect(
     function closeClient(s: State, name: string) {
       const client = s.clients[name]
       delete s.defs[name]
+      delete s.clients[name]
       if (!client) return Effect.void
       return Effect.tryPromise(() => client.close()).pipe(Effect.ignore)
     }
@@ -665,7 +695,6 @@ export const layer = Layer.effect(
       yield* requireMcpConfig(name)
       const s = yield* InstanceState.get(state)
       yield* closeClient(s, name)
-      delete s.clients[name]
       s.status[name] = { status: "disabled" }
     })
 

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -123,6 +123,7 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
   Client: class MockClient {
     _state!: MockClientState
     transport: any
+    onclose?: () => void
 
     constructor(_opts: any) {
       clientCreateCount++
@@ -975,4 +976,106 @@ it.instance(
       }),
     ),
   { config: { mcp: {} } },
+)
+
+// ========================================================================
+// Test: onclose triggers automatic reconnect (#17099)
+// ========================================================================
+
+it.instance(
+  "onclose triggers automatic reconnect when transport closes unexpectedly",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "reconnect-server"
+        const firstState = getOrCreateClientState("reconnect-server")
+        firstState.tools = [
+          { name: "tool_v1", description: "first", inputSchema: { type: "object", properties: {} } },
+        ]
+
+        yield* mcp.add("reconnect-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        const toolsBefore = yield* mcp.tools()
+        expect(Object.keys(toolsBefore).some((k) => k.includes("tool_v1"))).toBe(true)
+        expect((yield* mcp.status())["reconnect-server"]?.status).toBe("connected")
+
+        const clientsBefore = yield* mcp.clients()
+        const client = clientsBefore["reconnect-server"]
+        expect(client).toBeDefined()
+
+        clientStates.delete("reconnect-server")
+        const secondState = getOrCreateClientState("reconnect-server")
+        secondState.tools = [
+          { name: "tool_v2", description: "reconnected", inputSchema: { type: "object", properties: {} } },
+        ]
+
+        // Trigger onclose (simulating unexpected transport close)
+        lastCreatedClientName = "reconnect-server"
+        client.onclose?.()
+
+        // Give the async reconnect a moment to complete
+        yield* Effect.sleep("100 millis")
+
+        const statusAfter = yield* mcp.status()
+        expect(statusAfter["reconnect-server"]?.status).toBe("connected")
+
+        const toolsAfter = yield* mcp.tools()
+        expect(Object.keys(toolsAfter).some((k) => k.includes("tool_v2"))).toBe(true)
+        expect(Object.keys(toolsAfter).some((k) => k.includes("tool_v1"))).toBe(false)
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+// ========================================================================
+// Test: onclose does NOT reconnect on intentional disconnect
+// ========================================================================
+
+it.instance(
+  "onclose does not trigger reconnect on intentional disconnect()",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "intentional-disc"
+        const serverState = getOrCreateClientState("intentional-disc")
+        serverState.tools = [
+          { name: "my_tool", description: "a tool", inputSchema: { type: "object", properties: {} } },
+        ]
+
+        yield* mcp.add("intentional-disc", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        expect((yield* mcp.status())["intentional-disc"]?.status).toBe("connected")
+
+        // Intentional disconnect should NOT trigger reconnect
+        yield* mcp.disconnect("intentional-disc")
+
+        const statusAfter = yield* mcp.status()
+        expect(statusAfter["intentional-disc"]?.status).toBe("disabled")
+
+        // Wait to confirm no reconnect fires
+        yield* Effect.sleep("100 millis")
+
+        const statusFinal = yield* mcp.status()
+        expect(statusFinal["intentional-disc"]?.status).toBe("disabled")
+
+        const tools = yield* mcp.tools()
+        expect(Object.keys(tools).some((k) => k.includes("my_tool"))).toBe(false)
+      }),
+    ),
+  {
+    config: {
+      mcp: {
+        "intentional-disc": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
 )


### PR DESCRIPTION
### Issue for this PR

Closes #17099

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an MCP server process dies or the HTTP transport drops, the client stays in `connected` state with stale tool definitions. Tools vanish permanently for the session because nothing listens for transport closure.

The `watch()` function only subscribes to `ToolListChangedNotification`. It never registers an `onclose` handler on the client, so when the SDK fires `client.onclose` after transport death, nothing handles it.

This PR registers `client.onclose` in `watch()` that:
1. Checks `s.clients[name] !== client` to skip intentional disconnects
2. Marks status as `failed` and clears cached defs
3. Calls `createAndStore()` with the original config to reconnect
4. Publishes `ToolsChanged` so the UI updates

To prevent intentional disconnects from triggering reconnect, `closeClient()` now deletes `s.clients[name]` before calling `client.close()`. The finalizer also snapshots and clears `s.clients` before closing clients during instance disposal.

### How did you verify your code works?

- 2 new tests in `packages/opencode/test/mcp/lifecycle.test.ts`:
  - `onclose triggers automatic reconnect when transport closes unexpectedly` — simulates transport close by calling `client.onclose()`, verifies the server reconnects and tools update from the new client
  - `onclose does not trigger reconnect on intentional disconnect()` — calls `mcp.disconnect()`, verifies status stays `disabled` with no reconnect
- All 26 tests pass (24 existing + 2 new)
- Full typecheck across 23 packages passes (pre-push hook runs `bun turbo typecheck`)
- Manual verification steps:
  1. Configure a local MCP server
  2. Start OpenCode, confirm tools available
  3. Kill the MCP server process
  4. Observe log: `MCP transport closed unexpectedly`
  5. Restart the MCP server
  6. Confirm tools reappear without restarting OpenCode

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR