### PR TITLE
fix(opencode): expose structured MCP output

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -50,8 +50,8 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
   return dynamicTool({
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(inputSchema),
-    execute: (args: unknown, options) =>
-      client.callTool(
+    execute: async (args: unknown, options) => {
+      const result = await client.callTool(
         {
           name: mcpTool.name,
           arguments: (args || {}) as Record<string, unknown>,
@@ -62,7 +62,13 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
           signal: options.abortSignal,
           timeout,
         },
-      ),
+      )
+      if (result.structuredContent === undefined || result.structuredContent === null) return result
+      return {
+        ...result,
+        content: [{ type: "text" as const, text: JSON.stringify(result.structuredContent) }],
+      }
+    },
   })
 }
 


### PR DESCRIPTION
## Summary

- prefer non-null MCP `structuredContent` over unstructured `content`
- serialize structured results as compact JSON text for the model
- preserve existing MCP results when structured content is absent or null

This matches Codex behavior and allows tools that return only `structuredContent`, such as Qt Creator MCP tools, to provide visible results to the model.

Closes #27263.

Related to #27577, which separately requests exposing MCP `outputSchema` to the model. This PR does not change tool schema exposure or add client-side output validation.

## Validation

- `bun typecheck` from `packages/opencode`


Relates to: #28567 