### PR TITLE
feat(opencode): harden context-mode wrapper PoC

### DIFF
--- a/.opencode/plugins/trade-context-mode.ts
+++ b/.opencode/plugins/trade-context-mode.ts
@@ -79,7 +79,12 @@ const shadowHooks = (mode: TradeContextMode, hooks: Hooks | undefined) => {
   if (typeof fromDelegate === "function") {
     return {
       "tool.execute.after": async (...args: unknown[]) => {
-        await runHookSafely(mode, "tool.execute.after", fromDelegate, args)
+        await runHookSafely(
+          mode,
+          "tool.execute.after",
+          fromDelegate as (...hookArgs: unknown[]) => Promise<void> | void,
+          args,
+        )
       },
     }
   }

--- a/.opencode/plugins/trade-context-mode.ts
+++ b/.opencode/plugins/trade-context-mode.ts
@@ -1,0 +1,105 @@
+import type { Hooks, Plugin, PluginInput, PluginOptions } from "@opencode-ai/plugin"
+import path from "path"
+import { pathToFileURL } from "url"
+
+type TradeContextMode = "off" | "tools" | "shadow"
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+const readMode = (): TradeContextMode => {
+  const raw = process.env.OPENCODE_TRADE_CONTEXT_MODE?.trim().toLowerCase()
+  if (raw === "tools" || raw === "shadow") return raw
+  return "off"
+}
+
+const runHookSafely = async (
+  mode: TradeContextMode,
+  name: string,
+  hook: (...args: unknown[]) => Promise<void> | void,
+  args: unknown[],
+) => {
+  try {
+    await hook(...args)
+  } catch (error) {
+    if (mode === "off") return
+    console.warn(`[trade-context-mode] ${name} failed`, error)
+  }
+}
+
+const resolveDelegateSpec = (raw: string) => {
+  const value = raw.trim()
+  if (value.includes("://")) return value
+  if (value.startsWith(".") || value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value)) {
+    return pathToFileURL(path.resolve(process.cwd(), value)).href
+  }
+  return value
+}
+
+const loadContextModeDelegate = async (
+  input: PluginInput,
+  options: PluginOptions | undefined,
+): Promise<Hooks | undefined> => {
+  const configured = process.env.OPENCODE_TRADE_CONTEXT_MODE_DELEGATE?.trim()
+  const candidate = configured && resolveDelegateSpec(configured)
+  if (!candidate) return undefined
+
+  try {
+    const module = await import(candidate)
+    const factory = module.default
+    if (typeof factory !== "function") return undefined
+    const hooks = await factory(input, options)
+    return hooks ?? undefined
+  } catch (error) {
+    console.warn(`[trade-context-mode] context-mode delegate import failed: ${candidate}`, error)
+    return undefined
+  }
+}
+
+const toolOnlyHooks = (hooks: Hooks) => {
+  const tool = hooks.tool
+  if (!isRecord(tool)) return {}
+
+  const filtered = Object.fromEntries(
+    Object.entries(tool).filter(
+      ([name, value]) =>
+        name.startsWith("ctx_") &&
+        isRecord(value) &&
+        typeof value.execute === "function",
+    ),
+  ) as Hooks["tool"]
+
+  if (!filtered || Object.keys(filtered).length === 0) return {}
+  return { tool: filtered }
+}
+
+const shadowHooks = (mode: TradeContextMode, hooks: Hooks | undefined) => {
+  const fromDelegate = hooks?.["tool.execute.after"]
+  if (typeof fromDelegate === "function") {
+    return {
+      "tool.execute.after": async (...args: unknown[]) => {
+        await runHookSafely(mode, "tool.execute.after", fromDelegate, args)
+      },
+    }
+  }
+
+  return {
+    "tool.execute.after": async () => {},
+  }
+}
+
+export default (async (input, options) => {
+  const mode = readMode()
+
+  if (mode === "off") return {}
+
+  if (mode === "tools") {
+    const hooks = await loadContextModeDelegate(input, options)
+    if (!hooks) return {}
+    return toolOnlyHooks(hooks)
+  }
+
+  const hooks = await loadContextModeDelegate(input, options)
+  return shadowHooks(mode, hooks)
+}) satisfies Plugin

--- a/docs/opencode-trade-context-mode-plan.md
+++ b/docs/opencode-trade-context-mode-plan.md
@@ -1,0 +1,354 @@
+# opencode-trade Context Mode 導入案
+
+## 目的
+
+`context-mode` を `opencode-trade` 専用の **限定 PoC** として導入し、巨大ログや調査出力のコンテキスト圧迫を減らす。
+
+`trade-memory` の authoritative な役割は維持し、`context-mode` は raw output の sandbox / temporary index に限定する。
+
+## 方針
+
+- 直接 `context-mode` を `opencode.jsonc` に入れず、`.opencode/plugins/trade-context-mode.ts` でラップする
+- デフォルトは `off` にする
+- `trade-memory` は残す
+- `context-mode` は raw output の sandbox / temporary index 用に限定する
+- `mcp.context-mode` は使わない
+- upstream の routing file はそのまま上書きしない
+- 初期導入は `off` / `tools` / `shadow` のみとし、`on` / `strict` は後続 phase に送る
+- wrapper 例外は fail-open とし、OpenCode 本体と `trade-memory` を壊さない
+- wrapper は top-level import で `context-mode` を読まない
+- `OPENCODE_PURE=1` を最終 rollback 手段として明記する
+
+## 実装前監査の結論
+
+- `off` は runtime 停止であり、loader 障害の完全な保険ではない
+- `trade-memory` との主衝突点は tool 名ではなく、記憶の権威と hook 注入である
+- `context-mode` は強い実行系 tool を持ち得るため、権限境界の確認なしに全面導入してはいけない
+- 最初の実装単位は `context-mode` 依存追加ではなく、無害な wrapper skeleton と spike にする
+
+## 想定効果
+
+| 領域 | 期待効果 |
+| --- | --- |
+| 長いログ | MT5 log, CI log, grep 結果の圧縮 |
+| compaction | 再開時の文脈復元を補助 |
+| 調査 | script 化された検索・集計でノイズ削減 |
+| handoff | `trade-memory` と別経路で補助的検索が可能 |
+
+## 想定リスク
+
+| 領域 | リスク |
+| --- | --- |
+| 記憶の重複 | `trade-memory` と `context-mode` の両方に履歴が残る |
+| prompt 重複 | system transform が二重注入される |
+| hook 遅延 | tool 実行ごとの I/O が増える |
+| 作業阻害 | block/redirect が MT5 系作業を止める可能性 |
+| 障害範囲 | plugin 起動失敗が OpenCode 起動に波及する可能性 |
+| secret 保存 | MT5 logs、broker profile、token-like text を一時 index に入れる可能性 |
+| rollback | wrapper 破損時に `off` だけでは救えない可能性 |
+
+## `trade-memory` との分担
+
+| 役割 | 担当 |
+| --- | --- |
+| 作業中の会話履歴 | `trade-memory` |
+| 意思決定・risk・handoff | `trade-memory` |
+| compaction 用の補助 context | `context-mode` |
+| 大きな tool output の sandbox | `context-mode` |
+| 監査証跡 | `SPRINT.md` / `REVIEW_NOTES.md` / `backtest/results/*.json` |
+
+## wrapper plugin 案
+
+- ファイル: `.opencode/plugins/trade-context-mode.ts`
+- 役割: `context-mode` を遅延読み込みし、mode に応じて hook を絞る
+- 実装方針: `OPENCODE_TRADE_CONTEXT_MODE` で制御する
+- 初回 PR は inert skeleton のみで、実物 `context-mode` の import は後追いにする
+
+### 事前 spike
+
+- `context-mode` の OpenCode plugin export shape を確認する
+- import / plugin factory 呼び出しで副作用がないか確認する
+- `ctx_*` tool 名と実際の登録結果を確認する
+- storage path と purge 手順を確認する
+- delegated hook 例外を wrapper で握れるか確認する
+- `tools` / `shadow` で `trade-memory` 非干渉を確認してから依存追加する
+
+### mode
+
+| mode | 挙動 |
+| --- | --- |
+| `off` | 無効 |
+| `tools` | `ctx_*` tools のみ有効 |
+| `shadow` | 記録中心。block はしない |
+| `on` | 後続 phase でのみ検討 |
+| `strict` | 後続 phase でのみ検討 |
+
+### 初回実装範囲
+
+- `off` / `tools` / `shadow` のみ実装する
+- `on` / `strict` はコードにも routing にも入れない
+- `system.transform` と `session.compacting` は初期では無効のままにする
+- `tool.execute.before` は初期では返さない
+- `tool.execute.after` も初期は記録のためだけに限定する
+
+## 初期導入順
+
+1. `tools` mode を試す
+2. `shadow` mode で記録系 hook を確認する
+3. `on` / `strict` は実装しないまま保留する
+
+## 実行手順（PoC）
+
+- 無効化（既定）
+  - `OPENCODE_TRADE_CONTEXT_MODE=off`
+  - もしくは変数を未設定
+
+- ツール露出のみ
+  - `OPENCODE_TRADE_CONTEXT_MODE=tools`
+  - `OPENCODE_TRADE_CONTEXT_MODE_DELEGATE` に読み込む plugin パスを指定
+  - 指定候補の delegate 側で `ctx_*` プレフィックスの tool のみが `tool` hook として露出
+
+- 記録 hook（Fail-open）
+  - `OPENCODE_TRADE_CONTEXT_MODE=shadow`
+  - `tool.execute.after` を delegate から引き継ぎ、delegate 例外は握りつぶし
+
+- rollback
+  - `OPENCODE_TRADE_CONTEXT_MODE=off`
+  - それでも問題が残る場合は `OPENCODE_PURE=1`
+
+## 命名ガイドライン（PoC）
+
+- context-mode の tool は原則 `ctx_` で始める。
+- 推奨フォーマットは `ctx_<domain>_<action>`（例: `ctx_search`, `ctx_stats`, `ctx_audit_recent`）。
+- 非 `ctx_` の tool は公開されないため、PoC 外にある有効な機能でも露出されない。
+- 依存追加時は名前規則の見直しを必須とし、`ctx_` プレフィックスがないものは `tools` mode で検証しても使えないことを前提に扱う。
+
+## 運用チェック（軽量）
+
+- `off` → 起動時既定。`OPENCODE_TRADE_CONTEXT_MODE` を未設定でも同等扱い。
+- `tools` → `OPENCODE_TRADE_CONTEXT_MODE=tools` と `OPENCODE_TRADE_CONTEXT_MODE_DELEGATE=<path>` で有効化。
+- `shadow` → `tool.execute.after` の fail-open 挙動を目視。
+- 異常時 → `OPENCODE_TRADE_CONTEXT_MODE=off`、それでも悪化する場合は `OPENCODE_PURE=1`。
+
+## 実行テンプレート
+
+```sh
+export OPENCODE_TRADE_CONTEXT_MODE=tools
+export OPENCODE_TRADE_CONTEXT_MODE_DELEGATE="./.opencode/plugins/my-context-mode.ts"
+```
+
+```sh
+export OPENCODE_TRADE_CONTEXT_MODE=shadow
+export OPENCODE_TRADE_CONTEXT_MODE_DELEGATE="./.opencode/plugins/my-context-mode.ts"
+```
+
+```sh
+export OPENCODE_TRADE_CONTEXT_MODE=off
+```
+
+- `off` は最短の停止切替。必要なら続けて `export OPENCODE_PURE=1` で最終隔離。
+
+## 設定の現時点
+
+- plugin 本体: `.opencode/plugins/trade-context-mode.ts`
+- 実体の依存追加: 未実施（PoC スケルトン + spike）
+- `OPENCODE_TRADE_CONTEXT_MODE_DELEGATE` 未設定時は delegate なしとして扱い、`tools` / `shadow` はいずれも無害フォールバック
+
+## 段階導入
+
+### Phase 0
+
+- 方針固定
+- mode 名と default を決める
+
+### Phase 1
+
+- wrapper skeleton を追加
+- `ctx_*` tools のみ共存確認
+- `trade-memory` 非干渉を確認
+- `off/tools/shadow` の fail-open 挙動を確認する
+- ここでは `context-mode` 依存をまだ追加しない
+
+### Phase 2
+
+- `ctx doctor` / `ctx stats` の確認手順を整備する
+- fallback と rollback を明確化する
+- export shape / init side effect / storage path の spike 結果を反映する
+- 依存追加は spike 合格後に限定する
+
+### Phase 3
+
+- `tool.execute.after` などの記録系 hook を段階的に開く
+- system transform は最小注入に抑える
+- `tool.execute.before` はまだ開かない
+
+### Phase 4
+
+- routing を `opencode-trade` 用に短く調整する
+- upstream の汎用 routing はそのまま持ち込まない
+- `trade-memory` を authoritative とする前提を routing でも明記する
+
+### Phase 5
+
+- 必要なら `on` / `strict` を限定的に試す
+- MT5 / CI / web fetch の阻害がないか確認する
+
+## 実装の要点
+
+- dynamic import で壊れた依存に引きずられないようにする
+- 既存 config は壊さず、環境変数で on/off する
+- OpenCode restart 前提にする
+- 既存の `trade-handoff-bridge` と `system.transform` / `session.compacting` が衝突しないようにする
+- delegated hook はすべて fail-open にする
+- `context-mode` の version を pin する
+- wrapper 例外は `context-mode` 失敗として握りつぶし、OpenCode 本体には波及させない
+
+## 既知の確認項目
+
+- `sync_trade_memory` が引き続き使えること
+- `ctx_*` と trade-memory tools が共存すること
+- system prompt が過剰に長くならないこと
+- compaction 後に古い snapshot が優先されないこと
+- `OPENCODE_TRADE_CONTEXT_MODE=off` で即戻せること
+- `OPENCODE_PURE=1` で最終退避できること
+
+## Storage / Secret Policy
+
+- context-mode の保存場所を固定する
+- purge 手順を用意する
+- broker account、token-like output、local path を一時 index に入れる可能性を明示する
+- MT5 risk gate、live readiness、Class D 判断には `ctx_search` 結果だけを使わない
+- 初回 PoC では secret-like output を含む tool に `context-mode` を使わない
+
+## Go / No-Go
+
+### Go
+
+- wrapper skeleton が `off` で無害に起動する
+- `tools` / `shadow` の hook filter test が通る
+- hook 例外が fail-open で止まらない
+- storage / purge / export shape の spike が取れる
+
+### No-Go
+
+- import 時点で heavy side effect がある
+- `off` でも dynamic import が走る
+- `trade-memory` と snapshot 優先順位を決められない
+- `ctx_execute` の権限境界を説明できない
+- `OPENCODE_PURE=1` 以外の rollback がない
+
+## Test / Smoke
+
+- `off` で `{}` のみ返ること
+- `tools` で tools のみ返ること
+- `shadow` で `tool.execute.before` を返さないこと
+- delegated hook throw が呼び出し元へ伝播しないこと
+- `sync_trade_memory` 系 tool が消えないこと
+- MT5 workflow が block されないこと
+- `on` / `strict` が未実装でも既存 workflow が壊れないこと
+
+### `on` / `strict` の未実装保険テスト
+
+- `on` / `strict` は現状 off と同等として扱う。
+- これらの値を指定しても delegate import は起きないこと。
+- これらの値を指定しても `{}` のみを返し、既存の hook 追加が起きないこと。
+
+## 期待結果付き運用チェックリスト
+
+- `off` をセットして起動する
+  - 期待: `plugin` 初期化は `{}` のみ、警告ログが出ない
+
+- `tools` で有効化し、delegate を `ctx_*` 対応実装へ設定する
+  - 期待: `ctx_*` tool だけが見える。`tool.execute.before/after` や `system.transform` は出ない
+
+- `tools` で delegate を存在しないパスに設定する
+  - 期待: 起動継続、`{}` にフォールバック、警告ログ 1 回以上
+
+- `shadow` で delegate を存在しないパスに設定する
+  - 期待: `tool.execute.after` の noop hook を保持、警告ログ 1 回以上
+
+- `on` / `strict` を指定する
+  - 期待: `off` と同等で `{}` のみ、delegate import は起きない
+
+## PoC 完了チェック（レビュー向け）
+
+- `off` / 未設定 / 空白文字の mode
+  - `plugin` が `{}` を返す
+  - 未実装モード指定 (`on`, `strict`) としても import が走らない
+- `tools`
+  - `ctx_` で始まる tool のみが残る
+  - `tool.execute.after` / `tool.execute.before` / `experimental.*` は露出しない
+  - `ctx_` 名前でも tool 定義が不正な場合は除外される
+  - relative/absolute delegate パスが解決できる
+- `shadow`
+  - `tool.execute.after` を fail-open で委譲
+  - 委譲 hook が非関数でも noop で安全に復帰
+  - 委譲失敗時は起動継続（警告出力あり）
+- rollback
+  - `off` で delegate が未参照
+  - `off`→`OPENCODE_PURE=1` で最終隔離まで確認
+
+レビュー提出時は、`docs/opencode-trade-context-mode-review-checklist.md` を添付して 1 画面チェックを行う。
+
+## PR 提出テンプレ
+
+- PR テンプレ用: `docs/opencode-trade-context-mode-pr-template.md`
+- 本チェックリスト → テスト結果 → 想定リスクの順で添付する
+- PR 本文のコピペ例は同テンプレート内の `PR本文（コピペ例）` を使用
+- 完成版サンプル本文は `docs/opencode-trade-context-mode-pr-ready-example.md`
+- PR 提出前最終チェック（固定順）:
+  - チェックリストを添付し、全項目を確認済みとして埋める
+  - PR本文コピペ例を埋め、Verification を完了する
+  - Rollback 記載を残す（`OPENCODE_TRADE_CONTEXT_MODE=off` / `OPENCODE_PURE=1`）
+
+### 関連テスト
+
+- `trade-context-mode plugin > on` / `strict` 系の未実装ガード
+- `trade-context-mode plugin > non-function tool.execute.after` 系のフォールト耐性
+- `trade-context-mode plugin > malformed ctx_ tool` 系のハードニング
+- `trade-context-mode plugin > invalid delegate path` 系の fail-open 系
+
+## 快速スモーク手順
+
+- 1 行コマンド:
+
+```sh
+cd packages/opencode
+OPENCODE_TRADE_CONTEXT_MODE=tools OPENCODE_TRADE_CONTEXT_MODE_DELEGATE=./test/fixture/trade-context-mode-delegate-plugin.ts bun test test/plugin/trade-context-mode.test.ts
+```
+
+- 期待結果:
+  - `tools mode` 系のテストが通る（`ctx_search` のみが tool として検出される）
+  - delegate が不在なら同一テスト内の fallback 経路が成立し、失敗テストとして `{} にフォールバック` が観測される
+
+- 2 行目（rollback）:
+
+```sh
+cd packages/opencode
+OPENCODE_TRADE_CONTEXT_MODE=off bun test test/plugin/trade-context-mode.test.ts
+```
+
+- 期待結果:
+  - `off` で delegate import に触れず `{}` のみ
+
+## まず避けること
+
+- `plugin: ["context-mode"]` を直書きすること
+- MCP と plugin を同時に入れること
+- upstream の routing file をそのままコピーすること
+- 最初から `strict` を有効にすること
+- `trade-memory` を置き換えること
+- `ctx_search` だけで最終判断すること
+
+## 期待する運用像
+
+`trade-memory` が project の正式な記録系、`context-mode` が一時的な大出力の圧縮系、という二層構成にする。
+
+この形なら、試用時は `on/off` で切り替えられ、問題があれば `off` に戻して即座に従来運用へ復帰できる。
+
+## 監査後の結論
+
+- 本実装ではなく、限定 PoC として進める
+- 初期は `tools` / `shadow` のみ
+- `on` / `strict` は spike と test 完了後に判断する
+- まずは wrapper skeleton を実装し、context-mode 本体の依存追加はその後に行う

