### PR TITLE
fix(opencode): gate empty MCP resource discovery loops

### DIFF
--- a/packages/opencode/src/cli/cmd/run/permission.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/permission.shared.ts
@@ -109,6 +109,21 @@ export function permissionInfo(request: PermissionRequest): PermissionInfo {
   }
 
   if (request.permission === "doom_loop") {
+    const meta = dict(request.metadata)
+    if (meta.outcome === "empty_mcp_resource_discovery") {
+      const tool = text(meta.tool) || pats[0]
+      const count = typeof meta.count === "number" ? meta.count : undefined
+      return {
+        icon: "⟳",
+        title: "Continue after empty MCP resource searches",
+        lines: [
+          ...(tool ? [`Tool: ${tool}`] : []),
+          ...(count ? [`Empty results: ${count}`] : []),
+          "Continuing may waste time or tokens without finding new resources.",
+        ],
+      }
+    }
+
     return {
       icon: "⟳",
       title: "Continue after repeated failures",

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -83,11 +83,67 @@ interface ProcessorContext extends Input {
   currentTextID: string | undefined
   reasoningMap: Record<string, SessionV1.ReasoningPart>
   v2AssistantMessageID: SessionMessage.ID | undefined
+  noProgress: { key: string; count: number } | undefined
 }
 
 type StreamEvent = LLMEvent
+type ToolResultEvent = Extract<StreamEvent, { type: "tool-result" }>
+type ToolResultOutput = {
+  title: string
+  metadata: Record<string, unknown>
+  output: string
+  attachments?: SessionV1.FilePart[]
+}
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionProcessor") {}
+
+function isMcpResourceDiscoveryTool(name: string) {
+  const normalized = name.toLowerCase()
+  return (
+    normalized.includes("mcp") &&
+    normalized.includes("resource") &&
+    (normalized.includes("list") || normalized.includes("search"))
+  )
+}
+
+function isEmptyDiscoveryResult(value: unknown, output: string) {
+  if (Array.isArray(value)) return value.length === 0
+  if (isRecord(value)) {
+    const discoveryEntries = Object.entries(value).filter(
+      ([key, item]) =>
+        /^(content|items|matches|resources|results|tools)$/i.test(key) && Array.isArray(item),
+    )
+    if (discoveryEntries.length) {
+      if (hasDiscoveryCursor(value)) return false
+      if (hasDiscoverySideData(value)) return false
+      return discoveryEntries.every(([, item]) => Array.isArray(item) && item.length === 0)
+    }
+  }
+
+  const trimmed = output.trim().toLowerCase()
+  return (
+    trimmed === "" ||
+    trimmed === "[]" ||
+    trimmed === "{}" ||
+    /^no (matching )?(mcp )?resources? found[.!]?$/.test(trimmed)
+  )
+}
+
+function hasDiscoveryCursor(value: Record<string, unknown>) {
+  return typeof value.nextCursor === "string" && value.nextCursor.length > 0
+}
+
+function hasDiscoverySideData(value: Record<string, unknown>) {
+  return Object.entries(value).some(([key, item]) => {
+    if (/^(content|items|matches|resources|results|tools)$/i.test(key)) return Array.isArray(item) && item.length > 0
+    if (/^(cursor|filter|limit|nextCursor|offset|page|prefix|query|search|total|count)$/i.test(key)) return false
+    if (Array.isArray(item)) return item.length > 0
+    if (isRecord(item)) return Object.keys(item).length > 0
+    if (typeof item !== "string") return false
+    if (!/^(hint|message|note|reason|suggestion|suggestions)$/i.test(key)) return false
+    return !/^no (matching )?(mcp )?resources? found[.!]?$/.test(item.trim().toLowerCase())
+  })
+}
 
 export const layer = Layer.effect(
   Service,
@@ -125,6 +181,7 @@ export const layer = Layer.effect(
         currentTextID: undefined,
         reasoningMap: {},
         v2AssistantMessageID: undefined,
+        noProgress: undefined,
       }
       const mirrorAssistant = flags.experimentalEventSystem && !input.assistantMessage.summary
       let aborted = false
@@ -347,9 +404,7 @@ export const layer = Layer.effect(
 
       const isFilePart = (value: unknown): value is SessionV1.FilePart => Schema.is(SessionV1.FilePart)(value)
 
-      const toolResultOutput = (
-        value: Extract<StreamEvent, { type: "tool-result" }>,
-      ): { title: string; metadata: Record<string, any>; output: string; attachments?: SessionV1.FilePart[] } => {
+      const toolResultOutput = (value: ToolResultEvent): ToolResultOutput => {
         if (isRecord(value.result.value) && typeof value.result.value.output === "string") {
           return {
             title: typeof value.result.value.title === "string" ? value.result.value.title : value.name,
@@ -367,6 +422,45 @@ export const layer = Layer.effect(
             typeof value.result.value === "string" ? value.result.value : (JSON.stringify(value.result.value) ?? ""),
         }
       }
+
+      const noProgressKey = (value: ToolResultEvent, output: ToolResultOutput) => {
+        if (!isMcpResourceDiscoveryTool(value.name)) return
+        if (output.attachments?.length) return
+        if (hasDiscoveryCursor(output.metadata) || hasDiscoverySideData(output.metadata)) return
+        if (!isEmptyDiscoveryResult(value.result.value, output.output)) return
+        return `${value.name}:empty`
+      }
+
+      const checkNoProgress = Effect.fn("SessionProcessor.checkNoProgress")(function* (
+        value: ToolResultEvent,
+        output: ToolResultOutput,
+      ) {
+        const key = noProgressKey(value, output)
+        if (!key) {
+          ctx.noProgress = undefined
+          return
+        }
+
+        ctx.noProgress = {
+          key,
+          count: ctx.noProgress?.key === key ? ctx.noProgress.count + 1 : 1,
+        }
+        if (ctx.noProgress.count < DOOM_LOOP_THRESHOLD) return
+
+        const agent = yield* agents.get(ctx.assistantMessage.agent)
+        yield* permission.ask({
+          permission: "doom_loop",
+          patterns: [value.name],
+          sessionID: ctx.assistantMessage.sessionID,
+          metadata: {
+            tool: value.name,
+            outcome: "empty_mcp_resource_discovery",
+            count: ctx.noProgress.count,
+          },
+          always: [value.name],
+          ruleset: agent.permission,
+        })
+      })
 
       const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
         switch (value.type) {
@@ -643,6 +737,7 @@ export const layer = Layer.effect(
                 })
             }
             yield* completeToolCall(value.id, output)
+            yield* checkNoProgress(value, output)
             return
           }
 

--- a/packages/opencode/test/cli/run/permission.shared.test.ts
+++ b/packages/opencode/test/cli/run/permission.shared.test.ts
@@ -122,6 +122,28 @@ describe("run permission shared", () => {
 
     expect(permissionInfo(req({ permission: "doom_loop" }))).toMatchObject({
       title: "Continue after repeated failures",
+      lines: ["This keeps the session running despite repeated failures."],
+    })
+
+    expect(
+      permissionInfo(
+        req({
+          permission: "doom_loop",
+          patterns: ["gumps_mcp_resource_list"],
+          metadata: {
+            tool: "gumps_mcp_resource_list",
+            outcome: "empty_mcp_resource_discovery",
+            count: 3,
+          },
+        }),
+      ),
+    ).toMatchObject({
+      title: "Continue after empty MCP resource searches",
+      lines: [
+        "Tool: gumps_mcp_resource_list",
+        "Empty results: 3",
+        "Continuing may waste time or tokens without finding new resources.",
+      ],
     })
 
     expect(permissionInfo(req({ permission: "custom_tool" }))).toMatchObject({

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -70,6 +70,8 @@ const cfg = {
     },
   },
 }
+const denyDoomLoopCfg = { ...cfg, permission: { doom_loop: "deny" as const } }
+const allowDoomLoopCfg = { ...cfg, permission: { doom_loop: "allow" as const } }
 
 function providerCfg(url: string) {
   return {
@@ -209,6 +211,102 @@ const providerErrorEnv = LayerNode.buildLayer(root, {
 })
 const itProviderError = testEffect(providerErrorEnv)
 
+function providerToolEvents(name: string, results: unknown[]) {
+  return results.flatMap((value, index) => [
+    LLMEvent.toolInputStart({ id: `call-${index}`, name }),
+    LLMEvent.toolInputEnd({ id: `call-${index}`, name }),
+    LLMEvent.toolCall({
+      id: `call-${index}`,
+      name,
+      input: { filter: `m365-inbox-${index}` },
+      providerExecuted: true,
+    }),
+    LLMEvent.toolResult({
+      id: `call-${index}`,
+      name,
+      result: { type: "json" as const, value },
+      providerExecuted: true,
+    }),
+  ])
+}
+
+function mcpResourceListEvents(results: unknown[][]) {
+  return providerToolEvents(
+    "gumps_mcp_resource_list",
+    results.map((resources) => ({ resources })),
+  )
+}
+
+function toolStreamTest(events: LLMEvent[]) {
+  const llm = Layer.succeed(
+    LLM.Service,
+    LLM.Service.of({
+      stream: () =>
+        Stream.make(
+          LLMEvent.stepStart({ index: 0 }),
+          ...events,
+          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+          LLMEvent.finish({ reason: "tool-calls" }),
+        ),
+    }),
+  )
+  return testEffect(
+    LayerNode.buildLayer(root, {
+      replacements: [...replacements, LayerNode.replace(LLM.node, llm)],
+    }),
+  )
+}
+
+const itRepeatedEmptyMcpList = toolStreamTest(mcpResourceListEvents([[], [], [], [], [], []]))
+
+const itProgressingMcpList = toolStreamTest(mcpResourceListEvents([[], [], [{ uri: "mcp://mail/inbox" }], [], []]))
+
+const itEmptyNonMcpSearch = toolStreamTest(
+  providerToolEvents(
+    "repo_search",
+    Array.from({ length: 6 }, () => ({ results: [] })),
+  ),
+)
+
+const itEmptyMcpToolList = toolStreamTest(
+  providerToolEvents(
+    "gumps_mcp_tool_list",
+    Array.from({ length: 6 }, () => ({ tools: [] })),
+  ),
+)
+
+const itPaginatedEmptyMcpResourceList = toolStreamTest(
+  providerToolEvents(
+    "gumps_mcp_resource_list",
+    Array.from({ length: 6 }, (_, index) =>
+      index % 2 === 0
+        ? { resources: [], nextCursor: `page-${index + 1}` }
+        : { title: "Resources", output: "[]", metadata: { nextCursor: `page-${index + 1}` } },
+    ),
+  ),
+)
+
+const itSuggestingEmptyMcpResourceList = toolStreamTest(
+  providerToolEvents(
+    "gumps_mcp_resource_list",
+    Array.from({ length: 6 }, (_, index) => ({
+      resources: [],
+      suggestions: [`mcp://mail/candidate-${index}`],
+    })),
+  ),
+)
+
+const itEchoingEmptyMcpResourceList = toolStreamTest(
+  providerToolEvents(
+    "gumps_mcp_resource_list",
+    Array.from({ length: 6 }, (_, index) => ({
+      resources: [],
+      query: `m365-inbox-${index}`,
+      total: 0,
+    })),
+  ),
+)
+
 const fragmentFailureLLM = Layer.succeed(
   LLM.Service,
   LLM.Service.of({
@@ -235,9 +333,163 @@ const boot = Effect.fn("test.boot")(function* () {
   return { processors, session, provider }
 })
 
+const processSyntheticToolStream = Effect.fn("test.processSyntheticToolStream")(function* (dir: string) {
+  const { processors, session, provider } = yield* boot()
+
+  const chat = yield* session.create({})
+  const parent = yield* user(chat.id, "find m365-inbox")
+  const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+  const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+  const handle = yield* processors.create({
+    assistantMessage: msg,
+    sessionID: chat.id,
+    model: mdl,
+  })
+
+  const input = {
+    user: {
+      id: parent.id,
+      sessionID: chat.id,
+      role: "user",
+      time: parent.time,
+      agent: parent.agent,
+      model: { providerID: ref.providerID, modelID: ref.modelID },
+    } satisfies SessionV1.User,
+    sessionID: chat.id,
+    model: mdl,
+    agent: agent(),
+    system: [],
+    messages: [{ role: "user", content: "find m365-inbox" }],
+    tools: {},
+  } satisfies LLM.StreamInput
+
+  const value = yield* handle.process(input)
+
+  const calls = (yield* MessageV2.parts(msg.id)).filter((part): part is SessionV1.ToolPart => part.type === "tool")
+  return { value, calls, handle }
+})
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+itRepeatedEmptyMcpList.live("session.processor gates repeated empty MCP resource searches through doom_loop", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("stop")
+        expect(result.calls).toHaveLength(3)
+        expect(result.calls.every((call) => call.state.status === "completed")).toBe(true)
+        expect(JSON.stringify(result.handle.message.error)).toContain("prevents you from using this specific tool call")
+      }),
+    { config: denyDoomLoopCfg },
+  ),
+)
+
+itRepeatedEmptyMcpList.live("session.processor continues repeated empty MCP resource searches when doom_loop allows", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("continue")
+        expect(result.calls).toHaveLength(6)
+        expect(result.handle.message.error).toBeUndefined()
+      }),
+    { config: allowDoomLoopCfg },
+  ),
+)
+
+itProgressingMcpList.live("session.processor keeps MCP resource searches that produce progress", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("continue")
+        expect(result.calls).toHaveLength(5)
+        expect(result.handle.message.error).toBeUndefined()
+      }),
+    { config: cfg },
+  ),
+)
+
+itEmptyNonMcpSearch.live("session.processor does not stop repeated empty non-MCP searches", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("continue")
+        expect(result.calls).toHaveLength(6)
+        expect(result.calls.every((call) => call.tool === "repo_search")).toBe(true)
+        expect(result.handle.message.error).toBeUndefined()
+      }),
+    { config: cfg },
+  ),
+)
+
+itEmptyMcpToolList.live("session.processor does not stop repeated empty MCP tool-list searches", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("continue")
+        expect(result.calls).toHaveLength(6)
+        expect(result.calls.every((call) => call.tool === "gumps_mcp_tool_list")).toBe(true)
+        expect(result.handle.message.error).toBeUndefined()
+      }),
+    { config: cfg },
+  ),
+)
+
+itPaginatedEmptyMcpResourceList.live("session.processor does not stop MCP resource pagination that advances", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("continue")
+        expect(result.calls).toHaveLength(6)
+        expect(result.calls.every((call) => call.tool === "gumps_mcp_resource_list")).toBe(true)
+        expect(result.handle.message.error).toBeUndefined()
+      }),
+    { config: cfg },
+  ),
+)
+
+itSuggestingEmptyMcpResourceList.live("session.processor does not stop empty MCP resource searches with suggestions", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("continue")
+        expect(result.calls).toHaveLength(6)
+        expect(result.calls.every((call) => call.tool === "gumps_mcp_resource_list")).toBe(true)
+        expect(result.handle.message.error).toBeUndefined()
+      }),
+    { config: cfg },
+  ),
+)
+
+itEchoingEmptyMcpResourceList.live("session.processor gates empty MCP resource searches with only echoed queries", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const result = yield* processSyntheticToolStream(dir)
+
+        expect(result.value).toBe("stop")
+        expect(result.calls).toHaveLength(3)
+        expect(result.calls.every((call) => call.tool === "gumps_mcp_resource_list")).toBe(true)
+        expect(JSON.stringify(result.handle.message.error)).toContain("prevents you from using this specific tool call")
+      }),
+    { config: denyDoomLoopCfg },
+  ),
+)
 
 it.live("session.processor effect tests capture llm input cleanly", () =>
   provideTmpdirServer(


### PR DESCRIPTION
### Issue for this PR

Fixes #31942

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Detects repeated empty MCP resource discovery results and routes them through the existing `doom_loop` permission gate. The prompt explains that continuing may waste time or tokens without finding new resources.

The detector is intentionally conservative: it only applies to tool names that look like MCP resource list/search tools, and treats resources, pagination cursors, attachments, suggestions, and other discovery side data as progress.

### How did you verify your code works?

From `packages/opencode`:

- `bun test --timeout 30000 test/session/processor-effect.test.ts test/cli/run/permission.shared.test.ts`
- `bun typecheck`

The pre-push hook also ran `bun turbo typecheck` successfully.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
