### PR TITLE
fix(opencode): fix trivial bugs from open issues (#31763, #31812, #31782, #31779)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -606,7 +606,7 @@ function anthropicOpus47OrLater(apiId: string) {
 }
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
-  if (anthropicOpus47OrLater(apiId) || apiId.includes("fable-5")) {
+  if (anthropicOpus47OrLater(apiId) || apiId.includes("fable-5") || apiId.includes("fable5")) {
     return ["low", "medium", "high", "xhigh", "max"]
   }
   if (
@@ -620,7 +620,7 @@ function anthropicAdaptiveEfforts(apiId: string): string[] | null {
 }
 
 function anthropicOmitsThinking(apiId: string) {
-  return anthropicOpus47OrLater(apiId) || apiId.includes("fable-5")
+  return anthropicOpus47OrLater(apiId) || apiId.includes("fable-5") || apiId.includes("fable5")
 }
 
 function googleThinkingLevelEfforts(apiId: string) {

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -34,7 +34,7 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
         synthetic: true,
       })
     }
-    const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
+    const wasPlan = input.messages.findLast((msg) => msg.info.role === "assistant")?.info.agent === "plan"
     if (wasPlan && input.agent.name === "build") {
       userMessage.parts.push({
         id: PartID.ascending(),

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -129,7 +129,8 @@ export function retryable(error: Err, provider: string) {
     if (
       lower.includes("rate increased too quickly") ||
       lower.includes("rate limit") ||
-      lower.includes("too many requests")
+      lower.includes("too many requests") ||
+      lower.includes("engine busy")
     ) {
       return { message: msg }
     }

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -547,7 +547,7 @@ export const ShellTool = Tool.define(
             return Effect.sync(() => ctx.abort.removeEventListener("abort", handler))
           })
 
-          const timeout = Effect.sleep(`${input.timeout + 100} millis`)
+          const timeout = Effect.sleep(`${input.timeout} millis`)
 
           const exit = yield* Effect.raceAll([
             handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),


### PR DESCRIPTION
## Summary

Fixes 4 trivial but impactful bugs from open issues.

### Bug Fixes

**#31763 — Plan/build reminder fires every turn**
- `packages/opencode/src/session/reminders.ts`: Changed `.some()` to `.findLast()` so the "switched from plan to build" banner only fires on the turn immediately after the mode switch, not on every subsequent turn.

**#31812 — xfyun "engine busy" not retried**
- `packages/opencode/src/session/retry.ts`: Added `"engine busy"` to the retryable error text patterns, so xfyun's transient overload errors trigger automatic retries.

**#31782 — GitLab Duo Fable 5 model mapping missing**
- `packages/opencode/src/provider/transform.ts`: Added `apiId.includes("fable5")` alongside the existing `"fable-5"` check in both `anthropicAdaptiveEfforts` and `anthropicOmitsThinking`, covering GitLab Duo's hyphen-free model ID.

**#31779 — Shell tool adds undocumented +100ms to timeout**
- `packages/opencode/src/tool/shell.ts`: Removed the `+ 100` millisecond buffer from the timeout calculation so user-specified timeouts are respected exactly.

### Verification
- Typecheck passes for all modified packages
- All changes are minimal, surgical edits following existing code conventions