### PR TITLE
fix(web): set locale cookie on language picker change

### DIFF
--- a/packages/web/src/components/Footer.astro
+++ b/packages/web/src/components/Footer.astro
@@ -63,6 +63,17 @@ const discord = config.social?.find((item) => item.icon === "discord")
   )
 }
 
+<script>
+  const locales = new Set(["ar","bs","da","de","es","fr","it","ja","ko","nb","pl","pt-br","ru","th","tr","uk","zh-cn","zh-tw"])
+  document.querySelectorAll<HTMLSelectElement>("starlight-lang-select select").forEach((el) => {
+    el.addEventListener("change", () => {
+      const m = /^\/docs\/([^/]+)(?:\/|$)/.exec(el.value)
+      const locale = m && locales.has(m[1]) ? m[1] : "en"
+      document.cookie = `oc_locale=${encodeURIComponent(locale)};path=/;max-age=31536000;samesite=lax`
+    })
+  })
+</script>
+
 <style>
   footer.doc {
     margin-top: 3rem;


### PR DESCRIPTION
### Issue for this PR

Closes #29326

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The language picker in the docs footer navigates to the correct URL but never sets the `oc_locale` cookie. So on the next visit to `/docs`, the middleware reads `Accept-Language` instead of the user's choice and redirects back to whatever language the browser prefers.

Added a small `<script>` to `Footer.astro` that listens for changes on the Starlight language select and writes the `oc_locale` cookie with the same format the middleware expects. It checks the URL path segment against the known locale list so English (which has no path prefix) correctly maps to `en`.

### How did you verify your code works?

Ran `astro check` and `oxlint`, no new errors. Traced the cookie format against `middleware.ts:cookie()` to confirm they match (same name, encoding, path, max-age, samesite).

### Screenshots / recordings

N/A, no visual change, just cookie behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR