### PR TITLE
fix(snapshot): reuse source git objects to avoid re-hashing huge repos

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -191,6 +191,46 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.orDie)
         })
 
+        // Reuse the hashes for the git storage between the original repo and snapshot
+        // on huge repos like chromium checkout the git add --all rebuilding the
+        // hashes can take minutes. By doing this we eliminating this at all
+        const seed = Effect.fnUntraced(function* () {
+          if (state.vcs !== "git") return
+
+          const commonDir = yield* git(["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+            cwd: state.worktree,
+          })
+
+          if (commonDir.code !== 0) return
+          const source = commonDir.text.trim()
+          if (!source || !(yield* exists(source))) return
+
+          // Share the source object database (and the source's own alternates,
+          // skipping any that no longer exist) so seeded blobs resolve.
+          const sourceObjects = path.join(source, "objects")
+          const chained = (yield* read(path.join(sourceObjects, "info", "alternates")))
+            .split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean)
+          const alternates: string[] = []
+          for (const candidate of [sourceObjects, ...chained]) {
+            if (yield* exists(candidate)) alternates.push(candidate)
+          }
+          if (!alternates.length) return
+
+          yield* fs.ensureDir(path.join(state.gitdir, "objects", "info")).pipe(Effect.orDie)
+          yield* fs
+            .writeFileString(path.join(state.gitdir, "objects", "info", "alternates"), alternates.join("\n") + "\n")
+            .pipe(Effect.orDie)
+
+          // Seed the index from the source repo so already-hashed entries are reused.
+          // Best-effort: a missing/incompatible index just falls back to a full add.
+          const sourceIndex = path.join(source, "index")
+          if (yield* exists(sourceIndex)) {
+            yield* fs.copyFile(sourceIndex, path.join(state.gitdir, "index")).pipe(Effect.catch(() => Effect.void))
+          }
+        })
+
         const add = Effect.fnUntraced(function* () {
           yield* sync()
           const [diff, other] = yield* Effect.all(
@@ -288,6 +328,12 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
                 yield* git(["--git-dir", state.gitdir, "config", "core.longpaths", "true"])
                 yield* git(["--git-dir", state.gitdir, "config", "core.symlinks", "true"])
                 yield* git(["--git-dir", state.gitdir, "config", "core.fsmonitor", "false"])
+                // Tuning for very large worktrees so the first add stays bounded.
+                yield* git(["--git-dir", state.gitdir, "config", "feature.manyFiles", "true"])
+                yield* git(["--git-dir", state.gitdir, "config", "index.version", "4"])
+                yield* git(["--git-dir", state.gitdir, "config", "index.threads", "true"])
+                yield* git(["--git-dir", state.gitdir, "config", "core.untrackedCache", "true"])
+                yield* seed()
                 yield* Effect.logInfo("initialized")
               }
               yield* add()


### PR DESCRIPTION
### Issue for this PR

Closes #31797

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opening a session in a huge repo (chromium, ~500k files) hangs because the first `Snapshot.track` does `git add --all` into a brand-new, empty snapshot repo, so git re-hashes the entire working tree from scratch. That takes minutes, so the turn never finishes.

The source repo already has every file hashed in its own object DB. So when we create the snapshot repo, this PR seeds it from the source repo:

- point `objects/info/alternates` at the source repo's object dir (so git reuses blobs it already has)
- copy the source repo's `index` (so `add` becomes a stat-only diff instead of hashing everything)

It's all best-effort and guarded: non-git projects are skipped, and a missing/incompatible source index just falls back to the old full add. The resulting tree hash is identical to the old path, so snapshot/diff/revert behave exactly the same.

### How did you verify your code works?

- On a full chromium checkout (~500k files, 69G): before this change `git add --all` did not finish within 90s and `session.prompt` hung (process had to be killed). After, the first snapshot completes in ~5s and `opencode run` exits cleanly.
- Confirmed the snapshot produces the same valid tree hash as before (all 500,259 entries resolve).
- `bun typecheck` passes.
- `bun test test/snapshot/snapshot.test.ts` passes (52 pass, 0 fail).

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
