### PR TITLE
feat: improve deepseek prompt cache reuse

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -166,10 +166,16 @@ export const layer = Layer.effect(
       )
 
     const sameModel = Schema.toEquivalence(Schema.UndefinedOr(ModelV2.Ref))
-    const loadSystemContext = (agent: AgentV2.Selection) =>
+    const isDeepSeekModel = (id: string) => id.toLowerCase().includes("deepseek")
+    const loadSystemContext = (agent: AgentV2.Selection, modelID: string) =>
       Effect.all([systemContext.load(), skillGuidance.load(agent), referenceGuidance.load()], {
         concurrency: "unbounded",
-      }).pipe(Effect.map(SystemContext.combine))
+      }).pipe(
+        Effect.map(SystemContext.combine),
+        Effect.map((context) =>
+          isDeepSeekModel(modelID) ? SystemContext.omit(context, [SystemContext.Key.make("core/date")]) : context,
+        ),
+      )
 
     const runTurnAttempt = Effect.fn("SessionRunner.runTurn")(function* (
       sessionID: SessionSchema.ID,
@@ -181,9 +187,10 @@ export const layer = Layer.effect(
       if (session.location.directory !== location.directory || session.location.workspaceID !== location.workspaceID)
         return yield* Effect.interrupt
       const agent = yield* agents.select(session.agent)
+      const model = yield* models.resolve(session)
       const initialized = yield* SessionContextEpoch.initialize(
         db,
-        loadSystemContext(agent),
+        loadSystemContext(agent, model.id),
         session.id,
         session.location,
         agent.id,
@@ -203,7 +210,7 @@ export const layer = Layer.effect(
         (yield* SessionContextEpoch.prepare(
           db,
           events,
-          loadSystemContext(agent),
+          loadSystemContext(agent, model.id),
           session.id,
           session.location,
           agent.id,
@@ -211,7 +218,6 @@ export const layer = Layer.effect(
       const current = yield* getSession(sessionID)
       if ((yield* agents.select(current.agent)).id !== agent.id || !sameModel(current.model, session.model))
         return yield* Effect.die(rebuildPreparedTurn())
-      const model = yield* models.resolve(session)
       const entries = yield* SessionHistory.entriesForRunner(db, session.id, system.baselineSeq)
       const context = entries.map((entry) => entry.message)
       const isLastStep = agent.info?.steps !== undefined && step >= agent.info.steps

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -10,6 +10,28 @@ import {
 import { SessionMessage } from "../message"
 import type { FileAttachment } from "../prompt"
 
+function isDeepSeekModel(model: Model) {
+  return [model.id, model.provider].some((value) => String(value).toLowerCase().includes("deepseek"))
+}
+
+function appendDeepSeekDateContext(messages: Message[], model: Model) {
+  if (!isDeepSeekModel(model)) return messages
+  const target = messages.at(-1)
+  if (!target || target.role !== "user") return messages
+  // Keep the volatile date out of the system prefix so DeepSeek cache reuse
+  // is only affected at the trailing user turn boundary.
+  return [
+    ...messages.slice(0, -1),
+    Message.make({
+      id: target.id,
+      role: target.role,
+      content: [...target.content, Message.text(`Today's date: ${new Date().toDateString()}`)],
+      metadata: target.metadata,
+      native: target.native,
+    }),
+  ]
+}
+
 const media = (file: FileAttachment): ContentPart => ({
   type: "media",
   mediaType: file.mime,
@@ -155,4 +177,4 @@ ${message.recent}
 
 /** Translate projected V2 Session history into canonical @opencode-ai/llm context. */
 export const toLLMMessages = (messages: readonly SessionMessage.Message[], model: Model) =>
-  messages.flatMap((message) => toLLMMessage(message, model))
+  appendDeepSeekDateContext(messages.flatMap((message) => toLLMMessage(message, model)), model)

--- a/packages/core/src/system-context/index.ts
+++ b/packages/core/src/system-context/index.ts
@@ -175,6 +175,12 @@ export function combine(values: ReadonlyArray<SystemContext>): SystemContext {
   return context(sources)
 }
 
+/** Returns a context without the specified source keys. */
+export function omit(value: SystemContext, keys: ReadonlyArray<Key>): SystemContext {
+  const hidden = new Set(keys)
+  return context(value[ContextTypeId].filter((source) => !hidden.has(source.key)))
+}
+
 const observe = (value: SystemContext) =>
   Effect.forEach(
     value[ContextTypeId],

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -12,6 +12,7 @@ import { DateTime } from "effect"
 const created = DateTime.makeUnsafe(0)
 const id = (value: string) => SessionMessage.ID.make(`msg_${value}`)
 const model = Model.make({ id: "model", provider: "provider", route: OpenAIChat.route })
+const deepSeekModel = Model.make({ id: "deepseek-chat", provider: "deepseek", route: OpenAIChat.route })
 
 describe("toLLMMessages", () => {
   test("omits empty assistant turns", () => {
@@ -136,6 +137,27 @@ Recent work
 </conversation-checkpoint>`,
         },
       ],
+    ])
+  })
+
+  test("appends the current date to the trailing user message for DeepSeek", () => {
+    const messages = toLLMMessages(
+      [
+        new SessionMessage.User({
+          id: id("deepseek-user"),
+          type: "user",
+          text: "What changed?",
+          time: { created },
+        }),
+      ],
+      deepSeekModel,
+    )
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.role).toBe("user")
+    expect(messages[0]?.content).toEqual([
+      { type: "text", text: "What changed?" },
+      { type: "text", text: `Today's date: ${new Date().toDateString()}` },
     ])
   })
 

--- a/packages/core/test/system-context/index.test.ts
+++ b/packages/core/test/system-context/index.test.ts
@@ -286,6 +286,21 @@ describe("SystemContext", () => {
     }),
   )
 
+  it.effect("omits selected sources without reordering the remainder", () =>
+    Effect.gen(function* () {
+      const context = SystemContext.omit(
+        SystemContext.combine([
+          stringContext({ key: "core/date", value: "date" }),
+          stringContext({ key: "core/location", value: "location" }),
+          stringContext({ key: "core/skills", value: "skills" }),
+        ]),
+        [key("core/location")],
+      )
+
+      expect((yield* SystemContext.initialize(context)).baseline).toBe("date\n\nskills")
+    }),
+  )
+
   it.effect("requires namespaced source keys", () =>
     Effect.sync(() => {
       const decodeKey = Schema.decodeUnknownSync(SystemContext.Key)

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -61,6 +61,91 @@ function sdkKey(npm: string): string | undefined {
   return undefined
 }
 
+function isDeepSeekModel(model: Provider.Model) {
+  return [model.id, model.api.id, model.providerID].some((value) => value.toLowerCase().includes("deepseek"))
+}
+
+function isAssistantToolCallMessage(msg: ModelMessage) {
+  return (
+    msg.role === "assistant" && Array.isArray(msg.content) && msg.content.some((part) => part.type === "tool-call")
+  )
+}
+
+function deepSeekToolTurnIndexes(msgs: ModelMessage[]) {
+  const turns = new Set<number>()
+  let start = 0
+
+  for (let end = 0; end <= msgs.length; end++) {
+    if (end < msgs.length && msgs[end].role !== "user") continue
+
+    let hasTools = false
+    for (let index = start; index < end; index++) {
+      const msg = msgs[index]
+      if (msg.role === "tool" || isAssistantToolCallMessage(msg)) {
+        hasTools = true
+        break
+      }
+    }
+
+    if (hasTools) {
+      for (let index = start; index < end; index++) {
+        if (msgs[index].role === "assistant") turns.add(index)
+      }
+    }
+
+    start = end
+  }
+
+  return turns
+}
+
+function transformDeepSeekReasoning(msgs: ModelMessage[], field: string) {
+  const toolTurns = deepSeekToolTurnIndexes(msgs)
+
+  return msgs.map((msg, index) => {
+    if (msg.role !== "assistant") return msg
+    if (typeof msg.content === "string") {
+      if (!toolTurns.has(index)) return msg
+      return {
+        ...msg,
+        providerOptions: {
+          ...msg.providerOptions,
+          openaiCompatible: {
+            ...msg.providerOptions?.openaiCompatible,
+            [field]: "",
+          },
+        },
+      }
+    }
+    if (!Array.isArray(msg.content)) return msg
+
+    const reasoningText = msg.content
+      .filter((part): part is Extract<(typeof msg.content)[number], { type: "reasoning" }> => part.type === "reasoning")
+      .map((part) => part.text)
+      .join("")
+    const content = msg.content.filter((part) => part.type !== "reasoning")
+
+    if (!toolTurns.has(index)) {
+      return {
+        ...msg,
+        content,
+      }
+    }
+
+    return {
+      ...msg,
+      content,
+      providerOptions: {
+        ...msg.providerOptions,
+        openaiCompatible: {
+          ...msg.providerOptions?.openaiCompatible,
+          [field]: reasoningText,
+        },
+      },
+    }
+  })
+}
+
 // TODO: fix this stupid inefficient dogshit function
 function normalizeMessages(
   msgs: ModelMessage[],
@@ -265,30 +350,15 @@ function normalizeMessages(
     return result
   }
 
-  // Deepseek requires all assistant messages to have reasoning on them
-  if (model.api.id.toLowerCase().includes("deepseek")) {
-    msgs = msgs.map((msg) => {
-      if (msg.role !== "assistant") return msg
-      if (Array.isArray(msg.content)) {
-        if (msg.content.some((part) => part.type === "reasoning")) return msg
-        return { ...msg, content: [...msg.content, { type: "reasoning", text: "" }] }
-      }
-      return {
-        ...msg,
-        content: [
-          ...(msg.content ? [{ type: "text" as const, text: msg.content }] : []),
-          { type: "reasoning" as const, text: "" },
-        ],
-      }
-    })
-  }
-
   if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
     model.api.npm !== "@openrouter/ai-sdk-provider"
   ) {
     const field = model.capabilities.interleaved.field
+    if (isDeepSeekModel(model)) {
+      return transformDeepSeekReasoning(msgs, field)
+    }
     return msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
         const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
@@ -430,6 +500,7 @@ function mapProviderOptions(
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
+  const deepSeek = isDeepSeekModel(model)
   if (
     (model.providerID === "anthropic" ||
       model.providerID === "google-vertex-anthropic" ||
@@ -439,7 +510,8 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
       model.id.includes("claude") ||
       model.api.npm === "@ai-sdk/anthropic" ||
       model.api.npm === "@ai-sdk/alibaba") &&
-    model.api.npm !== "@ai-sdk/gateway"
+    model.api.npm !== "@ai-sdk/gateway" &&
+    !deepSeek
   ) {
     msgs = applyCaching(msgs, model)
   }

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -17,6 +17,29 @@ import { mergeDeep } from "remeda"
 
 const USER_AGENT = `opencode/${InstallationVersion}`
 
+function isDeepSeekModel(model: Provider.Model) {
+  return [model.id, model.api.id, model.providerID].some((value) => value.toLowerCase().includes("deepseek"))
+}
+
+function appendDeepSeekDateContext(messages: ModelMessage[], model: Provider.Model) {
+  if (!isDeepSeekModel(model)) return messages
+  const target = messages.at(-1)
+  if (!target || target.role !== "user") return messages
+  const date = { type: "text" as const, text: `Today's date: ${new Date().toDateString()}` }
+  // Keep the volatile date off the system prefix so DeepSeek cache reuse only
+  // changes at the trailing user turn boundary.
+  return [
+    ...messages.slice(0, -1),
+    {
+      ...target,
+      content:
+        typeof target.content === "string"
+          ? [{ type: "text" as const, text: target.content }, date]
+          : [...target.content, date],
+    },
+  ]
+}
+
 type PrepareInput = {
   readonly user: SessionV1.User
   readonly sessionID: string
@@ -110,6 +133,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
           ),
           ...input.messages,
         ]
+  const modelMessages = appendDeepSeekDateContext(messages, input.model)
 
   const params = yield* input.plugin.trigger(
     "chat.params",
@@ -170,7 +194,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
 
   return {
     system,
-    messages,
+    messages: modelMessages,
     tools: Object.fromEntries(Object.entries(tools).toSorted(([a], [b]) => a.localeCompare(b))),
     params,
     messageTransformOptions: options,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -22,6 +22,10 @@ import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { PluginBoot } from "@opencode-ai/core/plugin/boot"
 import { Reference } from "@opencode-ai/core/reference"
 
+function isDeepSeekModel(model: Provider.Model) {
+  return [model.id, model.api.id, model.providerID].some((value) => value.toLowerCase().includes("deepseek"))
+}
+
 export function provider(model: Provider.Model) {
   if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
     return [PROMPT_BEAST]
@@ -58,18 +62,19 @@ export const layer = Layer.effect(
           yield* (yield* PluginBoot.Service).wait()
           return (yield* (yield* Reference.Service).list()).filter((reference) => reference.description !== undefined)
         }).pipe(Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(ctx.directory) }))))
+        const environment = [
+          `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
+          `Here is some useful information about the environment you are running in:`,
+          `<env>`,
+          `  Working directory: ${ctx.directory}`,
+          `  Workspace root folder: ${ctx.worktree}`,
+          `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
+          `  Platform: ${process.platform}`,
+          isDeepSeekModel(model) ? undefined : `  Today's date: ${new Date().toDateString()}`,
+          `</env>`,
+        ].filter((line): line is string => line !== undefined)
         return [
-          [
-            `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
-            `Here is some useful information about the environment you are running in:`,
-            `<env>`,
-            `  Working directory: ${ctx.directory}`,
-            `  Workspace root folder: ${ctx.worktree}`,
-            `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
-            `  Platform: ${process.platform}`,
-            `  Today's date: ${new Date().toDateString()}`,
-            `</env>`,
-          ].join("\n"),
+          environment.join("\n"),
           references.length === 0
             ? undefined
             : [

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -401,6 +401,86 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.params.options.include).toBeUndefined()
   })
 
+  test("DeepSeek appends the current date to the trailing user message instead of system", async () => {
+    const model = {
+      id: "deepseek/deepseek-chat",
+      providerID: "deepseek",
+      api: {
+        id: "deepseek-chat",
+        url: "https://api.deepseek.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "DeepSeek Chat",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: true },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: {
+          field: "reasoning_content",
+        },
+      },
+      cost: {
+        input: 0.001,
+        output: 0.002,
+        cache: { read: 0.0001, write: 0.0002 },
+      },
+      limit: {
+        context: 128000,
+        output: 8192,
+      },
+      status: "active",
+      options: {},
+      headers: {},
+    } as any
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        user: {
+          id: "msg_user-test",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID: "deepseek", modelID: "deepseek-chat" },
+        } as any,
+        sessionID,
+        model,
+        agent: {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [],
+        } as any,
+        system: [],
+        messages: [{ role: "user", content: "Hello" }],
+        tools: {},
+        provider: { id: "deepseek", options: {} } as any,
+        auth: undefined,
+        plugin: {
+          trigger: (_name: string, _input: unknown, output: unknown) => Effect.succeed(output),
+          list: () => Effect.succeed([]),
+          init: () => Effect.void,
+        } as any,
+        flags: { outputTokenMax: 32_000, client: "test" } as any,
+        isWorkflow: false,
+      }),
+    )
+
+    expect(result.messages.at(-1)).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "Hello" },
+        { type: "text", text: `Today's date: ${new Date().toDateString()}` },
+      ],
+    })
+    expect(result.messages[0]).toEqual({
+      role: "system",
+      content: expect.stringContaining("You are"),
+    })
+  })
+
   test("gpt-5.1 should have textVerbosity set to low", () => {
     const model = createGpt5Model("gpt-5.1")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
@@ -1500,8 +1580,49 @@ describe("ProviderTransform.schema - moonshot $ref siblings", () => {
 })
 
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
+  const deepSeekModel = (overrides: Partial<any> = {}) =>
+    ({
+      id: ModelV2.ID.make("deepseek/deepseek-chat"),
+      providerID: ProviderV2.ID.make("deepseek"),
+      api: {
+        id: "deepseek-chat",
+        url: "https://api.deepseek.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "DeepSeek Chat",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: {
+          field: "reasoning_content",
+        },
+      },
+      cost: {
+        input: 0.001,
+        output: 0.002,
+        cache: { read: 0.0001, write: 0.0002 },
+      },
+      limit: {
+        context: 128000,
+        output: 8192,
+      },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2023-04-01",
+      ...overrides,
+    }) as any
+
   test("DeepSeek with tool calls includes reasoning_content in providerOptions", () => {
     const msgs = [
+      {
+        role: "user",
+        content: "Run a command",
+      },
       {
         role: "assistant",
         content: [
@@ -1518,45 +1639,12 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
 
     const result = ProviderTransform.message(
       msgs,
-      {
-        id: ModelV2.ID.make("deepseek/deepseek-chat"),
-        providerID: ProviderV2.ID.make("deepseek"),
-        api: {
-          id: "deepseek-chat",
-          url: "https://api.deepseek.com",
-          npm: "@ai-sdk/openai-compatible",
-        },
-        name: "DeepSeek Chat",
-        capabilities: {
-          temperature: true,
-          reasoning: true,
-          attachment: false,
-          toolcall: true,
-          input: { text: true, audio: false, image: false, video: false, pdf: false },
-          output: { text: true, audio: false, image: false, video: false, pdf: false },
-          interleaved: {
-            field: "reasoning_content",
-          },
-        },
-        cost: {
-          input: 0.001,
-          output: 0.002,
-          cache: { read: 0.0001, write: 0.0002 },
-        },
-        limit: {
-          context: 128000,
-          output: 8192,
-        },
-        status: "active",
-        options: {},
-        headers: {},
-        release_date: "2023-04-01",
-      },
+      deepSeekModel(),
       {},
     )
 
-    expect(result).toHaveLength(1)
-    expect(result[0].content).toEqual([
+    expect(result).toHaveLength(2)
+    expect(result[1].content).toEqual([
       {
         type: "tool-call",
         toolCallId: "test",
@@ -1564,7 +1652,113 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
         input: { command: "echo hello" },
       },
     ])
-    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
+    expect(result[1].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
+  })
+
+  test("DeepSeek omits reasoning_content for assistant replies without tools in the user turn", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "user",
+          content: "Hello",
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "This should not be replayed." },
+            { type: "text", text: "Answer" },
+          ],
+        },
+      ] as any[],
+      deepSeekModel(),
+      {},
+    )
+
+    expect(result[1].content).toEqual([{ type: "text", text: "Answer" }])
+    expect(result[1].providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+  })
+
+  test("DeepSeek replays reasoning_content across the full assistant tool turn", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "user",
+          content: "Check the repo",
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "Need to inspect files first." },
+            {
+              type: "tool-call",
+              toolCallId: "call-1",
+              toolName: "bash",
+              input: { command: "pwd" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "bash",
+              output: { type: "text", value: "/repo" },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "The repo is at /repo." }],
+        },
+      ] as any[],
+      deepSeekModel(),
+      {},
+    )
+
+    expect(result[1].content).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "bash",
+        input: { command: "pwd" },
+      },
+    ])
+    expect(result[1].providerOptions?.openaiCompatible?.reasoning_content).toBe("Need to inspect files first.")
+    expect(result[3].content).toEqual([{ type: "text", text: "The repo is at /repo." }])
+    expect(result[3].providerOptions?.openaiCompatible?.reasoning_content).toBe("")
+  })
+
+  test("DeepSeek skips cache control hints on Alibaba-compatible routes", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "system",
+          content: "System",
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      ] as any[],
+      deepSeekModel({
+        id: ModelV2.ID.make("alibaba/deepseek-v3"),
+        providerID: ProviderV2.ID.make("alibaba"),
+        api: {
+          id: "deepseek-v3",
+          url: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          npm: "@ai-sdk/alibaba",
+        },
+      }),
+      {},
+    )
+
+    expect(result[0].providerOptions).toBeUndefined()
+    expect(Array.isArray(result[1].content)).toBe(true)
+    if (Array.isArray(result[1].content)) {
+      expect(result[1].content[0]?.providerOptions).toBeUndefined()
+    }
   })
 
   test("Non-DeepSeek providers leave reasoning content unchanged", () => {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -812,6 +812,7 @@ describe("session.compaction.prune", () => {
       }),
     ),
   )
