### PR TITLE
fix(desktop): use server-side picker for all HTTP connections

### DIFF
--- a/packages/app/src/components/directory-picker-policy.ts
+++ b/packages/app/src/components/directory-picker-policy.ts
@@ -2,6 +2,6 @@ import { ServerConnection } from "@/context/server"
 import type { Platform } from "@/context/platform"
 
 export function directoryPickerKind(platform: Platform["platform"], server: ServerConnection.Any) {
-  if (platform === "desktop" && ServerConnection.local(server)) return "native" as const
+  if (platform === "desktop" && ServerConnection.builtin(server)) return "native" as const
   return "server" as const
 }

--- a/packages/app/src/components/directory-picker.test.ts
+++ b/packages/app/src/components/directory-picker.test.ts
@@ -1,21 +1,50 @@
 import { describe, expect, test } from "bun:test"
 import { directoryPickerKind } from "./directory-picker-policy"
 
-const local = {
+const sidecar = {
   type: "sidecar",
   variant: "base",
   http: { url: "http://localhost:4096" },
 } as const
-const remote = {
+
+const wsl = {
+  type: "sidecar",
+  variant: "wsl",
+  distro: "Ubuntu",
+  http: { url: "http://localhost:4097" },
+} as const
+
+const httpLocalhost = {
+  type: "http",
+  http: { url: "http://localhost:4096" },
+} as const
+
+const httpRemote = {
+  type: "http",
+  http: { url: "http://192.168.1.100:4096" },
+} as const
+
+const ssh = {
   type: "ssh",
   host: "example.test",
   http: { url: "http://localhost:4096" },
 } as const
 
 describe("directoryPickerKind", () => {
-  test("uses the native picker only for local desktop projects", () => {
-    expect(directoryPickerKind("desktop", local)).toBe("native")
-    expect(directoryPickerKind("desktop", remote)).toBe("server")
-    expect(directoryPickerKind("web", local)).toBe("server")
+  test("uses the native picker only for the built-in sidecar", () => {
+    // Only the embedded sidecar process is guaranteed to share the OS with the Desktop app
+    expect(directoryPickerKind("desktop", sidecar)).toBe("native")
+
+    // All HTTP connections use the server-side picker — a localhost URL could be a
+    // port-forwarded remote server (e.g. Linux behind SSH tunnel from Windows)
+    expect(directoryPickerKind("desktop", httpLocalhost)).toBe("server")
+    expect(directoryPickerKind("desktop", httpRemote)).toBe("server")
+
+    // WSL and SSH are always remote filesystems
+    expect(directoryPickerKind("desktop", wsl)).toBe("server")
+    expect(directoryPickerKind("desktop", ssh)).toBe("server")
+
+    // Web platform never has access to the native picker
+    expect(directoryPickerKind("web", sidecar)).toBe("server")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #25264

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

\`directoryPickerKind\` used \`ServerConnection.local()\` to decide whether to show the native OS file picker. That function returns \`true\` for any \`http://localhost\` URL — including a remote Linux server tunnelled via SSH port forwarding (\`ssh -L 4096:localhost:4096 linux-host\`). So Desktop opened the native Windows dialog, the selected Windows path was sent to the remote Linux server, and it rejected it: \`Error: Path is not absolute: D:\\renpy-workspace\`.

Fix: replace \`ServerConnection.local\` with \`ServerConnection.builtin\` in \`directory-picker-policy.ts\`. \`builtin\` matches only the embedded sidecar (\`type === \"sidecar\" && variant === \"base\"\`) — the only server guaranteed to share the OS with the Desktop app. All HTTP connections, including localhost, now route to \`DialogSelectDirectory\`.

Note: PR #27673 addresses the related \`isLocal\` memo in \`ServerContext\`. This PR targets the directory picker policy layer specifically.

### How did you verify your code works?

Added test cases to \`directory-picker.test.ts\` covering the five connection types (sidecar, WSL, localhost HTTP, remote HTTP, SSH):

\`\`\`
bun test src/components/directory-picker.test.ts
\`\`\`

Traced the code path for both cases:
- Desktop + remote server at \`http://localhost:PORT\` → in-app \`DialogSelectDirectory\` ✓
- Desktop + local sidecar → native OS picker (unchanged) ✓

### Screenshots / recordings

No UI changes — this only affects which picker component is invoked.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR