### PR TITLE
fix(opencode): include acp pending tool input

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -330,6 +330,7 @@ export class Subscription {
         ...pendingToolCall({
           toolCallId: part.callID,
           toolName: part.tool,
+          state: part.state,
         }),
       },
     })

--- a/packages/opencode/src/acp/tool.ts
+++ b/packages/opencode/src/acp/tool.ts
@@ -118,14 +118,18 @@ export function completedToolContent(toolName: string, state: CompletedToolState
   return content
 }
 
-export function pendingToolCall(input: { readonly toolCallId: string; readonly toolName: string }): ToolCall {
+export function pendingToolCall(input: {
+  readonly toolCallId: string
+  readonly toolName: string
+  readonly state: { readonly input: ToolInput; readonly title?: string }
+}): ToolCall {
   return {
     toolCallId: input.toolCallId,
-    title: input.toolName,
+    title: input.state.title || input.toolName,
     kind: toToolKind(input.toolName),
     status: "pending",
-    locations: [],
-    rawInput: {},
+    locations: toLocations(input.toolName, input.state.input),
+    rawInput: input.state.input,
   }
 }
 

--- a/packages/opencode/test/acp/event.test.ts
+++ b/packages/opencode/test/acp/event.test.ts
@@ -531,6 +531,38 @@ describe("acp event routing", () => {
     expect(harness.updates[1]?.update).toMatchObject({ status: "in_progress", toolCallId: "call_1" })
   })
 
+  it("includes available input in the synthetic pending tool call", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_pending_input", cwd: "/workspace" }))
+
+    await harness.subscription.handle(
+      toolUpdated({
+        id: "part_call_read",
+        sessionID: "ses_pending_input",
+        messageID: "msg_call_read",
+        type: "tool",
+        callID: "call_read",
+        tool: "read",
+        state: {
+          status: "running",
+          input: { filePath: "/workspace/file.ts" },
+          title: "Read file.ts",
+          time: { start: Date.now() },
+        },
+      } satisfies ToolPart),
+    )
+
+    expect(harness.updates[0]?.update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "call_read",
+      status: "pending",
+      title: "Read file.ts",
+      kind: "read",
+      rawInput: { filePath: "/workspace/file.ts" },
+      locations: [{ path: "/workspace/file.ts" }],
+    })
+  })
+
   it("does not emit duplicate synthetic pending after a replayed running tool", async () => {
     const harness = createHarness()
     await Effect.runPromise(harness.session.create({ id: "ses_replay", cwd: "/workspace" }))


### PR DESCRIPTION
- Populate initial ACP `tool_call` events with available title, `rawInput`, and locations.
- Pass tool state into `pendingToolCall()` so clients can render tool arguments before later updates arrive.
- Add regression coverage for synthetic pending tool input.

Closes #31313.
Closes #23947.
