### PR TITLE
fix(opencode): honor OpenAI baseURL for Codex OAuth

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -9,7 +9,7 @@ import type {
 import { Config } from "@/config/config"
 import { createOpencodeClient } from "@opencode-ai/sdk"
 import { ServerAuth } from "@/server/auth"
-import { CodexAuthPlugin } from "./openai/codex"
+import { CodexAuthPlugin, codexApiEndpointFromBaseURL } from "./openai/codex"
 import { Session } from "@/session/session"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { CopilotAuthPlugin } from "./github-copilot/copilot"
@@ -61,11 +61,12 @@ export function experimentalWebSocketsEnabled(input: { enabled: boolean; channel
 }
 
 // Built-in plugins that are directly imported (not installed from npm)
-function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
+function internalPlugins(flags: RuntimeFlags.Info, codexApiEndpoint?: string): PluginInstance[] {
   return [
     // Temporary rollout: pre-release builds use WebSockets by default; releases require explicit opt-in.
     (input) =>
       CodexAuthPlugin(input, {
+        codexApiEndpoint,
         experimentalWebSockets: experimentalWebSocketsEnabled({ enabled: flags.experimentalWebSockets }),
       }),
     CopilotAuthPlugin,
@@ -160,7 +161,9 @@ export const layer = Layer.effect(
           $: typeof Bun === "undefined" ? undefined : Bun.$,
         }
 
-        for (const plugin of flags.disableDefaultPlugins ? [] : internalPlugins(flags)) {
+        const openaiOptions = cfg.provider?.openai?.options
+        const codexApiEndpoint = codexApiEndpointFromBaseURL(openaiOptions?.baseURL)
+        for (const plugin of flags.disableDefaultPlugins ? [] : internalPlugins(flags, codexApiEndpoint)) {
           const init = yield* Effect.tryPromise({
             try: () => plugin(input),
             catch: errorMessage,

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -102,6 +102,15 @@ interface CodexAuthPluginOptions {
   experimentalWebSockets?: boolean
 }
 
+export function codexApiEndpointFromBaseURL(baseURL: unknown) {
+  if (typeof baseURL !== "string" || baseURL.trim() === "") return
+  if (!URL.canParse(baseURL)) return
+  const url = new URL(baseURL)
+  const path = url.pathname.replace(/\/+$/, "")
+  url.pathname = path.endsWith("/responses") ? path : `${path}/responses`
+  return url.toString()
+}
+
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   CodexAuthPlugin,
+  codexApiEndpointFromBaseURL,
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
@@ -14,6 +15,41 @@ function createTestJwt(payload: object): string {
 }
 
 describe("plugin.codex", () => {
+  describe("codexApiEndpointFromBaseURL", () => {
+    test("appends responses to an OpenAI-compatible base URL", () => {
+      expect(codexApiEndpointFromBaseURL("https://proxy.example.test/v1")).toBe(
+        "https://proxy.example.test/v1/responses",
+      )
+    })
+
+    test("appends responses after trimming trailing slashes", () => {
+      expect(codexApiEndpointFromBaseURL("https://proxy.example.test/v1/")).toBe(
+        "https://proxy.example.test/v1/responses",
+      )
+    })
+
+    test("keeps an explicit responses endpoint", () => {
+      expect(codexApiEndpointFromBaseURL("https://proxy.example.test/v1/responses")).toBe(
+        "https://proxy.example.test/v1/responses",
+      )
+    })
+
+    test("preserves query parameters", () => {
+      expect(codexApiEndpointFromBaseURL("https://proxy.example.test/v1?api-version=test")).toBe(
+        "https://proxy.example.test/v1/responses?api-version=test",
+      )
+    })
+
+    test("ignores missing or blank base URLs", () => {
+      expect(codexApiEndpointFromBaseURL(undefined)).toBeUndefined()
+      expect(codexApiEndpointFromBaseURL("   ")).toBeUndefined()
+    })
+
+    test("ignores invalid base URLs", () => {
+      expect(codexApiEndpointFromBaseURL("not a url")).toBeUndefined()
+    })
+  })
+
   describe("parseJwtClaims", () => {
     test("parses valid JWT with claims", () => {
       const payload = { email: "test@example.com", chatgpt_account_id: "acc-123" }


### PR DESCRIPTION
### Issue for this PR

Closes #31926

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes OpenAI ChatGPT subscription / Codex OAuth requests so they honor `provider.openai.options.baseURL`.

When `baseURL` is configured, the Codex response endpoint is derived from it. A base URL ending in `/v1` is normalized to `/v1/responses`, while an explicit `/v1/responses` endpoint is preserved. If no valid baseURL is configured, the existing default ChatGPT Codex endpoint is still used.

This matches the existing OpenAI provider configuration behavior without adding a separate Codex-specific config key.

### How did you verify your code works?

- `bun test test/plugin/codex.test.ts`
- `bun typecheck`
- `git diff --check`

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR