### PR TITLE
fix(tui): pass roots:true to session.list to prevent root sessions being hidden by LIMIT 100

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -37,7 +37,7 @@ export function DialogSessionList() {
     () => ({ query: search(), filter: sync.session.query() }),
     async (input) => {
       if (!input.query) return undefined
-      const result = await sdk.client.session.list({ search: input.query, limit: 30, ...input.filter })
+      const result = await sdk.client.session.list({ search: input.query, limit: 30, roots: true, ...input.filter })
       return result.data ?? []
     },
   )

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -155,7 +155,7 @@ export const {
 
     function listSessions() {
       return sdk.client.session
-        .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
+        .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, roots: true, ...sessionListQuery() })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 


### PR DESCRIPTION
## Summary

- Pass `roots: true` to `sdk.client.session.list` in `packages/tui/src/context/sync.tsx:158` (bootstrap session list)
- Pass `roots: true` to `sdk.client.session.list` in `packages/tui/src/component/dialog-session-list.tsx:40` (picker live search)
- Server-side support for `roots` already exists in `Session.listByProject` (`packages/opencode/src/session/session.ts:1022-1024`); SDK type already declares `roots?: boolean`. No server or SDK changes needed.

## Why

The TUI fetches at most 100 sessions ordered by `time_updated DESC`. The server SQL only filters `parent_id IS NULL` when `input.roots` is truthy. Without it, subagent children compete with root sessions for the 100-row budget. On projects with many subagents (e.g. 23 roots vs ~680 children in my case), older root sessions fall outside the cutoff before the TUI's client-side `parentID === undefined` filter at `dialog-session-list.tsx:136,158` and `local.tsx:461` ever runs, making them silently invisible in the picker.

## Testing

- `bunx tsgo --noEmit` in `packages/tui`: passes with zero errors.
- Manual verification with `OPENCODE_DISABLE_CHANNEL_DB=1 bun dev <project>` against a project with 23 root sessions and ~680 subagent children: previously-missing root sessions reappear in the picker. Subagent children remain hidden as before.

Fixes #31881