### PR TITLE
feat(opencode): configure Cohere North model

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -478,6 +478,7 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
 
 export function temperature(model: Provider.Model) {
   const id = model.id.toLowerCase()
+  if (id.includes("north-mini-code")) return 1.0
   if (id.includes("qwen")) return 0.55
   if (id.includes("claude")) return undefined
   if (id.includes("gemini")) return 1.0

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -826,7 +826,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "venice-ai-sdk-provider":
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
     case "@ai-sdk/openai-compatible":
-      if (model.api.id.toLowerCase() === "north-mini-code-1-0") {
+      if (model.api.id.toLowerCase().includes("north-mini-code")) {
         return Object.fromEntries(
           ["none", "high"].map((effort) => [effort, { reasoningEffort: effort }]),
         )
@@ -1110,7 +1110,7 @@ export function options(input: {
   }
 
   const modelId = input.model.api.id.toLowerCase()
-  if (modelId === "north-mini-code-1-0" && input.model.api.npm === "@ai-sdk/openai-compatible") {
+  if (modelId.includes("north-mini-code") && input.model.api.npm === "@ai-sdk/openai-compatible") {
     result["citation_options"] = { mode: "off" }
   }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -828,9 +828,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
     case "@ai-sdk/openai-compatible":
       if (model.api.id.toLowerCase().includes("north-mini-code")) {
-        return Object.fromEntries(
-          ["none", "high"].map((effort) => [effort, { reasoningEffort: effort }]),
-        )
+        return Object.fromEntries(["none", "high"].map((effort) => [effort, { reasoningEffort: effort }]))
       }
       const efforts = [...WIDELY_SUPPORTED_EFFORTS]
       if (model.api.id.toLowerCase().includes("deepseek-v4")) {
@@ -1112,7 +1110,7 @@ export function options(input: {
 
   const modelId = input.model.api.id.toLowerCase()
   if (modelId.includes("north-mini-code") && input.model.api.npm === "@ai-sdk/openai-compatible") {
-    result["citation_options"] = { mode: "off" }
+    result["options"] = { citation_options: { mode: "disabled" } }
   }
 
   // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -826,6 +826,11 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "venice-ai-sdk-provider":
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
     case "@ai-sdk/openai-compatible":
+      if (model.api.id.toLowerCase() === "north-mini-code-1-0") {
+        return Object.fromEntries(
+          ["none", "high"].map((effort) => [effort, { reasoningEffort: effort }]),
+        )
+      }
       const efforts = [...WIDELY_SUPPORTED_EFFORTS]
       if (model.api.id.toLowerCase().includes("deepseek-v4")) {
         efforts.push("max")
@@ -1105,6 +1110,10 @@ export function options(input: {
   }
 
   const modelId = input.model.api.id.toLowerCase()
+  if (modelId === "north-mini-code-1-0" && input.model.api.npm === "@ai-sdk/openai-compatible") {
+    result["citation_options"] = { mode: "off" }
+  }
+
   // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
   if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
     result["thinking"] = { type: "adaptive" }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2498,7 +2498,7 @@ describe("ProviderTransform.options - Cohere North", () => {
       } as any,
       sessionID: "test-session-123",
     })
-    expect(result.citation_options).toEqual({ mode: "disabled" })
+    expect(result.options).toEqual({ citation_options: { mode: "disabled" } })
   })
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2483,6 +2483,25 @@ describe("ProviderTransform.message - cache control on gateway", () => {
   })
 })
 
+describe("ProviderTransform.options - Cohere North", () => {
+  test("disables citations by default for north-mini-code-1-0", () => {
+    const result = ProviderTransform.options({
+      model: {
+        id: "cohere/north-mini-code-1-0",
+        providerID: "cohere",
+        api: {
+          id: "north-mini-code-1-0",
+          url: "https://api.cohere.com/compatibility/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+        capabilities: { reasoning: true },
+      } as any,
+      sessionID: "test-session-123",
+    })
+    expect(result.citation_options).toEqual({ mode: "off" })
+  })
+})
+
 describe("ProviderTransform.variants", () => {
   const createMockModel = (overrides: Partial<any> = {}): any => ({
     id: "test/test-model",
@@ -3208,6 +3227,23 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["low", "medium", "high"])
       expect(result.low).toEqual({ reasoningEffort: "low" })
       expect(result.high).toEqual({ reasoningEffort: "high" })
+    })
+
+    test("north-mini-code-1-0 returns only none and high", () => {
+      const model = createMockModel({
+        id: "cohere/north-mini-code-1-0",
+        providerID: "cohere",
+        api: {
+          id: "north-mini-code-1-0",
+          url: "https://api.cohere.com/compatibility/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({
+        none: { reasoningEffort: "none" },
+        high: { reasoningEffort: "high" },
+      })
     })
   })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2498,7 +2498,7 @@ describe("ProviderTransform.options - Cohere North", () => {
       } as any,
       sessionID: "test-session-123",
     })
-    expect(result.citation_options).toEqual({ mode: "off" })
+    expect(result.citation_options).toEqual({ mode: "disabled" })
   })
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2502,6 +2502,12 @@ describe("ProviderTransform.options - Cohere North", () => {
   })
 })
 
+describe("ProviderTransform.temperature - Cohere North", () => {
+  test("defaults north-mini-code models to 1.0", () => {
+    expect(ProviderTransform.temperature({ id: "cohere/North-Mini-Code-1-0-latest" } as any)).toBe(1.0)
+  })
+})
+
 describe("ProviderTransform.variants", () => {
   const createMockModel = (overrides: Partial<any> = {}): any => ({
     id: "test/test-model",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2490,7 +2490,7 @@ describe("ProviderTransform.options - Cohere North", () => {
         id: "cohere/north-mini-code-1-0",
         providerID: "cohere",
         api: {
-          id: "north-mini-code-1-0",
+          id: "North-Mini-Code-1-0-latest",
           url: "https://api.cohere.com/compatibility/v1",
           npm: "@ai-sdk/openai-compatible",
         },
@@ -3234,7 +3234,7 @@ describe("ProviderTransform.variants", () => {
         id: "cohere/north-mini-code-1-0",
         providerID: "cohere",
         api: {
-          id: "north-mini-code-1-0",
+          id: "North-Mini-Code-1-0-latest",
           url: "https://api.cohere.com/compatibility/v1",
           npm: "@ai-sdk/openai-compatible",
         },


### PR DESCRIPTION
## Summary
- limit `north-mini-code-1-0` to `none` and `high` reasoning efforts
- disable Cohere citations by default for the OpenAI-compatible model
- add focused transform regression coverage

## Testing
- `bun test test/provider/transform.test.ts`
- `bun typecheck`