--- a/docs/opencode-trade-context-mode-pr-ready-example.md
+++ b/docs/opencode-trade-context-mode-pr-ready-example.md
@@ -1,0 +1,56 @@
+# opencode-trade Context Mode PR 提出例
+
+以下は review 時にそのまま貼れる提出用本文です。
+
+```markdown
+## Summary
+
+- [x] `.opencode/plugins/trade-context-mode.ts` を追加・更新し、`off / tools / shadow` のみを扱う。
+- [x] delegate import 失敗時の fail-open 化を確認。
+- [x] `ctx_` ツール監査（malformed tool の除外）を追加。
+
+## Changes
+
+- Add/Update: `.opencode/plugins/trade-context-mode.ts`
+- Update: `packages/opencode/test/plugin/trade-context-mode.test.ts`
+- Add fixture: `packages/opencode/test/fixture/trade-context-mode-delegate-invalid-tool-plugin.ts`
+- Docs:
+  - `docs/opencode-trade-context-mode-review-checklist.md`
+  - `docs/opencode-trade-context-mode-pr-template.md`
+
+## Verification
+
+- [x] `cd packages/opencode && bun test test/plugin/trade-context-mode.test.ts`
+  - 結果: `25 pass`
+- [x] `cd packages/opencode && bun test test/plugin/loader-shared.test.ts test/plugin/trade-context-mode.test.ts`
+  - 結果: `53 pass`
+- [x] rollback 検証（`OPENCODE_TRADE_CONTEXT_MODE=off`）
+
+## Risk / Rollback
+
+- 既知制約: context-mode 本体依存は未導入（PoC）
+- Rollback 手順:
+  - `OPENCODE_TRADE_CONTEXT_MODE=off`
+  - 必要なら `OPENCODE_PURE=1`
+
+## Notes
+
+- on / strict は現時点 off 相当として扱い、delegate import しない。
+
+## Attachments
+
+- `docs/opencode-trade-context-mode-review-checklist.md`
+- `docs/opencode-trade-context-mode-pr-template.md`
+
+## PR提出前最終チェック
+
+- [x] `docs/opencode-trade-context-mode-review-checklist.md` を同梱し、全項目を確認済みとして埋めた。
+- [x] `PR本文（コピペ例）` を同じく埋め、Verification を完了した。
+- [x] rollback 手順を明記した。
+```
+
+## 参照
+
+- 運用フロー: `docs/opencode-trade-context-mode-plan.md`
+- チェックリスト: `docs/opencode-trade-context-mode-review-checklist.md`
+- テンプレ: `docs/opencode-trade-context-mode-pr-template.md`

