### PR TITLE
fix(desktop): hide Windows selected app subprocesses

### DIFF
--- a/packages/desktop/src/app-path-cache.test.ts
+++ b/packages/desktop/src/app-path-cache.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { createAppPathCache, forgetAppPath, getAppPath, rememberAppPath } from "./app-path-cache"
+
+describe("app path cache", () => {
+  test("bounds remembered app paths without retaining evicted entries", () => {
+    const cache = createAppPathCache()
+
+    for (const index of Array.from({ length: 33 }, (_, index) => index)) {
+      rememberAppPath(cache, `app-${index}`, `C:\\Tools\\app-${index}.exe`)
+    }
+
+    expect(cache.keys).toHaveLength(32)
+    expect(cache.values).toHaveLength(32)
+    expect(getAppPath(cache, "app-0")).toBeUndefined()
+    expect(getAppPath(cache, "app-1")).toBe("C:\\Tools\\app-1.exe")
+    expect(getAppPath(cache, "app-32")).toBe("C:\\Tools\\app-32.exe")
+  })
+
+  test("forgets stale app paths", () => {
+    const cache = createAppPathCache()
+
+    rememberAppPath(cache, "code", "C:\\Tools\\Code.exe")
+    forgetAppPath(cache, "code")
+
+    expect(getAppPath(cache, "code")).toBeUndefined()
+  })
+})

--- a/packages/desktop/src/app-path-cache.test.ts
+++ b/packages/desktop/src/app-path-cache.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, test } from "bun:test"
-import { createAppPathCache, forgetAppPath, getAppPath, rememberAppPath } from "./app-path-cache"
+import { APP_PATH_CACHE_LIMIT, createAppPathCache, forgetAppPath, getAppPath, rememberAppPath } from "./app-path-cache"
 
 describe("app path cache", () => {
   test("bounds remembered app paths without retaining evicted entries", () => {
     const cache = createAppPathCache()
 
-    for (const index of Array.from({ length: 33 }, (_, index) => index)) {
+    for (const index of Array.from({ length: APP_PATH_CACHE_LIMIT + 1 }, (_, index) => index)) {
       rememberAppPath(cache, `app-${index}`, `C:\\Tools\\app-${index}.exe`)
     }
 
-    expect(cache.keys).toHaveLength(32)
-    expect(cache.values).toHaveLength(32)
+    expect(cache.keys).toHaveLength(APP_PATH_CACHE_LIMIT)
+    expect(cache.values).toHaveLength(APP_PATH_CACHE_LIMIT)
     expect(getAppPath(cache, "app-0")).toBeUndefined()
     expect(getAppPath(cache, "app-1")).toBe("C:\\Tools\\app-1.exe")
-    expect(getAppPath(cache, "app-32")).toBe("C:\\Tools\\app-32.exe")
+    expect(getAppPath(cache, `app-${APP_PATH_CACHE_LIMIT}`)).toBe(`C:\\Tools\\app-${APP_PATH_CACHE_LIMIT}.exe`)
   })
 
   test("forgets stale app paths", () => {

--- a/packages/desktop/src/app-path-cache.ts
+++ b/packages/desktop/src/app-path-cache.ts
@@ -1,4 +1,4 @@
-const APP_PATH_CACHE_LIMIT = 32
+export const APP_PATH_CACHE_LIMIT = 32
 
 // Keep storage flat under high churn; this cache is small enough that linear lookup is cheaper than Map retention.
 type AppPathCache = {

--- a/packages/desktop/src/app-path-cache.ts
+++ b/packages/desktop/src/app-path-cache.ts
@@ -1,0 +1,43 @@
+const APP_PATH_CACHE_LIMIT = 32
+
+// Keep storage flat under high churn; this cache is small enough that linear lookup is cheaper than Map retention.
+type AppPathCache = {
+  keys: string[]
+  values: string[]
+}
+
+export function createAppPathCache(): AppPathCache {
+  return { keys: [], values: [] }
+}
+
+export function getAppPath(cache: AppPathCache, key: string) {
+  const index = indexOfAppPath(cache, key)
+  return index >= 0 ? cache.values[index] : undefined
+}
+
+export function forgetAppPath(cache: AppPathCache, key: string) {
+  const index = indexOfAppPath(cache, key)
+  if (index < 0) return
+  cache.keys.splice(index, 1)
+  cache.values.splice(index, 1)
+}
+
+export function rememberAppPath(cache: AppPathCache, key: string, value: string) {
+  const index = indexOfAppPath(cache, key)
+  if (index >= 0) {
+    cache.values[index] = value
+    return value
+  }
+
+  if (cache.keys.length >= APP_PATH_CACHE_LIMIT) {
+    cache.keys.shift()
+    cache.values.shift()
+  }
+  cache.keys.push(key)
+  cache.values.push(value)
+  return value
+}
+
+function indexOfAppPath(cache: AppPathCache, key: string) {
+  return cache.keys.indexOf(key)
+}

--- a/packages/desktop/src/main/apps.test.ts
+++ b/packages/desktop/src/main/apps.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { dirname, join } from "node:path"
+import { APP_PATH_CACHE_LIMIT } from "../app-path-cache"
+import { getWindowsFallbackSearchDirs } from "./apps"
+
+describe("Windows app path resolution", () => {
+  test("deduplicates fallback search directories from stale resolver output", () => {
+    const paths = Array.from({ length: APP_PATH_CACHE_LIMIT }, (_, index) =>
+      join("root", "Tools", "bin", `Missing-${index}.exe`),
+    )
+    const dirs = getWindowsFallbackSearchDirs(paths)
+    const bin = dirname(paths[0])
+    const tools = dirname(bin)
+    const root = dirname(tools)
+
+    expect(dirs).toEqual([bin, tools, root])
+  })
+
+  test("bounds fallback search directories from scattered stale resolver output", () => {
+    const dirs = getWindowsFallbackSearchDirs(
+      Array.from({ length: APP_PATH_CACHE_LIMIT + 1 }, (_, index) =>
+        join("root", `Tools-${index}`, "bin", "Missing.exe"),
+      ),
+    )
+
+    expect(dirs).toHaveLength(APP_PATH_CACHE_LIMIT)
+    expect(new Set(dirs).size).toBe(APP_PATH_CACHE_LIMIT)
+  })
+})

--- a/packages/desktop/src/main/apps.ts
+++ b/packages/desktop/src/main/apps.ts
@@ -1,6 +1,6 @@
 import { access, readFile, readdir } from "node:fs/promises"
 import { dirname, extname, join } from "node:path"
-import { createAppPathCache, forgetAppPath, getAppPath, rememberAppPath } from "../app-path-cache"
+import { APP_PATH_CACHE_LIMIT, createAppPathCache, forgetAppPath, getAppPath, rememberAppPath } from "../app-path-cache"
 import { execFileHidden } from "./child-process"
 
 const exists = (path: string) =>
@@ -10,12 +10,23 @@ const exists = (path: string) =>
 
 const windowsAppPathCache = createAppPathCache()
 
+// This scan runs after direct executable and command shim resolution, so keep it at app path cache size.
+const WINDOWS_APP_FALLBACK_DIR_LIMIT = APP_PATH_CACHE_LIMIT
+
 const searchKey = (value: string) =>
   value
     .split("")
     .filter((value: string) => /[a-z0-9]/i.test(value))
     .map((value: string) => value.toLowerCase())
     .join("")
+
+export function getWindowsFallbackSearchDirs(paths: string[]) {
+  return Array.from(
+    new Set(paths.flatMap((path) => [dirname(path), dirname(dirname(path)), dirname(dirname(dirname(path)))])),
+  )
+    .filter((dir) => dir !== ".")
+    .slice(0, WINDOWS_APP_FALLBACK_DIR_LIMIT)
+}
 
 export function checkAppExists(appName: string) {
   if (process.platform === "win32") return true
@@ -133,20 +144,17 @@ async function resolveWindowsAppPath(appName: string): Promise<string | null> {
   const key = searchKey(appName)
 
   if (key) {
-    for (const path of paths) {
-      const dirs = [dirname(path), dirname(dirname(path)), dirname(dirname(dirname(path)))]
-      for (const dir of dirs) {
-        try {
-          for (const entry of await readdir(dir)) {
-            const candidate = join(dir, entry)
-            if (!hasExt(candidate, "exe")) continue
-            const stem = entry.replace(/\.exe$/i, "")
-            const name = searchKey(stem)
-            if (name.includes(key) || key.includes(name)) return remember(candidate)
-          }
-        } catch {
-          continue
+    for (const dir of getWindowsFallbackSearchDirs(paths)) {
+      try {
+        for (const entry of await readdir(dir)) {
+          const candidate = join(dir, entry)
+          if (!hasExt(candidate, "exe")) continue
+          const stem = entry.replace(/\.exe$/i, "")
+          const name = searchKey(stem)
+          if (name.includes(key) || key.includes(name)) return remember(candidate)
         }
+      } catch {
+        continue
       }
     }
   }

--- a/packages/desktop/src/main/apps.ts
+++ b/packages/desktop/src/main/apps.ts
@@ -1,14 +1,21 @@
-import { execFile } from "node:child_process"
 import { access, readFile, readdir } from "node:fs/promises"
 import { dirname, extname, join } from "node:path"
-import util from "node:util"
-
-const execFilePromise = util.promisify(execFile)
+import { createAppPathCache, forgetAppPath, getAppPath, rememberAppPath } from "../app-path-cache"
+import { execFileHidden } from "./child-process"
 
 const exists = (path: string) =>
   access(path)
     .then(() => true)
     .catch(() => false)
+
+const windowsAppPathCache = createAppPathCache()
+
+const searchKey = (value: string) =>
+  value
+    .split("")
+    .filter((value: string) => /[a-z0-9]/i.test(value))
+    .map((value: string) => value.toLowerCase())
+    .join("")
 
 export function checkAppExists(appName: string) {
   if (process.platform === "win32") return true
@@ -31,15 +38,27 @@ async function checkMacosApp(appName: string) {
     if (await exists(location)) return true
   }
 
-  return execFilePromise("which", [appName])
+  return execFileHidden("which", [appName])
     .then(() => true)
     .catch(() => false)
 }
 
 async function resolveWindowsAppPath(appName: string): Promise<string | null> {
+  const cacheKey = appName.toLowerCase()
+  const cached = getAppPath(windowsAppPathCache, cacheKey)
+  if (cached) {
+    if (await exists(cached)) return cached
+    forgetAppPath(windowsAppPathCache, cacheKey)
+  }
+
+  // Cache only positive resolutions; missing apps may be installed while Desktop stays open.
+  const remember = (path: string) => {
+    return rememberAppPath(windowsAppPathCache, cacheKey, path)
+  }
+
   let output: string
   try {
-    output = await execFilePromise("where", [appName]).then((r) => r.stdout.toString())
+    output = await execFileHidden("where", [appName]).then((r) => r.stdout.toString())
   } catch {
     return null
   }
@@ -51,11 +70,19 @@ async function resolveWindowsAppPath(appName: string): Promise<string | null> {
 
   const hasExt = (path: string, ext: string) => extname(path).toLowerCase() === `.${ext}`
 
-  const exe = paths.find((path) => hasExt(path, "exe"))
-  if (exe) return exe
+  const executables = paths.filter((path) => hasExt(path, "exe") || hasExt(path, "com"))
+  if (executables[0] && (await exists(executables[0]))) return remember(executables[0])
+
+  const executable = (
+    await Promise.all(executables.slice(1).map(async (path) => ((await exists(path)) ? path : null)))
+  ).find((path) => path !== null)
+  if (executable) return remember(executable)
 
   const resolveCmd = async (path: string) => {
-    const content = await readFile(path, "utf8")
+    const content = await readFile(path, "utf8").catch(() => "")
+    if (!content) return null
+
+    // Windows package managers often expose .cmd shims; launch the target executable instead of the shim.
     for (const token of content.split('"').map((value: string) => value.trim())) {
       const lower = token.toLowerCase()
       if (!lower.includes(".exe")) continue
@@ -85,29 +112,25 @@ async function resolveWindowsAppPath(appName: string): Promise<string | null> {
   for (const path of paths) {
     if (hasExt(path, "cmd") || hasExt(path, "bat")) {
       const resolved = await resolveCmd(path)
-      if (resolved) return resolved
+      if (resolved) return remember(resolved)
     }
 
     if (!extname(path)) {
       const cmd = `${path}.cmd`
       if (await exists(cmd)) {
         const resolved = await resolveCmd(cmd)
-        if (resolved) return resolved
+        if (resolved) return remember(resolved)
       }
 
       const bat = `${path}.bat`
       if (await exists(bat)) {
         const resolved = await resolveCmd(bat)
-        if (resolved) return resolved
+        if (resolved) return remember(resolved)
       }
     }
   }
 
-  const key = appName
-    .split("")
-    .filter((value: string) => /[a-z0-9]/i.test(value))
-    .map((value: string) => value.toLowerCase())
-    .join("")
+  const key = searchKey(appName)
 
   if (key) {
     for (const path of paths) {
@@ -118,12 +141,8 @@ async function resolveWindowsAppPath(appName: string): Promise<string | null> {
             const candidate = join(dir, entry)
             if (!hasExt(candidate, "exe")) continue
             const stem = entry.replace(/\.exe$/i, "")
-            const name = stem
-              .split("")
-              .filter((value: string) => /[a-z0-9]/i.test(value))
-              .map((value: string) => value.toLowerCase())
-              .join("")
-            if (name.includes(key) || key.includes(name)) return candidate
+            const name = searchKey(stem)
+            if (name.includes(key) || key.includes(name)) return remember(candidate)
           }
         } catch {
           continue
@@ -132,5 +151,5 @@ async function resolveWindowsAppPath(appName: string): Promise<string | null> {
     }
   }
 
-  return paths[0] ?? null
+  return null
 }

--- a/packages/desktop/src/main/child-process.test.ts
+++ b/packages/desktop/src/main/child-process.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
+import { APP_PATH_CACHE_LIMIT } from "../app-path-cache"
 
 type ExecFileOptions = {
   windowsHide?: boolean
@@ -330,7 +331,7 @@ describe("child process helpers", () => {
     const restore = platform("win32")
 
     try {
-      for (const index of Array.from({ length: 33 }, (_, index) => index)) {
+      for (const index of Array.from({ length: APP_PATH_CACHE_LIMIT + 1 }, (_, index) => index)) {
         const file = path.join(dir, `Code-${index}.exe`)
         await fs.writeFile(file, "")
         output = `${file}\r\n`

--- a/packages/desktop/src/main/child-process.test.ts
+++ b/packages/desktop/src/main/child-process.test.ts
@@ -1,0 +1,350 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+type ExecFileOptions = {
+  windowsHide?: boolean
+}
+
+type SpawnOptions = {
+  stdio?: string
+  windowsHide?: boolean
+}
+
+type ExecFileCallback = (error: Error | null, stdout: Buffer, stderr: Buffer) => void
+
+const calls: Array<{ command: string; args: string[]; options: ExecFileOptions }> = []
+const spawnCalls: Array<{ command: string; args: string[]; options: SpawnOptions }> = []
+let error: Error | null = null
+let output = ""
+let spawnThrown: Error | null = null
+let spawnError: Error | null = null
+let unrefError: Error | null = null
+let spawnHandler: (() => void) | undefined
+
+const whereCall = (app: string) => ({ command: "where", args: [app], options: { windowsHide: true } })
+
+void mock.module("node:child_process", () => ({
+  execFile: (command: string, args: string[], options: ExecFileOptions, callback: ExecFileCallback) => {
+    calls.push({ command, args, options })
+    callback(error, Buffer.from(output), Buffer.from(""))
+    return undefined
+  },
+  spawn: (command: string, args: string[], options: SpawnOptions) => {
+    if (spawnThrown) throw spawnThrown
+    spawnCalls.push({ command, args, options })
+    return {
+      once(event: "error" | "spawn", callback: (error?: Error) => void) {
+        if (event === "error" && spawnError) callback(spawnError)
+        if (event === "spawn") spawnHandler = () => callback()
+        return this
+      },
+      unref: mock(() => {
+        if (unrefError) throw unrefError
+      }),
+    }
+  },
+}))
+
+const { execFileHidden } = await import("./child-process")
+const { openPathWithApp } = await import("./child-process")
+const { spawnHidden } = await import("./child-process")
+const { resolveAppPath } = await import("./apps")
+
+beforeEach(() => {
+  calls.length = 0
+  spawnCalls.length = 0
+  error = null
+  output = ""
+  spawnThrown = null
+  spawnError = null
+  unrefError = null
+  spawnHandler = undefined
+})
+
+function platform(value: NodeJS.Platform) {
+  const previous = process.platform
+  Object.defineProperty(process, "platform", { value })
+  return () => Object.defineProperty(process, "platform", { value: previous })
+}
+
+describe("child process helpers", () => {
+  test("hides Windows console windows for spawned commands", async () => {
+    await execFileHidden("where", ["code"])
+
+    expect(calls).toEqual([whereCall("code")])
+  })
+
+  test("preserves spawned command failures", async () => {
+    error = new Error("command failed")
+
+    await expect(execFileHidden("where", ["missing"])).rejects.toThrow("command failed")
+
+    expect(calls).toEqual([whereCall("missing")])
+  })
+
+  test("launches apps without waiting for them to exit", async () => {
+    const launched = spawnHidden("C:\\Tools\\Code.exe", ["C:\\repo"])
+
+    spawnHandler?.()
+    await expect(launched).resolves.toBeUndefined()
+
+    expect(spawnCalls).toEqual([
+      { command: "C:\\Tools\\Code.exe", args: ["C:\\repo"], options: { stdio: "ignore", windowsHide: true } },
+    ])
+  })
+
+  test("preserves app launch failures", async () => {
+    spawnError = new Error("launch failed")
+
+    await expect(spawnHidden("C:\\Tools\\Missing.exe", ["C:\\repo"])).rejects.toThrow("launch failed")
+
+    expect(spawnCalls).toEqual([
+      { command: "C:\\Tools\\Missing.exe", args: ["C:\\repo"], options: { stdio: "ignore", windowsHide: true } },
+    ])
+  })
+
+  test("preserves synchronous app launch failures", async () => {
+    spawnThrown = new Error("spawn failed before events")
+
+    await expect(spawnHidden("C:\\Tools\\Missing.exe", ["C:\\repo"])).rejects.toThrow("spawn failed before events")
+
+    expect(spawnCalls).toEqual([])
+  })
+
+  test("rejects when a launched child cannot be unreferenced", async () => {
+    unrefError = new Error("unref failed")
+
+    const launched = spawnHidden("C:\\Tools\\Code.exe", ["C:\\repo"])
+    spawnHandler?.()
+
+    await expect(launched).rejects.toThrow("unref failed")
+    expect(spawnCalls).toEqual([
+      { command: "C:\\Tools\\Code.exe", args: ["C:\\repo"], options: { stdio: "ignore", windowsHide: true } },
+    ])
+  })
+
+  test("uses non-blocking hidden spawn for Windows explicit app opens", async () => {
+    const restore = platform("win32")
+
+    try {
+      const opened = openPathWithApp("C:\\repo", "C:\\Tools\\Code.exe")
+      spawnHandler?.()
+      await opened
+    } finally {
+      restore()
+    }
+
+    expect(spawnCalls).toEqual([
+      { command: "C:\\Tools\\Code.exe", args: ["C:\\repo"], options: { stdio: "ignore", windowsHide: true } },
+    ])
+    expect(calls).toEqual([])
+  })
+
+  test("uses hidden execFile through macOS open for macOS explicit app opens", async () => {
+    const restore = platform("darwin")
+
+    try {
+      await openPathWithApp("/repo", "Visual Studio Code")
+    } finally {
+      restore()
+    }
+
+    expect(calls).toEqual([
+      { command: "open", args: ["-a", "Visual Studio Code", "/repo"], options: { windowsHide: true } },
+    ])
+    expect(spawnCalls).toEqual([])
+  })
+
+  test("uses hidden execFile directly for Linux explicit app opens", async () => {
+    const restore = platform("linux")
+
+    try {
+      await openPathWithApp("/repo", "code")
+    } finally {
+      restore()
+    }
+
+    expect(calls).toEqual([{ command: "code", args: ["/repo"], options: { windowsHide: true } }])
+    expect(spawnCalls).toEqual([])
+  })
+
+  test("uses hidden process creation for Windows app path resolution", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const file = path.join(dir, "Code.exe")
+    const restore = platform("win32")
+    output = `${file}\r\n`
+
+    try {
+      await fs.writeFile(file, "")
+      expect(await resolveAppPath("code")).toBe(file)
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls).toEqual([whereCall("code")])
+  })
+
+  test("skips stale direct Windows executable paths", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const restore = platform("win32")
+    output = `${path.join(dir, "Missing.exe")}\r\n`
+
+    try {
+      expect(await resolveAppPath("stale-code")).toBeNull()
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls).toEqual([whereCall("stale-code")])
+  })
+
+  test("continues past stale Windows executables to launchable paths", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const missing = path.join(dir, "Missing.exe")
+    const file = path.join(dir, "Code.exe")
+    const restore = platform("win32")
+    output = `${missing}\r\n${file}\r\n`
+
+    try {
+      await fs.writeFile(file, "")
+      expect(await resolveAppPath("stale-then-code")).toBe(file)
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls).toEqual([whereCall("stale-then-code")])
+  })
+
+  test("reuses resolved Windows app paths for repeated opens", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const file = path.join(dir, "Code.exe")
+    output = `${file}\r\n`
+    const restore = platform("win32")
+
+    try {
+      await fs.writeFile(file, "")
+
+      expect(await resolveAppPath("cached-code")).toBe(file)
+      expect(await resolveAppPath("cached-code")).toBe(file)
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls).toEqual([whereCall("cached-code")])
+  })
+
+  test("re-resolves cached Windows app paths that no longer exist", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const first = path.join(dir, "First.exe")
+    const second = path.join(dir, "Second.exe")
+    const restore = platform("win32")
+
+    try {
+      await fs.writeFile(first, "")
+      output = `${first}\r\n`
+      expect(await resolveAppPath("moving-code")).toBe(first)
+
+      await fs.rm(first)
+      await fs.writeFile(second, "")
+      output = `${second}\r\n`
+      expect(await resolveAppPath("moving-code")).toBe(second)
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls).toEqual([whereCall("moving-code"), whereCall("moving-code")])
+  })
+
+  test("does not cache missing Windows app paths", async () => {
+    const restore = platform("win32")
+
+    try {
+      expect(await resolveAppPath("missing-code")).toBeNull()
+      expect(await resolveAppPath("missing-code")).toBeNull()
+    } finally {
+      restore()
+    }
+
+    expect(calls).toEqual([whereCall("missing-code"), whereCall("missing-code")])
+  })
+
+  test("ignores unreadable Windows command shims", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const restore = platform("win32")
+    output = `${path.join(dir, "Missing.cmd")}\r\n`
+
+    try {
+      expect(await resolveAppPath("broken-shim")).toBeNull()
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls).toEqual([whereCall("broken-shim")])
+  })
+
+  test("does not return unresolved Windows command shims as launchable app paths", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const file = path.join(dir, "Code.cmd")
+    const restore = platform("win32")
+    output = `${file}\r\n`
+
+    try {
+      await fs.writeFile(file, "@echo off\r\nexit /b 0\r\n")
+      expect(await resolveAppPath("unresolved-shim")).toBeNull()
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls).toEqual([whereCall("unresolved-shim")])
+  })
+
+  test("treats malformed Windows resolver output as unresolved", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const restore = platform("win32")
+    const outputs = ["\r\n", `${path.join(dir, "Missing.exe")}\r\n`, `${path.join(dir, "Script.ps1")}\r\n`]
+
+    try {
+      for (const index of Array.from({ length: outputs.length }, (_, index) => index)) {
+        output = outputs[index]
+        expect(await resolveAppPath(`malformed-code-${index}`)).toBeNull()
+      }
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls.map((call) => call.args[0])).toEqual(["malformed-code-0", "malformed-code-1", "malformed-code-2"])
+  })
+
+  test("bounds cached Windows app paths across many unique apps", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-desktop-test-"))
+    const restore = platform("win32")
+
+    try {
+      for (const index of Array.from({ length: 33 }, (_, index) => index)) {
+        const file = path.join(dir, `Code-${index}.exe`)
+        await fs.writeFile(file, "")
+        output = `${file}\r\n`
+
+        expect(await resolveAppPath(`bounded-code-${index}`)).toBe(file)
+      }
+
+      output = `${path.join(dir, "Code-0.exe")}\r\n`
+      expect(await resolveAppPath("bounded-code-0")).toBe(path.join(dir, "Code-0.exe"))
+    } finally {
+      restore()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+
+    expect(calls.filter((call) => call.args[0] === "bounded-code-0")).toHaveLength(2)
+  })
+})

--- a/packages/desktop/src/main/child-process.ts
+++ b/packages/desktop/src/main/child-process.ts
@@ -1,0 +1,29 @@
+import { execFile, spawn } from "node:child_process"
+
+export function execFileHidden(command: string, args: string[]) {
+  return new Promise<{ stdout: string | Buffer; stderr: string | Buffer }>((resolve, reject) => {
+    execFile(command, args, { windowsHide: true }, (error, stdout, stderr) => {
+      if (error) return reject(error)
+      resolve({ stdout, stderr })
+    })
+  })
+}
+
+export function spawnHidden(command: string, args: string[]) {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "ignore", windowsHide: true })
+    child.once("error", reject)
+    child.once("spawn", () => {
+      Promise.resolve()
+        .then(() => child.unref())
+        .then(() => resolve(), reject)
+    })
+  })
+}
+
+export function openPathWithApp(path: string, app: string) {
+  // Windows GUI apps should detach immediately; waiting for exit would keep Desktop tied to the launched app.
+  if (process.platform === "win32") return spawnHidden(app, [path])
+  const [cmd, args] = process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)
+  return execFileHidden(cmd, [...args]).then(() => undefined)
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1,4 +1,3 @@
-import { execFile } from "node:child_process"
 import { stat } from "node:fs/promises"
 import { basename } from "node:path"
 import { app, BrowserWindow, Notification, clipboard, dialog, ipcMain, shell } from "electron"
@@ -12,6 +11,8 @@ import { getStore } from "./store"
 import { getPinchZoomEnabled, setPinchZoomEnabled, setTitlebar, updateTitlebar } from "./windows"
 import type { UpdaterController } from "./updater-controller"
 import { createUpdaterSubscriptions } from "./updater-subscriptions"
+import { openPathWithApp } from "./child-process"
+import { openDefaultPath } from "./open-path"
 
 const pickerFilters = (ext?: string[]) => {
   if (!ext || ext.length === 0) return undefined
@@ -41,7 +42,7 @@ type Deps = {
 
 export function registerIpcHandlers(deps: Deps) {
   const updaterSubscriptions = createUpdaterSubscriptions()
-  app.once("will-quit", updaterSubscriptions.clear)
+  app.once("will-quit", () => updaterSubscriptions.clear())
 
   ipcMain.handle("kill-sidecar", () => deps.killSidecar())
   ipcMain.handle("await-initialization", () => deps.awaitInitialization())
@@ -168,12 +169,8 @@ export function registerIpcHandlers(deps: Deps) {
   })
 
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
-    if (!app) return shell.openPath(path)
-    await new Promise<void>((resolve, reject) => {
-      const [cmd, args] =
-        process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)
-      execFile(cmd, args, (err) => (err ? reject(err) : resolve()))
-    })
+    if (!app) return openDefaultPath((path) => shell.openPath(path), path)
+    await openPathWithApp(path, app)
   })
 
   ipcMain.handle("read-clipboard-image", () => {

--- a/packages/desktop/src/main/open-path.test.ts
+++ b/packages/desktop/src/main/open-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { openDefaultPath } from "./open-path"
+
+describe("open default path", () => {
+  test("resolves when Electron reports success", async () => {
+    await expect(openDefaultPath(() => Promise.resolve(""), "C:\\repo")).resolves.toBeUndefined()
+  })
+
+  test("rejects Electron openPath error messages", async () => {
+    await expect(openDefaultPath(() => Promise.resolve("Windows cannot find the path."), "C:\\repo")).rejects.toThrow(
+      "Windows cannot find the path.",
+    )
+  })
+
+  test("preserves Electron openPath rejections", async () => {
+    await expect(openDefaultPath(() => Promise.reject(new Error("open failed")), "C:\\repo")).rejects.toThrow(
+      "open failed",
+    )
+  })
+})

--- a/packages/desktop/src/main/open-path.ts
+++ b/packages/desktop/src/main/open-path.ts
@@ -1,0 +1,5 @@
+export async function openDefaultPath(openPath: (path: string) => Promise<string>, path: string) {
+  // Electron returns an error message string here instead of rejecting.
+  const message = await openPath(path)
+  if (message) throw new Error(message)
+}

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -15,14 +15,15 @@ import {
   useWslServers,
 } from "@opencode-ai/app"
 import type { UpdaterState } from "@opencode-ai/app/updater"
-import * as Sentry from "@sentry/solid"
+import { init } from "@sentry/solid"
 import type { AsyncStorage } from "@solid-primitives/storage"
 import { MemoryRouter } from "@solidjs/router"
 import { createEffect, createMemo, createResource, createSignal, onCleanup, onMount, Show } from "solid-js"
 import { render } from "solid-js/web"
 import pkg from "../../package.json"
 import { initI18n, t } from "./i18n"
-import { initializationData, initializationReady } from "./initialization"
+import { initializationData } from "./initialization"
+import { createOpenPath } from "./open-path"
 import { resetZoom, setPinchZoomEnabled, webviewZoom, zoomIn, zoomOut } from "./webview-zoom"
 import { availableStartupServer, readyWslConnections } from "./wsl/connections"
 import "./styles.css"
@@ -35,7 +36,7 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
 }
 
 if (import.meta.env.VITE_SENTRY_DSN) {
-  Sentry.init({
+  init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE,
     release: import.meta.env.VITE_SENTRY_RELEASE ?? `desktop@${pkg.version}`,
@@ -99,7 +100,7 @@ const createPlatform = (): Platform => {
         return
     }
 
-    return window.api.runDesktopMenuAction(action)
+    void window.api.runDesktopMenuAction(action)
   }
 
   const storage = (() => {
@@ -130,6 +131,7 @@ const createPlatform = (): Platform => {
   })()
 
   const wslServersApi = os === "windows" ? window.api.wslServers : undefined
+  const openPath = createOpenPath(window.api, os)
 
   return {
     platform: "desktop",
@@ -170,13 +172,7 @@ const createPlatform = (): Platform => {
     openLink(url: string) {
       window.api.openLink(url)
     },
-    async openPath(path: string, app?: string) {
-      if (os === "windows") {
-        const resolvedApp = app ? await window.api.resolveAppPath(app).catch(() => null) : null
-        return window.api.openPath(path, resolvedApp ?? undefined)
-      }
-      return window.api.openPath(path, app)
-    },
+    openPath,
 
     back() {
       window.history.back()
@@ -281,9 +277,9 @@ render(() => {
     const current = await platform.storage?.("opencode.global.dat").getItem("language")
     const legacy = current ? undefined : await platform.storage?.().getItem("language.v1")
     const raw = current ?? legacy
-    if (!raw) return
+    if (!raw) return undefined
     const locale = raw.match(/"locale"\s*:\s*"([^"]+)"/)?.[1]
-    if (!locale) return
+    if (!locale) return undefined
     const next = normalizeLocale(locale)
     if (next !== "en") await loadLocaleDict(next)
     return next satisfies Locale
@@ -298,11 +294,11 @@ render(() => {
   const [locale] = createResource(loadLocale)
 
   function handleClick(e: MouseEvent) {
-    const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
-    if (link?.href) {
-      e.preventDefault()
-      platform.openLink(link.href)
-    }
+    if (!(e.target instanceof Element)) return
+    const link = e.target.closest("a.external-link")
+    if (!(link instanceof HTMLAnchorElement)) return
+    e.preventDefault()
+    platform.openLink(link.href)
   }
 
   function Inner() {

--- a/packages/desktop/src/renderer/open-path.test.ts
+++ b/packages/desktop/src/renderer/open-path.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test"
+import { createOpenPath } from "./open-path"
+
+function api(opts?: {
+  resolved?: string | null | Array<string | null>
+  resolveError?: Error
+  failOpen?: (app: string | undefined) => boolean
+}) {
+  const calls = {
+    resolve: [] as string[],
+    open: [] as Array<{ path: string; app?: string }>,
+  }
+  return {
+    calls,
+    api: {
+      async resolveAppPath(app: string) {
+        calls.resolve.push(app)
+        if (opts?.resolveError) throw opts.resolveError
+        if (Array.isArray(opts?.resolved)) return opts.resolved.shift() ?? null
+        if (opts && "resolved" in opts) return opts.resolved
+        return `C:\\Tools\\${app}.exe`
+      },
+      async openPath(path: string, app?: string) {
+        calls.open.push({ path, app })
+        if (opts?.failOpen?.(app)) throw new Error("open failed")
+      },
+    },
+  }
+}
+
+describe("renderer openPath", () => {
+  test("reuses resolved Windows app paths across repeated opens", async () => {
+    const current = api()
+    const openPath = createOpenPath(current.api, "windows")
+
+    await openPath("C:\\repo", "code")
+    await openPath("C:\\repo", "code")
+
+    expect(current.calls.resolve).toEqual(["code"])
+    expect(current.calls.open).toEqual([
+      { path: "C:\\repo", app: "C:\\Tools\\code.exe" },
+      { path: "C:\\repo", app: "C:\\Tools\\code.exe" },
+    ])
+  })
+
+  test("passes non-Windows open requests through without resolving", async () => {
+    const current = api()
+    const openPath = createOpenPath(current.api, "macos")
+
+    await openPath("/repo", "Visual Studio Code")
+
+    expect(current.calls.resolve).toEqual([])
+    expect(current.calls.open).toEqual([{ path: "/repo", app: "Visual Studio Code" }])
+  })
+
+  test("falls back to default app when Windows app resolution fails", async () => {
+    const current = api({ resolved: null })
+    const openPath = createOpenPath(current.api, "windows")
+
+    await openPath("C:\\repo", "missing")
+
+    expect(current.calls.resolve).toEqual(["missing"])
+    expect(current.calls.open).toEqual([{ path: "C:\\repo", app: undefined }])
+  })
+
+  test("falls back to default app when Windows app resolution rejects", async () => {
+    const current = api({ resolveError: new Error("resolver failed") })
+    const openPath = createOpenPath(current.api, "windows")
+
+    await openPath("C:\\repo", "missing")
+
+    expect(current.calls.resolve).toEqual(["missing"])
+    expect(current.calls.open).toEqual([{ path: "C:\\repo", app: undefined }])
+  })
+
+  test("does not cache missing Windows app resolutions", async () => {
+    const current = api({ resolved: [null, "C:\\Tools\\Installed.exe"] })
+    const openPath = createOpenPath(current.api, "windows")
+
+    await openPath("C:\\repo", "late-code")
+    await openPath("C:\\repo", "late-code")
+
+    expect(current.calls.resolve).toEqual(["late-code", "late-code"])
+    expect(current.calls.open).toEqual([
+      { path: "C:\\repo", app: undefined },
+      { path: "C:\\repo", app: "C:\\Tools\\Installed.exe" },
+    ])
+  })
+
+  test("invalidates cached Windows app paths after open failure", async () => {
+    let oldOpens = 0
+    const current = api({
+      resolved: ["C:\\Tools\\Old.exe", "C:\\Tools\\New.exe"],
+      failOpen: (app) => app === "C:\\Tools\\Old.exe" && ++oldOpens > 1,
+    })
+    const openPath = createOpenPath(current.api, "windows")
+
+    await openPath("C:\\repo", "moving-code")
+    await openPath("C:\\repo", "moving-code")
+
+    expect(current.calls.resolve).toEqual(["moving-code", "moving-code"])
+    expect(current.calls.open).toEqual([
+      { path: "C:\\repo", app: "C:\\Tools\\Old.exe" },
+      { path: "C:\\repo", app: "C:\\Tools\\Old.exe" },
+      { path: "C:\\repo", app: "C:\\Tools\\New.exe" },
+    ])
+  })
+
+  test("falls back to default app when stale cached Windows app paths cannot be re-resolved", async () => {
+    let oldOpens = 0
+    const current = api({
+      resolved: ["C:\\Tools\\Old.exe", null],
+      failOpen: (app) => app === "C:\\Tools\\Old.exe" && ++oldOpens > 1,
+    })
+    const openPath = createOpenPath(current.api, "windows")
+
+    await openPath("C:\\repo", "moving-code")
+    await openPath("C:\\repo", "moving-code")
+
+    expect(current.calls.resolve).toEqual(["moving-code", "moving-code"])
+    expect(current.calls.open).toEqual([
+      { path: "C:\\repo", app: "C:\\Tools\\Old.exe" },
+      { path: "C:\\repo", app: "C:\\Tools\\Old.exe" },
+      { path: "C:\\repo", app: undefined },
+    ])
+  })
+
+  test("bounds cached Windows app paths across many unique apps", async () => {
+    const current = api()
+    const openPath = createOpenPath(current.api, "windows")
+
+    for (const index of Array.from({ length: 33 }, (_, index) => index)) {
+      await openPath("C:\\repo", `bounded-code-${index}`)
+    }
+    await openPath("C:\\repo", "bounded-code-0")
+
+    expect(current.calls.resolve.filter((app) => app === "bounded-code-0")).toHaveLength(2)
+  })
+})

--- a/packages/desktop/src/renderer/open-path.test.ts
+++ b/packages/desktop/src/renderer/open-path.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { APP_PATH_CACHE_LIMIT } from "../app-path-cache"
 import { createOpenPath } from "./open-path"
 
 function api(opts?: {
@@ -129,7 +130,7 @@ describe("renderer openPath", () => {
     const current = api()
     const openPath = createOpenPath(current.api, "windows")
 
-    for (const index of Array.from({ length: 33 }, (_, index) => index)) {
+    for (const index of Array.from({ length: APP_PATH_CACHE_LIMIT + 1 }, (_, index) => index)) {
       await openPath("C:\\repo", `bounded-code-${index}`)
     }
     await openPath("C:\\repo", "bounded-code-0")

--- a/packages/desktop/src/renderer/open-path.ts
+++ b/packages/desktop/src/renderer/open-path.ts
@@ -1,0 +1,33 @@
+import type { ElectronAPI } from "../preload/types"
+import { createAppPathCache, forgetAppPath, getAppPath, rememberAppPath } from "../app-path-cache"
+
+type OpenPathAPI = Pick<ElectronAPI, "openPath" | "resolveAppPath">
+
+export function createOpenPath(api: OpenPathAPI, os: "macos" | "windows" | "linux" | undefined) {
+  const appPathCache = createAppPathCache()
+
+  const resolve = async (app: string) => {
+    const key = app.toLowerCase()
+    const resolved = await api.resolveAppPath(app).catch(() => null)
+    if (!resolved) {
+      forgetAppPath(appPathCache, key)
+      return undefined
+    }
+    return rememberAppPath(appPathCache, key, resolved)
+  }
+
+  return async (path: string, app?: string) => {
+    if (os !== "windows") return api.openPath(path, app)
+    if (!app) return api.openPath(path)
+
+    const key = app.toLowerCase()
+    const cached = getAppPath(appPathCache, key)
+    if (!cached) return api.openPath(path, await resolve(app))
+
+    return api.openPath(path, cached).catch(async () => {
+      // Resolved app paths can go stale after updates or uninstalls; retry through the resolver once.
+      forgetAppPath(appPathCache, key)
+      return api.openPath(path, await resolve(app))
+    })
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Fixes #31938
Refs #31629

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

While checking #31629, I found a related Windows Desktop path: opening a file with a selected app can spawn subprocesses for app resolution or launch. Those subprocesses should use hidden process creation too.

This PR fixes the selected app open path tracked in #31938. It does not claim to fix the shell tool or MCP subprocess path described in #31629.

Desktop subprocess creation for this path now goes through hidden child process helpers. Commands that need stdout or exit status use hidden `execFile`; Windows selected app launches use hidden `spawn` and resolve after the child starts instead of waiting for the app to exit.

Because validating resolved app paths adds cold path work, this PR also keeps valid resolved app paths in a bounded cache, retries stale cached paths once through the resolver, and leaves missing apps uncached. Stale paths, unreadable shims, malformed resolver output, and unresolved `.cmd` or `.bat` shims are treated as unresolved instead of launchable.

After adding that validation, I found one more stale Windows resolver case worth tightening: when `where` returns repeated stale paths, the fuzzy fallback scan could read the same directories over and over. The resolver now deduplicates those fallback directories and caps that scan at the app path cache size. The cap is tied to `APP_PATH_CACHE_LIMIT` so the fallback search uses the same scale as the cache it feeds.

macOS and Linux routing is covered by unit tests, but native UX verification was not done on those OSes. This PR should be reviewed as a Windows selected app launch fix.

### How did you verify your code works?

From `packages/desktop`:

- `bun test src/main/apps.test.ts src/main/open-path.test.ts src/app-path-cache.test.ts src/main/child-process.test.ts src/renderer/open-path.test.ts --timeout 30000`
- `bun typecheck`

Also ran the repository push hook through `git push origin hide-windows-spawn`; it ran `bun turbo typecheck` and passed.

I also used local benchmark checks around the Windows stale resolver path. The repeated stale directory case dropped from about p50 781ms to p50 39ms after deduping and bounding the fallback scan. A local cap sweep showed scan cost rises with the cap, so the fallback limit now follows the existing app path cache limit rather than using an unrelated number.

### Screenshots / recordings

N/A. This changes Windows subprocess launch behavior, not persistent app UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR