### PR TITLE
fix(opencode): add --dir option to web/serve for explicit working directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,10 @@ opencode --help          # Show all available commands
 opencode serve           # Start headless API server
 opencode web             # Start server + open web interface
 opencode <directory>     # Start TUI in specific directory
+
+# Both web and serve accept --dir to set the working directory
+opencode web --dir /path/to/project
+opencode serve --dir ./my-project
 ```
 
 ### Running the API Server

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -2,15 +2,27 @@ import { Effect } from "effect"
 import { effectCmd } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { resolveThreadDirectory } from "./tui"
 
 export const ServeCommand = effectCmd({
   command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("dir", {
+      type: "string",
+      describe: "directory to run in",
+    }),
   describe: "starts a headless opencode server",
   // Server loads instances per-request via x-opencode-directory header — no
   // need for an ambient project InstanceContext at startup.
   instance: false,
   handler: Effect.fn("Cli.serve")(function* (args) {
+    const resolved = resolveThreadDirectory(args.dir)
+    try {
+      process.chdir(resolved)
+    } catch {
+      console.log("Error: Failed to change directory to " + resolved)
+      return
+    }
     const { Server } = yield* Effect.promise(() => import("../../server/server"))
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
@@ -18,6 +30,7 @@ export const ServeCommand = effectCmd({
     const opts = yield* resolveNetworkOptions(args)
     const server = yield* Effect.promise(() => Server.listen(opts))
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    console.log(`  Working directory: ${process.cwd()}`)
 
     yield* Effect.never
   }),

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -3,6 +3,7 @@ import { UI } from "../ui"
 import { effectCmd } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { resolveThreadDirectory } from "./tui"
 import open from "open"
 import { networkInterfaces } from "os"
 
@@ -30,12 +31,23 @@ function getNetworkIPs() {
 
 export const WebCommand = effectCmd({
   command: "web",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("dir", {
+      type: "string",
+      describe: "directory to run in",
+    }),
   describe: "start opencode server and open web interface",
   // Server loads instances per-request via x-opencode-directory header — no
   // ambient project InstanceContext needed at startup.
   instance: false,
   handler: Effect.fn("Cli.web")(function* (args) {
+    const resolved = resolveThreadDirectory(args.dir)
+    try {
+      process.chdir(resolved)
+    } catch {
+      UI.println(UI.Style.TEXT_WARNING_BOLD + "!  Failed to change directory to " + resolved)
+      return
+    }
     const { Server } = yield* Effect.promise(() => import("../../server/server"))
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
@@ -45,6 +57,7 @@ export const WebCommand = effectCmd({
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
+    UI.println(UI.Style.TEXT_INFO_BOLD + "  Working directory: ", UI.Style.TEXT_NORMAL, process.cwd())
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -230,7 +230,8 @@ Options:
                                                                           [boolean] [default: false]
       --mdns-domain  custom domain name for mDNS service (default: opencode.local)
                                                                 [string] [default: "opencode.local"]
-      --cors         additional domains to allow for CORS                      [array] [default: []]"
+      --cors         additional domains to allow for CORS                      [array] [default: []]
+      --dir          directory to run in                                                    [string]"
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode web --help 1`] = `
@@ -250,7 +251,8 @@ Options:
                                                                           [boolean] [default: false]
       --mdns-domain  custom domain name for mDNS service (default: opencode.local)
                                                                 [string] [default: "opencode.local"]
-      --cors         additional domains to allow for CORS                      [array] [default: []]"
+      --cors         additional domains to allow for CORS                      [array] [default: []]
+      --dir          directory to run in                                                    [string]"
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode models --help 1`] = `


### PR DESCRIPTION
Fixes #26966
Also related to #24082, #30005, and #31401.
## Type of change
- [x] Bug fix
- [x] New feature
## What
Adds `--dir` to `opencode web` and `opencode serve` so the server starts with an explicit working directory:
    opencode web --dir /path/to/project
    opencode serve --dir ./my-project
Even without `--dir`, both commands now normalize `process.cwd()` at startup using `resolveThreadDirectory()` (same as the TUI). This fixes the Windows bug where CWD resolves to the drive root instead of the actual directory, and the Docker/container case where CWD defaults to `/`.
## Why
The server middleware falls back to `process.cwd()` when no `x-opencode-directory` header is sent (initial page load before a project is selected). On Windows, `process.cwd()` can return the drive root. In containers, CWD is `/` unless explicitly set. The TUI avoids this by calling `process.chdir()` with a resolved path at startup. This PR applies the same pattern to web/serve.
## Verification
- 349/354 CLI tests pass (5 skipped, 0 fail)
- Help-text snapshots updated for new `--dir` option
- Serve subprocess tests pass (new `Working directory:` output does not interfere with ready-state detection)
- `resolveThreadDirectory` unit tests pass
## Checklist
- [x] I have tested my changes locally
- [x] My changes do not introduce unrelated modifications