### PR TITLE
fix(opencode): match canonically equivalent Unicode in patches

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -426,6 +426,17 @@ function normalizeUnicode(str: string): string {
 
 type Comparator = (a: string, b: string) => boolean
 
+function tryTransformedMatch(
+  lines: string[],
+  pattern: string[],
+  startIndex: number,
+  transform: (value: string) => string,
+  eof: boolean,
+): number {
+  const transformedPattern = pattern.map(transform)
+  return tryMatch(lines, transformedPattern, startIndex, (a, b) => transform(a) === b, eof)
+}
+
 function tryMatch(lines: string[], pattern: string[], startIndex: number, compare: Comparator, eof: boolean): number {
   // If EOF anchor, try matching from end of file first
   if (eof) {
@@ -465,22 +476,19 @@ function seekSequence(lines: string[], pattern: string[], startIndex: number, eo
   if (exact !== -1) return exact
 
   // Pass 2: rstrip (trim trailing whitespace)
-  const rstrip = tryMatch(lines, pattern, startIndex, (a, b) => a.trimEnd() === b.trimEnd(), eof)
+  const rstrip = tryTransformedMatch(lines, pattern, startIndex, (line) => line.trimEnd(), eof)
   if (rstrip !== -1) return rstrip
 
   // Pass 3: trim (both ends)
-  const trim = tryMatch(lines, pattern, startIndex, (a, b) => a.trim() === b.trim(), eof)
+  const trim = tryTransformedMatch(lines, pattern, startIndex, (line) => line.trim(), eof)
   if (trim !== -1) return trim
 
   // Pass 4: normalized (Unicode punctuation to ASCII)
-  const normalized = tryMatch(
-    lines,
-    pattern,
-    startIndex,
-    (a, b) => normalizeUnicode(a.trim()) === normalizeUnicode(b.trim()),
-    eof,
-  )
-  return normalized
+  const normalized = tryTransformedMatch(lines, pattern, startIndex, (line) => normalizeUnicode(line.trim()), eof)
+  if (normalized !== -1) return normalized
+
+  // Pass 5: combine the accepted punctuation fallback with NFC for lines that differ in both ways.
+  return tryTransformedMatch(lines, pattern, startIndex, (line) => normalizeUnicode(line).normalize("NFC").trim(), eof)
 }
 
 function generateUnifiedDiff(oldContent: string, newContent: string): string {

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -316,6 +316,121 @@ PATCH`
   })
 
   describe("edge cases", () => {
+    test("should match canonically equivalent unicode lines", () => {
+      const result = Patch.deriveNewContentsFromChunks(
+        "unicode.md",
+        [
+          {
+            old_lines: ["Район: Астана".normalize("NFC")],
+            new_lines: ["Район: Алматы"],
+          },
+        ],
+        "# Сводка\nРайон: Астана\n".normalize("NFD"),
+      )
+
+      expect(result.content).toBe("# Сводка\nРайон: Алматы\n")
+    })
+
+    test("should combine canonical unicode and punctuation fallbacks", () => {
+      const result = Patch.deriveNewContentsFromChunks(
+        "unicode-punctuation.md",
+        [
+          {
+            old_lines: ['Район: Астана - "центр"'.normalize("NFC")],
+            new_lines: ["Район: Алматы"],
+          },
+        ],
+        "# Сводка\nРайон: Астана — “центр”\n".normalize("NFD"),
+      )
+
+      expect(result.content).toBe("# Сводка\nРайон: Алматы\n")
+    })
+
+    test("should match multi-line canonically equivalent unicode chunks", () => {
+      const result = Patch.deriveNewContentsFromChunks(
+        "unicode-multiline.md",
+        [
+          {
+            old_lines: ["Район: Астана".normalize("NFC"), "Статус: открыт".normalize("NFC")],
+            new_lines: ["Район: Алматы", "Статус: закрыт"],
+          },
+        ],
+        "# Сводка\nРайон: Астана\nСтатус: открыт\n".normalize("NFD"),
+      )
+
+      expect(result.content).toBe("# Сводка\nРайон: Алматы\nСтатус: закрыт\n")
+    })
+
+    test("should prefer eof canonical fallback matches from the end", () => {
+      const equivalent = "Район: Астана".normalize("NFD")
+
+      const result = Patch.deriveNewContentsFromChunks(
+        "unicode-eof.md",
+        [
+          {
+            old_lines: ["Район: Астана".normalize("NFC")],
+            new_lines: ["Район: Алматы"],
+            is_end_of_file: true,
+          },
+        ],
+        `${equivalent}\n${equivalent}\n`,
+      )
+
+      expect(result.content).toBe(`${equivalent}\nРайон: Алматы\n`)
+    })
+
+    test("should prefer exact unicode matches before canonical fallback", () => {
+      const exact = "Район: Астана".normalize("NFC")
+      const equivalent = "Район: Астана".normalize("NFD")
+
+      const result = Patch.deriveNewContentsFromChunks(
+        "unicode-order.md",
+        [
+          {
+            old_lines: [exact],
+            new_lines: ["Район: Алматы"],
+          },
+        ],
+        `${equivalent}\n${exact}\n`,
+      )
+
+      expect(result.content).toBe(`${equivalent}\nРайон: Алматы\n`)
+    })
+
+    test("should not match compatibility-equivalent unicode lines", () => {
+      expect(() =>
+        Patch.deriveNewContentsFromChunks(
+          "compatibility.md",
+          [
+            {
+              old_lines: ["office"],
+              new_lines: ["studio"],
+            },
+          ],
+          "ofﬁce\n",
+        ),
+      ).toThrow("Failed to find expected lines")
+    })
+
+    test("should match lines with trailing and leading whitespace differences", () => {
+      const result = Patch.deriveNewContentsFromChunks(
+        "whitespace.md",
+        [
+          {
+            old_lines: ["alpha"],
+            new_lines: ["ALPHA"],
+          },
+          {
+            old_lines: ["beta"],
+            new_lines: ["BETA"],
+          },
+        ],
+        "alpha   \n  beta\n",
+      )
+
+      expect(result.content).toBe("ALPHA\nBETA\n")
+    })
+
     it.live("should handle empty files", () =>
       Effect.gen(function* () {
         const emptyFile = path.join(tempDir, "empty.txt")


### PR DESCRIPTION
### Issue for this PR

Closes #31651

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`apply_patch` could fail to update files when the patch text and file contents were visually identical but encoded with different canonical Unicode forms, such as NFC patch text matching NFD file text.

This keeps patch matching ordered from strict to loose: exact matches still win first, then existing whitespace and punctuation fallbacks run, and only then does the matcher try NFC comparison after punctuation normalization. The final fallback combines the existing punctuation normalization with canonical NFC comparison. It does not use compatibility normalization such as NFKC, so compatibility equivalent lookalikes remain rejected.

The fallback matcher now precomputes transformed patch pattern lines so miss and normalization fallback paths do less repeated work.

### How did you verify your code works?

- `bun test test/patch/patch.test.ts --timeout 30000`
- `bun typecheck`
- `bunx prettier --check src/patch/index.ts test/patch/patch.test.ts`

Added regression coverage for NFC/NFD matching, punctuation plus NFC fallback, multi-line chunks, EOF fallback priority, exact match priority, compatibility equivalence rejection, and whitespace fallback preservation.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR