### PR TITLE
refactor(server): use nodes for global services

### DIFF
--- a/packages/core/src/credential.ts
+++ b/packages/core/src/credential.ts
@@ -3,6 +3,7 @@ export * as Credential from "./credential"
 import { asc, eq } from "drizzle-orm"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "./database/database"
+import { LayerNode } from "./effect/layer-node"
 import { IntegrationSchema } from "./integration/schema"
 import { NonNegativeInt, withStatics } from "./schema"
 import { Identifier } from "./util/identifier"
@@ -144,3 +145,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/core/src/permission/saved.ts
+++ b/packages/core/src/permission/saved.ts
@@ -3,6 +3,7 @@ export * as PermissionSaved from "./saved"
 import { eq } from "drizzle-orm"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
+import { LayerNode } from "../effect/layer-node"
 import { ProjectV2 } from "../project"
 import { withStatics } from "../schema"
 import { Identifier } from "../util/identifier"
@@ -85,3 +86,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -2,6 +2,7 @@ export * as SessionV2 from "./session"
 export * from "./session/schema"
 
 import { Cause, DateTime, Effect, Layer, Schema, Context, Stream } from "effect"
+import { LayerNode } from "./effect/layer-node"
 import { and, asc, desc, eq, gt, like, lt, or, type SQL } from "drizzle-orm"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
@@ -434,3 +435,11 @@ export const defaultLayer = layer.pipe(
   Layer.provide(ProjectV2.defaultLayer),
   Layer.orDie,
 )
+export const node = LayerNode.make(layer.pipe(Layer.orDie), [
+  Database.node,
+  EventV2.node,
+  ProjectV2.node,
+  SessionExecution.noopNode,
+  SessionProjector.node,
+  SessionStore.node,
+])

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -1,6 +1,7 @@
 export * as SessionExecution from "./execution"
 
 import { Context, Effect, Layer } from "effect"
+import { LayerNode } from "../effect/layer-node"
 import { SessionRunner } from "./runner/index"
 import { SessionSchema } from "./schema"
 
@@ -21,3 +22,4 @@ export const noopLayer = Layer.succeed(
   Service,
   Service.of({ resume: () => Effect.void, wake: () => Effect.void, interrupt: () => Effect.void }),
 )
+export const noopNode = LayerNode.make(noopLayer, [])

--- a/packages/core/src/session/execution/local.ts
+++ b/packages/core/src/session/execution/local.ts
@@ -1,4 +1,5 @@
 import { Effect, Layer } from "effect"
+import { LayerNode } from "../../effect/layer-node"
 import { LocationServiceMap } from "../../location-layer"
 import { SessionRunCoordinator } from "../run-coordinator"
 import { SessionRunner } from "../runner"
@@ -33,3 +34,6 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(SessionStore.defaultLayer))
+export const node = LayerNode.make(layer.pipe(Layer.provide(LocationServiceMap.layer)), [SessionStore.node])
+
+export * as SessionExecutionLocal from "./local"

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -3,6 +3,7 @@ export * as SessionStore from "./store"
 import { eq } from "drizzle-orm"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
+import { LayerNode } from "../effect/layer-node"
 import { SessionHistory } from "./history"
 import { MessageDecodeError } from "./error"
 import { SessionMessage } from "./message"
@@ -60,3 +61,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/server/src/handlers.ts
+++ b/packages/server/src/handlers.ts
@@ -1,6 +1,9 @@
-import { SessionV2 } from "@opencode-ai/core/session"
+import { Credential } from "@opencode-ai/core/credential"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
+import { SessionV2 } from "@opencode-ai/core/session"
+import { SessionExecutionLocal } from "@opencode-ai/core/session/execution/local"
 import { Layer } from "effect"
 import { layer as locationLayer } from "./groups/location"
 import { sessionLocationLayer } from "./middleware/session-location"
@@ -17,11 +20,9 @@ import { AgentHandler } from "./handlers/agent"
 import { HealthHandler } from "./handlers/health"
 import { QuestionHandler } from "./handlers/question"
 import { ReferenceHandler } from "./handlers/reference"
-import * as SessionExecutionLocal from "@opencode-ai/core/session/execution/local"
 import { LocationHandler } from "./handlers/location"
 import { IntegrationHandler } from "./handlers/integration"
 import { CredentialHandler } from "./handlers/credential"
-import { Credential } from "@opencode-ai/core/credential"
 import { ProjectCopyHandler } from "./handlers/project-copy"
 
 export const handlers = Layer.mergeAll(
@@ -45,9 +46,9 @@ export const handlers = Layer.mergeAll(
 ).pipe(
   Layer.provide(sessionLocationLayer),
   Layer.provide(locationLayer),
-  Layer.provide(SessionV2.defaultLayer),
-  Layer.provide(SessionExecutionLocal.defaultLayer),
-  Layer.provide(PermissionSaved.defaultLayer),
+  Layer.provide(LayerNode.buildLayer(SessionV2.node)),
+  Layer.provide(LayerNode.buildLayer(SessionExecutionLocal.node)),
+  Layer.provide(LayerNode.buildLayer(PermissionSaved.node)),
   Layer.provide(LocationServiceMap.layer),
-  Layer.provide(Credential.defaultLayer),
+  Layer.provide(LayerNode.buildLayer(Credential.node)),
 )

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -1,4 +1,5 @@
 import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { EventV2 } from "@opencode-ai/core/event"
 import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http"
@@ -21,8 +22,8 @@ export function createRoutes(password?: string) {
         : ServerAuth.Config.defaultLayer,
     ),
     Layer.provide(LocationServiceMap.layer),
-    Layer.provide(Database.defaultLayer),
-    Layer.provide(EventV2.defaultLayer),
+    Layer.provide(LayerNode.buildLayer(Database.node)),
+    Layer.provide(LayerNode.buildLayer(EventV2.node)),
     Layer.provide(FetchHttpClient.layer),
   )
 }


### PR DESCRIPTION
## Summary

- add layer nodes for the V2 database-backed process-global services
- preserve the standalone server's existing layer assembly and replace each process-global `defaultLayer` provision with its `LayerNode.buildLayer(...)` equivalent
- preserve the existing noop-then-local Session execution wiring
- leave `LocationServiceMap.layer` and its internal dependency wiring unchanged

## Validation

- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/server`
- `bun typecheck` from `packages/opencode`
- `bun test test/effect/app-graph-types.test.ts` from `packages/opencode`
- imported both standalone and integrated server route modules with Bun to verify graph construction has no runtime cycles
