### PR TITLE
fix: add 30s timeout to SQLite semaphore to prevent deadlock hangs

### DIFF
--- a/packages/core/src/database/sqlite.bun.ts
+++ b/packages/core/src/database/sqlite.bun.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import * as Context from "effect/Context"
+import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
 import { identity } from "effect/Function"
@@ -119,12 +120,40 @@ const make = (options: Config) =>
     })
 
     const semaphore = yield* Semaphore.make(1)
-    const acquirer = semaphore.withPermits(1)(Effect.succeed(connection))
+    const lockTimeout = Duration.seconds(30)
+    const acquirer = semaphore.withPermits(1)(Effect.succeed(connection)).pipe(
+      Effect.timeoutFail({
+        duration: lockTimeout,
+        onTimeout: () =>
+          new SqlError({
+            reason: classifySqliteError(new Error("Timed out waiting for database lock after 30s"), {
+              message: "Database lock timeout",
+              operation: "query",
+            }),
+          }),
+      }),
+    )
     const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
       const fiber = Fiber.getCurrent()!
       const scope = Context.getUnsafe(fiber.context, Scope.Scope)
       return Effect.as(
-        Effect.tap(restore(semaphore.take(1)), () => Scope.addFinalizer(scope, semaphore.release(1))),
+        Effect.tap(
+          restore(
+            semaphore.take(1).pipe(
+              Effect.timeoutFail({
+                duration: lockTimeout,
+                onTimeout: () =>
+                  new SqlError({
+                    reason: classifySqliteError(
+                      new Error("Timed out waiting for database transaction lock after 30s — possible deadlock"),
+                      { message: "Transaction lock timeout", operation: "transaction" },
+                    ),
+                  }),
+              }),
+            ),
+          ),
+          () => Scope.addFinalizer(scope, semaphore.release(1)),
+        ),
         connection,
       )
     })


### PR DESCRIPTION
### Issue for this PR
Closes #29395

### Type of change
- [x] Bug fix

### What does this PR do?
The in-process `Semaphore(1)` guarding the single SQLite connection in `sqlite.bun.ts` blocks forever when the permit can't be acquired (deadlock, re-entrant lock, or concurrent instance contention). This adds a 30-second `Effect.timeoutFail` to both the regular query acquirer and the transaction acquirer so the hang surfaces as a clear `SqlError` instead of a silent futex wait with no timeout, no error, and no progress.

### How did you verify your code works?
- Traced the full boot sequence (`InstanceStore.load` -> `boot` -> `fromDirectory` -> `bootstrap.run`) and confirmed both the `acquirer` and `transactionAcquirer` are the only JS-level serialization points for SQLite access
- Verified `Effect.timeoutFail` correctly interacts with `semaphore.withPermits` (timeout fires interruption, permit is not acquired, no leak)
- Verified `Effect.timeoutFail` works inside `Effect.uninterruptibleMask` + `restore(...)` (the restore region makes `semaphore.take` interruptible so the timeout signal can reach it)
- Confirmed `SqlError` with `classifySqliteError` matches the existing error handling path

### Screenshots / recordings
N/A (backend change)

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR