### PR TITLE
docs: add opencode-mimo-free-plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -23,6 +23,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                      |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                               |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                               |
+| [opencode-mimo-free-plugin](https://github.com/lilyzhaun/opencode-mimo-free-plugin)                | Add the MiMo Auto free provider as mimo/mimo-auto with no API key required                         |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                    |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling      |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                              |


### PR DESCRIPTION
### Issue for this PR

N/A - docs-only ecosystem listing update.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-mimo-free-plugin` to the official ecosystem plugins table. The plugin provides the MiMo Auto free provider as `mimo/mimo-auto` without requiring an API key.

### How did you verify your code works?

- Ran `bun run --cwd packages/web build` successfully.
- The pre-push hook ran `bun turbo typecheck` successfully before pushing the branch.

### Screenshots / recordings

N/A - documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR