### PR TITLE
fix(opencode): bundle fff native library

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -914,6 +914,7 @@
   "patchedDependencies": {
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "virtua@0.49.1": "patches/virtua@0.49.1.patch",
+    "@ff-labs/fff-bun@0.9.3": "patches/@ff-labs%2Ffff-bun@0.9.3.patch",
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
     "@ai-sdk/google@3.0.73": "patches/@ai-sdk%2Fgoogle@3.0.73.patch",
     "@ai-sdk/xai@3.0.82": "patches/@ai-sdk%2Fxai@3.0.82.patch",

--- a/bun.lock
+++ b/bun.lock
@@ -525,6 +525,7 @@
         "@clack/prompts": "1.0.0-alpha.1",
         "@effect/opentelemetry": "catalog:",
         "@effect/platform-node": "catalog:",
+        "@ff-labs/fff-bun": "0.9.3",
         "@gitlab/opencode-gitlab-auth": "1.3.3",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@octokit/graphql": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "@types/node": "catalog:"
   },
   "patchedDependencies": {
+    "@ff-labs/fff-bun@0.9.3": "patches/@ff-labs%2Ffff-bun@0.9.3.patch",
     "@npmcli/agent@4.0.2": "patches/@npmcli%2Fagent@4.0.2.patch",
     "@silvia-odwyer/photon-node@0.3.4": "patches/@silvia-odwyer%2Fphoton-node@0.3.4.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -78,6 +78,7 @@
     "@clack/prompts": "1.0.0-alpha.1",
     "@effect/opentelemetry": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@ff-labs/fff-bun": "0.9.3",
     "@gitlab/opencode-gitlab-auth": "1.3.3",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@octokit/graphql": "9.0.2",

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -165,7 +165,7 @@ for (const item of targets) {
   const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
 
   await Bun.build({
-    conditions: ["node"],
+    conditions: ["bun", "node"],
     tsconfig: "./tsconfig.json",
     plugins: [plugin],
     external: ["node-gyp"],

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -140,6 +140,7 @@ const binaries: Record<string, string> = {}
 if (!skipInstall) {
   await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
   await $`bun install --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
+  await $`bun install --os="*" --cpu="*" @ff-labs/fff-bun@${pkg.dependencies["@ff-labs/fff-bun"]}`
 }
 for (const item of targets) {
   const name = [
@@ -186,6 +187,7 @@ for (const item of targets) {
     files: embeddedFileMap ? { "opencode-web-ui.gen.ts": embeddedFileMap } : {},
     entrypoints: ["./src/index.ts", parserWorker, workerPath, ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
     define: {
+      FFF_LIBC: JSON.stringify(item.abi === "musl" ? "musl" : "gnu"),
       OPENCODE_VERSION: `'${Script.version}'`,
       OPENCODE_MODELS_DEV: generated.modelsData,
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,

--- a/patches/@ff-labs%2Ffff-bun@0.9.3.patch
+++ b/patches/@ff-labs%2Ffff-bun@0.9.3.patch
@@ -2,15 +2,16 @@ diff --git a/src/download.ts b/src/download.ts
 index 3454256..6dca25a 100644
 --- a/src/download.ts
 +++ b/src/download.ts
-@@ -7,7 +7,6 @@
+@@ -7,7 +7,7 @@
   */
  
++declare const FFF_LIBC: "gnu" | "musl";
  import { existsSync } from "node:fs";
 -import { createRequire } from "node:module";
  import { dirname, join } from "node:path";
  import { fileURLToPath } from "node:url";
  import { getLibFilename, getNpmPackageName } from "./platform";
-@@ -54,14 +53,14 @@ export function binaryExists(): boolean {
+@@ -54,14 +54,10 @@ export function binaryExists(): boolean {
   * in the same directory.
   */
  function resolveFromNpmPackage(): string | null {
@@ -22,13 +23,9 @@ index 3454256..6dca25a 100644
 -    const packageJsonPath = require.resolve(`${packageName}/package.json`);
 -    const packageDir = dirname(packageJsonPath);
 -    const binaryPath = join(packageDir, getLibFilename());
-+    const binaryPath = process.platform === "win32"
-+      ? require(`../../../../../@ff-labs+fff-bin-win32-${process.arch}@0.9.3/node_modules/@ff-labs/fff-bin-win32-${process.arch}/fff_c.dll`)
-+      : process.platform === "darwin"
-+        ? require(`../../../../../@ff-labs+fff-bin-darwin-${process.arch}@0.9.3/node_modules/@ff-labs/fff-bin-darwin-${process.arch}/libfff_c.dylib`)
-+        : getNpmPackageName().endsWith("musl")
-+          ? require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-musl@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-musl/libfff_c.so`)
-+          : require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-gnu@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-gnu/libfff_c.so`);
++    const binaryPath = require(
++      `@ff-labs/fff-bin-${process.platform === "linux" ? `linux-${process.arch}-${typeof FFF_LIBC === "string" ? FFF_LIBC : getNpmPackageName().endsWith("musl") ? "musl" : "gnu"}` : `${process.platform}-${process.arch}`}/${process.platform === "win32" ? "fff_c.dll" : process.platform === "darwin" ? "libfff_c.dylib" : "libfff_c.so"}`,
++    );
  
      if (existsSync(binaryPath)) {
        return binaryPath;

--- a/patches/@ff-labs%2Ffff-bun@0.9.3.patch
+++ b/patches/@ff-labs%2Ffff-bun@0.9.3.patch
@@ -1,0 +1,34 @@
+diff --git a/src/download.ts b/src/download.ts
+index 3454256..6dca25a 100644
+--- a/src/download.ts
++++ b/src/download.ts
+@@ -7,7 +7,6 @@
+  */
+ 
+ import { existsSync } from "node:fs";
+-import { createRequire } from "node:module";
+ import { dirname, join } from "node:path";
+ import { fileURLToPath } from "node:url";
+ import { getLibFilename, getNpmPackageName } from "./platform";
+@@ -54,14 +53,14 @@ export function binaryExists(): boolean {
+  * in the same directory.
+  */
+ function resolveFromNpmPackage(): string | null {
+-  const packageName = getNpmPackageName();
+-
+   try {
+-    // Use createRequire to resolve the platform package's location
+-    const require = createRequire(join(getPackageDir(), "package.json"));
+-    const packageJsonPath = require.resolve(`${packageName}/package.json`);
+-    const packageDir = dirname(packageJsonPath);
+-    const binaryPath = join(packageDir, getLibFilename());
++    const binaryPath = process.platform === "win32"
++      ? require(`../../../../../@ff-labs+fff-bin-win32-${process.arch}@0.9.3/node_modules/@ff-labs/fff-bin-win32-${process.arch}/fff_c.dll`)
++      : process.platform === "darwin"
++        ? require(`../../../../../@ff-labs+fff-bin-darwin-${process.arch}@0.9.3/node_modules/@ff-labs/fff-bin-darwin-${process.arch}/libfff_c.dylib`)
++        : getNpmPackageName().endsWith("musl")
++          ? require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-musl@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-musl/libfff_c.so`)
++          : require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-gnu@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-gnu/libfff_c.so`);
+ 
+     if (existsSync(binaryPath)) {
+       return binaryPath;

--- a/patches/@ff-labs%2Ffff-bun@0.9.3.patch
+++ b/patches/@ff-labs%2Ffff-bun@0.9.3.patch
@@ -2,18 +2,10 @@ diff --git a/src/download.ts b/src/download.ts
 index 3454256..6dca25a 100644
 --- a/src/download.ts
 +++ b/src/download.ts
-@@ -7,7 +7,6 @@
-  */
- 
+@@ -9,2 +9 @@
  import { existsSync } from "node:fs";
 -import { createRequire } from "node:module";
- import { dirname, join } from "node:path";
- import { fileURLToPath } from "node:url";
- import { getLibFilename, getNpmPackageName } from "./platform";
-@@ -54,14 +53,14 @@ export function binaryExists(): boolean {
-  * in the same directory.
-  */
- function resolveFromNpmPackage(): string | null {
+@@ -56,8 +55,8 @@ function resolveFromNpmPackage(): string | null {
 -  const packageName = getNpmPackageName();
 -
    try {
@@ -29,6 +21,3 @@ index 3454256..6dca25a 100644
 +        : getNpmPackageName().endsWith("musl")
 +          ? require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-musl@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-musl/libfff_c.so`)
 +          : require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-gnu@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-gnu/libfff_c.so`);
- 
-     if (existsSync(binaryPath)) {
-       return binaryPath;

--- a/patches/@ff-labs%2Ffff-bun@0.9.3.patch
+++ b/patches/@ff-labs%2Ffff-bun@0.9.3.patch
@@ -2,10 +2,18 @@ diff --git a/src/download.ts b/src/download.ts
 index 3454256..6dca25a 100644
 --- a/src/download.ts
 +++ b/src/download.ts
-@@ -9,2 +9 @@
+@@ -7,7 +7,6 @@
+  */
+ 
  import { existsSync } from "node:fs";
 -import { createRequire } from "node:module";
-@@ -56,8 +55,8 @@ function resolveFromNpmPackage(): string | null {
+ import { dirname, join } from "node:path";
+ import { fileURLToPath } from "node:url";
+ import { getLibFilename, getNpmPackageName } from "./platform";
+@@ -54,14 +53,14 @@ export function binaryExists(): boolean {
+  * in the same directory.
+  */
+ function resolveFromNpmPackage(): string | null {
 -  const packageName = getNpmPackageName();
 -
    try {
@@ -21,3 +29,6 @@ index 3454256..6dca25a 100644
 +        : getNpmPackageName().endsWith("musl")
 +          ? require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-musl@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-musl/libfff_c.so`)
 +          : require(`../../../../../@ff-labs+fff-bin-linux-${process.arch}-gnu@0.9.3/node_modules/@ff-labs/fff-bin-linux-${process.arch}-gnu/libfff_c.so`);
+ 
+     if (existsSync(binaryPath)) {
+       return binaryPath;


### PR DESCRIPTION
## Summary

- select the Bun filesystem implementation while retaining Node package conditions
- patch `@ff-labs/fff-bun` to expose its platform library through statically analyzable relative `require(...)` templates
- embed the FFF native library in compiled standalone binaries

## Verification

- `bun typecheck` from `packages/opencode`
- `bun run script/build.ts --single --skip-install --skip-embed-web-ui`
- started the compiled binary with `serve --print-logs` in tmux
- requested `GET /find/file?query=build.ts` and received HTTP 200 with FFF results
- confirmed no adjacent `libfff_c.so` is required

## Notes

`git diff --check` reports the two blank unified-diff context lines inside the Bun dependency patch. Those leading spaces are required by Bun's patch parser; removing them makes `bun install` reject the patch.