### PR TITLE
fix(core): resolve npm provider entrypoints

### DIFF
--- a/packages/core/src/npm-entrypoint.ts
+++ b/packages/core/src/npm-entrypoint.ts
@@ -1,0 +1,148 @@
+export * as NpmEntrypoint from "./npm-entrypoint"
+
+import path from "path"
+import { existsSync, readFileSync } from "fs"
+import { createRequire } from "module"
+import { pathToFileURL } from "url"
+import { Option } from "effect"
+
+export interface EntryPoint {
+  readonly directory: string
+  readonly entrypoint: Option.Option<string>
+}
+
+// This resolver feeds dynamic import(), so "require" is intentionally not a supported condition.
+const supportedExportConditions = new Set([
+  ...(process.execArgv.includes("--no-addons") ? [] : ["node-addons"]),
+  "node",
+  "import",
+  ...(typeof Bun === "undefined" ? ["module-sync"] : ["bun"]),
+])
+
+export function resolve(name: string, dir: string): EntryPoint {
+  return {
+    directory: dir,
+    entrypoint: tryResolvePackageEntryPoint(name, dir),
+  }
+}
+
+export function resolveManual(name: string, dir: string): EntryPoint {
+  return {
+    directory: dir,
+    entrypoint: tryResolveManualPackageEntryPoint(name, dir),
+  }
+}
+
+function tryResolvePackageEntryPoint(name: string, dir: string) {
+  if (typeof Bun !== "undefined") {
+    try {
+      return Option.some(import.meta.resolve(name, dir))
+    } catch {}
+  }
+
+  return tryResolveManualPackageEntryPoint(name, dir)
+}
+
+function tryResolveManualPackageEntryPoint(name: string, dir: string) {
+  try {
+    return Option.some(resolvePackageEntryPoint(name, dir))
+  } catch {
+    return Option.none()
+  }
+}
+
+function resolvePackageEntryPoint(name: string, dir: string): string {
+  const pkg = JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8")) as {
+    exports?: unknown
+    main?: unknown
+    module?: unknown
+  }
+  const target =
+    pkg.exports === undefined
+      ? resolveLegacyEntryPoint(name, dir, pkg)
+      : resolvePackageExport(pkg.exports, dir)
+  if (!target) throw new Error(`Package ${name} has no import entrypoint`)
+  return pathToFileURL(target).href
+}
+
+function resolveLegacyEntryPoint(name: string, dir: string, pkg: { main?: unknown; module?: unknown }): string {
+  try {
+    return createRequire(path.join(dir, "package.json")).resolve(name)
+  } catch {}
+
+  return resolveFile(
+    dir,
+    typeof pkg.module === "string" ? pkg.module : typeof pkg.main === "string" ? pkg.main : "index.js",
+  )
+}
+
+function resolvePackageExport(input: unknown, dir: string): string | undefined {
+  if (typeof input === "string") return resolvePackageTarget(dir, input)
+  if (Array.isArray(input)) {
+    return firstResolved(input, (item) => resolvePackageExport(item, dir))
+  }
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined
+
+  const record = input as Record<string, unknown>
+  const keys = Object.keys(record)
+  const hasSubpath = keys.some((key) => key.startsWith("."))
+  const hasCondition = keys.some((key) => !key.startsWith("."))
+  if (hasSubpath && hasCondition) return undefined
+  if (hasSubpath) return "." in record ? resolvePackageExport(record["."], dir) : undefined
+  return resolveConditionalExport(record, dir)
+}
+
+function resolveConditionalExport(input: Record<string, unknown>, dir: string): string | undefined {
+  return firstResolved(Object.keys(input), (key) =>
+    key === "default" || supportedExportConditions.has(key) ? resolvePackageExport(input[key], dir) : undefined,
+  )
+}
+
+function firstResolved<T>(input: Iterable<T>, resolve: (item: T) => string | undefined): string | undefined {
+  for (const item of input) {
+    const resolved = resolve(item)
+    if (resolved !== undefined) return resolved
+  }
+  return undefined
+}
+
+function resolvePackageTarget(dir: string, target: string): string | undefined {
+  if (!target.startsWith("./")) return undefined
+  if (
+    target
+      .slice(2)
+      .split(/[\\/]/)
+      .some(isInvalidPackageTargetSegment)
+  )
+    return undefined
+  const resolved = path.resolve(dir, target.replace(/\\/g, "/"))
+  const relative = path.relative(dir, resolved)
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return undefined
+  return resolved
+}
+
+function isInvalidPackageTargetSegment(segment: string) {
+  if (segment === "") return true
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(segment)
+  } catch {
+    return true
+  }
+  return (
+    decoded === "." ||
+    decoded === ".." ||
+    decoded.toLowerCase() === "node_modules" ||
+    decoded.includes("/") ||
+    decoded.includes("\\")
+  )
+}
+
+function resolveFile(dir: string, target: string): string {
+  const full = path.resolve(dir, target)
+  return (
+    [full, `${full}.js`, `${full}.mjs`, `${full}.cjs`, path.join(full, "index.js"), path.join(full, "index.mjs")].find(
+      existsSync,
+    ) ?? full
+  )
+}

--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -11,17 +11,16 @@ import { LayerNode } from "./effect/layer-node"
 import { filesystem } from "./effect/layer-node-platform"
 import { makeRuntime } from "./effect/runtime"
 import { NpmConfig } from "./npm-config"
+import type { EntryPoint } from "./npm-entrypoint"
+import { NpmEntrypoint } from "./npm-entrypoint"
+
+export type { EntryPoint } from "./npm-entrypoint"
 
 export class InstallFailedError extends Schema.TaggedErrorClass<InstallFailedError>()("NpmInstallFailedError", {
   add: Schema.Array(Schema.String).pipe(Schema.optional),
   dir: Schema.String,
   cause: Schema.optional(Schema.Defect),
 }) {}
-
-export interface EntryPoint {
-  readonly directory: string
-  readonly entrypoint: Option.Option<string>
-}
 
 export interface Interface {
   readonly add: (pkg: string) => Effect.Effect<EntryPoint, InstallFailedError | EffectFlock.LockError>
@@ -44,20 +43,6 @@ const illegal = process.platform === "win32" ? new Set(["<", ">", ":", '"', "|",
 export function sanitize(pkg: string) {
   if (!illegal) return pkg
   return Array.from(pkg, (char) => (illegal.has(char) || char.charCodeAt(0) < 32 ? "_" : char)).join("")
-}
-
-const resolveEntryPoint = (name: string, dir: string): EntryPoint => {
-  let entrypoint: Option.Option<string>
-  try {
-    const resolved = typeof Bun !== "undefined" ? import.meta.resolve(name, dir) : import.meta.resolve(dir)
-    entrypoint = Option.some(resolved)
-  } catch {
-    entrypoint = Option.none()
-  }
-  return {
-    directory: dir,
-    entrypoint,
-  }
 }
 
 interface ArboristNode {
@@ -123,17 +108,17 @@ export const layer = Layer.effect(
       })()
 
       if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
-        return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        return NpmEntrypoint.resolve(name, path.join(dir, "node_modules", name))
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
       const first = tree.edgesOut.values().next().value?.to
       if (!first) {
-        const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        const result = NpmEntrypoint.resolve(name, path.join(dir, "node_modules", name))
         if (Option.isSome(result.entrypoint)) return result
         return yield* new InstallFailedError({ add: [pkg], dir })
       }
-      return resolveEntryPoint(first.name, first.path)
+      return NpmEntrypoint.resolve(first.name, first.path)
     }, Effect.scoped)
 
     const install: Interface["install"] = Effect.fn("Npm.install")(function* (dir, input) {

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -6,6 +6,7 @@ import { Effect, Layer, Option } from "effect"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
 import { Npm } from "@opencode-ai/core/npm"
+import { NpmEntrypoint } from "@opencode-ai/core/npm-entrypoint"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { tmpdir } from "./fixture/tmpdir"
 
@@ -28,6 +29,33 @@ const npmLayer = (cache: string) =>
     Layer.provide(NodeFileSystem.layer),
   )
 
+const writePackageFixture = async (dir: string, pkg: Record<string, unknown>, files: Record<string, string>) => {
+  await fs.mkdir(dir, { recursive: true })
+  await writePackage(dir, pkg)
+  await Promise.all(
+    Object.entries(files).map(async ([file, contents]) => {
+      const filePath = path.join(dir, file)
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      await Bun.write(filePath, contents)
+    }),
+  )
+}
+
+const addPackage = (cache: string, spec: string) =>
+  Effect.gen(function* () {
+    const npm = yield* Npm.Service
+    return yield* npm.add(spec)
+  }).pipe(Effect.scoped, Effect.provide(npmLayer(cache)), Effect.runPromise)
+
+const addLocalPackage = (root: string, name: string, dir: string) =>
+  addPackage(path.join(root, "cache"), `${name}@file:${dir}`)
+
+const expectEntryPoint = (entry: { entrypoint: Option.Option<string> }) => {
+  expect(Option.isSome(entry.entrypoint)).toBe(true)
+  if (Option.isNone(entry.entrypoint)) throw new Error("entrypoint was not resolved")
+  return entry.entrypoint.value
+}
+
 describe("Npm.sanitize", () => {
   test("keeps normal scoped package specs unchanged", () => {
     expect(Npm.sanitize("@opencode/acme")).toBe("@opencode/acme")
@@ -45,22 +73,384 @@ describe("Npm.sanitize", () => {
 describe("Npm.add", () => {
   test("reifies when package cache directory exists without the package installed", async () => {
     await using tmp = await tmpdir()
-    await fs.mkdir(path.join(tmp.path, "fixture-provider"))
-    await writePackage(path.join(tmp.path, "fixture-provider"), {
-      name: "fixture-provider",
-      main: "index.js",
-    })
-    await Bun.write(path.join(tmp.path, "fixture-provider", "index.js"), "export const fixture = true\n")
+    await writePackageFixture(
+      path.join(tmp.path, "fixture-provider"),
+      {
+        name: "fixture-provider",
+        main: "index.js",
+      },
+      {
+        "index.js": "export const fixture = true\n",
+      },
+    )
 
     const spec = `fixture-provider@file:${path.join(tmp.path, "fixture-provider")}`
     await fs.mkdir(path.join(tmp.path, "cache", "packages", Npm.sanitize(spec)), { recursive: true })
 
-    const entry = await Effect.gen(function* () {
-      const npm = yield* Npm.Service
-      return yield* npm.add(spec)
-    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+    const entry = await addPackage(path.join(tmp.path, "cache"), spec)
 
     expect(Option.isSome(entry.entrypoint)).toBe(true)
+  })
+
+  test("resolves ESM package exports to an importable file entrypoint", async () => {
+    await using tmp = await tmpdir()
+    await writePackageFixture(
+      path.join(tmp.path, "fixture-provider"),
+      {
+        name: "fixture-provider",
+        type: "module",
+        exports: "./dist/index.js",
+      },
+      {
+        "dist/index.js": "export const createFixture = () => ({ languageModel: () => undefined })\n",
+      },
+    )
+
+    const entry = await addLocalPackage(tmp.path, "fixture-provider", path.join(tmp.path, "fixture-provider"))
+
+    const entrypoint = expectEntryPoint(entry)
+    expect(entrypoint).toEndWith("/dist/index.js")
+    await expect(import(entrypoint)).resolves.toHaveProperty("createFixture")
+  })
+
+  test("resolves scoped ESM package exports", async () => {
+    await using tmp = await tmpdir()
+    await writePackageFixture(
+      path.join(tmp.path, "scoped-provider"),
+      {
+        name: "@scope/fixture.provider-name",
+        type: "module",
+        exports: "./dist/index.js",
+      },
+      {
+        "dist/index.js": "export const createScopedFixture = () => ({ languageModel: () => undefined })\n",
+      },
+    )
+
+    const entry = await addLocalPackage(tmp.path, "@scope/fixture.provider-name", path.join(tmp.path, "scoped-provider"))
+
+    const entrypoint = expectEntryPoint(entry)
+    expect(entrypoint).toEndWith("/dist/index.js")
+    await expect(import(entrypoint)).resolves.toHaveProperty("createScopedFixture")
+  })
+})
+
+describe("NpmEntrypoint.resolveManual", () => {
+  test("resolves legacy main entrypoints", async () => {
+    await using tmp = await tmpdir()
+    const dir = path.join(tmp.path, "node_modules", "legacy-provider")
+    await writePackageFixture(
+      dir,
+      {
+        name: "legacy-provider",
+        type: "module",
+        main: "index.js",
+      },
+      {
+        "index.js": "export const selected = 'legacy'\n",
+      },
+    )
+
+    const entrypoint = expectEntryPoint(NpmEntrypoint.resolveManual("legacy-provider", dir))
+
+    expect(entrypoint).toEndWith("/index.js")
+    expect((await import(entrypoint)).selected).toBe("legacy")
+  })
+
+  const conditionalExportFixtures: Array<{
+    name: string
+    folder: string
+    exports: unknown
+    files: Record<string, string>
+    suffix: string
+    selected: string
+  }> = [
+    {
+      name: "resolves import-only conditional exports",
+      folder: "conditional-provider",
+      exports: { ".": { import: "./dist/index.js" } },
+      files: { "dist/index.js": "export const selected = 'import'\n" },
+      suffix: "/dist/index.js",
+      selected: "import",
+    },
+    {
+      name: "resolves export array targets in order",
+      folder: "array-provider",
+      exports: ["./dist/first.js", "./dist/second.js"],
+      files: {
+        "dist/first.js": "export const selected = 'first'\n",
+        "dist/second.js": "export const selected = 'second'\n",
+      },
+      suffix: "/dist/first.js",
+      selected: "first",
+    },
+    {
+      name: "skips invalid export array alternatives",
+      folder: "array-fallback-provider",
+      exports: [null, "./%2e%2e/outside.js", "./dist/index.js"],
+      files: { "dist/index.js": "export const selected = 'index'\n" },
+      suffix: "/dist/index.js",
+      selected: "index",
+    },
+    {
+      name: "resolves conditional exports in package key order",
+      folder: "ordered-provider",
+      exports: {
+        ".": {
+          types: "./dist/index.d.ts",
+          node: "./dist/node.js",
+          import: "./dist/import.js",
+          default: "./dist/default.js",
+        },
+      },
+      files: {
+        "dist/node.js": "export const selected = 'node'\n",
+        "dist/import.js": "export const selected = 'import'\n",
+        "dist/default.js": "export const selected = 'default'\n",
+      },
+      suffix: "/dist/node.js",
+      selected: "node",
+    },
+    {
+      name: "resolves default before node when package order says so",
+      folder: "default-first-provider",
+      exports: { ".": { default: "./dist/default.js", node: "./dist/node.js" } },
+      files: {
+        "dist/default.js": "export const selected = 'default'\n",
+        "dist/node.js": "export const selected = 'node'\n",
+      },
+      suffix: "/dist/default.js",
+      selected: "default",
+    },
+    {
+      name: "skips require condition for dynamic imports",
+      folder: "require-provider",
+      exports: {
+        ".": {
+          require: "./dist/require.js",
+          import: "./dist/import.js",
+          default: "./dist/default.js",
+        },
+      },
+      files: {
+        "dist/require.js": "export const selected = 'require'\n",
+        "dist/import.js": "export const selected = 'import'\n",
+        "dist/default.js": "export const selected = 'default'\n",
+      },
+      suffix: "/dist/import.js",
+      selected: "import",
+    },
+    {
+      name: "resolves the node-addons export condition when it is first",
+      folder: "node-addons-provider",
+      exports: {
+        ".": {
+          "node-addons": "./dist/node-addons.js",
+          node: "./dist/node.js",
+          import: "./dist/import.js",
+          default: "./dist/default.js",
+        },
+      },
+      files: {
+        "dist/node-addons.js": "export const selected = 'node-addons'\n",
+        "dist/node.js": "export const selected = 'node'\n",
+        "dist/import.js": "export const selected = 'import'\n",
+        "dist/default.js": "export const selected = 'default'\n",
+      },
+      suffix: "/dist/node-addons.js",
+      selected: "node-addons",
+    },
+    {
+      name: "resolves the bun export condition when it is first",
+      folder: "bun-provider",
+      exports: { ".": { bun: "./dist/bun.js", node: "./dist/node.js", import: "./dist/import.js" } },
+      files: {
+        "dist/bun.js": "export const selected = 'bun'\n",
+        "dist/node.js": "export const selected = 'node'\n",
+        "dist/import.js": "export const selected = 'import'\n",
+      },
+      suffix: "/dist/bun.js",
+      selected: "bun",
+    },
+    {
+      name: "does not use Node-only module-sync exports under Bun",
+      folder: "module-sync-provider",
+      exports: { ".": { "module-sync": "./dist/module-sync.js", import: "./dist/import.js", default: "./dist/default.js" } },
+      files: {
+        "dist/module-sync.js": "export const selected = 'module-sync'\n",
+        "dist/import.js": "export const selected = 'import'\n",
+        "dist/default.js": "export const selected = 'default'\n",
+      },
+      suffix: "/dist/import.js",
+      selected: "import",
+    },
+    {
+      name: "skips unsupported custom export conditions",
+      folder: "custom-condition-provider",
+      exports: {
+        ".": {
+          electron: "./dist/electron.js",
+          development: "./dist/development.js",
+          default: "./dist/default.js",
+        },
+      },
+      files: {
+        "dist/electron.js": "export const selected = 'electron'\n",
+        "dist/development.js": "export const selected = 'development'\n",
+        "dist/default.js": "export const selected = 'default'\n",
+      },
+      suffix: "/dist/default.js",
+      selected: "default",
+    },
+  ]
+
+  conditionalExportFixtures.forEach((fixture) => {
+    test(fixture.name, async () => {
+      await using tmp = await tmpdir()
+      const dir = path.join(tmp.path, fixture.folder)
+      await writePackageFixture(
+        dir,
+        {
+          name: fixture.folder,
+          type: "module",
+          exports: fixture.exports,
+        },
+        fixture.files,
+      )
+
+      const entrypoint = expectEntryPoint(NpmEntrypoint.resolveManual(fixture.folder, dir))
+      expect(entrypoint).toEndWith(fixture.suffix)
+      expect((await import(entrypoint)).selected).toBe(fixture.selected)
+    })
+  })
+
+  test.each([
+    "./../outside.js",
+    "./dist/../../outside.js",
+    "dist/index.js",
+    "/dist/index.js",
+    "file:///tmp/index.js",
+    "./",
+    "././index.js",
+    "./dist/../index.js",
+    "./node_modules/pkg/index.js",
+    "./%2e%2e/outside.js",
+    "./%6eode_modules/outside.js",
+    "./dist%2findex.js",
+    "./dist%5cindex.js",
+    "./dist/%zz/index.js",
+  ])(
+    "does not resolve invalid export target: %s",
+    async (target) => {
+      await using tmp = await tmpdir()
+      await writePackageFixture(
+        path.join(tmp.path, "invalid-provider"),
+        {
+          name: "invalid-provider",
+          type: "module",
+          exports: target,
+        },
+        {},
+      )
+      await Bun.write(path.join(tmp.path, "outside.js"), "export const leaked = true\n")
+
+      const entry = NpmEntrypoint.resolveManual("invalid-provider", path.join(tmp.path, "invalid-provider"))
+
+      expect(Option.isNone(entry.entrypoint)).toBe(true)
+    },
+  )
+
+  test("does not resolve subpath-only export objects as package entrypoints", async () => {
+    await using tmp = await tmpdir()
+    await writePackageFixture(
+      path.join(tmp.path, "subpath-provider"),
+      {
+        name: "subpath-provider",
+        type: "module",
+        exports: {
+          "./feature": "./dist/feature.js",
+        },
+      },
+      {
+        "dist/feature.js": "export const feature = true\n",
+      },
+    )
+
+    const entry = NpmEntrypoint.resolveManual("subpath-provider", path.join(tmp.path, "subpath-provider"))
+
+    expect(Option.isNone(entry.entrypoint)).toBe(true)
+  })
+
+  test("does not resolve mixed subpath and condition export objects", async () => {
+    await using tmp = await tmpdir()
+    await writePackageFixture(
+      path.join(tmp.path, "mixed-provider"),
+      {
+        name: "mixed-provider",
+        type: "module",
+        exports: {
+          ".": "./dist/index.js",
+          default: "./dist/default.js",
+        },
+      },
+      {
+        "dist/index.js": "export const mixed = true\n",
+        "dist/default.js": "export const mixed = true\n",
+      },
+    )
+
+    const entry = NpmEntrypoint.resolveManual("mixed-provider", path.join(tmp.path, "mixed-provider"))
+
+    expect(Option.isNone(entry.entrypoint)).toBe(true)
+  })
+
+  test("normalizes raw backslashes in export targets", async () => {
+    await using tmp = await tmpdir()
+    await writePackageFixture(
+      path.join(tmp.path, "backslash-provider"),
+      {
+        name: "backslash-provider",
+        type: "module",
+        exports: "./dist\\index.js",
+      },
+      {
+        "dist/index.js": "export const selected = 'backslash'\n",
+      },
+    )
+
+    const entrypoint = expectEntryPoint(
+      NpmEntrypoint.resolveManual("backslash-provider", path.join(tmp.path, "backslash-provider")),
+    )
+    expect(entrypoint).toEndWith("/dist/index.js")
+    expect((await import(entrypoint)).selected).toBe("backslash")
+  })
+
+  test("resolves ESM exports from awkward nested file paths", async () => {
+    await using tmp = await tmpdir()
+    const dir = path.join(
+      tmp.path,
+      "path with spaces [one] & percent %25",
+      "nested folder (two)",
+      "very-long-segment-name-for-entrypoint-resolution",
+      "fixture-provider",
+    )
+    await writePackageFixture(
+      dir,
+      {
+        name: "fixture-provider-long-path",
+        type: "module",
+        exports: "./dist/index.js",
+      },
+      {
+        "dist/index.js": "export const createLongPathFixture = () => ({ languageModel: () => undefined })\n",
+      },
+    )
+
+    const entry = NpmEntrypoint.resolveManual("fixture-provider-long-path", dir)
+
+    const entrypoint = expectEntryPoint(entry)
+    expect(entrypoint).toEndWith("/dist/index.js")
+    await expect(import(entrypoint)).resolves.toHaveProperty("createLongPathFixture")
   })
 })
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, expect, test } from "bun:test"
-import { mkdir, unlink } from "fs/promises"
+import { mkdir, rm, unlink } from "fs/promises"
 import path from "path"
 import { Effect, Layer } from "effect"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Global } from "@opencode-ai/core/global"
-import { disposeAllInstances, provideInstanceEffect, tmpdirScoped, TestInstance } from "../fixture/fixture"
+import { disposeAllInstances, provideInstanceEffect, provideTmpdirInstance, tmpdirScoped, TestInstance } from "../fixture/fixture"
 import { markPluginDependenciesReady } from "../fixture/plugin"
 import { Auth } from "@/auth"
 import { Config } from "@/config/config"
@@ -20,6 +20,7 @@ import { InstanceLayer } from "@/project/instance-layer"
 import { testEffect } from "../lib/effect"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { Npm } from "@opencode-ai/core/npm"
 
 const originalEnv = new Map<string, string | undefined>()
 
@@ -216,6 +217,73 @@ it.instance(
       },
     },
   },
+)
+
+it.effect("configured custom ESM npm provider loads through package exports", () =>
+  Effect.gen(function* () {
+    const root = yield* tmpdirScoped()
+    const dir = path.join(root, "provider package [one] & chars", "fixture-provider")
+    yield* Effect.promise(() => mkdir(path.join(dir, "dist"), { recursive: true }))
+    yield* Effect.promise(() =>
+      Bun.write(
+        path.join(dir, "package.json"),
+        JSON.stringify({
+          name: "@scope/fixture-provider",
+          version: "1.0.0",
+          type: "module",
+          exports: "./dist/index.js",
+        }),
+      ),
+    )
+    yield* Effect.promise(() =>
+      Bun.write(
+        path.join(dir, "dist", "index.js"),
+        [
+          "export function createFixtureProvider(options) {",
+          "  return {",
+          "    languageModel(modelID) {",
+          "      return { modelID, providerName: options.name }",
+          "    },",
+          "  }",
+          "}",
+          "",
+        ].join("\n"),
+      ),
+    )
+
+    const spec = `@scope/fixture-provider@file:${dir}`
+    yield* Effect.addFinalizer(() =>
+      Effect.promise(() => rm(path.join(Global.Path.cache, "packages", Npm.sanitize(spec)), { recursive: true, force: true })),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const model = yield* provider.getModel(ProviderV2.ID.make("custom-provider"), ModelV2.ID.make("my-model"))
+          const language = yield* provider.getLanguage(model)
+          const loaded = language as unknown as { modelID: string; providerName: string }
+          expect(loaded.modelID).toBe("my-model")
+          expect(loaded.providerName).toBe("custom-provider")
+        }),
+      {
+        config: {
+          provider: {
+            "custom-provider": {
+              name: "Custom Provider",
+              npm: spec,
+              api: "https://example.com/v1",
+              models: {
+                "my-model": {
+                  name: "My Model",
+                },
+              },
+            },
+          },
+        },
+      },
+    )
+  }).pipe(Effect.provide(CrossSpawnSpawner.defaultLayer)),
 )
 
 it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #31909

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom npm providers can now load from package exports in Desktop and other Node runtimes.

The old resolver used Bun to resolve the package name, but in Node it resolved the installed package directory instead. That made Node try to import a directory instead of the provider entry file.

This adds a shared npm entrypoint resolver. Bun keeps its native resolution path. Node and Electron use a package exports resolver for dynamic import, with checks that reject invalid export targets or paths that leave the package.

The tests cover the reported ESM provider case plus scoped names, awkward file paths, conditional exports, export arrays, encoded traversal, and related edge cases.

During development I also used a local benchmark to compare the Bun path with the manual Node and Electron path. The benchmark was only used for measurement and is not part of this PR.

### How did you verify your code works?

- `packages/core`: `bun test test/npm.test.ts`
- `packages/core`: `bun typecheck`
- `packages/opencode`: `bun test test/provider/provider.test.ts -t "configured custom ESM npm provider"`
- `packages/opencode`: `bun typecheck`
- Push hook: `bun turbo typecheck`, 23 packages passed

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR