### PR TITLE
fix(session): avoid sticky prompt tool overrides

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1198,11 +1198,8 @@ export const layer = Layer.effect(
         permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
       }
       if (permissions.length > 0) {
-        // Merge so per-call tool rules don't clobber inherited session rules
-        // (e.g. external_directory allows from the parent session).
-        const merged = Permission.merge(session.permission ?? [], permissions)
-        session.permission = merged
-        yield* sessions.setPermission({ sessionID: session.id, permission: merged })
+        session.permission = permissions
+        yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
       }
 
       if (input.noReply === true) return message

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -125,6 +125,24 @@ export const TaskTool = Tool.define(
       const parentAgent = parent.agent
         ? yield* agent.get(parent.agent).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
         : undefined
+      const childPermission = deriveSubagentSessionPermission({
+        parentSessionPermission: parent.permission ?? [],
+        parentAgent,
+        subagent: next,
+      })
+      const childToolDenies = [
+        ...(next.permission.some((rule) => rule.permission === "todowrite")
+          ? []
+          : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
+        ...(next.permission.some((rule) => rule.permission === id)
+          ? []
+          : [{ permission: id, pattern: "*" as const, action: "deny" as const }]),
+        ...(cfg.experimental?.primary_tools?.map((permission) => ({
+          permission,
+          pattern: "*" as const,
+          action: "deny" as const,
+        })) ?? []),
+      ]
       const nextSession =
         session ??
         (yield* sessions.create({
@@ -132,16 +150,14 @@ export const TaskTool = Tool.define(
           title: params.description + ` (@${next.name} subagent)`,
           agent: next.name,
           permission: [
-            ...deriveSubagentSessionPermission({
-              parentSessionPermission: parent.permission ?? [],
-              parentAgent,
-              subagent: next,
-            }),
-            ...(cfg.experimental?.primary_tools?.map((item) => ({
-              pattern: "*",
-              action: "allow" as const,
-              permission: item,
-            })) ?? []),
+            ...childPermission,
+            ...childToolDenies.filter(
+              (deny) =>
+                !childPermission.some(
+                  (rule) =>
+                    rule.permission === deny.permission && rule.pattern === deny.pattern && rule.action === deny.action,
+                ),
+            ),
           ],
         }))
 
@@ -182,11 +198,6 @@ export const TaskTool = Tool.define(
           },
           variant: next.model ? undefined : variant,
           agent: next.name,
-          tools: {
-            ...(next.permission.some((rule) => rule.permission === "todowrite") ? {} : { todowrite: false }),
-            ...(next.permission.some((rule) => rule.permission === id) ? {} : { task: false }),
-            ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),
-          },
           parts,
         })
         return result.parts.findLast((item) => item.type === "text")?.text ?? ""

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -824,6 +824,33 @@ it.instance("subtask child inherits parent session external_directory allow", ()
   }),
 )
 
+noLLMServer.instance("prompt tools replace previous prompt tool rules", () =>
+  Effect.gen(function* () {
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({ title: "Prompt tools" })
+
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      tools: { bash: false },
+      parts: [{ type: "text", text: "first" }],
+    })
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      tools: { read: true },
+      parts: [{ type: "text", text: "second" }],
+    })
+
+    const reloaded = yield* sessions.get(session.id)
+    expect(reloaded.permission).toEqual([{ permission: "read", pattern: "*", action: "allow" }])
+    expect(Permission.evaluate("bash", "anything", reloaded.permission ?? []).action).toBe("ask")
+  }),
+)
+
 it.instance(
   "running subtask preserves metadata after tool-call transition",
   () =>

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -421,19 +421,15 @@ describe("tool.task", () => {
           {
             permission: "bash",
             pattern: "*",
-            action: "allow",
+            action: "deny",
           },
           {
             permission: "read",
             pattern: "*",
-            action: "allow",
+            action: "deny",
           },
         ])
-        expect(seen?.tools).toEqual({
-          todowrite: false,
-          bash: false,
-          read: false,
-        })
+        expect(seen?.tools).toBeUndefined()
       }),
     {
       config: {


### PR DESCRIPTION
## Summary

- restore deprecated `PromptInput.tools` replacement semantics so tool settings from one prompt do not carry into later non-empty tool overrides
- move task subagent tool restrictions into the child session permission created by the task tool instead of sending prompt-time `tools`
- keep the subagent `external_directory` inheritance regression covered while adding a regression test for sticky prompt tool rules

## Root Cause

#30529 fixed subagent permission inheritance by merging prompt-time `tools` rules into `session.permission`, but that made prompt tool overrides accumulate across later prompts. A tool disabled in one prompt could remain denied after a later prompt supplied a different `tools` map.

## Verification

- `bun test --timeout 30000 test/session/prompt.test.ts -t "subtask child inherits parent session external_directory allow|prompt tools replace previous prompt tool rules"`
- `bun test --timeout 30000 test/tool/task.test.ts -t "execute shapes child permissions for task, todowrite, and primary tools"`
- `bun test --timeout 30000 test/session/prompt.test.ts test/tool/task.test.ts`
- `bun typecheck` from `packages/opencode`
- pre-push hook: `bun turbo typecheck`