### PR TITLE
fix(desktop): timeout Store.load to recover from hung persistence

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -181,11 +181,21 @@ const createPlatform = (): Platform => {
         return store
       }
 
+      const STORE_LOAD_TIMEOUT_MS = 5_000
+
+      const loadStore = (name: string) =>
+        Promise.race([
+          Store.load(name),
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error(`Store.load(${name}) timed out`)), STORE_LOAD_TIMEOUT_MS)
+          }),
+        ])
+
       const getStore = (name: string) => {
         const cached = storeCache.get(name)
         if (cached) return cached
 
-        const store = Store.load(name).catch(() => {
+        const store = loadStore(name).catch(() => {
           const cached = memoryCache.get(name)
           if (cached) return cached
 


### PR DESCRIPTION
Fixes https://github.com/anomalyco/opencode/issues/31642

### Issue for this PR

Fixes #31642

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Wraps `Store.load(name)` in a 5 second `Promise.race` timeout in the desktop platform storage layer. If persistence hangs, the existing `.catch()` path still falls back to the in-memory store instead of blocking app startup forever.

### How did you verify your code works?

Reviewed the storage init path in `packages/desktop/src/index.tsx`. The timeout rejects into the same `.catch()` that already creates/returns the memory cache fallback — no new control flow beyond the race wrapper.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR