### PR TITLE
fix(opencode): propagate tool.definition hook parameter modifications to MCP tools

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -117,6 +117,11 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   for (const [key, item] of Object.entries(yield* mcp.tools())) {
     const execute = item.execute
     if (!execute) continue
+    // Fire tool.definition hook so plugins can modify MCP tool description AND parameters
+    const defOutput = { description: item.description, parameters: item.inputSchema }
+    yield* plugin.trigger("tool.definition", { toolID: key }, defOutput)
+    item.description = defOutput.description
+    item.inputSchema = defOutput.parameters
 
     const schema = yield* Effect.promise(() => Promise.resolve(asSchema(item.inputSchema).jsonSchema))
     const transformed = ProviderTransform.schema(input.model, schema)

--- a/packages/opencode/test/tool/tool-definition-mcp.test.ts
+++ b/packages/opencode/test/tool/tool-definition-mcp.test.ts
@@ -156,4 +156,46 @@ describe("tool.definition MCP hook", () => {
       expect(tool!.description).toBe("PREFIX: Original MCP tool description")
     }),
   )
+
+  it.instance("plugin can modify MCP tool parameters via tool.definition hook", () =>
+    Effect.gen(function* () {
+      const modifyingPlugin = Plugin.Service.of({
+        init: () => Effect.void,
+        list: () => Effect.succeed([]),
+        trigger: ((_name: string, _input: any, output: any) => {
+          output.parameters = jsonSchema({
+            type: "object",
+            properties: {
+              modified: { type: "boolean", description: "Added by plugin" },
+            },
+            required: ["modified"],
+          })
+          return Effect.succeed(output)
+        }) as Plugin.Interface["trigger"],
+      })
+
+      const tools = yield* SessionTools.resolve({
+        agent: {
+          name: "test",
+          mode: "primary" as const,
+          options: {},
+          permission: [
+            { action: "allow", permission: "*", pattern: "*" },
+          ] as PermissionV1.Rule[],
+        },
+        model: ProviderTest.model(),
+        session: testSession,
+        processor: testProcessor,
+        bypassAgentCheck: false,
+        messages: [],
+        promptOps: testPromptOps,
+      }).pipe(Effect.provideService(Plugin.Service, modifyingPlugin))
+
+      const tool = tools["test_mcp_tool_v2"]
+      expect(tool).toBeDefined()
+      expect((tool!.inputSchema as any).jsonSchema?.properties?.modified).toBeDefined()
+      expect((tool!.inputSchema as any).jsonSchema?.properties?.modified.description).toBe("Added by plugin")
+    }),
+  )
+
 })

--- a/packages/opencode/test/tool/tool-definition-mcp.test.ts
+++ b/packages/opencode/test/tool/tool-definition-mcp.test.ts
@@ -56,16 +56,10 @@ const permissionLayer = Layer.mock(Permission.Service, {
 })
 
 // --- Truncate mock (output is never called during resolve) ---
-const truncateLayer = Layer.succeed(
-  Truncate.Service,
-  Truncate.Service.of({
-    init: () => Effect.void,
-    cleanup: () => Effect.void,
-    write: () => Effect.succeed(""),
-    output: () => Effect.succeed({ content: "", truncated: false as const }),
-    limits: () => Effect.succeed({ maxLines: 2000, maxBytes: 50000 }),
-  }),
-)
+const truncateLayer = Layer.mock(Truncate.Service, {
+  output: () => Effect.succeed({ content: "", truncated: false as const }),
+  limits: () => Effect.succeed({ maxLines: 2000, maxBytes: 50000 }),
+})
 
 // Compose all mock layers
 const testLayer = Layer.mergeAll(pluginLayer, mcpLayer, registryLayer, permissionLayer, truncateLayer)
