### PR TITLE
fix(plug): skip spinner animation in non-TTY environments

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -1,4 +1,4 @@
-import { intro, log, outro, spinner } from "@clack/prompts"
+import { intro, log, outro, spinner as clackSpinner } from "@clack/prompts"
 import { Effect } from "effect"
 
 import { ConfigPaths } from "@/config/paths"
@@ -45,7 +45,12 @@ export type PlugCtx = {
 }
 
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => {
+    if (process.stdout.isTTY) return clackSpinner()
+    const noop = (msg: string, code?: number) => {}
+    const start = (msg: string) => console.error(msg)
+    return { start, stop: noop }
+  },
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),


### PR DESCRIPTION
## Description

When running \opencode plugin install\ in a non-TTY environment (e.g., CI, piped output, PowerShell with redirected stdout), the \@clack/prompts\ spinner emits raw ANSI escape sequences and Unicode Braille frames as individual lines, producing garbage output.

## Fix

Check \process.stdout.isTTY\ before creating the spinner. When not a TTY:
- Print the message as a plain \console.error\ line instead of starting an animated spinner
- Make \stop()\ a no-op (no animation to stop)

This is the minimal fix for the plugin install command. The same pattern applies to other CLI commands using \@clack/prompts\ spinners (\upgrade\, \uninstall\, \mcp\, \gent\), which can be fixed separately.

## Related issues

Fixes #27908