### PR TITLE
fix(cli): check for browser opener before spawning to avoid ENOENT in containers

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -5,6 +5,23 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
+import { execFileSync } from "child_process"
+import { platform } from "process"
+
+function canOpenBrowser(): boolean {
+  const os = platform
+  if (os === "darwin" || os === "win32") return true
+  // The `open` npm package tries these openers on Linux/WSL in order
+  for (const bin of ["xdg-open", "wslview", "gio"]) {
+    try {
+      execFileSync("which", [bin], { stdio: "ignore" })
+      return true
+    } catch {
+      continue
+    }
+  }
+  return false
+}
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -72,11 +89,19 @@ export const WebCommand = effectCmd({
       }
 
       // Open localhost in browser
-      open(localhostUrl).catch(() => {})
+      if (canOpenBrowser()) {
+        open(localhostUrl).catch(() => {})
+      } else {
+        UI.println(UI.Style.TEXT_DIM + "  Open in browser:   ", UI.Style.TEXT_NORMAL, localhostUrl)
+      }
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      if (canOpenBrowser()) {
+        open(displayUrl).catch(() => {})
+      } else {
+        UI.println(UI.Style.TEXT_DIM + "  Open in browser:   ", UI.Style.TEXT_NORMAL, displayUrl)
+      }
     }
 
     yield* Effect.never


### PR DESCRIPTION
### Issue for this PR

Closes #31815

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When running `opencode web` in a container (Docker/Podman) without a desktop environment, `xdg-open` is not available and Bun prints a noisy ENOENT stack trace to stderr before the JS `.catch()` can suppress it. The server works fine, but the error output is confusing for users.

This adds a `canOpenBrowser()` pre-check that verifies a browser-opener binary exists in `$PATH` before attempting to spawn it:
- macOS/Windows: always returns `true` (built-in openers)
- Linux: checks for `xdg-open`, `wslview` (WSL), or `gio` — the same openers the `open` npm package tries

When no opener is found, it prints a clean message like `Open in browser: http://localhost:3000` instead of attempting the spawn.

The existing `.catch(() => {})` is preserved as a safety net for other failure modes (e.g., opener exists but fails to launch).

### How did you verify your code works?

- `tsc --noEmit` passes with no errors
- Verified on Linux without `xdg-open` in PATH: no ENOENT error, clean URL message printed
- Verified on Linux with `xdg-open` available: browser opens normally as before

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR