### PR TITLE
fix(tui): show prompt submission errors

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1086,22 +1086,31 @@ export function Prompt(props: PromptProps) {
     } else {
       move.startSubmit()
       sdk.client.session
-        .prompt({
-          sessionID,
-          ...selectedModel,
-          agent: agent.name,
-          model: selectedModel,
-          variant,
-          parts: [
-            ...editorParts,
-            {
-              type: "text",
-              text: inputText,
-            },
-            ...nonTextParts,
-          ],
+        .prompt(
+          {
+            sessionID,
+            ...selectedModel,
+            agent: agent.name,
+            model: selectedModel,
+            variant,
+            parts: [
+              ...editorParts,
+              {
+                type: "text",
+                text: inputText,
+              },
+              ...nonTextParts,
+            ],
+          },
+          { throwOnError: true },
+        )
+        .catch((error) => {
+          toast.show({
+            title: "Sending prompt failed",
+            message: errorMessage(error),
+            variant: "error",
+          })
         })
-        .catch(() => {})
       if (editorParts.length > 0) editor.markSelectionSent()
     }
     history.append({

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1106,7 +1106,7 @@ export function Prompt(props: PromptProps) {
         )
         .catch((error) => {
           toast.show({
-            title: "Sending prompt failed",
+            title: "Failed to send prompt",
             message: errorMessage(error),
             variant: "error",
           })


### PR DESCRIPTION
## Summary

- opt prompt submission into SDK `throwOnError` handling so HTTP failures reject
- replace the empty rejection handler with an error toast using the existing error formatter

This prevents failed prompt admissions, including invalid attachments, from silently clearing the input with no feedback.

## Testing

- `bun test test/cli/tui/prompt-submit-race.test.ts`