### PR TITLE
fix(session): preserve model message cache snapshots

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -10,7 +10,7 @@ import { Session } from "./session"
 import { Agent } from "../agent/agent"
 import { Provider } from "@/provider/provider"
 
-import { type Tool as AITool, tool, jsonSchema } from "ai"
+import { type ModelMessage, type Tool as AITool, tool, jsonSchema } from "ai"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import { SessionCompaction } from "./compaction"
 import { SystemPrompt } from "./system"
@@ -83,6 +83,48 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   return part.state.status === "error" && part.state.metadata?.interrupted === true
 }
 
+export type PromptModelSnapshot = {
+  modelKey: string
+  messageIDs: Set<MessageID>
+  modelMessages: ModelMessage[]
+}
+
+function promptModelKey(model: Provider.Model) {
+  return `${model.providerID}/${model.id}`
+}
+
+export function appendOnlyModelMessages(input: {
+  snapshot: PromptModelSnapshot | undefined
+  messages: SessionV1.WithParts[]
+  model: Provider.Model
+}) {
+  return Effect.gen(function* () {
+    const modelKey = promptModelKey(input.model)
+    if (!input.snapshot || input.snapshot.modelKey !== modelKey) {
+      const modelMessages = yield* Effect.promise(() => MessageV2.toModelMessages(input.messages, input.model))
+      return {
+        modelMessages,
+        snapshot: {
+          modelKey,
+          messageIDs: new Set(input.messages.map((message) => message.info.id)),
+          modelMessages: structuredClone(modelMessages),
+        },
+      }
+    }
+
+    const newMessages = input.messages.filter((message) => !input.snapshot?.messageIDs.has(message.info.id))
+    const newModelMessages = yield* Effect.promise(() => MessageV2.toModelMessages(newMessages, input.model))
+    const modelMessages = [...structuredClone(input.snapshot.modelMessages), ...newModelMessages]
+    return {
+      modelMessages,
+      snapshot: {
+        modelKey,
+        messageIDs: new Set(input.messages.map((message) => message.info.id)),
+        modelMessages: structuredClone(modelMessages),
+      },
+    }
+  })
+}
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
@@ -1136,6 +1178,7 @@ export const layer = Layer.effect(
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
+        let promptSnapshot: PromptModelSnapshot | undefined
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1196,6 +1239,7 @@ export const layer = Layer.effect(
 
           if (task?.type === "subtask") {
             yield* handleSubtask({ task, model, lastUser, sessionID, session, msgs })
+            promptSnapshot = undefined
             continue
           }
 
@@ -1208,6 +1252,7 @@ export const layer = Layer.effect(
               overflow: task.overflow,
             })
             if (result === "stop") break
+            promptSnapshot = undefined
             continue
           }
 
@@ -1217,6 +1262,7 @@ export const layer = Layer.effect(
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
             yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+            promptSnapshot = undefined
             continue
           }
 
@@ -1324,12 +1370,14 @@ export const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, modelMsgs] = yield* Effect.all([
+            const [skills, env, instructions, promptMessages] = yield* Effect.all([
               sys.skills(agent),
               sys.environment(model),
               instruction.system().pipe(Effect.orDie),
-              MessageV2.toModelMessagesEffect(msgs, model),
+              appendOnlyModelMessages({ snapshot: promptSnapshot, messages: msgs, model }),
             ])
+            promptSnapshot = promptMessages.snapshot
+            const modelMsgs = promptMessages.modelMessages
             const system = [...env, ...instructions, ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
@@ -1374,6 +1422,7 @@ export const layer = Layer.effect(
                 auto: true,
                 overflow: !handle.message.finish,
               })
+              promptSnapshot = undefined
             }
             return "continue" as const
           }).pipe(

--- a/packages/opencode/test/session/prompt-cache-snapshot.test.ts
+++ b/packages/opencode/test/session/prompt-cache-snapshot.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import type { Provider } from "@/provider/provider"
+import { appendOnlyModelMessages } from "../../src/session/prompt"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+
+const sessionID = SessionID.make("session")
+const providerID = ProviderV2.ID.make("test")
+const model: Provider.Model = {
+  id: ModelV2.ID.make("test-model"),
+  providerID,
+  api: {
+    id: "test-model",
+    url: "https://example.com",
+    npm: "@ai-sdk/openai",
+  },
+  name: "Test Model",
+  capabilities: {
+    temperature: true,
+    reasoning: false,
+    attachment: false,
+    toolcall: true,
+    input: { text: true, audio: false, image: false, video: false, pdf: false },
+    output: { text: true, audio: false, image: false, video: false, pdf: false },
+    interleaved: false,
+  },
+  cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+  limit: { context: 0, input: 0, output: 0 },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2026-01-01",
+}
+
+function userInfo(id: string): SessionV1.User {
+  return {
+    id: MessageID.make(id),
+    sessionID,
+    role: "user",
+    time: { created: 0 },
+    agent: "user",
+    model: { providerID, modelID: ModelV2.ID.make("test") },
+    tools: {},
+    mode: "",
+  } as unknown as SessionV1.User
+}
+
+function textMessage(messageID: string, partID: string, text: string): SessionV1.WithParts {
+  return {
+    info: userInfo(messageID),
+    parts: [
+      {
+        id: PartID.make(partID),
+        sessionID,
+        messageID: MessageID.make(messageID),
+        type: "text",
+        text,
+      },
+    ] as SessionV1.Part[],
+  }
+}
+
+describe("session.prompt.appendOnlyModelMessages", () => {
+  test("preserves previously serialized model messages after source messages mutate", async () => {
+    const firstMessage = textMessage("msg_first", "prt_first", "stable prefix")
+    const secondMessage = textMessage("msg_second", "prt_second", "new suffix")
+
+    const first = await Effect.runPromise(
+      appendOnlyModelMessages({ snapshot: undefined, messages: [firstMessage], model }),
+    )
+
+    const firstText = firstMessage.parts.find((part): part is SessionV1.TextPart => part.type === "text")
+    expect(firstText).toBeDefined()
+    if (firstText) firstText.text = "mutated prefix"
+
+    const second = await Effect.runPromise(
+      appendOnlyModelMessages({ snapshot: first.snapshot, messages: [firstMessage, secondMessage], model }),
+    )
+
+    expect(second.modelMessages).toStrictEqual([
+      { role: "user", content: [{ type: "text", text: "stable prefix" }] },
+      { role: "user", content: [{ type: "text", text: "new suffix" }] },
+    ])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #25366
Closes #24841

Related: #14743
Supersedes the closed/unmerged approach in #25367 with a model-message snapshot instead of preserving mutable DB message objects.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Tool-call continuation steps can mutate message parts that have already been sent to the model. The prompt loop then rebuilds the full model-message list from the current DB state, so the already-sent prefix can serialize differently on the next provider request. For Anthropic/Claude this can invalidate the prompt-cache prefix after tool calls and force large cache writes again.

This PR keeps a per-loop snapshot of the serialized model messages. After the first model request in a loop, later continuation steps reuse the serialized prefix from that snapshot and only convert/append newly-created messages. That preserves byte identity for messages the provider has already seen while still allowing the suffix to grow normally.

The snapshot is reset when OpenCode intentionally rewrites conversation structure:
- subtask handling
- explicit compaction tasks
- automatic overflow compaction
- model changes

This targets the tool-call continuation cache bust described in #25366 and #24841. It is complementary to #14743, which improves earlier system/tool-prefix stability but does not preserve already-sent message serialization across prompt-loop continuations.

### How did you verify your code works?

- `bun test test/session/prompt-cache-snapshot.test.ts`
- `bun run typecheck` from `packages/opencode`

The regression mutates a source message after it has been snapshotted, then verifies that the next model-message list keeps the original serialized prefix and appends only the new suffix.

### Screenshots / recordings

N/A - no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR