### PR TITLE
feat(web): file mentions now open files in the editor

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1814,6 +1814,13 @@ export default function Page() {
                       setRevealMessage={(fn) => {
                         revealMessage = fn
                       }}
+                      onFileClick={(path) => {
+                        const tab = file.tab(path)
+                        tabs().open(tab)
+                        tabs().setActive(tab)
+                        file.load(path)
+                        openReviewPanel()
+                      }}
                     />
                   </Show>
                 </Match>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -282,6 +282,7 @@ export function MessageTimeline(props: {
   userMessages: UserMessage[]
   anchor: (id: string) => string
   setRevealMessage?: (fn: (id: string) => void) => void
+  onFileClick?: (path: string) => void
 }) {
   let touchGesture: number | undefined
 
@@ -1064,6 +1065,7 @@ export function MessageTimeline(props: {
                 onToolOpenChange={(open) => setToolOpen(part().id, open)}
                 deferToolContent={false}
                 virtualizeDiff={false}
+                onFileClick={props.onFileClick}
               />
             )}
           </Show>

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -55,6 +55,10 @@
     text-underline-offset: 2px;
   }
 
+  a.file-link {
+    cursor: pointer;
+  }
+
   /* Lists */
   ul,
   ol {

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -175,12 +175,33 @@ function markCodeLinks(root: HTMLDivElement) {
   }
 }
 
+function markFileLinks(root: HTMLDivElement) {
+  const codeNodes = Array.from(root.querySelectorAll(":not(pre) > code"))
+  for (const code of codeNodes) {
+    const text = code.textContent ?? ""
+    if (code.parentElement instanceof HTMLAnchorElement) continue
+
+    const raw = text.trim().replace(/[),.;!?]+$/, "")
+    if (!raw.includes(".")) continue
+    if (/^https?:\/\//i.test(raw)) continue
+    const path = raw.replace(/([:#]\d+).*$/, "")
+    if (/[<>:"|?*]/.test(path)) continue
+
+    const link = document.createElement("a")
+    link.setAttribute("data-file-path", path)
+    link.classList.add("file-link")
+    code.parentNode?.replaceChild(link, code)
+    link.appendChild(code)
+  }
+}
+
 function decorate(root: HTMLDivElement, labels: CopyLabels) {
   const blocks = Array.from(root.querySelectorAll("pre"))
   for (const block of blocks) {
     ensureCodeWrapper(block, labels)
   }
   markCodeLinks(root)
+  markFileLinks(root)
 }
 
 function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
@@ -227,6 +248,20 @@ function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
   }
 }
 
+function setupFileClick(root: HTMLDivElement, onFileClick: (path: string) => void) {
+  const handler = (event: MouseEvent) => {
+    const target = event.target
+    if (!(target instanceof Element)) return
+    const link = target.closest("[data-file-path]")
+    if (!(link instanceof HTMLAnchorElement)) return
+    event.preventDefault()
+    const path = link.getAttribute("data-file-path")
+    if (path) onFileClick(path)
+  }
+  root.addEventListener("click", handler)
+  return () => root.removeEventListener("click", handler)
+}
+
 function touch(key: string, value: Entry) {
   cache.delete(key)
   cache.set(key, value)
@@ -243,11 +278,12 @@ export function Markdown(
     text: string
     cacheKey?: string
     streaming?: boolean
+    onFileClick?: (path: string) => void
     class?: string
     classList?: Record<string, boolean>
   },
 ) {
-  const [local, others] = splitProps(props, ["text", "cacheKey", "streaming", "class", "classList"])
+  const [local, others] = splitProps(props, ["text", "cacheKey", "streaming", "class", "classList", "onFileClick"])
   const marked = useMarked()
   const i18n = useI18n()
   const [root, setRoot] = createSignal<HTMLDivElement>()
@@ -288,6 +324,7 @@ export function Markdown(
   )
 
   let copyCleanup: (() => void) | undefined
+let fileClickCleanup: (() => void) | undefined
 
   createEffect(() => {
     const container = root()
@@ -325,6 +362,9 @@ export function Markdown(
       },
     })
 
+    if (local.onFileClick && !fileClickCleanup)
+      fileClickCleanup = setupFileClick(container, local.onFileClick)
+
     if (!copyCleanup)
       copyCleanup = setupCodeCopy(container, () => ({
         copy: i18n.t("ui.message.copy"),
@@ -334,6 +374,7 @@ export function Markdown(
 
   onCleanup(() => {
     if (copyCleanup) copyCleanup()
+    if (fileClickCleanup) fileClickCleanup()
   })
 
   return (

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -181,6 +181,7 @@ export interface MessagePartProps {
   virtualizeDiff?: boolean
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
+  onFileClick?: (path: string) => void
 }
 
 export type PartComponent = Component<MessagePartProps>
@@ -261,7 +262,7 @@ function createPacedValue(getValue: () => string, live?: () => boolean) {
   return value
 }
 
-function PacedMarkdown(props: { text: string; cacheKey: string; streaming: boolean }) {
+function PacedMarkdown(props: { text: string; cacheKey: string; streaming: boolean; onFileClick?: (path: string) => void }) {
   const value = createPacedValue(
     () => props.text,
     () => props.streaming,
@@ -269,7 +270,7 @@ function PacedMarkdown(props: { text: string; cacheKey: string; streaming: boole
 
   return (
     <Show when={value()}>
-      <Markdown text={value()} cacheKey={props.cacheKey} streaming={props.streaming} />
+      <Markdown text={value()} cacheKey={props.cacheKey} streaming={props.streaming} onFileClick={props.onFileClick} />
     </Show>
   )
 }
@@ -1274,6 +1275,7 @@ export function Part(props: MessagePartProps) {
         virtualizeDiff={props.virtualizeDiff}
         showAssistantCopyPartID={props.showAssistantCopyPartID}
         turnDurationMs={props.turnDurationMs}
+        onFileClick={props.onFileClick}
       />
     </Show>
   )
@@ -1546,8 +1548,8 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     <Show when={text()}>
       <div data-component="text-part" data-timeline-part-id={part().id}>
         <div data-slot="text-part-body">
-          <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} />}>
-            <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />
+          <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} onFileClick={props.onFileClick} />}>
+            <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} onFileClick={props.onFileClick} />
           </Show>
         </div>
         <Show when={showCopy()}>
@@ -1589,8 +1591,8 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
   return (
     <Show when={text()}>
       <div data-component="reasoning-part" data-timeline-part-id={part().id}>
-        <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} />}>
-          <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />
+        <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} onFileClick={props.onFileClick} />}>
+          <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} onFileClick={props.onFileClick} />
         </Show>
       </div>
     </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #31406

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

paths (e.g., `packages/app/README.md`) that appear in chat messages are now rendered as clickable links. Clicking a path opens the file in the side panel editor tab.

**Changes**

`packages/ui/src/components/markdown.tsx` — added `markFileLinks()` that scans inline `<code>` elements (not inside `<pre>`) for file path patterns (contains `.`, not an HTTP URL, no invalid path characters `<>:"|?*`) and wraps them in `<a data-file-path="..." class="file-link">`. Added `setupFileClick` handler and `onFileClick` prop.

`packages/ui/src/components/message-part.tsx` — passed `onFileClick` through the component chain to `Markdown`.

`packages/app/src/pages/session.tsx` — wired `onFileClick` to open the tab, load file content, and show the side panel.

### How did you verify your code works?

By testing it across my sessions.

### Screenshots / recordings

A screencast: https://youtu.be/OBDPo-FNuwo

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


