### PR TITLE
fix: retry on provider connection blocking errors with 60s delay

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -465,6 +465,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       Effect.succeed({
         autoload: provider.source === "config",
         options: {
+          headerTimeout: 60_000,
           headers: {
             "HTTP-Referer": "https://opencode.ai/",
             "X-Title": "opencode",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -684,6 +684,15 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case typeof (e as any)?.message === "string" && (e as any).message.includes("EngineCore"):
+      return new APIError(
+        {
+          message: (e as any).message,
+          isRetryable: true,
+          metadata: { code: "ProviderEngineError" },
+        },
+        { cause: e },
+      ).toObject()
     case APICallError.isInstance(e):
       const parsed = ProviderError.parseAPICallError({
         providerID: ctx.providerID,

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -32,8 +32,22 @@ function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
 }
 
+export const RETRY_DELAY_BLOCKED = 60_000
+
+function isConnectionBlockingError(error: SessionV1.APIError) {
+  const code = error.data.metadata?.["code"]
+  return (
+    code === "ECONNRESET" ||
+    code === "ProviderHeaderTimeoutError" ||
+    code === "ProviderEngineError" ||
+    error.data.statusCode === 504
+  )
+}
+
 export function delay(attempt: number, error?: SessionV1.APIError) {
   if (error) {
+    // Provider hung or gateway timeout: fixed 5s delay regardless of attempt count
+    if (isConnectionBlockingError(error)) return RETRY_DELAY_BLOCKED
     const headers = error.data.responseHeaders
     if (headers) {
       const retryAfterMs = headers["retry-after-ms"]


### PR DESCRIPTION
### Issue for this PR

Closes #31712

### Type of change

- [x] Bug fix

### What does this PR do?

When providers like NVIDIA hang a connection without responding (ECONNRESET after 10+ minutes, HTTP 504 after 5+ minutes) or return an in-stream engine crash (`EngineCore encountered an issue`), the session would stop with an error and require manual retry. The IDE appeared frozen while the connection hung.

Three changes:

1. **`provider/provider.ts`** — adds `headerTimeout: 60_000` to the NVIDIA provider. Without this, a hung TCP connection would block the session for 10+ minutes before producing an ECONNRESET. With it, the connection aborts after 60s and triggers a retry.

2. **`session/retry.ts`** — introduces `isConnectionBlockingError()` that detects ECONNRESET, HTTP 504, header timeout, and NVIDIA engine errors, and returns a fixed 60s retry delay for them instead of the standard exponential backoff.

3. **`session/message-v2.ts`** — handles `EngineCore` errors from NVIDIA's inference engine. These arrive as plain objects (not `Error` instances) with a `.message` field, so they weren't matched by existing cases and fell through as non-retryable `NamedError.Unknown`. Now they're converted to retryable `APIError` with `metadata.code = "ProviderEngineError"`.

### How did you verify your code works?

Reproduced the issue using session logs (`~/.local/share/opencode/log/`) that showed ECONNRESET after 694s, HTTP 504 after 302s, and `EngineCore` errors failing definitively. Confirmed the retry status display (spinner + countdown) already works for the `retry` status type — no UI changes needed.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR