### PR TITLE
fix(config): use writeWithDirs in ensureGitignore to prevent ENOENT crash

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -289,9 +289,9 @@ export const layer = Layer.effect(
       const hasIgnore = yield* fs.existsSafe(gitignore)
       if (!hasIgnore) {
         yield* fs
-          .writeFileString(
+          .writeWithDirs(
             gitignore,
-            ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
+            Buffer.from(["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n")),
           )
           .pipe(
             Effect.catchIf(

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -919,6 +919,23 @@ it.effect("installs dependencies in writable OPENCODE_CONFIG_DIR", () =>
   }).pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
 )
 
+it.effect("creates .gitignore in OPENCODE_CONFIG_DIR when directory does not yet exist", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const configDir = path.join(dir, "nonexistent-config-dir")
+
+    yield* withProcessEnv(
+      "OPENCODE_CONFIG_DIR",
+      configDir,
+      Config.Service.use((svc) => svc.get().pipe(Effect.andThen(svc.waitForDependencies()))).pipe(
+        provideInstanceEffect(dir),
+      ),
+    )
+
+    expect(yield* FSUtil.use.readFileString(path.join(configDir, ".gitignore"))).toContain("node_modules")
+  }).pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
+)
+
 // Note: deduplication and serialization of npm installs is now handled by the
 // core Npm.Service (via EffectFlock). Those behaviors are tested in the core
 // package's npm tests, not here.


### PR DESCRIPTION
### Issue for this PR

Closes #31341

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem:** `ensureGitignore` in `packages/opencode/src/config/config.ts` uses `fs.writeFileString` to create `.gitignore` in each config directory. `writeFileString` does not create parent directories — when a config directory returned by `ConfigPaths.directories()` does not exist on disk, it throws ENOENT. The call site in `loadInstanceState` uses `Effect.orDie`, making this error fatal and crashing the server process on startup.

This is reproducible on Windows when `OPENCODE_CONFIG_DIR` is set (e.g. as a user environment variable) and the directory gets removed — the most common case being OpenCode Desktop auto-update, where the NSIS installer wipes the installation directory.

**Impact:** OpenCode Desktop crashes on every startup after auto-update, with no way to recover except manually creating the directory or deleting the environment variable.

**Fix:** Changed `fs.writeFileString` to `fs.writeWithDirs` in `ensureGitignore`. `writeWithDirs` calls `mkdir -p` on the parent path before writing, so the directory is created automatically.

**Relationship to #30897:** Both PRs fix the same crash. #30897 catches `NotFound` and silently skips — this means no `.gitignore` is created in the config directory. This PR takes the approach of actually creating the directory and the `.gitignore` file, which ensures the gitignore protection is in place even for custom config paths.

### How did you verify your code works?

1. Set `OPENCODE_CONFIG_DIR` to a non-existent path
2. Before fix: OpenCode crashes with ENOENT
3. After fix: OpenCode starts normally, `.gitignore` is created in the new directory
4. Added a test case that creates a non-existent config dir and verifies `.gitignore` is written
5. Ran existing config tests — all pass:
   ```
   bun test packages/opencode/test/config/config.test.ts
   ```

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR