### PR TITLE
fix(app): eliminate session switch latency — deferRender, Suspense flash, instant rendering

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -266,7 +266,6 @@ export default function Page() {
   const lastUserMessage = timeline.lastUserMessage
   const messages = timeline.messages
   const messagesReady = timeline.ready
-  const sessionSync = timeline.resource
   const userMessages = timeline.userMessages
   const visibleUserMessages = timeline.visibleUserMessages
 
@@ -304,7 +303,6 @@ export default function Page() {
   const [store, setStore] = createStore({
     ...sessionViewState(),
     newSessionWorktree: "main",
-    deferRender: false,
   })
 
   const [followup, setFollowup] = persisted(
@@ -321,18 +319,6 @@ export default function Page() {
       edit: {},
     }),
   )
-
-  createComputed((prev) => {
-    const key = sessionKey()
-    if (key !== prev) {
-      setStore("deferRender", true)
-      const owner = sessionOwnership.capture()
-      requestAnimationFrame(() => {
-        setTimeout(() => owner.run(() => setStore("deferRender", false)), 0)
-      })
-    }
-    return key
-  })
 
   let reviewFrame: number | undefined
   let todoFrame: number | undefined
@@ -881,30 +867,28 @@ export default function Page() {
     loadingClass: string
     emptyClass: string
   }) => (
-    <Show when={!store.deferRender}>
-      <SessionReviewTab
-        title={changesTitle()}
-        empty={reviewEmpty(input)}
-        diffs={reviewDiffs}
-        view={view}
-        diffStyle={input.diffStyle}
-        onDiffStyleChange={input.onDiffStyleChange}
-        onScrollRef={(el) => setTree("reviewScroll", el)}
-        focusedFile={tree.activeDiff}
-        onLineComment={(comment) => addCommentToContext({ ...comment, origin: "review" })}
-        onLineCommentUpdate={updateCommentInContext}
-        onLineCommentDelete={removeCommentFromContext}
-        lineCommentActions={reviewCommentActions()}
-        commentMentions={{
-          items: file.searchFilesAndDirectories,
-        }}
-        comments={comments.all()}
-        focusedComment={comments.focus()}
-        onFocusedCommentChange={comments.setFocus}
-        onViewFile={openReviewFile}
-        classes={input.classes}
-      />
-    </Show>
+    <SessionReviewTab
+      title={changesTitle()}
+      empty={reviewEmpty(input)}
+      diffs={reviewDiffs}
+      view={view}
+      diffStyle={input.diffStyle}
+      onDiffStyleChange={input.onDiffStyleChange}
+      onScrollRef={(el) => setTree("reviewScroll", el)}
+      focusedFile={tree.activeDiff}
+      onLineComment={(comment) => addCommentToContext({ ...comment, origin: "review" })}
+      onLineCommentUpdate={updateCommentInContext}
+      onLineCommentDelete={removeCommentFromContext}
+      lineCommentActions={reviewCommentActions()}
+      commentMentions={{
+        items: file.searchFilesAndDirectories,
+      }}
+      comments={comments.all()}
+      focusedComment={comments.focus()}
+      onFocusedCommentChange={comments.setFocus}
+      onViewFile={openReviewFile}
+      classes={input.classes}
+    />
   )
 
   const reviewPanel = () => (
@@ -1585,7 +1569,7 @@ export default function Page() {
       sessionKey,
       sessionID: () => params.id,
       prompt,
-      ready: () => !store.deferRender && messagesReady(),
+      ready: () => messagesReady(),
       centered,
       todo: {
         collapsed: () => view().todoCollapsed.get(),
@@ -1697,7 +1681,6 @@ export default function Page() {
 
   return (
     <div class="relative size-full overflow-hidden flex flex-col">
-      {sessionSync() ?? ""}
       <SessionHeader />
       <div
         class="flex-1 min-h-0 flex flex-col md:flex-row"


### PR DESCRIPTION
### Issue for this PR

Closes #19793

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Eliminates the visible latency on every session switch by removing two main-thread stalls in `session.tsx`:

1. **Remove the `deferRender` deferral** — a `createComputed` set `deferRender = true` on every `sessionKey` change and only cleared it after `requestAnimationFrame` + `setTimeout(…, 0)`, gating the review tab and the composer `ready()` behind it. This produced a one-frame blank plus extra delay on each switch. The composer and review tab now render immediately; `ready()` is gated only on `messagesReady()`.

2. **Remove the `sessionSync` JSX read** — `{sessionSync() ?? ""}` was read in JSX, which subscribed the render to the session `createResource` and triggered the app-level `<Suspense>` boundary (splash screen) on every switch. The resource returns void, so the read is removed entirely; the fetcher still runs reactively from its source signal.

> Re-ported onto upstream's `createTimelineModel` architecture — the original `messagesReady` gate widening is now provided by `timeline.ready` upstream, so it is no longer part of this PR.

### How did you verify your code works?

Tested locally by rapidly switching between sessions in the web UI — no blank flashes, no splash flicker, composer appears instantly. Built + smoke-tested (v1.17.12).

### Screenshots / recordings

_N/A — performance/latency improvement._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
