### PR TITLE
feat(minimax): offer adaptive thinking variants for MiniMax-M3

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -595,6 +595,10 @@ function anthropicAdaptiveEfforts(apiId: string): string[] | null {
   ) {
     return ["low", "medium", "high", "max"]
   }
+  // MiniMax-M3 is Anthropic-compatible and accepts the adaptive thinking format.
+  if (apiId.toLowerCase().includes("minimax-m3")) {
+    return ["low", "medium", "high", "max"]
+  }
   return null
 }
 
@@ -648,7 +652,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("deepseek-reasoner") ||
     id.includes("deepseek-r1") ||
     id.includes("deepseek-v3") ||
-    id.includes("minimax") ||
+    // MiniMax M2.x leaks reasoning into content and has no usable thinking
+    // controls; M3 is Anthropic-compatible and handled via adaptiveEfforts below.
+    (id.includes("minimax") && !id.includes("minimax-m3")) ||
     id.includes("glm") ||
     id.includes("kimi") ||
     id.includes("k2p") ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2452,6 +2452,40 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
+  test("minimax M2.x stays excluded (no adaptive thinking)", () => {
+    const model = createMockModel({
+      id: "minimax/minimax-m2.7",
+      providerID: "minimax",
+      api: {
+        id: "MiniMax-M2.7",
+        url: "https://api.minimax.io/anthropic",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({})
+  })
+
+  test("minimax-m3 returns adaptive thinking options", () => {
+    const model = createMockModel({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "MiniMax-M3",
+        url: "https://api.minimax.io/anthropic",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+    expect(result.medium).toEqual({
+      thinking: {
+        type: "adaptive",
+      },
+      effort: "medium",
+    })
+  })
+
   test("glm returns empty object", () => {
     const model = createMockModel({
       id: "glm/glm-4",


### PR DESCRIPTION
## Summary

`MiniMax-M3` is an Anthropic Messages–compatible model that accepts the **adaptive thinking** format (`thinking: { type: "adaptive" }` + `effort`) — the same shape opencode already exposes for Claude Opus 4.6+/4.7+ and Sonnet 4.6.

Today every MiniMax model is excluded from reasoning-variant generation in `variants()`, so M3 offers no thinking controls at all. This routes M3 onto the existing adaptive path while keeping the legacy M2.x family excluded (its Anthropic-compat stream leaks reasoning into content and has no usable thinking controls).

## Changes

- `packages/opencode/src/provider/transform.ts`
  - Narrow the `variants()` exclusion: `id.includes("minimax")` → `id.includes("minimax") && !id.includes("minimax-m3")`, so M2.x stays excluded and M3 flows through.
  - Add an M3 branch to `anthropicAdaptiveEfforts()` returning `["low","medium","high","max"]` (matching the non-Opus Sonnet 4.6 peer; no `xhigh`, no `display`).
- `packages/opencode/test/provider/transform.test.ts` — add `minimax-m3 returns adaptive thinking options` and `minimax M2.x stays excluded` (regression guard for the narrowed condition).

M3 routes through `@ai-sdk/anthropic`, whose vendored version supports `type: "adaptive"`. No schema/protocol changes.

## Verification

- `bun test test/provider/transform.test.ts` — 250 pass, 0 fail (incl. the new M3 + M2.x-excluded tests).
- `tsgo --noEmit` (full monorepo via turbo) — 23 tasks successful.
- Cross-checked every MiniMax model id / provider-prefix form from models.dev: all three M3 entries (`minimax`, `minimax-cn`, `*-coding-plan`) now produce adaptive variants; all M2/M2.1/M2.5/M2.7(+highspeed) stay excluded.
- Live-checked against the M3 endpoint: the adaptive format is accepted and `effort` modulates thinking depth.
