### PR TITLE
fix(tui): trim select footer action highlight

### DIFF
--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -462,7 +462,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     return (
       <box
         flexDirection="row"
-        paddingRight={1}
         backgroundColor={active() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
         onMouseUp={() => triggerAction(item)}
       >


### PR DESCRIPTION
### Issue for this PR

Closes #31410

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the right padding from select dialog footer actions. The focused background was painting that padding, which added a highlighted blank cell after the shortcut label. Footer groups already use a gap for spacing, so the highlight can cover only the visible action text without changing spacing between actions.

### How did you verify your code works?

Confirmed the focused footer highlight ends with the visible action text. The pre-push hook also passed typechecking for all 23 packages.

### Screenshots / recordings

Not included. The change was verified directly in the TUI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR