### PR TITLE
fix(tui): restore HOME/END keys after first message and add double Ctrl+C exit

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -939,6 +939,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     bindings: tuiConfig.keybinds.gather("app.global", appGlobalBindingCommands),
   }))
 
+  let lastExitKeybindTime: number | undefined
   useBindings(() => ({
     mode: OPENCODE_BASE_MODE,
     enabled: () => {
@@ -946,7 +947,22 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       if (!current?.focused) return true
       return current.current.input === ""
     },
-    bindings: tuiConfig.keybinds.gather("app_exit", ["app.exit"]),
+    bindings: tuiConfig.keybinds.gather("app_exit", ["app.exit"]).map((b) => ({
+      ...b,
+      cmd: () => {
+        const now = Date.now()
+        if (lastExitKeybindTime && now - lastExitKeybindTime < 2000) {
+          exit()
+        } else {
+          lastExitKeybindTime = now
+          toast.show({
+            title: "Press again to exit",
+            variant: "info",
+            duration: 2000,
+          })
+        }
+      },
+    })),
   }))
 
   event.on("tui.command.execute", (evt, { workspace }) => {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1423,9 +1423,11 @@ export function Prompt(props: PromptProps) {
                 }
                 props.ref?.(ref)
                 setTimeout(() => {
-                  // setTimeout is a workaround and needs to be addressed properly
                   if (!input || input.isDestroyed) return
                   input.cursorColor = theme.text
+                  // Re-establish focus after remount so the managed textarea layer
+                  // (HOME/END and other input commands) recognizes the new instance.
+                  if (props.visible !== false && !input.focused) input.focus()
                 }, 0)
               }}
               onMouseDown={(r: MouseEvent) => r.target?.focus()}


### PR DESCRIPTION
## Summary

- **Fix HOME/END key navigation** breaking after the first message is sent. The `keyed` `<Show>` in `app.tsx` destroys and remounts the `<Session />` tree when navigating from the Home screen, causing the `TextareaRenderable` to lose focus. The managed textarea layer (`registerManagedTextareaLayer`) then fails to recognize the new instance, disabling all `inputCommands` including `input.buffer.home` / `input.buffer.end`. Fixed by explicitly re-establishing focus in the textarea `ref` callback after remount.
- **Add double-press Ctrl+C confirmation** to prevent accidental exits. The Ctrl+X (open agents) and Ctrl+C (exit) keys are adjacent on QWERTY keyboards, causing frequent mispresses. First Ctrl+C press now shows a toast ("Press again to exit"); second press within 2 seconds exits. Slash commands (`/exit`, `/quit`, `/q`) and `<leader>q` still exit immediately since they are intentional.

Fixes #32058
Fixes #32059

## Test plan

- [ ] Launch OpenCode, type text in prompt, verify HOME/END move cursor correctly
- [ ] Send a message, wait for response, type new text — verify HOME/END still work
- [ ] Press Ctrl+C with empty prompt — verify toast appears instead of immediate exit
- [ ] Press Ctrl+C twice within 2 seconds — verify app exits
- [ ] Wait >2 seconds after first Ctrl+C, press again — verify toast reappears (no exit)
- [ ] Type `/exit` — verify app exits immediately without double-press
- [ ] Press `<leader>q` (Ctrl+X then Q) — verify app exits immediately via the `app.exit` command (no double-press since it goes through the command, not the keybinding override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)