### PR TITLE
fix(docker): handle sigterm & sigint

### DIFF
--- a/packages/opencode/Dockerfile
+++ b/packages/opencode/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine AS base
 # On ephemeral containers, the cache is not useful
 ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
 ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
-RUN apk add libgcc libstdc++ ripgrep
+RUN apk add libgcc libstdc++ ripgrep tini
 
 FROM base AS build-amd64
 COPY dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
@@ -15,4 +15,7 @@ COPY dist/opencode-linux-arm64-musl/bin/opencode /usr/local/bin/opencode
 ARG TARGETARCH
 FROM build-${TARGETARCH}
 RUN opencode --version
-ENTRYPOINT ["opencode"]
+# Run under tini as PID 1 so SIGINT/SIGTERM are forwarded to opencode and
+# zombies are reaped. Without an init, PID 1 ignores signals that have no
+# explicit handler (e.g. `serve`), so `^C` / `docker stop` would hang.
+ENTRYPOINT ["tini", "--", "opencode"]


### PR DESCRIPTION
### Issue for this PR

- Fixes #12439 - but doesn't fix the `opencode web` issue of `error: Executable not found in $PATH: "xdg-open"`


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Currently running `docker run -it ghcr.io/anomalyco/opencode serve` never always the process to be gracefully closed with SIGTERM and handles forever. This is because it runs as the `ENTRYPOINT` on PID 1 with no process handler. 

Running with docker flag `--init` does fix it but this is only for the docker runner and isn't cross platform (e.g. kubernetes).

Instead we bake tini into the image which handles signal forwarding and child reaping.

### How did you verify your code works?

```sh
~/WEBDEV/tmp/opencode/packages/opencode 11s ❯ docker buildx build --platform linux/arm64 -t opencode-test --load .
[+] Building 0.7s (10/10) FINISHED                                   docker-container:mybuilder
 => [internal] load build definition from Dockerfile                                       0.0s
 => => transferring dockerfile: 870B                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                           0.3s
 => [internal] load .dockerignore                                                          0.0s
 => => transferring context: 2B                                                            0.0s
 => [base 1/2] FROM docker.io/library/alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e  0.0s
 => => resolve docker.io/library/alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e  0.0s
 => [internal] load build context                                                          0.0s
 => => transferring context: 195B                                                          0.0s
 => CACHED [base 2/2] RUN apk add libgcc libstdc++ ripgrep tini                            0.0s
 => CACHED [build-arm64 1/1] COPY dist/opencode-linux-arm64-musl/bin/opencode /usr/local/  0.0s
 => CACHED [stage-3 1/1] RUN opencode --version                                            0.0s
 => exporting to docker image format                                                       0.2s
 => => exporting layers                                                                    0.0s
 => => exporting manifest sha256:f68e6670a7e68fc1798eb39e5a89c56396a8d2c65247ec39e47c6f75  0.0s
 => => exporting config sha256:cc45a97f594b9108cb6c660778b629c5e35fc10e3a2e3b0da1e4d2a10e  0.0s
 => => sending tarball                                                                     0.2s
 => importing to docker                                                                    0.0s

View build details: docker-desktop://dashboard/build/mybuilder/mybuilder0/pf4iengevap7kf510kmz97l17
~/WEBDEV/tmp/opencode/packages/opencode ❯ docker run -it opencode-test serve
Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.
opencode server listening on http://127.0.0.1:4096
^C⏎                                                                                             ~/WEBDEV/tmp/opencode/packages/opencode ❯
```

### Screenshots / recordings

_nil_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
