### PR TITLE
fix: drain pending events before breaking on session idle in JSON format mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -632,8 +632,13 @@ export const RunCommand = effectCmd({
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
           let error: string | undefined
+          let activeSteps = 0
+          let pendingIdle = false
+          let idleTimeoutHandle: ReturnType<typeof setTimeout> | undefined
+          let idleTimedOut = false
 
           for await (const event of events.stream) {
+            if (idleTimedOut) break
             if (
               event.type === "message.updated" &&
               event.properties.sessionID === sessionID &&
@@ -673,11 +678,17 @@ export const RunCommand = effectCmd({
               }
 
               if (part.type === "step-start") {
+                activeSteps++
                 if (emit("step_start", { part })) continue
               }
 
               if (part.type === "step-finish") {
-                if (emit("step_finish", { part })) continue
+                activeSteps = Math.max(0, activeSteps - 1)
+                if (emit("step_finish", { part })) {
+                  if (pendingIdle && activeSteps <= 0) { clearTimeout(idleTimeoutHandle); break }
+                  continue
+                }
+                if (pendingIdle && activeSteps <= 0) { clearTimeout(idleTimeoutHandle); break }
               }
 
               if (part.type === "text" && part.time?.end) {
@@ -716,8 +727,12 @@ export const RunCommand = effectCmd({
                 err = String(props.error.data.message)
               }
               error = error ? error + EOL + err : err
-              if (emit("error", { error: props.error })) continue
+              if (emit("error", { error: props.error })) {
+                if (pendingIdle) { clearTimeout(idleTimeoutHandle); break }
+                continue
+              }
               UI.error(err)
+              if (pendingIdle) { clearTimeout(idleTimeoutHandle); break }
             }
 
             if (
@@ -725,6 +740,11 @@ export const RunCommand = effectCmd({
               event.properties.sessionID === sessionID &&
               event.properties.status.type === "idle"
             ) {
+              if (activeSteps > 0) {
+                pendingIdle = true
+                idleTimeoutHandle = setTimeout(() => { idleTimedOut = true }, 3_000)
+                continue
+              }
               break
             }
 
@@ -750,6 +770,7 @@ export const RunCommand = effectCmd({
               }
             }
           }
+          clearTimeout(idleTimeoutHandle)
           return error
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)


### PR DESCRIPTION
### Issue for this PR

Closes #31435

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --format json` exits immediately when `session.status = idle` fires, but in containerized/CI environments the idle event races ahead of `text` and `step-finish` part events in the SSE pipeline. The result is truncated JSONL output — only `step_start` is emitted while `text` and `step_finish` are lost.

The fix tracks active steps with a counter (`activeSteps`). When idle arrives while steps are still open, it defers the break (`pendingIdle = true`) and continues draining events until all `step-finish` events arrive. A 3-second safety timeout ensures the loop doesn't hang if a `step-finish` is never delivered.

I understand why this works: the idle event is published by the Runner's `onIdle` callback after the processor finishes, but it travels through a different path (session status → PubSub) than part events (LLM stream → processor → PubSub). In containerized environments with higher event delivery latency, idle consistently wins the race. By deferring the break and waiting for the step lifecycle to complete, we guarantee all parts are consumed before exiting.

### How did you verify your code works?

Tested in three configurations:

1. **From source (macOS):** `bun run --conditions=node src/index.ts run --format json -m google-vertex-anthropic/claude-sonnet-4@20250514 "Say hello"` — all 3 events emitted (step_start, text, step_finish)
2. **Compiled binary in container (UBI10):** patched binary with `OPENCODE_EXPERIMENTAL=true` — all 3 events emitted
3. **Unpatched binary in container (control):** only `step_start` emitted, confirming the race condition

Also verified:
- Non-JSON mode (`opencode run "prompt"`) works unchanged
- The 3s timeout fires correctly when simulated (step-finish withheld)

### Screenshots / recordings

**Before fix (container):** only `step_start` emitted
```
{"type":"step_start","timestamp":...,"part":{"type":"step-start",...}}
```

**After fix (container):** all events emitted
```
{"type":"step_start","timestamp":...,"part":{"type":"step-start",...}}
{"type":"text","timestamp":...,"part":{"type":"text","text":"Hello! I'm OpenCode...",...}}
{"type":"step_finish","timestamp":...,"part":{"type":"step-finish","tokens":{"total":12997,...},...}}
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR