### PR TITLE
feat(desktop): make window title reflect currently selected project a…

### DIFF
--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -232,6 +232,9 @@ function HomeDesign() {
   })
 
   createEffect(() => {
+    document.title = "OpenCode"
+  })
+  createEffect(() => {
     const pending = pendingHomeNavigation
     if (!pending || pending.server !== server.key) return
     pendingHomeNavigation = undefined

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -25,6 +25,7 @@ import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { Dialog } from "@opencode-ai/ui/dialog"
+import { first } from "@opencode-ai/ui/utils/first"
 import { getFilename } from "@opencode-ai/core/util/path"
 import { Session, type Message } from "@opencode-ai/sdk/v2/client"
 import { usePlatform } from "@/context/platform"
@@ -638,6 +639,12 @@ export default function Layout(props: ParentProps) {
     return result
   })
 
+  const currentSession = createMemo(() => {
+    const id = params.id
+    if (!id) return
+    return currentSessions().find((s) => s.id === id)
+  })
+
   type PrefetchQueue = {
     inflight: Set<string>
     pending: string[]
@@ -885,6 +892,14 @@ export default function Layout(props: ParentProps) {
     }
 
     warm(sessions, index)
+  })
+  createEffect(() => {
+    const project = currentProject()
+    const session = currentSession()
+    const projectName = project ? displayName(project) : getFilename(currentDir() ?? "")
+    const letter = first(projectName).toUpperCase()
+    const title = session?.title
+    document.title = title ? `${letter}|${title} - ${projectName}` : `${letter}|${projectName}`
   })
 
   function navigateSessionByOffset(offset: number) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
     "./icons/app": "./src/components/app-icons/types.ts",
     "./fonts/*": "./src/assets/fonts/*",
     "./audio/*": "./src/assets/audio/*",
+    "./utils/*": "./src/utils/*.ts",
     "./v2/*.css": "./src/v2/components/*.css",
     "./v2/*": "./src/v2/components/*.tsx",
     "./v2/styles/*": "./src/v2/styles/*"

--- a/packages/ui/src/utils/first.ts
+++ b/packages/ui/src/utils/first.ts
@@ -1,0 +1,10 @@
+const segmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : undefined
+
+export function first(value: string) {
+  if (!value) return ""
+  if (!segmenter) return Array.from(value)[0] ?? ""
+  return segmenter.segment(value)[Symbol.iterator]().next().value?.segment ?? Array.from(value)[0] ?? ""
+}

--- a/packages/ui/src/v2/components/avatar-v2.tsx
+++ b/packages/ui/src/v2/components/avatar-v2.tsx
@@ -1,16 +1,6 @@
+import { first } from "../../utils/first"
 import { type ComponentProps, splitProps, Show } from "solid-js"
 import "./avatar-v2.css"
-
-const segmenter =
-  typeof Intl !== "undefined" && "Segmenter" in Intl
-    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
-    : undefined
-
-function first(value: string) {
-  if (!value) return ""
-  if (!segmenter) return Array.from(value)[0] ?? ""
-  return segmenter.segment(value)[Symbol.iterator]().next().value?.segment ?? Array.from(value)[0] ?? ""
-}
 
 export interface AvatarProps extends ComponentProps<"div"> {
   fallback: string

--- a/packages/ui/src/v2/components/project-avatar-v2.tsx
+++ b/packages/ui/src/v2/components/project-avatar-v2.tsx
@@ -1,16 +1,6 @@
+import { first } from "../../utils/first"
 import { type ComponentProps, splitProps, Show } from "solid-js"
 import "./project-avatar-v2.css"
-
-const segmenter =
-  typeof Intl !== "undefined" && "Segmenter" in Intl
-    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
-    : undefined
-
-function first(value: string) {
-  if (!value) return ""
-  if (!segmenter) return Array.from(value)[0] ?? ""
-  return segmenter.segment(value)[Symbol.iterator]().next().value?.segment ?? Array.from(value)[0] ?? ""
-}
 
 export const PROJECT_AVATAR_VARIANTS = [
   "orange",


### PR DESCRIPTION
### Issue for this PR

Closes #31423

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The browser window title was static ("OpenCode") regardless of which project or session was active, making it hard to identify tabs when multiple OpenCode windows are open.

**Сhanges**

Added a reactive `createEffect` in the layout component that updates `document.title` based on the current project and session.

The title now shows a single-letter initial, optional session name, and project name (e.g. `M|Refactor store - MyProject`).

**Small refactor**:  As I also needed the `first()` function from `project-avatar-v2.tsx`/`avatar-v2.tsx` (dups?), I extracted it from those and placed into `./utils/*` and exported.

### How did you verify your code works?

Tested in web ui.

### Screenshots / recordings

https://www.youtube.com/watch?v=TFx2Pl_9Nv4

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


