### PR TITLE
fix(app): round session prompt dock bottom corners in v2 layout

### DIFF
--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -146,7 +146,7 @@ export function SessionComposerRegion(props: {
       data-component="session-prompt-dock"
       classList={{
         "w-full flex flex-col justify-center items-center pointer-events-none": true,
-        "shrink-0 pb-3 bg-background-stronger": props.placement !== "inline",
+        "shrink-0 pb-3 bg-background-stronger rounded-b-[10px]": props.placement !== "inline",
       }}
     >
       <div


### PR DESCRIPTION
### Issue for this PR
Closes #31439

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `rounded-b-[10px]` to the dock's non-inline background container so its bottom corners match the panel radius.

**Why not `overflow-hidden` on the panel**
It would clip things that intentionally overflow: the resize handle's `-right-1` offset, the scroll-to-bottom button, and tooltips/dropdowns.

### How did you verify your code works?

Running it locally and viewing the change

### Screenshots / recordings

| Before | After |
|--------|--------|
| <img width="615" height="126" alt="image" src="https://github.com/user-attachments/assets/6adfd438-cb35-45e5-85ac-a3fd7ae24fc8" /> | <img width="615" height="126" alt="image" src="https://github.com/user-attachments/assets/58119f5d-59da-4e58-b4dd-b35b7ac7bdc3" /> |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

