### PR TITLE
feat(app): add session-wide review changes

### DIFF
--- a/packages/app/src/pages/session-review-mode.test.ts
+++ b/packages/app/src/pages/session-review-mode.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import {
+  changeModeTitleKey,
+  createChangeModeOptions,
+  defaultChangeMode,
+  reviewDiffsForMode,
+  reviewReadyForMode,
+} from "./session-review-mode"
+
+const sessionDiff = { file: "session.ts", additions: 1, deletions: 0, status: "modified" as const }
+const turnDiff = { file: "turn.ts", additions: 2, deletions: 1, status: "modified" as const }
+const gitDiff = { file: "git.ts", additions: 3, deletions: 0, status: "added" as const }
+
+describe("session review mode", () => {
+  test("defaults review to current session changes", () => {
+    expect(defaultChangeMode).toBe("session")
+  })
+
+  test("lists session changes before git, branch, and turn modes", () => {
+    expect(
+      createChangeModeOptions({
+        vcs: "git",
+        branch: "feature",
+        defaultBranch: "main",
+      }),
+    ).toEqual(["session", "git", "branch", "turn"])
+  })
+
+  test("uses session diffs for the session review mode", () => {
+    expect(
+      reviewDiffsForMode({
+        mode: "session",
+        sessionDiffs: [sessionDiff],
+        turnDiffs: [turnDiff],
+        vcsDiffs: [gitDiff],
+        vcsFetched: true,
+      }),
+    ).toEqual([sessionDiff])
+  })
+
+  test("uses fetched vcs diffs for git and branch modes", () => {
+    expect(
+      reviewDiffsForMode({
+        mode: "git",
+        sessionDiffs: [sessionDiff],
+        turnDiffs: [turnDiff],
+        vcsDiffs: [gitDiff],
+        vcsFetched: true,
+      }),
+    ).toEqual([gitDiff])
+    expect(
+      reviewDiffsForMode({
+        mode: "branch",
+        sessionDiffs: [sessionDiff],
+        turnDiffs: [turnDiff],
+        vcsDiffs: [gitDiff],
+        vcsFetched: false,
+      }),
+    ).toEqual([])
+  })
+
+  test("uses turn diffs for last turn mode", () => {
+    expect(
+      reviewDiffsForMode({
+        mode: "turn",
+        sessionDiffs: [sessionDiff],
+        turnDiffs: [turnDiff],
+        vcsDiffs: [gitDiff],
+        vcsFetched: true,
+      }),
+    ).toEqual([turnDiff])
+  })
+
+  test("waits for session diff loading before reporting review ready", () => {
+    expect(reviewReadyForMode({ mode: "session", sessionDiffsLoaded: false, vcsPending: false })).toBe(false)
+    expect(reviewReadyForMode({ mode: "session", sessionDiffsLoaded: true, vcsPending: false })).toBe(true)
+  })
+
+  test("waits for vcs loading only for git and branch modes", () => {
+    expect(reviewReadyForMode({ mode: "git", sessionDiffsLoaded: false, vcsPending: true })).toBe(false)
+    expect(reviewReadyForMode({ mode: "branch", sessionDiffsLoaded: false, vcsPending: false })).toBe(true)
+    expect(reviewReadyForMode({ mode: "turn", sessionDiffsLoaded: false, vcsPending: true })).toBe(true)
+  })
+
+  test("maps session mode to a dedicated title key", () => {
+    expect(changeModeTitleKey("session")).toBe("ui.sessionReview.title.session")
+  })
+})

--- a/packages/app/src/pages/session-review-mode.ts
+++ b/packages/app/src/pages/session-review-mode.ts
@@ -1,0 +1,41 @@
+import type { SnapshotFileDiff } from "@opencode-ai/sdk/v2"
+
+export type ChangeMode = "session" | "git" | "branch" | "turn"
+export type VcsMode = "git" | "branch"
+
+export const defaultChangeMode = "session" satisfies ChangeMode
+
+export function createChangeModeOptions(input: { vcs?: string; branch?: string; defaultBranch?: string }) {
+  const list: ChangeMode[] = ["session"]
+  if (input.vcs === "git") list.push("git")
+  if (input.vcs === "git" && input.branch && input.defaultBranch && input.branch !== input.defaultBranch) {
+    list.push("branch")
+  }
+  list.push("turn")
+  return list
+}
+
+export function changeModeTitleKey(mode: ChangeMode) {
+  if (mode === "session") return "ui.sessionReview.title.session"
+  if (mode === "git") return "ui.sessionReview.title.git"
+  if (mode === "branch") return "ui.sessionReview.title.branch"
+  return "ui.sessionReview.title.lastTurn"
+}
+
+export function reviewDiffsForMode(input: {
+  mode: ChangeMode
+  sessionDiffs: SnapshotFileDiff[]
+  turnDiffs: SnapshotFileDiff[]
+  vcsDiffs: SnapshotFileDiff[]
+  vcsFetched: boolean
+}) {
+  if (input.mode === "session") return input.sessionDiffs
+  if (input.mode === "git" || input.mode === "branch") return input.vcsFetched ? input.vcsDiffs : []
+  return input.turnDiffs
+}
+
+export function reviewReadyForMode(input: { mode: ChangeMode; sessionDiffsLoaded: boolean; vcsPending: boolean }) {
+  if (input.mode === "session") return input.sessionDiffsLoaded
+  if (input.mode === "git" || input.mode === "branch") return !input.vcsPending
+  return true
+}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -70,14 +70,20 @@ import { extractPromptFromParts } from "@/utils/prompt"
 import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
 import { useUsageExceededDialogs } from "./session/usage-exceeded-dialogs"
+import {
+  changeModeTitleKey,
+  createChangeModeOptions,
+  defaultChangeMode,
+  reviewDiffsForMode,
+  reviewReadyForMode,
+  type ChangeMode,
+  type VcsMode,
+} from "./session-review-mode"
 
 const emptyUserMessages: UserMessage[] = []
 type FollowupItem = FollowupDraft & { id: string }
 type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
 const emptyFollowups: FollowupItem[] = []
