### PR TITLE
fix(llm): allow disabling compatible stream usage

### DIFF
--- a/packages/llm/src/protocols/openai-compatible-chat.ts
+++ b/packages/llm/src/protocols/openai-compatible-chat.ts
@@ -1,11 +1,41 @@
+import { Effect } from "effect"
 import { Route, type RouteRoutedModelInput } from "../route/client"
 import { Endpoint } from "../route/endpoint"
 import { Framing } from "../route/framing"
+import { Protocol } from "../route/protocol"
+import type { LLMRequest } from "../schema"
 import * as OpenAIChat from "./openai-chat"
+import { isRecord } from "./shared"
 
 const ADAPTER = "openai-compatible-chat"
 
 export type OpenAICompatibleChatModelInput = RouteRoutedModelInput
+
+const includeUsage = (request: LLMRequest) => {
+  const provider = String(request.model.provider).split(".")[0]
+  const providerOptions = request.providerOptions
+  const options =
+    providerOptions?.openaiCompatible ??
+    providerOptions?.["openai-compatible"] ??
+    (provider ? providerOptions?.[provider] : undefined)
+  return !isRecord(options) || options.includeUsage !== false
+}
+
+export const protocol = Protocol.make({
+  ...OpenAIChat.protocol,
+  body: {
+    schema: OpenAIChat.protocol.body.schema,
+    from: (request) =>
+      OpenAIChat.protocol.body.from(request).pipe(
+        Effect.map((body) => {
+          if (includeUsage(request)) return body
+          const withoutStreamOptions = { ...body }
+          delete withoutStreamOptions.stream_options
+          return withoutStreamOptions
+        }),
+      ),
+  },
+})
 
 /**
  * Route for non-OpenAI providers that expose an OpenAI Chat-compatible
@@ -16,7 +46,7 @@ export type OpenAICompatibleChatModelInput = RouteRoutedModelInput
  */
 export const route = Route.make({
   id: ADAPTER,
-  protocol: OpenAIChat.protocol,
+  protocol,
   endpoint: Endpoint.path("/chat/completions"),
   framing: Framing.sse,
 })

--- a/packages/llm/src/providers/openai-compatible.ts
+++ b/packages/llm/src/providers/openai-compatible.ts
@@ -1,4 +1,4 @@
-import { ProviderID, type ModelID } from "../schema"
+import { ProviderID, type ModelID, type ProviderOptions } from "../schema"
 import * as OpenAICompatibleChat from "../protocols/openai-compatible-chat"
 import type { RouteDefaultsInput } from "../route/client"
 import { AuthOptions, type ProviderAuthOption } from "../route/auth-options"
@@ -6,15 +6,27 @@ import { profiles, type OpenAICompatibleProfile } from "./openai-compatible-prof
 
 export const id = ProviderID.make("openai-compatible")
 
-type GenericModelOptions = RouteDefaultsInput &
+export interface OpenAICompatibleOptionsInput {
+  readonly [key: string]: unknown
+  readonly includeUsage?: boolean
+}
+
+export type OpenAICompatibleProviderOptionsInput = ProviderOptions & {
+  readonly openaiCompatible?: OpenAICompatibleOptionsInput
+  readonly "openai-compatible"?: OpenAICompatibleOptionsInput
+}
+
+type GenericModelOptions = Omit<RouteDefaultsInput, "providerOptions"> &
   ProviderAuthOption<"optional"> & {
     readonly provider?: string
     readonly baseURL: string
+    readonly providerOptions?: OpenAICompatibleProviderOptionsInput
   }
 
-export type FamilyModelOptions = RouteDefaultsInput &
+export type FamilyModelOptions = Omit<RouteDefaultsInput, "providerOptions"> &
   ProviderAuthOption<"optional"> & {
     readonly baseURL?: string
+    readonly providerOptions?: OpenAICompatibleProviderOptionsInput
   }
 
 export const routes = [OpenAICompatibleChat.route]

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -4,6 +4,7 @@ import { HttpClientRequest } from "effect/unstable/http"
 import { LLM, LLMError, Message, Model, ToolCallPart, Usage } from "../../src"
 import * as Azure from "../../src/providers/azure"
 import * as OpenAI from "../../src/providers/openai"
+import * as OpenAICompatible from "../../src/providers/openai-compatible"
 import * as OpenAIChat from "../../src/protocols/openai-chat"
 import { ProviderShared } from "../../src/protocols/shared"
 import { Auth, LLMClient } from "../../src/route"
@@ -48,6 +49,41 @@ describe("OpenAI Chat route", () => {
         max_tokens: 20,
         temperature: 0,
       })
+    }),
+  )
+
+  it.effect("prepares OpenAI-compatible Chat payload with stream usage by default", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          model: OpenAICompatible.configure({
+            provider: "databricks",
+            baseURL: "https://databricks.test/serving-endpoints",
+            apiKey: "test",
+          }).model("qwen3"),
+          prompt: "Say hello.",
+        }),
+      )
+
+      expect(prepared.body.stream_options).toEqual({ include_usage: true })
+    }),
+  )
+
+  it.effect("omits OpenAI-compatible stream usage when disabled", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          model: OpenAICompatible.configure({
+            provider: "databricks",
+            baseURL: "https://databricks.test/serving-endpoints",
+            apiKey: "test",
+          }).model("qwen3"),
+          prompt: "Say hello.",
+          providerOptions: { databricks: { includeUsage: false } },
+        }),
+      )
+
+      expect(prepared.body).not.toHaveProperty("stream_options")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #31156

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI-compatible chat requests currently always include `stream_options: { include_usage: true }`. Some compatible gateways, including the Databricks AI Gateway case in #31156, reject unknown `stream_options` fields.

This keeps the existing default, but lets OpenAI-compatible routes omit the field when `includeUsage: false` is set in `providerOptions.openaiCompatible`, `providerOptions["openai-compatible"]`, or the concrete provider namespace such as `providerOptions.databricks`. The provider namespace matters for OpenCode config because provider options are keyed by the configured provider id.

### How did you verify your code works?

- `cd packages/llm && bun test test/provider/openai-chat.test.ts`
- `cd packages/llm && bun typecheck`
- `bunx prettier --check packages/llm/src/protocols/openai-compatible-chat.ts packages/llm/src/providers/openai-compatible.ts packages/llm/test/provider/openai-chat.test.ts`
- Pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR