### PR TITLE
fix(ui): prevent renderer hang on large file diffs

### DIFF
--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -60,66 +60,13 @@ function fileDiffFromPatch(file: string, patch: string) {
     return hit
   }
 
-  const contents = completePatchContents(patch)
-  const input = contents ? undefined : patchInput(file, patch)
-  const value = contents
-    ? fileDiffFromContent(file, contents.before, contents.after)
-    : ((input ? parsePatchFiles(input)[0]?.files[0] : undefined) ?? emptyFileDiff(file))
+  const input = patchInput(file, patch)
+  const value = input
+    ? (parsePatchFiles(input)[0]?.files[0] ?? emptyFileDiff(file))
+    : emptyFileDiff(file)
   patchFileDiffCache.set(key, value)
   while (patchFileDiffCache.size > diffCacheLimit) patchFileDiffCache.delete(patchFileDiffCache.keys().next().value!)
   return value
-}
-
-function completePatchContents(patch: string) {
-  try {
-    const parsed = parsePatch(patch)[0]
-    if (!parsed || (!parsed.index && !parsed.oldFileName && !parsed.newFileName)) return
-    // Snapshot and VCS producers request full context. Tool patches use jsdiff's shorter default context.
-    if (!patch.startsWith("diff --git ") && !/^--- [^\n]*\t\r?\n\+\+\+ [^\n]*\t(?:\r?\n|$)/m.test(patch)) return
-    // Full patches collapse into one leading hunk. Separated hunks omit ranges and must stay partial.
-    if (parsed.hunks.length !== 1) return
-
-    const hunk = parsed.hunks[0]
-    if (!hunk || hunk.oldStart > 1 || hunk.newStart > 1) return
-
-    const before: Array<{ text: string; newline: boolean }> = []
-    const after: Array<{ text: string; newline: boolean }> = []
-    let previous: "-" | "+" | " " | undefined
-
-    for (const line of hunk.lines) {
-      if (line.startsWith("\\")) {
-        if (previous === "-" || previous === " ") {
-          const value = before.at(-1)
-          if (value) value.newline = false
-        }
-        if (previous === "+" || previous === " ") {
-          const value = after.at(-1)
-          if (value) value.newline = false
-        }
-        continue
-      }
-      if (line.startsWith("-")) {
-        before.push({ text: line.slice(1), newline: true })
-        previous = "-"
-        continue
-      }
-      if (line.startsWith("+")) {
-        after.push({ text: line.slice(1), newline: true })
-        previous = "+"
-        continue
-      }
-      if (!line.startsWith(" ")) return
-      before.push({ text: line.slice(1), newline: true })
-      after.push({ text: line.slice(1), newline: true })
-      previous = " "
-    }
-
-    const text = (lines: Array<{ text: string; newline: boolean }>) =>
-      lines.map((line) => line.text + (line.newline ? "\n" : "")).join("")
-    return { before: text(before), after: text(after) }
-  } catch {
-    return
-  }
 }
 
 function patchInput(file: string, patch: string) {
@@ -136,6 +83,7 @@ function patchInput(file: string, patch: string) {
 
 function fileDiffFromContent(file: string, before: string, after: string) {
   if (!before && !after) return emptyFileDiff(file)
+  if (before.length > 500_000 || after.length > 500_000) return emptyFileDiff(file)
   return parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
 }
 


### PR DESCRIPTION
## Problem

The desktop app's renderer process hangs (becomes unresponsive) when computing file diffs for session review. The stack trace shows the hang occurs in `execEditLength`, which is the Myers diff algorithm from the `diff` npm package, with O(N*M) complexity.

**Root cause:** `fileDiffFromPatch` was calling `completePatchContents` to reconstruct full before/after content from a patch, then passing it to `fileDiffFromContent` → `parseDiffFromFile` (`@pierre/diffs`) → `createTwoFilesPatch` (`diff` package). For large patches with full context, this recomputes an expensive diff from scratch instead of simply parsing the already-computed patch.

**Stack trace from debug logs:**
```
execEditLength → LineDiff.diff → diffLines → structuredPatch → createTwoFilesPatch → parseDiffFromFile → fileDiffFromContent → fileDiffFromPatch → resolveFileDiff → normalize
```

## Fix

1. **`fileDiffFromPatch`**: Removed the `completePatchContents` → `fileDiffFromContent` code path entirely. Now it always goes through `patchInput` → `parsePatchFiles`, which parses the existing patch string without recomputing the diff. This is safe because `parsePatchFiles` and `parseDiffFromFile` both call the same `processFile` function internally.

2. **`fileDiffFromContent`**: Added a 500KB size guard for the bare-content path (`before`/`after` without a patch) to prevent blocking the renderer on oversized content.

3. Removed the now-unused `completePatchContents` function (~55 lines).

## Typecheck

The `@opencode-ai/ui` package passes typecheck (`tsgo --noEmit`). The unrelated `@opencode-ai/app` has a pre-existing error in `custom-elements.d.ts`.