### PR TITLE
fix(plugin): skip cross-kind plugins in readV1Plugin detect mode

### DIFF
--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -281,6 +281,9 @@ export function readV1Plugin(
     throw new TypeError(`Plugin ${spec} must default export an object with ${kind}()`)
   }
   if (mode === "detect" && !("id" in value) && !("server" in value) && !("tui" in value)) return
+  // detect: skip plugins that don't have the requested kind
+  if (mode === "detect" && kind === "server" && !("server" in value)) return
+  if (mode === "detect" && kind === "tui" && !("tui" in value)) return
 
   const server = "server" in value ? value.server : undefined
   const tui = "tui" in value ? value.tui : undefined


### PR DESCRIPTION
### Issue for this PR

Closes # (no existing issue — this was discovered via canix config investigation)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The server plugin loader (`packages/opencode/src/plugin/index.ts`) calls `readV1Plugin(mod, spec, "server", "detect")` for every plugin in the user's config. When a TUI-only plugin (one that exports `{ id, tui }` but not `server`) is configured via `settings.plugin`, the existing detect-mode guard only short-circuits when all three fields (`id`, `server`, `tui`) are absent. Since `id` and `tui` are present, the function proceeds to the kind-specific check and throws:

```
TypeError: Plugin ... must default export an object with server()
```

This error is caught and logged at ERROR level by the server loader, which is both noisy and misleading — the plugin is not a server plugin, it just happens to be configured in the same `plugin` array.

The fix adds two short-circuit guards after the existing detect check that also return early when the plugin lacks the field for the requested kind. This is safe because:

- A plugin with only `server` is correctly skipped when `kind = "tui"` (previously it would have been caught by the `tui === undefined` check)
- A plugin with only `tui` is correctly skipped when `kind = "server"` (the crash case being fixed)
- A plugin with both `server` and `tui` is still rejected at line 293 (plugins must export one or the other, not both)
- A plugin with neither `id`, `server`, nor `tui` still returns at line 283

### How did you verify your code works?

- Ran `bun test test/plugin/shared.test.ts test/plugin/loader-shared.test.ts` — 40 pass, 0 fail.
- Manually traced the detect-mode control flow for each combination of (`kind`, `server`, `tui`, `id`) to confirm early-return behavior matches expectations.

### Screenshots / recordings

N/A — logic-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR