### PR TITLE
fix(app): extract message from structured API error responses

### DIFF
--- a/packages/app/src/utils/server-errors.test.ts
+++ b/packages/app/src/utils/server-errors.test.ts
@@ -96,8 +96,13 @@ describe("formatServerError", () => {
 
   test("falls back for unknown error objects and names", () => {
     expect(formatServerError({ name: "ServerTimeoutError", data: { seconds: 30 } }, language.t)).toBe(
-      "Erro desconhecido",
+      "ServerTimeoutError",
     )
+  })
+
+  test("extracts message from structured API error objects", () => {
+    expect(formatServerError({ data: { message: "  Sidecar unavailable  " } }, language.t)).toBe("Sidecar unavailable")
+    expect(formatServerError({ message: "Connection refused" }, language.t)).toBe("Connection refused")
   })
 
   test("formats provider model errors using provider/model", () => {

--- a/packages/app/src/utils/server-errors.ts
+++ b/packages/app/src/utils/server-errors.ts
@@ -30,6 +30,16 @@ export function formatServerError(error: unknown, translate?: Translator, fallba
   if (isProviderModelNotFoundErrorLike(error)) return parseReadableProviderModelNotFoundError(error, translate)
   if (error instanceof Error && error.message) return error.message
   if (typeof error === "string" && error) return error
+  if (typeof error === "object" && error !== null) {
+    const o = error as Record<string, unknown>
+    const data = o.data
+    if (typeof data === "object" && data !== null) {
+      const message = (data as Record<string, unknown>).message
+      if (typeof message === "string" && message.trim()) return message.trim()
+    }
+    if (typeof o.message === "string" && o.message.trim()) return o.message.trim()
+    if (typeof o.name === "string" && o.name !== "UnknownError") return o.name
+  }
   if (fallback) return fallback
   return tr(translate, "error.chain.unknown", "Unknown error")
 }


### PR DESCRIPTION
Fixes anomalyco/opencode#31643

### Issue for this PR

Fixes #31643

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Teaches `formatServerError` to read plain object shapes before falling back to "Unknown error": `data.message`, top-level `message`, and `name` (when not `UnknownError`). Sidecar/API errors often arrive as JSON objects, not `Error` instances.

### How did you verify your code works?

`bun test packages/app/src/utils/server-errors.test.ts` — added cases for structured objects and updated the existing unknown-object test.

### Screenshots / recordings

_N/A — error string only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR