### PR TITLE
fix(opencode): handle malformed percent-encoding in decodeDataUrl

### DIFF
--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -5,5 +5,12 @@ export function decodeDataUrl(url: string) {
   const head = url.slice(0, idx)
   const body = url.slice(idx + 1)
   if (head.includes(";base64")) return Buffer.from(body, "base64").toString("utf8")
-  return decodeURIComponent(body)
+  // Non-base64 data URLs carry percent-encoded text (RFC 2397), but external
+  // sources (MCP resources, plugins) can emit unescaped "%", which makes
+  // decodeURIComponent throw; fall back to the raw body instead of crashing.
+  try {
+    return decodeURIComponent(body)
+  } catch {
+    return body
+  }
 }

--- a/packages/opencode/test/util/data-url.test.ts
+++ b/packages/opencode/test/util/data-url.test.ts
@@ -11,4 +11,13 @@ describe("decodeDataUrl", () => {
   test("decodes plain data URLs", () => {
     expect(decodeDataUrl("data:text/plain,hello%20world")).toBe("hello world")
   })
+
+  test("returns raw body when percent-encoding is malformed", () => {
+    expect(decodeDataUrl("data:text/plain,100%off")).toBe("100%off")
+    expect(decodeDataUrl("data:text/plain;charset=utf-8,Reported 50% savings")).toBe("Reported 50% savings")
+  })
+
+  test("returns empty string when there is no comma", () => {
+    expect(decodeDataUrl("data:text/plain")).toBe("")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31793

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`decodeDataUrl` decoded non-base64 `data:` URLs with `decodeURIComponent`, which throws `URIError` when the body contains an unescaped `%`. These URLs reach the helper from prompt assembly (`session/prompt.ts`) and ACP content conversion, and can come from external sources such as MCP resources and plugins, so a single malformed URL crashed the whole request. The non-base64 branch now falls back to the raw body when `decodeURIComponent` throws, so it degrades gracefully instead of crashing. Base64 and correctly percent-encoded inputs behave exactly as before.

### How did you verify your code works?

Added unit tests in `packages/opencode/test/util/data-url.test.ts` for an unescaped `%`, a mediatype with params, and a missing comma. `bun test test/util/data-url.test.ts` passes (4/4); the new test throws `URIError` on the old code and passes after the fix. `oxlint` on the changed files and `tsgo --noEmit` (`bun run typecheck`) for the `opencode` package are both clean.

### Screenshots / recordings

N/A (not a UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