--- a/docs/opencode-trade-context-mode-pr-template.md
+++ b/docs/opencode-trade-context-mode-pr-template.md
@@ -1,0 +1,118 @@
+# opencode-trade Context Mode PR テンプレート
+
+## 概要
+
+- 目的: `context-mode` を無害な wrapper で PoC 検証し、`trade-memory` と衝突しない最小 hook 絞り込みを確立
+- 範囲: `.opencode/plugins/trade-context-mode.ts` と plugin テスト一式
+
+## 変更点（簡潔）
+
+- 追加: `.opencode/plugins/trade-context-mode.ts`（`off / tools / shadow` のみ）
+- ハードニング: `tool` 定義と `tool.execute.after` の非関数・不正値ガード
+- テスト追加: `packages/opencode/test/fixture/trade-context-mode-delegate-invalid-tool-plugin.ts`
+- テスト更新: `packages/opencode/test/plugin/trade-context-mode.test.ts`
+- レビュー資料: `docs/opencode-trade-context-mode-review-checklist.md`
+
+## 完成提出例
+
+- `docs/opencode-trade-context-mode-pr-ready-example.md` に、添付情報を埋めたまま提出できる最終本文の完成形があります。
+
+
+## 行った確認
+
+- `bun test test/plugin/trade-context-mode.test.ts`
+- `bun test test/plugin/loader-shared.test.ts test/plugin/trade-context-mode.test.ts`
+
+## レビュー観点
+
+- `OPENCODE_TRADE_CONTEXT_MODE` 未実装値（`on` / `strict`）は `off` フォールバックで delegate import しない
+- `tools`: `ctx_` ツールのみ、かつ tool 定義が正常なものだけ露出
+- `shadow`: `tool.execute.after` は fail-open（例外を上位へ伝播しない）
+- 破損 delegate でも起動継続
+
+## 監査観点チェック
+
+- 既存 workflow の停止がないか（`trade-memory` と衝突しないか）
+- `off` モードでの即時 rollback が可能か（必要なら `OPENCODE_PURE=1`）
+
+## 添付
+
+- `docs/opencode-trade-context-mode-review-checklist.md`
+- 重要ログ: test 実行結果（pass lines）
+- 既知制約: 本体 `context-mode` 依存追加は未実施（PoC 導入のみ）
+
+## PR本文（貼り付け用）
+
+- 対象機能: `off / tools / shadow` の context-mode wrapper PoC
+- 変更: `.opencode/plugins/trade-context-mode.ts`
+- テスト: plugin 側の PoC 監査テストを更新
+- 目的: `trade-memory` と衝突しない最小 hook 絞り込み
+
+### Summary
+
+- 変更内容:
+  - [ ] `.opencode/plugins/trade-context-mode.ts` の追加・更新
+  - [ ] `tool` 定義/`tool.execute.after` の不正値ガード
+  - [ ] malformed `ctx_` tool 監査
+- 設定値:
+  - `OPENCODE_TRADE_CONTEXT_MODE`（`off / tools / shadow`）
+  - `OPENCODE_TRADE_CONTEXT_MODE_DELEGATE`（`tools` / `shadow`）
+
+### Verification
+
+- [ ] `cd packages/opencode && bun test test/plugin/trade-context-mode.test.ts`
+- [ ] `cd packages/opencode && bun test test/plugin/loader-shared.test.ts test/plugin/trade-context-mode.test.ts`
+- [ ] 失敗ケース（存在しない delegate）で起動継続確認
+
+### Risk & Rollback
+
+- Rollback: `OPENCODE_TRADE_CONTEXT_MODE=off` → `OPENCODE_PURE=1`
+- 既知制約: context-mode 本体依存は未導入（PoC）
+
+### Attachments
+
+- `docs/opencode-trade-context-mode-review-checklist.md`
+- テスト結果（pass summary）
+- 完成版サンプル: `docs/opencode-trade-context-mode-pr-ready-example.md`
+
+## PR本文（コピペ例）
+
+```markdown
+## Summary
+
+- [ ] `.opencode/plugins/trade-context-mode.ts` を追加・更新し、`off / tools / shadow` のみを扱う。
+- [ ] delegate import 失敗時の fail-open 化を確認。
+- [ ] `ctx_` ツール監査（malformed tool の除外）を追加。
+
+## Changes
+
+- Add/Update: `.opencode/plugins/trade-context-mode.ts`
+- Update: `packages/opencode/test/plugin/trade-context-mode.test.ts`
+- Add fixture: `packages/opencode/test/fixture/trade-context-mode-delegate-invalid-tool-plugin.ts`
+- Docs:
+  - `docs/opencode-trade-context-mode-review-checklist.md`
+  - `docs/opencode-trade-context-mode-pr-template.md`
+
+## Verification
+
+- [ ] `cd packages/opencode && bun test test/plugin/trade-context-mode.test.ts`
+- [ ] `cd packages/opencode && bun test test/plugin/loader-shared.test.ts test/plugin/trade-context-mode.test.ts`
+- [ ] rollback 検証（`OPENCODE_TRADE_CONTEXT_MODE=off`）
+
+## Risk / Rollback
+
+- 既知制約: context-mode 本体依存は未導入（PoC）
+- Rollback 手順:
+  - `OPENCODE_TRADE_CONTEXT_MODE=off`
+  - 必要なら `OPENCODE_PURE=1`
+
+## Notes
+
+- on / strict は現時点 off 相当として扱い、delegate import しない。
+```
+
+## PR 提出前最終チェック（固定順）
+
+- [ ] `docs/opencode-trade-context-mode-review-checklist.md` を同梱し、全項目を確認済みとして埋める
+- [ ] `PR本文（コピペ例）` の `Verification` を完了し、チェックを残す
+- [ ] ロールバック手順を明記する（`OPENCODE_TRADE_CONTEXT_MODE=off` / `OPENCODE_PURE=1`）

