### PR TITLE
fix(processor): detect doom loops across messages instead of within current message

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -516,21 +516,18 @@ export const layer = Layer.effect(
                 : value.providerMetadata,
             }))
 
-            const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
+            const msgs = yield* MessageV2.filterCompactedEffect(ctx.sessionID).pipe(
               Effect.provideService(Database.Service, database),
             )
-            const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
+            const matchingParts = msgs.flatMap((m) => m.parts).filter(
+              (part) =>
+                part.type === "tool" &&
+                part.tool === value.name &&
+                part.state.status !== "pending" &&
+                JSON.stringify(part.state.input) === JSON.stringify(input),
+            )
 
-            if (
-              recentParts.length !== DOOM_LOOP_THRESHOLD ||
-              !recentParts.every(
-                (part) =>
-                  part.type === "tool" &&
-                  part.tool === value.name &&
-                  part.state.status !== "pending" &&
-                  JSON.stringify(part.state.input) === JSON.stringify(input),
-              )
-            ) {
+            if (matchingParts.length < DOOM_LOOP_THRESHOLD) {
               return
             }
 


### PR DESCRIPTION
### Issue for this PR

Closes #25254

### Type of change

- [x] Bug fix

### What does this PR do?

The doom loop detection in processor.ts had two bugs:

1. **Scope limited to current message only**: MessageV2.parts(ctx.assistantMessage.id) only returns parts from the current assistant message. When a model repeats the same tool call across multiple messages (e.g. three separate turns each calling ead_file with the same path), the doom loop check silently passes because each individual message has fewer than 3 matching parts.

2. **Slice before filter inverts the logic**: parts.slice(-3).every(...) takes the last 3 parts regardless of type, then checks if all 3 match. If any text or reasoning part appears in the tail, every returns false and the check passes even when there are plenty of repeated tool calls in the message.

Fix: use MessageV2.filterCompactedEffect(ctx.sessionID) to search all messages in the session (same function already used by the prompt loop), filter matching tool parts first, then check if the count reaches DOOM_LOOP_THRESHOLD.

### How did you verify your code works?

- un typecheck passes in packages/opencode
- Reviewed the diff to confirm ilterCompactedEffect and ctx.sessionID are both available in the current codebase
- The previous PR #25255 identified the same root cause and proposed the same fix direction, but was closed by automated cleanup (not rejected for technical reasons)

### Screenshots / recordings

Not applicable; logic-only change with no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR