### PR TITLE
fix(tui): show terminal tool failure labels

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1831,6 +1831,7 @@ function InlineTool(props: {
   color?: RGBA
   complete: unknown
   pending: string
+  failure?: string
   spinner?: boolean
   subagent?: boolean
   children: JSX.Element
@@ -1861,7 +1862,6 @@ function InlineTool(props: {
   )
 
   const failed = createMemo(() => Boolean(error() && !denied()))
-  const failure = createMemo(() => toolFailureLabel(props.part.tool))
   const clickable = createMemo(() => Boolean(props.onClick || failed()))
   const fg = createMemo(() => {
     if (props.color) return props.color
@@ -1885,7 +1885,7 @@ function InlineTool(props: {
       errorExpanded={errorExpanded()}
       complete={props.complete}
       pending={props.pending}
-      failure={failure()}
+      failure={props.failure}
       spinner={props.spinner}
       subagent={props.subagent}
       separateAfter={(id) => id !== undefined && ctx.userMessageIDs().has(id)}
@@ -1976,7 +1976,7 @@ export function InlineToolRow(props: {
                 fg={props.failed ? props.errorColor : props.color}
                 attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
               >
-                {props.failed ? (props.failure ?? props.children) : props.children}
+                {props.failed && !props.complete ? (props.failure ?? props.children) : props.children}
               </text>
             </box>
           </Show>
@@ -2448,7 +2448,7 @@ function ApplyPatch(props: ToolProps) {
         </For>
       </Match>
       <Match when={true}>
-        <InlineTool icon="%" pending="Preparing patch..." complete={false} part={props.part}>
+        <InlineTool icon="%" pending="Preparing patch..." failure="Patch failed" complete={false} part={props.part}>
           Patch
         </InlineTool>
       </Match>
@@ -2468,7 +2468,13 @@ function TodoWrite(props: ToolProps) {
         </BlockTool>
       </Match>
       <Match when={true}>
-        <InlineTool icon="⚙" pending="Updating todos..." complete={false} part={props.part}>
+        <InlineTool
+          icon="⚙"
+          pending="Updating todos..."
+          failure="Todo update failed"
+          complete={false}
+          part={props.part}
+        >
           Updating todos...
         </InlineTool>
       </Match>
@@ -2581,15 +2587,6 @@ const toolDisplays = new Set([
 
 export function toolDisplay(tool: string) {
   return toolDisplays.has(tool) ? tool : "generic"
-}
-
-export function toolFailureLabel(tool: string) {
-  if (tool === "apply_patch") return "Patch failed"
-  if (tool === "bash") return "Command failed"
-  if (tool === "webfetch") return "Web fetch failed"
-  if (tool === "websearch") return "Web search failed"
-  if (tool === "todowrite") return "Todo update failed"
-  return `${Locale.titlecase(tool.replaceAll("_", " "))} failed`
 }
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1861,6 +1861,7 @@ function InlineTool(props: {
   )
 
   const failed = createMemo(() => Boolean(error() && !denied()))
+  const failure = createMemo(() => toolFailureLabel(props.part.tool))
   const clickable = createMemo(() => Boolean(props.onClick || failed()))
   const fg = createMemo(() => {
     if (props.color) return props.color
@@ -1884,6 +1885,7 @@ function InlineTool(props: {
       errorExpanded={errorExpanded()}
       complete={props.complete}
       pending={props.pending}
+      failure={failure()}
       spinner={props.spinner}
       subagent={props.subagent}
       separateAfter={(id) => id !== undefined && ctx.userMessageIDs().has(id)}
@@ -1915,6 +1917,7 @@ export function InlineToolRow(props: {
   errorExpanded?: boolean
   complete: unknown
   pending: string
+  failure?: string
   spinner?: boolean
   subagent?: boolean
   children: JSX.Element
@@ -1958,7 +1961,7 @@ export function InlineToolRow(props: {
                 ~ {props.pending}
               </text>
             }
-            when={props.complete}
+            when={props.complete || props.failed}
           >
             <box flexDirection="row">
               <text
@@ -1973,7 +1976,7 @@ export function InlineToolRow(props: {
                 fg={props.failed ? props.errorColor : props.color}
                 attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
               >
-                {props.children}
+                {props.failed ? (props.failure ?? props.children) : props.children}
               </text>
             </box>
           </Show>
@@ -2578,6 +2581,15 @@ const toolDisplays = new Set([
 
 export function toolDisplay(tool: string) {
   return toolDisplays.has(tool) ? tool : "generic"
+}
+
+export function toolFailureLabel(tool: string) {
+  if (tool === "apply_patch") return "Patch failed"
+  if (tool === "bash") return "Command failed"
+  if (tool === "webfetch") return "Web fetch failed"
+  if (tool === "websearch") return "Web search failed"
+  if (tool === "todowrite") return "Todo update failed"
+  return `${Locale.titlecase(tool.replaceAll("_", " "))} failed`
 }
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -14,6 +14,7 @@ import {
   parseQuestions,
   parseTodos,
   toolDisplay,
+  toolFailureLabel,
 } from "../../../src/routes/session"
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined
@@ -155,6 +156,20 @@ function StickyScrollFixture(props: { separated: boolean; scroll: (scroll: Scrol
   )
 }
 
+function FailedPendingToolFixture() {
+  return (
+    <InlineToolRow
+      icon="%"
+      complete={false}
+      pending="Preparing patch..."
+      failed={true}
+      failure="Patch failed"
+    >
+      Patch
+    </InlineToolRow>
+  )
+}
+
 async function renderFrame(component: () => JSX.Element, options: { width: number; height: number }) {
   testSetup = await testRender(component, options)
   await testSetup.renderOnce()
@@ -171,6 +186,22 @@ describe("TUI inline tool wrapping", () => {
   test("falls back for unknown tool names", () => {
     expect(toolDisplay("bash")).toBe("bash")
     expect(toolDisplay("plugin_tool")).toBe("generic")
+  })
+
+  test("formats failure labels for built-in and plugin tools", () => {
+    expect(toolFailureLabel("apply_patch")).toBe("Patch failed")
+    expect(toolFailureLabel("bash")).toBe("Command failed")
+    expect(toolFailureLabel("webfetch")).toBe("Web fetch failed")
+    expect(toolFailureLabel("websearch")).toBe("Web search failed")
+    expect(toolFailureLabel("todowrite")).toBe("Todo update failed")
+    expect(toolFailureLabel("edit")).toBe("Edit failed")
+    expect(toolFailureLabel("plugin_tool")).toBe("Plugin Tool failed")
+  })
+
+  test("replaces pending copy when a tool fails before completion", async () => {
+    const frame = await renderFrame(() => <FailedPendingToolFixture />, { width: 72, height: 3 })
+    expect(frame).toContain("Patch failed")
+    expect(frame).not.toContain("Preparing patch")
   })
 
   test("filters malformed nested tool wire data", () => {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -14,7 +14,6 @@ import {
   parseQuestions,
   parseTodos,
   toolDisplay,
-  toolFailureLabel,
 } from "../../../src/routes/session"
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined
@@ -170,6 +169,20 @@ function FailedPendingToolFixture() {
   )
 }
 
+function FailedCompleteToolFixture() {
+  return (
+    <InlineToolRow
+      icon="→"
+      complete={true}
+      pending="Reading file..."
+      failed={true}
+      failure="Read failed"
+    >
+      Read src/index.ts
+    </InlineToolRow>
+  )
+}
+
 async function renderFrame(component: () => JSX.Element, options: { width: number; height: number }) {
   testSetup = await testRender(component, options)
   await testSetup.renderOnce()
@@ -188,20 +201,16 @@ describe("TUI inline tool wrapping", () => {
     expect(toolDisplay("plugin_tool")).toBe("generic")
   })
 
-  test("formats failure labels for built-in and plugin tools", () => {
-    expect(toolFailureLabel("apply_patch")).toBe("Patch failed")
-    expect(toolFailureLabel("bash")).toBe("Command failed")
-    expect(toolFailureLabel("webfetch")).toBe("Web fetch failed")
-    expect(toolFailureLabel("websearch")).toBe("Web search failed")
-    expect(toolFailureLabel("todowrite")).toBe("Todo update failed")
-    expect(toolFailureLabel("edit")).toBe("Edit failed")
-    expect(toolFailureLabel("plugin_tool")).toBe("Plugin Tool failed")
-  })
-
   test("replaces pending copy when a tool fails before completion", async () => {
     const frame = await renderFrame(() => <FailedPendingToolFixture />, { width: 72, height: 3 })
     expect(frame).toContain("Patch failed")
     expect(frame).not.toContain("Preparing patch")
+  })
+
+  test("preserves useful completed copy when a tool fails", async () => {
+    const frame = await renderFrame(() => <FailedCompleteToolFixture />, { width: 72, height: 3 })
+    expect(frame).toContain("Read src/index.ts")
+    expect(frame).not.toContain("Read failed")
   })
 
   test("filters malformed nested tool wire data", () => {


### PR DESCRIPTION
## Summary
- replace stale pending copy only when an inline tool reaches a terminal error without useful completion content
- show `Patch failed` for failed apply-patch fallbacks and `Todo update failed` for failed todo fallbacks
- preserve useful red failure descriptions such as `Read <path>` and `Edit <path>`
- preserve permission-denial styling and expandable error details

## Testing
- `bun test test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- `bun typecheck`
- `git diff --check`

The full TUI suite was also run: 173 passed, 1 skipped, and 8 pre-existing sync tests failed because `Exit context must be used within a context provider`.