### PR TITLE
fix(tui): restore terminal capability detection over ssh

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
@@ -14,6 +14,7 @@ import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { Global } from "@opencode-ai/core/global"
 import { openEditor } from "@opencode-ai/tui/editor"
 import { registerOpencodeKeymap } from "@opencode-ai/tui/keymap"
+import { TERMINAL_ENV_KEYS } from "@opencode-ai/tui/terminal-env"
 import { Session as SessionApi } from "@/session/session"
 import * as Locale from "@/util/locale"
 import { resolveInteractiveStdin } from "./runtime.stdin"
@@ -186,6 +187,7 @@ export async function createRuntimeLifecycle(input: LifecycleInput): Promise<Lif
       autoFocus: false,
       openConsoleOnError: false,
       exitOnCtrlC: false,
+      forwardEnvKeys: TERMINAL_ENV_KEYS,
       useKittyKeyboard: { events: process.platform === "win32" },
       screenMode: "split-footer",
       footerHeight: FOOTER_HEIGHT,

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -28,6 +28,7 @@
     "./editor": "./src/editor.ts",
     "./editor-zed": "./src/editor-zed.ts",
     "./runtime": "./src/runtime.tsx",
+    "./terminal-env": "./src/terminal-env.ts",
     "./terminal-win32": "./src/terminal-win32.ts",
     "./config/keybind": "./src/config/keybind.ts",
     "./keymap": "./src/keymap.tsx",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -56,6 +56,7 @@ import { DialogAlert } from "./ui/dialog-alert"
 import { DialogConfirm } from "./ui/dialog-confirm"
 import { ToastProvider, useToast } from "./ui/toast"
 import { isDefaultTitle } from "./util/session"
+import { TERMINAL_ENV_KEYS } from "./terminal-env"
 import { KVProvider, useKV } from "./context/kv"
 import * as Model from "./util/model"
 import { ArgsProvider, useArgs, type Args } from "./context/args"
@@ -190,6 +191,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
             useKittyKeyboard: {},
             autoFocus: false,
             openConsoleOnError: false,
+            forwardEnvKeys: TERMINAL_ENV_KEYS,
             useMouse: !Flag.OPENCODE_DISABLE_MOUSE && input.config.mouse,
             consoleOptions: {
               keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }],

--- a/packages/tui/src/terminal-env.ts
+++ b/packages/tui/src/terminal-env.ts
@@ -1,0 +1,37 @@
+// opentui v0.3.0+ auto-detects SSH/mosh sessions (SSH_CONNECTION, SSH_CLIENT,
+// SSH_TTY, MOSH_CONNECTION) as "remote" and stops reading the process
+// environment for terminal capability detection unless the host environment is
+// forwarded explicitly. Without forwarding, ssh sessions ignore TERM, COLORTERM,
+// TMUX, and the OPENTUI_FORCE_* overrides and render with a 16-color,
+// query-only capability floor, which breaks the TUI (#31284).
+//
+// Forwarding the same env keys opentui inspects for local sessions restores
+// pre-1.16 capability detection while keeping remote-mode behavior like OSC52
+// clipboard. Mirrors DEFAULT_FORWARDED_ENV_KEYS in @opentui/core, which is not
+// exported as of 0.3.4.
+export const TERMINAL_ENV_KEYS = [
+  "TMUX",
+  "ZELLIJ",
+  "ZELLIJ_SESSION_NAME",
+  "ZELLIJ_PANE_ID",
+  "TERM",
+  "OPENTUI_GRAPHICS",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TERM_FEATURES",
+  "ALACRITTY_SOCKET",
+  "ALACRITTY_LOG",
+  "COLORTERM",
+  "TERMUX_VERSION",
+  "VHS_RECORD",
+  "OPENTUI_FORCE_WCWIDTH",
+  "OPENTUI_FORCE_UNICODE",
+  "OPENTUI_FORCE_NOZWJ",
+  "OPENTUI_FORCE_EXPLICIT_WIDTH",
+  "OPENTUI_NOTIFICATION_PROTOCOL",
+  "OPENTUI_NOTIFICATIONS",
+  "WT_SESSION",
+  "STY",
+  "WSL_DISTRO_NAME",
+  "WSL_INTEROP",
+]

--- a/packages/tui/test/terminal-env.test.ts
+++ b/packages/tui/test/terminal-env.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { TERMINAL_ENV_KEYS } from "../src/terminal-env"
+
+// opentui auto-detects SSH sessions as remote and only reads terminal
+// capability env vars that are forwarded explicitly. These tests spawn child
+// processes with a controlled environment to verify that forwarding
+// TERMINAL_ENV_KEYS keeps capability detection working over ssh (#31284).
+
+const CHILD = `
+import { createTestRenderer } from "@opentui/core/testing"
+const forward = process.env.PROBE_FORWARD === "1"
+const { renderer } = await createTestRenderer(
+  forward ? { width: 40, height: 10, forwardEnvKeys: ${JSON.stringify(TERMINAL_ENV_KEYS)} } : { width: 40, height: 10 },
+)
+const internals = renderer as any
+console.log("CAPS:" + JSON.stringify(internals.lib.getTerminalCapabilities(internals.rendererPtr)))
+renderer.destroy()
+process.exit(0)
+`
+
+const SESSION_KEYS = ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY", "MOSH_CONNECTION", ...TERMINAL_ENV_KEYS]
+
+async function capabilities(overrides: Record<string, string>) {
+  const env: Record<string, string | undefined> = { ...process.env }
+  for (const key of SESSION_KEYS) delete env[key]
+  Object.assign(env, overrides)
+  const proc = Bun.spawn([process.execPath, "--eval", CHILD], {
+    cwd: path.join(import.meta.dir, ".."),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  expect(code, stderr).toBe(0)
+  const line = stdout
+    .trim()
+    .split(/\r?\n/)
+    .find((item) => item.startsWith("CAPS:"))
+  expect(line, stdout + stderr).toBeDefined()
+  return JSON.parse(line!.slice(5))
+}
+
+const TERM_ENV = { TERM: "xterm-256color", COLORTERM: "truecolor" }
+const SSH_ENV = { ...TERM_ENV, SSH_CONNECTION: "192.0.2.1 54231 192.0.2.2 22", SSH_TTY: "/dev/pts/1" }
+
+test("ssh session with forwarded env keys keeps color capabilities", async () => {
+  const caps = await capabilities({ ...SSH_ENV, PROBE_FORWARD: "1" })
+  expect(caps.remote).toBe(true)
+  expect(caps.ansi256).toBe(true)
+  expect(caps.rgb).toBe(true)
+})
+
+test("ssh session with forwarded env keys detects tmux", async () => {
+  const caps = await capabilities({
+    ...SSH_ENV,
+    PROBE_FORWARD: "1",
+    TMUX: "/tmp/tmux-1000/default,12345,0",
+  })
+  expect(caps.multiplexer).toBe("tmux")
+  expect(caps.unicode).toBe("wcwidth")
+})
+
+test("local session keeps local capability detection", async () => {
+  const caps = await capabilities({ ...TERM_ENV, PROBE_FORWARD: "1" })
+  expect(caps.remote).toBe(false)
+  expect(caps.ansi256).toBe(true)
+  expect(caps.rgb).toBe(true)
+})
+
+// Canary for the upstream behavior this works around. When this starts
+// failing, opentui reads the environment over ssh again and forwarding may be
+// dropped.
+test("ssh session without forwarded env keys hits the capability floor", async () => {
+  const caps = await capabilities(SSH_ENV)
+  expect(caps.remote).toBe(true)
+  expect(caps.ansi256).toBe(false)
+  expect(caps.rgb).toBe(false)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31284

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Since 1.16.0 the TUI renders broken over ssh (16-color output, wrong theme colors, no tmux awareness). 1.15.13 was fine. #31284 bisected the regression to 1.16.0.

Root cause: 1.16.0 bumped `@opentui/core` 0.2.16 -> 0.3.x, which includes anomalyco/opentui#1116. opentui now auto-detects ssh/mosh sessions (`SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY`/`MOSH_CONNECTION`) as "remote" and then skips all env-based capability detection unless the embedder forwards the environment explicitly (`checkEnvironmentOverrides` returns early when `remote` is set and no env map was forwarded). opencode never sets `forwardEnvKeys`, so over ssh `TERM`, `COLORTERM`, `TMUX`, and even the `OPENTUI_FORCE_*` escape hatches are ignored: `ansi256`/`rgb` stay false and the renderer only recovers on terminals that answer XTVERSION/DECRQM probes. sshd does forward `TERM`, so that information is trustworthy and dropping it is what broke rendering.

Fix: pass `forwardEnvKeys` to both `createCliRenderer` call sites (main TUI and `opencode run` split-footer), using the same key list opentui reads for local sessions (opentui does not export it, so it is mirrored in `packages/tui/src/terminal-env.ts`). This restores pre-1.16 capability detection over ssh while keeping remote mode and its OSC52 clipboard behavior. Local sessions resolve the identical key set, so behavior there is unchanged.

### How did you verify your code works?

- New test `packages/tui/test/terminal-env.test.ts` spawns renderers against the pinned `@opentui/core` build with a controlled environment. With `SSH_CONNECTION` set and no forwarding: `remote=true ansi256=false rgb=false` (the bug, kept as a canary so the workaround can be dropped when upstream changes). With forwarding: `remote=true ansi256=true rgb=true`, and `TMUX` is detected again (`unicode=wcwidth`). Local sessions unchanged.
- `bun run typecheck` passes in `packages/tui` and `packages/opencode`.
- Reproduced the broken capability set on a real ssh session to a linux host (`TERM=xterm-256color`) and confirmed forwarding restores the 1.15.13 values.

### Screenshots / recordings

Capability probe against `@opentui/core` 0.3.4 with `TERM=xterm-256color COLORTERM=truecolor`:

| scenario | remote | ansi256 | rgb | multiplexer |
| --- | --- | --- | --- | --- |
| local | false | true | true | none |
| ssh, no forwarding (current) | true | false | false | none |
| ssh + forwardEnvKeys (this PR) | true | true | true | none |
| ssh + tmux + forwardEnvKeys | true | true | true | tmux |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
