### PR TITLE
fix(file-tree): sort file names numerically instead of lexicographically

### DIFF
--- a/packages/app/src/components/file-tree.test.ts
+++ b/packages/app/src/components/file-tree.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, mock, test } from "bun:test"
 let shouldListRoot: typeof import("./file-tree").shouldListRoot
 let shouldListExpanded: typeof import("./file-tree").shouldListExpanded
 let dirsToExpand: typeof import("./file-tree").dirsToExpand
+let compareFileTreeNodes: typeof import("@/utils/file-tree-sorting").compareFileTreeNodes
 
 beforeAll(async () => {
   mock.module("@solidjs/router", () => ({
@@ -35,6 +36,8 @@ beforeAll(async () => {
   shouldListRoot = mod.shouldListRoot
   shouldListExpanded = mod.shouldListExpanded
   dirsToExpand = mod.dirsToExpand
+  const sortingMod = await import("@/utils/file-tree-sorting")
+  compareFileTreeNodes = sortingMod.compareFileTreeNodes
 })
 
 describe("file tree fetch discipline", () => {
@@ -76,5 +79,88 @@ describe("file tree fetch discipline", () => {
 
     expect(second).toEqual([])
     expect(dirsToExpand({ level: 1, filter, expanded: () => false })).toEqual([])
+  })
+})
+
+describe("file tree numeric sorting", () => {
+  test("sorts files with numbers numerically", () => {
+    const treeForSort = {
+      nodes: [
+        { kind: "file", name: "lesson-1" },
+        { kind: "file", name: "lesson-10" },
+        { kind: "file", name: "lesson-11" },
+        { kind: "file", name: "lesson-2" },
+        { kind: "file", name: "lesson-3" },
+      ],
+    }
+    const indices = treeForSort.nodes.map((_, idx) => idx)
+    const sortedIndices = indices.slice().sort((a, b) => compareFileTreeNodes(treeForSort, a, b))
+    const sortedNames = sortedIndices.map((idx) => treeForSort.nodes[idx]!.name)
+
+    expect(sortedNames).toEqual(["lesson-1", "lesson-2", "lesson-3", "lesson-10", "lesson-11"])
+  })
+
+  test("sorts directories before files", () => {
+    const treeForSort = {
+      nodes: [
+        { kind: "file", name: "file1.txt" },
+        { kind: "directory", name: "dir1" },
+        { kind: "file", name: "file2.txt" },
+        { kind: "directory", name: "dir2" },
+      ],
+    }
+    const indices = treeForSort.nodes.map((_, idx) => idx)
+    const sortedIndices = indices.slice().sort((a, b) => compareFileTreeNodes(treeForSort, a, b))
+    const sortedNodes = sortedIndices.map((idx) => treeForSort.nodes[idx]!)
+
+    expect(sortedNodes.map((node) => node.kind)).toEqual(["directory", "directory", "file", "file"])
+  })
+
+  test("sorts directories alphabetically within each group", () => {
+    const treeForSort = {
+      nodes: [
+        { kind: "directory", name: "zebra" },
+        { kind: "directory", name: "apple" },
+        { kind: "file", name: "zebra.txt" },
+        { kind: "file", name: "apple.txt" },
+      ],
+    }
+    const indices = treeForSort.nodes.map((_, idx) => idx)
+    const sortedIndices = indices.slice().sort((a, b) => compareFileTreeNodes(treeForSort, a, b))
+    const sortedNodes = sortedIndices.map((idx) => treeForSort.nodes[idx]!)
+
+    expect(sortedNodes.map((node) => node.name)).toEqual(["apple", "zebra", "apple.txt", "zebra.txt"])
+  })
+
+  test("handles mixed alphanumeric names", () => {
+    const treeForSort = {
+      nodes: [
+        { kind: "file", name: "version-2.1" },
+        { kind: "file", name: "version-10.0" },
+        { kind: "file", name: "version-1.5" },
+        { kind: "file", name: "version-2.0" },
+      ],
+    }
+    const indices = treeForSort.nodes.map((_, idx) => idx)
+    const sortedIndices = indices.slice().sort((a, b) => compareFileTreeNodes(treeForSort, a, b))
+    const sortedNames = sortedIndices.map((idx) => treeForSort.nodes[idx]!.name)
+
+    expect(sortedNames).toEqual(["version-1.5", "version-2.0", "version-2.1", "version-10.0"])
+  })
+
+  test("handles leading zeros", () => {
+    const treeForSort = {
+      nodes: [
+        { kind: "file", name: "file-001" },
+        { kind: "file", name: "file-010" },
+        { kind: "file", name: "file-002" },
+        { kind: "file", name: "file-1" },
+      ],
+    }
+    const indices = treeForSort.nodes.map((_, idx) => idx)
+    const sortedIndices = indices.slice().sort((a, b) => compareFileTreeNodes(treeForSort, a, b))
+    const sortedNames = sortedIndices.map((idx) => treeForSort.nodes[idx]!.name)
+
+    expect(sortedNames).toEqual(["file-1", "file-001", "file-002", "file-010"])
   })
 })

--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -1,5 +1,6 @@
 import { useFile } from "@/context/file"
 import { encodeFilePath } from "@/context/file/path"
+import { compareFileTreeNodes } from "@/utils/file-tree-sorting"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -373,12 +374,8 @@ export default function FileTree(props: {
       seen.add(item)
     }
 
-    out.sort((a, b) => {
-      if (a.type !== b.type) {
-        return a.type === "directory" ? -1 : 1
-      }
-      return a.name.localeCompare(b.name)
-    })
+    const treeForSort = { nodes: out.map((node) => ({ kind: node.type, name: node.name })) }
+    out.sort((a, b) => compareFileTreeNodes(treeForSort, out.indexOf(a), out.indexOf(b)))
 
     return out
   })

--- a/packages/app/src/utils/file-tree-sorting.ts
+++ b/packages/app/src/utils/file-tree-sorting.ts
@@ -1,0 +1,78 @@
+export function compareFileTreeNodes(tree: { nodes: { kind: "directory" | "file"; name: string }[] }, left: number, right: number) {
+  const leftNode = tree.nodes[left]!
+  const rightNode = tree.nodes[right]!
+  if (leftNode.kind !== rightNode.kind) return leftNode.kind === "directory" ? -1 : 1
+  return compareNames(leftNode.name, rightNode.name)
+}
+
+function compareNames(a: string, b: string): -1 | 0 | 1 {
+  const suffix = countCommonSuffix(a, b)
+  a = a.substring(0, a.length - suffix)
+  b = b.substring(0, b.length - suffix)
+
+  for (;;) {
+    const prefix = countCommonPrefix(a, b)
+    a = a.substring(prefix)
+    b = b.substring(prefix)
+
+    const aNum = parseNumber(a)
+    const bNum = parseNumber(b)
+
+    if (!isNaN(aNum) && !isNaN(bNum)) {
+      if (aNum < bNum) {
+        return -1
+      }
+      if (aNum > bNum) {
+        return 1
+      }
+      a = removeNumberPrefix(a, aNum)
+      b = removeNumberPrefix(b, bNum)
+      continue
+    }
+
+    return a < b ? -1 : a > b ? 1 : 0
+  }
+}
+
+function parseNumber(s: string): number {
+  if (s.length === 0) {
+    return NaN
+  }
+  if (s[0] === '-') {
+    return NaN
+  }
+  return parseFloat(s.replace('e', ' ').replace('.', ' '))
+}
+
+function removeNumberPrefix(s: string, num: number): string {
+  if (num === 0) {
+    return s.replace(/^0+/, '')
+  }
+  return s.replace(/^0+/, '').slice(String(num).length)
+}
+
+function countCommonSuffix(a: string, b: string): number {
+  const n = Math.min(a.length, b.length)
+  let tail = 0
+  for (let i = 0; i < n; i++) {
+    if (a[a.length - 1 - i] === b[b.length - 1 - i]) {
+      tail++
+    } else {
+      break
+    }
+  }
+  return tail
+}
+
+function countCommonPrefix(a: string, b: string): number {
+  const n = Math.min(a.length, b.length)
+  let prefix = 0
+  for (let i = 0; i < n; i++) {
+    if (a[i] === b[i]) {
+      prefix++
+    } else {
+      break
+    }
+  }
+  return prefix
+}

--- a/packages/tui/src/feature-plugins/system/diff-viewer-file-tree-utils.ts
+++ b/packages/tui/src/feature-plugins/system/diff-viewer-file-tree-utils.ts
@@ -3,6 +3,8 @@
 // Each leaf remembers what has been,
 // And waits where careful light aligns.
 
+import { compareFileTreeNodesFromUI } from "@opencode-ai/ui/file-tree-sorting"
+
 export type FileTreeItem = {
   readonly file: string
   readonly status?: "added" | "deleted" | "modified"
@@ -111,12 +113,8 @@ function collapsedFileTreeDirectoryChain(tree: FileTree, id: number): FileTreeNo
 }
 
 export function compareFileTreeNodes(tree: FileTree, left: number, right: number) {
-  const leftNode = tree.nodes[left]!
-  const rightNode = tree.nodes[right]!
-  if (leftNode.kind !== rightNode.kind) return leftNode.kind === "directory" ? -1 : 1
-  if (leftNode.name < rightNode.name) return -1
-  if (leftNode.name > rightNode.name) return 1
-  return left - right
+  const treeForSort = { nodes: tree.nodes.map((node) => ({ kind: node.kind, name: node.name })) }
+  return compareFileTreeNodesFromUI(treeForSort, left, right)
 }
 
 export function moveFileTreeSelection(rows: readonly FileTreeRow[], selected: number | undefined, offset: number) {

--- a/packages/tui/test/feature-plugins/diff-viewer-file-tree-utils.test.ts
+++ b/packages/tui/test/feature-plugins/diff-viewer-file-tree-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   allExpandedFileTreeDirectories,
   buildFileTree,
+  compareFileTreeNodes,
   fileTreeFileSelection,
   flattenFileTree,
   moveFileTreeSelection,
@@ -57,6 +58,42 @@ describe("diff viewer file tree utilities", () => {
       "  file:alpha.ts",
       "  file:file.ts",
       "file:z-file.ts",
+    ])
+  })
+
+  test("sorts files with numbers numerically", () => {
+    const tree = buildFileTree([
+      { file: "lesson-10.ts" },
+      { file: "lesson-1.ts" },
+      { file: "lesson-11.ts" },
+      { file: "lesson-2.ts" },
+      { file: "lesson-3.ts" },
+    ])
+
+    const rows = flattenFileTree(tree)
+    expect(rows.map((row) => row.name)).toEqual([
+      "lesson-1.ts",
+      "lesson-2.ts",
+      "lesson-3.ts",
+      "lesson-10.ts",
+      "lesson-11.ts",
+    ])
+  })
+
+  test("sorts directories with numbers numerically", () => {
+    const tree = buildFileTree([
+      { file: "src/dir-10/file.ts" },
+      { file: "src/dir-1/file.ts" },
+      { file: "src/dir-11/file.ts" },
+      { file: "src/dir-2/file.ts" },
+    ])
+
+    const rows = flattenFileTree(tree)
+    expect(rows.map((row) => row.name)).toEqual([
+      "src/dir-1",
+      "src/dir-2",
+      "src/dir-10",
+      "src/dir-11",
     ])
   })
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,8 @@
     "./audio/*": "./src/assets/audio/*",
     "./v2/*.css": "./src/v2/components/*.css",
     "./v2/*": "./src/v2/components/*.tsx",
-    "./v2/styles/*": "./src/v2/styles/*"
+    "./v2/styles/*": "./src/v2/styles/*",
+    "./file-tree-sorting": "./src/file-tree-sorting.ts"
   },
   "scripts": {
     "typecheck": "tsgo --noEmit",

--- a/packages/ui/src/file-tree-sorting.ts
+++ b/packages/ui/src/file-tree-sorting.ts
@@ -1,0 +1,78 @@
+export function compareFileTreeNodesFromUI(tree: { nodes: { kind: "directory" | "file"; name: string }[] }, left: number, right: number) {
+  const leftNode = tree.nodes[left]!
+  const rightNode = tree.nodes[right]!
+  if (leftNode.kind !== rightNode.kind) return leftNode.kind === "directory" ? -1 : 1
+  return compareNames(leftNode.name, rightNode.name)
+}
+
+function compareNames(a: string, b: string): -1 | 0 | 1 {
+  const suffix = countCommonSuffix(a, b)
+  a = a.substring(0, a.length - suffix)
+  b = b.substring(0, b.length - suffix)
+
+  for (;;) {
+    const prefix = countCommonPrefix(a, b)
+    a = a.substring(prefix)
+    b = b.substring(prefix)
+
+    const aNum = parseNumber(a)
+    const bNum = parseNumber(b)
+
+    if (!isNaN(aNum) && !isNaN(bNum)) {
+      if (aNum < bNum) {
+        return -1
+      }
+      if (aNum > bNum) {
+        return 1
+      }
+      a = removeNumberPrefix(a, aNum)
+      b = removeNumberPrefix(b, bNum)
+      continue
+    }
+
+    return a < b ? -1 : a > b ? 1 : 0
+  }
+}
+
+function parseNumber(s: string): number {
+  if (s.length === 0) {
+    return NaN
+  }
+  if (s[0] === '-') {
+    return NaN
+  }
+  return parseFloat(s.replace('e', ' ').replace('.', ' '))
+}
+
+function removeNumberPrefix(s: string, num: number): string {
+  if (num === 0) {
+    return s.replace(/^0+/, '')
+  }
+  return s.replace(/^0+/, '').slice(String(num).length)
+}
+
+function countCommonSuffix(a: string, b: string): number {
+  const n = Math.min(a.length, b.length)
+  let tail = 0
+  for (let i = 0; i < n; i++) {
+    if (a[a.length - 1 - i] === b[b.length - 1 - i]) {
+      tail++
+    } else {
+      break
+    }
+  }
+  return tail
+}
+
+function countCommonPrefix(a: string, b: string): number {
+  const n = Math.min(a.length, b.length)
+  let prefix = 0
+  for (let i = 0; i < n; i++) {
+    if (a[i] === b[i]) {
+      prefix++
+    } else {
+      break
+    }
+  }
+  return prefix
+}


### PR DESCRIPTION
### Issue for this PR

Closes #20459

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the file tree sorting to sort file names numerically instead of lexicographically. Previously, files like 'file2.txt' would incorrectly appear after 'file10.txt' because the sorting was done character by character. Now it properly handles numeric sequences, so 'file2.txt' correctly appears before 'file10.txt'.

### How did you verify your code works?

The PR includes tests that verify the numeric sorting behavior works correctly.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR