### PR TITLE
feat(opencode): add Snowflake Cortex SSO (external browser) authentication

### DIFF
--- a/packages/core/test/plugin/provider-snowflake-cortex.test.ts
+++ b/packages/core/test/plugin/provider-snowflake-cortex.test.ts
@@ -5,6 +5,10 @@ import { SnowflakeCortexPlugin, cortexFetch } from "@opencode-ai/core/plugin/pro
 import { ProviderPlugins } from "@opencode-ai/core/plugin/provider"
 import { expectPluginRegistered, it, model, withEnv } from "./provider-helper"
 
+// Duplicated from packages/opencode/src/auth/index.ts — cross-package import is impractical in tests.
+// Must stay in sync with the OAUTH_DUMMY_KEY constant exported from that file.
+const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
+
 describe("SnowflakeCortexPlugin", () => {
   it.effect("is registered in ProviderPlugins before OpenAICompatiblePlugin", () =>
     Effect.sync(() => {
@@ -100,6 +104,45 @@ describe("SnowflakeCortexPlugin", () => {
       }),
     ),
   )
+
+  it.effect("creates SDK when options.apiKey is OAUTH_DUMMY_KEY and options.fetch is custom (SSO path)", () =>
+    withEnv({ SNOWFLAKE_CORTEX_PAT: undefined }, () =>
+      Effect.gen(function* () {
+        const plugin = yield* PluginV2.Service
+        yield* plugin.add(SnowflakeCortexPlugin)
+        const captured: { apiKey?: unknown; fetch?: unknown }[] = []
+        yield* plugin.add({
+          id: PluginV2.ID.make("sso-inspector"),
+          effect: Effect.succeed({
+            "aisdk.sdk": (evt) =>
+              Effect.sync(() => {
+                captured.push({ apiKey: evt.options.apiKey, fetch: evt.options.fetch })
+              }),
+          }),
+        })
+        const ssoFetch: FetchLike = async () => new Response("{}", { status: 200 })
+        const result = yield* plugin.trigger(
+          "aisdk.sdk",
+          {
+            model: model("snowflake-cortex", "claude-sonnet-4-6"),
+            package: "@ai-sdk/openai-compatible",
+            options: {
+              name: "snowflake-cortex",
+              baseURL: "https://test.snowflakecomputing.com/api/v2/cortex/v1",
+              apiKey: OAUTH_DUMMY_KEY,
+              fetch: ssoFetch,
+            },
+          },
+          {},
+        )
+        expect(result.sdk).toBeDefined()
+        // options.apiKey stays as OAUTH_DUMMY_KEY on the evt (plugin reads it but doesn't mutate it)
+        expect(captured[0]?.apiKey).toBe(OAUTH_DUMMY_KEY)
+        // options.fetch stays as the original ssoFetch (plugin wraps it internally for SDK creation)
+        expect(captured[0]?.fetch).toBe(ssoFetch)
+      }),
+    ),
+  )
 })
 
 type FetchLike = (url: string | URL | Request, init?: RequestInit) => Promise<Response>
@@ -189,5 +232,22 @@ describe("cortexFetch", () => {
     const text = await response.text()
     expect(text).toContain('"role":"assistant"')
     expect(text).not.toContain('"role":""')
+  })
+
+  bun_it("wraps custom SSO fetch and rewrites max_tokens (SSO path integration)", async () => {
+    const captured: RequestInit[] = []
+    const ssoFetch: FetchLike = async (_url, init) => {
+      captured.push(init ?? {})
+      return new Response("{}", { status: 200 })
+    }
+    // Simulate what the V2 plugin does: cortexFetch(ssoFetch)
+    const wrapped = cortexFetch(ssoFetch)
+    await wrapped("https://test.snowflakecomputing.com/api/v2/cortex/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({ model: "claude-sonnet-4-6", max_tokens: 512 }),
+    })
+    const body = JSON.parse(captured[0].body as string)
+    expect(body.max_completion_tokens).toBe(512)
+    expect(body.max_tokens).toBeUndefined()
   })
 })

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -32,7 +32,16 @@ export class WellKnown extends Schema.Class<WellKnown>("WellKnownAuth")({
   token: Schema.String,
 }) {}
 
