### PR TITLE
fix: add 5min timeout to npm reify to prevent silent deadlocks

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -103,7 +103,18 @@ export const layer = Layer.effect(
               add,
               dir: input.dir,
             }),
-        }) as Effect.Effect<ArboristTree, InstallFailedError>
+        }).pipe(
+          Effect.timeout("5 minutes"),
+          Effect.catchTag("TimeoutException", () =>
+            Effect.fail(
+              new InstallFailedError({
+                cause: new Error("npm install timed out after 5 minutes"),
+                add,
+                dir: input.dir,
+              })
+            )
+          )
+        ) as Effect.Effect<ArboristTree, InstallFailedError>
       }).pipe(
         Effect.withSpan("Npm.reify", {
           attributes: input,


### PR DESCRIPTION
### Issue for this PR

Closes #31463

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Npm.add()` in `packages/core/src/npm.ts` calls Arborist `reify()` when the npm cache is cold. `reify()` can deadlock silently with no error. This PR wraps it with `Effect.timeout("5 minutes")` so a hang surfaces as a visible error through the existing plugin error pipeline, instead of blocking the process indefinitely.

### How did you verify your code works?

`Effect.timeout("5 minutes")` is the same pattern already used elsewhere in the codebase (`"30 seconds"`, `"10 seconds"`). The timeout path cannot be triggered under normal conditions — it is a safety net for the rare deadlock case.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR