### PR TITLE
fix: correct org reference in docs-update workflow from sst to anomalyco

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   update-docs:
-    if: github.repository == 'sst/opencode'
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run opencode
         if: steps.commits.outputs.has_commits == 'true'
-        uses: sst/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
+        uses: anomalyco/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:


### PR DESCRIPTION
## Description

Fixes #31471

The `.github/workflows/docs-update.yml` workflow references `sst/opencode` instead of `anomalyco/opencode` in two places, making the workflow completely dead on the actual repo.

## Changes

- `docs-update.yml:13`: Changed `github.repository == 'sst/opencode'` → `'anomalyco/opencode'`
- `docs-update.yml:46`: Changed `uses: sst/opencode/github@...` → `anomalyco/opencode/github@...`

## Impact

This fixes the automated docs-update workflow that runs every 12 hours.