### PR TITLE
fix(bash): lazy Windows code page detection with periodic refresh

### DIFF
--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -1,5 +1,6 @@
 export * as BashTool from "./bash"
 
+import { execSync } from "node:child_process"
 import path from "path"
 import { ToolFailure } from "@opencode-ai/llm"
 import { Duration, Effect, Layer, Schema } from "effect"
@@ -49,6 +50,38 @@ const Output = Schema.Struct({
 type Output = typeof Output.Type
 
 const defaultShell = () => (process.platform === "win32" ? (process.env.COMSPEC ?? "cmd.exe") : "/bin/sh")
+
+// Windows code page detection — lazy init, periodic refresh.
+const CODE_PAGE_MAP: Record<string, string> = {
+  "932": "shift-jis",
+  "936": "gbk",
+  "949": "euc-kr",
+  "950": "big5",
+}
+const CODEPAGE_TTL_MS = 30_000
+let codepageCache: string | undefined
+let codepageLastCheck = 0
+
+const detectCodePage = (): string => {
+  const now = Date.now()
+  if (codepageCache !== undefined && now - codepageLastCheck < CODEPAGE_TTL_MS) return codepageCache
+  codepageLastCheck = now
+  try {
+    const out = execSync("chcp.com", { encoding: "latin1", timeout: 2000 })
+    const m = (out as string).match(/(\d+)/)
+    codepageCache = m ? (CODE_PAGE_MAP[m[1]] ?? "utf-8") : "utf-8"
+  } catch {
+    codepageCache = "utf-8"
+  }
+  return codepageCache
+}
+
+const decodeOutput = (buf: Buffer): string => {
+  if (process.platform !== "win32") return buf.toString("utf8")
+  const cp = detectCodePage()
+  if (cp === "utf-8") return buf.toString("utf8")
+  return new TextDecoder(cp).decode(buf)
+}
 
 const compactOutput = (stdout: string, stderr: string) => {
   const output = stdout && stderr ? `${stdout}\n\nstderr:\n${stderr}` : stderr ? `stderr:\n${stderr}` : stdout
@@ -186,7 +219,7 @@ export const layer = Layer.effectDiscard(
                 }
               }
 
-              const compact = compactOutput(result.stdout.toString("utf8"), result.stderr.toString("utf8"))
+              const compact = compactOutput(decodeOutput(result.stdout), decodeOutput(result.stderr))
               const notice = captureNotice(result.stdoutTruncated, result.stderrTruncated)
               return {
                 command: input.command,


### PR DESCRIPTION
### Issue for this PR

Closes #31775

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows non-UTF-8 systems (e.g. Chinese GBK, Japanese Shift-JIS, Korean EUC-KR), bash tool output is hardcoded to `toString("utf8")` at `packages/core/src/tool/bash.ts:189`, which produces garbled text.

This PR replaces hardcoded UTF-8 decoding with lazy code page detection:

- **Lazy detection**: `chcp.com` runs on first bash tool call, not at module load, avoiding startup delay
- **30s TTL cache**: code page is re-detected periodically, so runtime changes (e.g. `chcp 65001`) are picked up within a reasonable window
- **`decodeOutput()` helper**: uses native `TextDecoder` for non-UTF-8 code pages (GBK, Shift-JIS, EUC-KR, Big5)
- **No new dependencies**: uses Node.js built-in `TextDecoder` and `execSync`
- **Non-Windows unaffected**: returns direct `buf.toString("utf8")` on POSIX

### How did you verify your code works?

- Tested on Windows 11 (GBK): bash tool output correctly decodes Chinese characters
- Tested on Windows (UTF-8 code page 65001): behavior identical to current `toString("utf8")`
- Tested on Windows (Shift-JIS 932, EUC-KR 949, Big5 950): correct decoding
- Verified macOS/Linux: unchanged path, `decodeOutput` returns `buf.toString("utf8")` directly
- No startup delay regression from `execSync` (lazy init)
- Running `chcp 65001` in terminal + next bash tool call picks up new code page within 30s

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR