### PR TITLE
fix(tui): restore subtask invocation spacing

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1527,6 +1527,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
       </Show>
       <Show when={props.message.error && props.message.error.name !== "MessageAbortedError"}>
         <box
+          id={`assistant-error-${props.message.id}`}
           border={["left"]}
           paddingTop={1}
           paddingBottom={1}
@@ -1541,7 +1542,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
       </Show>
       <Switch>
         <Match when={props.last || final() || props.message.error?.name === "MessageAbortedError"}>
-          <box paddingLeft={3}>
+          <box id={`assistant-summary-${props.message.id}`} paddingLeft={3}>
             <text marginTop={1}>
               <span
                 style={{
@@ -1939,6 +1940,8 @@ export function InlineToolRow(props: {
           const previousSubagent = previous?.id.startsWith("tool-inline-subagent-") ?? false
           return previous?.id.startsWith("text-") ||
             previous?.id.startsWith("tool-block-") ||
+            previous?.id.startsWith("assistant-error-") ||
+            previous?.id.startsWith("assistant-summary-") ||
             (previousInline && previousSubagent !== Boolean(props.subagent)) ||
             props.separateAfter?.(previous?.id)
             ? 1

--- a/packages/tui/test/cli/tui/__snapshots__/inline-tool-wrap-snapshot.test.tsx.snap
+++ b/packages/tui/test/cli/tui/__snapshots__/inline-tool-wrap-snapshot.test.tsx.snap
@@ -70,3 +70,19 @@ exports[`TUI inline tool wrapping separates a subagent group after an expanded r
    ✓ Explore Task — Inspect active task spacing
      ↳ 1 toolcall · 501ms"
 `;
+
+exports[`TUI inline tool wrapping separates a subagent from the previous assistant summary 1`] = `
+"   ▣ Build · Little Frank · 53.1s
+
+   ✓ Build Task — Review changes
+     ↳ 48 toolcalls · 1m 40s"
+`;
+
+exports[`TUI inline tool wrapping separates a subagent from the previous assistant error 1`] = `
+"│
+│  Managed inference requires an active Member plan
+│
+
+   ✓ Build Task — Review changes
+     ↳ 48 toolcalls · 1m 40s"
+`;

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -134,6 +134,32 @@ function LoadedReadBeforeSubagentFixture() {
   )
 }
 
+function AssistantSummaryBeforeSubagentFixture() {
+  return (
+    <box flexDirection="column" width={72}>
+      <box id="assistant-summary-message-one" paddingLeft={3}>
+        <text>▣ Build · Little Frank · 53.1s</text>
+      </box>
+      <InlineToolRow id="tool-inline-subagent-one" icon="✓" complete={true} pending="" subagent={true}>
+        {"Build Task — Review changes\n↳ 48 toolcalls · 1m 40s"}
+      </InlineToolRow>
+    </box>
+  )
+}
+
+function AssistantErrorBeforeSubagentFixture() {
+  return (
+    <box flexDirection="column" width={72}>
+      <box id="assistant-error-message-one" border={["left"]} paddingTop={1} paddingBottom={1} paddingLeft={2}>
+        <text>Managed inference requires an active Member plan</text>
+      </box>
+      <InlineToolRow id="tool-inline-subagent-one" icon="✓" complete={true} pending="" subagent={true}>
+        {"Build Task — Review changes\n↳ 48 toolcalls · 1m 40s"}
+      </InlineToolRow>
+    </box>
+  )
+}
+
 function StickyScrollFixture(props: { separated: boolean; scroll: (scroll: ScrollBoxRenderable) => void }) {
   return (
     <scrollbox ref={props.scroll} stickyScroll={true} stickyStart="bottom" height={3} width={72}>
@@ -274,6 +300,16 @@ describe("TUI inline tool wrapping", () => {
 
   test("separates a subagent group after an expanded read", async () => {
     expect(await renderFrame(() => <LoadedReadBeforeSubagentFixture />, { width: 72, height: 8 })).toMatchSnapshot()
+  })
+
+  test("separates a subagent from the previous assistant summary", async () => {
+    expect(
+      await renderFrame(() => <AssistantSummaryBeforeSubagentFixture />, { width: 72, height: 5 }),
+    ).toMatchSnapshot()
+  })
+
+  test("separates a subagent from the previous assistant error", async () => {
+    expect(await renderFrame(() => <AssistantErrorBeforeSubagentFixture />, { width: 72, height: 7 })).toMatchSnapshot()
   })
 
   test("updates sticky-bottom geometry when a text separator mounts and unmounts", async () => {


### PR DESCRIPTION
## Summary
- identify assistant summaries and error cards in the TUI layout tree
- preserve a blank-row boundary when a subtask invocation follows either element
- add snapshot coverage for summary-to-subtask and error-to-subtask transitions

## Verification
- `bun test test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- `bun typecheck`
- `bunx prettier --check src/routes/session/index.tsx test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- `git diff --check`