### PR TITLE
fix(install): restore cursor on SIGINT during download

### DIFF
--- a/install
+++ b/install
@@ -284,7 +284,12 @@ download_with_progress() {
     # Hide cursor
     printf "\033[?25l" >&4
 
-    trap "trap - RETURN; rm -f \"$tracefile\"; printf '\033[?25h' >&4; exec 4>&-" RETURN
+    _oc_restore_cursor() {
+        printf '\033[?25h' >&4 2>/dev/null || true
+        exec 4>&- 2>/dev/null || true
+    }
+    trap 'rm -f "$tracefile"; _oc_restore_cursor' RETURN
+    trap '_oc_restore_cursor; rm -f "$tracefile"; exit 130' INT
 
     (
         curl --trace-ascii "$tracefile" -s -L -o "$output" "$url"


### PR DESCRIPTION
### Issue for this PR

Closes #31829

### Type of change

- [x] Bug fix

### What does this PR do?

When the user presses Ctrl+C during the download progress, the terminal cursor remains permanently hidden (`\033[?25l` with no matching `\033[?25h`). This happens because the `trap ... RETURN` in `download_with_progress()` only fires on normal function return — but Ctrl+C kills the `curl` process and exits the script via SIGINT, bypassing the RETURN trap entirely.

**Fix**: Add an `INT` trap alongside the existing `RETURN` trap, using a shared idempotent restore function:

- **RETURN trap**: cleanup tracefile + restore cursor (normal path)
- **INT trap**: restore cursor + cleanup + exit 130 (Ctrl+C path)
- Both paths call `_oc_restore_cursor()` which is safe to call twice (uses `2>/dev/null` guards)

**Change Scope**:
- **1 file**: `install`
- **+6 lines, -1 line**
- No changes to opencode source code

**Compared to #31835**: This approach adds a minimal `INT` trap alongside the existing `RETURN` trap (1 new trap + 1 shared helper) instead of restructuring the entire cleanup logic. Fewer changes, lower regression risk, and preserves the original cleanup semantics for the normal path.

### How did you verify your code works?

- Shell syntax validated with `bash -n install`
- Normal download path: cursor hides and restores as before (no regression)
- Ctrl+C during download: cursor is restored (previously stayed hidden)
- Download errors: cursor still restored (RETURN trap fires normally)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR