### PR TITLE
fix(opencode): retry transient network errors instead of surfacing as terminal with raw content

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -66,7 +66,8 @@ function message(providerID: ProviderV2.ID, e: APICallError) {
       return msg
     }
 
-    return `${msg}: ${e.responseBody}`
+    const body = e.responseBody.length > 200 ? e.responseBody.slice(0, 200) + "..." : e.responseBody
+    return `${msg}: ${body}`
   }).trim()
 }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -611,6 +611,17 @@ export function latest(msgs: WithParts[]) {
   return { user, assistant, finished, tasks }
 }
 
+const TRANSIENT_CODES = new Set(["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "ENOTFOUND", "EAI_AGAIN", "ENETUNREACH", "EPIPE"])
+const TRANSIENT_PATTERNS = ["failed to fetch", "network connection was lost", "network request failed", "socket hang up", "unexpected end of data", "premature close", "response closed without sending", "load failed", "fetch failed", "body is unusable"]
+
+function isTransientNetworkError(e: unknown): e is Error {
+  if (!(e instanceof Error)) return false
+  const code = (e as Error & { code?: string }).code
+  if (code && TRANSIENT_CODES.has(code)) return true
+  const msg = e.message.toLowerCase()
+  return TRANSIENT_PATTERNS.some((p) => msg.includes(p))
+}
+
 export function fromError(
   e: unknown,
   ctx: { providerID: ProviderV2.ID; aborted?: boolean },
@@ -707,6 +718,18 @@ export function fromError(
           responseHeaders: parsed.responseHeaders,
           responseBody: parsed.responseBody,
           metadata: parsed.metadata,
+        },
+        { cause: e },
+      ).toObject()
+    case isTransientNetworkError(e):
+      return new APIError(
+        {
+          message: e.message,
+          isRetryable: true,
+          metadata: {
+            type: "network_error",
+            code: e.name,
+          },
         },
         { cause: e },
       ).toObject()


### PR DESCRIPTION
### Issue for this PR

Closes #31133, closes #20822, closes #15350, closes #21893

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a network request drops mid-flight (ECONNRESET, ECONNREFUSED, fetch failure, premature close, etc.), the error was classified as `NamedError.Unknown` and never retried — leaving the raw error body (potentially an HTML error page or thousands of characters) dumped on screen.

Two changes:

1. **Transport error detection in `MessageV2.fromError()`** — Added `isTransientNetworkError()` helper that catches SystemError codes (ECONNRESET, ECONNREFUSED, ETIMEDOUT, ENOTFOUND, EAI_AGAIN, ENETUNREACH, EPIPE), TypeError from fetch, and common transient message patterns. These now produce an `APIError` with `isRetryable: true` so `SessionRetry` retries instead of surfacing a terminal error.

2. **Truncate long error response bodies in `ProviderError.message()`** — When a proxy/gateway returns an HTML error page or any long non-JSON body, `e.responseBody` was embedded verbatim. Now truncated at 200 chars with `"..."` suffix.

### How did you verify your code works?

- Typecheck passes (`bun typecheck` in packages/opencode)
- All 33 retry classification tests pass
- All 4 account CLI tests pass
- Full repo typecheck passes (23/23 packages)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR