### PR TITLE
fix(tui): shorten move session description

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -540,7 +540,7 @@ export function Prompt(props: PromptProps) {
       },
       {
         title: "Move session",
-        desc: "Move the session to another project directory",
+        desc: "Move to another project dir",
         name: "session.move",
         category: "Session",
         slashName: "move",


### PR DESCRIPTION
## Summary
- Shorten the Move session command palette description so it does not wrap under shortcut hints.

## Testing
- bun typecheck (packages/tui)
- bun turbo typecheck (pre-push hook)