### PR TITLE
fix(opencode): prevent approved wildcard from overriding config deny rules

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -80,6 +80,14 @@ export const layer = Layer.effect(
       let needsAsk = false
 
       for (const pattern of request.patterns) {
+        // Check config deny rules first — they cannot be overridden by approved rules
+        const configRule = evaluate(request.permission, pattern, ruleset)
+        if (configRule.action === "deny") {
+          yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: configRule })
+          return yield* new PermissionV1.DeniedError({
+            ruleset: ruleset.filter((rule) => Wildcard.match(request.permission, rule.permission)),
+          })
+        }
         const rule = evaluate(request.permission, pattern, ruleset, approved)
         yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: rule })
         if (rule.action === "deny") {

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -449,6 +449,19 @@ test("evaluate - merges multiple rulesets", () => {
   expect(result.action).toBe("deny")
 })
 
+test("evaluate - approved wildcard allow overrides config deny (documents bug)", () => {
+  // This test documents the evaluate() behavior that enables the bug.
+  // The fix is in Permission.ask() which checks config deny rules first.
+  const config: PermissionV1.Ruleset = [
+    { permission: "edit", pattern: "*", action: "ask" },
+    { permission: "edit", pattern: "*/AGENTS.md", action: "deny" },
+  ]
+  const approved: PermissionV1.Ruleset = [{ permission: "edit", pattern: "*", action: "allow" }]
+  const result = Permission.evaluate("edit", "Users/someone/workspace/AGENTS.md", config, approved)
+  // evaluate() alone still returns "allow" — the fix is in ask() which checks config deny first
+  expect(result.action).toBe("allow")
+})
+
 // disabled tests
 
 test("disabled - returns empty set when all tools allowed", () => {
@@ -586,6 +599,44 @@ it.instance(
           metadata: {},
           always: [],
           ruleset: [{ permission: "bash", pattern: "*", action: "deny" }],
+        }),
+      )
+      expect(err).toBeInstanceOf(PermissionV1.DeniedError)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - config deny is not overridden by approved wildcard allow",
+  () =>
+    Effect.gen(function* () {
+      // First, approve an edit with "always" to populate the approved list
+      const fiber = yield* ask({
+        id: PermissionV1.ID.make("per_deny_override_1"),
+        sessionID: SessionID.make("session_test"),
+        permission: "edit",
+        patterns: ["some/file.ts"],
+        metadata: {},
+        always: ["*"],
+        ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+      }).pipe(Effect.forkScoped)
+
+      yield* waitForPending(1)
+      yield* reply({ requestID: PermissionV1.ID.make("per_deny_override_1"), reply: "always" })
+      yield* Fiber.join(fiber)
+
+      // Now attempt an edit that config explicitly denies — should still be denied
+      const err = yield* fail(
+        ask({
+          sessionID: SessionID.make("session_test2"),
+          permission: "edit",
+          patterns: ["Users/someone/workspace/AGENTS.md"],
+          metadata: {},
+          always: [],
+          ruleset: [
+            { permission: "edit", pattern: "*", action: "ask" },
+            { permission: "edit", pattern: "*/AGENTS.md", action: "deny" },
+          ],
         }),
       )
       expect(err).toBeInstanceOf(PermissionV1.DeniedError)


### PR DESCRIPTION

### Issue for this PR

Closes #31540 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When a user clicks "Allow always" on an edit permission prompt, `always: ["*"]` stores `{permission: "edit", pattern: "*", action: "allow"}` in the approved list. `Permission.ask()` calls `evaluate(permission, pattern, ruleset, approved)` which flattens to `[...ruleset, ...approved]` and uses `findLast` — the approved wildcard always wins over config deny rules.
Fix: evaluate config deny rules (ruleset-only) before the combined evaluation. If the config explicitly denies a pattern, DeniedError fires immediately regardless of runtime approvals.

### How did you verify your code works?

- Added integration test that first approves with "always", then verifies a config-denied pattern still throws DeniedError
- All 81 existing permission tests pass
- `bun typecheck` clean

### Screenshots / recordings

N/A — logic fix, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
