### PR TITLE
fix: write tool data-loss prevention - atomic pre-existence check before overwrite

### DIFF
--- a/packages/core/src/tool/write.ts
+++ b/packages/core/src/tool/write.ts
@@ -82,8 +82,15 @@ export const layer = Layer.effectDiscard(
                   agent: context.agent,
                   source,
                 })
-                return yield* files.writeTextPreservingBom({ target, content: input.content })
-              }).pipe(Effect.mapError(() => new ToolFailure({ message: `Unable to write ${input.path}` }))),
+                const result = yield* files.writeTextPreservingBom({ target, content: input.content })
+                if (result.existed)
+                  return yield* new ToolFailure({ message: `File already exists: ${target.resource}. Use edit to modify existing files.` })
+                return result
+              }).pipe(
+                Effect.mapError((error) =>
+                  error instanceof ToolFailure ? error : new ToolFailure({ message: `Unable to write ${input.path}` }),
+                ),
+              ) as Effect.Effect<Output, ToolFailure>,
           }),
           "edit",
         ),

--- a/packages/core/src/tool/write.ts
+++ b/packages/core/src/tool/write.ts
@@ -82,9 +82,11 @@ export const layer = Layer.effectDiscard(
                   agent: context.agent,
                   source,
                 })
-                const result = yield* files.writeTextPreservingBom({ target, content: input.content })
-                if (result.existed)
-                  return yield* Effect.fail(new ToolFailure({ message: `File already exists: ${target.resource}. Use edit to modify existing files.` }))
+                const result = yield* files.create({ target, content: input.content }).pipe(
+                  Effect.catchTag("FileMutation.TargetExistsError", () =>
+                    Effect.fail(new ToolFailure({ message: `File already exists: ${target.resource}. Use edit to modify existing files.` })),
+                  ),
+                )
                 return result
               }).pipe(
                 Effect.mapError((error) =>

--- a/packages/core/src/tool/write.ts
+++ b/packages/core/src/tool/write.ts
@@ -84,7 +84,7 @@ export const layer = Layer.effectDiscard(
                 })
                 const result = yield* files.writeTextPreservingBom({ target, content: input.content })
                 if (result.existed)
-                  return yield* new ToolFailure({ message: `File already exists: ${target.resource}. Use edit to modify existing files.` })
+                  return yield* Effect.fail(new ToolFailure({ message: `File already exists: ${target.resource}. Use edit to modify existing files.` }))
                 return result
               }).pipe(
                 Effect.mapError((error) =>


### PR DESCRIPTION
### Issue for this PR

Closes #31248 #30864

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fix write tool silently overwriting existing files - add atomic pre-existence check with wx flag, preserve ToolFailure errors, clear 'use edit' message.

### How did you verify your code works?

Tested in custom fork, verified write refuses to overwrite and returns actionable error.

### Screenshots / recordings

N/A - logic change, not UI

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR