### PR TITLE
fix(mcp): preserve headers during auth and debug

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -744,6 +744,7 @@ export const McpDebugCommand = effectCmd({
         const response = await fetch(serverConfig.url, {
           method: "POST",
           headers: {
+            ...serverConfig.headers,
             "Content-Type": "application/json",
             Accept: "application/json, text/event-stream",
           },
@@ -792,6 +793,7 @@ export const McpDebugCommand = effectCmd({
           // Try creating transport with auth provider to trigger discovery
           const transport = new StreamableHTTPClientTransport(new URL(serverConfig.url), {
             authProvider,
+            requestInit: serverConfig.headers ? { headers: serverConfig.headers } : undefined,
           })
 
           try {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -741,7 +741,10 @@ export const layer = Layer.effect(
         auth,
       )
 
-      const transport = new StreamableHTTPClientTransport(url, { authProvider })
+      const transport = new StreamableHTTPClientTransport(url, {
+        authProvider,
+        requestInit: mcpConfig.headers ? { headers: mcpConfig.headers } : undefined,
+      })
 
       return yield* Effect.tryPromise({
         try: () => {

--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -38,7 +38,7 @@ class MockUnauthorizedError extends Error {
 const transportCalls: Array<{
   type: "streamable" | "sse"
   url: string
-  options: { authProvider?: unknown }
+  options: { authProvider?: unknown; requestInit?: RequestInit }
 }> = []
 
 // Mock the transport constructors
@@ -46,7 +46,10 @@ void mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: class MockStreamableHTTP {
     url: string
     authProvider: { redirectToAuthorization?: (url: URL) => Promise<void> } | undefined
-    constructor(url: URL, options?: { authProvider?: { redirectToAuthorization?: (url: URL) => Promise<void> } }) {
+    constructor(
+      url: URL,
+      options?: { authProvider?: { redirectToAuthorization?: (url: URL) => Promise<void> }; requestInit?: RequestInit },
+    ) {
       this.url = url.toString()
       this.authProvider = options?.authProvider
       transportCalls.push({
@@ -127,11 +130,12 @@ const mcpTest = testEffect(
 )
 const service = MCP.Service as unknown as Effect.Effect<MCPNS.Interface, never, never>
 
-const config = (name: string) => ({
+const config = (name: string, headers?: Record<string, string>) => ({
   mcp: {
     [name]: {
       type: "remote" as const,
       url: "https://example.com/mcp",
+      headers,
     },
   },
 })
@@ -227,6 +231,7 @@ mcpTest.instance(
       expect(failure).toEqual(Option.none())
       expect(typeof url).toBe("string")
       expect(url).toContain("https://")
+      expect(transportCalls[0]?.options.requestInit?.headers).toEqual({ "X-Custom-Header": "custom-value" })
     }),
-  { config: config("test-oauth-server-3") },
+  { config: config("test-oauth-server-3", { "X-Custom-Header": "custom-value" }) },
 )

--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -231,7 +231,7 @@ mcpTest.instance(
       expect(failure).toEqual(Option.none())
       expect(typeof url).toBe("string")
       expect(url).toContain("https://")
-      expect(transportCalls[0]?.options.requestInit?.headers).toEqual({ "X-Custom-Header": "custom-value" })
+      expect(transportCalls.at(-1)?.options.requestInit?.headers).toEqual({ "X-Custom-Header": "custom-value" })
     }),
   { config: config("test-oauth-server-3", { "X-Custom-Header": "custom-value" }) },
 )


### PR DESCRIPTION
## Summary
- pass configured MCP headers through the explicit OAuth transport
- include configured headers in both `mcp debug` connection probes
- preserve required MCP content negotiation headers in the raw debug request

## Testing
- `bun test test/mcp/oauth-browser.test.ts test/mcp/headers.test.ts`
- `bun typecheck`
- `bunx prettier --check packages/opencode/src/mcp/index.ts packages/opencode/src/cli/cmd/mcp.ts packages/opencode/test/mcp/oauth-browser.test.ts`

Closes #20286
Relates to: #28567