### PR TITLE
chore: pin gitlab-ai-provider to 6.9.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -288,7 +288,7 @@
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "3.1.0",
-        "gitlab-ai-provider": "6.9.1",
+        "gitlab-ai-provider": "6.9.0",
         "glob": "13.0.5",
         "google-auth-library": "10.5.0",
         "gray-matter": "4.0.3",
@@ -564,7 +564,7 @@
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "3.1.0",
-        "gitlab-ai-provider": "6.9.1",
+        "gitlab-ai-provider": "6.9.0",
         "glob": "13.0.5",
         "google-auth-library": "10.5.0",
         "gray-matter": "4.0.3",
@@ -3626,7 +3626,7 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
-    "gitlab-ai-provider": ["gitlab-ai-provider@6.9.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=3.0.0", "@ai-sdk/provider-utils": ">=4.0.0" } }, "sha512-2qd8UCwS3qTGk0uVq+tMT+06cpMjTw8ShECCAnI3+pXynnxG3rEo4tRojl9ES281pA+WwijsO6gCHuiuleYBjg=="],
+    "gitlab-ai-provider": ["gitlab-ai-provider@6.9.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=3.0.0", "@ai-sdk/provider-utils": ">=4.0.0" } }, "sha512-CEdKuUfbKwDfYXsY+LwvxXFLdu6hl7cwTA1lMM8Hzvfq6rxUwzVS2YXCS9hs79H2fkZnu/vMZ3aFO/8Ll80GyQ=="],
 
     "glob": ["glob@13.0.5", "", { "dependencies": { "minimatch": "^10.2.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,7 +104,7 @@
     "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "3.1.0",
-    "gitlab-ai-provider": "6.9.1",
+    "gitlab-ai-provider": "6.9.0",
     "glob": "13.0.5",
     "google-auth-library": "10.5.0",
     "gray-matter": "4.0.3",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -117,7 +117,7 @@
     "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "3.1.0",
-    "gitlab-ai-provider": "6.9.1",
+    "gitlab-ai-provider": "6.9.0",
     "glob": "13.0.5",
     "google-auth-library": "10.5.0",
     "gray-matter": "4.0.3",


### PR DESCRIPTION
### Issue for this PR

Closes #31743

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pins the `gitlab-ai-provider` dependency to `6.9.0` (down from `6.9.1`) in the two workspace packages that consume it (`@opencode-ai/core` and `opencode`), and regenerates `bun.lock` accordingly.

`gitlab-ai-provider@6.9.1` shipped a broad security/reliability hardening pass that introduced an authentication regression: intermittent `401 Forbidden by auth provider` responses from the GitLab AI Gateway when authenticating with both OAuth and personal access tokens. `6.9.0` predates that hardening pass and is known-good — it contains the Claude Fable 5 model mapping on top of the stable `6.8.x` auth code, without the regression.

This pins opencode to `6.9.0` as a workaround until a fixed provider release is validated end-to-end. This is a dependency-version change only; there are no opencode source changes.

Diff scope:
- `packages/core/package.json`: `gitlab-ai-provider` `6.9.1` → `6.9.0`
- `packages/opencode/package.json`: `gitlab-ai-provider` `6.9.1` → `6.9.0`
- `bun.lock`: regenerated to resolve `gitlab-ai-provider@6.9.0`

### How did you verify your code works?

- Ran `bun install`; the lockfile resolves `gitlab-ai-provider@6.9.0` for both `@opencode-ai/core` and `opencode`.
- Confirmed the installed package version is `6.9.0` (`require('gitlab-ai-provider/package.json').version`).
- Verified the diff contains only the two workspace `package.json` changes plus the lockfile (no unrelated changes; the root `package.json` is untouched).

### Screenshots / recordings

_Not applicable — dependency version change only, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
