### PR TITLE
fix(core): consolidate diff size constants into packages/core/src/dif…

### DIFF
--- a/packages/core/src/diff-constants.ts
+++ b/packages/core/src/diff-constants.ts
@@ -1,0 +1,12 @@
+// Messages API returns ALL diffs per session, so use conservative 100KB limit.
+export const MAX_INFO_DIFF_PATCH_BYTES = 100_000
+
+// Frontend skip content reconstruction for patches >100KB (defense-in-depth).
+export const MAX_RECONSTRUCT_BYTES = 100_000
+
+// Per-file patch generation limit. Dedicated diff endpoints serve one file at a
+// time, so 1MB is acceptable.
+export const MAX_DIFF_PATCH_BYTES = 1_000_000
+
+// Absolute fallback: even with context=0, discard patches >10MB.
+export const ABSOLUTE_MAX_DIFF_BYTES = 10_000_000

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process"
+import { createRequire } from "node:module"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
@@ -7,6 +8,8 @@ import type { Configuration } from "electron-builder"
 
 const execFileAsync = promisify(execFile)
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const require = createRequire(import.meta.url)
+const electronDist = path.join(path.dirname(require.resolve("electron/package.json")), "dist")
 const signScript = path.join(rootDir, "script", "sign-windows.ps1")
 
 async function signWindows(configuration: { path: string }) {
@@ -27,6 +30,7 @@ const channel = (() => {
 })()
 
 const getBase = (): Configuration => ({
+  electronDist,
   artifactName: "opencode-desktop-${os}-${arch}.${ext}",
   directories: {
     output: "dist",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -88,12 +88,24 @@ export const cursor = {
   },
 }
 
-const info = (row: typeof MessageTable.$inferSelect) =>
-  ({
-    ...row.data,
+import { MAX_INFO_DIFF_PATCH_BYTES } from "@opencode-ai/core/diff-constants"
+
+const info = (row: typeof MessageTable.$inferSelect) => {
+  const data = { ...row.data }
+  if (typeof data.summary === "object" && data.summary?.diffs) {
+    data.summary.diffs = data.summary.diffs.map((d) => {
+      if (d.patch !== undefined && Buffer.byteLength(d.patch) > MAX_INFO_DIFF_PATCH_BYTES) {
+        return { ...d, patch: undefined }
+      }
+      return d
+    })
+  }
+  return {
+    ...data,
     id: row.id,
     sessionID: row.session_id,
-  }) as Info
+  } as Info
+}
 
 const part = (row: typeof PartTable.$inferSelect) =>
   ({

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -6,6 +6,7 @@ import { Snapshot } from "@/snapshot"
 import { Session } from "./session"
 import { SessionID, MessageID } from "./schema"
 import { Config } from "@/config/config"
+import { MAX_DIFF_PATCH_BYTES } from "@opencode-ai/core/diff-constants"
 
 function unquoteGitPath(input: string) {
   if (!input.startsWith('"')) return input
@@ -136,6 +137,9 @@ export const layer = Layer.effect(
       return diffs.map((item) => {
         if (item.file === undefined) return item
         const file = unquoteGitPath(item.file)
+        if (item.patch !== undefined && Buffer.byteLength(item.patch) > MAX_DIFF_PATCH_BYTES) {
+          return { ...item, file, patch: undefined }
+        }
         if (file === item.file) return item
         return { ...item, file }
       })

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -9,6 +9,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { Config } from "@/config/config"
 import { Global } from "@opencode-ai/core/global"
+import { MAX_DIFF_PATCH_BYTES, ABSOLUTE_MAX_DIFF_BYTES } from "@opencode-ai/core/diff-constants"
 
 export const Patch = Schema.Struct({
   hash: Schema.String,
@@ -686,8 +687,24 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               }
 
               const step = 100
-              const patch = (file: string, before: string, after: string) =>
-                formatPatch(structuredPatch(file, file, before, after, "", "", { context: Number.MAX_SAFE_INTEGER }))
+              // Dedicated diff endpoint serves one file at a time, so 1MB is acceptable.
+              const patch = (file: string, before: string, after: string) => {
+                const tryContext = (ctx: number) => {
+                  const p = formatPatch(structuredPatch(file, file, before, after, "", "", { context: ctx }))
+                  return Buffer.byteLength(p) <= MAX_DIFF_PATCH_BYTES ? p : undefined
+                }
+                if (before.length + after.length <= MAX_DIFF_PATCH_BYTES * 2) {
+                  const full = tryContext(Number.MAX_SAFE_INTEGER)
+                  if (full !== undefined) return full
+                }
+                for (let ctx = 100; ctx >= 0; ctx -= 10) {
+                  const p = tryContext(ctx)
+                  if (p !== undefined) return p
+                }
+                const minimal = formatPatch(structuredPatch(file, file, before, after, "", "", { context: 0 }))
+                if (Buffer.byteLength(minimal) <= ABSOLUTE_MAX_DIFF_BYTES) return minimal
+                return ""
+              }
 
               for (let i = 0; i < rows.length; i += step) {
                 const run = rows.slice(i, i + step)

--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -1,6 +1,7 @@
 import { parseDiffFromFile, parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs"
 import { parsePatch } from "diff"
 import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
+import { MAX_RECONSTRUCT_BYTES } from "@opencode-ai/core/diff-constants"
 
 type LegacyDiff = {
   file: string
@@ -26,6 +27,10 @@ export type ViewDiff = {
 
 const diffCacheLimit = 16
 const patchFileDiffCache = new Map<string, FileDiffMetadata>()
+const utf8ByteLength = (s: string) => {
+  if (typeof Buffer !== "undefined") return Buffer.byteLength(s)
+  return new TextEncoder().encode(s).length
+}
 
 export function resolveFileDiff(diff: DiffSource) {
   if (typeof diff.patch === "string") return fileDiffFromPatch(diff.file, diff.patch)
@@ -60,7 +65,7 @@ function fileDiffFromPatch(file: string, patch: string) {
     return hit
   }
 
-  const contents = completePatchContents(patch)
+  const contents = utf8ByteLength(patch) <= MAX_RECONSTRUCT_BYTES ? completePatchContents(patch) : undefined
   const input = contents ? undefined : patchInput(file, patch)
   const value = contents
     ? fileDiffFromContent(file, contents.before, contents.after)


### PR DESCRIPTION
…f-constants.ts

[Fixes issues/31655](fix: https://github.com/anomalyco/opencode/issues/31655)

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

fix: https://github.com/anomalyco/opencode/issues/31655

- Three-layer defense: generation (snapshot), dedicated endpoint (summary), messages serialization (message-v2)
- 100KB threshold for messages API (batch returns all diffs at once) vs 1MB for per-file diff endpoints (one file at a time) — conservative at batch API to prevent frontend freeze
- Frontend guard (`MAX_RECONSTRUCT_BYTES`) as defense-in-depth: skip expensive content reconstruction + re-diff, fall through to fast unified-diff parser
- Pre-check file content size in snapshot before attempting `Number.MAX_SAFE_INTEGER` to avoid wasted Myers diff on large files
 

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
