### PR TITLE
docs: add rotator ecosystem entries

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -50,6 +50,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                    |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                             |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                           |
+| [opencode-rotator-plugin](https://github.com/xnnnc/opencode-rotator-plugin)                        | TUI sidebar for a local ChatGPT account rotator server                                             |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                           |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
@@ -71,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI            |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
+| [OpenCode ChatGPT Account Rotator](https://github.com/xnnnc/opencode-chatgpt-account-rotator) | Local GUI and CLI for rotating saved OpenCode ChatGPT auth entries |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #32114

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds two OpenCode-specific community projects to the Ecosystem docs:

- `opencode-rotator-plugin` under Plugins: an OpenCode TUI sidebar plugin for a local ChatGPT account rotator server.
- `opencode-chatgpt-account-rotator` under Projects: the companion local GUI/CLI server for managing saved OpenCode ChatGPT auth entries on one trusted machine.

Why these belong in Ecosystem:

- The plugin integrates with OpenCode plugin/TUI surfaces.
- The companion app is built specifically around local OpenCode ChatGPT auth state.
- Both repositories are public, OpenCode-focused, and documented with local-only auth safety notes.

Security context: the companion app handles sensitive local auth state and is intended for one trusted user on one trusted machine. The plugin only talks to the local rotator server; it does not read or write auth files directly.

### How did you verify your code works?

- Ran `git diff --cached --check` before committing.
- Verified this is a docs-only MDX table update.
- Confirmed the PR standards and compliance checks are passing after linking the compliant feature issue.

### Screenshots / recordings

Not applicable; this is a docs-only ecosystem entry update.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR