### PR TITLE
docs(ecosystem): add Hindsight memory plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [@vectorize-io/opencode-hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/opencode) | Persistent long-term memory across sessions via Hindsight, with auto-retain and recall on session start |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes # N/A — documentation addition, no associated issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the `## Plugins` table on the ecosystem page for `@vectorize-io/opencode-hindsight`, a published npm plugin that gives OpenCode persistent long-term memory across sessions (auto-retain on session idle, recall injected at session start). It sits alongside the existing `opencode-supermemory` row, which is the same category of plugin.

### How did you verify your code works?

It is a single Markdown table row in `packages/web/src/content/docs/ecosystem.mdx`. I matched the exact column format of the surrounding rows (linked name + one-line description) and confirmed the link resolves to the plugin's source.

### Screenshots / recordings

Not a UI change — docs table only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR