### PR TITLE
fix(tui): fix right-click paste on windows

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1058,8 +1058,21 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       flexDirection="column"
       backgroundColor={theme.background}
       onMouseDown={(evt) => {
-        if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
         if (evt.button !== MouseButton.RIGHT) return
+
+        // On Windows, right-click is the native paste gesture for cmd.exe,
+        // powershell.exe and Windows Terminal. Enabling mouse tracking
+        // suppresses the terminal's built-in right-click paste (the click is
+        // delivered to us as a mouse event instead), so emulate it: copy the
+        // current selection if there is one, otherwise paste into the prompt.
+        if (process.platform === "win32") {
+          if (!Selection.copy(renderer, toast, clipboard)) keymap.dispatchCommand("prompt.paste")
+          evt.preventDefault()
+          evt.stopPropagation()
+          return
+        }
+
+        if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
 
         if (!Selection.copy(renderer, toast, clipboard)) return
         evt.preventDefault()

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -193,6 +193,17 @@ export function DialogProvider(props: ParentProps) {
     return true
   }
 
+  // Paste clipboard text into the focused dialog input. Used to emulate the
+  // native right-click paste gesture on Windows terminals, where enabling mouse
+  // tracking suppresses the terminal's built-in right-click paste.
+  function pasteIntoFocused() {
+    const focused = renderer.currentFocusedRenderable as { insertText?: (text: string) => void } | null
+    if (!focused?.insertText) return
+    void clipboard.read?.().then((content) => {
+      if (content?.mime === "text/plain") focused.insertText!(content.data)
+    })
+  }
+
   return (
     <ctx.Provider value={value}>
       {props.children}
@@ -200,8 +211,18 @@ export function DialogProvider(props: ParentProps) {
         position="absolute"
         zIndex={3000}
         onMouseDown={(evt: { button: number; preventDefault(): void; stopPropagation(): void }) => {
-          if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
           if (evt.button !== MouseButton.RIGHT) return
+
+          // On Windows, emulate the native right-click paste gesture: copy the
+          // current selection if there is one, otherwise paste into the input.
+          if (process.platform === "win32") {
+            if (!copySelection()) pasteIntoFocused()
+            evt.preventDefault()
+            evt.stopPropagation()
+            return
+          }
+
+          if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
 
           if (!copySelection()) return
           evt.preventDefault()


### PR DESCRIPTION
### Issue for this PR

Closes #10780

Also fixes possible duplicate issues related with copy-pasting on Windows using mouse right click behavior which should be working as like Claude Code, Codex, and Antigravity-cli

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes copy pasting behavior on windows using right click

### How did you verify your code works?

Manually verified on Windows Terminal using cmd.exe

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR
