### PR TITLE
feat: discover nested plugin index entrypoints under .opencode/plugin

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -273,14 +273,24 @@ export namespace Config {
 
   async function loadPlugin(dir: string) {
     const plugins: PluginSpec[] = []
+    const seen = new Set<string>()
+    const patterns = [
+      "{plugin,plugins}/*.{ts,js}",
+      "{plugin,plugins}/*/index.{ts,js}",
+      "{plugin,plugins}/*/*/index.{ts,js}",
+    ]
 
-    for (const item of await Glob.scan("{plugin,plugins}/*.{ts,js}", {
-      cwd: dir,
-      absolute: true,
-      dot: true,
-      symlink: true,
-    })) {
-      plugins.push(pathToFileURL(item).href)
+    for (const pattern of patterns) {
+      for (const item of await Glob.scan(pattern, {
+        cwd: dir,
+        absolute: true,
+        dot: true,
+        symlink: true,
+      })) {
+        if (seen.has(item)) continue
+        seen.add(item)
+        plugins.push(pathToFileURL(item).href)
+      }
     }
     return plugins
   }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2047,6 +2047,38 @@ describe("deduplicatePluginOrigins", () => {
       },
     })
   })
+
+  test("loads nested plugin entrypoints from subdirectories", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const projectDir = path.join(dir, "project")
+        const pluginDir = path.join(projectDir, ".opencode", "plugin", "cloud-runner")
+        await fs.mkdir(pluginDir, { recursive: true })
+
+        await Filesystem.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+          }),
+        )
+
+        await Filesystem.write(path.join(pluginDir, "index.js"), "export default {}")
+        await Filesystem.write(path.join(pluginDir, "helper.js"), "export const helper = 1")
+      },
+    })
+
+    await Instance.provide({
+      directory: path.join(tmp.path, "project"),
+      fn: async () => {
+        const config = await load()
+        const plugins = config.plugin ?? []
+        const specs = plugins.map((p) => Config.pluginSpecifier(p))
+
+        expect(specs.some((spec) => spec.endsWith("/cloud-runner/index.js"))).toBe(true)
+        expect(specs.some((spec) => spec.endsWith("/helper.js"))).toBe(false)
+      },
+    })
+  })
 })
 
 describe("OPENCODE_DISABLE_PROJECT_CONFIG", () => {


### PR DESCRIPTION
### Issue for this PR

Feature PR; no linked issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extends auto-discovery under `.opencode/plugin/` to pick up nested `index.{js,ts}` entrypoints (one and two levels deep), in addition to top-level `*.{js,ts}` files. Helper modules in the same folder are not auto-loaded.

This matches how multi-file plugins are usually laid out (e.g. `plugin/my-runner/index.js` plus local helpers).

### How did you verify your code works?

`bun test packages/opencode/test/config/config.test.ts --test-name-pattern "loads nested plugin|loads auto-discovered"`

### Screenshots / recordings

_N/A — config loading only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR