### PR TITLE
fix(mcp): fail clearly when OAuth callback port is in use

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -144,7 +144,13 @@ export async function ensureRunning(redirectUri?: string): Promise<void> {
 
   const running = await isPortInUse(port)
   if (running) {
-    return
+    // Cannot reuse: the other listener may not be opencode, and OAuth
+    // callbacks landing there surface as a misleading CSRF error.
+    throw new Error(
+      `OAuth callback port ${port} is already in use. ` +
+        `Set "oauth.callbackPort" (or "oauth.redirectUri") on the MCP server ` +
+        `entry in your opencode config to use a different port.`,
+    )
   }
 
   currentPort = port


### PR DESCRIPTION
### Issue for this PR

Closes #30888

Also addresses the same root cause as the long-standing #23562 / #23563 / #23568.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ensureRunning()` in `packages/opencode/src/mcp/oauth-callback.ts` previously silently returned when `127.0.0.1:19876` (or the configured port) was already in use. That left the OAuth flow waiting on a callback that landed in whatever other process owned the port, and the user saw a misleading `Invalid or expired state parameter - potential CSRF attack` message — pointing them at a CSRF / cookie / browser issue when the real cause was just "the callback port is occupied".

This change makes `ensureRunning()` throw a clear error that names the config knobs that already exist for this case:

```
OAuth callback port 19876 is already in use. Set "oauth.callbackPort"
(or "oauth.redirectUri") on the MCP server entry in your opencode config
to use a different port.
```

Diff is 9 lines in one file.

**Behaviour change to flag:** this removes the silent fallback that allowed two opencode instances on the same host to share one callback server. AFAICT that fallback was already broken — `pendingAuths` is in-process memory, so the second instance's `state` is never known to the first instance's HTTP handler and the auth fails anyway (which is exactly what #23562 / #23563 / #23568 are reporting). The simpler fix is to stop pretending the fallback works and tell the user how to pick a different port. Happy to switch to a probe (e.g. GET the path and check for our 400 response body) if you'd rather preserve cross-instance sharing as a real feature later.

### How did you verify your code works?

Locally reproduced the original bug by holding `:19876` with a Python listener and running `opencode mcp auth Notion` → got the misleading CSRF error. After this patch, the same setup produces the new error and exits cleanly:

```
$ bun dev mcp auth Notion
┌  MCP OAuth Authentication
│
◇  Notion already has valid credentials. Re-authenticate?
│  Yes
│
■  Authentication failed
│
■  OAuth callback port 19876 is already in use. Set "oauth.callbackPort"
   (or "oauth.redirectUri") on the MCP server entry in your opencode config
   to use a different port.
│
└  Done
```

`bun turbo typecheck --filter=opencode` passes.

### Screenshots / recordings

N/A — CLI behaviour change, before/after captured in the block above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