--- a/docs/opencode-trade-context-mode-review-checklist.md
+++ b/docs/opencode-trade-context-mode-review-checklist.md
@@ -1,0 +1,63 @@
+# opencode-trade Context Mode PoC レビュー・チェックリスト
+
+## 概要
+
+`off` / `tools` / `shadow` の PoC 仕様と回帰ハードニングが満たされているかを、レビュー時に 1 画面で確認するためのチェックです。
+
+## 事前条件
+
+- 対象リポジトリ: `packages/opencode`
+- テスト実行場所: `packages/opencode`
+- 追加プラグイン: `.opencode/plugins/trade-context-mode.ts`
+- fixture: `packages/opencode/test/fixture/*trade-context-mode*`
+
+## 実行順（レビュー前）
+
+1. `cd packages/opencode`
+2. `bun test test/plugin/trade-context-mode.test.ts`
+3. `bun test test/plugin/loader-shared.test.ts test/plugin/trade-context-mode.test.ts`
+
+## 想定結果
+
+- `trade-context-mode.test.ts`: `pass`
+- `loader-shared.test.ts` と同時実行: `pass`
+- 失敗テストなし
+
+## 受け入れチェック
+
+- `off`/未設定/空白: `plugin` が `{}` を返す
+- 未実装モード (`on` / `strict`): delegate import が起きない
+- `tools`
+  - `ctx_` ツールのみ露出
+  - `tool.execute.before` / `tool.execute.after` / `experimental.*` は非露出
+  - relative/absolute delegate パスが解決される
+  - `ctx_` だが形状が不正な tool は除外される
+- `shadow`
+  - `tool.execute.after` が fail-open で委譲（または noop）
+  - 非関数 hook を delegate しても noop に寄せて継続
+- delegate import 失敗
+  - `tools`: 起動継続、`{}` フォールバック
+  - `shadow`: 起動継続、`tool.execute.after` noop 残存
+- rollback
+  - `OPENCODE_TRADE_CONTEXT_MODE=off` で `off` 相当へ復帰
+
+## 参考観点
+
+- `trade-memory` の主要 flow（`sync_trade_memory` 系）に影響しないことを目視確認
+- 本番投入前はこのチェックの 3 項目を添付
+  - 実行ログ
+  - 追加・更新ファイル
+  - 期待値が変わったテストの説明
+
+## 提出用アセット
+
+- PR テンプレート: `docs/opencode-trade-context-mode-pr-template.md`
+- このチェックリストを PR 説明文に貼付し、該当項目を確認済みとしてチェック
+- PR 本文のコピペ例: `docs/opencode-trade-context-mode-pr-template.md` の `PR本文（コピペ例）`
+- 完成版: `docs/opencode-trade-context-mode-pr-ready-example.md`
+
+## PR提出前最終チェック（固定順）
+
+- [ ] `docs/opencode-trade-context-mode-review-checklist.md` を同梱し、全項目を確認済みとして埋める
+- [ ] `PR本文（コピペ例）` を同じく埋め、`Verification` の 3 つを完了する
+- [ ] ロールバック手順を明記する（`OPENCODE_TRADE_CONTEXT_MODE=off` / `OPENCODE_PURE=1`）

