### PR TITLE
fix(opencode): surface usage errors instead of only printing help

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -109,6 +109,9 @@ const cli = yargs(args)
     ) {
       if (err) throw err
       cli.showHelp(show)
+      // yargs passes the usage error in `msg`; surface it so an invalid flag
+      // isn't indistinguishable from plain `--help`.
+      if (msg) UI.error(msg)
     }
     if (err) throw err
     process.exit(1)

--- a/packages/opencode/test/cli/fail-handler.test.ts
+++ b/packages/opencode/test/cli/fail-handler.test.ts
@@ -1,0 +1,17 @@
+// Regression test for #29390: yargs usage errors must surface the error
+// message, not just reprint help text. Before the fix, `opencode --badflag`
+// produced output identical to `opencode --help`, leaving the user with no
+// indication that their argument was wrong.
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../lib/cli-process"
+
+describe("opencode CLI usage errors", () => {
+  cliIt.live("an unknown flag reports the error, not just help", ({ opencode }) =>
+    Effect.gen(function* () {
+      const result = yield* opencode.spawn(["--this-flag-does-not-exist"])
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain("Unknown argument")
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29390

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The yargs `.fail()` handler in `packages/opencode/src/index.ts` printed help text for usage errors (unknown argument, missing positional, invalid values) but never wrote the `msg` that yargs passes in. As a result `opencode --badflag` produced output identical to `opencode --help`, leaving the user with no indication their argument was wrong. The handler now writes the message to stderr (via `UI.error`) after showing help, so the error appears at the bottom where it's visible. Exit code stays 1.

### How did you verify your code works?

Added a regression test at `packages/opencode/test/cli/fail-handler.test.ts` using the existing CLI subprocess harness: it spawns `opencode --this-flag-does-not-exist` and asserts exit code 1 and that stderr contains `Unknown argument`. The test fails on the current code and passes with the fix. Also verified manually: before, the command printed only help; after, it ends with `Error: Unknown arguments: ...`. `oxlint` on the changed files and `tsgo --noEmit` (`bun run typecheck`) for the `opencode` package are both clean.

### Screenshots / recordings

N/A (CLI stderr text change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
