### PR TITLE
fix(opencode): bound SSE event backlogs and disconnect stalled consumers

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/backlog.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/backlog.ts
@@ -1,0 +1,17 @@
+// The per-subscriber backlog of events awaiting SSE delivery is bounded so a
+// consumer that stops draining cannot grow it without limit. A TCP connection
+// stuck in CLOSE_WAIT never surfaces an abort, so the only cleanup signal for
+// an event stream used to be one a half-dead peer never sends; meanwhile its
+// queue kept absorbing the full event firehose (#20695).
+//
+// On overflow the queue ends instead of dropping events silently: buffered
+// events still flush, the response completes, finalizers unsubscribe the
+// listener, and a live client reconnects and resyncs from the event log
+// (sync events carry a total order, see src/sync/README.md, which is what
+// makes disconnection safe).
+//
+// Sizing: events are small JSON payloads; healthy consumers drain within
+// milliseconds while heavy streaming bursts run to the low thousands. 10k
+// absorbs bursts with ample margin yet caps a dead connection's cost at a
+// few megabytes instead of unbounded gigabytes.
+export const SUBSCRIBER_BACKLOG_CAPACITY = 10_000

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -2,11 +2,12 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { GlobalBus } from "@/bus/global"
 import { EventV2 } from "@opencode-ai/core/event"
-import { Effect, Queue } from "effect"
+import { Cause, Effect, Queue } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
+import { SUBSCRIBER_BACKLOG_CAPACITY } from "./backlog"
 import { EventApi } from "../groups/event"
 
 function eventData(data: unknown): Sse.Event {
@@ -28,15 +29,22 @@ function eventResponse(events: EventV2.Interface) {
     const workspaceID = yield* InstanceState.workspaceID
     // Listener registration is eager, so events published after this point cannot
     // be lost while the HTTP body fiber is starting or emitting server.connected.
-    const queue = yield* Queue.unbounded<EventV2.Payload>()
-    const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
+    const queue = yield* Queue.bounded<EventV2.Payload, Cause.Done>(SUBSCRIBER_BACKLOG_CAPACITY)
+    const unsubscribe = yield* events.listen((event) =>
+      Effect.sync(() => {
+        // Filter before buffering so other instances' events never occupy
+        // this subscriber's backlog.
+        if (event.location?.directory !== instance.directory) return
+        if (event.location.workspaceID !== undefined && event.location.workspaceID !== workspaceID) return
+        if (Queue.offerUnsafe(queue, event)) return
+        // The consumer stopped draining (e.g. a half-closed socket that will
+        // never signal an abort): end the stream so the connection tears down
+        // and the client resyncs, instead of buffering without bound.
+        Queue.endUnsafe(queue)
+      }),
+    )
     yield* Effect.addFinalizer(() => unsubscribe)
     const stream = Stream.fromQueue(queue).pipe(
-      Stream.filter(
-        (event) =>
-          event.location?.directory === instance.directory &&
-          (event.location.workspaceID === undefined || event.location.workspaceID === workspaceID),
-      ),
       Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
     )
     const disposed = Stream.callback<{ id: string; type: string; properties: unknown }>((queue) => {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -5,11 +5,12 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { Installation } from "@/installation"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
-import { Effect, Queue, Schema } from "effect"
+import { Cause, Effect, Queue, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
+import { SUBSCRIBER_BACKLOG_CAPACITY } from "./backlog"
 import { RootHttpApi } from "../api"
 import { GlobalUpgradeInput } from "../groups/global"
 
@@ -33,13 +34,17 @@ function parseBody(body: string) {
 function eventResponse() {
   return Effect.gen(function* () {
     yield* Effect.logInfo("global event connected")
-    const events = Stream.callback<GlobalBusEvent>((queue) => {
-      const handler = (event: GlobalBusEvent) => Queue.offerUnsafe(queue, event)
-      return Effect.acquireRelease(
-        Effect.sync(() => GlobalBus.on("event", handler)),
-        () => Effect.sync(() => GlobalBus.off("event", handler)),
-      )
-    })
+    // Listener registration is eager (matching the instance event endpoint)
+    // and the backlog is bounded: a subscriber that stops draining ends the
+    // stream instead of buffering global events without limit.
+    const queue = yield* Queue.bounded<GlobalBusEvent, Cause.Done>(SUBSCRIBER_BACKLOG_CAPACITY)
+    const handler = (event: GlobalBusEvent) => {
+      if (Queue.offerUnsafe(queue, event)) return
+      Queue.endUnsafe(queue)
+    }
+    yield* Effect.sync(() => GlobalBus.on("event", handler))
+    yield* Effect.addFinalizer(() => Effect.sync(() => GlobalBus.off("event", handler)))
+    const events = Stream.fromQueue(queue)
     const heartbeat = Stream.tick("10 seconds").pipe(
       Stream.drop(1),
       Stream.map(() => ({ payload: { id: EventV2.ID.create(), type: "server.heartbeat", properties: {} } })),

--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect } from "bun:test"
 import { Effect, Layer, Queue, Schema, Stream } from "effect"
+import { GlobalBus } from "@/bus/global"
+import { SUBSCRIBER_BACKLOG_CAPACITY } from "../../src/server/routes/instance/httpapi/handlers/backlog"
 import { EventPaths } from "../../src/server/routes/instance/httpapi/groups/event"
+import { GlobalPaths } from "../../src/server/routes/instance/httpapi/groups/global"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
-import { httpApiLayer, requestInDirectory } from "./httpapi-layer"
+import { httpApiLayer, request, requestInDirectory } from "./httpapi-layer"
 
 const EventData = Schema.Struct({
   id: Schema.optional(Schema.String),
@@ -88,6 +91,86 @@ describe("event HttpApi", () => {
         const created = yield* requestInDirectory("/session", directory, { method: "POST" })
         expect(created.status).toBe(200)
         expect(yield* readEvent(reader)).toMatchObject({ type: "session.created" })
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "ends the global stream instead of buffering without bound when the consumer stalls",
+    () =>
+      Effect.gen(function* () {
+        const response = yield* request(GlobalPaths.event)
+        expect(response.status).toBe(200)
+
+        // Do not consume the body: this is the half-dead consumer (#20695).
+        // The listener is registered eagerly, so the backlog fills anyway;
+        // emitting in one tight loop reproduces a consumer that never drains.
+        yield* Effect.sync(() => {
+          for (let index = 0; index < SUBSCRIBER_BACKLOG_CAPACITY + 100; index++) {
+            GlobalBus.emit("event", { directory: "global", payload: { type: "flood", properties: { index } } })
+          }
+        })
+
+        // With a bounded backlog the response stream completes after flushing
+        // what fit; before the fix this drain never terminates because the
+        // queue keeps the stream open while growing with every event.
+        yield* response.stream.pipe(
+          Stream.runDrain,
+          Effect.timeoutOrElse({
+            duration: "15 seconds",
+            orElse: () => Effect.fail(new Error("stream did not terminate after backlog overflow")),
+          }),
+        )
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "keeps a draining global consumer connected past the backlog capacity",
+    () =>
+      Effect.gen(function* () {
+        const response = yield* request(GlobalPaths.event)
+        expect(response.status).toBe(200)
+        const reader = yield* Queue.unbounded<Uint8Array>()
+        yield* response.stream.pipe(
+          Stream.runForEach((value) => Queue.offer(reader, value)),
+          Effect.forkScoped,
+        )
+
+        // More total events than the backlog holds, paced in batches so the
+        // consumer can drain between bursts: the bound applies to the
+        // undrained backlog, never to total throughput. The sleep simulates
+        // producer pacing on purpose; it is not a synchronization hack.
+        const batches = 24
+        const perBatch = 500
+        const total = batches * perBatch
+        for (let batch = 0; batch < batches; batch++) {
+          yield* Effect.sync(() => {
+            for (let index = 0; index < perBatch; index++) {
+              GlobalBus.emit("event", { directory: "global", payload: { type: "flood", properties: { index } } })
+            }
+          })
+          yield* Effect.sleep("5 millis")
+        }
+
+        const decoder = new TextDecoder()
+        let seen = 0
+        while (seen < total) {
+          const chunk = yield* Queue.take(reader).pipe(
+            Effect.timeoutOrElse({
+              duration: "30 seconds",
+              orElse: () => Effect.fail(new Error(`stream ended early: saw ${seen} of ${total} events`)),
+            }),
+          )
+          seen += (decoder.decode(chunk).match(/"type":"flood"/g) ?? []).length
+        }
+
+        // No overflow happened, so the stream must still be open.
+        const status = yield* Queue.take(reader).pipe(
+          Effect.as("event" as const),
+          Effect.timeoutOrElse({ duration: "250 millis", orElse: () => Effect.succeed("open" as const) }),
+        )
+        expect(status).toBe("open")
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #22198

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bounds the per-subscriber SSE backlog and disconnects consumers that stop draining.

Both event endpoints buffer events in an unbounded queue per connection, and the only cleanup is the response fiber ending. A connection stuck in CLOSE_WAIT never delivers that signal, so the listener stays registered and the queue absorbs every event the server emits. This is the leak measured in #20695 (24.5GB RSS with zombie connections, https://github.com/anomalyco/opencode/issues/20695#issuecomment-4232747716).

The backlog is now bounded at 10k (sizing rationale in `backlog.ts`). On overflow the queue ends rather than dropping events silently: buffered events still flush, the response completes, finalizers unsubscribe the listener, and a live client reconnects and resyncs from the event log. Disconnection is the safe policy because sync events carry a total order (`src/sync/README.md`), so a reconnect recovers cleanly, while silently dropped events would corrupt a live client's view. The instance endpoint now filters before buffering so other instances' events never occupy a subscriber's backlog, and the global endpoint registers its listener eagerly, matching the instance endpoint.

### How did you verify your code works?

A new regression test holds an unconsumed connection and floods past capacity: it times out on the previous handlers (the stream never terminates) and passes with this change. A companion test drains 12k events through the 10k backlog with batch pacing and stays connected, so the bound applies to the undrained backlog, not to throughput. The three existing event endpoint tests pass unchanged. `bun test test/server/httpapi-event.test.ts`: 5 pass. `tsgo --noEmit` clean, oxlint 0 errors, prettier applied.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR