### PR TITLE
feat(app): tabs help button

### DIFF
--- a/packages/app/src/components/help-button.tsx
+++ b/packages/app/src/components/help-button.tsx
@@ -1,0 +1,46 @@
+import { Icon } from "@opencode-ai/ui/v2/icon"
+import { Popover } from "@opencode-ai/ui/popover"
+import { createSignal, Show } from "solid-js"
+
+const channel = import.meta.env.VITE_OPENCODE_CHANNEL
+
+export function HelpButton() {
+  if (!["beta", "dev"].includes(channel)) return null
+
+  const [shown, setShown] = createSignal(false)
+
+  return (
+    <div class="fixed bottom-4 right-4 z-50">
+      <Popover
+        open={shown()}
+        onOpenChange={setShown}
+        triggerAs="button"
+        triggerProps={{
+          type: "button",
+          "aria-label": "Help",
+          class:
+            "size-10 rounded-full bg-background-base shadow-[var(--shadow-lg-border-base)] flex items-center justify-center text-text-base hover:text-text-strong transition-colors",
+        }}
+        trigger={<Icon name="help" />}
+        class="[&_[data-slot=popover-body]]:p-0 w-[320px] max-w-[calc(100vw-40px)] bg-transparent border-0 shadow-none rounded-xl"
+        gutter={8}
+        placement="top-end"
+      >
+        <Show when={shown()}>
+          <div class="flex flex-col gap-3 w-[320px] p-4 rounded-xl bg-background-strong shadow-[var(--shadow-lg-border-base)]">
+            <div class="aspect-video w-full rounded-md bg-background-base flex items-center justify-center text-text-weak">
+              <Icon name="help" />
+            </div>
+            <div class="flex flex-col gap-1">
+              <span class="text-14-regular text-text-strong">Lorem ipsum dolor sit amet</span>
+              <p class="text-12-regular text-text-weak">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
+              </p>
+            </div>
+          </div>
+        </Show>
+      </Popover>
+    </div>
+  )
+}

--- a/packages/app/src/components/help-button.tsx
+++ b/packages/app/src/components/help-button.tsx
@@ -1,11 +1,8 @@
-import { Icon } from "@opencode-ai/ui/v2/icon"
 import { Popover } from "@opencode-ai/ui/popover"
 import { createSignal, Show } from "solid-js"
 
-const channel = import.meta.env.VITE_OPENCODE_CHANNEL
-
 export function HelpButton() {
-  if (!["beta", "dev"].includes(channel)) return null
+  if (import.meta.env.VITE_OPENCODE_CHANNEL !== "dev") return null
 
   const [shown, setShown] = createSignal(false)
 
@@ -19,25 +16,20 @@ export function HelpButton() {
           type: "button",
           "aria-label": "Help",
           class:
-            "size-10 rounded-full bg-background-base shadow-[var(--shadow-lg-border-base)] flex items-center justify-center text-text-base hover:text-text-strong transition-colors",
+            "size-7 rounded-full bg-background-base shadow-[var(--shadow-lg-border-base)] flex items-center justify-center text-text-base hover:text-text-strong transition-colors",
         }}
-        trigger={<Icon name="help" />}
+        trigger={<span aria-hidden="true">?</span>}
         class="[&_[data-slot=popover-body]]:p-0 w-[320px] max-w-[calc(100vw-40px)] bg-transparent border-0 shadow-none rounded-xl"
         gutter={8}
         placement="top-end"
       >
         <Show when={shown()}>
-          <div class="flex flex-col gap-3 w-[320px] p-4 rounded-xl bg-background-strong shadow-[var(--shadow-lg-border-base)]">
-            <div class="aspect-video w-full rounded-md bg-background-base flex items-center justify-center text-text-weak">
-              <Icon name="help" />
-            </div>
-            <div class="flex flex-col gap-1">
-              <span class="text-14-regular text-text-strong">Lorem ipsum dolor sit amet</span>
-              <p class="text-12-regular text-text-weak">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
-                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
-              </p>
-            </div>
+          <div class="flex flex-col gap-1 w-[320px] p-4 rounded-xl bg-background-strong shadow-[var(--shadow-lg-border-base)]">
+            <span class="text-14-regular text-text-strong">Lorem ipsum dolor sit amet</span>
+            <p class="text-12-regular text-text-weak">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
+            </p>
           </div>
         </Show>
       </Popover>

--- a/packages/app/src/components/help-button.tsx
+++ b/packages/app/src/components/help-button.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "@opencode-ai/ui/v2/icon"
 import { Popover } from "@opencode-ai/ui/popover"
 import { createSignal, Show } from "solid-js"
 
@@ -24,7 +25,15 @@ export function HelpButton() {
         placement="top-end"
       >
         <Show when={shown()}>
-          <div class="flex flex-col gap-1 w-[320px] p-4 rounded-xl bg-background-strong shadow-[var(--shadow-lg-border-base)]">
+          <div class="relative flex flex-col gap-1 w-[320px] p-4 rounded-xl bg-background-strong shadow-[var(--shadow-lg-border-base)]">
+            <button
+              type="button"
+              aria-label="Close"
+              class="absolute top-3.5 right-3.5 size-6 rounded-md flex items-center justify-center text-text-base hover:text-text-strong hover:bg-surface-raised-base-hover transition-colors"
+              onClick={() => setShown(false)}
+            >
+              <Icon name="xmark-small" />
+            </button>
             <span class="text-14-regular text-text-strong">Lorem ipsum dolor sit amet</span>
             <p class="text-12-regular text-text-weak">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et

--- a/packages/app/src/components/help-button.tsx
+++ b/packages/app/src/components/help-button.tsx
@@ -1,47 +1,54 @@
 import { Icon } from "@opencode-ai/ui/v2/icon"
 import { Popover } from "@opencode-ai/ui/popover"
 import { createSignal, Show } from "solid-js"
+import { createStore } from "solid-js/store"
 
 export function HelpButton() {
   if (import.meta.env.VITE_OPENCODE_CHANNEL !== "dev") return null
 
+  const [state, setState] = /* persisted(Persist.global("help-button"), */ createStore({ dismissed: false }) /* ) */
   const [shown, setShown] = createSignal(false)
 
   return (
-    <div class="fixed bottom-4 right-4 z-50">
-      <Popover
-        open={shown()}
-        onOpenChange={setShown}
-        triggerAs="button"
-        triggerProps={{
-          type: "button",
-          "aria-label": "Help",
-          class:
-            "size-7 rounded-full bg-background-base shadow-[var(--shadow-lg-border-base)] flex items-center justify-center text-text-base hover:text-text-strong transition-colors",
-        }}
-        trigger={<span aria-hidden="true">?</span>}
-        class="[&_[data-slot=popover-body]]:p-0 w-[320px] max-w-[calc(100vw-40px)] bg-transparent border-0 shadow-none rounded-xl"
-        gutter={8}
-        placement="top-end"
-      >
-        <Show when={shown()}>
-          <div class="relative flex flex-col gap-1 w-[320px] p-4 rounded-xl bg-background-strong shadow-[var(--shadow-lg-border-base)]">
-            <button
-              type="button"
-              aria-label="Close"
-              class="absolute top-3.5 right-3.5 size-6 rounded-md flex items-center justify-center text-text-base hover:text-text-strong hover:bg-surface-raised-base-hover transition-colors"
-              onClick={() => setShown(false)}
-            >
-              <Icon name="xmark-small" />
-            </button>
-            <span class="text-14-regular text-text-strong">Lorem ipsum dolor sit amet</span>
-            <p class="text-12-regular text-text-weak">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
-              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
-            </p>
-          </div>
-        </Show>
-      </Popover>
-    </div>
+    <Show when={!state.dismissed}>
+      <div class="fixed bottom-4 right-4 z-50">
+        <Popover
+          open={shown()}
+          onOpenChange={setShown}
+          triggerAs="button"
+          triggerProps={{
+            type: "button",
+            "aria-label": "Help",
+            class:
+              "size-7 rounded-full bg-background-base shadow-[var(--shadow-lg-border-base)] flex items-center justify-center text-text-base hover:text-text-strong transition-colors",
+          }}
+          trigger={<span aria-hidden="true">?</span>}
+          class="[&_[data-slot=popover-body]]:p-0 w-[320px] max-w-[calc(100vw-40px)] bg-transparent border-0 shadow-none rounded-xl"
+          gutter={8}
+          placement="top-end"
+        >
+          <Show when={shown()}>
+            <div class="relative flex flex-col gap-1 w-[320px] p-4 rounded-xl bg-background-strong shadow-[var(--shadow-lg-border-base)]">
+              <button
+                type="button"
+                aria-label="Close"
+                class="absolute top-3.5 right-3.5 size-6 rounded-md flex items-center justify-center text-text-base hover:text-text-strong hover:bg-surface-raised-base-hover transition-colors"
+                onClick={() => {
+                  setShown(false)
+                  setState("dismissed", true)
+                }}
+              >
+                <Icon name="xmark-small" />
+              </button>
+              <span class="text-14-regular text-text-strong">Lorem ipsum dolor sit amet</span>
+              <p class="text-12-regular text-text-weak">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
+              </p>
+            </div>
+          </Show>
+        </Popover>
+      </div>
+    </Show>
   )
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -63,6 +63,7 @@ import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
 import { useCommand, type CommandOption } from "@/context/command"
 import { ConstrainDragXAxis, getDraggableId } from "@/utils/solid-dnd"
 import { DebugBar } from "@/components/debug-bar"
+import { HelpButton } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
 import { useDirectoryPicker } from "@/components/directory-picker"
 import { ServerConnection, useServer } from "@/context/server"
@@ -2364,6 +2365,7 @@ export default function Layout(props: ParentProps) {
             </Show>
           </main>
           {import.meta.env.DEV && <DebugBar />}
+          <HelpButton />
           <ToastRegion v2={newDesign()} />
         </div>
       }
@@ -2517,6 +2519,7 @@ export default function Layout(props: ParentProps) {
           </div>
           {import.meta.env.DEV && <DebugBar />}
         </div>
+        <HelpButton />
         <ToastRegion v2={newDesign()} />
       </div>
     </Show>


### PR DESCRIPTION
Adds a question button + popover that only shows in dev for now. Will be filled in with tabs info.

<img width="355" height="221" alt="image" src="https://github.com/user-attachments/assets/1145d37f-c09f-4ace-9c06-7abdd46d39d1" />

