### PR TITLE
fix(core): improve search fallbacks

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -232,6 +232,15 @@ export const fffLayer = Layer.effect(
   }),
 )
 
+const fffWithRipgrepFallbackLayer = fffLayer.pipe(
+  Layer.catchCause((cause) =>
+    Layer.merge(
+      Layer.effectDiscard(Effect.logWarning("FFF search initialization failed; falling back to ripgrep", { cause })),
+      ripgrepLayer,
+    ),
+  ),
+)
+
 export const defaultLayer = Layer.unwrap(
-  Effect.sync(() => (Flag.OPENCODE_DISABLE_FFF || !Fff.available() ? ripgrepLayer : fffLayer)),
+  Effect.sync(() => (Flag.OPENCODE_DISABLE_FFF || !Fff.available() ? ripgrepLayer : fffWithRipgrepFallbackLayer)),
 )

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -161,6 +161,7 @@ export const layer = Layer.effect(
           args: [
             "--no-config",
             "--files",
+            "--no-ignore-vcs",
             ...(input.hidden ? ["--hidden"] : []),
             ...(input.follow ? ["--follow"] : []),
             `--glob=${input.pattern}`,

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -30,6 +30,27 @@ describe("Ripgrep", () => {
     ),
   )
 
+  it.live("includes gitignored files in glob results", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, "node_modules", "pkg"), { recursive: true }))
+          yield* Effect.promise(() => Bun.$`git init -q ${tmp.path}`)
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, ".gitignore"), "node_modules/\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "node_modules", "pkg", "index.js"), "ignored\n"))
+
+          const files = yield* (yield* Ripgrep.Service).glob({
+            cwd: tmp.path,
+            pattern: "node_modules/pkg/index.js",
+            limit: 10,
+          })
+          expect(files.map((item) => item.path)).toContain(RelativePath.make("node_modules/pkg/index.js"))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("never includes git metadata", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
### Issue for this PR

Closes #31994
Closes #32034

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two search fallback cases:

- `glob` now passes `--no-ignore-vcs` to ripgrep so exact file globs can find gitignored files like `node_modules` or `dist`, while still excluding `.git` metadata.
- If FFF search initialization fails, the default search layer logs a warning and falls back to the existing ripgrep-backed search layer instead of failing search entirely.

### How did you verify your code works?

From `packages/core`:

```bash
bun test test/ripgrep.test.ts
bun typecheck
```

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
