### PR TITLE
fix(mcp): log actionable connection statuses

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -458,6 +458,19 @@ export const layer = Layer.effect(
           : yield* connectLocal(key, mcp as ConfigMCPV1.Info & { type: "local" })
 
       if (!mcpClient) {
+        if (status.status === "failed") {
+          yield* Effect.logWarning("connection failed", { key, type: mcp.type, error: status.error })
+        }
+        if (status.status === "needs_auth") {
+          yield* Effect.logWarning("connection requires authentication", { key, type: mcp.type })
+        }
+        if (status.status === "needs_client_registration") {
+          yield* Effect.logWarning("connection requires client registration", {
+            key,
+            type: mcp.type,
+            error: status.error,
+          })
+        }
         return { status } satisfies CreateResult
       }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -458,19 +458,12 @@ export const layer = Layer.effect(
           : yield* connectLocal(key, mcp as ConfigMCPV1.Info & { type: "local" })
 
       if (!mcpClient) {
-        if (status.status === "failed") {
-          yield* Effect.logWarning("connection failed", { key, type: mcp.type, error: status.error })
-        }
-        if (status.status === "needs_auth") {
-          yield* Effect.logWarning("connection requires authentication", { key, type: mcp.type })
-        }
-        if (status.status === "needs_client_registration") {
-          yield* Effect.logWarning("connection requires client registration", {
-            key,
-            type: mcp.type,
-            error: status.error,
-          })
-        }
+        yield* Effect.logWarning("connection unavailable", {
+          key,
+          type: mcp.type,
+          status: status.status,
+          ...("error" in status ? { error: status.error } : {}),
+        })
         return { status } satisfies CreateResult
       }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -458,18 +458,8 @@ export const layer = Layer.effect(
           : yield* connectLocal(key, mcp as ConfigMCPV1.Info & { type: "local" })
 
       if (!mcpClient) {
-        if (status.status === "failed") {
-          yield* Effect.logWarning("connection failed", { key, type: mcp.type, error: status.error })
-        }
-        if (status.status === "needs_auth") {
-          yield* Effect.logWarning("connection requires authentication", { key, type: mcp.type })
-        }
-        if (status.status === "needs_client_registration") {
-          yield* Effect.logWarning("connection requires client registration", {
-            key,
-            type: mcp.type,
-            error: status.error,
-          })
+        if (status.status !== "connected" && status.status !== "disabled") {
+          yield* Effect.logWarning("server unavailable", { key, type: mcp.type, status: status.status })
         }
         return { status } satisfies CreateResult
       }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -458,12 +458,19 @@ export const layer = Layer.effect(
           : yield* connectLocal(key, mcp as ConfigMCPV1.Info & { type: "local" })
 
       if (!mcpClient) {
-        yield* Effect.logWarning("connection unavailable", {
-          key,
-          type: mcp.type,
-          status: status.status,
-          ...("error" in status ? { error: status.error } : {}),
-        })
+        if (status.status === "failed") {
+          yield* Effect.logWarning("connection failed", { key, type: mcp.type, error: status.error })
+        }
+        if (status.status === "needs_auth") {
+          yield* Effect.logWarning("connection requires authentication", { key, type: mcp.type })
+        }
+        if (status.status === "needs_client_registration") {
+          yield* Effect.logWarning("connection requires client registration", {
+            key,
+            type: mcp.type,
+            error: status.error,
+          })
+        }
         return { status } satisfies CreateResult
       }
 


### PR DESCRIPTION
## Summary

- warn when an MCP server exhausts connection attempts and ends in `failed`
- warn when a server requires authentication or client registration
- keep intentionally disabled servers quiet while preserving existing connected logs

This makes MCP startup outcomes visible in logs instead of requiring `opencode mcp list` to diagnose them.

## Testing

- `bun test test/mcp/lifecycle.test.ts`
- `bun typecheck`
- verified `mcp list --print-logs --log-level WARN` emits one concise warning for a failed server