### PR TITLE
fix: set default UTF-8 encoding for spawned subprocess on Windows

### DIFF
--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -187,8 +187,8 @@ export function args(file: string, command: string, cwd: string) {
       cwd,
     ]
   }
-  if (n === "cmd") return ["/c", command]
-  if (ps(file)) return ["-NoProfile", "-Command", command]
+  if (n === "cmd") return ["/d", "/c", `chcp 65001 >nul && ${command}`]
+  if (ps(file)) return ["-NoProfile", "-Command", `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ${command}`]
   return ["-c", command]
 }
 

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -300,7 +300,7 @@ function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv
   if (process.platform === "win32" && Shell.ps(shell)) {
     return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ${command}`], {
       cwd,
-      env,
+      env: { ...env, PYTHONIOENCODING: "utf-8" },
       stdin: "ignore",
       detached: false,
     })
@@ -309,7 +309,7 @@ function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv
   if (process.platform === "win32" && Shell.name(shell) === "cmd") {
     return ChildProcess.make(shell, ["/d", "/c", `chcp 65001 >nul && ${command}`], {
       cwd,
-      env,
+      env: { ...env, PYTHONIOENCODING: "utf-8" },
       stdin: "ignore",
       detached: false,
     })

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -298,7 +298,16 @@ const ask = Effect.fn("ShellTool.ask")(function* (
 
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && Shell.ps(shell)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ${command}`], {
+      cwd,
+      env,
+      stdin: "ignore",
+      detached: false,
+    })
+  }
+
+  if (process.platform === "win32" && Shell.name(shell) === "cmd") {
+    return ChildProcess.make(shell, ["/d", "/c", `chcp 65001 >nul && ${command}`], {
       cwd,
       env,
       stdin: "ignore",


### PR DESCRIPTION
### Issue for this PR

Closes #23636 
Closes #31187 
Closes #30205 
Closes #31830 
Closes #26882 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On zh-CN Windows systems, the default active code page (ACP) is 936 (GBK). New subprocesses spawned by OpenCode inherit this encoding. Garbled characters occur when tools output non-ASCII characters such as CJK characters.

This PR fixes the garbled text bug by prepending the command `$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);` before the executed command to set the character encoding to UTF-8; this fix targets PowerShell. When the spawned subprocess is CMD, `chcp 65001 >nul` is prepended to the command to switch the code page.

When running the python command in Windows Terminal, if stdout is a pipe (rather than the console), Python ignores the code page set via chcp and falls back to the system ANSI code page (GBK on Chinese-language Windows systems). The fix is to append the environment variable `PYTHONIOENCODING=utf-8` in the shell environment.

### How did you verify your code works?
I ran OpenCode locally with `bun dev`. In shell mode, I ran the `ls` command to list a directory containing files with Chinese filenames, and the output displayed correctly. I also executed `Write-Output "中文输出"` to inspect console output, which rendered properly as well.

I have completed local tests with both PowerShell and CMD set as the default shells. The results meet expectations with no garbled characters present.

### Screenshots / recordings
before
<img width="550" height="375" alt="image" src="https://github.com/user-attachments/assets/53b16591-c3d6-46f0-a3af-6c45c4da059a" />
<img width="300" height="190" alt="image" src="https://github.com/user-attachments/assets/28312d3a-c45f-4ec3-9ab0-14c5cf4a9f8b" />

after
<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/773208d5-a692-4dbf-b0d8-91d52b0a9612" />
<img width="240" height="160" alt="image" src="https://github.com/user-attachments/assets/27258954-52e5-48b5-a9d1-1372bf06416a" />



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
