### PR TITLE
fix(tui): handle End key in prompt input

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1366,10 +1366,14 @@ export function Prompt(props: PromptProps) {
                 setCursorVersion((value) => value + 1)
               }}
               onCursorChange={() => setCursorVersion((value) => value + 1)}
-              onKeyDown={(e: { preventDefault(): void }) => {
+              onKeyDown={(e: KeyEvent) => {
                 if (props.disabled) {
                   e.preventDefault()
                   return
+                }
+                if (e.name === "end") {
+                  e.preventDefault()
+                  input.gotoBufferEnd()
                 }
               }}
               onSubmit={() => {


### PR DESCRIPTION
### Issue for this PR

Closes #31332 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

fix(tui): handle End key in prompt input

The End key was not navigating to the end of text in the prompt textarea. Add explicit handling in onKeyDown to call gotoBufferEnd() when the End key is pressed.

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
