### PR TITLE
fix(sdk): normalize scheme-less base URLs so location query params apply

### DIFF
--- a/packages/opencode/test/server/sdk-base-url.test.ts
+++ b/packages/opencode/test/server/sdk-base-url.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+
+function captureClient(baseUrl: string) {
+  const requests: Request[] = []
+  const sdk = createOpencodeClient({
+    baseUrl,
+    directory: "/tmp/client-project",
+    fetch: (async (request: Request) => {
+      requests.push(request)
+      return Response.json({
+        location: { directory: "/tmp/client-project", workspaceID: null, project: { id: "test", directory: "/" } },
+        data: [],
+      })
+    }) as unknown as typeof fetch,
+  })
+  return { sdk, requests }
+}
+
+describe("createOpencodeClient base URL", () => {
+  test("scheme-less base URL still routes the configured directory to /api endpoints", async () => {
+    const { sdk, requests } = captureClient("localhost:4096")
+    await sdk.v2.fs.find({ query: "file" })
+
+    expect(requests).toHaveLength(1)
+    const url = new URL(requests[0].url)
+    expect(url.protocol).toBe("http:")
+    expect(url.host).toBe("localhost:4096")
+    expect(url.pathname).toBe("/api/fs/find")
+    expect(url.searchParams.get("location[directory]")).toBe("/tmp/client-project")
+  })
+
+  test("explicit http scheme is preserved", async () => {
+    const { sdk, requests } = captureClient("http://localhost:4096")
+    await sdk.v2.fs.find({ query: "file" })
+
+    const url = new URL(requests[0].url)
+    expect(url.protocol).toBe("http:")
+    expect(url.host).toBe("localhost:4096")
+    expect(url.searchParams.get("location[directory]")).toBe("/tmp/client-project")
+  })
+
+  test("explicit https scheme is preserved", async () => {
+    const { sdk, requests } = captureClient("https://opencode.example.com")
+    await sdk.v2.fs.find({ query: "file" })
+
+    const url = new URL(requests[0].url)
+    expect(url.protocol).toBe("https:")
+    expect(url.host).toBe("opencode.example.com")
+    expect(url.searchParams.get("location[directory]")).toBe("/tmp/client-project")
+  })
+})

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -47,7 +47,20 @@ function rewrite(request: Request, values: { directory?: string; workspace?: str
   return next
 }
 
+function normalizeBaseUrl(baseUrl: string) {
+  // A scheme-less base URL like "localhost:4096" produces requests that fetch
+  // still resolves, but URL parsing treats "localhost" as the protocol, so the
+  // pathname no longer starts with "/" and rewrite() skips the location query
+  // params. Default to http so URL handling sees the real pathname.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(baseUrl)) return baseUrl
+  return `http://${baseUrl}`
+}
+
 export function createOpencodeClient(config?: Config & { directory?: string; experimental_workspaceID?: string }) {
+  if (config?.baseUrl) {
+    config = { ...config, baseUrl: normalizeBaseUrl(config.baseUrl) }
+  }
+
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
       // @ts-ignore


### PR DESCRIPTION
### Issue for this PR

Closes #32077

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode attach localhost:4096 --dir .` currently lets `@` file search use the server's directory instead of the attached client's directory.

The SDK request interceptor only adds `location[directory]` for `/api/...` paths. With a scheme-less base URL, `new URL("localhost:4096/api/fs/find")` treats `localhost` as the protocol, so the pathname check misses `/api/fs/find`.

This defaults scheme-less SDK base URLs to `http://...` before creating requests. Explicit `http://` and `https://` URLs are unchanged.

### How did you verify your code works?

- `cd packages/opencode && bun test test/server/sdk-base-url.test.ts --timeout 30000`
- `cd packages/sdk/js && bun run typecheck`
- `cd packages/opencode && bun run typecheck`

I also temporarily removed the fix and confirmed the new regression test fails with `protocol === "localhost:"`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
