### PR TITLE
fix(shell): add PowerShell UTF-8 command wrapper on Windows

### DIFF
--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -8,6 +8,7 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { Flag } from "./flag/flag"
 import { FSUtil } from "./fs-util"
 import { which } from "./util/which"
+import { PowerShell } from "./shell/powershell"
 
 const SIGKILL_TIMEOUT_MS = 200
 const META: Record<string, { deny?: boolean; login?: boolean; posix?: boolean; ps?: boolean }> = {
@@ -195,7 +196,7 @@ export function args(file: string, command: string, cwd: string) {
     ]
   }
   if (n === "cmd") return ["/c", command]
-  if (ps(file)) return ["-NoProfile", "-Command", command]
+  if (ps(file)) return PowerShell.args(command)
   return ["-c", command]
 }
 

--- a/packages/core/src/shell/powershell.ts
+++ b/packages/core/src/shell/powershell.ts
@@ -1,0 +1,15 @@
+export * as PowerShell from "./powershell"
+
+export function args(command: string) {
+  return ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", wrapped(command)]
+}
+
+function wrapped(command: string) {
+  const payload = Buffer.from(command, "utf8").toString("base64")
+  return `
+[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false);
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false);
+$OutputEncoding = [Console]::OutputEncoding;
+& ([scriptblock]::Create([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${payload}'))))
+`
+}

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -11,6 +11,7 @@ import { LocationMutation } from "../location-mutation"
 import { AppProcess } from "../process"
 import { PermissionV2 } from "../permission"
 import { PositiveInt } from "../schema"
+import { PowerShell } from "../shell/powershell"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -47,6 +48,31 @@ const Output = Schema.Struct({
 type Output = typeof Output.Type
 
 const defaultShell = () => (process.platform === "win32" ? (process.env.COMSPEC ?? "cmd.exe") : "/bin/sh")
+const POWERSHELL_SHELLS = new Set(["powershell", "powershell.exe", "pwsh", "pwsh.exe"])
+
+const isPowerShell = (shell: string) => {
+  const name = path.basename(shell.trim().replace(/^["']|["']$/g, "")).toLowerCase()
+  return POWERSHELL_SHELLS.has(name)
+}
+
+function makeShellCommand(command: string, shell: string, cwd: string) {
+  if (process.platform === "win32" && isPowerShell(shell)) {
+    return ChildProcess.make(shell, PowerShell.args(command), {
+      cwd,
+      stdin: "ignore",
+      detached: false,
+      forceKillAfter: Duration.seconds(3),
+    })
+  }
+
+  return ChildProcess.make(command, [], {
+    cwd,
+    shell,
+    stdin: "ignore",
+    detached: process.platform !== "win32",
+    forceKillAfter: Duration.seconds(3),
+  })
+}
 
 const modelOutput = (output: Output) => {
   const warnings = output.warnings?.length
@@ -155,13 +181,7 @@ const layer = Layer.effectDiscard(
               const shell =
                 Object.assign({}, ...entries.flatMap((entry) => (entry.type === "document" ? [entry.info] : [])))
                   .shell ?? defaultShell()
-              const command = ChildProcess.make(input.command, [], {
-                cwd: target.canonical,
-                shell,
-                stdin: "ignore",
-                detached: process.platform !== "win32",
-                forceKillAfter: Duration.seconds(3),
-              })
+              const command = makeShellCommand(input.command, shell, target.canonical)
               const timeout = input.timeout ?? DEFAULT_TIMEOUT_MS
               const result = yield* appProcess
                 .run(command, {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -292,7 +292,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
 
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && Shell.ps(shell)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+    return ChildProcess.make(shell, Shell.args(shell, command, cwd), {
       cwd,
       env,
       stdin: "ignore",


### PR DESCRIPTION
### Issue for this PR

Closes #23636
Closes #31187
Closes #30205
Closes #31830
Closes #26882

Supersedes #31925 (which was closed before the third code path was added)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, opencode captures shell output as bytes and decodes it as UTF-8. PowerShell, however, can write stdout/stderr using the active console code page when `[Console]::OutputEncoding` is not set explicitly. On non-UTF-8 systems, such as GBK/CP936 or Shift-JIS/CP932 environments, this can cause PowerShell output to be decoded incorrectly by opencode.

This PR adds a shared PowerShell command wrapper that:

- Sets `[Console]::InputEncoding` to UTF-8
- Sets `[Console]::OutputEncoding` to UTF-8
- Sets `` to the same UTF-8 encoding
- Runs the original user command as a separate scriptblock

The user command is stored inside the wrapper as an inner UTF-8 Base64 payload, then decoded and passed to `[scriptblock]::Create()`. The Base64 payload is used to avoid quoting and escaping issues when embedding arbitrary user command text inside the wrapper. The separate scriptblock invocation avoids prepending the UTF-8 setup directly to the user script, preserving script-level constructs such as leading `param(...)` blocks and `#requires` directives.

**Files changed (all three PowerShell execution paths):**

| File | Change |
|------|--------|
| `packages/core/src/shell/powershell.ts` | Add shared PowerShell argument/wrapper construction |
| `packages/core/src/tool/bash.ts` | Detect PowerShell on Windows and invoke it through the shared wrapper |
| `packages/core/src/shell.ts` | Use the shared PowerShell wrapper from `Shell.args(...)` |
| `packages/opencode/src/tool/shell.ts` | Delegate PowerShell invocation to `Shell.args(...)` instead of hardcoding argv |

### How did you verify your code works?

- Applied the patch locally and verified that `Write-Output "测试中文输出"` renders correctly in opencode shell output on Windows with a non-UTF-8 code page
- Verified the same commands work with both `powershell` 5.1 and `pwsh` 7+
- Tested TUI `!` shell mode (`! echo 你好世界`) — Chinese output displays correctly
- TypeScript typecheck passes (`tsgo --noEmit` on all 23 packages)

### Screenshots / recordings

N/A — this is a shell encoding fix, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR