### PR TITLE
test(core): avoid Windows worker close race

### DIFF
--- a/packages/core/test/util/effect-flock.test.ts
+++ b/packages/core/test/util/effect-flock.test.ts
@@ -65,19 +65,25 @@ function spawnWorker(msg: Msg) {
   })
 }
 
-function stopWorker(proc: ReturnType<typeof spawnWorker>) {
-  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve()
+async function stopWorker(proc: ReturnType<typeof spawnWorker>) {
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+
+  const closed = new Promise<void>((resolve) => proc.once("close", () => resolve()))
+
   if (process.platform !== "win32" || !proc.pid) {
     proc.kill()
-    return Promise.resolve()
+    await closed
+    return
   }
-  return new Promise<void>((resolve) => {
+
+  await new Promise<void>((resolve) => {
     const killProc = spawn("taskkill", ["/pid", String(proc.pid), "/T", "/F"])
     killProc.on("close", () => {
       proc.kill()
       resolve()
     })
   })
+  await closed
 }
 
 async function waitForFile(file: string, timeout = 3_000) {
@@ -363,7 +369,6 @@ describe("util.effect-flock", () => {
         try {
           await waitForFile(ready, 5_000)
           await stopWorker(proc)
-          await new Promise((resolve) => proc.on("close", resolve))
 
           // Backdate lock files so they're past STALE_MS (60s)
           const lockDir = lock(dir, "eflock:crash")

--- a/packages/core/test/util/flock.test.ts
+++ b/packages/core/test/util/flock.test.ts
@@ -88,21 +88,25 @@ function spawnWorker(msg: Msg) {
   })
 }
 
-function stopWorker(proc: ReturnType<typeof spawnWorker>) {
-  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve()
+async function stopWorker(proc: ReturnType<typeof spawnWorker>) {
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+
+  const closed = new Promise<void>((resolve) => proc.once("close", () => resolve()))
 
   if (process.platform !== "win32" || !proc.pid) {
     proc.kill()
-    return Promise.resolve()
+    await closed
+    return
   }
 
-  return new Promise<void>((resolve) => {
+  await new Promise<void>((resolve) => {
     const killProc = spawn("taskkill", ["/pid", String(proc.pid), "/T", "/F"])
     killProc.on("close", () => {
       proc.kill()
       resolve()
     })
   })
+  await closed
 }
 
 async function readJson<T>(p: string): Promise<T> {
@@ -175,7 +179,6 @@ describe("util.flock", () => {
       expect(seen.every((x) => x === key)).toBe(true)
     } finally {
       await stopWorker(proc).catch(() => undefined)
-      await new Promise((resolve) => proc.on("close", resolve))
     }
   }, 15_000)
 
@@ -195,7 +198,6 @@ describe("util.flock", () => {
 
     await wait(ready, 5_000)
     await stopWorker(proc)
-    await new Promise((resolve) => proc.on("close", resolve))
 
     let hit = false
     await Flock.withLock(


### PR DESCRIPTION
## Summary
- register worker `close` listeners before terminating subprocesses
- make `stopWorker` wait for process closure directly
- remove late `close` listeners that intermittently hung Windows flock tests

## Cause
On Windows, `taskkill` could terminate the worker and emit `close` before the tests attached their follow-up listener. The resulting unresolved promise caused the tests to hit their exact 15s or 30s outer timeout.

## Verification
- `bun test test/util/flock.test.ts test/util/effect-flock.test.ts`
- `bun typecheck`
- `git diff --check`