### PR TITLE
fix(opencode): recover expired MCP sessions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -914,6 +914,7 @@
   "patchedDependencies": {
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "virtua@0.49.1": "patches/virtua@0.49.1.patch",
+    "@modelcontextprotocol/sdk@1.29.0": "patches/@modelcontextprotocol%2Fsdk@1.29.0.patch",
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
     "@ai-sdk/google@3.0.73": "patches/@ai-sdk%2Fgoogle@3.0.73.patch",
     "@ai-sdk/xai@3.0.82": "patches/@ai-sdk%2Fxai@3.0.82.patch",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "@ai-sdk/xai@3.0.82": "patches/@ai-sdk%2Fxai@3.0.82.patch",
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
     "pacote@21.5.0": "patches/pacote@21.5.0.patch",
-    "@ai-sdk/google@3.0.73": "patches/@ai-sdk%2Fgoogle@3.0.73.patch"
+    "@ai-sdk/google@3.0.73": "patches/@ai-sdk%2Fgoogle@3.0.73.patch",
+    "@modelcontextprotocol/sdk@1.29.0": "patches/@modelcontextprotocol%2Fsdk@1.29.0.patch"
   }
 }

--- a/packages/opencode/test/fixture/mcp-session-recovery.ts
+++ b/packages/opencode/test/fixture/mcp-session-recovery.ts
@@ -1,0 +1,50 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
+
+const posts: Array<{ method: string; session: string | null }> = []
+let initializeCount = 0
+let pingCount = 0
+const server = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    if (request.method === "GET") return new Response(null, { status: 405 })
+    if (request.method === "DELETE") return new Response(null, { status: 200 })
+
+    const message = (await request.json()) as { id?: number; method: string }
+    const session = request.headers.get("mcp-session-id")
+    posts.push({ method: message.method, session })
+
+    if (message.method === "initialize") {
+      initializeCount++
+      return Response.json(
+        {
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            protocolVersion: LATEST_PROTOCOL_VERSION,
+            capabilities: {},
+            serverInfo: { name: "test", version: "1" },
+          },
+        },
+        { headers: { "mcp-session-id": initializeCount === 1 ? "expired" : "replacement" } },
+      )
+    }
+
+    if (message.method === "notifications/initialized") return new Response(null, { status: 202 })
+
+    pingCount++
+    if (pingCount === 1) return new Response("Session not found", { status: 404 })
+    return Response.json({ jsonrpc: "2.0", id: message.id, result: {} })
+  },
+})
+const client = new Client({ name: "test", version: "1" })
+
+try {
+  await client.connect(new StreamableHTTPClientTransport(server.url))
+  await client.ping()
+  process.stdout.write(JSON.stringify(posts))
+} finally {
+  await client.close()
+  server.stop(true)
+}

--- a/packages/opencode/test/mcp/session-recovery.test.ts
+++ b/packages/opencode/test/mcp/session-recovery.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
+
+describe("mcp session recovery", () => {
+  test("reinitializes and retries once after a session-bound POST returns 404", async () => {
+    const posts: Array<{ method: string; session: string | null }> = []
+    let initializeCount = 0
+    let pingCount = 0
+    const transport = new StreamableHTTPClientTransport(new URL("https://example.test/mcp"), {
+      fetch: async (_input, init) => {
+        if (init?.method === "GET") return new Response(null, { status: 405 })
+        if (init?.method === "DELETE") return new Response(null, { status: 200 })
+
+        const message = JSON.parse(String(init?.body)) as { id?: number; method: string }
+        const session = new Headers(init?.headers).get("mcp-session-id")
+        posts.push({ method: message.method, session })
+
+        if (message.method === "initialize") {
+          initializeCount++
+          return Response.json(
+            {
+              jsonrpc: "2.0",
+              id: message.id,
+              result: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                serverInfo: { name: "test", version: "1" },
+              },
+            },
+            { headers: { "mcp-session-id": initializeCount === 1 ? "expired" : "replacement" } },
+          )
+        }
+
+        if (message.method === "notifications/initialized") return new Response(null, { status: 202 })
+
+        pingCount++
+        if (pingCount === 1) return new Response("Session not found", { status: 404 })
+        return Response.json({ jsonrpc: "2.0", id: message.id, result: {} })
+      },
+    })
+    const client = new Client({ name: "test", version: "1" })
+
+    try {
+      await client.connect(transport)
+      await expect(client.ping()).resolves.toEqual({})
+
+      expect(posts).toEqual([
+        { method: "initialize", session: null },
+        { method: "notifications/initialized", session: "expired" },
+        { method: "ping", session: "expired" },
+        { method: "initialize", session: null },
+        { method: "notifications/initialized", session: "replacement" },
+        { method: "ping", session: "replacement" },
+      ])
+    } finally {
+      await client.close()
+    }
+  })
+})

--- a/packages/opencode/test/mcp/session-recovery.test.ts
+++ b/packages/opencode/test/mcp/session-recovery.test.ts
@@ -1,61 +1,27 @@
+import path from "node:path"
 import { describe, expect, test } from "bun:test"
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
-import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
 
 describe("mcp session recovery", () => {
   test("reinitializes and retries once after a session-bound POST returns 404", async () => {
-    const posts: Array<{ method: string; session: string | null }> = []
-    let initializeCount = 0
-    let pingCount = 0
-    const transport = new StreamableHTTPClientTransport(new URL("https://example.test/mcp"), {
-      fetch: async (_input, init) => {
-        if (init?.method === "GET") return new Response(null, { status: 405 })
-        if (init?.method === "DELETE") return new Response(null, { status: 200 })
-
-        const message = JSON.parse(String(init?.body)) as { id?: number; method: string }
-        const session = new Headers(init?.headers).get("mcp-session-id")
-        posts.push({ method: message.method, session })
-
-        if (message.method === "initialize") {
-          initializeCount++
-          return Response.json(
-            {
-              jsonrpc: "2.0",
-              id: message.id,
-              result: {
-                protocolVersion: LATEST_PROTOCOL_VERSION,
-                capabilities: {},
-                serverInfo: { name: "test", version: "1" },
-              },
-            },
-            { headers: { "mcp-session-id": initializeCount === 1 ? "expired" : "replacement" } },
-          )
-        }
-
-        if (message.method === "notifications/initialized") return new Response(null, { status: 202 })
-
-        pingCount++
-        if (pingCount === 1) return new Response("Session not found", { status: 404 })
-        return Response.json({ jsonrpc: "2.0", id: message.id, result: {} })
-      },
+    const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "../fixture/mcp-session-recovery.ts")], {
+      cwd: path.join(import.meta.dir, "../.."),
+      stdout: "pipe",
+      stderr: "pipe",
     })
-    const client = new Client({ name: "test", version: "1" })
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited,
+      Bun.readableStreamToText(child.stdout),
+      Bun.readableStreamToText(child.stderr),
+    ])
 
-    try {
-      await client.connect(transport)
-      await expect(client.ping()).resolves.toEqual({})
-
-      expect(posts).toEqual([
-        { method: "initialize", session: null },
-        { method: "notifications/initialized", session: "expired" },
-        { method: "ping", session: "expired" },
-        { method: "initialize", session: null },
-        { method: "notifications/initialized", session: "replacement" },
-        { method: "ping", session: "replacement" },
-      ])
-    } finally {
-      await client.close()
-    }
+    expect(code, stderr).toBe(0)
+    expect(JSON.parse(stdout)).toEqual([
+      { method: "initialize", session: null },
+      { method: "notifications/initialized", session: "expired" },
+      { method: "ping", session: "expired" },
+      { method: "initialize", session: null },
+      { method: "notifications/initialized", session: "replacement" },
+      { method: "ping", session: "replacement" },
+    ])
   })
 })

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -1,27 +1,12 @@
-diff --git a/dist/cjs/client/index.d.ts b/dist/cjs/client/index.d.ts
-index 6f567a193626587a2730b5a49293ca5dfd4181ea..eacfe9a2b20ab8567a256f8af3ccc2a2af1a362b 100644
---- a/dist/cjs/client/index.d.ts
-+++ b/dist/cjs/client/index.d.ts
-@@ -153,6 +153,7 @@ export declare class Client<RequestT extends Request = Request, NotificationT ex
-     setRequestHandler<T extends AnyObjectSchema>(requestSchema: T, handler: (request: SchemaOutput<T>, extra: RequestHandlerExtra<ClientRequest | RequestT, ClientNotification | NotificationT>) => ClientResult | ResultT | Promise<ClientResult | ResultT>): void;
-     protected assertCapability(capability: keyof ServerCapabilities, method: string): void;
-     connect(transport: Transport, options?: RequestOptions): Promise<void>;
-+    private _initialize;
-     /**
-      * After initialization has completed, this will be populated with the server's reported capabilities.
-      */
 diff --git a/dist/cjs/client/index.js b/dist/cjs/client/index.js
-index 6ac1da14dc7f6211ae70f7711c124b76098816d8..a840bc93e68182d6913132bb98c8cde3cace4115 100644
+index 6ac1da14dc7f6211ae70f7711c124b76098816d8..f239ab8e1ede3fdad2a08de3ac4f69c2f8e8f80d 100644
 --- a/dist/cjs/client/index.js
 +++ b/dist/cjs/client/index.js
-@@ -288,41 +288,19 @@ class Client extends protocol_js_1.Protocol {
+@@ -288,41 +288,16 @@ class Client extends protocol_js_1.Protocol {
      }
      async connect(transport, options) {
          await super.connect(transport);
 +        transport.onsessionexpired = async () => {
-+            this._serverCapabilities = undefined;
-+            this._serverVersion = undefined;
-+            this._instructions = undefined;
 +            await this._initialize(transport, options);
 +        };
          // When transport sessionId is already set this means we are trying to reconnect.
@@ -63,7 +48,7 @@ index 6ac1da14dc7f6211ae70f7711c124b76098816d8..a840bc93e68182d6913132bb98c8cde3
          }
          catch (error) {
              // Disconnect if initialization fails.
-@@ -330,6 +308,37 @@ class Client extends protocol_js_1.Protocol {
+@@ -330,6 +305,37 @@ class Client extends protocol_js_1.Protocol {
              throw error;
          }
      }
@@ -101,126 +86,42 @@ index 6ac1da14dc7f6211ae70f7711c124b76098816d8..a840bc93e68182d6913132bb98c8cde3
      /**
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
-diff --git a/dist/cjs/client/streamableHttp.d.ts b/dist/cjs/client/streamableHttp.d.ts
-index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..8bfac2353697b4b84f0bf05ca96a32d25a20a6d5 100644
---- a/dist/cjs/client/streamableHttp.d.ts
-+++ b/dist/cjs/client/streamableHttp.d.ts
-@@ -110,9 +110,12 @@ export declare class StreamableHTTPClientTransport implements Transport {
-     private _lastUpscopingHeader?;
-     private _serverRetryMs?;
-     private _reconnectionTimeout?;
-+    private _sessionRecovery?;
-+    private _recoveringSessionId?;
-     onclose?: () => void;
-     onerror?: (error: Error) => void;
-     onmessage?: (message: JSONRPCMessage) => void;
-+    onsessionexpired?: () => void | Promise<void>;
-     constructor(url: URL, opts?: StreamableHTTPClientTransportOptions);
-     private _authThenStart;
-     private _commonHeaders;
-@@ -141,7 +144,11 @@ export declare class StreamableHTTPClientTransport implements Transport {
-     send(message: JSONRPCMessage | JSONRPCMessage[], options?: {
-         resumptionToken?: string;
-         onresumptiontoken?: (token: string) => void;
-+        signal?: AbortSignal;
-+        isRequestActive?: () => boolean;
-     }): Promise<void>;
-+    private _recoverSession;
-+    private _send;
-     get sessionId(): string | undefined;
-     /**
-      * Terminates the current session by sending a DELETE request to the server.
 diff --git a/dist/cjs/client/streamableHttp.js b/dist/cjs/client/streamableHttp.js
-index a29a7d3a0f14d9cd800ef5b296485237350c666f..f35df6d922e482f962791c80a465cdbeadc46267 100644
+index a29a7d3a0f14d9cd800ef5b296485237350c666f..b687a62d9c12231a6bff4737b36c185a55bb8f71 100644
 --- a/dist/cjs/client/streamableHttp.js
 +++ b/dist/cjs/client/streamableHttp.js
-@@ -85,6 +85,7 @@ class StreamableHTTPClientTransport {
-             // Try to open an initial SSE stream with GET to listen for server messages
-             // This is optional according to the spec - server may not support it
-             const headers = await this._commonHeaders();
-+            const requestSessionId = headers.get('mcp-session-id') ?? undefined;
-             headers.set('Accept', 'text/event-stream');
-             // Include Last-Event-ID header for resumable streams if provided
-             if (resumptionToken) {
-@@ -97,6 +98,11 @@ class StreamableHTTPClientTransport {
-             });
-             if (!response.ok) {
-                 await response.body?.cancel();
-+                if (response.status === 404 && requestSessionId) {
-+                    if (await this._recoverSession(requestSessionId, true)) {
-+                        return;
-+                    }
-+                }
-                 if (response.status === 401 && this._authProvider) {
-                     // Need to authenticate
-                     return await this._authThenStart();
-@@ -290,7 +296,73 @@ class StreamableHTTPClientTransport {
+@@ -290,7 +290,38 @@ class StreamableHTTPClientTransport {
          this.onclose?.();
      }
      async send(message, options) {
 +        return this._send(message, options, false);
 +    }
-+    async _recoverSession(expiredSessionId, waitForCurrent = false, force = false) {
++    async _recoverSession(expiredSessionId) {
 +        if (this._sessionRecovery) {
-+            if (this._recoveringSessionId !== expiredSessionId) {
-+                if (!waitForCurrent) {
-+                    if (this._sessionId === expiredSessionId) {
-+                        this._sessionId = undefined;
-+                    }
-+                    return false;
-+                }
-+                try {
-+                    await this._sessionRecovery;
-+                }
-+                catch {
-+                    return false;
-+                }
-+                if (this._abortController?.signal.aborted) {
-+                    return false;
-+                }
-+                if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
-+                    return true;
-+                }
-+                return this._recoverSession(expiredSessionId, false, true);
-+            }
 +            await this._sessionRecovery;
 +            return this._sessionId !== undefined;
 +        }
-+        if (!force && this._sessionId !== expiredSessionId) {
++        if (this._sessionId !== expiredSessionId)
 +            return this._sessionId !== undefined;
-+        }
-+        if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
-+            return true;
-+        }
 +        this._sessionId = undefined;
-+        this._recoveringSessionId = expiredSessionId;
-+        const recovery = Promise.resolve().then(() => this.onsessionexpired?.());
-+        const tracked = recovery.finally(() => {
-+            if (this._sessionRecovery === tracked) {
-+                this._sessionRecovery = undefined;
-+                this._recoveringSessionId = undefined;
-+            }
-+        });
-+        this._sessionRecovery = tracked;
-+        try {
-+            await tracked;
++        this._sessionRecovery = Promise.resolve().then(() => this.onsessionexpired?.());
+         try {
++            await this._sessionRecovery;
 +        }
 +        catch (error) {
 +            this._sessionId = undefined;
 +            await this.close();
 +            throw error;
 +        }
++        finally {
++            this._sessionRecovery = undefined;
++        }
 +        return this._sessionId !== undefined;
 +    }
 +    async _send(message, options, isSessionRetry) {
-         try {
-+            options?.signal?.throwIfAborted();
-+            if (options?.isRequestActive?.() === false) {
-+                throw new Error('Request is no longer active');
-+            }
++        try {
 +            if (this._sessionRecovery && !(0, types_js_1.isInitializeRequest)(message) && !(0, types_js_1.isInitializedNotification)(message)) {
 +                await this._sessionRecovery;
-+                options?.signal?.throwIfAborted();
 +                if (options?.isRequestActive?.() === false) {
 +                    throw new Error('Request is no longer active');
 +                }
@@ -228,7 +129,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..f35df6d922e482f962791c80a465cdbe
              const { resumptionToken, onresumptiontoken } = options || {};
              if (resumptionToken) {
                  // If we have at last event ID, we need to reconnect the SSE stream
-@@ -298,6 +370,7 @@ class StreamableHTTPClientTransport {
+@@ -298,6 +329,7 @@ class StreamableHTTPClientTransport {
                  return;
              }
              const headers = await this._commonHeaders();
@@ -236,24 +137,23 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..f35df6d922e482f962791c80a465cdbe
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -315,6 +388,16 @@ class StreamableHTTPClientTransport {
+@@ -315,6 +347,15 @@ class StreamableHTTPClientTransport {
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId) {
++                if (response.status === 404 && requestSessionId && !isSessionRetry) {
 +                    const recovered = await this._recoverSession(requestSessionId);
-+                    options?.signal?.throwIfAborted();
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');
 +                    }
-+                    if (recovered && !isSessionRetry) {
++                    if (recovered) {
 +                        return this._send(message, options, true);
 +                    }
 +                }
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -335,7 +418,7 @@ class StreamableHTTPClientTransport {
+@@ -335,7 +376,7 @@ class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -262,7 +162,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..f35df6d922e482f962791c80a465cdbe
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = (0, auth_js_1.extractWWWAuthenticateParams)(response);
-@@ -362,7 +445,7 @@ class StreamableHTTPClientTransport {
+@@ -362,7 +403,7 @@ class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new auth_js_1.UnauthorizedError();
                          }
@@ -272,10 +172,10 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..f35df6d922e482f962791c80a465cdbe
                  }
                  throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);
 diff --git a/dist/cjs/shared/protocol.js b/dist/cjs/shared/protocol.js
-index 3617e787f0ba70447c99501aee7aa67584d89758..2530b5dc01b4ba3ffeac324b2db9b336c8883957 100644
+index 3617e787f0ba70447c99501aee7aa67584d89758..4a96d6a0328fa348b96f3869ab7e0bb77538182b 100644
 --- a/dist/cjs/shared/protocol.js
 +++ b/dist/cjs/shared/protocol.js
-@@ -744,7 +744,13 @@ class Protocol {
+@@ -744,7 +744,12 @@ class Protocol {
              }
              else {
                  // No related task - send through transport normally
@@ -284,56 +184,20 @@ index 3617e787f0ba70447c99501aee7aa67584d89758..2530b5dc01b4ba3ffeac324b2db9b336
 +                    relatedRequestId,
 +                    resumptionToken,
 +                    onresumptiontoken,
-+                    signal: options?.signal,
 +                    isRequestActive: () => this._responseHandlers.has(messageId)
 +                }).catch(error => {
                      this._cleanupTimeout(messageId);
                      reject(error);
                  });
-diff --git a/dist/cjs/shared/transport.d.ts b/dist/cjs/shared/transport.d.ts
-index 1bd95efb41fcfd1ae09712ca968c57d828e0acaf..5d5d66e368a426a4afd8ffeb3e194d4f10b86950 100644
---- a/dist/cjs/shared/transport.d.ts
-+++ b/dist/cjs/shared/transport.d.ts
-@@ -34,6 +34,15 @@ export type TransportSendOptions = {
-      * This allows clients to persist the latest token for potential reconnection.
-      */
-     onresumptiontoken?: (token: string) => void;
-+    /**
-+     * Aborts this send before it is dispatched or replayed after transport recovery.
-+     */
-+    signal?: AbortSignal;
-+    /**
-+     * Returns whether the request is still waiting for a response.
-+     * @internal
-+     */
-+    isRequestActive?: () => boolean;
- };
- /**
-  * Describes the minimal contract for an MCP transport that a client or server can communicate over.
-diff --git a/dist/esm/client/index.d.ts b/dist/esm/client/index.d.ts
-index 6f567a193626587a2730b5a49293ca5dfd4181ea..eacfe9a2b20ab8567a256f8af3ccc2a2af1a362b 100644
---- a/dist/esm/client/index.d.ts
-+++ b/dist/esm/client/index.d.ts
-@@ -153,6 +153,7 @@ export declare class Client<RequestT extends Request = Request, NotificationT ex
-     setRequestHandler<T extends AnyObjectSchema>(requestSchema: T, handler: (request: SchemaOutput<T>, extra: RequestHandlerExtra<ClientRequest | RequestT, ClientNotification | NotificationT>) => ClientResult | ResultT | Promise<ClientResult | ResultT>): void;
-     protected assertCapability(capability: keyof ServerCapabilities, method: string): void;
-     connect(transport: Transport, options?: RequestOptions): Promise<void>;
-+    private _initialize;
-     /**
-      * After initialization has completed, this will be populated with the server's reported capabilities.
-      */
 diff --git a/dist/esm/client/index.js b/dist/esm/client/index.js
-index 49b12c6cd918c457420fef7ad5528a9443d1a191..a4bf651835025b0c6df497063ede63049af0ea5c 100644
+index 49b12c6cd918c457420fef7ad5528a9443d1a191..ac182f6ce128ed27ec7fa4abb816879d54163824 100644
 --- a/dist/esm/client/index.js
 +++ b/dist/esm/client/index.js
-@@ -284,41 +284,19 @@ export class Client extends Protocol {
+@@ -284,41 +284,16 @@ export class Client extends Protocol {
      }
      async connect(transport, options) {
          await super.connect(transport);
 +        transport.onsessionexpired = async () => {
-+            this._serverCapabilities = undefined;
-+            this._serverVersion = undefined;
-+            this._instructions = undefined;
 +            await this._initialize(transport, options);
 +        };
          // When transport sessionId is already set this means we are trying to reconnect.
@@ -375,7 +239,7 @@ index 49b12c6cd918c457420fef7ad5528a9443d1a191..a4bf651835025b0c6df497063ede6304
          }
          catch (error) {
              // Disconnect if initialization fails.
-@@ -326,6 +304,37 @@ export class Client extends Protocol {
+@@ -326,6 +301,37 @@ export class Client extends Protocol {
              throw error;
          }
      }
@@ -413,37 +277,8 @@ index 49b12c6cd918c457420fef7ad5528a9443d1a191..a4bf651835025b0c6df497063ede6304
      /**
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
-diff --git a/dist/esm/client/streamableHttp.d.ts b/dist/esm/client/streamableHttp.d.ts
-index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..8bfac2353697b4b84f0bf05ca96a32d25a20a6d5 100644
---- a/dist/esm/client/streamableHttp.d.ts
-+++ b/dist/esm/client/streamableHttp.d.ts
-@@ -110,9 +110,12 @@ export declare class StreamableHTTPClientTransport implements Transport {
-     private _lastUpscopingHeader?;
-     private _serverRetryMs?;
-     private _reconnectionTimeout?;
-+    private _sessionRecovery?;
-+    private _recoveringSessionId?;
-     onclose?: () => void;
-     onerror?: (error: Error) => void;
-     onmessage?: (message: JSONRPCMessage) => void;
-+    onsessionexpired?: () => void | Promise<void>;
-     constructor(url: URL, opts?: StreamableHTTPClientTransportOptions);
-     private _authThenStart;
-     private _commonHeaders;
-@@ -141,7 +144,11 @@ export declare class StreamableHTTPClientTransport implements Transport {
-     send(message: JSONRPCMessage | JSONRPCMessage[], options?: {
-         resumptionToken?: string;
-         onresumptiontoken?: (token: string) => void;
-+        signal?: AbortSignal;
-+        isRequestActive?: () => boolean;
-     }): Promise<void>;
-+    private _recoverSession;
-+    private _send;
-     get sessionId(): string | undefined;
-     /**
-      * Terminates the current session by sending a DELETE request to the server.
 diff --git a/dist/esm/client/streamableHttp.js b/dist/esm/client/streamableHttp.js
-index 624172aa24ae255a67c083f9c19053343e4a0581..1ae8ac911690da60d7050c13ba6de5669d6a6b7d 100644
+index 624172aa24ae255a67c083f9c19053343e4a0581..4a1810d4b128f59be33d91e0f96deaa0b4b99de4 100644
 --- a/dist/esm/client/streamableHttp.js
 +++ b/dist/esm/client/streamableHttp.js
 @@ -1,5 +1,5 @@
@@ -453,93 +288,38 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..1ae8ac911690da60d7050c13ba6de566
  import { auth, extractWWWAuthenticateParams, UnauthorizedError } from './auth.js';
  import { EventSourceParserStream } from 'eventsource-parser/stream';
  // Default reconnection options for StreamableHTTP connections
-@@ -81,6 +81,7 @@ export class StreamableHTTPClientTransport {
-             // Try to open an initial SSE stream with GET to listen for server messages
-             // This is optional according to the spec - server may not support it
-             const headers = await this._commonHeaders();
-+            const requestSessionId = headers.get('mcp-session-id') ?? undefined;
-             headers.set('Accept', 'text/event-stream');
-             // Include Last-Event-ID header for resumable streams if provided
-             if (resumptionToken) {
-@@ -93,6 +94,11 @@ export class StreamableHTTPClientTransport {
-             });
-             if (!response.ok) {
-                 await response.body?.cancel();
-+                if (response.status === 404 && requestSessionId) {
-+                    if (await this._recoverSession(requestSessionId, true)) {
-+                        return;
-+                    }
-+                }
-                 if (response.status === 401 && this._authProvider) {
-                     // Need to authenticate
-                     return await this._authThenStart();
-@@ -286,7 +292,73 @@ export class StreamableHTTPClientTransport {
+@@ -286,7 +286,38 @@ export class StreamableHTTPClientTransport {
          this.onclose?.();
      }
      async send(message, options) {
 +        return this._send(message, options, false);
 +    }
-+    async _recoverSession(expiredSessionId, waitForCurrent = false, force = false) {
++    async _recoverSession(expiredSessionId) {
 +        if (this._sessionRecovery) {
-+            if (this._recoveringSessionId !== expiredSessionId) {
-+                if (!waitForCurrent) {
-+                    if (this._sessionId === expiredSessionId) {
-+                        this._sessionId = undefined;
-+                    }
-+                    return false;
-+                }
-+                try {
-+                    await this._sessionRecovery;
-+                }
-+                catch {
-+                    return false;
-+                }
-+                if (this._abortController?.signal.aborted) {
-+                    return false;
-+                }
-+                if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
-+                    return true;
-+                }
-+                return this._recoverSession(expiredSessionId, false, true);
-+            }
 +            await this._sessionRecovery;
 +            return this._sessionId !== undefined;
 +        }
-+        if (!force && this._sessionId !== expiredSessionId) {
++        if (this._sessionId !== expiredSessionId)
 +            return this._sessionId !== undefined;
-+        }
-+        if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
-+            return true;
-+        }
 +        this._sessionId = undefined;
-+        this._recoveringSessionId = expiredSessionId;
-+        const recovery = Promise.resolve().then(() => this.onsessionexpired?.());
-+        const tracked = recovery.finally(() => {
-+            if (this._sessionRecovery === tracked) {
-+                this._sessionRecovery = undefined;
-+                this._recoveringSessionId = undefined;
-+            }
-+        });
-+        this._sessionRecovery = tracked;
-+        try {
-+            await tracked;
++        this._sessionRecovery = Promise.resolve().then(() => this.onsessionexpired?.());
+         try {
++            await this._sessionRecovery;
 +        }
 +        catch (error) {
 +            this._sessionId = undefined;
 +            await this.close();
 +            throw error;
 +        }
++        finally {
++            this._sessionRecovery = undefined;
++        }
 +        return this._sessionId !== undefined;
 +    }
 +    async _send(message, options, isSessionRetry) {
-         try {
-+            options?.signal?.throwIfAborted();
-+            if (options?.isRequestActive?.() === false) {
-+                throw new Error('Request is no longer active');
-+            }
++        try {
 +            if (this._sessionRecovery && !isInitializeRequest(message) && !isInitializedNotification(message)) {
 +                await this._sessionRecovery;
-+                options?.signal?.throwIfAborted();
 +                if (options?.isRequestActive?.() === false) {
 +                    throw new Error('Request is no longer active');
 +                }
@@ -547,7 +327,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..1ae8ac911690da60d7050c13ba6de566
              const { resumptionToken, onresumptiontoken } = options || {};
              if (resumptionToken) {
                  // If we have at last event ID, we need to reconnect the SSE stream
-@@ -294,6 +366,7 @@ export class StreamableHTTPClientTransport {
+@@ -294,6 +325,7 @@ export class StreamableHTTPClientTransport {
                  return;
              }
              const headers = await this._commonHeaders();
@@ -555,24 +335,23 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..1ae8ac911690da60d7050c13ba6de566
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -311,6 +384,16 @@ export class StreamableHTTPClientTransport {
+@@ -311,6 +343,15 @@ export class StreamableHTTPClientTransport {
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId) {
++                if (response.status === 404 && requestSessionId && !isSessionRetry) {
 +                    const recovered = await this._recoverSession(requestSessionId);
-+                    options?.signal?.throwIfAborted();
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');
 +                    }
-+                    if (recovered && !isSessionRetry) {
++                    if (recovered) {
 +                        return this._send(message, options, true);
 +                    }
 +                }
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -331,7 +414,7 @@ export class StreamableHTTPClientTransport {
+@@ -331,7 +372,7 @@ export class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -581,7 +360,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..1ae8ac911690da60d7050c13ba6de566
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = extractWWWAuthenticateParams(response);
-@@ -358,7 +441,7 @@ export class StreamableHTTPClientTransport {
+@@ -358,7 +399,7 @@ export class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new UnauthorizedError();
                          }
@@ -591,10 +370,10 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..1ae8ac911690da60d7050c13ba6de566
                  }
                  throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);
 diff --git a/dist/esm/shared/protocol.js b/dist/esm/shared/protocol.js
-index bfa2b7120a0f50c569364ea5264e6f811076f44f..6a263b77f28e1dae462b32d031fc1826e598e622 100644
+index bfa2b7120a0f50c569364ea5264e6f811076f44f..abd8dfd707c155f71dae7aeeeeaf7547368ac749 100644
 --- a/dist/esm/shared/protocol.js
 +++ b/dist/esm/shared/protocol.js
-@@ -740,7 +740,13 @@ export class Protocol {
+@@ -740,7 +740,12 @@ export class Protocol {
              }
              else {
                  // No related task - send through transport normally
@@ -603,29 +382,8 @@ index bfa2b7120a0f50c569364ea5264e6f811076f44f..6a263b77f28e1dae462b32d031fc1826
 +                    relatedRequestId,
 +                    resumptionToken,
 +                    onresumptiontoken,
-+                    signal: options?.signal,
 +                    isRequestActive: () => this._responseHandlers.has(messageId)
 +                }).catch(error => {
                      this._cleanupTimeout(messageId);
                      reject(error);
                  });
-diff --git a/dist/esm/shared/transport.d.ts b/dist/esm/shared/transport.d.ts
-index 1bd95efb41fcfd1ae09712ca968c57d828e0acaf..5d5d66e368a426a4afd8ffeb3e194d4f10b86950 100644
---- a/dist/esm/shared/transport.d.ts
-+++ b/dist/esm/shared/transport.d.ts
-@@ -34,6 +34,15 @@ export type TransportSendOptions = {
-      * This allows clients to persist the latest token for potential reconnection.
-      */
-     onresumptiontoken?: (token: string) => void;
-+    /**
-+     * Aborts this send before it is dispatched or replayed after transport recovery.
-+     */
-+    signal?: AbortSignal;
-+    /**
-+     * Returns whether the request is still waiting for a response.
-+     * @internal
-+     */
-+    isRequestActive?: () => boolean;
- };
- /**
-  * Describes the minimal contract for an MCP transport that a client or server can communicate over.

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -128,28 +128,58 @@ index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8
      /**
       * Terminates the current session by sending a DELETE request to the server.
 diff --git a/dist/cjs/client/streamableHttp.js b/dist/cjs/client/streamableHttp.js
-index a29a7d3a0f14d9cd800ef5b296485237350c666f..efb99bee59955347b6f89c53b8c90a87c73e4b89 100644
+index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2af962432 100644
 --- a/dist/cjs/client/streamableHttp.js
 +++ b/dist/cjs/client/streamableHttp.js
-@@ -290,7 +290,46 @@ class StreamableHTTPClientTransport {
+@@ -85,6 +85,7 @@ class StreamableHTTPClientTransport {
+             // Try to open an initial SSE stream with GET to listen for server messages
+             // This is optional according to the spec - server may not support it
+             const headers = await this._commonHeaders();
++            const requestSessionId = headers.get('mcp-session-id') ?? undefined;
+             headers.set('Accept', 'text/event-stream');
+             // Include Last-Event-ID header for resumable streams if provided
+             if (resumptionToken) {
+@@ -97,6 +98,11 @@ class StreamableHTTPClientTransport {
+             });
+             if (!response.ok) {
+                 await response.body?.cancel();
++                if (response.status === 404 && requestSessionId) {
++                    if (await this._recoverSession(requestSessionId, true)) {
++                        return;
++                    }
++                }
+                 if (response.status === 401 && this._authProvider) {
+                     // Need to authenticate
+                     return await this._authThenStart();
+@@ -290,7 +296,56 @@ class StreamableHTTPClientTransport {
          this.onclose?.();
      }
      async send(message, options) {
 +        return this._send(message, options, false);
 +    }
-+    async _recoverSession(expiredSessionId) {
++    async _recoverSession(expiredSessionId, waitForCurrent = false, force = false) {
 +        if (this._sessionRecovery) {
 +            if (this._recoveringSessionId !== expiredSessionId) {
-+                if (this._sessionId === expiredSessionId) {
-+                    this._sessionId = undefined;
++                if (!waitForCurrent) {
++                    if (this._sessionId === expiredSessionId) {
++                        this._sessionId = undefined;
++                    }
++                    return false;
 +                }
-+                return false;
++                await this._sessionRecovery.catch(() => undefined);
++                if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
++                    return true;
++                }
++                return this._recoverSession(expiredSessionId, false, true);
 +            }
 +            await this._sessionRecovery;
 +            return this._sessionId !== undefined;
 +        }
-+        if (this._sessionId !== expiredSessionId) {
++        if (!force && this._sessionId !== expiredSessionId) {
 +            return this._sessionId !== undefined;
++        }
++        if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
++            return true;
 +        }
 +        this._sessionId = undefined;
 +        this._recoveringSessionId = expiredSessionId;
@@ -178,7 +208,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..efb99bee59955347b6f89c53b8c90a87
              const { resumptionToken, onresumptiontoken } = options || {};
              if (resumptionToken) {
                  // If we have at last event ID, we need to reconnect the SSE stream
-@@ -298,6 +337,7 @@ class StreamableHTTPClientTransport {
+@@ -298,6 +353,7 @@ class StreamableHTTPClientTransport {
                  return;
              }
              const headers = await this._commonHeaders();
@@ -186,7 +216,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..efb99bee59955347b6f89c53b8c90a87
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -315,6 +355,11 @@ class StreamableHTTPClientTransport {
+@@ -315,6 +371,11 @@ class StreamableHTTPClientTransport {
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
@@ -198,7 +228,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..efb99bee59955347b6f89c53b8c90a87
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -335,7 +380,7 @@ class StreamableHTTPClientTransport {
+@@ -335,7 +396,7 @@ class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -207,7 +237,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..efb99bee59955347b6f89c53b8c90a87
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = (0, auth_js_1.extractWWWAuthenticateParams)(response);
-@@ -362,7 +407,7 @@ class StreamableHTTPClientTransport {
+@@ -362,7 +423,7 @@ class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new auth_js_1.UnauthorizedError();
                          }
@@ -346,7 +376,7 @@ index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8
      /**
       * Terminates the current session by sending a DELETE request to the server.
 diff --git a/dist/esm/client/streamableHttp.js b/dist/esm/client/streamableHttp.js
-index 624172aa24ae255a67c083f9c19053343e4a0581..f22a2543bc824961a02ad1e0d898840fdac1b92b 100644
+index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2f458faff 100644
 --- a/dist/esm/client/streamableHttp.js
 +++ b/dist/esm/client/streamableHttp.js
 @@ -1,5 +1,5 @@
@@ -356,25 +386,55 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..f22a2543bc824961a02ad1e0d898840f
  import { auth, extractWWWAuthenticateParams, UnauthorizedError } from './auth.js';
  import { EventSourceParserStream } from 'eventsource-parser/stream';
  // Default reconnection options for StreamableHTTP connections
-@@ -286,7 +286,46 @@ export class StreamableHTTPClientTransport {
+@@ -81,6 +81,7 @@ export class StreamableHTTPClientTransport {
+             // Try to open an initial SSE stream with GET to listen for server messages
+             // This is optional according to the spec - server may not support it
+             const headers = await this._commonHeaders();
++            const requestSessionId = headers.get('mcp-session-id') ?? undefined;
+             headers.set('Accept', 'text/event-stream');
+             // Include Last-Event-ID header for resumable streams if provided
+             if (resumptionToken) {
+@@ -93,6 +94,11 @@ export class StreamableHTTPClientTransport {
+             });
+             if (!response.ok) {
+                 await response.body?.cancel();
++                if (response.status === 404 && requestSessionId) {
++                    if (await this._recoverSession(requestSessionId, true)) {
++                        return;
++                    }
++                }
+                 if (response.status === 401 && this._authProvider) {
+                     // Need to authenticate
+                     return await this._authThenStart();
+@@ -286,7 +292,56 @@ export class StreamableHTTPClientTransport {
          this.onclose?.();
      }
      async send(message, options) {
 +        return this._send(message, options, false);
 +    }
-+    async _recoverSession(expiredSessionId) {
++    async _recoverSession(expiredSessionId, waitForCurrent = false, force = false) {
 +        if (this._sessionRecovery) {
 +            if (this._recoveringSessionId !== expiredSessionId) {
-+                if (this._sessionId === expiredSessionId) {
-+                    this._sessionId = undefined;
++                if (!waitForCurrent) {
++                    if (this._sessionId === expiredSessionId) {
++                        this._sessionId = undefined;
++                    }
++                    return false;
 +                }
-+                return false;
++                await this._sessionRecovery.catch(() => undefined);
++                if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
++                    return true;
++                }
++                return this._recoverSession(expiredSessionId, false, true);
 +            }
 +            await this._sessionRecovery;
 +            return this._sessionId !== undefined;
 +        }
-+        if (this._sessionId !== expiredSessionId) {
++        if (!force && this._sessionId !== expiredSessionId) {
 +            return this._sessionId !== undefined;
++        }
++        if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
++            return true;
 +        }
 +        this._sessionId = undefined;
 +        this._recoveringSessionId = expiredSessionId;
@@ -403,7 +463,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..f22a2543bc824961a02ad1e0d898840f
              const { resumptionToken, onresumptiontoken } = options || {};
              if (resumptionToken) {
                  // If we have at last event ID, we need to reconnect the SSE stream
-@@ -294,6 +333,7 @@ export class StreamableHTTPClientTransport {
+@@ -294,6 +349,7 @@ export class StreamableHTTPClientTransport {
                  return;
              }
              const headers = await this._commonHeaders();
@@ -411,7 +471,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..f22a2543bc824961a02ad1e0d898840f
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -311,6 +351,11 @@ export class StreamableHTTPClientTransport {
+@@ -311,6 +367,11 @@ export class StreamableHTTPClientTransport {
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
@@ -423,7 +483,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..f22a2543bc824961a02ad1e0d898840f
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -331,7 +376,7 @@ export class StreamableHTTPClientTransport {
+@@ -331,7 +392,7 @@ export class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -432,7 +492,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..f22a2543bc824961a02ad1e0d898840f
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = extractWWWAuthenticateParams(response);
-@@ -358,7 +403,7 @@ export class StreamableHTTPClientTransport {
+@@ -358,7 +419,7 @@ export class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new UnauthorizedError();
                          }

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -102,7 +102,7 @@ index 6ac1da14dc7f6211ae70f7711c124b76098816d8..a840bc93e68182d6913132bb98c8cde3
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
 diff --git a/dist/cjs/client/streamableHttp.d.ts b/dist/cjs/client/streamableHttp.d.ts
-index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8ff60261b 100644
+index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..8bfac2353697b4b84f0bf05ca96a32d25a20a6d5 100644
 --- a/dist/cjs/client/streamableHttp.d.ts
 +++ b/dist/cjs/client/streamableHttp.d.ts
 @@ -110,9 +110,12 @@ export declare class StreamableHTTPClientTransport implements Transport {
@@ -118,9 +118,12 @@ index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8
      constructor(url: URL, opts?: StreamableHTTPClientTransportOptions);
      private _authThenStart;
      private _commonHeaders;
-@@ -142,6 +145,8 @@ export declare class StreamableHTTPClientTransport implements Transport {
+@@ -141,7 +144,11 @@ export declare class StreamableHTTPClientTransport implements Transport {
+     send(message: JSONRPCMessage | JSONRPCMessage[], options?: {
          resumptionToken?: string;
          onresumptiontoken?: (token: string) => void;
++        signal?: AbortSignal;
++        isRequestActive?: () => boolean;
      }): Promise<void>;
 +    private _recoverSession;
 +    private _send;
@@ -128,7 +131,7 @@ index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8
      /**
       * Terminates the current session by sending a DELETE request to the server.
 diff --git a/dist/cjs/client/streamableHttp.js b/dist/cjs/client/streamableHttp.js
-index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2af962432 100644
+index a29a7d3a0f14d9cd800ef5b296485237350c666f..f35df6d922e482f962791c80a465cdbeadc46267 100644
 --- a/dist/cjs/client/streamableHttp.js
 +++ b/dist/cjs/client/streamableHttp.js
 @@ -85,6 +85,7 @@ class StreamableHTTPClientTransport {
@@ -151,7 +154,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2
                  if (response.status === 401 && this._authProvider) {
                      // Need to authenticate
                      return await this._authThenStart();
-@@ -290,7 +296,56 @@ class StreamableHTTPClientTransport {
+@@ -290,7 +296,73 @@ class StreamableHTTPClientTransport {
          this.onclose?.();
      }
      async send(message, options) {
@@ -166,7 +169,15 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2
 +                    }
 +                    return false;
 +                }
-+                await this._sessionRecovery.catch(() => undefined);
++                try {
++                    await this._sessionRecovery;
++                }
++                catch {
++                    return false;
++                }
++                if (this._abortController?.signal.aborted) {
++                    return false;
++                }
 +                if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
 +                    return true;
 +                }
@@ -191,24 +202,33 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2
 +            }
 +        });
 +        this._sessionRecovery = tracked;
-         try {
++        try {
 +            await tracked;
 +        }
 +        catch (error) {
 +            this._sessionId = undefined;
++            await this.close();
 +            throw error;
 +        }
 +        return this._sessionId !== undefined;
 +    }
 +    async _send(message, options, isSessionRetry) {
-+        try {
+         try {
++            options?.signal?.throwIfAborted();
++            if (options?.isRequestActive?.() === false) {
++                throw new Error('Request is no longer active');
++            }
 +            if (this._sessionRecovery && !(0, types_js_1.isInitializeRequest)(message) && !(0, types_js_1.isInitializedNotification)(message)) {
 +                await this._sessionRecovery;
++                options?.signal?.throwIfAborted();
++                if (options?.isRequestActive?.() === false) {
++                    throw new Error('Request is no longer active');
++                }
 +            }
              const { resumptionToken, onresumptiontoken } = options || {};
              if (resumptionToken) {
                  // If we have at last event ID, we need to reconnect the SSE stream
-@@ -298,6 +353,7 @@ class StreamableHTTPClientTransport {
+@@ -298,6 +370,7 @@ class StreamableHTTPClientTransport {
                  return;
              }
              const headers = await this._commonHeaders();
@@ -216,19 +236,24 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -315,6 +371,11 @@ class StreamableHTTPClientTransport {
+@@ -315,6 +388,16 @@ class StreamableHTTPClientTransport {
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
 +                if (response.status === 404 && requestSessionId) {
-+                    if (await this._recoverSession(requestSessionId) && !isSessionRetry) {
++                    const recovered = await this._recoverSession(requestSessionId);
++                    options?.signal?.throwIfAborted();
++                    if (options?.isRequestActive?.() === false) {
++                        throw new Error('Request is no longer active');
++                    }
++                    if (recovered && !isSessionRetry) {
 +                        return this._send(message, options, true);
 +                    }
 +                }
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -335,7 +396,7 @@ class StreamableHTTPClientTransport {
+@@ -335,7 +418,7 @@ class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -237,7 +262,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = (0, auth_js_1.extractWWWAuthenticateParams)(response);
-@@ -362,7 +423,7 @@ class StreamableHTTPClientTransport {
+@@ -362,7 +445,7 @@ class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new auth_js_1.UnauthorizedError();
                          }
@@ -246,6 +271,45 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..a0e9102f6e8da19689f895e4ba014eb2
                      }
                  }
                  throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);
+diff --git a/dist/cjs/shared/protocol.js b/dist/cjs/shared/protocol.js
+index 3617e787f0ba70447c99501aee7aa67584d89758..2530b5dc01b4ba3ffeac324b2db9b336c8883957 100644
+--- a/dist/cjs/shared/protocol.js
++++ b/dist/cjs/shared/protocol.js
+@@ -744,7 +744,13 @@ class Protocol {
+             }
+             else {
+                 // No related task - send through transport normally
+-                this._transport.send(jsonrpcRequest, { relatedRequestId, resumptionToken, onresumptiontoken }).catch(error => {
++                this._transport.send(jsonrpcRequest, {
++                    relatedRequestId,
++                    resumptionToken,
++                    onresumptiontoken,
++                    signal: options?.signal,
++                    isRequestActive: () => this._responseHandlers.has(messageId)
++                }).catch(error => {
+                     this._cleanupTimeout(messageId);
+                     reject(error);
+                 });
+diff --git a/dist/cjs/shared/transport.d.ts b/dist/cjs/shared/transport.d.ts
+index 1bd95efb41fcfd1ae09712ca968c57d828e0acaf..5d5d66e368a426a4afd8ffeb3e194d4f10b86950 100644
+--- a/dist/cjs/shared/transport.d.ts
++++ b/dist/cjs/shared/transport.d.ts
+@@ -34,6 +34,15 @@ export type TransportSendOptions = {
+      * This allows clients to persist the latest token for potential reconnection.
+      */
+     onresumptiontoken?: (token: string) => void;
++    /**
++     * Aborts this send before it is dispatched or replayed after transport recovery.
++     */
++    signal?: AbortSignal;
++    /**
++     * Returns whether the request is still waiting for a response.
++     * @internal
++     */
++    isRequestActive?: () => boolean;
+ };
+ /**
+  * Describes the minimal contract for an MCP transport that a client or server can communicate over.
 diff --git a/dist/esm/client/index.d.ts b/dist/esm/client/index.d.ts
 index 6f567a193626587a2730b5a49293ca5dfd4181ea..eacfe9a2b20ab8567a256f8af3ccc2a2af1a362b 100644
 --- a/dist/esm/client/index.d.ts
@@ -350,7 +414,7 @@ index 49b12c6cd918c457420fef7ad5528a9443d1a191..a4bf651835025b0c6df497063ede6304
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
 diff --git a/dist/esm/client/streamableHttp.d.ts b/dist/esm/client/streamableHttp.d.ts
-index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8ff60261b 100644
+index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..8bfac2353697b4b84f0bf05ca96a32d25a20a6d5 100644
 --- a/dist/esm/client/streamableHttp.d.ts
 +++ b/dist/esm/client/streamableHttp.d.ts
 @@ -110,9 +110,12 @@ export declare class StreamableHTTPClientTransport implements Transport {
@@ -366,9 +430,12 @@ index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8
      constructor(url: URL, opts?: StreamableHTTPClientTransportOptions);
      private _authThenStart;
      private _commonHeaders;
-@@ -142,6 +145,8 @@ export declare class StreamableHTTPClientTransport implements Transport {
+@@ -141,7 +144,11 @@ export declare class StreamableHTTPClientTransport implements Transport {
+     send(message: JSONRPCMessage | JSONRPCMessage[], options?: {
          resumptionToken?: string;
          onresumptiontoken?: (token: string) => void;
++        signal?: AbortSignal;
++        isRequestActive?: () => boolean;
      }): Promise<void>;
 +    private _recoverSession;
 +    private _send;
@@ -376,7 +443,7 @@ index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8
      /**
       * Terminates the current session by sending a DELETE request to the server.
 diff --git a/dist/esm/client/streamableHttp.js b/dist/esm/client/streamableHttp.js
-index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2f458faff 100644
+index 624172aa24ae255a67c083f9c19053343e4a0581..1ae8ac911690da60d7050c13ba6de5669d6a6b7d 100644
 --- a/dist/esm/client/streamableHttp.js
 +++ b/dist/esm/client/streamableHttp.js
 @@ -1,5 +1,5 @@
@@ -406,7 +473,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2
                  if (response.status === 401 && this._authProvider) {
                      // Need to authenticate
                      return await this._authThenStart();
-@@ -286,7 +292,56 @@ export class StreamableHTTPClientTransport {
+@@ -286,7 +292,73 @@ export class StreamableHTTPClientTransport {
          this.onclose?.();
      }
      async send(message, options) {
@@ -421,7 +488,15 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2
 +                    }
 +                    return false;
 +                }
-+                await this._sessionRecovery.catch(() => undefined);
++                try {
++                    await this._sessionRecovery;
++                }
++                catch {
++                    return false;
++                }
++                if (this._abortController?.signal.aborted) {
++                    return false;
++                }
 +                if (this._sessionId !== undefined && this._sessionId !== expiredSessionId) {
 +                    return true;
 +                }
@@ -446,24 +521,33 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2
 +            }
 +        });
 +        this._sessionRecovery = tracked;
-         try {
++        try {
 +            await tracked;
 +        }
 +        catch (error) {
 +            this._sessionId = undefined;
++            await this.close();
 +            throw error;
 +        }
 +        return this._sessionId !== undefined;
 +    }
 +    async _send(message, options, isSessionRetry) {
-+        try {
+         try {
++            options?.signal?.throwIfAborted();
++            if (options?.isRequestActive?.() === false) {
++                throw new Error('Request is no longer active');
++            }
 +            if (this._sessionRecovery && !isInitializeRequest(message) && !isInitializedNotification(message)) {
 +                await this._sessionRecovery;
++                options?.signal?.throwIfAborted();
++                if (options?.isRequestActive?.() === false) {
++                    throw new Error('Request is no longer active');
++                }
 +            }
              const { resumptionToken, onresumptiontoken } = options || {};
              if (resumptionToken) {
                  // If we have at last event ID, we need to reconnect the SSE stream
-@@ -294,6 +349,7 @@ export class StreamableHTTPClientTransport {
+@@ -294,6 +366,7 @@ export class StreamableHTTPClientTransport {
                  return;
              }
              const headers = await this._commonHeaders();
@@ -471,19 +555,24 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -311,6 +367,11 @@ export class StreamableHTTPClientTransport {
+@@ -311,6 +384,16 @@ export class StreamableHTTPClientTransport {
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
 +                if (response.status === 404 && requestSessionId) {
-+                    if (await this._recoverSession(requestSessionId) && !isSessionRetry) {
++                    const recovered = await this._recoverSession(requestSessionId);
++                    options?.signal?.throwIfAborted();
++                    if (options?.isRequestActive?.() === false) {
++                        throw new Error('Request is no longer active');
++                    }
++                    if (recovered && !isSessionRetry) {
 +                        return this._send(message, options, true);
 +                    }
 +                }
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -331,7 +392,7 @@ export class StreamableHTTPClientTransport {
+@@ -331,7 +414,7 @@ export class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -492,7 +581,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = extractWWWAuthenticateParams(response);
-@@ -358,7 +419,7 @@ export class StreamableHTTPClientTransport {
+@@ -358,7 +441,7 @@ export class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new UnauthorizedError();
                          }
@@ -501,3 +590,42 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..7074b8a233690053a8226dc409ce32b2
                      }
                  }
                  throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);
+diff --git a/dist/esm/shared/protocol.js b/dist/esm/shared/protocol.js
+index bfa2b7120a0f50c569364ea5264e6f811076f44f..6a263b77f28e1dae462b32d031fc1826e598e622 100644
+--- a/dist/esm/shared/protocol.js
++++ b/dist/esm/shared/protocol.js
+@@ -740,7 +740,13 @@ export class Protocol {
+             }
+             else {
+                 // No related task - send through transport normally
+-                this._transport.send(jsonrpcRequest, { relatedRequestId, resumptionToken, onresumptiontoken }).catch(error => {
++                this._transport.send(jsonrpcRequest, {
++                    relatedRequestId,
++                    resumptionToken,
++                    onresumptiontoken,
++                    signal: options?.signal,
++                    isRequestActive: () => this._responseHandlers.has(messageId)
++                }).catch(error => {
+                     this._cleanupTimeout(messageId);
+                     reject(error);
+                 });
+diff --git a/dist/esm/shared/transport.d.ts b/dist/esm/shared/transport.d.ts
+index 1bd95efb41fcfd1ae09712ca968c57d828e0acaf..5d5d66e368a426a4afd8ffeb3e194d4f10b86950 100644
+--- a/dist/esm/shared/transport.d.ts
++++ b/dist/esm/shared/transport.d.ts
+@@ -34,6 +34,15 @@ export type TransportSendOptions = {
+      * This allows clients to persist the latest token for potential reconnection.
+      */
+     onresumptiontoken?: (token: string) => void;
++    /**
++     * Aborts this send before it is dispatched or replayed after transport recovery.
++     */
++    signal?: AbortSignal;
++    /**
++     * Returns whether the request is still waiting for a response.
++     * @internal
++     */
++    isRequestActive?: () => boolean;
+ };
+ /**
+  * Describes the minimal contract for an MCP transport that a client or server can communicate over.

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -1,0 +1,443 @@
+diff --git a/dist/cjs/client/index.d.ts b/dist/cjs/client/index.d.ts
+index 6f567a193626587a2730b5a49293ca5dfd4181ea..eacfe9a2b20ab8567a256f8af3ccc2a2af1a362b 100644
+--- a/dist/cjs/client/index.d.ts
++++ b/dist/cjs/client/index.d.ts
+@@ -153,6 +153,7 @@ export declare class Client<RequestT extends Request = Request, NotificationT ex
+     setRequestHandler<T extends AnyObjectSchema>(requestSchema: T, handler: (request: SchemaOutput<T>, extra: RequestHandlerExtra<ClientRequest | RequestT, ClientNotification | NotificationT>) => ClientResult | ResultT | Promise<ClientResult | ResultT>): void;
+     protected assertCapability(capability: keyof ServerCapabilities, method: string): void;
+     connect(transport: Transport, options?: RequestOptions): Promise<void>;
++    private _initialize;
+     /**
+      * After initialization has completed, this will be populated with the server's reported capabilities.
+      */
+diff --git a/dist/cjs/client/index.js b/dist/cjs/client/index.js
+index 6ac1da14dc7f6211ae70f7711c124b76098816d8..a840bc93e68182d6913132bb98c8cde3cace4115 100644
+--- a/dist/cjs/client/index.js
++++ b/dist/cjs/client/index.js
+@@ -288,41 +288,19 @@ class Client extends protocol_js_1.Protocol {
+     }
+     async connect(transport, options) {
+         await super.connect(transport);
++        transport.onsessionexpired = async () => {
++            this._serverCapabilities = undefined;
++            this._serverVersion = undefined;
++            this._instructions = undefined;
++            await this._initialize(transport, options);
++        };
+         // When transport sessionId is already set this means we are trying to reconnect.
+         // In this case we don't need to initialize again.
+         if (transport.sessionId !== undefined) {
+             return;
+         }
+         try {
+-            const result = await this.request({
+-                method: 'initialize',
+-                params: {
+-                    protocolVersion: types_js_1.LATEST_PROTOCOL_VERSION,
+-                    capabilities: this._capabilities,
+-                    clientInfo: this._clientInfo
+-                }
+-            }, types_js_1.InitializeResultSchema, options);
+-            if (result === undefined) {
+-                throw new Error(`Server sent invalid initialize result: ${result}`);
+-            }
+-            if (!types_js_1.SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
+-                throw new Error(`Server's protocol version is not supported: ${result.protocolVersion}`);
+-            }
+-            this._serverCapabilities = result.capabilities;
+-            this._serverVersion = result.serverInfo;
+-            // HTTP transports must set the protocol version in each header after initialization.
+-            if (transport.setProtocolVersion) {
+-                transport.setProtocolVersion(result.protocolVersion);
+-            }
+-            this._instructions = result.instructions;
+-            await this.notification({
+-                method: 'notifications/initialized'
+-            });
+-            // Set up list changed handlers now that we know server capabilities
+-            if (this._pendingListChangedConfig) {
+-                this._setupListChangedHandlers(this._pendingListChangedConfig);
+-                this._pendingListChangedConfig = undefined;
+-            }
++            await this._initialize(transport, options);
+         }
+         catch (error) {
+             // Disconnect if initialization fails.
+@@ -330,6 +308,37 @@ class Client extends protocol_js_1.Protocol {
+             throw error;
+         }
+     }
++    async _initialize(transport, options) {
++        const result = await this.request({
++            method: 'initialize',
++            params: {
++                protocolVersion: types_js_1.LATEST_PROTOCOL_VERSION,
++                capabilities: this._capabilities,
++                clientInfo: this._clientInfo
++            }
++        }, types_js_1.InitializeResultSchema, options);
++        if (result === undefined) {
++            throw new Error(`Server sent invalid initialize result: ${result}`);
++        }
++        if (!types_js_1.SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
++            throw new Error(`Server's protocol version is not supported: ${result.protocolVersion}`);
++        }
++        this._serverCapabilities = result.capabilities;
++        this._serverVersion = result.serverInfo;
++        // HTTP transports must set the protocol version in each header after initialization.
++        if (transport.setProtocolVersion) {
++            transport.setProtocolVersion(result.protocolVersion);
++        }
++        this._instructions = result.instructions;
++        await this.notification({
++            method: 'notifications/initialized'
++        });
++        // Set up list changed handlers now that we know server capabilities
++        if (this._pendingListChangedConfig) {
++            this._setupListChangedHandlers(this._pendingListChangedConfig);
++            this._pendingListChangedConfig = undefined;
++        }
++    }
+     /**
+      * After initialization has completed, this will be populated with the server's reported capabilities.
+      */
+diff --git a/dist/cjs/client/streamableHttp.d.ts b/dist/cjs/client/streamableHttp.d.ts
+index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8ff60261b 100644
+--- a/dist/cjs/client/streamableHttp.d.ts
++++ b/dist/cjs/client/streamableHttp.d.ts
+@@ -110,9 +110,12 @@ export declare class StreamableHTTPClientTransport implements Transport {
+     private _lastUpscopingHeader?;
+     private _serverRetryMs?;
+     private _reconnectionTimeout?;
++    private _sessionRecovery?;
++    private _recoveringSessionId?;
+     onclose?: () => void;
+     onerror?: (error: Error) => void;
+     onmessage?: (message: JSONRPCMessage) => void;
++    onsessionexpired?: () => void | Promise<void>;
+     constructor(url: URL, opts?: StreamableHTTPClientTransportOptions);
+     private _authThenStart;
+     private _commonHeaders;
+@@ -142,6 +145,8 @@ export declare class StreamableHTTPClientTransport implements Transport {
+         resumptionToken?: string;
+         onresumptiontoken?: (token: string) => void;
+     }): Promise<void>;
++    private _recoverSession;
++    private _send;
+     get sessionId(): string | undefined;
+     /**
+      * Terminates the current session by sending a DELETE request to the server.
+diff --git a/dist/cjs/client/streamableHttp.js b/dist/cjs/client/streamableHttp.js
+index a29a7d3a0f14d9cd800ef5b296485237350c666f..efb99bee59955347b6f89c53b8c90a87c73e4b89 100644
+--- a/dist/cjs/client/streamableHttp.js
++++ b/dist/cjs/client/streamableHttp.js
+@@ -290,7 +290,46 @@ class StreamableHTTPClientTransport {
+         this.onclose?.();
+     }
+     async send(message, options) {
++        return this._send(message, options, false);
++    }
++    async _recoverSession(expiredSessionId) {
++        if (this._sessionRecovery) {
++            if (this._recoveringSessionId !== expiredSessionId) {
++                if (this._sessionId === expiredSessionId) {
++                    this._sessionId = undefined;
++                }
++                return false;
++            }
++            await this._sessionRecovery;
++            return this._sessionId !== undefined;
++        }
++        if (this._sessionId !== expiredSessionId) {
++            return this._sessionId !== undefined;
++        }
++        this._sessionId = undefined;
++        this._recoveringSessionId = expiredSessionId;
++        const recovery = Promise.resolve().then(() => this.onsessionexpired?.());
++        const tracked = recovery.finally(() => {
++            if (this._sessionRecovery === tracked) {
++                this._sessionRecovery = undefined;
++                this._recoveringSessionId = undefined;
++            }
++        });
++        this._sessionRecovery = tracked;
+         try {
++            await tracked;
++        }
++        catch (error) {
++            this._sessionId = undefined;
++            throw error;
++        }
++        return this._sessionId !== undefined;
++    }
++    async _send(message, options, isSessionRetry) {
++        try {
++            if (this._sessionRecovery && !(0, types_js_1.isInitializeRequest)(message) && !(0, types_js_1.isInitializedNotification)(message)) {
++                await this._sessionRecovery;
++            }
+             const { resumptionToken, onresumptiontoken } = options || {};
+             if (resumptionToken) {
+                 // If we have at last event ID, we need to reconnect the SSE stream
+@@ -298,6 +337,7 @@ class StreamableHTTPClientTransport {
+                 return;
+             }
+             const headers = await this._commonHeaders();
++            const requestSessionId = headers.get('mcp-session-id') ?? undefined;
+             headers.set('content-type', 'application/json');
+             headers.set('accept', 'application/json, text/event-stream');
+             const init = {
+@@ -315,6 +355,11 @@ class StreamableHTTPClientTransport {
+             }
+             if (!response.ok) {
+                 const text = await response.text().catch(() => null);
++                if (response.status === 404 && requestSessionId) {
++                    if (await this._recoverSession(requestSessionId) && !isSessionRetry) {
++                        return this._send(message, options, true);
++                    }
++                }
+                 if (response.status === 401 && this._authProvider) {
+                     // Prevent infinite recursion when server returns 401 after successful auth
+                     if (this._hasCompletedAuthFlow) {
+@@ -335,7 +380,7 @@ class StreamableHTTPClientTransport {
+                     // Mark that we completed auth flow
+                     this._hasCompletedAuthFlow = true;
+                     // Purposely _not_ awaited, so we don't call onerror twice
+-                    return this.send(message);
++                    return this._send(message, options, isSessionRetry);
+                 }
+                 if (response.status === 403 && this._authProvider) {
+                     const { resourceMetadataUrl, scope, error } = (0, auth_js_1.extractWWWAuthenticateParams)(response);
+@@ -362,7 +407,7 @@ class StreamableHTTPClientTransport {
+                         if (result !== 'AUTHORIZED') {
+                             throw new auth_js_1.UnauthorizedError();
+                         }
+-                        return this.send(message);
++                        return this._send(message, options, isSessionRetry);
+                     }
+                 }
+                 throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);
+diff --git a/dist/esm/client/index.d.ts b/dist/esm/client/index.d.ts
+index 6f567a193626587a2730b5a49293ca5dfd4181ea..eacfe9a2b20ab8567a256f8af3ccc2a2af1a362b 100644
+--- a/dist/esm/client/index.d.ts
++++ b/dist/esm/client/index.d.ts
+@@ -153,6 +153,7 @@ export declare class Client<RequestT extends Request = Request, NotificationT ex
+     setRequestHandler<T extends AnyObjectSchema>(requestSchema: T, handler: (request: SchemaOutput<T>, extra: RequestHandlerExtra<ClientRequest | RequestT, ClientNotification | NotificationT>) => ClientResult | ResultT | Promise<ClientResult | ResultT>): void;
+     protected assertCapability(capability: keyof ServerCapabilities, method: string): void;
+     connect(transport: Transport, options?: RequestOptions): Promise<void>;
++    private _initialize;
+     /**
+      * After initialization has completed, this will be populated with the server's reported capabilities.
+      */
+diff --git a/dist/esm/client/index.js b/dist/esm/client/index.js
+index 49b12c6cd918c457420fef7ad5528a9443d1a191..a4bf651835025b0c6df497063ede63049af0ea5c 100644
+--- a/dist/esm/client/index.js
++++ b/dist/esm/client/index.js
+@@ -284,41 +284,19 @@ export class Client extends Protocol {
+     }
+     async connect(transport, options) {
+         await super.connect(transport);
++        transport.onsessionexpired = async () => {
++            this._serverCapabilities = undefined;
++            this._serverVersion = undefined;
++            this._instructions = undefined;
++            await this._initialize(transport, options);
++        };
+         // When transport sessionId is already set this means we are trying to reconnect.
+         // In this case we don't need to initialize again.
+         if (transport.sessionId !== undefined) {
+             return;
+         }
+         try {
+-            const result = await this.request({
+-                method: 'initialize',
+-                params: {
+-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+-                    capabilities: this._capabilities,
+-                    clientInfo: this._clientInfo
+-                }
+-            }, InitializeResultSchema, options);
+-            if (result === undefined) {
+-                throw new Error(`Server sent invalid initialize result: ${result}`);
+-            }
+-            if (!SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
+-                throw new Error(`Server's protocol version is not supported: ${result.protocolVersion}`);
+-            }
+-            this._serverCapabilities = result.capabilities;
+-            this._serverVersion = result.serverInfo;
+-            // HTTP transports must set the protocol version in each header after initialization.
+-            if (transport.setProtocolVersion) {
+-                transport.setProtocolVersion(result.protocolVersion);
+-            }
+-            this._instructions = result.instructions;
+-            await this.notification({
+-                method: 'notifications/initialized'
+-            });
+-            // Set up list changed handlers now that we know server capabilities
+-            if (this._pendingListChangedConfig) {
+-                this._setupListChangedHandlers(this._pendingListChangedConfig);
+-                this._pendingListChangedConfig = undefined;
+-            }
++            await this._initialize(transport, options);
+         }
+         catch (error) {
+             // Disconnect if initialization fails.
+@@ -326,6 +304,37 @@ export class Client extends Protocol {
+             throw error;
+         }
+     }
++    async _initialize(transport, options) {
++        const result = await this.request({
++            method: 'initialize',
++            params: {
++                protocolVersion: LATEST_PROTOCOL_VERSION,
++                capabilities: this._capabilities,
++                clientInfo: this._clientInfo
++            }
++        }, InitializeResultSchema, options);
++        if (result === undefined) {
++            throw new Error(`Server sent invalid initialize result: ${result}`);
++        }
++        if (!SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
++            throw new Error(`Server's protocol version is not supported: ${result.protocolVersion}`);
++        }
++        this._serverCapabilities = result.capabilities;
++        this._serverVersion = result.serverInfo;
++        // HTTP transports must set the protocol version in each header after initialization.
++        if (transport.setProtocolVersion) {
++            transport.setProtocolVersion(result.protocolVersion);
++        }
++        this._instructions = result.instructions;
++        await this.notification({
++            method: 'notifications/initialized'
++        });
++        // Set up list changed handlers now that we know server capabilities
++        if (this._pendingListChangedConfig) {
++            this._setupListChangedHandlers(this._pendingListChangedConfig);
++            this._pendingListChangedConfig = undefined;
++        }
++    }
+     /**
+      * After initialization has completed, this will be populated with the server's reported capabilities.
+      */
+diff --git a/dist/esm/client/streamableHttp.d.ts b/dist/esm/client/streamableHttp.d.ts
+index 6035b24625d7e7227a71a57fb8d8beccc2cea2f4..3ca1c5330cd5a4c3bc54622a50e54fc8ff60261b 100644
+--- a/dist/esm/client/streamableHttp.d.ts
++++ b/dist/esm/client/streamableHttp.d.ts
+@@ -110,9 +110,12 @@ export declare class StreamableHTTPClientTransport implements Transport {
+     private _lastUpscopingHeader?;
+     private _serverRetryMs?;
+     private _reconnectionTimeout?;
++    private _sessionRecovery?;
++    private _recoveringSessionId?;
+     onclose?: () => void;
+     onerror?: (error: Error) => void;
+     onmessage?: (message: JSONRPCMessage) => void;
++    onsessionexpired?: () => void | Promise<void>;
+     constructor(url: URL, opts?: StreamableHTTPClientTransportOptions);
+     private _authThenStart;
+     private _commonHeaders;
+@@ -142,6 +145,8 @@ export declare class StreamableHTTPClientTransport implements Transport {
+         resumptionToken?: string;
+         onresumptiontoken?: (token: string) => void;
+     }): Promise<void>;
++    private _recoverSession;
++    private _send;
+     get sessionId(): string | undefined;
+     /**
+      * Terminates the current session by sending a DELETE request to the server.
+diff --git a/dist/esm/client/streamableHttp.js b/dist/esm/client/streamableHttp.js
+index 624172aa24ae255a67c083f9c19053343e4a0581..f22a2543bc824961a02ad1e0d898840fdac1b92b 100644
+--- a/dist/esm/client/streamableHttp.js
++++ b/dist/esm/client/streamableHttp.js
+@@ -1,5 +1,5 @@
+ import { createFetchWithInit, normalizeHeaders } from '../shared/transport.js';
+-import { isInitializedNotification, isJSONRPCRequest, isJSONRPCResultResponse, JSONRPCMessageSchema } from '../types.js';
++import { isInitializedNotification, isInitializeRequest, isJSONRPCRequest, isJSONRPCResultResponse, JSONRPCMessageSchema } from '../types.js';
+ import { auth, extractWWWAuthenticateParams, UnauthorizedError } from './auth.js';
+ import { EventSourceParserStream } from 'eventsource-parser/stream';
+ // Default reconnection options for StreamableHTTP connections
+@@ -286,7 +286,46 @@ export class StreamableHTTPClientTransport {
+         this.onclose?.();
+     }
+     async send(message, options) {
++        return this._send(message, options, false);
++    }
++    async _recoverSession(expiredSessionId) {
++        if (this._sessionRecovery) {
++            if (this._recoveringSessionId !== expiredSessionId) {
++                if (this._sessionId === expiredSessionId) {
++                    this._sessionId = undefined;
++                }
++                return false;
++            }
++            await this._sessionRecovery;
++            return this._sessionId !== undefined;
++        }
++        if (this._sessionId !== expiredSessionId) {
++            return this._sessionId !== undefined;
++        }
++        this._sessionId = undefined;
++        this._recoveringSessionId = expiredSessionId;
++        const recovery = Promise.resolve().then(() => this.onsessionexpired?.());
++        const tracked = recovery.finally(() => {
++            if (this._sessionRecovery === tracked) {
++                this._sessionRecovery = undefined;
++                this._recoveringSessionId = undefined;
++            }
++        });
++        this._sessionRecovery = tracked;
+         try {
++            await tracked;
++        }
++        catch (error) {
++            this._sessionId = undefined;
++            throw error;
++        }
++        return this._sessionId !== undefined;
++    }
++    async _send(message, options, isSessionRetry) {
++        try {
++            if (this._sessionRecovery && !isInitializeRequest(message) && !isInitializedNotification(message)) {
++                await this._sessionRecovery;
++            }
+             const { resumptionToken, onresumptiontoken } = options || {};
+             if (resumptionToken) {
+                 // If we have at last event ID, we need to reconnect the SSE stream
+@@ -294,6 +333,7 @@ export class StreamableHTTPClientTransport {
+                 return;
+             }
+             const headers = await this._commonHeaders();
++            const requestSessionId = headers.get('mcp-session-id') ?? undefined;
+             headers.set('content-type', 'application/json');
+             headers.set('accept', 'application/json, text/event-stream');
+             const init = {
+@@ -311,6 +351,11 @@ export class StreamableHTTPClientTransport {
+             }
+             if (!response.ok) {
+                 const text = await response.text().catch(() => null);
++                if (response.status === 404 && requestSessionId) {
++                    if (await this._recoverSession(requestSessionId) && !isSessionRetry) {
++                        return this._send(message, options, true);
++                    }
++                }
+                 if (response.status === 401 && this._authProvider) {
+                     // Prevent infinite recursion when server returns 401 after successful auth
+                     if (this._hasCompletedAuthFlow) {
+@@ -331,7 +376,7 @@ export class StreamableHTTPClientTransport {
+                     // Mark that we completed auth flow
+                     this._hasCompletedAuthFlow = true;
+                     // Purposely _not_ awaited, so we don't call onerror twice
+-                    return this.send(message);
++                    return this._send(message, options, isSessionRetry);
+                 }
+                 if (response.status === 403 && this._authProvider) {
+                     const { resourceMetadataUrl, scope, error } = extractWWWAuthenticateParams(response);
+@@ -358,7 +403,7 @@ export class StreamableHTTPClientTransport {
+                         if (result !== 'AUTHORIZED') {
+                             throw new UnauthorizedError();
+                         }
+-                        return this.send(message);
++                        return this._send(message, options, isSessionRetry);
+                     }
+                 }
+                 throw new StreamableHTTPError(response.status, `Error POSTing to endpoint: ${text}`);

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -87,7 +87,7 @@ index 6ac1da14dc7f6211ae70f7711c124b76098816d8..f239ab8e1ede3fdad2a08de3ac4f69c2
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
 diff --git a/dist/cjs/client/streamableHttp.js b/dist/cjs/client/streamableHttp.js
-index a29a7d3a0f14d9cd800ef5b296485237350c666f..b687a62d9c12231a6bff4737b36c185a55bb8f71 100644
+index a29a7d3a0f14d9cd800ef5b296485237350c666f..930ba95105655418440e7d0e932e97530d0b0bfb 100644
 --- a/dist/cjs/client/streamableHttp.js
 +++ b/dist/cjs/client/streamableHttp.js
 @@ -290,7 +290,38 @@ class StreamableHTTPClientTransport {
@@ -137,11 +137,17 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..b687a62d9c12231a6bff4737b36c185a
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -315,6 +347,15 @@ class StreamableHTTPClientTransport {
+@@ -310,11 +342,20 @@ class StreamableHTTPClientTransport {
+             const response = await (this._fetch ?? fetch)(this._url, init);
+             // Handle session ID received during initialization
+             const sessionId = response.headers.get('mcp-session-id');
+-            if (sessionId) {
++            if (sessionId && (requestSessionId === undefined || this._sessionId === requestSessionId)) {
+                 this._sessionId = sessionId;
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId && !isSessionRetry) {
++                if (response.status === 404 && requestSessionId && !isSessionRetry && !(0, types_js_1.isInitializedNotification)(message)) {
 +                    const recovered = await this._recoverSession(requestSessionId);
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');
@@ -278,7 +284,7 @@ index 49b12c6cd918c457420fef7ad5528a9443d1a191..ac182f6ce128ed27ec7fa4abb816879d
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
 diff --git a/dist/esm/client/streamableHttp.js b/dist/esm/client/streamableHttp.js
-index 624172aa24ae255a67c083f9c19053343e4a0581..4a1810d4b128f59be33d91e0f96deaa0b4b99de4 100644
+index 624172aa24ae255a67c083f9c19053343e4a0581..be2518af2fec26c7c9398f52e5d667bfa42d0879 100644
 --- a/dist/esm/client/streamableHttp.js
 +++ b/dist/esm/client/streamableHttp.js
 @@ -1,5 +1,5 @@
@@ -335,11 +341,17 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..4a1810d4b128f59be33d91e0f96deaa0
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -311,6 +343,15 @@ export class StreamableHTTPClientTransport {
+@@ -306,11 +338,20 @@ export class StreamableHTTPClientTransport {
+             const response = await (this._fetch ?? fetch)(this._url, init);
+             // Handle session ID received during initialization
+             const sessionId = response.headers.get('mcp-session-id');
+-            if (sessionId) {
++            if (sessionId && (requestSessionId === undefined || this._sessionId === requestSessionId)) {
+                 this._sessionId = sessionId;
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId && !isSessionRetry) {
++                if (response.status === 404 && requestSessionId && !isSessionRetry && !isInitializedNotification(message)) {
 +                    const recovered = await this._recoverSession(requestSessionId);
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/cjs/client/index.js b/dist/cjs/client/index.js
-index 6ac1da14dc7f6211ae70f7711c124b76098816d8..f239ab8e1ede3fdad2a08de3ac4f69c2f8e8f80d 100644
+index 6ac1da14dc7f6211ae70f7711c124b76098816d8..adb5b7bd45514a406a0f7e40b64631c101584c84 100644
 --- a/dist/cjs/client/index.js
 +++ b/dist/cjs/client/index.js
 @@ -288,41 +288,16 @@ class Client extends protocol_js_1.Protocol {
@@ -7,7 +7,7 @@ index 6ac1da14dc7f6211ae70f7711c124b76098816d8..f239ab8e1ede3fdad2a08de3ac4f69c2
      async connect(transport, options) {
          await super.connect(transport);
 +        transport.onsessionexpired = async () => {
-+            await this._initialize(transport, options);
++            await this._initialize(transport);
 +        };
          // When transport sessionId is already set this means we are trying to reconnect.
          // In this case we don't need to initialize again.
@@ -87,7 +87,7 @@ index 6ac1da14dc7f6211ae70f7711c124b76098816d8..f239ab8e1ede3fdad2a08de3ac4f69c2
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
 diff --git a/dist/cjs/client/streamableHttp.js b/dist/cjs/client/streamableHttp.js
-index a29a7d3a0f14d9cd800ef5b296485237350c666f..930ba95105655418440e7d0e932e97530d0b0bfb 100644
+index a29a7d3a0f14d9cd800ef5b296485237350c666f..c362ae5fe6c62c8c8eae7e2e61de1eedff5443c9 100644
 --- a/dist/cjs/client/streamableHttp.js
 +++ b/dist/cjs/client/streamableHttp.js
 @@ -290,7 +290,38 @@ class StreamableHTTPClientTransport {
@@ -99,10 +99,10 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..930ba95105655418440e7d0e932e9753
 +    async _recoverSession(expiredSessionId) {
 +        if (this._sessionRecovery) {
 +            await this._sessionRecovery;
-+            return this._sessionId !== undefined;
++            return true;
 +        }
 +        if (this._sessionId !== expiredSessionId)
-+            return this._sessionId !== undefined;
++            return true;
 +        this._sessionId = undefined;
 +        this._sessionRecovery = Promise.resolve().then(() => this.onsessionexpired?.());
          try {
@@ -116,7 +116,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..930ba95105655418440e7d0e932e9753
 +        finally {
 +            this._sessionRecovery = undefined;
 +        }
-+        return this._sessionId !== undefined;
++        return true;
 +    }
 +    async _send(message, options, isSessionRetry) {
 +        try {
@@ -196,7 +196,7 @@ index 3617e787f0ba70447c99501aee7aa67584d89758..4a96d6a0328fa348b96f3869ab7e0bb7
                      reject(error);
                  });
 diff --git a/dist/esm/client/index.js b/dist/esm/client/index.js
-index 49b12c6cd918c457420fef7ad5528a9443d1a191..ac182f6ce128ed27ec7fa4abb816879d54163824 100644
+index 49b12c6cd918c457420fef7ad5528a9443d1a191..2afe2e22e960f26c9d516ef135d89f8eb9e4caff 100644
 --- a/dist/esm/client/index.js
 +++ b/dist/esm/client/index.js
 @@ -284,41 +284,16 @@ export class Client extends Protocol {
@@ -204,7 +204,7 @@ index 49b12c6cd918c457420fef7ad5528a9443d1a191..ac182f6ce128ed27ec7fa4abb816879d
      async connect(transport, options) {
          await super.connect(transport);
 +        transport.onsessionexpired = async () => {
-+            await this._initialize(transport, options);
++            await this._initialize(transport);
 +        };
          // When transport sessionId is already set this means we are trying to reconnect.
          // In this case we don't need to initialize again.
@@ -284,7 +284,7 @@ index 49b12c6cd918c457420fef7ad5528a9443d1a191..ac182f6ce128ed27ec7fa4abb816879d
       * After initialization has completed, this will be populated with the server's reported capabilities.
       */
 diff --git a/dist/esm/client/streamableHttp.js b/dist/esm/client/streamableHttp.js
-index 624172aa24ae255a67c083f9c19053343e4a0581..be2518af2fec26c7c9398f52e5d667bfa42d0879 100644
+index 624172aa24ae255a67c083f9c19053343e4a0581..ac75b14545fda44aff7ff4d97cc5da884fcc627a 100644
 --- a/dist/esm/client/streamableHttp.js
 +++ b/dist/esm/client/streamableHttp.js
 @@ -1,5 +1,5 @@
@@ -303,10 +303,10 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..be2518af2fec26c7c9398f52e5d667bf
 +    async _recoverSession(expiredSessionId) {
 +        if (this._sessionRecovery) {
 +            await this._sessionRecovery;
-+            return this._sessionId !== undefined;
++            return true;
 +        }
 +        if (this._sessionId !== expiredSessionId)
-+            return this._sessionId !== undefined;
++            return true;
 +        this._sessionId = undefined;
 +        this._sessionRecovery = Promise.resolve().then(() => this.onsessionexpired?.());
          try {
@@ -320,7 +320,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..be2518af2fec26c7c9398f52e5d667bf
 +        finally {
 +            this._sessionRecovery = undefined;
 +        }
-+        return this._sessionId !== undefined;
++        return true;
 +    }
 +    async _send(message, options, isSessionRetry) {
 +        try {


### PR DESCRIPTION
## Summary

- locally patch `@modelcontextprotocol/sdk@1.29.0` to reinitialize a Streamable HTTP session after a POST carrying a session ID receives 404
- coalesce concurrent stale-session failures into one initialization and retry each rejected POST at most once
- support replacement servers that initialize without issuing another optional session ID
- prevent delayed responses from an expired session from overwriting the replacement session state
- avoid replaying a request that timed out or was aborted while recovery was running
- close the client if replacement initialization fails
- add a focused regression test using the real SDK transport against a loopback HTTP server

This is intentionally limited to the POST failure reported in #25137. It does not infer session expiry from optional GET/SSE failures and does not retry ambiguous network failures. Recovery uses fresh request options rather than retaining the original connection signal. The patch can be removed after an equivalent SDK release is adopted.

Closes #25137.
Related to master MCP issue #28567.

## Validation

- `bun test test/mcp/session-recovery.test.ts` from `packages/opencode`
- `bun test test/mcp` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun install --frozen-lockfile`
- regression test verifies over real loopback HTTP that the stale request receives 404, replacement initialization omits the expired session header, and the original request retries once with the replacement session
- manually verified concurrent failures share one initialization, timed-out requests are not replayed, stateless replacement initialization succeeds, delayed stale responses cannot replace the recovered session, and GET 404 does not trigger recovery