-export const Info = Schema.Union([Oauth, Api, WellKnown]).annotate({ discriminator: "type", identifier: "Auth" })
+export class SnowflakeSession extends Schema.Class<SnowflakeSession>("SnowflakeSessionAuth")({
+  type: Schema.Literal("snowflake-session"),
+  account: Schema.String,
+  session_token: Schema.String,
+  master_token: Schema.String,
+  session_expires: Schema.Number,
+  master_expires: Schema.Number,
+}) {}
+
+export const Info = Schema.Union([Oauth, Api, WellKnown, SnowflakeSession]).annotate({ discriminator: "type", identifier: "Auth" })
 export type Info = Schema.Schema.Type<typeof Info>
 
 export class AuthError extends Schema.TaggedErrorClass<AuthError>()("AuthError", {

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -475,20 +475,46 @@ export const ProvidersLoginCommand = effectCmd({
     }
 
     if (provider === "snowflake-cortex") {
+      const method = yield* promptValue(
+        yield* Prompt.select({
+          message: "Authentication method",
+          options: [
+            { label: "PAT (Programmatic Access Token)", value: "pat" },
+            { label: "SSO (External Browser)", value: "sso" },
+          ],
+        }),
+      )
+
       const account = yield* promptValue(
         yield* Prompt.text({
           message: "Snowflake Account Identifier",
-          placeholder: "xy12345.us-east-1",
+          placeholder: "myorg-myaccount or xy12345.us-east-1",
           validate: (x) => (x && x.length > 0 ? undefined : "Required"),
         }),
       )
-      const pat = yield* promptValue(
-        yield* Prompt.password({
-          message: "Programmatic Access Token (PAT)",
-          validate: (x) => (x && x.length > 0 ? undefined : "Required"),
-        }),
-      )
-      yield* Effect.orDie(authSvc.set(provider, { type: "api", key: pat, metadata: { account } }))
+
+      if (method === "pat") {
+        const pat = yield* promptValue(
+          yield* Prompt.password({
+            message: "Programmatic Access Token (PAT)",
+            validate: (x) => (x && x.length > 0 ? undefined : "Required"),
+          }),
+        )
+        yield* Effect.orDie(authSvc.set(provider, { type: "api", key: pat, metadata: { account } }))
+      }
+
+      if (method === "sso") {
+        yield* Prompt.log.info("Opening browser for SSO login…")
+        const result = yield* Effect.tryPromise({
+          try: async () => {
+            const { performExternalBrowserAuth } = await import("@/provider/snowflake/externalbrowser")
+            return performExternalBrowserAuth(account)
+          },
+          catch: (err) => new CliError({ message: "SSO failed: " + errorMessage(err) }),
+        })
+        yield* Effect.orDie(authSvc.set(provider, { type: "snowflake-session", ...result }))
+      }
+
       yield* Prompt.outro("Done")
       return
     }

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -19,6 +19,7 @@ import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cl
 import { AzureAuthPlugin } from "./azure"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
 import { XaiAuthPlugin } from "./xai"
+import { SnowflakeCortexAuthPlugin } from "./snowflake-cortex"
 import { Effect, Layer, Context } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
@@ -76,6 +77,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     AzureAuthPlugin,
     DigitalOceanAuthPlugin,
     XaiAuthPlugin,
+    SnowflakeCortexAuthPlugin,
   ]
 }
 

--- a/packages/opencode/src/plugin/snowflake-cortex.ts
+++ b/packages/opencode/src/plugin/snowflake-cortex.ts
@@ -1,0 +1,55 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+
+export async function SnowflakeCortexAuthPlugin(_input: PluginInput): Promise<Hooks> {
+  const accountPrompt = {
+    type: "text" as const,
+    key: "account",
+    message: "Snowflake Account Identifier",
+    placeholder: "myorg-myaccount or xy12345.us-east-1",
+  }
+
+  return {
+    auth: {
+      provider: "snowflake-cortex",
+      methods: [
+        {
+          type: "api",
+          label: "PAT (Programmatic Access Token)",
+          prompts: [accountPrompt],
+        },
+        {
+          type: "oauth",
+          label: "SSO (External Browser)",
+          prompts: [accountPrompt],
+          async authorize(inputs = {}) {
+            const account = (inputs.account ?? "").trim()
+            if (!account) throw new Error("Snowflake account identifier is required")
+            const { initiateExternalBrowserAuth } = await import("@/provider/snowflake/externalbrowser")
+            const { default: open } = await import("open")
+            const { ssoUrl, callback: completeFn } = await initiateExternalBrowserAuth(account)
+            await open(ssoUrl)
+            return {
+              url: ssoUrl,
+              instructions: "Complete SSO login in your browser. Waiting for redirect...",
+              method: "auto" as const,
+              async callback() {
+                const tokens = await completeFn()
+                return {
+                  type: "success" as const,
+                  key: tokens.session_token,
+                  metadata: {
+                    _auth_type: "snowflake-session",
+                    account: tokens.account,
+                    master_token: tokens.master_token,
+                    session_expires: String(tokens.session_expires),
+                    master_expires: String(tokens.master_expires),
+                  },
+                }
+              },
+            }
+          },
+        },
+      ],
+    },
+  }
+}

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -201,11 +201,26 @@ export const layer: Layer.Layer<Service, never, Auth.Service | Plugin.Service> =
       if (!result || result.type !== "success") return yield* new OauthCallbackFailed({})
 
       if ("key" in result) {
-        yield* auth.set(input.providerID, {
-          type: "api",
-          key: result.key,
-          ...(result.metadata ? { metadata: result.metadata } : {}),
-        })
+        // Snowflake SSO via TUI /connect: the plugin callback returns {type:"success", key:session_token,
+        // metadata:{_auth_type:"snowflake-session", ...}} because ProviderAuthMethod.type is a closed
+        // "oauth"|"api" union. Detect the sentinel and persist as a snowflake-session credential so
+        // provider.ts + createSsoFetch work unchanged (same shape as CLI path).
+        if (result.metadata?.["_auth_type"] === "snowflake-session") {
+          yield* auth.set(input.providerID, {
+            type: "snowflake-session",
+            account: result.metadata["account"] ?? "",
+            session_token: result.key,
+            master_token: result.metadata["master_token"] ?? "",
+            session_expires: Number(result.metadata["session_expires"] ?? 0),
+            master_expires: Number(result.metadata["master_expires"] ?? 0),
+          })
+        } else {
+          yield* auth.set(input.providerID, {
+            type: "api",
+            key: result.key,
+            ...(result.metadata ? { metadata: result.metadata } : {}),
+          })
+        }
       }
 
       if ("refresh" in result) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -146,6 +146,7 @@ type CustomLoader = (provider: Info) => Effect.Effect<{
 
 type CustomDep = {
   auth: (id: string) => Effect.Effect<Auth.Info | undefined>
+  authSet: (id: string, info: Auth.Info) => Effect.Effect<void>
   config: () => Effect.Effect<ConfigV1.Info>
   env: () => Effect.Effect<Record<string, string | undefined>>
   get: (key: string) => Effect.Effect<string | undefined>
@@ -163,6 +164,59 @@ function selectBedrockMantleLanguageModel(sdk: BundledSDK, modelID: string) {
   if (modelID === "openai.gpt-oss-safeguard-20b" || modelID === "openai.gpt-oss-safeguard-120b")
     return sdk.chat?.(modelID) ?? sdk.languageModel(modelID)
   return sdk.responses?.(modelID) ?? sdk.languageModel(modelID)
+}
+
+// Applies Snowflake Cortex API quirks: max_tokens→max_completion_tokens rewrite,
+// 400 "conversation complete" normalization, and role:"" SSE fix.
+function makeCortexFetch(upstream: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  return async (url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (init?.body && typeof init.body === "string") {
+      try {
+        const body = JSON.parse(init.body)
+        if ("max_tokens" in body) {
+          body.max_completion_tokens = body.max_tokens
+          delete body.max_tokens
+          init = { ...init, body: JSON.stringify(body) }
+        }
+      } catch {}
+    }
+
+    const response = await upstream(url, init)
+
+    if (!response.ok && response.status === 400) {
+      try {
+        const errorData = (await response.clone().json()) as Record<string, unknown>
+        if (String(errorData.message || errorData.error || "").toLowerCase().includes("conversation complete")) {
+          return new Response(
+            JSON.stringify({ choices: [{ finish_reason: "stop", message: { content: "", role: "assistant" } }] }),
+            { status: 200, headers: new Headers({ "content-type": "application/json" }) },
+          )
+        }
+      } catch {}
+    }
+
+    if (response.body && response.headers.get("content-type")?.includes("text/event-stream")) {
+      const reader = response.body.getReader()
+      const encoder = new TextEncoder()
+      const decoder = new TextDecoder()
+      const stream = new ReadableStream({
+        async pull(ctrl) {
+          const { done, value } = await reader.read()
+          if (done) {
+            ctrl.close()
+            return
+          }
+          ctrl.enqueue(encoder.encode(decoder.decode(value, { stream: true }).replace(/"role"\s*:\s*""/g, '"role":"assistant"')))
+        },
+        cancel() {
+          reader.cancel()
+        },
+      })
+      return new Response(stream, { headers: response.headers, status: response.status })
+    }
+
+    return response
+  }
 }
 
 function custom(dep: CustomDep): Record<string, CustomLoader> {
@@ -850,12 +904,53 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       const env = yield* dep.env()
       const auth = yield* dep.auth(input.id)
 
-      const account =
+      const ssoCredential = auth?.type === "snowflake-session" ? auth : undefined
+
+      const rawAccount =
         env["SNOWFLAKE_ACCOUNT"] ??
         (auth?.type === "api" ? auth.metadata?.account : undefined) ??
+        ssoCredential?.account ??
         input.options?.account
 
+      const account = rawAccount
+        ? rawAccount.trim().replace(/^https?:\/\//i, "").split("/")[0].replace(/\.snowflakecomputing\.com$/i, "")
+        : undefined
+
       const pat = env["SNOWFLAKE_CORTEX_PAT"] ?? (auth?.type === "api" ? auth.key : undefined) ?? input.options?.apiKey
+
+      const baseURL = `https://${account}.snowflakecomputing.com/api/v2/cortex/v1`
+
+      // SSO branch: use session token auth; bypasses the PAT guard below
+      if (ssoCredential && !env["SNOWFLAKE_CORTEX_PAT"] && account) {
+        const { createSsoFetch } = yield* Effect.promise(() => import("./snowflake/externalbrowser"))
+        return {
+          autoload: true,
+          options: {
+            baseURL,
+            apiKey: Auth.OAUTH_DUMMY_KEY,
+            fetch: makeCortexFetch(
+              createSsoFetch({
+                account,
+                session: ssoCredential,
+                onRenew: (s) => {
+                  void Effect.runPromise(
+                    dep.authSet(input.id, {
+                      type: "snowflake-session",
+                      account,
+                      session_token: s.session_token,
+                      session_expires: s.session_expires,
+                      master_token: ssoCredential.master_token,
+                      master_expires: ssoCredential.master_expires,
+                    }),
+                  ).catch((err) => {
+                    console.error("Failed to persist renewed Snowflake SSO token:", err)
+                  })
+                },
+              }),
+            ),
+          },
+        }
+      }
 
       if (!account || !pat) {
         const missing = [!account && "SNOWFLAKE_ACCOUNT", !pat && "SNOWFLAKE_CORTEX_PAT"].filter(Boolean).join(", ")
@@ -869,67 +964,12 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         }
       }
 
-      const baseURL = `https://${account}.snowflakecomputing.com/api/v2/cortex/v1`
-
       return {
         autoload: input.source === "config",
         options: {
           baseURL,
           apiKey: pat,
-          fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
-            if (init?.body && typeof init.body === "string") {
-              try {
-                const body = JSON.parse(init.body)
-                if ("max_tokens" in body) {
-                  body.max_completion_tokens = body.max_tokens
-                  delete body.max_tokens
-                  init = { ...init, body: JSON.stringify(body) }
-                }
-              } catch {}
-            }
-
-            const response = await fetch(url, init)
-
-            // Cortex returns 400 "conversation complete" as a normal stop condition
-            if (!response.ok && response.status === 400) {
-              try {
-                const errorData = await response.clone().json()
-                const errorMessage = String(errorData.message || errorData.error || "")
-                if (errorMessage.toLowerCase().includes("conversation complete")) {
-                  return new Response(
-                    JSON.stringify({
-                      choices: [{ finish_reason: "stop", message: { content: "", role: "assistant" } }],
-                    }),
-                    { status: 200, headers: new Headers({ "content-type": "application/json" }) },
-                  )
-                }
-              } catch {}
-            }
-
-            // Cortex returns role:"" in streaming deltas; the AI SDK schema requires "assistant"
-            if (response.body && response.headers.get("content-type")?.includes("text/event-stream")) {
-              const reader = response.body.getReader()
-              const encoder = new TextEncoder()
-              const decoder = new TextDecoder()
-              const stream = new ReadableStream({
-                async pull(ctrl) {
-                  const { done, value } = await reader.read()
-                  if (done) {
-                    ctrl.close()
-                    return
-                  }
-                  const text = decoder.decode(value, { stream: true })
-                  ctrl.enqueue(encoder.encode(text.replace(/"role"\s*:\s*""/g, '"role":"assistant"')))
-                },
-                cancel() {
-                  reader.cancel()
-                },
-              })
-              return new Response(stream, { headers: response.headers, status: response.status })
-            }
-
-            return response
-          },
+          fetch: makeCortexFetch(fetch),
         },
       }
     }),
@@ -1302,6 +1342,7 @@ export const layer = Layer.effect(
         } = {}
         const dep = {
           auth: (id: string) => auth.get(id).pipe(Effect.orDie),
+          authSet: (id: string, info: Auth.Info) => auth.set(id, info).pipe(Effect.orDie),
           config: () => config.get(),
           env: () => env.all(),
           get: (key: string) => env.get(key),
@@ -1345,9 +1386,11 @@ export const layer = Layer.effect(
           const provider = database[providerID]
           if (!provider) continue
           const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
+          // SnowflakeSession is V1-only; V2 plugin models hook uses V2 Auth types only
+          const authForModels = pluginAuth?.type === "snowflake-session" ? undefined : pluginAuth
 
           provider.models = yield* Effect.promise(async () => {
-            const next = await models(toPublicInfo(provider), { auth: pluginAuth })
+            const next = await models(toPublicInfo(provider), { auth: authForModels })
             return Object.fromEntries(
               Object.entries(next).map(([id, model]) => [
                 id,

--- a/packages/opencode/src/provider/snowflake/externalbrowser.ts
+++ b/packages/opencode/src/provider/snowflake/externalbrowser.ts
@@ -1,0 +1,263 @@
+import { createServer } from "node:http"
+import { randomUUID } from "node:crypto"
+import open from "open"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+
+export type FetchLike = (url: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+const CLIENT_APP_ID = "opencode"
+const TOKEN_TIMEOUT_MS = 5 * 60 * 1000
+
+function sanitizeAccount(account: string): string {
+  return account.trim().replace(/^https?:\/\//i, "").split("/")[0]
+}
+
+function accountHost(account: string): string {
+  const clean = sanitizeAccount(account)
+  if (clean.includes("snowflakecomputing.com")) return `https://${clean}`
+  return `https://${clean}.snowflakecomputing.com`
+}
+
+// ACCOUNT_NAME for Snowflake auth bodies = first dot-segment uppercased (e.g. AI43986)
+function accountName(account: string): string {
+  const clean = sanitizeAccount(account)
+  return clean.split(".")[0].toUpperCase()
+}
+
+function commonHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "User-Agent": `${CLIENT_APP_ID}/${InstallationVersion}`,
+  }
+}
+
+// Binds to 127.0.0.1:0 (OS-assigned port). Returns {port, waitForToken} where
+// waitForToken resolves with the IdP token from GET /?token=.
+function startLoopback(): Promise<{ port: number; waitForToken: () => Promise<string> }> {
+  return new Promise((resolveSetup, rejectSetup) => {
+    const callbacks = { resolve: (_: string) => {}, reject: (_: Error) => {} }
+    const tokenPromise = new Promise<string>((res, rej) => {
+      callbacks.resolve = res
+      callbacks.reject = rej
+    })
+    // timeout is assigned after the server binds; the request handler captures it via closure
+    let timeout: ReturnType<typeof setTimeout>
+
+        const server = createServer((req, res) => {
+      let token: string | null = null
+      try {
+        token = new URL(req.url ?? "/", "http://localhost").searchParams.get("token")
+      } catch {
+        res.writeHead(400, { "Content-Type": "text/plain" })
+        res.end("Invalid URL")
+        return
+      }
+
+      if (!token) {
+        res.writeHead(400, { "Content-Type": "text/plain" })
+        res.end("Missing token parameter")
+        return
+      }
+      res.writeHead(200, { "Content-Type": "text/html" })
+      res.end("<html><body><h2>Authentication complete. You may close this window.</h2></body></html>")
+      server.close()
+      clearTimeout(timeout)
+      callbacks.resolve(token)
+    })
+
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address()
+      if (!addr || typeof addr === "string") {
+        rejectSetup(new Error("Failed to bind loopback server"))
+        return
+      }
+      // Timeout fires independently; cleared in the success path so the process can exit cleanly
+      timeout = setTimeout(() => {
+        server.close()
+        callbacks.reject(new Error("Timed out waiting for IdP token after 5 minutes"))
+      }, TOKEN_TIMEOUT_MS)
+
+      resolveSetup({
+        port: addr.port,
+        waitForToken: () => tokenPromise,
+      })
+    })
+
+    server.on("error", rejectSetup)
+  })
+}
+
+// POST /session/authenticator-request — returns {ssoUrl, proofKey}
+async function requestSsoUrl(account: string, port: number, fetchImpl: FetchLike = fetch): Promise<{ ssoUrl: string; proofKey: string }> {
+  const res = await fetchImpl(`${accountHost(account)}/session/authenticator-request?requestId=${randomUUID()}`, {
+    method: "POST",
+    headers: commonHeaders(),
+    body: JSON.stringify({
+      data: {
+        CLIENT_APP_ID,
+        CLIENT_APP_VERSION: InstallationVersion,
+        ACCOUNT_NAME: accountName(account),
+        AUTHENTICATOR: "externalbrowser",
+        BROWSER_MODE_REDIRECT_PORT: String(port),
+      },
+    }),
+  })
+  if (!res.ok) throw new Error(`authenticator-request failed: HTTP ${res.status}`)
+  const json = (await res.json()) as { data?: { ssoUrl?: string; proofKey?: string } }
+  if (!json.data?.ssoUrl || !json.data?.proofKey) throw new Error("Unexpected authenticator-request response shape")
+  return { ssoUrl: json.data.ssoUrl, proofKey: json.data.proofKey }
+}
+
+// POST /session/v1/login-request — exchanges IdP token for session+master tokens
+async function completeLogin(
+  account: string,
+  idpToken: string,
+  proofKey: string,
+  port: number,
+  fetchImpl: FetchLike = fetch,
+): Promise<{ session_token: string; master_token: string; session_expires: number; master_expires: number }> {
+  const res = await fetchImpl(
+    `${accountHost(account)}/session/v1/login-request?requestId=${randomUUID()}&request_guid=${randomUUID()}`,
+    {
+      method: "POST",
+      headers: commonHeaders(),
+      body: JSON.stringify({
+        data: {
+          CLIENT_APP_ID,
+          CLIENT_APP_VERSION: InstallationVersion,
+          ACCOUNT_NAME: accountName(account),
+          AUTHENTICATOR: "externalbrowser",
+          TOKEN: idpToken,
+          PROOF_KEY: proofKey,
+          BROWSER_MODE_REDIRECT_PORT: String(port),
+        },
+      }),
+    },
+  )
+  if (!res.ok) throw new Error(`login-request failed: HTTP ${res.status}`)
+  const json = (await res.json()) as {
+    data?: { token?: string; masterToken?: string; validityInSeconds?: number; masterValidityInSeconds?: number }
+  }
+  const d = json.data
+  if (!d?.token || !d?.masterToken) throw new Error("Unexpected login-request response shape")
+  const now = Date.now()
+  return {
+    session_token: d.token,
+    master_token: d.masterToken,
+    session_expires: now + (d.validityInSeconds ?? 3600) * 1000,
+    master_expires: now + (d.masterValidityInSeconds ?? 14400) * 1000,
+  }
+}
+
+// Split-phase auth: the plugin's authorize() calls this to bind the loopback and get the SSO URL;
+// the returned callback() awaits the redirect and exchanges the IdP token for session tokens.
+// Browser-open is intentionally NOT done here — the caller (plugin authorize) opens the URL.
+export async function initiateExternalBrowserAuth(
+  account: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<{
+  ssoUrl: string
+  callback: () => Promise<{
+    account: string
+    session_token: string
+    master_token: string
+    session_expires: number
+    master_expires: number
+  }>
+}> {
+  const cleanAccount = sanitizeAccount(account)
+  const { port, waitForToken } = await startLoopback()
+  const { ssoUrl, proofKey } = await requestSsoUrl(cleanAccount, port, fetchImpl)
+  return {
+    ssoUrl,
+    async callback() {
+      const idpToken = await waitForToken()
+      return { account: cleanAccount, ...(await completeLogin(cleanAccount, idpToken, proofKey, port, fetchImpl)) }
+    },
+  }
+}
+
+// Full interactive flow: loopback server + authenticator-request + open browser + login-request.
+export async function performExternalBrowserAuth(account: string): Promise<{
+  account: string
+  session_token: string
+  master_token: string
+  session_expires: number
+  master_expires: number
+}> {
+  const cleanAccount = sanitizeAccount(account)
+  const { port, waitForToken } = await startLoopback()
+  const { ssoUrl, proofKey } = await requestSsoUrl(cleanAccount, port)
+  await open(ssoUrl)
+  const idpToken = await waitForToken()
+  return { account: cleanAccount, ...(await completeLogin(cleanAccount, idpToken, proofKey, port)) }
+}
+
+// Renew session token via POST /session/token-request (REQUEST_TYPE=RENEW).
+export async function renewSessionToken(
+  account: string,
+  sessionToken: string,
+  masterToken: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<{ session_token: string; session_expires: number }> {
+  const res = await fetchImpl(`${accountHost(account)}/session/token-request?requestId=${randomUUID()}`, {
+    method: "POST",
+    headers: {
+      ...commonHeaders(),
+      // Renewal uses the master token in the Authorization header
+      Authorization: `Snowflake Token="${masterToken}"`,
+    },
+    body: JSON.stringify({
+      data: { REQUEST_TYPE: "RENEW", oldSessionToken: sessionToken, masterToken },
+    }),
+  })
+  if (!res.ok) throw new Error(`token-request failed: HTTP ${res.status}`)
+  const json = (await res.json()) as { data?: { sessionToken?: string; validityInSecondsST?: number } }
+  if (!json.data?.sessionToken) throw new Error("Unexpected token-request response shape")
+  return {
+    session_token: json.data.sessionToken,
+    session_expires: Date.now() + (json.data.validityInSecondsST ?? 3600) * 1000,
+  }
+}
+
+// Token-renewing fetch wrapper for use by provider.ts.
+// Uses confirmed Format B: Authorization: Snowflake Token="<session_token>".
+// Single-flight renewal: when within 60s of session_expires, renew once (shared promise).
+// If master_expires has passed, throws with a clear re-auth message.
+export function createSsoFetch(input: {
+  account: string
+  session: { session_token: string; master_token: string; session_expires: number; master_expires: number }
+  renewFn?: typeof renewSessionToken
+  fetchImpl?: FetchLike
+  onRenew?: (s: { session_token: string; session_expires: number }) => void
+}): FetchLike {
+  const currentSession = { ...input.session }
+  let renewPromise: Promise<void> | undefined
+  const renewFn = input.renewFn ?? renewSessionToken
+
+  return async (url, init) => {
+    if (Date.now() >= currentSession.session_expires - 60_000) {
+      if (Date.now() >= currentSession.master_expires) {
+        throw new Error("Snowflake master token expired — run opencode auth login snowflake-cortex to re-authenticate")
+      }
+      if (!renewPromise) {
+        renewPromise = renewFn(input.account, currentSession.session_token, currentSession.master_token, input.fetchImpl)
+          .then((r) => {
+            currentSession.session_token = r.session_token
+            currentSession.session_expires = r.session_expires
+            input.onRenew?.(r)
+          })
+          .finally(() => {
+            renewPromise = undefined
+          })
+      }
+      await renewPromise
+    }
+
+    const headers = new Headers(init?.headers)
+    // Confirmed Format B — Bearer does NOT work for session tokens against the Cortex REST API
+    headers.set("Authorization", `Snowflake Token="${currentSession.session_token}"`)
+    return (input.fetchImpl ?? fetch)(url, { ...init, headers })
+  }
+}

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { describe, expect, it as bun_it } from "bun:test"
+import { Effect, Layer, Option, Schema } from "effect"
 import { Auth } from "../../src/auth"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
@@ -74,4 +74,111 @@ describe("Auth", () => {
       expect(after["anthropic"]).toBeUndefined()
     }),
   )
+})
+
+const decodeInfo = Schema.decodeUnknownOption(Auth.Info)
+const decodeInfoSync = Schema.decodeUnknownSync(Auth.Info)
+
+describe("SnowflakeSession schema", () => {
+  const validSession = {
+    type: "snowflake-session",
+    account: "myorg-myaccount",
+    session_token: "sess-abc",
+    master_token: "mast-xyz",
+    session_expires: 1_700_000_000_000,
+    master_expires: 1_700_014_400_000,
+  }
+
+  bun_it("decodes a valid snowflake-session object with all 5 fields", () => {
+    const result = decodeInfo(validSession)
+    expect(Option.isSome(result)).toBe(true)
+    const value = Option.getOrThrow(result)
+    expect(value).toBeInstanceOf(Auth.SnowflakeSession)
+    expect(value.type).toBe("snowflake-session")
+    if (value instanceof Auth.SnowflakeSession) {
+      expect(value.account).toBe("myorg-myaccount")
+      expect(value.session_token).toBe("sess-abc")
+      expect(value.master_token).toBe("mast-xyz")
+      expect(value.session_expires).toBe(1_700_000_000_000)
+      expect(value.master_expires).toBe(1_700_014_400_000)
+    }
+  })
+
+  bun_it("encode/decode round-trips to deep-equal original", () => {
+    const decoded = decodeInfoSync(validSession)
+    // encode back via Schema.encodeSync and re-decode; result should equal original
+    const encodeSync = Schema.encodeSync(Auth.Info)
+    const reencoded = encodeSync(decoded as Auth.SnowflakeSession)
+    const redecoded = decodeInfoSync(reencoded)
+    expect(redecoded).toEqual(decoded)
+  })
+
+  bun_it("returns None when master_token is missing", () => {
+    const { master_token: _, ...noMaster } = validSession
+    const result = decodeInfo(noMaster)
+    expect(Option.isNone(result)).toBe(true)
+  })
+
+  bun_it("existing Oauth type still decodes after union change (regression)", () => {
+    const oauth = {
+      type: "oauth",
+      refresh: "r",
+      access: "a",
+      expires: 0,
+    }
+    const result = decodeInfo(oauth)
+    expect(Option.isSome(result)).toBe(true)
+    expect(Option.getOrThrow(result)).toBeInstanceOf(Auth.Oauth)
+  })
+
+  bun_it("existing Api type still decodes after union change (regression)", () => {
+    const api = { type: "api", key: "sk-test" }
+    const result = decodeInfo(api)
+    expect(Option.isSome(result)).toBe(true)
+    expect(Option.getOrThrow(result)).toBeInstanceOf(Auth.Api)
+  })
+
+  bun_it("existing WellKnown type still decodes after union change (regression)", () => {
+    const wk = { type: "wellknown", key: "k", token: "t" }
+    const result = decodeInfo(wk)
+    expect(Option.isSome(result)).toBe(true)
+    expect(Option.getOrThrow(result)).toBeInstanceOf(Auth.WellKnown)
+  })
+
+  // Verifies that the TUI sentinel path (ProviderAuth.callback converting metadata strings to numbers)
+  // produces a SnowflakeSession that is shape-identical to what the CLI writes directly.
+  bun_it("TUI sentinel conversion produces same SnowflakeSession shape as CLI direct write", () => {
+    const sessionExpires = 1700000000000
+    const masterExpires = 1700014400000
+
+    // Simulate what ProviderAuth.callback does when it sees the sentinel:
+    // metadata values are strings, converted to numbers via Number()
+    const fromTuiPath = decodeInfoSync({
+      type: "snowflake-session",
+      account: "myorg-myaccount",
+      session_token: "session-tok",
+      master_token: "master-tok",
+      session_expires: Number("1700000000000"),
+      master_expires: Number("1700014400000"),
+    })
+
+    // CLI path writes numbers directly
+    const fromCliPath = decodeInfoSync({
+      type: "snowflake-session",
+      account: "myorg-myaccount",
+      session_token: "session-tok",
+      master_token: "master-tok",
+      session_expires: sessionExpires,
+      master_expires: masterExpires,
+    })
+
+    expect(fromTuiPath).toEqual(fromCliPath)
+    expect(fromTuiPath).toBeInstanceOf(Auth.SnowflakeSession)
+    if (fromTuiPath instanceof Auth.SnowflakeSession) {
+      expect(typeof fromTuiPath.session_expires).toBe("number")
+      expect(typeof fromTuiPath.master_expires).toBe("number")
+      expect(fromTuiPath.session_expires).toBe(sessionExpires)
+      expect(fromTuiPath.master_expires).toBe(masterExpires)
+    }
+  })
 })

--- a/packages/opencode/test/plugin/snowflake-cortex.test.ts
+++ b/packages/opencode/test/plugin/snowflake-cortex.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { SnowflakeCortexAuthPlugin } from "../../src/plugin/snowflake-cortex"
+
+describe("SnowflakeCortexAuthPlugin", () => {
+  test("returns auth hook for snowflake-cortex provider", async () => {
+    const hooks = await SnowflakeCortexAuthPlugin({} as any)
+    expect(hooks.auth).toBeDefined()
+    expect(hooks.auth!.provider).toBe("snowflake-cortex")
+  })
+
+  test("includes exactly two methods: PAT (api) and SSO (oauth)", async () => {
+    const hooks = await SnowflakeCortexAuthPlugin({} as any)
+    const methods = hooks.auth!.methods
+    expect(methods).toHaveLength(2)
+    expect(methods[0].type).toBe("api")
+    expect(methods[0].label).toBe("PAT (Programmatic Access Token)")
+    expect(methods[1].type).toBe("oauth")
+    expect(methods[1].label).toBe("SSO (External Browser)")
+  })
+
+  test("both methods include the account text prompt", async () => {
+    const hooks = await SnowflakeCortexAuthPlugin({} as any)
+    for (const method of hooks.auth!.methods) {
+      expect(method.prompts).toBeDefined()
+      const accountPrompt = method.prompts!.find((p) => p.key === "account")
+      expect(accountPrompt).toBeDefined()
+      expect(accountPrompt!.type).toBe("text")
+    }
+  })
+
+  test("SSO method authorize() rejects empty account string", async () => {
+    const hooks = await SnowflakeCortexAuthPlugin({} as any)
+    const ssoMethod = hooks.auth!.methods.find((m) => m.type === "oauth")
+    expect(ssoMethod).toBeDefined()
+    if (ssoMethod?.type === "oauth") {
+      await expect(ssoMethod.authorize!({ account: "" })).rejects.toThrow()
+    }
+  })
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1791,3 +1791,111 @@ it.effect("opencode loader keeps paid models when auth exists", () =>
     expect(keyedCount).toBeGreaterThan(0)
   }).pipe(provideMultiInstance),
 )
+
+// snowflake-cortex SSO fix tests
+
+it.effect("snowflake-cortex appears in provider list when SSO credential is stored", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const authPath = path.join(Global.Path.data, "auth.json")
+    const original = yield* Effect.promise(() => Filesystem.readText(authPath).catch(() => undefined))
+
+    yield* Effect.acquireRelease(
+      Effect.promise(() =>
+        Filesystem.write(
+          authPath,
+          JSON.stringify({
+            "snowflake-cortex": {
+              type: "snowflake-session",
+              account: "test-account",
+              session_token: "test-session-tok",
+              master_token: "test-master-tok",
+              session_expires: Date.now() + 3_600_000,
+              master_expires: Date.now() + 86_400_000,
+            },
+          }),
+        ),
+      ),
+      () =>
+        Effect.promise(async () => {
+          if (original !== undefined) await Filesystem.write(authPath, original)
+          else await unlink(authPath).catch(() => undefined)
+        }),
+    )
+
+    const providers = yield* Provider.use
+      .list()
+      .pipe(provideInstanceEffect(dir))
+      .pipe(Effect.provide(InstanceLayer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+
+    const provider = providers[ProviderV2.ID.make("snowflake-cortex")]
+    expect(provider).toBeDefined()
+    expect(Object.keys(provider.models).length).toBeGreaterThan(0)
+  }).pipe(provideMultiInstance),
+)
+
+it.effect("snowflake-cortex appears in provider list when PAT credential is stored", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const authPath = path.join(Global.Path.data, "auth.json")
+    const original = yield* Effect.promise(() => Filesystem.readText(authPath).catch(() => undefined))
+
+    yield* Effect.acquireRelease(
+      Effect.promise(() =>
+        Filesystem.write(
+          authPath,
+          JSON.stringify({
+            "snowflake-cortex": {
+              type: "api",
+              key: "test-pat",
+              metadata: { account: "test-account" },
+            },
+          }),
+        ),
+      ),
+      () =>
+        Effect.promise(async () => {
+          if (original !== undefined) await Filesystem.write(authPath, original)
+          else await unlink(authPath).catch(() => undefined)
+        }),
+    )
+
+    const providers = yield* Provider.use
+      .list()
+      .pipe(provideInstanceEffect(dir))
+      .pipe(Effect.provide(InstanceLayer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+
+    const provider = providers[ProviderV2.ID.make("snowflake-cortex")]
+    expect(provider).toBeDefined()
+    expect(Object.keys(provider.models).length).toBeGreaterThan(0)
+  }).pipe(provideMultiInstance),
+)
+
+it.effect("snowflake-cortex absent from provider list when no credential is stored", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const authPath = path.join(Global.Path.data, "auth.json")
+    const original = yield* Effect.promise(() => Filesystem.readText(authPath).catch(() => undefined))
+
+    // Ensure no snowflake-cortex credential exists
+    const authData = original ? (JSON.parse(original) as Record<string, unknown>) : {}
+    delete authData["snowflake-cortex"]
+
+    yield* Effect.acquireRelease(
+      Effect.promise(() => Filesystem.write(authPath, JSON.stringify(authData))),
+      () =>
+        Effect.promise(async () => {
+          if (original !== undefined) await Filesystem.write(authPath, original)
+          else await unlink(authPath).catch(() => undefined)
+        }),
+    )
+
+    const providers = yield* Provider.use
+      .list()
+      .pipe(provideInstanceEffect(dir))
+      .pipe(Effect.provide(InstanceLayer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+
+    const provider = providers[ProviderV2.ID.make("snowflake-cortex")]
+    expect(provider).toBeUndefined()
+  }).pipe(provideMultiInstance),
+)

--- a/packages/opencode/test/provider/snowflake-auth-callback.test.ts
+++ b/packages/opencode/test/provider/snowflake-auth-callback.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import type { Hooks } from "@opencode-ai/plugin"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { Auth } from "../../src/auth"
+import { Plugin } from "../../src/plugin"
+import { ProviderAuth } from "../../src/provider/auth"
+import { testEffect } from "../lib/effect"
+
+const capturedAuth = new Map<string, Auth.Info>()
+beforeEach(() => capturedAuth.clear())
+
+const fakeAuthLayer = Layer.succeed(
+  Auth.Service,
+  Auth.Service.of({
+    get: () => Effect.succeed(undefined),
+    all: () => Effect.succeed(Object.fromEntries(capturedAuth)),
+    set: (key, info) => Effect.sync(() => { capturedAuth.set(key, info) }),
+    remove: (key) => Effect.sync(() => { capturedAuth.delete(key) }),
+  }),
+)
+
+const ssoHook: Hooks = {
+  auth: {
+    provider: "test-sso-provider",
+    methods: [
+      {
+        type: "oauth",
+        label: "SSO Test",
+        async authorize() {
+          return {
+            url: "https://example.snowflakecomputing.com/sso",
+            instructions: "Complete login in browser",
+            method: "auto" as const,
+            async callback() {
+              return {
+                type: "success" as const,
+                key: "session-tok",
+                metadata: {
+                  _auth_type: "snowflake-session",
+                  account: "myorg-myaccount",
+                  master_token: "master-tok",
+                  session_expires: "1700000000000",
+                  master_expires: "1700014400000",
+                },
+              }
+            },
+          }
+        },
+      },
+    ],
+  },
+}
+
+const apiHook: Hooks = {
+  auth: {
+    provider: "test-api-provider",
+    methods: [
+      {
+        type: "oauth",
+        label: "API Test",
+        async authorize() {
+          return {
+            url: "https://example.com",
+            instructions: "Authorize",
+            method: "auto" as const,
+            async callback() {
+              return { type: "success" as const, key: "my-api-key" }
+            },
+          }
+        },
+      },
+    ],
+  },
+}
+
+const fakePluginLayer = Layer.succeed(
+  Plugin.Service,
+  Plugin.Service.of({
+    list: () => Effect.succeed([ssoHook, apiHook]),
+    trigger: ((_name, _input, output) => Effect.succeed(output)) as Plugin.Interface["trigger"],
+    init: () => Effect.void,
+  }),
+)
+
+const it = testEffect(ProviderAuth.layer.pipe(Layer.provide(Layer.merge(fakeAuthLayer, fakePluginLayer))))
+
+describe("ProviderAuth.callback", () => {
+  it.instance(
+    "persists snowflake-session credential when _auth_type sentinel is in metadata",
+    Effect.gen(function* () {
+      const svc = yield* ProviderAuth.Service
+      const pid = ProviderV2.ID.make("test-sso-provider")
+      yield* svc.authorize({ providerID: pid, method: 0 })
+      yield* svc.callback({ providerID: pid, method: 0 })
+      const stored = capturedAuth.get(pid)
+      expect(stored).toBeDefined()
+      expect(stored!.type).toBe("snowflake-session")
+      if (stored!.type === "snowflake-session") {
+        expect(stored!.account).toBe("myorg-myaccount")
+        expect(stored!.session_token).toBe("session-tok")
+        expect(stored!.master_token).toBe("master-tok")
+        // session_expires and master_expires must be numbers, not strings
+        expect(typeof stored!.session_expires).toBe("number")
+        expect(typeof stored!.master_expires).toBe("number")
+        expect(stored!.session_expires).toBe(1700000000000)
+        expect(stored!.master_expires).toBe(1700014400000)
+      }
+    }),
+  )
+
+  it.instance(
+    "persists plain api credential when no _auth_type sentinel in metadata",
+    Effect.gen(function* () {
+      const svc = yield* ProviderAuth.Service
+      const pid = ProviderV2.ID.make("test-api-provider")
+      yield* svc.authorize({ providerID: pid, method: 0 })
+      yield* svc.callback({ providerID: pid, method: 0 })
+      const stored = capturedAuth.get(pid)
+      expect(stored).toBeDefined()
+      expect(stored!.type).toBe("api")
+      if (stored!.type === "api") {
+        expect(stored!.key).toBe("my-api-key")
+      }
+    }),
+  )
+})

--- a/packages/opencode/test/provider/snowflake-externalbrowser.test.ts
+++ b/packages/opencode/test/provider/snowflake-externalbrowser.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "bun:test"
+import { createSsoFetch, renewSessionToken, initiateExternalBrowserAuth } from "../../src/provider/snowflake/externalbrowser"
+import type { FetchLike } from "../../src/provider/snowflake/externalbrowser"
+
+describe("renewSessionToken", () => {
+  it("POSTs to token-request with correct Authorization header and body", async () => {
+    const captured: { url: string; init: RequestInit }[] = []
+    const fakeFetch: FetchLike = async (url, init) => {
+      captured.push({ url: String(url), init: init ?? {} })
+      return new Response(JSON.stringify({ data: { sessionToken: "new-token", validityInSecondsST: 3600 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
+
+    const before = Date.now()
+    const result = await renewSessionToken("myaccount", "old-session", "master-token", fakeFetch)
+    const after = Date.now()
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0].url).toMatch(/^https:\/\/myaccount\.snowflakecomputing\.com\/session\/token-request/)
+    expect(captured[0].init.method).toBe("POST")
+
+    const headers = new Headers(captured[0].init.headers as HeadersInit)
+    expect(headers.get("Authorization")).toBe('Snowflake Token="master-token"')
+
+    const body = JSON.parse(captured[0].init.body as string)
+    expect(body.data.REQUEST_TYPE).toBe("RENEW")
+    expect(body.data.oldSessionToken).toBe("old-session")
+    expect(body.data.masterToken).toBe("master-token")
+
+    expect(result.session_token).toBe("new-token")
+    expect(result.session_expires).toBeGreaterThanOrEqual(before + 3600 * 1000)
+    expect(result.session_expires).toBeLessThanOrEqual(after + 3600 * 1000)
+  })
+})
+
+describe("createSsoFetch", () => {
+  it("injects Authorization: Snowflake Token header on a non-expired session", async () => {
+    const captured: RequestInit[] = []
+    const fakeFetch: FetchLike = async (_url, init) => {
+      captured.push(init ?? {})
+      return new Response("{}", { status: 200 })
+    }
+
+    const ssoFetch = createSsoFetch({
+      account: "myaccount",
+      session: {
+        session_token: "active-session",
+        master_token: "master",
+        session_expires: Date.now() + 10 * 60 * 1000,
+        master_expires: Date.now() + 4 * 60 * 60 * 1000,
+      },
+      fetchImpl: fakeFetch,
+    })
+
+    await ssoFetch("https://example.com/api", { method: "POST" })
+
+    expect(captured).toHaveLength(1)
+    const headers = new Headers(captured[0].headers as HeadersInit)
+    expect(headers.get("Authorization")).toBe('Snowflake Token="active-session"')
+  })
+
+  it("triggers renewal exactly once when session_expires is within the 60s buffer", async () => {
+    let renewCalls = 0
+    const onRenewCaptures: Array<{ session_token: string; session_expires: number }> = []
+    const fakeRenewFn = async (
+      _account: string,
+      _sessionToken: string,
+      _masterToken: string,
+    ): Promise<{ session_token: string; session_expires: number }> => {
+      renewCalls++
+      return { session_token: "renewed-token", session_expires: Date.now() + 3600 * 1000 }
+    }
+
+    const authHeaders: string[] = []
+    const fakeFetch: FetchLike = async (_url, init) => {
+      const headers = new Headers(init?.headers as HeadersInit)
+      authHeaders.push(headers.get("Authorization") ?? "")
+      return new Response("{}", { status: 200 })
+    }
+
+    const ssoFetch = createSsoFetch({
+      account: "myaccount",
+      session: {
+        session_token: "old-session",
+        master_token: "master",
+        session_expires: Date.now() + 30 * 1000, // within 60s buffer
+        master_expires: Date.now() + 4 * 60 * 60 * 1000,
+      },
+      renewFn: fakeRenewFn,
+      fetchImpl: fakeFetch,
+      onRenew: (s) => onRenewCaptures.push(s),
+    })
+
+    await ssoFetch("https://example.com/api", {})
+
+    expect(renewCalls).toBe(1)
+    expect(authHeaders[0]).toBe('Snowflake Token="renewed-token"')
+    expect(onRenewCaptures).toHaveLength(1)
+    expect(onRenewCaptures[0].session_token).toBe("renewed-token")
+  })
+
+  it("single-flights renewal: 5 concurrent calls with expiring session call renewFn exactly once", async () => {
+    let renewCalls = 0
+    const fakeRenewFn = async (
+      _account: string,
+      _sessionToken: string,
+      _masterToken: string,
+    ): Promise<{ session_token: string; session_expires: number }> => {
+      renewCalls++
+      // small delay so concurrent calls pile up
+      await new Promise<void>((r) => setTimeout(r, 20))
+      return { session_token: "renewed", session_expires: Date.now() + 3600 * 1000 }
+    }
+
+    const fakeFetch: FetchLike = async () => new Response("{}", { status: 200 })
+
+    const ssoFetch = createSsoFetch({
+      account: "myaccount",
+      session: {
+        session_token: "old",
+        master_token: "master",
+        session_expires: Date.now() + 30 * 1000, // within 60s buffer
+        master_expires: Date.now() + 4 * 60 * 60 * 1000,
+      },
+      renewFn: fakeRenewFn,
+      fetchImpl: fakeFetch,
+    })
+
+    await Promise.all(Array.from({ length: 5 }, () => ssoFetch("https://example.com", {})))
+
+    expect(renewCalls).toBe(1)
+  })
+
+  it("throws a clear re-auth error when master_expires is in the past", async () => {
+    const ssoFetch = createSsoFetch({
+      account: "myaccount",
+      session: {
+        session_token: "expired-session",
+        master_token: "expired-master",
+        session_expires: Date.now() - 1000,
+        master_expires: Date.now() - 1000,
+      },
+    })
+
+    await expect(ssoFetch("https://example.com", {})).rejects.toThrow(/re-authenticate/)
+  })
+})
+
+describe("sanitizeAccount integration", () => {
+  it("sanitizes account strings with protocols and trailing slashes in renewSessionToken", async () => {
+    const captured: string[] = []
+    const fakeFetch: FetchLike = async (url) => {
+      captured.push(String(url))
+      return new Response(JSON.stringify({ data: { sessionToken: "new-token", validityInSecondsST: 3600 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
+
+    await renewSessionToken("https://myaccount.snowflakecomputing.com/", "old-session", "master-token", fakeFetch)
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toMatch(/^https:\/\/myaccount\.snowflakecomputing\.com\/session\/token-request/)
+  })
+})
+
+describe("startLoopback error handling", () => {
+  it("ignores malformed request URLs without crashing, responds with 400, and successfully processes subsequent valid requests", async () => {
+    let capturedPort = 0
+    const fakeFetch: FetchLike = async (url, init) => {
+      const urlStr = String(url)
+      if (urlStr.includes("authenticator-request")) {
+        if (init?.body) {
+          const body = JSON.parse(init.body as string)
+          capturedPort = Number(body.data.BROWSER_MODE_REDIRECT_PORT)
+        }
+        return new Response(JSON.stringify({ data: { ssoUrl: "https://sso.example.com", proofKey: "proof" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      } else if (urlStr.includes("login-request")) {
+        return new Response(JSON.stringify({
+          data: {
+            token: "my-session-token",
+            masterToken: "my-master-token",
+            validityInSeconds: 3600,
+            masterValidityInSeconds: 14400,
+          }
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      return new Response("{}", { status: 404 })
+    }
+
+    // Override global.URL to simulate URL constructor throwing TypeError on malformed URLs
+    const OriginalURL = global.URL
+    let urlConstructorCalls = 0
+    global.URL = class extends OriginalURL {
+      constructor(url: string | URL, base?: string | URL) {
+        urlConstructorCalls++
+        if (typeof url === "string" && url.includes("malformed")) {
+          throw new TypeError("Invalid URL")
+        }
+        super(url, base)
+      }
+    } as any
+
+    try {
+      const { callback } = await initiateExternalBrowserAuth("myaccount", fakeFetch)
+      expect(capturedPort).toBeGreaterThan(0)
+
+      // Send malformed request that causes URL to throw
+      const malformedRes = await fetch(`http://127.0.0.1:${capturedPort}/malformed`)
+      expect(malformedRes.status).toBe(400)
+      const malformedText = await malformedRes.text()
+      expect(malformedText).toBe("Invalid URL")
+
+      // Send a second request that is missing the token parameter
+      const missingRes = await fetch(`http://127.0.0.1:${capturedPort}/`)
+      expect(missingRes.status).toBe(400)
+      const missingText = await missingRes.text()
+      expect(missingText).toBe("Missing token parameter")
+
+      // Send a third request that is valid
+      const validRes = await fetch(`http://127.0.0.1:${capturedPort}/?token=my-secret-idp-token`)
+      expect(validRes.status).toBe(200)
+      const validText = await validRes.text()
+      expect(validText).toContain("Authentication complete")
+
+      // Await the callback to ensure it received the token and completed successfully
+      const result = await callback()
+      expect(result.session_token).toBe("my-session-token")
+      expect(result.master_token).toBe("my-master-token")
+    } finally {
+      global.URL = OriginalURL
+    }
+  })
+})
+

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -1,4 +1,39 @@
 {
+  "snowflake-cortex": {
+      "id": "snowflake-cortex",
+      "env": [],
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Snowflake Cortex",
+      "models": {
+        "claude-sonnet-4-6": {
+          "id": "claude-sonnet-4-6",
+          "name": "Claude Sonnet 4.6",
+          "attachment": true,
+          "reasoning": false,
+          "tool_call": true,
+          "temperature": true,
+          "release_date": "2025-01-01",
+          "last_updated": "2025-01-01",
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "open_weights": false,
+          "limit": {
+            "context": 200000,
+            "output": 8192
+          },
+          "cost": {
+            "input": 0,
+            "output": 0
+          }
+        }
+      }
+    },
   "302ai": {
     "id": "302ai",
     "env": ["302AI_API_KEY"],

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1997,6 +1997,22 @@ The model catalog is provided automatically. A minimal `opencode.json` is all th
 }
 ```
 
+#### Alternative: SSO (External Browser)
+
+If your Snowflake account uses an external identity provider (e.g. Okta, Entra ID), you
+can authenticate with SSO instead of a PAT.
+
+1. Run `/connect` and select **Snowflake Cortex**.
+2. When prompted for the authentication method, select **SSO (External Browser)**.
+3. Enter your account identifier.
+4. Your browser will open automatically. Complete the IdP login.
+5. opencode stores a session token (valid ~1 hour) and master token (valid ~4 hours).
+   It renews the session token automatically. After ~4 hours, re-run `/connect` to log in again.
+
+> **Note**: SSO requires your Snowflake account to have an external IdP configured and your
+> user to have browser-based SSO access. Contact your Snowflake administrator if unsure.
+> PrivateLink accounts require network or VPN reachability to the account host.
+
 ---
 
 ### Together AI


### PR DESCRIPTION
### Issue for this PR

Closes #31702

### Type of change

- [x] New feature

### What does this PR do?

Snowflake Cortex previously only supported PAT auth. This adds SSO via the external browser flow, so users on accounts with an external IdP can log in without a token.

It replicates the Snowflake driver EXTERNALBROWSER handshake: POST `/session/authenticator-request` → open the browser → capture the IdP token on a local 127.0.0.1 loopback → POST `/session/v1/login-request` to get a session + master token. The custom fetch sends `Authorization: Snowflake Token="<session>"` (the format the Cortex REST API actually accepts — `Bearer` is rejected, verified against a live account) and transparently renews the session token via `/session/token-request` when it nears expiry. When the master token expires the user is asked to log in again.

SSO is selectable from both `opencode auth login` (PAT | SSO) and the TUI `/connect` dialog. PAT auth is unchanged.

### How did you verify your code works?

- Unit tests (run from `packages/opencode` and `packages/core`):
  - the auth schema round-trips the new `snowflake-session` credential
  - the external-browser module: session-token renewal request shape, the `Snowflake Token` header injection, single-flight renewal under concurrent requests, and the master-token-expired error path
  - the `/connect` plugin exposes PAT + SSO methods and persists a `snowflake-session` credential identical to the CLI path
  - the provider appears in the model list (with its catalog models) when an SSO or PAT credential is stored, and is absent with none
  - the V2 provider plugin passes the SSO fetch through unchanged
- Manual: `bun dev`, `/connect` → Snowflake Cortex → SSO, completed the IdP login in the browser, confirmed the model picker lists the Cortex models and a chat request streams successfully; confirmed PAT login still works.

### Screenshots / recordings

_TUI change — `/connect` now shows a PAT/SSO method selector for Snowflake Cortex. Happy to attach a recording if useful._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