-
-type ChangeMode = "git" | "branch" | "turn"
-type VcsMode = "git" | "branch"
 
 type SessionHistoryWindowInput = {
   sessionID: () => string | undefined
@@ -392,7 +398,7 @@ export default function Page() {
   const [store, setStore] = createStore({
     messageId: undefined as string | undefined,
     mobileTab: "session" as "session" | "changes",
-    changes: "git" as ChangeMode,
+    changes: defaultChangeMode,
     newSessionWorktree: "main",
     deferRender: false,
   })
@@ -446,20 +452,13 @@ export default function Page() {
 
   const turnDiffs = createMemo(() => list(lastUserMessage()?.summary?.diffs))
   const nogit = createMemo(() => !!sync.project && sync.project.vcs !== "git")
-  const changesOptions = createMemo<ChangeMode[]>(() => {
-    const list: ChangeMode[] = []
-    if (sync.project?.vcs === "git") list.push("git")
-    if (
-      sync.project?.vcs === "git" &&
-      sync.data.vcs?.branch &&
-      sync.data.vcs?.default_branch &&
-      sync.data.vcs.branch !== sync.data.vcs.default_branch
-    ) {
-      list.push("branch")
-    }
-    list.push("turn")
-    return list
-  })
+  const changesOptions = createMemo<ChangeMode[]>(() =>
+    createChangeModeOptions({
+      vcs: sync.project?.vcs,
+      branch: sync.data.vcs?.branch,
+      defaultBranch: sync.data.vcs?.default_branch,
+    }),
+  )
   const mobileChanges = createMemo(() => !isDesktop() && store.mobileTab === "changes")
   const wantsReview = createMemo(() =>
     isDesktop()
@@ -493,16 +492,23 @@ export default function Page() {
   })
   const refreshVcs = debounce(() => void queryClient.invalidateQueries({ queryKey: vcsKey() }), 100)
   const reviewDiffs = () => {
-    if (store.changes === "git" || store.changes === "branch")
+    return reviewDiffsForMode({
+      mode: store.changes,
+      sessionDiffs: diffs(),
+      turnDiffs: turnDiffs(),
       // avoids suspense
-      return vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
-    return turnDiffs()
+      vcsDiffs: vcsQuery.data ?? [],
+      vcsFetched: vcsQuery.isFetched,
+    })
   }
   const reviewCount = () => reviewDiffs().length
   const hasReview = () => reviewCount() > 0
   const reviewReady = () => {
-    if (store.changes === "git" || store.changes === "branch") return !vcsQuery.isPending
-    return true
+    return reviewReadyForMode({
+      mode: store.changes,
+      sessionDiffsLoaded: params.id ? sync.data.session_diff[params.id] !== undefined : true,
+      vcsPending: vcsQuery.isPending,
+    })
   }
 
   const newSessionWorktree = createMemo(() => {
@@ -717,7 +723,7 @@ export default function Page() {
       sessionKey,
       () => {
         setStore("messageId", undefined)
-        setStore("changes", "git")
+        setStore("changes", defaultChangeMode)
         setUi("pendingMessage", undefined)
       },
       { defer: true },
@@ -930,9 +936,7 @@ export default function Page() {
     }
 
     const label = (option: ChangeMode) => {
-      if (option === "git") return language.t("ui.sessionReview.title.git")
-      if (option === "branch") return language.t("ui.sessionReview.title.branch")
-      return language.t("ui.sessionReview.title.lastTurn")
+      return language.t(changeModeTitleKey(option))
     }
 
     return (
@@ -977,8 +981,11 @@ export default function Page() {
   })
 
   const reviewEmpty = (input: { loadingClass: string; emptyClass: string }) => {
+    if (store.changes !== "turn" && !reviewReady()) {
+      return <div class={input.loadingClass}>{language.t("session.review.loadingChanges")}</div>
+    }
+
     if (store.changes === "git" || store.changes === "branch") {
-      if (!reviewReady()) return <div class={input.loadingClass}>{language.t("session.review.loadingChanges")}</div>
       return empty(reviewEmptyText())
     }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -172,8 +172,9 @@ export const SessionApi = HttpApi.make("session")
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "session.diff",
-            summary: "Get message diff",
-            description: "Get the file changes (diff) that resulted from a specific user message in the session.",
+            summary: "Get session or message diff",
+            description:
+              "Get the file changes (diff) for the whole session, or for a specific user message when messageID is provided.",
           }),
         ),
         HttpApiEndpoint.get("messages", SessionPaths.messages, {

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -71,6 +71,9 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionSummary") {}
 
+const SESSION_DIFF_MAX_FILES = 500
+const SESSION_DIFF_MAX_PATCH_BYTES = 100_000
+
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -99,6 +102,45 @@ export const layer = Layer.effect(
       return []
     })
 
+    const computeSessionDiff = Effect.fn("SessionSummary.computeSessionDiff")(function* (input: {
+      messages: SessionV1.WithParts[]
+    }) {
+      let from: string | undefined
+      let to: string | undefined
+      for (const item of input.messages) {
+        if (!from) {
+          for (const part of item.parts) {
+            if (part.type === "step-start" && part.snapshot) {
+              from = part.snapshot
+              break
+            }
+          }
+        }
+        for (const part of item.parts) {
+          if (part.type === "step-finish" && part.snapshot) to = part.snapshot
+        }
+      }
+      if (!from || !to) return { available: false, diffs: [] as Snapshot.FileDiff[] }
+      return { available: true, diffs: yield* snapshot.diffFull(from, to) }
+    })
+
+    const normalizeDiffs = (items: Snapshot.FileDiff[]) =>
+      items.slice(0, SESSION_DIFF_MAX_FILES).map((item) => {
+        const normalized =
+          item.file === undefined
+            ? item
+            : (() => {
+                const file = unquoteGitPath(item.file)
+                if (file === item.file) return item
+                return { ...item, file }
+              })()
+        if (normalized.patch === undefined) return normalized
+        if (Buffer.byteLength(normalized.patch, "utf8") <= SESSION_DIFF_MAX_PATCH_BYTES) return normalized
+        const { patch, ...rest } = normalized
+        void patch
+        return rest
+      })
+
     const summarize = Effect.fn("SessionSummary.summarize")(function* (input: {
       sessionID: SessionID
       messageID: MessageID
@@ -111,7 +153,6 @@ export const layer = Layer.effect(
           files: 0,
         },
       })
-      yield* events.publish(Session.Event.Diff, { sessionID: input.sessionID, diff: [] })
       if ((yield* config.get()).snapshot === false) return
       const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
       if (!all.length) return
@@ -127,18 +168,21 @@ export const layer = Layer.effect(
     })
 
     const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {
-      if (!input.messageID) return []
-      const message = (yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
-        (item) => item.info.id === input.messageID,
-      )
+      const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
+      if (!input.messageID) {
+        const info = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
+        const visible = info.revert?.messageID ? all.filter((item) => item.info.id < info.revert!.messageID) : all
+        const computed = yield* computeSessionDiff({ messages: visible })
+        const diffs = computed.available
+          ? computed.diffs
+          : visible.flatMap((item) => (item.info.role === "user" ? (item.info.summary?.diffs ?? []) : []))
+        return normalizeDiffs(diffs)
+      }
+
+      const message = all.find((item) => item.info.id === input.messageID)
       if (!message || message.info.role !== "user") return []
       const diffs = message.info.summary?.diffs ?? []
-      return diffs.map((item) => {
-        if (item.file === undefined) return item
-        const file = unquoteGitPath(item.file)
-        if (file === item.file) return item
-        return { ...item, file }
-      })
+      return normalizeDiffs(diffs)
     })
 
     return Service.of({ summarize, diff, computeDiff })

--- a/packages/opencode/test/server/session-diff-missing-patch.test.ts
+++ b/packages/opencode/test/server/session-diff-missing-patch.test.ts
@@ -93,4 +93,83 @@ describe("session diff with missing patch (#26574)", () => {
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )
+
+  it.instance(
+    "GET /session/<id>/diff returns all session turn diffs when no messageID is provided",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const session = yield* withSession({ title: "session-diff" })
+        const firstMessageID = MessageID.ascending()
+        const secondMessageID = MessageID.ascending()
+
+        yield* Session.use.updateMessage({
+          id: firstMessageID,
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("model") },
+          summary: {
+            diffs: [{ file: "first.ts", additions: 1, deletions: 0, status: "added" }],
+          },
+        } satisfies SessionV1.User)
+
+        yield* Session.use.updateMessage({
+          id: secondMessageID,
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() + 1 },
+          agent: "build",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("model") },
+          summary: {
+            diffs: [{ file: "second.ts", additions: 2, deletions: 1, status: "modified" }],
+          },
+        } satisfies SessionV1.User)
+
+        const response = yield* requestInDirectory(
+          pathFor(SessionPaths.diff, { sessionID: session.id }),
+          test.directory,
+        )
+
+        expect(response.status).toBe(200)
+        expect(yield* response.json).toEqual([
+          { file: "first.ts", additions: 1, deletions: 0, status: "added" },
+          { file: "second.ts", additions: 2, deletions: 1, status: "modified" },
+        ])
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "GET /session/<id>/diff omits oversized session patches",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const session = yield* withSession({ title: "large-session-diff" })
+        const messageID = MessageID.ascending()
+        const patch = `@@ -1 +1 @@\n-${"x".repeat(120_000)}\n+small\n`
+
+        yield* Session.use.updateMessage({
+          id: messageID,
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("model") },
+          summary: {
+            diffs: [{ file: "large.ts", additions: 1, deletions: 1, status: "modified", patch }],
+          },
+        } satisfies SessionV1.User)
+
+        const response = yield* requestInDirectory(
+          pathFor(SessionPaths.diff, { sessionID: session.id }),
+          test.directory,
+        )
+
+        expect(response.status).toBe(200)
+        expect(yield* response.json).toEqual([{ file: "large.ts", additions: 1, deletions: 1, status: "modified" }])
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
 })

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -1,5 +1,6 @@
 export const dict: Record<string, string> = {
   "ui.sessionReview.title": "Session changes",
+  "ui.sessionReview.title.session": "Session changes",
   "ui.sessionReview.title.git": "Git changes",
   "ui.sessionReview.title.branch": "Branch changes",
   "ui.sessionReview.title.lastTurn": "Last turn changes",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -4,6 +4,9 @@ type Keys = keyof typeof en
 
 export const dict = {
   "ui.sessionReview.title": "会话变更",
+  "ui.sessionReview.title.session": "会话变更",
+  "ui.sessionReview.title.git": "Git 变更",
+  "ui.sessionReview.title.branch": "分支变更",
   "ui.sessionReview.title.lastTurn": "上一轮变更",
   "ui.sessionReview.diffStyle.unified": "统一",
   "ui.sessionReview.diffStyle.split": "拆分",


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a session-wide review mode to the session review selector and makes it the default review source.

Previously, the review panel could show Git changes, branch changes, or last-turn changes. This adds a session-level option so users can review file changes across the current session.

The backend session diff endpoint now supports session-wide diffs when `messageID` is omitted, while preserving the existing message-specific behavior when `messageID` is provided. Session diff responses are bounded to avoid returning oversized patches.

### How did you verify your code works?

- `bun test src/pages/session-review-mode.test.ts`
- `bun --config ..\..\bunfig.toml test test/server/session-diff-missing-patch.test.ts`
- `bun run typecheck` in `packages/opencode`
- `bun run typecheck` in `packages/ui`
- `OPENCODE_CHANNEL=prod bun run build` in `packages/desktop`
- `OPENCODE_CHANNEL=prod npx electron-builder --win --publish never --config electron-builder.config.ts`

### Screenshots / recordings

Not included yet.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR