### PR TITLE
TUI: Add provider disconnect option to /connect dialog

### DIFF
--- a/packages/tui/src/component/dialog-provider.tsx
+++ b/packages/tui/src/component/dialog-provider.tsx
@@ -145,6 +145,33 @@ export function createDialogProviderOptions() {
           async onSelect() {
             if (consoleManaged) return
 
+            if (connected && onboarded()) {
+              const choice = await new Promise<"reconnect" | "disconnect" | null>((resolve) => {
+                dialog.replace(
+                  () => (
+                    <DialogSelect
+                      title={provider.title}
+                      options={[
+                        { title: "Connect with different credentials", value: "reconnect" },
+                        { title: "Disconnect", value: "disconnect" },
+                      ]}
+                      onSelect={(opt) => resolve(opt.value)}
+                    />
+                  ),
+                  () => resolve(null),
+                )
+              })
+              if (choice === null) return
+              if (choice === "disconnect") {
+                await sdk.client.auth.remove({ providerID })
+                await sdk.client.instance.dispose()
+                await sync.bootstrap()
+                toast.show({ variant: "info", message: `Disconnected from ${provider.title}` })
+                dialog.replace(() => <DialogProvider />)
+                return
+              }
+            }
+
             const methods = sync.data.provider_auth[providerID] ?? [
               {
                 type: "api",


### PR DESCRIPTION
Currently users can connect to any provider through the TUI, but logging out requires dropping to the CLI (`opencode providers logout`). This adds a "Disconnect" option directly to the provider selection dialog.

When a connected provider is selected from `/connect`, users now see:
- **Connect with different credentials** — proceeds with existing auth flow
- **Disconnect** — removes credentials, refreshes state, and shows a toast

Non-connected providers, console-managed providers, and custom providers are unaffected. Pressing Esc in the disconnect dialog returns to the provider list gracefully.