### PR TITLE
docs(stackit): update example models to Qwen3.6 27B and GPT-OSS 20B

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1876,7 +1876,7 @@ STACKIT AI Model Serving provides fully managed sovereign hosting environment fo
    └ enter
    ```
 
-4. Run the `/models` command to select from available models like _Qwen3-VL 235B_ or _Llama 3.3 70B_.
+4. Run the `/models` command to select from available models like _Qwen3.6 27B_, _GPT-OSS 20B_, or _Llama 3.3 70B_.
 
    ```txt
    /models


### PR DESCRIPTION
## Summary

Updates the STACKIT provider example in the docs to reflect newly available models:

- Replace _Qwen3-VL 235B_ (vision model) with _Qwen3.6 27B_ and _GPT-OSS 20B_ — both are now available on STACKIT AI Model Serving as general text/chat models

These models are being added to models.dev in a separate PR (sst/models.dev#2065).

## Test plan

- [ ] Verify model names match what's listed on [STACKIT AI Model Serving docs](https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models)