### PR TITLE
fix: output error message in CLI .fail() handler

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -108,6 +108,8 @@ const cli = yargs(args)
       msg?.startsWith("Invalid values:")
     ) {
       if (err) throw err
+      process.stderr.write(UI.logo() + EOL + EOL)
+      process.stderr.write(msg + EOL + EOL)
       cli.showHelp(show)
     }
     if (err) throw err


### PR DESCRIPTION
## Problem

The CLI `.fail()` handler swallows the error message from yargs. When a user runs `opencode --unkown-flag`, the output is identical to `opencode --help` — the error message is never displayed, so the user has no idea what went wrong.

The issue is in `packages/opencode/src/index.ts:181-192`. The `.fail()` handler calls `cli.showHelp(show)` but never outputs `msg`.

## Fix

Output the error message to stderr (with the logo) before calling `cli.showHelp(show)`. This way the user sees both the error reason and the help text.

**Before:**
```
$ opencode --unkown-flag
# Shows help text only — no error message
```

**After:**
```
$ opencode --unkown-flag
# Shows logo + "Unknown argument: unkown-flag" + help text
```

## Testing

- `opencode --unkown-flag` → shows error message followed by help
- `opencode --help` → unchanged behavior
- `opencode run` → unchanged behavior

Closes #29390