@@ -105,6 +99,8 @@ describe("tool.definition MCP hook", () => {
       const tools = yield* SessionTools.resolve({
         agent: {
           name: "test",
+          mode: "primary" as const,
+          options: {},
           permission: [
             { action: "allow", permission: "*", pattern: "*" },
           ] as PermissionV1.Rule[],
@@ -141,6 +137,8 @@ describe("tool.definition MCP hook", () => {
       const tools = yield* SessionTools.resolve({
         agent: {
           name: "test",
+          mode: "primary" as const,
+          options: {},
           permission: [
             { action: "allow", permission: "*", pattern: "*" },
           ] as PermissionV1.Rule[],

--- a/packages/opencode/test/tool/tool-definition-mcp.test.ts
+++ b/packages/opencode/test/tool/tool-definition-mcp.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, beforeEach } from "bun:test"
+import { Effect, Layer } from "effect"
+import { dynamicTool, jsonSchema } from "ai"
+import { testEffect } from "../lib/effect"
+import { SessionTools } from "@/session/tools"
+import { MCP } from "@/mcp"
+import { Plugin } from "@/plugin"
+import { ToolRegistry } from "@/tool/registry"
+import { Permission } from "@/permission"
+import { Truncate } from "@/tool/truncate"
+import { ProviderTest } from "../fake/provider"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { SessionID, MessageID } from "@/session/schema"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import type { TaskPromptOps } from "@/tool/task"
+
+// --- Mutable capture array shared between the mock plugin layer and test body ---
+const captured = { calls: [] as Array<{ toolID: string; description: string }> }
+
+// --- Plugin layer that records tool.definition invocations ---
+const pluginLayer = Layer.succeed(
+  Plugin.Service,
+  Plugin.Service.of({
+    init: () => Effect.void,
+    list: () => Effect.succeed([]),
+    trigger: ((name: string, input: any, output: any) => {
+      if (name === "tool.definition") {
+        captured.calls.push({ toolID: input.toolID, description: output.description })
+      }
+      return Effect.succeed(output)
+    }) as Plugin.Interface["trigger"],
+  }),
+)
+
+// --- MCP layer returning a single known tool ---
+const mcpLayer = Layer.mock(MCP.Service, {
+  tools: () =>
+    Effect.succeed({
+      "test_mcp_tool_v2": dynamicTool({
+        description: "Original MCP tool description",
+        inputSchema: jsonSchema({ type: "object", properties: {} }),
+        execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+      }),
+    }),
+})
+
+// --- Registry returning no tools (focus is the MCP path) ---
+const registryLayer = Layer.mock(ToolRegistry.Service, {
+  tools: () => Effect.succeed([]),
+})
+
+// --- Permission mock (ask is never called during resolve) ---
+const permissionLayer = Layer.mock(Permission.Service, {
+  ask: () => Effect.void,
+})
+
+// --- Truncate mock (output is never called during resolve) ---
+const truncateLayer = Layer.succeed(
+  Truncate.Service,
+  Truncate.Service.of({
+    init: () => Effect.void,
+    cleanup: () => Effect.void,
+    write: () => Effect.succeed(""),
+    output: () => Effect.succeed({ content: "", truncated: false as const }),
+    limits: () => Effect.succeed({ maxLines: 2000, maxBytes: 50000 }),
+  }),
+)
+
+// Compose all mock layers
+const testLayer = Layer.mergeAll(pluginLayer, mcpLayer, registryLayer, permissionLayer, truncateLayer)
+
+const it = testEffect(testLayer)
+
+// --- Minimal resolve input fields (closures capture these but don't run during resolve) ---
+const testSession = {
+  id: SessionID.make("ses_test"),
+  slug: "test",
+  projectID: "test" as ProjectV2.ID,
+  directory: "",
+  title: "Test Session",
+  version: "1.0",
+  time: { created: 0, updated: 0 },
+} satisfies Parameters<typeof SessionTools.resolve>[0]["session"]
+
+const testProcessor = {
+  message: (({ id: "msg_test" as MessageID }) as unknown) as SessionV1.Assistant,
+  updateToolCall: () => Effect.succeed(undefined as any),
+  completeToolCall: () => Effect.void,
+}
+
+const testPromptOps: TaskPromptOps = {
+  cancel: () => Effect.void,
+  resolvePromptParts: () => Effect.succeed([]),
+  prompt: () => Effect.succeed({} as any),
+}
+
+describe("tool.definition MCP hook", () => {
+  beforeEach(() => {
+    captured.calls = []
+  })
+
+  it.instance("fires tool.definition hook for MCP tools during resolve", () =>
+    Effect.gen(function* () {
+      const tools = yield* SessionTools.resolve({
+        agent: {
+          name: "test",
+          permission: [
+            { action: "allow", permission: "*", pattern: "*" },
+          ] as PermissionV1.Rule[],
+        },
+        model: ProviderTest.model(),
+        session: testSession,
+        processor: testProcessor,
+        bypassAgentCheck: false,
+        messages: [],
+        promptOps: testPromptOps,
+      })
+
+      // The hook must have been called exactly once — for our MCP tool
+      expect(captured.calls.length).toBe(1)
+      expect(captured.calls[0].toolID).toBe("test_mcp_tool_v2")
+      expect(captured.calls[0].description).toBe("Original MCP tool description")
+
+      // The tool must appear in the returned map
+      expect(tools["test_mcp_tool_v2"]).toBeDefined()
+    }),
+  )
+
+  it.instance("plugin can modify MCP tool description via tool.definition hook", () =>
+    Effect.gen(function* () {
+      const modifyingPlugin = Plugin.Service.of({
+        init: () => Effect.void,
+        list: () => Effect.succeed([]),
+        trigger: ((_name: string, _input: any, output: any) => {
+          output.description = "PREFIX: " + output.description
+          return Effect.succeed(output)
+        }) as Plugin.Interface["trigger"],
+      })
+
+      const tools = yield* SessionTools.resolve({
+        agent: {
+          name: "test",
+          permission: [
+            { action: "allow", permission: "*", pattern: "*" },
+          ] as PermissionV1.Rule[],
+        },
+        model: ProviderTest.model(),
+        session: testSession,
+        processor: testProcessor,
+        bypassAgentCheck: false,
+        messages: [],
+        promptOps: testPromptOps,
+      }).pipe(Effect.provideService(Plugin.Service, modifyingPlugin))
+
+      const tool = tools["test_mcp_tool_v2"]
+      expect(tool).toBeDefined()
+      expect(tool!.description).toBe("PREFIX: Original MCP tool description")
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31677

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `tool.definition` hook in `session/tools.ts` was passing a `{description}` object to plugins, but only reading back the description. Any modifications plugins made to `parameters` (the input schema) were silently dropped — the original MCP tool's schema was used instead.

This fix adds `item.inputSchema = defOutput.parameters` so the plugin's parameter modifications actually propagate to the final tool registration. Without this, the MCP router plugin's parameter-stripping hook (and any future schema-modifying plugins) would have no effect on MCP tools.

### How did you verify your code works?

- Ran `bun test tool/tool-definition-mcp.test.ts` — 3/3 tests pass, 9 expect() calls, 0 failures
- The new test creates a plugin that modifies `output.parameters` to add a `modified` boolean property, then verifies the schema change appears on the resolved tool
- Cherry-picked existing tests from #31671 to ensure hook fires and description modification still work

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR