### PR TITLE
fix(opencode): pass abort signal to MCP tool calls

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -166,7 +166,7 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
   return dynamicTool({
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(schema),
-    execute: async (args: unknown) => {
+    execute: async (args: unknown, options) => {
       return client.callTool(
         {
           name: mcpTool.name,
@@ -175,6 +175,7 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
         CallToolResultSchema,
         {
           resetTimeoutOnProgress: true,
+          signal: options.abortSignal,
           timeout,
         },
       )

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -19,6 +19,7 @@ interface MockClientState {
   listResourcesShouldFail: boolean
   prompts: Array<{ name: string; description?: string }>
   resources: Array<{ name: string; uri: string; description?: string }>
+  callToolSignal?: AbortSignal
   closed: boolean
   notificationHandlers: Map<unknown, (...args: any[]) => any>
 }
@@ -173,6 +174,11 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return { resources: this._state?.resources ?? [] }
     }
 
+    async callTool(_params: unknown, _schema: unknown, options?: { signal?: AbortSignal }) {
+      if (this._state) this._state.callToolSignal = options?.signal
+      return { content: [] }
+    }
+
     async close() {
       if (this._state) this._state.closed = true
     }
@@ -229,6 +235,30 @@ it.instance(
         expect(Object.keys(toolsA).length).toBeGreaterThan(0)
         expect(Object.keys(toolsB).length).toBeGreaterThan(0)
         expect(serverState.listToolsCalls).toBe(1)
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "forwards tool cancellation to the MCP request",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "cancel-server"
+        const serverState = getOrCreateClientState("cancel-server")
+        const controller = new AbortController()
+
+        yield* mcp.add("cancel-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        const tools = yield* mcp.tools()
+        yield* Effect.promise(() =>
+          tools["cancel-server_test_tool"].execute!({}, { abortSignal: controller.signal } as never),
+        )
+        expect(serverState.callToolSignal).toBe(controller.signal)
       }),
     ),
   { config: { mcp: {} } },

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -19,7 +19,6 @@ interface MockClientState {
   listResourcesShouldFail: boolean
   prompts: Array<{ name: string; description?: string }>
   resources: Array<{ name: string; uri: string; description?: string }>
-  callToolSignal?: AbortSignal
   closed: boolean
   notificationHandlers: Map<unknown, (...args: any[]) => any>
 }
@@ -174,11 +173,6 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return { resources: this._state?.resources ?? [] }
     }
 
-    async callTool(_params: unknown, _schema: unknown, options?: { signal?: AbortSignal }) {
-      if (this._state) this._state.callToolSignal = options?.signal
-      return { content: [] }
-    }
-
     async close() {
       if (this._state) this._state.closed = true
     }
@@ -235,30 +229,6 @@ it.instance(
         expect(Object.keys(toolsA).length).toBeGreaterThan(0)
         expect(Object.keys(toolsB).length).toBeGreaterThan(0)
         expect(serverState.listToolsCalls).toBe(1)
-      }),
-    ),
-  { config: { mcp: {} } },
-)
-
-it.instance(
-  "forwards tool cancellation to the MCP request",
-  () =>
-    MCP.Service.use((mcp: MCPNS.Interface) =>
-      Effect.gen(function* () {
-        lastCreatedClientName = "cancel-server"
-        const serverState = getOrCreateClientState("cancel-server")
-        const controller = new AbortController()
-
-        yield* mcp.add("cancel-server", {
-          type: "local",
-          command: ["echo", "test"],
-        })
-
-        const tools = yield* mcp.tools()
-        yield* Effect.promise(() =>
-          tools["cancel-server_test_tool"].execute!({}, { abortSignal: controller.signal } as never),
-        )
-        expect(serverState.callToolSignal).toBe(controller.signal)
       }),
     ),
   { config: { mcp: {} } },


### PR DESCRIPTION
## Summary
- forward the AI SDK tool abort signal to MCP `callTool` requests
- allow the MCP SDK to send `notifications/cancelled` when users cancel an active turn

## Testing
- `bun typecheck`
- `bunx prettier --check src/mcp/index.ts`

Closes #24312

Relates to: #28567