### PR TITLE
docs: add Vestige MCP server example

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Vestige](https://github.com/samvallad33/vestige)                                          | Local MCP memory server for OpenCode agents across sessions      |
 
 ---
 

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -110,6 +110,24 @@ And to use it I can add `use the mcp_everything tool` to my prompts.
 use the mcp_everything tool to add the number 3 and 4
 ```
 
+You can also add [`Vestige`](https://github.com/samvallad33/vestige) for local persistent memory across OpenCode sessions.
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "vestige": {
+      "type": "local",
+      "command": ["npx", "-y", "-p", "vestige-mcp-server@latest", "vestige-mcp"],
+      "enabled": true,
+      "timeout": 60000
+    }
+  }
+}
+```
+
+Vestige stores memory locally and exposes tools for saving, searching, and reusing project decisions, preferences, architecture context, and previous fixes.
+
 ---
 
 #### Options


### PR DESCRIPTION
Closes #31402

Adds a small Vestige example to the MCP servers docs and lists Vestige in the ecosystem projects table.

Vestige is a local stdio MCP server for persistent agent memory. For OpenCode users, it provides searchable memory for project decisions, preferences, architecture context, and previous fixes across sessions.

Verified with OpenCode 1.16.2 using `opencode debug config` and `opencode mcp list` against the documented `mcp.vestige` schema.
