### PR TITLE
feat: add X-Session-Id header for proxy cache routing affinity

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -185,6 +185,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
           }
         : {
             "x-session-affinity": input.sessionID,
+            "X-Session-Id": input.sessionID,
             ...(input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
             "User-Agent": USER_AGENT,
           }),


### PR DESCRIPTION
### Issue for this PR

Closes N/A (improvement — no existing issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an `X-Session-Id` header (set to the session ID) alongside the existing `x-session-affinity` header for all non-opencode providers.

**Why**: Anthropic API proxies (e.g. enterprise gateways that front multiple upstream Anthropic accounts) use `X-Session-Id` to implement routing affinity — pinning all requests from the same session to the same upstream account. This maximizes KV-Cache hit rate on the upstream side because the cached prompt prefix lives on that specific account.

Without this header, multi-turn conversations get scattered across different upstream accounts by the load balancer, causing frequent prompt cache misses and significantly higher latency + cost.

The header name `X-Session-Id` is the convention used by Anthropic-compatible proxy providers (documented in their API specs). It is sent unconditionally for non-opencode providers — providers that do not recognize it will simply ignore an unknown header, so there is no behavioral change for direct Anthropic API usage or other providers.

The change is a single line addition in `packages/opencode/src/session/llm/request.ts`.

### How did you verify your code works?

1. Built locally with `bun run build --skip-embed-web-ui --single`
2. Set up an HTTP header inspection proxy between opencode and the API endpoint — confirmed `X-Session-Id` is present in all outgoing requests
3. Ran an end-to-end cache hit test: two sequential requests with the same session ID and same system prompt showed `cache_creation_input_tokens: 1538` on request 1, then `cache_read_input_tokens: 1538` on request 2 — confirming the routing affinity enables cache hits
4. Full typecheck passed (23/23 packages)

### Screenshots / recordings

_N/A — backend-only change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR