### PR TITLE
fix(opencode): match canonically-equivalent Unicode in apply_patch

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -480,7 +480,16 @@ function seekSequence(lines: string[], pattern: string[], startIndex: number, eo
     (a, b) => normalizeUnicode(a.trim()) === normalizeUnicode(b.trim()),
     eof,
   )
-  return normalized
+  if (normalized !== -1) return normalized
+
+  // Pass 5: NFC canonical equivalence (e.g. decomposed NFD on disk vs precomposed NFC from the model)
+  return tryMatch(
+    lines,
+    pattern,
+    startIndex,
+    (a, b) => a.normalize("NFC").trim() === b.normalize("NFC").trim(),
+    eof,
+  )
 }
 
 function generateUnifiedDiff(oldContent: string, newContent: string): string {

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -380,4 +380,24 @@ PATCH`
       }),
     )
   })
+
+  describe("deriveNewContentsFromChunks", () => {
+    test("matches canonically-equivalent Unicode lines (NFD on disk, NFC in patch)", () => {
+      // A file can store decomposed Unicode (NFD) while models emit precomposed (NFC).
+      // The two are canonically equivalent and render identically, so apply_patch must still match.
+      const original = "Район: Астана\n".normalize("NFD")
+      const result = Patch.deriveNewContentsFromChunks(
+        "city.md",
+        [
+          {
+            old_lines: ["Район: Астана".normalize("NFC")],
+            new_lines: ["Район: Алматы"],
+            is_end_of_file: false,
+          },
+        ],
+        original,
+      )
+      expect(result.content).toBe("Район: Алматы\n")
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31651

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`apply_patch` locates a chunk's lines with `seekSequence`, which runs four passes (exact, rstrip, trim, `normalizeUnicode`+trim). None of them normalize Unicode *composition* — `normalizeUnicode` only swaps smart quotes/dashes/ellipsis/NBSP — so a file stored as NFD (e.g. Cyrillic `й` as `и`+combining breve) never matches the precomposed NFC `й` that models emit. It fails with "Failed to find expected lines", and the model loops re-reading/retrying.

This adds a fifth pass comparing lines after `.normalize("NFC")`. NFC + exact equality only matches text Unicode defines as identical, so it fixes the NFD/NFC mismatch with no false-positive matches. The pass only runs when the first four fail, so existing matching behavior is unchanged.

### How did you verify your code works?

Added a unit test that feeds NFD file content and an NFC patch line through `Patch.deriveNewContentsFromChunks`. It throws "Failed to find expected lines" before the change and passes after.

- `cd packages/opencode && bun test test/patch/patch.test.ts` → 21 pass (was 20 pass / 1 fail before the fix)
- `bun test test/tool/apply_patch.test.ts` → 27 pass (no regressions)
- `bun run typecheck` → clean

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
