### PR TITLE
fix(opencode): await run event loop

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -762,10 +762,15 @@ export const RunCommand = effectCmd({
 
         if (!args.interactive) {
           const events = await client.event.subscribe()
-          loop(client, events).catch((e) => {
+          const completed = loop(client, events).catch((e) => {
             console.error(e)
-            process.exit(1)
+            process.exitCode = 1
           })
+          async function finish() {
+            if (args.attach) return
+            const error = await completed
+            if (error) process.exitCode = 1
+          }
 
           if (args.command) {
             const result = await client.session.command({
@@ -779,7 +784,9 @@ export const RunCommand = effectCmd({
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
               process.exitCode = 1
+              return
             }
+            await finish()
             return
           }
 
@@ -794,7 +801,9 @@ export const RunCommand = effectCmd({
           if (result.error) {
             if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
             process.exitCode = 1
+            return
           }
+          await finish()
           return
         }
 


### PR DESCRIPTION
### Issue for this PR

Closes #26855.

Also addresses the same local premature output-consumer teardown reported in #29131 and #31365, and likely local timing variants in #29866, #31382, and #28605. Related exit-status reports include #26509, #15558, #17854, and #2489.

This differs from #29132 by preserving the immediate request-error behavior introduced for #27371 and by limiting the event-loop join to local mode.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Local non-interactive `opencode run` starts an SSE event consumer alongside the synchronous prompt or command request. The request waits for session execution, but it can resolve before the separate event iterator has processed all queued events and written them to stdout. Returning from the command then disposes the in-process instance and terminates its event stream.

This change retains and awaits the event-loop promise after successful local prompt and command requests. Instance disposal therefore waits until the consumer observes `session.status: idle`, after the preceding text, tool, reasoning, and `step_finish` events have been processed.

The join is intentionally limited to local mode. In `--attach` mode the remote SSE connection has an independent lifecycle and can miss transient events, so this PR preserves its existing behavior rather than introducing a new completion contract.

If the prompt or command request itself returns an error, the command returns immediately without awaiting the event loop. This preserves the #27371 fix because request-level failures are not guaranteed to publish an idle event.

Loop rejections set `process.exitCode` instead of calling `process.exit(1)`, allowing normal stdout flushing and cleanup.

This does not claim to fix #15267, which concerns post-idle plugin continuation, or #17516, which concerns a session that never reaches idle.

### How did you verify your code works?

- `bun test test/cli/run/run-process.test.ts --rerun-each 10` from `packages/opencode`: 40 passed
- `bun typecheck` from `packages/opencode`: passed
- Manually ran local `opencode run` in a non-Git temporary directory with inline `{"snapshot":false}` config

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR