### PR TITLE
refactor(app): use v2 filesystem search for pickers

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -25,6 +25,7 @@ import { useServerSDK } from "./server-sdk"
 import { SessionRouteKey, SessionStateKey } from "@/utils/server-scope"
 import { createFileTreeStore } from "./file/tree-store"
 import { invalidateFromWatcher } from "./file/watcher"
+import { searchFiles } from "./file/search"
 import {
   selectionFromLines,
   type FileState,
@@ -199,11 +200,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       return promise
     }
 
-    const search = (query: string, dirs: "true" | "false") =>
-      sdk.client.find.files({ query, dirs }).then(
-        (x) => (x.data ?? []).map(path.normalize),
-        () => [],
-      )
+    const search = (query: string, type?: "file") => searchFiles(sdk.client, path.normalize, query, type)
 
     const stop = sdk.event.listen((e) => {
       invalidateFromWatcher(e.details, {
@@ -278,8 +275,8 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       setScrollLeft,
       selectedLines,
       setSelectedLines,
-      searchFiles: (query: string) => search(query, "false"),
-      searchFilesAndDirectories: (query: string) => search(query, "true"),
+      searchFiles: (query: string) => search(query, "file"),
+      searchFilesAndDirectories: (query: string) => search(query),
     }
   },
 })

--- a/packages/app/src/context/file/search.test.ts
+++ b/packages/app/src/context/file/search.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { searchFiles } from "./search"
+
+describe("file search", () => {
+  test("maps v2 filesystem entries without changing backend order", async () => {
+    const requests: unknown[] = []
+    const client = {
+      v2: {
+        fs: {
+          find: async (input: unknown) => {
+            requests.push(input)
+            return {
+              data: {
+                data: [{ path: "src\\second.ts" }, { path: "src/first.ts" }],
+              },
+            }
+          },
+        },
+      },
+    }
+
+    const result = await searchFiles(client, (path) => path.replaceAll("\\", "/"), "src", "file")
+
+    expect(requests).toEqual([{ query: "src", type: "file", limit: "10" }])
+    expect(result).toEqual(["src/second.ts", "src/first.ts"])
+  })
+
+  test("searches files and directories without a type restriction", async () => {
+    const requests: unknown[] = []
+    const client = {
+      v2: {
+        fs: {
+          find: async (input: unknown) => {
+            requests.push(input)
+            return { data: { data: [] } }
+          },
+        },
+      },
+    }
+
+    await searchFiles(client, (path) => path, "src")
+
+    expect(requests).toEqual([{ query: "src", type: undefined, limit: "10" }])
+  })
+
+  test("returns no results when search fails", async () => {
+    const client = {
+      v2: {
+        fs: {
+          find: async () => {
+            throw new Error("offline")
+          },
+        },
+      },
+    }
+
+    expect(await searchFiles(client, (path) => path, "src")).toEqual([])
+  })
+})

--- a/packages/app/src/context/file/search.ts
+++ b/packages/app/src/context/file/search.ts
@@ -1,0 +1,21 @@
+type FileSearchClient = {
+  v2: {
+    fs: {
+      find: (input: { query: string; type?: "file"; limit: string }) => Promise<{
+        data?: { data: readonly { path: string }[] }
+      }>
+    }
+  }
+}
+
+export function searchFiles(
+  client: FileSearchClient,
+  normalize: (path: string) => string,
+  query: string,
+  type?: "file",
+) {
+  return client.v2.fs.find({ query, type, limit: "10" }).then(
+    (response) => (response.data?.data ?? []).map((entry) => normalize(entry.path)),
+    () => [],
+  )
+}


### PR DESCRIPTION
## Summary
- migrate shared app file pickers from the legacy find endpoint to v2.fs.find
- centralize response mapping and preserve backend ordering, path normalization, and the existing result limit
- retain file-only and mixed file/directory search semantics

## Testing
- bun test:unit (packages/app)
- bun typecheck (packages/app)
- repository pre-push typecheck (23 packages)
- manual desktop verification of picker search