### PR TITLE
fix(opencode): support MiniMax M3 thinking toggle

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -641,10 +641,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (!model.capabilities.reasoning) return {}
 
   const id = model.id.toLowerCase()
-  if (model.api.id.toLowerCase().includes("minimax-m3") && model.api.npm === "@ai-sdk/anthropic") {
+  if (
+    model.api.id.toLowerCase().includes("minimax-m3") &&
+    ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)
+  ) {
     return {
       none: { thinking: { type: "disabled" } },
-      high: { thinking: { type: "adaptive" } },
+      thinking: { thinking: { type: "adaptive" } },
     }
   }
   const adaptiveOpus = anthropicOpus47OrLater(model.api.id)
@@ -1083,9 +1086,11 @@ export function options(input: {
   }
 
   const modelId = input.model.api.id.toLowerCase()
-  // MiniMax's Anthropic interface defaults thinking off, so keep normal requests
-  // consistent with its thinking-on Chat Completions interface.
-  if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
+  // Set MiniMax thinking explicitly instead of relying on its interface-specific defaults.
+  if (
+    modelId.includes("minimax-m3") &&
+    ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(input.model.api.npm)
+  ) {
     result["thinking"] = { type: "adaptive" }
   }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1086,11 +1086,8 @@ export function options(input: {
   }
 
   const modelId = input.model.api.id.toLowerCase()
-  // Set MiniMax thinking explicitly instead of relying on its interface-specific defaults.
-  if (
-    modelId.includes("minimax-m3") &&
-    ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(input.model.api.npm)
-  ) {
+  // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
+  if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
     result["thinking"] = { type: "adaptive" }
   }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -641,6 +641,12 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (!model.capabilities.reasoning) return {}
 
   const id = model.id.toLowerCase()
+  if (model.api.id.toLowerCase().includes("minimax-m3") && model.api.npm === "@ai-sdk/anthropic") {
+    return {
+      none: { thinking: { type: "disabled" } },
+      high: { thinking: { type: "adaptive" } },
+    }
+  }
   const adaptiveOpus = anthropicOpus47OrLater(model.api.id)
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
   if (
@@ -1076,8 +1082,14 @@ export function options(input: {
     }
   }
 
-  // Enable thinking by default for kimi models using anthropic SDK
   const modelId = input.model.api.id.toLowerCase()
+  // MiniMax's Anthropic interface defaults thinking off, so keep normal requests
+  // consistent with its thinking-on Chat Completions interface.
+  if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
+    result["thinking"] = { type: "adaptive" }
+  }
+
+  // Enable thinking by default for kimi models using anthropic SDK
   if (
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
     (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -175,6 +175,39 @@ describe("ProviderTransform.options - zai/zhipuai thinking", () => {
   }
 })
 
+describe("ProviderTransform.options - minimax m3 thinking", () => {
+  const createModel = (npm: string) =>
+    ({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "minimax-m3",
+        url: "https://api.minimax.com",
+        npm,
+      },
+      capabilities: { reasoning: true },
+      limit: { output: 64_000 },
+    }) as any
+
+  test("explicitly enables adaptive thinking with the anthropic SDK", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("@ai-sdk/anthropic"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toEqual({ type: "adaptive" })
+  })
+
+  test("does not set anthropic thinking controls for the openai-compatible SDK", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("@ai-sdk/openai-compatible"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
   const sessionID = "test-session-123"
 
@@ -2450,6 +2483,36 @@ describe("ProviderTransform.variants", () => {
     })
     const result = ProviderTransform.variants(model)
     expect(result).toEqual({})
+  })
+
+  test("minimax m3 using anthropic returns thinking toggles", () => {
+    const model = createMockModel({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "MiniMax-M3",
+        url: "https://api.minimax.com/anthropic/v1",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      none: { thinking: { type: "disabled" } },
+      high: { thinking: { type: "adaptive" } },
+    })
+  })
+
+  test("minimax m3 using openai-compatible returns no thinking toggles", () => {
+    const model = createMockModel({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "minimax-m3",
+        url: "https://api.minimax.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({})
   })
 
   test("glm returns empty object", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -198,13 +198,13 @@ describe("ProviderTransform.options - minimax m3 thinking", () => {
     ).toEqual({ type: "adaptive" })
   })
 
-  test("does not set anthropic thinking controls for the openai-compatible SDK", () => {
+  test("explicitly enables adaptive thinking with the openai-compatible SDK", () => {
     expect(
       ProviderTransform.options({
         model: createModel("@ai-sdk/openai-compatible"),
         sessionID: "test-session-123",
       }).thinking,
-    ).toBeUndefined()
+    ).toEqual({ type: "adaptive" })
   })
 })
 
@@ -2498,11 +2498,11 @@ describe("ProviderTransform.variants", () => {
     const result = ProviderTransform.variants(model)
     expect(result).toEqual({
       none: { thinking: { type: "disabled" } },
-      high: { thinking: { type: "adaptive" } },
+      thinking: { thinking: { type: "adaptive" } },
     })
   })
 
-  test("minimax m3 using openai-compatible returns no thinking toggles", () => {
+  test("minimax m3 using openai-compatible returns thinking toggles", () => {
     const model = createMockModel({
       id: "minimax/minimax-m3",
       providerID: "minimax",
@@ -2512,7 +2512,10 @@ describe("ProviderTransform.variants", () => {
         npm: "@ai-sdk/openai-compatible",
       },
     })
-    expect(ProviderTransform.variants(model)).toEqual({})
+    expect(ProviderTransform.variants(model)).toEqual({
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    })
   })
 
   test("glm returns empty object", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -198,13 +198,13 @@ describe("ProviderTransform.options - minimax m3 thinking", () => {
     ).toEqual({ type: "adaptive" })
   })
 
-  test("explicitly enables adaptive thinking with the openai-compatible SDK", () => {
+  test("uses the native default with the openai-compatible SDK", () => {
     expect(
       ProviderTransform.options({
         model: createModel("@ai-sdk/openai-compatible"),
         sessionID: "test-session-123",
       }).thinking,
-    ).toEqual({ type: "adaptive" })
+    ).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- explicitly enable adaptive thinking for MiniMax M3 on the Anthropic interface
- expose `none` and `thinking` variants on Anthropic and OpenAI-compatible interfaces
- preserve the native Chat Completions thinking default unless a variant is selected

## Model catalog verification
- confirmed `MiniMax-M3` under `minimax`, `minimax-cn`, `minimax-coding-plan`, and `minimax-cn-coding-plan`
- confirmed all four first-party providers use `@ai-sdk/anthropic`

## Testing
- `bun test test/provider/transform.test.ts`
- `bun typecheck`

Closes #31180