### PR TITLE
fix(app): reduce reactive cascade overhead on session switch

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -73,6 +73,7 @@ import { Identifier } from "@/utils/id"
 import { diffs as list } from "@/utils/diffs"
 import { Persist, persisted } from "@/utils/persist"
 import { extractPromptFromParts } from "@/utils/prompt"
+import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
 import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/session-route"
 import { useUsageExceededDialogs } from "./session/usage-exceeded-dialogs"
@@ -247,7 +248,7 @@ export default function Page() {
 
   const info = createMemo(() => (params.id ? sync().session.get(params.id) : undefined))
   const isChildSession = createMemo(() => !!info()?.parentID)
-  const diffs = createMemo(() => (params.id ? list(sync().data.session_diff[params.id]) : []))
+  const diffs = createMemo(() => (params.id ? list(sync().data.session_diff[params.id]) : []), [], { equals: same })
   const canReview = createMemo(() => !!sync().project)
   const reviewTab = createMemo(() => isDesktop())
   const tabState = createSessionTabs({
@@ -291,11 +292,15 @@ export default function Page() {
 
   createEffect(
     on(
-      () => ({ dir: sdk().directory, id: params.id }),
-      (next, prev) => {
+      // Use a primitive string key instead of creating a new object on every
+      // evaluation. SolidJS on() uses === comparison, so a string avoids
+      // the always-different-reference problem that objects have.
+      () => `${params.dir}\0${params.id ?? ""}`,
+      (_next, prev) => {
         if (!prev) return
-        if (next.dir === prev.dir && next.id === prev.id) return
-        if (prev.id && !next.id) local.session.reset()
+        // prev had a session ID (non-empty after the separator) and now there's none
+        const prevHadId = prev.indexOf("\0") < prev.length - 1
+        if (prevHadId && !params.id) local.session.reset()
       },
       { defer: true },
     ),

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -1,6 +1,6 @@
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { useLocation, useNavigate } from "@solidjs/router"
-import { createEffect, createMemo, onCleanup, onMount } from "solid-js"
+import { createEffect, onCleanup, onMount } from "solid-js"
 import { messageIdFromHash } from "./message-id-from-hash"
 
 export const useSessionHashScroll = (input: {
@@ -22,8 +22,10 @@ export const useSessionHashScroll = (input: {
   scheduleScrollState: (el: HTMLDivElement) => void
   consumePendingMessage: (key: string) => string | undefined
 }) => {
-  const visibleUserMessages = createMemo(() => input.visibleUserMessages())
-  const messageById = createMemo(() => new Map(visibleUserMessages().map((m) => [m.id, m])))
+  // Use input directly instead of wrapping in a memo without an equality comparator.
+  // Replace the Map (rebuilt on every change) with a lazy lookup — user message
+  // counts are small enough that linear scan is fine for the point lookups here.
+  const findMessage = (id: string) => input.visibleUserMessages().find((m) => m.id === id)
   let pendingKey = ""
   let clearing = false
 
@@ -110,7 +112,7 @@ export const useSessionHashScroll = (input: {
     const messageId = messageIdFromHash(hash)
     if (messageId) {
       input.autoScroll.pause()
-      const msg = messageById().get(messageId)
+      const msg = findMessage(messageId)
       if (msg) {
         scrollToMessage(msg, behavior)
         return
@@ -141,7 +143,8 @@ export const useSessionHashScroll = (input: {
   createEffect(() => {
     if (!input.sessionID() || !input.messagesReady()) return
 
-    visibleUserMessages()
+    // Subscribe to message list changes
+    input.visibleUserMessages()
 
     let targetId = input.pendingMessage()
     if (!targetId) {
@@ -160,7 +163,7 @@ export const useSessionHashScroll = (input: {
     if (!targetId) return
 
     const pending = input.pendingMessage() === targetId
-    const msg = messageById().get(targetId)
+    const msg = findMessage(targetId)
     if (!msg) return
 
     if (pending) input.setPendingMessage(undefined)
@@ -175,12 +178,13 @@ export const useSessionHashScroll = (input: {
     const sessionID = input.sessionID()
     if (!sessionID || !input.messagesReady()) return
 
-    visibleUserMessages()
+    // Subscribe to message list changes
+    input.visibleUserMessages()
 
     let targetId = input.pendingMessage()
     if (!targetId && !clearing) targetId = messageIdFromHash(location.hash)
     if (!targetId) return
-    if (messageById().has(targetId)) return
+    if (findMessage(targetId)) return
     if (!input.historyMore() || input.historyLoading()) return
 
     void input.loadMore(sessionID)


### PR DESCRIPTION
### Issue for this PR

Related to #31548

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

> **Scope note:** This PR originally bundled three web-UI perf fixes (skip Shiki during streaming, single store mutation per SSE delta, scroll-anchor thrashing). Upstream has since addressed all three independently — Shiki now runs in a Web Worker, the event reducer dual-writes the accum store, and the timeline was rewritten with projection + `solid-virtual` virtualization. This PR is now reduced to the one change that is still relevant: cutting reactive-cascade overhead on session switch.

Reduces redundant reactive work that runs on every session switch (and during streaming):

- **Lazy `findMessage()` instead of `messageById` Map recreation** (`use-session-hash-scroll.ts`): the Map was rebuilt (O(n) insertions) on every `visibleUserMessages` change, including during streaming. Replaced with a lazy linear scan, and the wrapping memo that lacked an equality comparator was removed.
- **`{ equals: same }` on the `diffs` memo** (`session.tsx`): downstream components no longer re-render when diff content is unchanged.
- **Primitive string key for the dir/id `on()` effect** (`session.tsx`): SolidJS `on()` uses `===`, so the previous object literal always re-ran the effect body even when `dir`/`id` were unchanged. Now keyed on a primitive string.
- **Removed the redundant `historyLoader.userMessages` memo** that rewrapped `visibleUserMessages()` with `{ equals: same }` — the input already uses the same comparator.

### How did you verify your code works?

- `bun typecheck` from `packages/app` — clean for all touched files
- Built with `OPENCODE_CHANNEL=latest bun run script/build.ts --single` — build + smoke test passed (v1.17.12)
- Tested session switching between cached sessions

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
