### PR TITLE
fix(tui): handle Home and End keys in prompt input

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1366,10 +1366,18 @@ export function Prompt(props: PromptProps) {
                 setCursorVersion((value) => value + 1)
               }}
               onCursorChange={() => setCursorVersion((value) => value + 1)}
-              onKeyDown={(e: { preventDefault(): void }) => {
+              onKeyDown={(e: KeyEvent) => {
                 if (props.disabled) {
                   e.preventDefault()
                   return
+                }
+                if (e.name === "end") {
+                  e.preventDefault()
+                  input.gotoBufferEnd()
+                }
+                if (e.name === "home") {
+                  e.preventDefault()
+                  input.cursorOffset = 0
                 }
               }}
               onSubmit={() => {


### PR DESCRIPTION
### Issue for this PR

Closes #27661

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Home and End keys did not navigate to the start/end of text in the prompt textarea. Add explicit handling in onKeyDown to move the cursor to buffer start (Home) and buffer end (End).



### How did you verify your code works?

Verified by running `bun dev` and pressing Home/End in the prompt input — cursor now jumps to the beginning and end of the text as expected.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
