### PR TITLE
fix(core): guard against null event.seq when inserting session_messages

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -413,7 +413,7 @@ export const layer = Layer.effect(
               sessionID,
               timestamp: yield* DateTime.now,
             })
-            if (event.seq === undefined)
+            if (event.seq == null)
               return yield* Effect.die("Interrupt request event is missing aggregate sequence")
             yield* execution.interrupt(sessionID, event.seq)
           }),

--- a/packages/core/src/session/input.ts
+++ b/packages/core/src/session/input.ts
@@ -74,7 +74,7 @@ export const admit = Effect.fn("SessionInput.admit")(function* (
     })
     .pipe(
       Effect.flatMap((event) =>
-        event.seq === undefined
+        event.seq == null
           ? Effect.die("Prompt admission event is missing aggregate sequence")
           : Effect.succeed(
               new Admitted({

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -114,7 +114,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
     const decodeRow = (row: typeof SessionMessageTable.$inferSelect) =>
       decodeMessage({ ...row.data, id: row.id, type: row.type })
     const updateMessage = (message: SessionMessage.Message) => {
-      if (event.seq === undefined) return Effect.die("Synchronized Session event is missing aggregate sequence")
+      if (event.seq == null) return Effect.die("Synchronized Session event is missing aggregate sequence")
       const encoded = encodeMessage(message)
       const { id, type, ...data } = encoded
       return db
@@ -191,7 +191,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
 }
 
 function insertMessage(db: DatabaseService, event: SessionEvent.Event, message: SessionMessage.Message) {
-  if (event.seq === undefined) return Effect.die("Synchronized Session event is missing aggregate sequence")
+  if (event.seq == null) return Effect.die("Synchronized Session event is missing aggregate sequence")
   const encoded = encodeMessage(message)
   const { id, type, ...data } = encoded
   return db
@@ -330,7 +330,7 @@ export const layer = Layer.effectDiscard(
       }),
     )
     yield* events.project(SessionEvent.AgentSwitched, (event) => {
-      if (event.seq === undefined) return Effect.die("Synchronized Session event is missing aggregate sequence")
+      if (event.seq == null) return Effect.die("Synchronized Session event is missing aggregate sequence")
       return db
         .update(SessionTable)
         .set({ agent: event.data.agent, time_updated: DateTime.toEpochMillis(event.data.timestamp) })
@@ -351,7 +351,7 @@ export const layer = Layer.effectDiscard(
           .run()
           .pipe(Effect.orDie)
         yield* run(db, event)
-        if (event.seq === undefined)
+        if (event.seq == null)
           return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
         yield* SessionContextEpoch.requestReplacement(db, event.data.sessionID, event.seq)
       }),
@@ -367,7 +367,7 @@ export const layer = Layer.effectDiscard(
           .pipe(Effect.orDie)
         if (existing) return yield* Effect.die(new PromptAlreadyProjected())
         yield* run(db, event)
-        if (event.seq === undefined)
+        if (event.seq == null)
           return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
         yield* SessionInput.projectLegacyPrompted(db, {
           id: messageID,
@@ -381,7 +381,7 @@ export const layer = Layer.effectDiscard(
     )
     yield* events.project(SessionEvent.PromptLifecycle.Admitted, (event) =>
       Effect.gen(function* () {
-        if (event.seq === undefined)
+        if (event.seq == null)
           return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
         yield* SessionInput.projectAdmitted(db, {
           admittedSeq: event.seq,
@@ -395,7 +395,7 @@ export const layer = Layer.effectDiscard(
     )
     yield* events.project(SessionEvent.PromptLifecycle.Promoted, (event) =>
       Effect.gen(function* () {
-        if (event.seq === undefined)
+        if (event.seq == null)
           return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
         yield* insertMessage(
           db,
@@ -412,7 +412,7 @@ export const layer = Layer.effectDiscard(
     )
     yield* events.project(SessionEvent.InterruptRequested, () => Effect.void)
     yield* events.project(SessionEvent.ContextUpdated, (event) => {
-      if (!event.replay || event.seq === undefined) return run(db, event)
+      if (!event.replay || event.seq == null) return run(db, event)
       return run(db, event).pipe(
         Effect.andThen(SessionContextEpoch.requestReplacement(db, event.data.sessionID, event.seq)),
       )

--- a/packages/opencode/src/event-v2-bridge.ts
+++ b/packages/opencode/src/event-v2-bridge.ts
@@ -45,7 +45,7 @@ export const layer = Layer.effect(
           payload: { id: event.id, type: event.type, properties: event.data },
         })
         const sync = EventV2.registry.get(event.type)?.sync
-        if (sync === undefined || event.seq === undefined || event.version === undefined) return
+        if (sync === undefined || event.seq == null || event.version == null) return
         const aggregateID = (event.data as Record<string, unknown>)[sync.aggregate]
         if (typeof aggregateID !== "string") return
         GlobalBus.emit("event", {


### PR DESCRIPTION
### Issue for this PR

Closes #31204

### Type of change

- [x] Bug fix

### What does this PR do?

When switching from plan to build agent the db throws `NOT NULL constraint failed: session_message.seq` because `event.seq` is null but the check only catches undefined. Changed all `=== undefined` checks on `event.seq` to `== null`.

### How did you verify your code works?

Ran `bun test` in packages/core — all existing tests pass.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR