### PR TITLE
fix(tui): remove debug console.log statements from production code

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -976,7 +976,6 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   })
 
   event.on("installation.update-available", async (evt) => {
-    console.log("installation.update-available", evt)
     const version = evt.properties.version
 
     const skipped = kv.get("skipped_version")

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1003,7 +1003,6 @@ export function Prompt(props: PromptProps) {
 
       if (res.error) {
         if (finishMoveProgress) move.finishSubmit()
-        console.log("Creating a session failed:", res.error)
 
         toast.show({
           message: "Creating a session failed. Open console for more details.",


### PR DESCRIPTION
Fixes #31476

Removes two leftover console.log calls in the TUI package that leak debug output into the terminal:

1. packages/tui/src/app.tsx:979 - removed log of installation update event (dialog handles UX)
2. packages/tui/src/component/prompt/index.tsx:1006 - removed log and updated misleading toast message

Changes: 2 files, +1 -3 lines.