### PR TITLE
fix: persist project edits for global/no-ID projects

### DIFF
--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -88,6 +88,9 @@ export function DialogEditProject(props: { project: LocalProject; server: Server
           commands: { start },
         })
         serverSync().project.icon(props.project.worktree, store.iconOverride || undefined)
+        serverSync().project.meta(props.project.worktree, {
+          icon: { color: store.color || undefined },
+        })
         dialog.close()
         return
       }

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -418,7 +418,19 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
       // Without this, different subdirectories of the same git repo would share the same
       // icon from the database instead of using their individual overrides.
-      const base = { ...metadata, ...project }
+      let base = { ...metadata, ...project }
+      // For projects edited via the dialog (especially "global" or no-ID projects),
+      // merge local projectMeta on top so the user's changes take precedence
+      // over the server-side metadata (which may have stale auto-assigned values).
+      if (childStore.projectMeta) {
+        const meta = childStore.projectMeta
+        base = {
+          ...base,
+          name: meta.name ?? base.name,
+          icon: { ...base.icon, ...meta.icon },
+          commands: { ...base.commands, ...meta.commands },
+        }
+      }
       if (childStore.icon) {
         return { ...base, icon: { ...base.icon, override: childStore.icon } }
       }


### PR DESCRIPTION
### Issue for this PR

Closes #31739

### Type of change

- [X] Bug fix

### What does this PR do?

Project edits (name, color, commands) made via the edit dialog don't persist for 'global' projects or projects without a server-side ID. The dialog closes without error, but re-opening shows the original values.

**Root cause**: When saving via the dialog, the icon color was never synced to the local store. Additionally, enrich() in the layout context always gave precedence to server-side metadata (which contained stale auto-assigned colors) over the local user edits stored in childStore.projectMeta.

**Fix** (two changes, 16 lines):

1. dialog-edit-project.tsx: After project.update() to the server, also call project.meta() to sync the icon color to the local store.

2. layout.tsx (enrich function): Merge childStore.projectMeta on top of server metadata so user edits from the dialog take precedence over stale auto-assigned values.

### How did you verify your code works?

- Built and ran the desktop app from source (Electron + Vite)
- Opened a 'global' project (no server-side ID), changed its color via edit dialog, saved, re-opened dialog — change persisted
- Same test with name change
- Confirmed console showed the save taking the local path (project.id === 'global')
- Tested with projects that have server-side IDs as well

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR