### PR TITLE
fix(app): fade overflowing titlebar tabs

### DIFF
--- a/packages/app/src/components/titlebar.css
+++ b/packages/app/src/components/titlebar.css
@@ -1,61 +1,46 @@
-@property --titlebar-tab-fade-left {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 0px;
-}
-
-@property --titlebar-tab-fade-right {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 0px;
-}
-
 @keyframes titlebar-tab-fade-left {
   from {
-    --titlebar-tab-fade-left: 0px;
+    visibility: hidden;
   }
   to {
-    --titlebar-tab-fade-left: 24px;
+    visibility: visible;
   }
 }
 
 @keyframes titlebar-tab-fade-right {
   from {
-    --titlebar-tab-fade-right: 24px;
+    visibility: visible;
   }
   to {
-    --titlebar-tab-fade-right: 0px;
+    visibility: hidden;
   }
 }
 
-/* Scroll position drives the edge fades: the left fade is on at full width for
-   any scroll position past the start, the right fade turns off within 1px of
-   the end. The 0.1px animation ranges make the on/off thresholds effectively
-   binary: they are wider than a layout unit (1/64px) so they cannot collapse
-   into a degenerate range, yet narrower than any real scroll quantum (1/dpr px)
-   so no resting scroll position lands inside them. When the strip does not
-   overflow the timeline is inactive, the animations apply nothing, and the
-   initial 0px values make the mask a no-op.
+/* The narrow ranges preserve the binary thresholds of scrollLeft > 0 and
+   remaining scroll distance > 1px. Hidden defaults make an inactive timeline
+   (no overflow) a no-op. Unsupported browsers also degrade to no fades. */
+[data-slot="titlebar-tabs"] {
+  timeline-scope: --titlebar-tabs-scroll;
 
-   The @supports guard matters: without timeline support the animations would
-   resolve as 0s time-based animations and `fill: both` would pin their end
-   state permanently. Guarded, unsupporting browsers simply show no fades. */
-@supports (animation-timeline: --titlebar-tabs-scroll) {
+  [data-slot^="titlebar-tabs-fade-"] {
+    visibility: hidden;
+  }
+}
+
+@supports (animation-timeline: --titlebar-tabs-scroll) and (timeline-scope: --titlebar-tabs-scroll) {
   [data-slot="titlebar-tabs-scroll"] {
-    mask: linear-gradient(
-      to right,
-      #0000,
-      #ffff var(--titlebar-tab-fade-left),
-      #ffff calc(100% - var(--titlebar-tab-fade-right)),
-      #0000
-    );
-    animation:
-      titlebar-tab-fade-left linear both,
-      titlebar-tab-fade-right linear both;
-    animation-timeline: --titlebar-tabs-scroll, --titlebar-tabs-scroll;
-    animation-range:
-      0 0.1px,
-      calc(100% - 1.1px) calc(100% - 1px);
     scroll-timeline: --titlebar-tabs-scroll x;
+  }
+
+  [data-slot="titlebar-tabs-fade-left"] {
+    animation: titlebar-tab-fade-left linear both;
+    animation-timeline: --titlebar-tabs-scroll;
+    animation-range: 0 0.1px;
+  }
+
+  [data-slot="titlebar-tabs-fade-right"] {
+    animation: titlebar-tab-fade-right linear both;
+    animation-timeline: --titlebar-tabs-scroll;
+    animation-range: calc(100% - 1.1px) calc(100% - 1px);
   }
 }

--- a/packages/app/src/components/titlebar.css
+++ b/packages/app/src/components/titlebar.css
@@ -1,0 +1,49 @@
+@property --titlebar-tab-fade-left {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@property --titlebar-tab-fade-right {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@keyframes titlebar-tab-fade-left {
+  from {
+    --titlebar-tab-fade-left: 0px;
+  }
+  to {
+    --titlebar-tab-fade-left: 24px;
+  }
+}
+
+@keyframes titlebar-tab-fade-right {
+  from {
+    --titlebar-tab-fade-right: 24px;
+  }
+  to {
+    --titlebar-tab-fade-right: 0px;
+  }
+}
+
+/* Scroll position drives the edge fades: the left fade is on at full width past
+   1px of scroll, the right fade turns off within 1px of the end. When the strip
+   does not overflow the timeline is inactive, the animations apply nothing, and
+   the initial 0px values make the mask a no-op. */
+[data-slot="titlebar-tabs-scroll"] {
+  mask: linear-gradient(
+    to right,
+    #0000,
+    #ffff var(--titlebar-tab-fade-left),
+    #ffff calc(100% - var(--titlebar-tab-fade-right)),
+    #0000
+  );
+  animation:
+    titlebar-tab-fade-left linear both,
+    titlebar-tab-fade-right linear both;
+  animation-timeline: --titlebar-tabs-scroll, --titlebar-tabs-scroll;
+  animation-range: 0 1px, calc(100% - 1px) 100%;
+  scroll-timeline: --titlebar-tabs-scroll x;
+}

--- a/packages/app/src/components/titlebar.css
+++ b/packages/app/src/components/titlebar.css
@@ -28,22 +28,34 @@
   }
 }
 
-/* Scroll position drives the edge fades: the left fade is on at full width past
-   1px of scroll, the right fade turns off within 1px of the end. When the strip
-   does not overflow the timeline is inactive, the animations apply nothing, and
-   the initial 0px values make the mask a no-op. */
-[data-slot="titlebar-tabs-scroll"] {
-  mask: linear-gradient(
-    to right,
-    #0000,
-    #ffff var(--titlebar-tab-fade-left),
-    #ffff calc(100% - var(--titlebar-tab-fade-right)),
-    #0000
-  );
-  animation:
-    titlebar-tab-fade-left linear both,
-    titlebar-tab-fade-right linear both;
-  animation-timeline: --titlebar-tabs-scroll, --titlebar-tabs-scroll;
-  animation-range: 0 1px, calc(100% - 1px) 100%;
-  scroll-timeline: --titlebar-tabs-scroll x;
+/* Scroll position drives the edge fades: the left fade is on at full width for
+   any scroll position past the start, the right fade turns off within 1px of
+   the end. The 0.1px animation ranges make the on/off thresholds effectively
+   binary: they are wider than a layout unit (1/64px) so they cannot collapse
+   into a degenerate range, yet narrower than any real scroll quantum (1/dpr px)
+   so no resting scroll position lands inside them. When the strip does not
+   overflow the timeline is inactive, the animations apply nothing, and the
+   initial 0px values make the mask a no-op.
+
+   The @supports guard matters: without timeline support the animations would
+   resolve as 0s time-based animations and `fill: both` would pin their end
+   state permanently. Guarded, unsupporting browsers simply show no fades. */
+@supports (animation-timeline: --titlebar-tabs-scroll) {
+  [data-slot="titlebar-tabs-scroll"] {
+    mask: linear-gradient(
+      to right,
+      #0000,
+      #ffff var(--titlebar-tab-fade-left),
+      #ffff calc(100% - var(--titlebar-tab-fade-right)),
+      #0000
+    );
+    animation:
+      titlebar-tab-fade-left linear both,
+      titlebar-tab-fade-right linear both;
+    animation-timeline: --titlebar-tabs-scroll, --titlebar-tabs-scroll;
+    animation-range:
+      0 0.1px,
+      calc(100% - 1.1px) calc(100% - 1px);
+    scroll-timeline: --titlebar-tabs-scroll x;
+  }
 }

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -437,21 +437,22 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                   state={!!homeMatch() ? "pressed" : undefined}
                 />
 
-                <div
-                  data-slot="titlebar-tabs-scroll"
-                  class="flex min-w-0 flex-row items-center gap-1.5 overflow-x-auto no-scrollbar [app-region:no-drag]"
-                  ref={(el) => {
-                    tabScrollRef = el
-                    createResizeObserver(el, refreshTabsAreOverflowing)
-                  }}
-                >
+                <div data-slot="titlebar-tabs" class="relative min-w-0">
                   <div
-                    class="flex min-w-0 flex-row items-center gap-1.5"
-                    ref={(el) => createResizeObserver(el, refreshTabsAreOverflowing)}
+                    data-slot="titlebar-tabs-scroll"
+                    class="flex min-w-0 flex-row items-center gap-1.5 overflow-x-auto no-scrollbar [app-region:no-drag]"
+                    ref={(el) => {
+                      tabScrollRef = el
+                      createResizeObserver(el, refreshTabsAreOverflowing)
+                    }}
                   >
-                    <For each={tabsStore}>
-                      {(tab, i) => {
-                        let ref!: HTMLDivElement
+                    <div
+                      class="flex min-w-0 flex-row items-center gap-1.5"
+                      ref={(el) => createResizeObserver(el, refreshTabsAreOverflowing)}
+                    >
+                      <For each={tabsStore}>
+                        {(tab, i) => {
+                          let ref!: HTMLDivElement
 
                         const divider = () =>
                           i() !== 0 && (
@@ -525,7 +526,18 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                         )
                       }}
                     </Show>
+                    </div>
                   </div>
+                  <div
+                    data-slot="titlebar-tabs-fade-left"
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-[linear-gradient(to_right,var(--v2-background-bg-deep),transparent)]"
+                  />
+                  <div
+                    data-slot="titlebar-tabs-fade-right"
+                    aria-hidden="true"
+                    class="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-[linear-gradient(to_left,var(--v2-background-bg-deep),transparent)]"
+                  />
                 </div>
                 <Show when={!(creating() && params.dir)}>
                   <IconButtonV2

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -34,11 +34,13 @@ import { ProjectAvatar } from "@opencode-ai/ui/v2/project-avatar-v2"
 import { displayName, getProjectAvatarSource, projectForSession } from "@/pages/layout/helpers"
 import { useSessionTabAvatarState } from "@/pages/layout/project-avatar-state"
 import { makeEventListener } from "@solid-primitives/event-listener"
+import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { readSessionTabsRemovedDetail, SESSION_TABS_REMOVED_EVENT } from "@/components/titlebar-session-events"
 import { useGlobal } from "@/context/global"
 import { decode64 } from "@/utils/base64"
 import { ServerConnection, useServer } from "@/context/server"
 import { tabHref, useTabs, type Tab } from "@/context/tabs"
+import "./titlebar.css"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -436,17 +438,20 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                 />
 
                 <div
+                  data-slot="titlebar-tabs-scroll"
                   class="flex min-w-0 flex-row items-center gap-1.5 overflow-x-auto no-scrollbar [app-region:no-drag]"
-                  ref={tabScrollRef}
+                  ref={(el) => {
+                    tabScrollRef = el
+                    createResizeObserver(el, refreshTabsAreOverflowing)
+                  }}
                 >
-                  <div class="flex min-w-0 flex-row items-center gap-1.5">
+                  <div
+                    class="flex min-w-0 flex-row items-center gap-1.5"
+                    ref={(el) => createResizeObserver(el, refreshTabsAreOverflowing)}
+                  >
                     <For each={tabsStore}>
                       {(tab, i) => {
                         let ref!: HTMLDivElement
-
-                        onMount(() => {
-                          refreshTabsAreOverflowing()
-                        })
 
                         const divider = () =>
                           i() !== 0 && (


### PR DESCRIPTION
### Issue for this PR

Adds the titlebar tab overflow affordance.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds 24px edge fades to the titlebar tab strip when it overflows, so it is visible that more tabs exist off-screen. The left fade appears after scrolling past the start; the right fade disappears within 1px of the end.

The fade elements, gradients, dimensions, stacking, and wrapper match the design implementation exactly. A CSS scroll timeline drives only their visibility, removing JavaScript scroll state, effects, and microtask ordering. Unsupported browsers safely show no fades.

The existing `tabsAreOverflowing` signal still drives `forceTruncate`, but is refreshed by `ResizeObserver` on the scroller and inner row instead of per-tab `onMount`. This also refreshes truncation when the window or asynchronously-loaded tab content changes size.

### How did you verify your code works?

- Drove the strip in headless Chromium and asserted the computed fade values at each scroll state: start -> right fade only, middle -> both, end -> left fade only, non-overflowing strip -> none. Also asserted the right fade returns when content widens while scrolled to the end (no scroll/resize event fires there, which is what rules out JS measurement).
- Verified the built CSS output (Tailwind/LightningCSS) preserves the visibility keyframes, `animation-range`, `timeline-scope`, and `scroll-timeline` declarations.
- `bun typecheck` (all packages) and `bun test` in `packages/app` (376 pass).

### Screenshots / recordings

Behavior matches the existing design: 24px fades over `--v2-background-bg-deep`, on/off at the same scroll thresholds.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


