### PR TITLE
feat: register themes in $CONFIG/opencode/desktop-themes/

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -7,7 +7,7 @@ import { MarkedProvider } from "@opencode-ai/ui/context/marked"
 import { File } from "@opencode-ai/ui/file"
 import { Font } from "@opencode-ai/ui/font"
 import { Splash } from "@opencode-ai/ui/logo"
-import { ThemeProvider } from "@opencode-ai/ui/theme/context"
+import { ThemeProvider, useTheme } from "@opencode-ai/ui/theme/context"
 import { MetaProvider } from "@solidjs/meta"
 import { type BaseRouterProps, Navigate, Route, Router, useParams, useSearchParams } from "@solidjs/router"
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
@@ -39,6 +39,7 @@ import { LayoutProvider } from "@/context/layout"
 import { ModelsProvider } from "@/context/models"
 import { NotificationProvider } from "@/context/notification"
 import { PermissionProvider } from "@/context/permission"
+import { usePlatform } from "@/context/platform"
 import { PromptProvider } from "@/context/prompt"
 import { ServerConnection, ServerProvider, serverName, useServer } from "@/context/server"
 import { SettingsProvider, useSettings } from "@/context/settings"
@@ -50,6 +51,7 @@ import DirectoryLayout, { DirectoryDataProvider } from "@/pages/directory-layout
 import Layout from "@/pages/layout"
 import { ErrorPage } from "./pages/error"
 import { useCheckServerHealth } from "./utils/server-health"
+import { fetchDesktopThemes } from "./utils/desktop-themes"
 
 const HomeRoute = lazy(() => import("@/pages/home"))
 const Session = lazy(() => import("@/pages/session"))
@@ -227,6 +229,29 @@ function RouterRoot(props: ParentProps<{ appChildren?: JSX.Element }>) {
   )
 }
 
+function DesktopThemeLoader() {
+  const server = useServer()
+  const platform = usePlatform()
+  const theme = useTheme()
+
+  createEffect(() => {
+    const current = server.current
+    if (!current) return
+    let cancelled = false
+    void fetchDesktopThemes({ server: current.http, fetch: platform.fetch })
+      .then((themes) => {
+        if (cancelled) return
+        for (const item of themes) theme.registerTheme(item)
+      })
+      .catch(() => {})
+    onCleanup(() => {
+      cancelled = true
+    })
+  })
+
+  return null
+}
+
 export function AppBaseProviders(props: ParentProps<{ locale?: Locale }>) {
   return (
     <MetaProvider>
@@ -391,6 +416,7 @@ export function AppInterface(props: {
       canonicalLocalServer={props.canonicalLocalServer}
       servers={props.servers}
     >
+      <DesktopThemeLoader />
       <GlobalProvider>
         <ConnectionGate disableHealthCheck={props.disableHealthCheck}>
           <Dynamic

--- a/packages/app/src/utils/desktop-themes.test.ts
+++ b/packages/app/src/utils/desktop-themes.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import type { DesktopTheme } from "@opencode-ai/ui/theme"
+import { fetchDesktopThemes } from "./desktop-themes"
+
+function theme(id: string): DesktopTheme {
+  return {
+    id,
+    name: id,
+    light: {
+      palette: {
+        neutral: "#ffffff",
+        ink: "#111111",
+        primary: "#222222",
+        success: "#00aa00",
+        warning: "#aaaa00",
+        error: "#aa0000",
+        info: "#0000aa",
+      },
+    },
+    dark: {
+      palette: {
+        neutral: "#000000",
+        ink: "#eeeeee",
+        primary: "#222222",
+        success: "#00aa00",
+        warning: "#aaaa00",
+        error: "#aa0000",
+        info: "#0000aa",
+      },
+    },
+  }
+}
+
+function fetcher(calls: Request[]) {
+  return (async (input, init) => {
+    calls.push(new Request(input, init))
+    return new Response(JSON.stringify({ themes: [theme("custom")] }))
+  }) as typeof fetch
+}
+
+test("fetches desktop themes from the server route", async () => {
+  const calls: Request[] = []
+  const result = await fetchDesktopThemes({
+    server: { url: "http://localhost:4096" },
+    fetch: fetcher(calls),
+  })
+
+  expect(calls[0]!.url).toBe("http://localhost:4096/theme/desktop")
+  expect(result).toEqual([theme("custom")])
+})
+
+test("sends basic auth when server has credentials", async () => {
+  const calls: Request[] = []
+  await fetchDesktopThemes({
+    server: { url: "http://localhost:4096", username: "user", password: "pass" },
+    fetch: fetcher(calls),
+  })
+
+  expect(calls[0]!.headers.get("authorization")).toBe("Basic dXNlcjpwYXNz")
+})

--- a/packages/app/src/utils/desktop-themes.ts
+++ b/packages/app/src/utils/desktop-themes.ts
@@ -1,0 +1,16 @@
+import type { DesktopTheme } from "@opencode-ai/ui/theme"
+import type { ServerConnection } from "@/context/server"
+import { authTokenFromCredentials } from "./server"
+
+export async function fetchDesktopThemes(input: { server: ServerConnection.HttpBase; fetch?: typeof fetch }) {
+  const response = await (input.fetch ?? globalThis.fetch)(new URL("/theme/desktop", input.server.url), {
+    headers: input.server.password
+      ? {
+          Authorization: `Basic ${authTokenFromCredentials({ username: input.server.username, password: input.server.password })}`,
+        }
+      : undefined,
+  })
+  if (!response.ok) return []
+  const json = (await response.json()) as { themes?: DesktopTheme[] }
+  return Array.isArray(json.themes) ? json.themes : []
+}

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -100,6 +100,7 @@ import { corsVaryFix } from "./middleware/cors-vary"
 import { errorLayer } from "./middleware/error"
 import { fenceLayer } from "./middleware/fence"
 import { schemaErrorLayer } from "./middleware/schema-error"
+import { desktopThemeDirectories, discoverDesktopThemes } from "@/theme/desktop"
 
 export const context = Context.makeUnsafe<unknown>(new Map())
 
@@ -175,6 +176,14 @@ const docRoute = HttpRouter.use((router) => router.add("GET", "/doc", () => Effe
   Layer.provide(authOnlyRouterLayer),
 )
 
+const desktopThemeRoute = HttpRouter.use((router) =>
+  router.add("GET", "/theme/desktop", () =>
+    Effect.promise(() => discoverDesktopThemes(desktopThemeDirectories())).pipe(
+      Effect.map((themes) => HttpServerResponse.jsonUnsafe({ themes })),
+    ),
+  ),
+).pipe(Layer.provide(authOnlyRouterLayer))
+
 const uiRoute = HttpRouter.use((router) =>
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
@@ -203,6 +212,7 @@ export function createRoutes(
     instanceRoutes,
     serverRoutes,
     docRoute,
+    desktopThemeRoute,
     uiRoute,
   ).pipe(
     Layer.provide([

--- a/packages/opencode/src/theme/desktop.ts
+++ b/packages/opencode/src/theme/desktop.ts
@@ -1,0 +1,80 @@
+import { Glob } from "@opencode-ai/core/util/glob"
+import { Global } from "@opencode-ai/core/global"
+import { Option, Schema } from "effect"
+import path from "node:path"
+
+const HexColor = Schema.String.check(
+  Schema.isPattern(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/),
+)
+const CssVar = Schema.String.check(Schema.isPattern(/^var\(--[a-z0-9-]+\)$/))
+const ThemeID = Schema.String.check(Schema.isPattern(/^[a-z0-9-]+$/))
+const ColorValue = Schema.Union([HexColor, CssVar])
+const VariantBase = {
+  overrides: Schema.optional(Schema.Record(Schema.String, ColorValue)),
+  v2Overrides: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+}
+const Palette = Schema.Struct({
+  neutral: HexColor,
+  ink: HexColor,
+  primary: HexColor,
+  success: HexColor,
+  warning: HexColor,
+  error: HexColor,
+  info: HexColor,
+  accent: Schema.optional(HexColor),
+  interactive: Schema.optional(HexColor),
+  diffAdd: Schema.optional(HexColor),
+  diffDelete: Schema.optional(HexColor),
+})
+const Seeds = Schema.Struct({
+  neutral: HexColor,
+  primary: HexColor,
+  success: HexColor,
+  warning: HexColor,
+  error: HexColor,
+  info: HexColor,
+  interactive: HexColor,
+  diffAdd: HexColor,
+  diffDelete: HexColor,
+})
+const ThemeVariant = Schema.Union([
+  Schema.Struct({ palette: Palette, ...VariantBase }),
+  Schema.Struct({ seeds: Seeds, ...VariantBase }),
+])
+const DesktopTheme = Schema.Struct({
+  $schema: Schema.optional(Schema.String),
+  name: Schema.String,
+  id: ThemeID,
+  light: ThemeVariant,
+  dark: ThemeVariant,
+})
+const decodeTheme = Schema.decodeUnknownOption(DesktopTheme)
+
+export function desktopThemeDirectories(cwd = process.cwd()) {
+  const directories = [Global.Path.config]
+  for (let current = cwd; ; current = path.dirname(current)) {
+    directories.push(path.join(current, ".opencode"))
+    if (path.dirname(current) === current) break
+  }
+  return directories
+}
+
+export async function discoverDesktopThemes(directories: string[]) {
+  const result: Record<string, typeof DesktopTheme.Type> = {}
+  for (const directory of directories) {
+    const files = await Glob.scan("desktop-themes/*.json", { cwd: directory, absolute: true, dot: true, symlink: true }).catch(
+      () => [],
+    )
+    for (const file of files) {
+      const theme = Option.getOrUndefined(
+        decodeTheme(
+          await Bun.file(file)
+            .json()
+            .catch(() => undefined),
+        ),
+      )
+      if (theme) result[theme.id] = theme
+    }
+  }
+  return Object.values(result)
+}

--- a/packages/opencode/test/theme/desktop.test.ts
+++ b/packages/opencode/test/theme/desktop.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { discoverDesktopThemes } from "@/theme/desktop"
+import { tmpdir } from "../fixture/fixture"
+
+function theme(id: string, primary: string) {
+  return {
+    $schema: "https://opencode.ai/desktop-theme.json",
+    id,
+    name: id,
+    light: {
+      palette: {
+        neutral: "#ffffff",
+        ink: "#111111",
+        primary,
+        success: "#00aa00",
+        warning: "#aaaa00",
+        error: "#aa0000",
+        info: "#0000aa",
+      },
+    },
+    dark: {
+      palette: {
+        neutral: "#000000",
+        ink: "#eeeeee",
+        primary,
+        success: "#00aa00",
+        warning: "#aaaa00",
+        error: "#aa0000",
+        info: "#0000aa",
+      },
+    },
+  }
+}
+
+test("discovers desktop themes with later directories overriding earlier ones", async () => {
+  await using tmp = await tmpdir()
+  const global = path.join(tmp.path, "global")
+  const project = path.join(tmp.path, "project")
+  await mkdir(path.join(global, "desktop-themes"), { recursive: true })
+  await mkdir(path.join(project, "desktop-themes"), { recursive: true })
+  await writeFile(path.join(global, "desktop-themes", "custom.json"), JSON.stringify(theme("custom", "#111111")))
+  await writeFile(path.join(project, "desktop-themes", "custom.json"), JSON.stringify(theme("custom", "#222222")))
+
+  await expect(discoverDesktopThemes([global, project])).resolves.toMatchObject([
+    {
+      id: "custom",
+      light: { palette: { primary: "#222222" } },
+    },
+  ])
+})
+
+test("ignores invalid desktop theme files", async () => {
+  await using tmp = await tmpdir()
+  await mkdir(path.join(tmp.path, "desktop-themes"), { recursive: true })
+  await writeFile(path.join(tmp.path, "desktop-themes", "broken.json"), "{")
+  await writeFile(path.join(tmp.path, "desktop-themes", "invalid.json"), JSON.stringify({ id: "bad", theme: {} }))
+
+  await expect(discoverDesktopThemes([tmp.path])).resolves.toEqual([])
+})


### PR DESCRIPTION
### Issue for this PR
Closes #31948


### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

Functionality for loading themes in as JSON already exists. This automatically does that for themes in `$GLOBAL_CONFIG/desktop-themes/theme.json` and `$PROJECT_CONFIG/desktop-themes/theme.json`. 

### How did you verify your code works?
I ran opencode locally and added themes to my local config. They showed up. I also added tests which test this functionality.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
