### PR TITLE
TUI: Add provider disconnect option to /connect dialog

### DIFF
--- a/packages/tui/src/component/dialog-provider.tsx
+++ b/packages/tui/src/component/dialog-provider.tsx
@@ -145,6 +145,33 @@ export function createDialogProviderOptions() {
           async onSelect() {
             if (consoleManaged) return
 
+            if (connected && onboarded()) {
+              const choice = await new Promise<"reconnect" | "disconnect" | null>((resolve) => {
+                dialog.replace(
+                  () => (
+                    <DialogSelect
+                      title={provider.title}
+                      options={[
+                        { title: "Connect with different credentials", value: "reconnect" },
+                        { title: "Disconnect", value: "disconnect" },
+                      ]}
+                      onSelect={(opt) => resolve(opt.value)}
+                    />
+                  ),
+                  () => resolve(null),
+                )
+              })
+              if (choice === null) return
+              if (choice === "disconnect") {
+                await sdk.client.auth.remove({ providerID })
+                await sdk.client.instance.dispose()
+                await sync.bootstrap()
+                toast.show({ variant: "info", message: `Disconnected from ${provider.title}` })
+                dialog.replace(() => <DialogProvider />)
+                return
+              }
+            }
+
             const methods = sync.data.provider_auth[providerID] ?? [
               {
                 type: "api",


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Currently users can connect to any provider through the TUI, but logging out requires dropping to the CLI (`opencode providers logout`). This adds a "Disconnect" option directly to the provider selection dialog so users can manage credentials without leaving their session.

When a connected provider is selected from `/connect`, users now see a choice:
- **Connect with different credentials** — proceeds with existing auth flow
- **Disconnect** — calls the existing `auth.remove()` to clear stored credentials, refreshes state, and shows a confirmation toast

Non-connected providers flow directly to auth as before. Console-managed providers and custom providers are unaffected. Pressing Esc in the disconnect dialog returns to the provider list.

25 lines added. No backend or SDK changes — everything (`DELETE /auth/:providerID`, `sdk.client.auth.remove()`) was already wired up.

### How did you verify your code works?

Tested locally with `bun dev` using an isolated `XDG_DATA_HOME`:
1. Connected an Anthropic provider via API key through the TUI
2. Opened `/connect` again, selected the connected provider — saw the disconnect/reconnect choice
3. Selected "Disconnect" — provider was removed from connected list, toast confirmed
4. Selected a non-connected provider — went directly to auth flow (no intermediate dialog)
5. Selected "Connect with different credentials" — continued to normal auth prompt

### Screenshots / recordings

N/A — terminal UI change, simple dialog select flow

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