+
 })
 
 describe("session.compaction.process", () => {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -41,6 +41,38 @@ const build: Agent.Info = {
   options: {},
 }
 
+const model = (id: string, providerID = "test", npm = "@ai-sdk/openai-compatible") =>
+  ({
+    id: `${providerID}/${id}`,
+    providerID,
+    api: {
+      id,
+      url: "https://api.example.com",
+      npm,
+    },
+    name: id,
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: {
+      input: 0,
+      output: 0,
+      cache: { read: 0, write: 0 },
+    },
+    limit: {
+      context: 128_000,
+      output: 8_192,
+    },
+    options: {},
+    headers: {},
+  }) as any
+
 const it = testEffect(
   SystemPrompt.layer.pipe(
     Layer.provide(LocationServiceMap.layer),
@@ -81,6 +113,18 @@ describe("session.system", () => {
       expect(middle).toBeGreaterThan(alpha)
       expect(zeta).toBeGreaterThan(middle)
       expect(output).not.toContain("manual-skill")
+    }),
+  )
+
+  it.instance(
+    "omits the dynamic date line for DeepSeek environments",
+    Effect.gen(function* () {
+      const prompt = yield* SystemPrompt.Service
+      const output = yield* prompt.environment(model("deepseek-chat", "deepseek"))
+
+      expect(output.join("\n")).not.toContain("Today's date:")
+      expect(output.join("\n")).toContain("Working directory:")
+      expect(output.join("\n")).toContain(`Platform: ${process.platform}`)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31979

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

DeepSeek prompt cache reuse was weaker than it should be because the current date was being injected into the system context, which makes the cacheable prompt prefix change over time and across replay/
  compaction paths. DeepSeek tool turns also need reasoning state to be replayed more carefully than other providers.

This PR moves the date for DeepSeek out of the system prefix and appends it only to the trailing user message in both the `opencode` request path and the `core` session runner path. It also omits the
  `core/date` system-context source for DeepSeek sessions, preserves `reasoning_content` only for assistant messages that belong to a tool turn, strips reasoning parts from non-tool assistant content, and
  avoids applying the generic cache-control path to DeepSeek message transforms.

This works because the reusable prompt prefix now stays stable for DeepSeek while the model still receives the current date at the active user turn boundary. Tool-turn reasoning replay also stays scoped to
  the turns that actually need it, which keeps the serialized history closer to DeepSeek's expectations and improves cache reuse instead of invalidating it.

### How did you verify your code works?

I ran focused local tests for the files and behaviors touched by this change:

```bash
  cd packages/opencode
  bun test test/provider/transform.test.ts test/session/system.test.ts test/session/compaction.test.ts

  cd packages/core
  bun test test/session-runner-message.test.ts test/system-context/index.test.ts
```
Results:

- packages/opencode: 317 passed, 1 skipped, 0 failed
- packages/core: 24 passed, 0 failed

### Screenshots / recordings

N/A — this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