--- a/packages/opencode/test/fixture/trade-context-mode-delegate-invalid-tool-plugin.ts
+++ b/packages/opencode/test/fixture/trade-context-mode-delegate-invalid-tool-plugin.ts
@@ -1,0 +1,15 @@
+export default async () => ({
+  tool: {
+    ctx_search: "not-a-tool",
+    ctx_stats: {
+      description: "Safe tool",
+      parameters: {},
+      execute: async () => ({ output: "ok" }),
+    },
+    other_search: {
+      description: "Ignored",
+      parameters: {},
+      execute: async () => ({ output: "ignored" }),
+    },
+  },
+} as const)

--- a/packages/opencode/test/fixture/trade-context-mode-delegate-nonfn-plugin.ts
+++ b/packages/opencode/test/fixture/trade-context-mode-delegate-nonfn-plugin.ts
@@ -1,0 +1,10 @@
+export default async () => ({
+  tool: {
+    ctx_search: {
+      description: "Non-function fallback test tool",
+      parameters: {},
+      execute: async () => ({ output: "ok" }),
+    },
+  },
+  "tool.execute.after": "not-a-hook",
+} as const)

--- a/packages/opencode/test/fixture/trade-context-mode-delegate-plugin.ts
+++ b/packages/opencode/test/fixture/trade-context-mode-delegate-plugin.ts
@@ -1,0 +1,20 @@
+export default async () => ({
+  tool: {
+    ctx_search: {
+      description: "Context mode search tool",
+      parameters: {},
+      execute: async () => ({ output: "ok" }),
+    },
+    non_ctx_search: {
+      description: "Hidden tool",
+      parameters: {},
+      execute: async () => ({ output: "hidden" }),
+    },
+  },
+  "tool.execute.after": async () => {
+    throw new Error("delegated hook failed")
+  },
+  "experimental.chat.system.transform": async () => {
+    throw new Error("system transform should be filtered")
+  },
+} as const)

--- a/packages/opencode/test/plugin/trade-context-mode.test.ts
+++ b/packages/opencode/test/plugin/trade-context-mode.test.ts
@@ -1,0 +1,256 @@
+import { fileURLToPath } from "url"
+import { describe, expect, spyOn, test } from "bun:test"
+import type { Hooks } from "@opencode-ai/plugin"
+
+const delegatePlugin = new URL("../fixture/trade-context-mode-delegate-plugin.ts", import.meta.url).href
+const invalidToolShapeDelegate = new URL(
+  "../fixture/trade-context-mode-delegate-invalid-tool-plugin.ts",
+  import.meta.url,
+).href
+
+const loadPlugin = async (mode?: string, delegate?: string) => {
+  const previous = process.env.OPENCODE_TRADE_CONTEXT_MODE
+  const previousDelegate = process.env.OPENCODE_TRADE_CONTEXT_MODE_DELEGATE
+  if (mode === undefined) {
+    delete process.env.OPENCODE_TRADE_CONTEXT_MODE
+  } else {
+    process.env.OPENCODE_TRADE_CONTEXT_MODE = mode
+  }
+
+  if (delegate === undefined) {
+    delete process.env.OPENCODE_TRADE_CONTEXT_MODE_DELEGATE
+  } else if (delegate.length === 0) {
+    delete process.env.OPENCODE_TRADE_CONTEXT_MODE_DELEGATE
+  } else {
+    process.env.OPENCODE_TRADE_CONTEXT_MODE_DELEGATE = delegate
+  }
+
+  try {
+    const pluginModule = await import("../../../../.opencode/plugins/trade-context-mode")
+    return (await pluginModule.default()) as Partial<Hooks>
+  } finally {
+    if (previous === undefined) delete process.env.OPENCODE_TRADE_CONTEXT_MODE
+    else process.env.OPENCODE_TRADE_CONTEXT_MODE = previous
+    if (previousDelegate === undefined) delete process.env.OPENCODE_TRADE_CONTEXT_MODE_DELEGATE
+    else process.env.OPENCODE_TRADE_CONTEXT_MODE_DELEGATE = previousDelegate
+  }
+}
+
+const withWarnSuppressed = async <T>(input: () => Promise<T>) => {
+  const spy = spyOn(console, "warn").mockImplementation(() => {})
+  try {
+    return await input()
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+const withWarnCapture = async <T>(input: () => Promise<T>) => {
+  const spy = spyOn(console, "warn").mockImplementation(() => {})
+  try {
+    const result = await input()
+    return { result, calls: spy.mock.calls.length }
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+describe("trade-context-mode plugin", () => {
+  test("off mode returns no hooks", async () => {
+    const hooks = await loadPlugin("off")
+    expect(Object.keys(hooks).length).toBe(0)
+    expect(Object.keys(hooks)).toEqual([])
+  })
+
+  test("off mode does not attempt delegate import", async () => {
+    const out = await withWarnCapture(() =>
+      loadPlugin("off", "file:///tmp/non-existent-context-mode-delegate.js"),
+    )
+
+    expect(Object.keys(out.result)).toEqual([])
+    expect(out.calls).toBe(0)
+  })
+
+  test("unset mode returns no hooks", async () => {
+    const hooks = await loadPlugin()
+    expect(Object.keys(hooks)).toEqual([])
+  })
+
+  test("empty/invalid mode returns no hooks", async () => {
+    const hooks = await loadPlugin("\t")
+    expect(Object.keys(hooks).length).toBe(0)
+    expect(Object.keys(hooks)).toEqual([])
+  })
+
+  test("tools mode returns no hooks", async () => {
+    const hooks = await loadPlugin("tools")
+    expect(Object.keys(hooks).length).toBe(0)
+    expect(Object.keys(hooks)).toEqual([])
+  })
+
+  test("shadow mode registers tool.execute.after hook", async () => {
+    const hooks = await loadPlugin("shadow")
+    expect(Object.keys(hooks)).toEqual(["tool.execute.after"])
+    expect(typeof hooks["tool.execute.after"]).toBe("function")
+  })
+
+  test("mode parsing is case-insensitive", async () => {
+    const hooks = await loadPlugin("ShAdOw")
+    expect(typeof hooks["tool.execute.after"]).toBe("function")
+  })
+
+  test("shadow tool hook is fail-open", async () => {
+    const hooks = await loadPlugin("shadow")
+    await expect((hooks["tool.execute.after"] as (() => Promise<void>) | undefined)?.()).resolves.toBeUndefined()
+  })
+
+  test("tools mode forwards only ctx_* tools from delegate", async () => {
+    const hooks = await loadPlugin("tools", delegatePlugin)
+
+    expect(Object.keys(hooks)).toEqual(["tool"])
+    expect(hooks.tool).toBeDefined()
+    expect(hooks.tool).toHaveProperty("ctx_search")
+    expect(hooks.tool).not.toHaveProperty("non_ctx_search")
+    expect(typeof hooks["tool.execute.after"]).toBe("undefined")
+  })
+
+  test("tools mode ignores non-function tool.execute.after from delegate", async () => {
+    const nonFunctionHookDelegate = new URL("../fixture/trade-context-mode-delegate-nonfn-plugin.ts", import.meta.url).href
+    const hooks = await loadPlugin("tools", nonFunctionHookDelegate)
+
+    expect(Object.keys(hooks)).toEqual(["tool"])
+    expect(hooks.tool).toBeDefined()
+    expect(hooks.tool).toHaveProperty("ctx_search")
+    expect((hooks as Record<string, unknown>)["tool.execute.after"]).toBeUndefined()
+  })
+
+  test("tools mode ignores malformed ctx_ tool entries", async () => {
+    const hooks = await loadPlugin("tools", invalidToolShapeDelegate)
+
+    expect(Object.keys(hooks)).toEqual(["tool"])
+    expect(hooks.tool).toBeDefined()
+    expect(hooks.tool).toHaveProperty("ctx_stats")
+    expect(hooks.tool).not.toHaveProperty("ctx_search")
+    expect(hooks.tool).not.toHaveProperty("other_search")
+  })
+
+  test("tools mode exposes no non-tool hooks", async () => {
+    const hooks = await loadPlugin("tools", delegatePlugin)
+
+    expect(Object.keys(hooks)).toEqual(["tool"])
+    expect((hooks as Record<string, unknown>)["experimental.chat.system.transform"]).toBeUndefined()
+    expect((hooks as Record<string, unknown>)["tool.execute.before"]).toBeUndefined()
+    expect((hooks as Record<string, unknown>)["tool.execute.after"]).toBeUndefined()
+  })
+
+  test("unknown mode falls back to off", async () => {
+    const hooks = await loadPlugin("on")
+    expect(Object.keys(hooks)).toEqual([])
+  })
+
+  test("unknown mode should not attempt delegate import", async () => {
+    const out = await withWarnCapture(() =>
+      loadPlugin("on", "file:///tmp/non-existent-context-mode-delegate.js"),
+    )
+
+    expect(Object.keys(out.result)).toEqual([])
+    expect(out.calls).toBe(0)
+  })
+
+  test("case-insensitive unknown mode should not attempt delegate import", async () => {
+    const out = await withWarnCapture(() =>
+      loadPlugin("On", "file:///tmp/non-existent-context-mode-delegate.js"),
+    )
+
+    expect(Object.keys(out.result)).toEqual([])
+    expect(out.calls).toBe(0)
+  })
+
+  test("unknown mode ignores delegate even when configured", async () => {
+    const out = await withWarnCapture(() => loadPlugin("strict", "file:///tmp/non-existent-context-mode-delegate.js"))
+
+    expect(Object.keys(out.result)).toEqual([])
+    expect(out.calls).toBe(0)
+  })
+
+  test("case-insensitive strict-like mode should ignore delegate", async () => {
+    const out = await withWarnCapture(() =>
+      loadPlugin("StRiCt", "file:///tmp/non-existent-context-mode-delegate.js"),
+    )
+
+    expect(Object.keys(out.result)).toEqual([])
+    expect(out.calls).toBe(0)
+  })
+
+  test("strict mode falls back to off", async () => {
+    const hooks = await loadPlugin("strict")
+    expect(Object.keys(hooks)).toEqual([])
+  })
+
+  test("tools mode resolves relative delegate path", async () => {
+    const hooks = await loadPlugin("tools", "./test/fixture/trade-context-mode-delegate-plugin.ts")
+
+    expect(Object.keys(hooks)).toEqual(["tool"])
+    expect(hooks.tool).toBeDefined()
+    expect(hooks.tool).toHaveProperty("ctx_search")
+    expect(hooks.tool).not.toHaveProperty("non_ctx_search")
+  })
+
+  test("tools mode resolves absolute delegate path", async () => {
+    const absoluteDelegate = fileURLToPath(new URL("../fixture/trade-context-mode-delegate-plugin.ts", import.meta.url))
+    const hooks = await loadPlugin("tools", absoluteDelegate)
+
+    expect(Object.keys(hooks)).toEqual(["tool"])
+    expect(hooks.tool).toBeDefined()
+    expect(hooks.tool).toHaveProperty("ctx_search")
+    expect(hooks.tool).not.toHaveProperty("non_ctx_search")
+  })
+
+  test("shadow mode uses delegated hook and fail-opens on throw", async () => {
+    const hooks = await withWarnSuppressed(() => loadPlugin("shadow", delegatePlugin))
+    expect(Object.keys(hooks)).toEqual(["tool.execute.after"])
+    await withWarnSuppressed(async () =>
+      expect((hooks["tool.execute.after"] as (() => Promise<void>) | undefined)?.()).resolves.toBeUndefined(),
+    )
+  })
+
+  test("shadow mode falls back to noop when delegated after-hook is not function", async () => {
+    const nonFunctionHookDelegate = new URL("../fixture/trade-context-mode-delegate-nonfn-plugin.ts", import.meta.url).href
+    const out = await withWarnCapture(() => loadPlugin("shadow", nonFunctionHookDelegate))
+
+    expect(Object.keys(out.result)).toEqual(["tool.execute.after"])
+    expect(typeof out.result["tool.execute.after"]).toBe("function")
+    expect(out.calls).toBe(0)
+
+    await expect(
+      (out.result["tool.execute.after"] as (() => Promise<void>) | undefined)?.(),
+    ).resolves.toBeUndefined()
+  })
+
+  test("invalid delegate path fails open to local fallback in shadow mode", async () => {
+    const hooks = await withWarnSuppressed(() => loadPlugin("shadow", "file:///tmp/non-existent-context-mode-delegate.js"))
+
+    expect(Object.keys(hooks)).toEqual(["tool.execute.after"])
+    await withWarnSuppressed(async () =>
+      expect((hooks["tool.execute.after"] as (() => Promise<void>) | undefined)?.()).resolves.toBeUndefined(),
+    )
+  })
+
+  test("invalid delegate path is harmless in tools mode", async () => {
+    const out = await withWarnCapture(() =>
+      loadPlugin("tools", "file:///tmp/non-existent-context-mode-delegate.js"),
+    )
+
+    expect(Object.keys(out.result)).toEqual([])
+    expect(out.calls).toBeGreaterThan(0)
+  })
+
+  test("invalid delegate path warns in shadow mode", async () => {
+    const out = await withWarnCapture(() =>
+      loadPlugin("shadow", "file:///tmp/non-existent-context-mode-delegate.js"),
+    )
+
+    expect(Object.keys(out.result)).toEqual(["tool.execute.after"])
+    expect(out.calls).toBeGreaterThan(0)
+  })
+})

--- a/packages/opencode/test/plugin/trade-context-mode.test.ts
+++ b/packages/opencode/test/plugin/trade-context-mode.test.ts
@@ -27,7 +27,8 @@ const loadPlugin = async (mode?: string, delegate?: string) => {
 
   try {
     const pluginModule = await import("../../../../.opencode/plugins/trade-context-mode")
-    return (await pluginModule.default()) as Partial<Hooks>
+    const pluginInput = {} as unknown as Parameters<typeof pluginModule.default>[0]
+    return (await pluginModule.default(pluginInput, undefined)) as Partial<Hooks>
   } finally {
     if (previous === undefined) delete process.env.OPENCODE_TRADE_CONTEXT_MODE
     else process.env.OPENCODE_TRADE_CONTEXT_MODE = previous


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds a constrained `context-mode` wrapper plugin PoC for opencode-trade with fail-open behavior.

- Adds `.opencode/plugins/trade-context-mode.ts` supporting `off`, `tools`, and `shadow` modes only.
- Filters tool exports to only keep `ctx_` tools that are valid object shapes with `execute` functions.
- Delegates `tool.execute.after` in `shadow` mode through fail-open and gracefully falls back to a no-op when delegation is unavailable.
- Prevents `on`/`strict` from importing context-mode delegate.
- Keeps rollback path default as `OPENCODE_TRADE_CONTEXT_MODE=off` (and optional `OPENCODE_PURE=1`).

### How did you verify your code works?

- `cd packages/opencode && bun run test test/plugin/trade-context-mode.test.ts` (`25 pass`)
- `cd packages/opencode && bun run test test/plugin/loader-shared.test.ts test/plugin/trade-context-mode.test.ts` (`53 pass`)
- `cd packages/opencode && bun run typecheck` (passes after applying type-safety follow-up)
- Manual verification against official fork PR flow on `anomalyco/opencode`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

