### PR TITLE
fix(tui): allow terminal native paste when clipboard read fails

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -367,10 +367,10 @@ export function Prompt(props: PromptProps) {
         category: "Prompt",
         hidden: true,
         run: async (ctx: CommandContext<Renderable, KeyEvent>) => {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
           const content = await clipboard.read?.()
           if (content?.mime.startsWith("image/")) {
+            ctx.event.preventDefault()
+            ctx.event.stopPropagation()
             await pasteAttachment({
               filename: "clipboard",
               mime: content.mime,
@@ -379,7 +379,10 @@ export function Prompt(props: PromptProps) {
             return
           }
           if (content?.mime === "text/plain") {
+            ctx.event.preventDefault()
+            ctx.event.stopPropagation()
             await pasteInputText(content.data)
+            return
           }
         },
       },


### PR DESCRIPTION
### Issue for this PR

Closes #31253, #31314, #31305

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In containerized/SSH environments (e.g., GNOME Terminal → dtach → podman), the system clipboard is not accessible. The `ctrl+v` handler was calling `preventDefault()` unconditionally, which blocked the terminal's native paste behavior (bracketed paste mode).

**The fix**: Move `preventDefault()` to only be called when clipboard content is successfully read. If the clipboard read fails, the event is not prevented, allowing the terminal to handle the paste natively via bracketed paste mode.

**Why this works**: @opentui/core already enables bracketed paste mode (`\x1b[?2004h`) during `setupTerminal()`, and the `onPaste` handler already exists and correctly processes bracketed paste events. The bug was that the `ctrl+v` handler was blocking this fallback path by calling `preventDefault()` before attempting to read the clipboard.

### How did you verify your code works?

Need to test in:
- GNOME Terminal → dtach → podman → opencode (the reported failing case)
- Direct terminal access (no multiplexer)
- SSH sessions

### Screenshots / recordings

N/A - paste functionality fix

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR