### PR TITLE
fix(tui): let gutter replace current marker

### DIFF
--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -669,7 +669,7 @@ function Option(props: {
 
   return (
     <>
-      <Show when={props.current}>
+      <Show when={props.current && !props.gutter}>
         <text flexShrink={0} fg={text()} marginRight={0}>
           ●
         </text>


### PR DESCRIPTION
## Summary
- render a select option gutter instead of the current-selection dot
- prevent running session spinners from being pushed over by the selected marker

## Testing
- `bun typecheck` in `packages/tui`