### PR TITLE
fix(opencode): start git HEAD watcher at instance bootstrap

### DIFF
--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -3,14 +3,17 @@ export * as Watcher from "./watcher"
 // @ts-ignore
 import { createWrapper } from "@parcel/watcher/wrapper"
 import type ParcelWatcher from "@parcel/watcher"
-import { Cause, Context, Effect, Layer, Schema } from "effect"
+import { Cause, Context, Effect, Layer, LayerMap, Schema } from "effect"
 import path from "path"
 import { Config } from "../config"
+import { LayerNode } from "../effect/layer-node"
 import { EventV2 } from "../event"
 import { Flag } from "../flag/flag"
 import { FSUtil } from "../fs-util"
 import { Git } from "../git"
+import { Global } from "../global"
 import { Location } from "../location"
+import { Project } from "../project"
 import { lazy } from "../util/lazy"
 import { Ignore } from "./ignore"
 import { Protected } from "./protected"
@@ -140,3 +143,20 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer.pipe(Layer.provide(Config.locationLayer), Layer.provide(Git.defaultLayer))
+
+// Watchers keyed by location so every consumer of a directory shares one
+// subscription. Entries are refcounted: holders keep them alive (e.g. an
+// instance holding its .git/HEAD watch) and idle entries expire.
+export class ServiceMap extends LayerMap.Service<ServiceMap>()("@opencode/v2/FileWatcherMap", {
+  lookup: (ref: Location.Ref) => locationLayer.pipe(Layer.provide(Location.layer(ref))),
+  idleTimeToLive: "60 minutes",
+  dependencies: [
+    Project.defaultLayer,
+    EventV2.defaultLayer,
+    FSUtil.defaultLayer,
+    Global.defaultLayer,
+    Git.defaultLayer,
+  ],
+}) {}
+
+export const node = LayerNode.make(ServiceMap.layer, [])

--- a/packages/core/src/location-layer.ts
+++ b/packages/core/src/location-layer.ts
@@ -58,7 +58,7 @@ export class LocationServiceMap extends LayerMap.Service<LocationServiceMap>()("
       AgentV2.locationLayer,
       PluginBoot.locationLayer,
       FileSystem.locationLayer,
-      Watcher.locationLayer,
+      Watcher.ServiceMap.get({ directory: ref.directory }),
       Pty.locationLayer,
       SkillV2.locationLayer,
       systemContext,
@@ -113,5 +113,6 @@ export class LocationServiceMap extends LayerMap.Service<LocationServiceMap>()("
     FetchHttpClient.layer,
     ToolOutputStore.defaultCleanupLayer,
     ApplicationTools.layer,
+    Watcher.ServiceMap.layer,
   ],
 }) {}

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -6,6 +6,7 @@ import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { Git } from "@/git"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { EventV2 } from "@opencode-ai/core/event"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 
 const PATCH_CONTEXT_LINES = 2_147_483_647
 const MAX_PATCH_BYTES = 10_000_000
@@ -301,11 +302,14 @@ interface State {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Vcs") {}
 
-export const layer: Layer.Layer<Service, never, Git.Service | EventV2Bridge.Service> = Layer.effect(
+type Requirements = Git.Service | EventV2Bridge.Service | Watcher.ServiceMap
+
+export const layer: Layer.Layer<Service, never, Requirements> = Layer.effect(
   Service,
   Effect.gen(function* () {
     const git = yield* Git.Service
     const events = yield* EventV2Bridge.Service
+    const watchers = yield* Watcher.ServiceMap
     const scope = yield* Scope.Scope
 
     const state = yield* InstanceState.make<State>(
@@ -313,6 +317,13 @@ export const layer: Layer.Layer<Service, never, Git.Service | EventV2Bridge.Serv
         if (ctx.project.vcs !== "git") {
           return { current: undefined, root: undefined }
         }
+
+        // Nothing builds the file watcher for an idle instance, so hold one for
+        // the instance lifetime to keep .git/HEAD updates flowing (#30956).
+        yield* watchers.contextEffect({ directory: AbsolutePath.make(ctx.directory) }).pipe(
+          Effect.catchCause((cause) => Effect.logWarning("failed to start file watcher", { cause })),
+          Effect.forkScoped,
+        )
 
         const get = Effect.fnUntraced(function* () {
           return yield* git.branch(ctx.directory)
@@ -424,8 +435,12 @@ export const layer: Layer.Layer<Service, never, Git.Service | EventV2Bridge.Serv
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(Git.defaultLayer), Layer.provide(EventV2Bridge.defaultLayer))
+export const defaultLayer = layer.pipe(
+  Layer.provide(Git.defaultLayer),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(Watcher.ServiceMap.layer),
+)
 
-export const node = LayerNode.make(layer, [Git.node, EventV2Bridge.node])
+export const node = LayerNode.make(layer, [Git.node, EventV2Bridge.node, Watcher.node])
 
 export * as Vcs from "./vcs"

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -25,7 +25,11 @@ import { testEffect } from "../lib/effect"
 const weird = process.platform === "win32" ? "space file.txt" : "tab\tfile.txt"
 
 const layer = Layer.mergeAll(
-  Vcs.layer.pipe(Layer.provideMerge(Git.defaultLayer), Layer.provideMerge(EventV2Bridge.defaultLayer)),
+  Vcs.layer.pipe(
+    Layer.provideMerge(Git.defaultLayer),
+    Layer.provideMerge(EventV2Bridge.defaultLayer),
+    Layer.provideMerge(Watcher.ServiceMap.layer),
+  ),
   CrossSpawnSpawner.defaultLayer,
   FSUtil.defaultLayer,
 )


### PR DESCRIPTION
### Issue for this PR

Closes #30956
Closes #31469

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Since v1.16.0 the branch name in the TUI footer stops updating when you `git checkout` outside opencode.

Root cause: in 1.16.0 the file watcher moved from instance bootstrap (`FileWatcher.init()` in `project/bootstrap.ts`) into the location services (`Watcher.locationLayer` inside `LocationServiceMap`). Location services are only built when something needs them — the `/file` or pty endpoints, or a tool run. An idle instance never builds them, so nothing watches `.git/HEAD`, `Vcs` never notices the branch change, and `vcs.branch.updated` is never published. The `/vcs` endpoint also keeps returning the stale cached branch. This is why the footer recovers "sometimes": the first tool run happens to build the location services and the watcher comes up as a side effect.

The fix adds `Watcher.ServiceMap`, a `LayerMap` keyed by location, and has `Vcs` hold the entry for its directory for the instance lifetime, so the `.git/HEAD` watch starts at bootstrap again. `LocationServiceMap` reuses the same map entry instead of building its own `Watcher.locationLayer`, so a directory still gets exactly one filesystem subscription no matter how many consumers are up. The hold is forked and failures only log a warning, so vcs init latency and error behaviour are unchanged.

### How did you verify your code works?

- Reproduced before the fix: started `opencode serve` against a fresh git repo and hit every endpoint the TUI calls at startup (`/vcs`, `/config`, `/lsp`, ...) — no watcher started, `git checkout` produced no `vcs.branch.updated`, and `/vcs` kept returning the old branch. Only after `GET /file` (which builds the location services) did updates start flowing.
- After the fix: creating the instance alone starts the watcher ("watcher backend" appears in logs), `git checkout` emits `vcs.branch.updated` within a second, and `/vcs` returns the new branch.
- Dedup check: hitting `/file` afterwards does not start a second watcher (still one "watcher backend" log line), and two branch switches produce exactly two events.
- `bun test test/project/vcs.test.ts` passes repeatedly (12/12); `test/control-plane/workspace.test.ts` (35 tests) and `test/plugin/workspace-adapter.test.ts` pass; typecheck passes for `core` and `opencode`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
