### PR TITLE
fix(opencode): auto-discover models for OpenAI-compatible custom providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1544,6 +1544,56 @@ export const layer = Layer.effect(
           })
         }
 
+        // auto-discover models for user-configured OpenAI-compatible providers (e.g. LM Studio)
+        for (const [id, provider] of Object.entries(providers)) {
+          const providerID = ProviderV2.ID.make(id)
+          if (disabled.has(providerID)) continue
+          if (provider.source !== "config") continue
+          const baseURL = provider.options?.baseURL
+          if (!baseURL) continue
+          const hasOpenAICompatible = Object.values(provider.models).some(m => m.api.npm === "@ai-sdk/openai-compatible")
+          if (!hasOpenAICompatible) continue
+          yield* Effect.promise(async () => {
+            try {
+              const cleanURL = baseURL.replace(/\/+$/, "")
+              const headers: Record<string, string> = {}
+              if (provider.key) headers["Authorization"] = `Bearer ${provider.key}`
+              const response = await fetch(`${cleanURL}/models`, { headers, signal: AbortSignal.timeout(5000) })
+              if (!response.ok) return
+              const data = await response.json() as { data?: Array<{ id: string }> }
+              if (!data?.data) return
+              for (const item of data.data) {
+                const modelID = item.id
+                if (!provider.models[modelID]) {
+                  provider.models[modelID] = {
+                    id: ModelV2.ID.make(modelID),
+                    providerID,
+                    name: modelID,
+                    family: "",
+                    api: { id: modelID, url: cleanURL, npm: "@ai-sdk/openai-compatible" },
+                    status: "active",
+                    headers: {},
+                    options: {},
+                    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+                    limit: { context: 0, output: 0 },
+                    capabilities: {
+                      temperature: false,
+                      reasoning: false,
+                      attachment: false,
+                      toolcall: true,
+                      input: { text: true, audio: false, image: false, video: false, pdf: false },
+                      output: { text: true, audio: false, image: false, video: false, pdf: false },
+                      interleaved: false,
+                    },
+                    release_date: "",
+                    variants: {},
+                  }
+                }
+              }
+            } catch (e) {}
+          })
+        }
+
         for (const [id, provider] of Object.entries(providers)) {
           const providerID = ProviderV2.ID.make(id)
           if (!isProviderAllowed(providerID)) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1544,23 +1544,24 @@ export const layer = Layer.effect(
           })
         }
 
-        // auto-discover models for user-configured OpenAI-compatible providers (e.g. LM Studio)
+        // auto-discover models for user-configured providers with a baseURL (e.g. LM Studio)
         for (const [id, provider] of Object.entries(providers)) {
           const providerID = ProviderV2.ID.make(id)
           if (disabled.has(providerID)) continue
           if (provider.source !== "config") continue
           const baseURL = provider.options?.baseURL
           if (!baseURL) continue
-          const hasOpenAICompatible = Object.values(provider.models).some(m => m.api.npm === "@ai-sdk/openai-compatible")
-          if (!hasOpenAICompatible) continue
           yield* Effect.promise(async () => {
             try {
               const cleanURL = baseURL.replace(/\/+$/, "")
               const headers: Record<string, string> = {}
               if (provider.key) headers["Authorization"] = `Bearer ${provider.key}`
-              const response = await fetch(`${cleanURL}/models`, { headers, signal: AbortSignal.timeout(5000) })
-              if (!response.ok) return
-              const data = await response.json() as { data?: Array<{ id: string }> }
+              const urls = [`${cleanURL}/v1/models`, `${cleanURL}/models`]
+              let data: { data?: Array<{ id: string }> } | undefined
+              for (const url of urls) {
+                const res = await fetch(url, { headers, signal: AbortSignal.timeout(5000) })
+                if (res.ok) { data = await res.json() as typeof data; break }
+              }
               if (!data?.data) return
               for (const item of data.data) {
                 const modelID = item.id


### PR DESCRIPTION
### Issue for this PR

Closes #32076

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a user configures a custom provider (e.g. LM Studio, Ollama, llama.cpp) with a baseURL in opencode.json, automatically fetch the model list from GET /v1/models or /models at startup and register discovered models.

The discovery runs for any user-configured provider (source: "config") that has an explicit baseURL in options. It first tries /v1/models (OpenAI standard), then falls back to /models. If an API key is stored, it is passed as a Bearer token.

Discovered models do not overwrite manually defined ones. If the endpoint is unreachable or returns nothing, the discovery is silently skipped.

Previously only the 3 LM Studio models hardcoded in the models.dev catalog would appear. Now all models loaded in LM Studio are visible in the UI.

### How did you verify your code works?

- Ran bun run typecheck (passes with no errors)
- Reviewed the initialization flow to ensure the discovery runs after config providers are merged and before the final provider model filtering loop

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
