### PR TITLE
fix(opencode): skip invalid agent config files instead of crashing startup

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -1,12 +1,11 @@
 export * as ConfigAgent from "./agent"
 
 import path from "path"
-import { Exit, Schema } from "effect"
+import { Cause, Exit, Schema } from "effect"
 import { Glob } from "@opencode-ai/core/util/glob"
 import { ConfigAgentV1 } from "@opencode-ai/core/v1/config/agent"
 import { configEntryNameFromPath } from "./entry-name"
 import * as ConfigMarkdown from "./markdown"
-import { ConfigParse } from "./parse"
 
 export async function load(dir: string) {
   const result: Record<string, ConfigAgentV1.Info> = {}
@@ -26,7 +25,12 @@ export async function load(dir: string) {
       ...md.data,
       prompt: md.content.trim(),
     }
-    result[config.name] = ConfigParse.schema(ConfigAgentV1.Info, config, item)
+    const parsed = Schema.decodeUnknownExit(ConfigAgentV1.Info)(config, { errors: "all", propertyOrder: "original" })
+    if (Exit.isSuccess(parsed)) {
+      result[config.name] = parsed.value
+      continue
+    }
+    console.warn(`Skipping invalid agent config ${item}: ${Cause.pretty(parsed.cause)}`)
   }
   return result
 }
@@ -53,7 +57,9 @@ export async function loadMode(dir: string) {
         ...parsed.value,
         mode: "primary" as const,
       }
+      continue
     }
+    console.warn(`Skipping invalid mode config ${item}: ${Cause.pretty(parsed.cause)}`)
   }
   return result
 }

--- a/packages/opencode/test/config/agent.test.ts
+++ b/packages/opencode/test/config/agent.test.ts
@@ -1,0 +1,48 @@
+import { expect, test, describe, beforeAll, afterAll } from "bun:test"
+import * as fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { ConfigAgent } from "@/config/agent"
+
+const frontmatter = (lines: string[]) => ["---", ...lines, "---", "prompt body"].join("\n")
+
+describe("ConfigAgent: invalid files are skipped, not fatal", () => {
+  let dir: string
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-agent-config-"))
+    await fs.mkdir(path.join(dir, "agents"), { recursive: true })
+    await fs.mkdir(path.join(dir, "modes"), { recursive: true })
+
+    await fs.writeFile(path.join(dir, "agents", "valid.md"), frontmatter(["name: valid", "temperature: 0.5"]))
+    // Cursor-format agent: `tools` is a YAML array, not an object (#31481)
+    await fs.writeFile(
+      path.join(dir, "agents", "cursor.md"),
+      frontmatter(["name: cursor", "tools: [execute/runNotebookCell, read_file]"]),
+    )
+
+    await fs.writeFile(path.join(dir, "modes", "valid.md"), frontmatter(["name: validmode", "temperature: 0.3"]))
+    // invalid mode: wrong type for temperature (#27133)
+    await fs.writeFile(path.join(dir, "modes", "bad.md"), frontmatter(["name: badmode", "temperature: nope"]))
+  })
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  test("load() does not throw when an agent file is invalid", async () => {
+    expect(ConfigAgent.load(dir)).resolves.toBeDefined()
+  })
+
+  test("load() keeps valid agents and skips the invalid Cursor-format one", async () => {
+    const agents = await ConfigAgent.load(dir)
+    expect(Object.keys(agents)).toContain("valid")
+    expect(Object.keys(agents)).not.toContain("cursor")
+  })
+
+  test("loadMode() keeps valid modes and skips the invalid one", async () => {
+    const modes = await ConfigAgent.loadMode(dir)
+    expect(Object.keys(modes)).toContain("validmode")
+    expect(Object.keys(modes)).not.toContain("badmode")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31481
Closes #27133

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Skips an invalid agent or mode config file instead of crashing startup or dropping it without an explanation.

Before this change, `load()` validated each agent file with `ConfigParse.schema()`, which throws whenever a file does not match the schema. A single malformed file, such as a Cursor-format agent where `tools` is a YAML array instead of an object, would throw partway through the loop, so none of the agents loaded and startup failed with "4 of 5 requests failed". The `loadMode()` function right next to it already skipped invalid files, but it did so silently, so a broken mode would just disappear with no explanation (#27133).

This switches both functions to decode with `Schema.decodeUnknownExit` and skip an invalid file with a warning that names it, instead of throwing or dropping it silently. Valid agents and modes still load normally. I left `ConfigParse.schema()` itself unchanged, since throwing is the right behavior for a single config file like `opencode.json`.

### How did you verify your code works?

- `bun typecheck` (clean)
- `oxlint` (0 warnings, 0 errors)
- `git diff --check` (clean)
- `bun test test/config test/agent` (233 pass, 3 skip, 0 fail)
- added `test/config/agent.test.ts` with a valid + invalid file; it throws on the current code and passes after the fix

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
