### PR TITLE
fix(core): accept deprecated reference config key

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -2,7 +2,9 @@
   "$schema": "https://opencode.ai/config.json",
   "provider": {},
   "permission": {},
-  "references": {
+  // TODO: flip back to `references` once a release containing the v1 `reference` migration ships.
+  // The release pipeline runs the latest published opencode against this file, which only knows `reference`.
+  "reference": {
     "effect": {
       "repository": "github.com/Effect-TS/effect-smol",
       "description": "Use for Effect v4 and effect-smol implementation details",

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -45,6 +45,9 @@ export const Info = Schema.Struct({
   references: Schema.optional(ConfigReference.Info).annotate({
     description: "Named git or local directory references",
   }),
+  reference: Schema.optional(ConfigReference.Info).annotate({
+    description: "@deprecated Use 'references' field instead. Named git or local directory references",
+  }),
   watcher: Schema.optional(Schema.Struct({ ignore: Schema.optional(Schema.mutable(Schema.Array(Schema.String))) })),
   snapshot: Schema.optional(Schema.Boolean).annotate({
     description:

--- a/packages/core/src/v1/config/migrate.ts
+++ b/packages/core/src/v1/config/migrate.ts
@@ -12,6 +12,7 @@ const keys = new Set([
   "logLevel",
   "server",
   "command",
+  "reference",
   "snapshot",
   "plugin",
   "autoshare",
@@ -62,7 +63,7 @@ export function migrate(info: typeof ConfigV1.Info.Type) {
     skills: info.skills && [...(info.skills.paths ?? []), ...(info.skills.urls ?? [])],
     commands: info.command,
     instructions: info.instructions,
-    references: info.references,
+    references: info.references ?? info.reference,
     plugins: info.plugin?.map((plugin) =>
       typeof plugin === "string" ? plugin : { package: plugin[0], options: plugin[1] },
     ),

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -70,7 +70,9 @@ describe("Config", () => {
     Effect.sync(() => {
       expect(ConfigMigrateV1.isV1({ snapshot: false })).toBe(true)
       expect(ConfigMigrateV1.isV1({ snapshot: false, agents: {} })).toBe(true)
+      expect(ConfigMigrateV1.isV1({ reference: {} })).toBe(true)
       expect(ConfigMigrateV1.isV1({ shell: "/bin/zsh", model: "anthropic/claude" })).toBe(false)
+      expect(ConfigMigrateV1.isV1({ references: {} })).toBe(false)
     }),
   )
 
@@ -425,6 +427,42 @@ describe("Config", () => {
               "opencode-helicone-session",
               { package: "@my-org/audit-plugin", options: { endpoint: "https://audit.example.com" } },
             ])
+          }).pipe(Effect.provide(testLayer(tmp.path)))
+        }),
+      ),
+    ),
+  )
+
+  it.live("migrates the deprecated reference key into references", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            fs.writeFile(
+              path.join(tmp.path, "opencode.json"),
+              JSON.stringify({
+                reference: {
+                  local: { path: "../library" },
+                  sdk: { repository: "github.com/example/sdk", branch: "main" },
+                  shorthand: "github.com/example/docs",
+                },
+              }),
+            ),
+          )
+
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const documents = (yield* config.entries()).filter((entry) => entry.type === "document")
+
+            expect(documents).toHaveLength(1)
+            expect(documents[0]?.info.references).toEqual({
+              local: { path: "../library" },
+              sdk: { repository: "github.com/example/sdk", branch: "main" },
+              shorthand: "github.com/example/docs",
+            })
           }).pipe(Effect.provide(testLayer(tmp.path)))
         }),
       ),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -722,6 +722,26 @@ it.instance("migrates mode field to agent field", () =>
   }),
 )
 
+it.instance("accepts the deprecated reference field", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      reference: {
+        local: { path: "../library" },
+        sdk: { repository: "github.com/example/sdk", branch: "main" },
+        shorthand: "github.com/example/docs",
+      },
+    })
+    const config = yield* Config.use.get()
+    expect(config.reference).toEqual({
+      local: { path: "../library" },
+      sdk: { repository: "github.com/example/sdk", branch: "main" },
+      shorthand: "github.com/example/docs",
+    })
+  }),
+)
+
 it.instance("loads config from .opencode directory", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1931,6 +1931,9 @@ export type Config = {
   references?: {
     [key: string]: string | ConfigV2ReferenceGit | ConfigV2ReferenceLocal
   }
+  reference?: {
+    [key: string]: string | ConfigV2ReferenceGit | ConfigV2ReferenceLocal
+  }
   watcher?: {
     ignore?: Array<string>
   }


### PR DESCRIPTION
## Problem

The \`release patch\` run failed (https://github.com/anomalyco/opencode/actions/runs/27264318252): the changelog step installs the latest published opencode and runs it against this repo, and \`.opencode/opencode.jsonc\` on dev uses the new \`references\` key from #31601, which released builds reject:

```
Error: Configuration is invalid at .opencode/opencode.jsonc
↳ Unrecognized key: references
```

Beyond CI, #31601 renamed \`reference\` → \`references\` and removed the old key from the schema entirely, so any existing user config with \`reference\` hard-errors on upgrade.

## Fix

Restore the established deprecated-key pattern (same treatment as \`autoshare\`→\`share\` and \`mode\`→\`agent\`, which remain in the schema):

- re-add \`reference\` to \`ConfigV1.Info\` with an \`@deprecated\` description, reusing \`ConfigReference.Info\` (old entry shapes are a strict subset of the new ones, so the migration is lossless)
- restore \`"reference"\` to the v1 detection keys and coalesce \`references: info.references ?? info.reference\` in \`ConfigMigrateV1.migrate\`
- flip \`.opencode/opencode.jsonc\` to the singular form so the release pipeline works with both the currently published binary (native key) and dev builds (via migration); flip back once a release containing this lands
- regenerate the JS SDK

## Verification

- new file-based migration tests in core and opencode config suites, mirroring the existing autoshare/mode migration tests (fail before, pass after)
- full config + reference suites pass in packages/core (48) and packages/opencode (93); typecheck clean in core, opencode, sdk/js
- ran released 1.17.0 and a source build against the updated repo config: both load it (1.17.0 verified end-to-end with a real prompt)

Follow-up worth considering separately: have the changelog step run the source build from the release commit instead of npm-latest, which removes this class of failure entirely.