### PR TITLE
fix: add 30s timeout to plugin dynamic import to prevent silent deadlocks

### DIFF
--- a/packages/opencode/src/plugin/loader.ts
+++ b/packages/opencode/src/plugin/loader.ts
@@ -133,10 +133,18 @@ export namespace PluginLoader {
   }
 
   // Import the resolved module only after all earlier validation has succeeded.
-  export async function load(row: Resolved): Promise<{ ok: true; value: Loaded } | { ok: false; error: unknown }> {
+  //
+  // Dynamic import of a misconfigured or incompatible npm package can deadlock without throwing.
+  // A timeout ensures the process surfaces a visible error instead of hanging silently.
+  export async function load(row: Resolved, timeoutMs = 30000): Promise<{ ok: true; value: Loaded } | { ok: false; error: unknown }> {
     let mod
     try {
-      mod = await import(row.entry)
+      mod = await Promise.race([
+        import(row.entry),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`Plugin import timed out after ${timeoutMs}ms: ${row.spec}`)), timeoutMs),
+        ),
+      ])
     } catch (error) {
       return { ok: false, error }
     }


### PR DESCRIPTION
### Issue for this PR

Closes #31463

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`PluginLoader.load()` calls `await import(row.entry)` with no timeout. The broader deadlock is in `Npm.add()` → Arborist `reify()` (cold cache only), but adding a timeout to `import()` prevents silent hangs regardless of where the deadlock occurs. If the import times out, a clear error is surfaced instead of an invisible hang.

### Root cause (confirmed via cache inspection)

The real deadlock is in `Npm.add()` — Arborist `reify()` hangs when the npm cache is cold. Once `~/.cache/opencode/packages/oh-my-openagent@latest/` is populated, the cache fast-path skips `reify()` and everything works. This is likely related to #23143 (no TTL on @latest re-reify).

### How did you verify your code works

- Built OpenCode from source with the change
- Running the dev binary against `oh-my-openagent@latest` with a cold cache triggered `Npm.add()` → `reify()` successfully (populated the cache)
- Original installed OpenCode 1.16.2 then also works against the same specifier (cache hit)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR