### PR TITLE
docs(ecosystem): add Hindsight memory plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [@vectorize-io/opencode-hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/opencode) | Persistent long-term memory across sessions via Hindsight, with auto-retain and recall on session start |
 
 ---
 


### PR DESCRIPTION
Adds [`@vectorize-io/opencode-hindsight`](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/opencode) to the Plugins list on the ecosystem page.

It gives OpenCode persistent long-term memory across sessions via [Hindsight](https://github.com/vectorize-io/hindsight) — auto-retain on session idle, and memory recall injected at session start. Published on npm; same category as the existing `opencode-supermemory` entry.

One-line docs change.