### PR TITLE
fix(opencode): classify fetch timeouts as retryable

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -661,6 +661,18 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case e instanceof DOMException && e.name === "TimeoutError":
+      return new APIError(
+        {
+          message: "Request timed out",
+          isRetryable: true,
+          metadata: {
+            code: e.name,
+            message: e.message,
+          },
+        },
+        { cause: e },
+      ).toObject()
     case e instanceof ProviderError.HeaderTimeoutError:
       return new APIError(
         {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1443,6 +1443,23 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("serializes fetch timeouts as retryable APIError", () => {
+    const input = new DOMException("The operation timed out.", "TimeoutError")
+    const result = MessageV2.fromError(input, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: "Request timed out",
+        isRetryable: true,
+        metadata: {
+          code: "TimeoutError",
+          message: "The operation timed out.",
+        },
+      },
+    })
+  })
+
   test("detects context overflow from APICallError provider messages", () => {
     const cases = [
       "prompt is too long: 213462 tokens > 200000 maximum",


### PR DESCRIPTION
## Problem

When a provider config sets `timeout` (e.g. `"timeout": 180000`), it is attached to the fetch as `AbortSignal.timeout(...)` (`provider.ts`). When it fires, the request rejects with a `DOMException` named `TimeoutError` ("The operation timed out.").

`MessageV2.fromError` only matches `DOMException` with name `AbortError` (user cancellation), so `TimeoutError` falls through to the generic `e instanceof Error` case and becomes `NamedError.Unknown`. `SessionRetry.retryable` doesn't retry `Unknown` errors, so a single transient provider timeout permanently fails the turn instead of being retried.

## Fix

Add a `TimeoutError` case in `fromError` that maps to `APIError` with `isRetryable: true`, mirroring the existing handling for `ProviderError.HeaderTimeoutError` and `ProviderError.ResponseStreamError`. There is no conflict with user cancellation, which always surfaces as `AbortError`.

## Test

Added a unit test in `test/session/message-v2.test.ts` asserting the timeout DOMException serializes to a retryable `APIError`.