### PR TITLE
fix(opencode): end the turn when a permission is rejected with feedback

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -238,7 +238,11 @@ export const layer = Layer.effect(
             time: { start: match.part.state.time.start, end: Date.now() },
           },
         })
-        if (error instanceof PermissionV1.RejectedError || error instanceof Question.RejectedError) {
+        if (
+          error instanceof PermissionV1.RejectedError ||
+          error instanceof PermissionV1.CorrectedError ||
+          error instanceof Question.RejectedError
+        ) {
           ctx.blocked = ctx.shouldBreak
         }
         yield* settleToolCall(toolCallID)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2279,8 +2279,6 @@ noLLMServer.instance(
   30_000,
 )
 
-// Permission deny / reject loop semantics — auto-reject helper mimics a plugin
-// using the v1 SDK that rejects every permission ask as soon as it is published.
 const autoRejectAsks = Effect.fn("test.autoRejectAsks")(function* (message?: string) {
   const events = yield* EventV2Bridge.Service
   const permission = yield* Permission.Service
@@ -2305,9 +2303,6 @@ unix(
   () =>
     withSh(() =>
       Effect.gen(function* () {
-        // A reject sent WITH a message produces PermissionV1.CorrectedError.
-        // Without CorrectedError in the blocked check, the model receives the
-        // feedback as a tool error and retries the same call in a tight loop.
         const { llm, dir } = yield* useServerConfig((url) => ({
           ...providerCfg(url),
           experimental: { continue_loop_on_deny: false },
@@ -2331,7 +2326,6 @@ unix(
 
         const result = yield* prompt.loop({ sessionID: session.id })
         expect(result.info.role).toBe("assistant")
-        // Only 1 LLM call: the first reject with feedback must end the turn.
         expect(yield* llm.calls).toBe(1)
 
         const msgs = yield* MessageV2.filterCompactedEffect(session.id)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2278,3 +2278,67 @@ noLLMServer.instance(
     }),
   30_000,
 )
+
+// Permission deny / reject loop semantics — auto-reject helper mimics a plugin
+// using the v1 SDK that rejects every permission ask as soon as it is published.
+const autoRejectAsks = Effect.fn("test.autoRejectAsks")(function* (message?: string) {
+  const events = yield* EventV2Bridge.Service
+  const permission = yield* Permission.Service
+  const off = yield* events.listen((event) =>
+    Effect.gen(function* () {
+      if (event.type !== "permission.asked") return
+      const data = event.data as { id: string; sessionID: string }
+      yield* permission
+        .reply({
+          requestID: data.id as any,
+          reply: "reject",
+          message,
+        })
+        .pipe(Effect.ignore)
+    }),
+  )
+  yield* Effect.addFinalizer(() => off)
+})
+
+unix(
+  "rejected permission with feedback blocks loop by default",
+  () =>
+    withSh(() =>
+      Effect.gen(function* () {
+        // A reject sent WITH a message produces PermissionV1.CorrectedError.
+        // Without CorrectedError in the blocked check, the model receives the
+        // feedback as a tool error and retries the same call in a tight loop.
+        const { llm, dir } = yield* useServerConfig((url) => ({
+          ...providerCfg(url),
+          experimental: { continue_loop_on_deny: false },
+        }))
+        yield* autoRejectAsks("Permission expired and was rejected.")
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const session = yield* sessions.create({
+          title: "CorrectedStop",
+          permission: [{ permission: "bash", pattern: "*", action: "ask" }],
+        })
+        yield* prompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "run a command" }],
+        })
+        const call = { command: "rm -rf /tmp/corrected-stop", workdir: dir, description: "Remove dir" }
+        for (let i = 0; i < 6; i++) yield* llm.tool("bash", call)
+        yield* llm.text("should never be requested")
+
+        const result = yield* prompt.loop({ sessionID: session.id })
+        expect(result.info.role).toBe("assistant")
+        // Only 1 LLM call: the first reject with feedback must end the turn.
+        expect(yield* llm.calls).toBe(1)
+
+        const msgs = yield* MessageV2.filterCompactedEffect(session.id)
+        const tool = msgs.flatMap((m) => m.parts).find((p): p is SessionV1.ToolPart => p.type === "tool")
+        expect(tool?.state.status).toBe("error")
+        if (tool?.state.status === "error") expect(tool.state.error).toContain("Permission expired and was rejected.")
+      }),
+    ),
+  15_000,
+)


### PR DESCRIPTION
### Issue for this PR

Fixes #31108
Fixes #30726

Supersedes #31216 which was closed because it didn't follow the PR template.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`failToolCall` in `processor.ts` only checked for `PermissionV1.RejectedError` when deciding whether to block the loop. A rejection sent **with a message** (e.g. from a plugin's permission-timeout auto-reject) produces `PermissionV1.CorrectedError` instead, which was not in the check. The model received the feedback as a normal tool error, retried the same call, got rejected again, and looped.

The fix adds `CorrectedError` to the `instanceof` check alongside `RejectedError`, so messaged rejects follow the same `continue_loop_on_deny` semantics as plain rejects. `DeniedError` (static ruleset denies) intentionally stays out since those are routine and the model should adapt.

### How did you verify your code works?

Regression test that auto-rejects a permission ask with feedback, with `continue_loop_on_deny: false`. Without the fix the test gets 7 LLM calls (the model retries the denied call in a tight loop). With the fix it gets 1 LLM call (the turn ends immediately). Ran the full `test/session/prompt.test.ts` suite and `bun typecheck` in `packages/opencode`.

### Screenshots / recordings

N/A (loop-behavior fix, covered by the regression test)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR