### PR TITLE
fix(shell): use PowerShell EncodedCommand for reliable UTF-8 output

### DIFF
--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -50,6 +50,55 @@ type Output = typeof Output.Type
 
 const defaultShell = () => (process.platform === "win32" ? (process.env.COMSPEC ?? "cmd.exe") : "/bin/sh")
 
+const POWERSHELL_SHELLS = new Set(["powershell", "powershell.exe", "pwsh", "pwsh.exe"])
+
+const isPowerShell = (shell: string) => {
+  const name = path.basename(shell.trim().replace(/^["']|["']$/g, "")).toLowerCase()
+  return POWERSHELL_SHELLS.has(name)
+}
+
+function encodePowerShellCommand(command: string) {
+  return Buffer.from(command, "utf16le").toString("base64")
+}
+
+function withPowerShellUtf8Preamble(command: string) {
+  return `
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false);
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);
+$OutputEncoding = [Console]::OutputEncoding;
+${command}
+`
+}
+
+function makeShellCommand(command: string, shell: string, cwd: string) {
+  if (process.platform === "win32" && isPowerShell(shell)) {
+    return ChildProcess.make(
+      shell,
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        encodePowerShellCommand(withPowerShellUtf8Preamble(command)),
+      ],
+      {
+        cwd,
+        stdin: "ignore",
+        detached: false,
+        forceKillAfter: Duration.seconds(3),
+      },
+    )
+  }
+
+  return ChildProcess.make(command, [], {
+    cwd,
+    shell,
+    stdin: "ignore",
+    detached: process.platform !== "win32",
+    forceKillAfter: Duration.seconds(3),
+  })
+}
+
 const compactOutput = (stdout: string, stderr: string) => {
   const output = stdout && stderr ? `${stdout}\n\nstderr:\n${stderr}` : stderr ? `stderr:\n${stderr}` : stdout
   return output || "(no output)"
@@ -156,13 +205,7 @@ export const layer = Layer.effectDiscard(
               const shell =
                 Object.assign({}, ...entries.flatMap((entry) => (entry.type === "document" ? [entry.info] : [])))
                   .shell ?? defaultShell()
-              const command = ChildProcess.make(input.command, [], {
-                cwd: target.canonical,
-                shell,
-                stdin: "ignore",
-                detached: process.platform !== "win32",
-                forceKillAfter: Duration.seconds(3),
-              })
+              const command = makeShellCommand(input.command, shell, target.canonical)
               const timeout = input.timeout ?? DEFAULT_TIMEOUT_MS
               const result = yield* appProcess
                 .run(command, {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -296,14 +296,37 @@ const ask = Effect.fn("ShellTool.ask")(function* (
   })
 })
 
+function encodePowerShellCommand(command: string) {
+  return Buffer.from(command, "utf16le").toString("base64")
+}
+
+function withPowerShellUtf8Preamble(command: string) {
+  return `
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false);
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);
+$OutputEncoding = [Console]::OutputEncoding;
+${command}
+`
+}
+
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && Shell.ps(shell)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
-      cwd,
-      env,
-      stdin: "ignore",
-      detached: false,
-    })
+    return ChildProcess.make(
+      shell,
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        encodePowerShellCommand(withPowerShellUtf8Preamble(command)),
+      ],
+      {
+        cwd,
+        env,
+        stdin: "ignore",
+        detached: false,
+      },
+    )
   }
 
   return ChildProcess.make(command, [], {


### PR DESCRIPTION
### Issue for this PR

Closes #23636
Closes #31187
Closes #30205
Closes #31830
Closes #26882

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, PowerShell commands were passed via the `-Command` flag, causing encoding corruption when the active console code page is not UTF-8 (e.g. GBK/CP936 on zh-CN systems, Shift-JIS/CP932 on ja-JP systems). Previous attempts to fix this by prepending a UTF-8 preamble run too late — `-Command` parses the string in the current code page **before** execution, so the preamble itself is already corrupted.

This PR switches to **`-EncodedCommand`** with **Base64(UTF-16LE)** encoding, which guarantees the command string survives transport intact regardless of the console code page. The UTF-8 preamble (`[Console]::InputEncoding`, `[Console]::OutputEncoding`, `$OutputEncoding`) is injected before the user command inside the encoded payload.

**Files changed:**

| File | Change |
|------|--------|
| `packages/core/src/tool/bash.ts` | Add `isPowerShell()`, `encodePowerShellCommand()`, `withPowerShellUtf8Preamble()`, `makeShellCommand()`. Replace direct `ChildProcess.make` with `makeShellCommand()` |
| `packages/opencode/src/tool/shell.ts` | Add `encodePowerShellCommand()`, `withPowerShellUtf8Preamble()`. Modify `cmd()` to use `-EncodedCommand` for PowerShell |

**Why `-EncodedCommand` over `-Command`:** All existing PRs (#31346, #31297, #31658) use `-Command`, which means the UTF-8 preamble is decoded in the current code page *before* PowerShell parses it — so on a GBK system the preamble itself gets corrupted. `-EncodedCommand` bypasses this by encoding as Base64(UTF-16LE), which PowerShell decodes directly. The preamble then runs correctly and sets up UTF-8 before the user command.

### How did you verify your code works?

- Applied the patch locally and verified that `Write-Output "测试中文输出"` renders correctly in opencode shell output on Windows with GBK code page
- Verified the same commands work with both `powershell` (5.1) and `pwsh` (7+)

### Screenshots / recordings

N/A — this is a shell encoding fix, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR