### PR TITLE
docs: remove references to deleted scout agent

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -516,21 +516,18 @@ export const layer = Layer.effect(
                 : value.providerMetadata,
             }))
 
-            const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
+            const msgs = yield* MessageV2.filterCompactedEffect(ctx.sessionID).pipe(
               Effect.provideService(Database.Service, database),
             )
-            const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
+            const matchingParts = msgs.flatMap((m) => m.parts).filter(
+              (part) =>
+                part.type === "tool" &&
+                part.tool === value.name &&
+                part.state.status !== "pending" &&
+                JSON.stringify(part.state.input) === JSON.stringify(input),
+            )
 
-            if (
-              recentParts.length !== DOOM_LOOP_THRESHOLD ||
-              !recentParts.every(
-                (part) =>
-                  part.type === "tool" &&
-                  part.tool === value.name &&
-                  part.state.status !== "pending" &&
-                  JSON.stringify(part.state.input) === JSON.stringify(input),
-              )
-            ) {
+            if (matchingParts.length < DOOM_LOOP_THRESHOLD) {
               return
             }
 

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -36,13 +36,13 @@ look at these below.
 
 Subagents are specialized assistants that primary agents can invoke for specific tasks. You can also manually invoke them by **@ mentioning** them in your messages.
 
-OpenCode comes with three built-in subagents, **General**, **Explore**, and **Scout**. We'll look at this below.
+OpenCode comes with two built-in subagents, **General** and **Explore**. We'll look at these below.
 
 ---
 
 ## Built-in
 
-OpenCode comes with two built-in primary agents and three built-in subagents.
+OpenCode comes with two built-in primary agents and two built-in subagents.
 
 ---
 
@@ -81,14 +81,6 @@ A general-purpose agent for researching complex questions and executing multi-st
 _Mode_: `subagent`
 
 A fast, read-only agent for exploring codebases. Cannot modify files. Use this when you need to quickly find files by patterns, search code for keywords, or answer questions about the codebase.
-
----
-
-### Use scout
-
-_Mode_: `subagent`
-
-A read-only agent for external docs and dependency research. Use this when you need to clone a dependency repository into OpenCode's managed cache, inspect library source, or cross-reference local code against upstream implementations without modifying your workspace.
 
 ---
 

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -728,5 +728,4 @@ These environment variables enable experimental features that may change or be r
 | `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM`            | boolean | Enable experimental event system        |
 | `OPENCODE_EXPERIMENTAL_NATIVE_LLM`              | boolean | Enable native LLM request path          |
 | `OPENCODE_EXPERIMENTAL_PARALLEL`                | boolean | Enable parallel web search execution    |
-| `OPENCODE_EXPERIMENTAL_SCOUT`                   | boolean | Enable Scout subagent                   |
 | `OPENCODE_EXPERIMENTAL_WORKSPACES`              | boolean | Enable workspace support                |


### PR DESCRIPTION
Closes #32105

## Changes

- Removed scout agent section from agents.mdx
- Updated subagent count from three to two
- Removed OPENCODE_EXPERIMENTAL_SCOUT from cli.mdx environment variables table

## Notes

Translations in other languages still reference scout agent but can be updated separately by translators.