### PR TITLE
feat(mcp): support server log notifications

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -7,7 +7,12 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
-import { type Tool as MCPToolDef, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+import {
+  type LoggingMessageNotification,
+  LoggingMessageNotificationSchema,
+  type Tool as MCPToolDef,
+  ToolListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js"
 import { Config } from "@/config/config"
 import { ConfigMCPV1 } from "@opencode-ai/core/v1/config/mcp"
 import { NamedError } from "@opencode-ai/core/util/error"
@@ -391,6 +396,10 @@ export const layer = Layer.effect(
     )
 
     function watch(s: State, name: string, client: MCPClient, bridge: EffectBridge.Shape, timeout?: number) {
+      client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) =>
+        bridge.promise(serverLog(name, notification.params)),
+      )
+
       if (!client.getServerCapabilities()?.tools) return
       client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
         if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
@@ -402,6 +411,14 @@ export const layer = Layer.effect(
         s.defs[name] = listed
         await bridge.promise(events.publish(ToolsChanged, { server: name }).pipe(Effect.ignore))
       })
+    }
+
+    function serverLog(name: string, params: LoggingMessageNotification["params"]) {
+      const fields = { server: name, logger: params.logger, level: params.level, data: params.data }
+      if (params.level === "debug") return Effect.logDebug("MCP server log", fields)
+      if (params.level === "info" || params.level === "notice") return Effect.logInfo("MCP server log", fields)
+      if (params.level === "warning") return Effect.logWarning("MCP server log", fields)
+      return Effect.logError("MCP server log", fields)
     }
 
     const state = yield* InstanceState.make<State>(

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -415,10 +415,20 @@ export const layer = Layer.effect(
 
     function serverLog(name: string, params: LoggingMessageNotification["params"]) {
       const fields = { server: name, logger: params.logger, level: params.level, data: params.data }
-      if (params.level === "debug") return Effect.logDebug("MCP server log", fields)
-      if (params.level === "info" || params.level === "notice") return Effect.logInfo("MCP server log", fields)
-      if (params.level === "warning") return Effect.logWarning("MCP server log", fields)
-      return Effect.logError("MCP server log", fields)
+      switch (params.level) {
+        case "debug":
+          return Effect.logDebug("MCP server log", fields)
+        case "info":
+        case "notice":
+          return Effect.logInfo("MCP server log", fields)
+        case "warning":
+          return Effect.logWarning("MCP server log", fields)
+        case "error":
+        case "critical":
+        case "alert":
+        case "emergency":
+          return Effect.logError("MCP server log", fields)
+      }
     }
 
     const state = yield* InstanceState.make<State>(

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { expect, mock, beforeEach } from "bun:test"
-import { LoggingMessageNotificationSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
-import { Cause, Effect, Exit, Logger, References } from "effect"
+import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+import { Cause, Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { testEffect } from "../lib/effect"
 
@@ -405,70 +405,6 @@ it.instance(
         expect(serverState.listToolsCalls).toBe(2)
       }),
     ),
-  { config: { mcp: {} } },
-)
-
-it.instance(
-  "routes server log notifications to diagnostic logging",
-  () => {
-    const logs: Array<{ level: string; fields: unknown }> = []
-    const logger = Logger.make((options) => {
-      if (!Array.isArray(options.message) || options.message[0] !== "MCP server log") return
-      logs.push({
-        level: options.logLevel,
-        fields: options.message[1],
-      })
-    })
-
-    return MCP.Service.use((mcp: MCPNS.Interface) =>
-      Effect.gen(function* () {
-        lastCreatedClientName = "logging-server"
-        const serverState = getOrCreateClientState("logging-server")
-
-        yield* mcp.add("logging-server", {
-          type: "local",
-          command: ["echo", "test"],
-        })
-
-        const handler = serverState.notificationHandlers.get(LoggingMessageNotificationSchema)
-        expect(handler).toBeDefined()
-        for (const level of [
-          "debug",
-          "info",
-          "notice",
-          "warning",
-          "error",
-          "critical",
-          "alert",
-          "emergency",
-        ] as const) {
-          yield* Effect.promise(() =>
-            handler?.({ method: "notifications/message", params: { level, logger: "worker", data: { id: 42 } } }),
-          )
-        }
-
-        expect(logs.map((entry) => entry.level)).toEqual([
-          "Debug",
-          "Info",
-          "Info",
-          "Warn",
-          "Error",
-          "Error",
-          "Error",
-          "Error",
-        ])
-        expect(logs[0]?.fields).toEqual({
-          server: "logging-server",
-          logger: "worker",
-          level: "debug",
-          data: { id: 42 },
-        })
-      }),
-    ).pipe(
-      Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
-      Effect.provideService(References.MinimumLogLevel, "Debug"),
-    )
-  },
   { config: { mcp: {} } },
 )
 

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { expect, mock, beforeEach } from "bun:test"
-import { Cause, Effect, Exit } from "effect"
+import { LoggingMessageNotificationSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+import { Cause, Effect, Exit, Logger, References } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { testEffect } from "../lib/effect"
 
@@ -394,7 +395,7 @@ it.instance(
           { name: "next_tool", description: "next", inputSchema: { type: "object", properties: {} } },
         ]
 
-        const handler = Array.from(serverState.notificationHandlers.values())[0]
+        const handler = serverState.notificationHandlers.get(ToolListChangedNotificationSchema)
         expect(handler).toBeDefined()
         yield* Effect.promise(() => handler?.())
 
@@ -404,6 +405,70 @@ it.instance(
         expect(serverState.listToolsCalls).toBe(2)
       }),
     ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "routes server log notifications to diagnostic logging",
+  () => {
+    const logs: Array<{ level: string; fields: unknown }> = []
+    const logger = Logger.make((options) => {
+      if (!Array.isArray(options.message) || options.message[0] !== "MCP server log") return
+      logs.push({
+        level: options.logLevel,
+        fields: options.message[1],
+      })
+    })
+
+    return MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "logging-server"
+        const serverState = getOrCreateClientState("logging-server")
+
+        yield* mcp.add("logging-server", {
+          type: "local",
+          command: ["echo", "test"],
+        })
+
+        const handler = serverState.notificationHandlers.get(LoggingMessageNotificationSchema)
+        expect(handler).toBeDefined()
+        for (const level of [
+          "debug",
+          "info",
+          "notice",
+          "warning",
+          "error",
+          "critical",
+          "alert",
+          "emergency",
+        ] as const) {
+          yield* Effect.promise(() =>
+            handler?.({ method: "notifications/message", params: { level, logger: "worker", data: { id: 42 } } }),
+          )
+        }
+
+        expect(logs.map((entry) => entry.level)).toEqual([
+          "Debug",
+          "Info",
+          "Info",
+          "Warn",
+          "Error",
+          "Error",
+          "Error",
+          "Error",
+        ])
+        expect(logs[0]?.fields).toEqual({
+          server: "logging-server",
+          logger: "worker",
+          level: "debug",
+          data: { id: 42 },
+        })
+      }),
+    ).pipe(
+      Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
+      Effect.provideService(References.MinimumLogLevel, "Debug"),
+    )
+  },
   { config: { mcp: {} } },
 )
 


### PR DESCRIPTION
## Summary
- handle standard MCP `notifications/message` notifications
- route all MCP severities to matching OpenCode diagnostic log levels
- preserve server, remote logger, level, and structured data context
- register logging independently of tool capabilities

## Testing
- `bun test test/mcp/lifecycle.test.ts`
- `bun typecheck`
- `bunx prettier --check packages/opencode/src/mcp/index.ts packages/opencode/test/mcp/lifecycle.test.ts`

Relates to: #28567