### PR TITLE
fix(opencode): retry on xfyun engine busy response

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -129,7 +129,8 @@ export function retryable(error: Err, provider: string) {
     if (
       lower.includes("rate increased too quickly") ||
       lower.includes("rate limit") ||
-      lower.includes("too many requests")
+      lower.includes("too many requests") ||
+      lower.includes("engine busy")
     ) {
       return { message: msg }
     }


### PR DESCRIPTION
### Issue for this PR

Closes #31812

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When using xfyun (讯飞云) as the provider, the API returns "engine busy" during temporary overload. OpenCode was not retrying on this error, causing requests to fail unnecessarily.

Adds "engine busy" to the retryable plain-text error patterns in `packages/opencode/src/session/retry.ts`, matching the existing behavior for "rate limit" and "too many requests".

### How did you verify your code works?

Built the binary and confirmed the change compiles and the smoke test passes.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
