### PR TITLE
fix(shell): set utf8 output encoding for powershell

### DIFF
--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -146,6 +146,14 @@ export function ps(file: string) {
   return meta(file)?.ps === true
 }
 
+export function psCommand(command: string) {
+  return [
+    "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+    "$OutputEncoding = [Console]::OutputEncoding",
+    command,
+  ].join("; ")
+}
+
 function info(file: string): Item {
   const item = full(file)
   const n = name(item)
@@ -188,7 +196,7 @@ export function args(file: string, command: string, cwd: string) {
     ]
   }
   if (n === "cmd") return ["/c", command]
-  if (ps(file)) return ["-NoProfile", "-Command", command]
+  if (ps(file)) return ["-NoProfile", "-Command", psCommand(command)]
   return ["-c", command]
 }
 

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -301,7 +301,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (
 
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && Shell.ps(shell)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", Shell.psCommand(command)], {
       cwd,
       env,
       stdin: "ignore",


### PR DESCRIPTION
### Issue for this PR

Closes #23636
Closes #31187
Closes #30205

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PowerShell on Windows can emit shell output using the active console code page, while opencode decodes captured output as UTF-8. This makes Chinese and other non-ASCII output render as mojibake.

This PR wraps PowerShell commands with UTF-8 output encoding setup before running the user command. The wrapper is used by both direct shell execution and the shell tool path.

### How did you verify your code works?

- Manually verified. Input in opencode cli or desktop: use pwsh exec command: Write-Output "测试中文输出".
If renders correctly in the shell output prove it works. And i have checked it locally.

### Screenshots / recordings
before fix this bug, there are mojibake in output:
<img width="1730" height="1175" alt="image" src="https://github.com/user-attachments/assets/c9c6935c-3285-4a02-b8a8-555a27f45ace" />
After fix there are no mojibake in output:
<img width="1730" height="923" alt="image" src="https://github.com/user-attachments/assets/aa69fe39-a3b1-48c2-85bf-4f0e59c64cdd" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR