### PR TITLE
fix(plugin): reject bootstrap client reentry

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -120,6 +120,15 @@ async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks:
   }
 }
 
+function pluginClientReentryResponse(directory: string) {
+  return new Response(`Plugin client request cannot enter instance ${directory} while its plugins are still loading`, {
+    status: 409,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+    },
+  })
+}
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -139,11 +148,17 @@ const layer = Layer.effect(
         const { Server } = yield* Effect.promise(() => import("../server/server"))
 
         const serverUrl = Server.url
+        let bootstrapping = true
         const client = createOpencodeClient({
           baseUrl: serverUrl?.toString() ?? "http://localhost:4096",
           directory: ctx.directory,
           headers: ServerAuth.headers(),
-          ...(serverUrl ? {} : { fetch: async (...args) => Server.Default().app.fetch(...args) }),
+          fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+            const request = new Request(input, init)
+            if (bootstrapping) return pluginClientReentryResponse(ctx.directory)
+            if (serverUrl) return globalThis.fetch(request)
+            return Server.Default().app.fetch(request)
+          },
         })
         const cfg = yield* config.get()
         const input: PluginInput = {
@@ -247,6 +262,8 @@ const layer = Layer.effect(
             Effect.ignore,
           )
         }
+
+        bootstrapping = false
 
         const unsubscribe = yield* events.listen((event) => {
           if (event.location?.directory !== ctx.directory) return Effect.void

--- a/packages/opencode/test/server/httpapi-listen.test.ts
+++ b/packages/opencode/test/server/httpapi-listen.test.ts
@@ -167,6 +167,49 @@ async function openPtySocket(listener: Awaited<ReturnType<typeof startListener>>
 }
 
 describe("HttpApi Server.listen", () => {
+  test("rejects plugin client re-entry while plugins are loading", async () => {
+    await using tmp = await tmpdir({
+      config: { formatter: false, lsp: false, plugin: ["./server-plugin.js"] },
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "server-plugin.js"),
+          `export default {
+  id: "plugin-client-reentry-probe",
+  async server(input) {
+    try {
+      const result = await input.client.config.get();
+      await Bun.write(${JSON.stringify(path.join(dir, "plugin-client-result.json"))}, JSON.stringify({ ok: !result.error, error: result.error }));
+    } catch (error) {
+      await Bun.write(${JSON.stringify(path.join(dir, "plugin-client-result.json"))}, JSON.stringify({ ok: false, error: String(error) }));
+    }
+    return {};
+  },
+};
+`,
+        )
+      },
+    })
+    const listener = await startListener()
+    try {
+      const response = await withTimeout(
+        fetch(new URL("/config", listener.url), {
+          headers: { authorization: authorization(), "x-opencode-directory": tmp.path },
+        }),
+        5_000,
+        "timed out waiting for plugin re-entry guarded request",
+      )
+      expect(response.status).toBe(200)
+      const result = JSON.parse(await Bun.file(path.join(tmp.path, "plugin-client-result.json")).text()) as {
+        ok?: boolean
+        error?: unknown
+      }
+      expect(result.ok).toBe(false)
+      expect(JSON.stringify(result.error)).toContain("Plugin client request cannot enter instance")
+    } finally {
+      await stop(listener, "timed out cleaning up plugin re-entry listener").catch(() => undefined)
+    }
+  })
+
   testPty("serves HTTP routes and upgrades PTY websocket through Server.listen", async () => {
     await using tmp = await tmpdir({ config: { formatter: false, lsp: false } })
     const listener = await startListener()


### PR DESCRIPTION
### Issue for this PR

Closes #31858

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR has been narrowed after upstream landed `87c33b3d85a6c874e7b5af6af8fd6784e0e1bfbd` (`fix(plugin): reuse active server for client requests`).

That upstream commit fixes the main runtime split for normal post-init plugin SDK calls: when `opencode serve` or Desktop has an active listener, plugin `input.client` now targets the active listener instead of the default in-process `Server.Default()` runtime. That prevents the duplicate plugin load / duplicate `promptAsync` runner split for the common live-server path.

I verified that narrower upstream fix against the Docker repro: bare `opencode-ai@1.17.7` no longer reproduces the main issue (`plugin_init count: 1`, and the `promptAsync` marker has one assistant child with one `stop`).

What remains unsolved is bootstrap re-entry. If a plugin calls `input.client.*` while its `server(input)` / config hooks are still loading, the active listener can route the request back into the same instance load. The instance is already booting and its deferred is not resolved yet, so the request can wait on the plugin load that is itself waiting on the request.

This PR now focuses only on that remaining path:

- While a plugin instance is still bootstrapping, plugin client requests return `409 Conflict` instead of re-entering the same instance load.
- After bootstrapping completes, plugin client requests continue to use upstream's existing `Server.url` active-listener bridge unchanged.
- The previous broader runtime replacement has been removed from this PR.

### How did you verify your code works?

- Verified the main repro against bare `opencode-ai@1.17.7`: not reproduced (`plugin_init count: 1`; `promptAsync` marker had one assistant child / one `stop`).
- Added focused regression coverage for plugin client re-entry during plugin loading.
- Ran `git diff --check` and source diagnostics for the narrowed patch.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
