### PR TITLE
fix(app): reconcile session_status in bootstrap so stale busy clears

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -90,6 +90,76 @@ describe("bootstrapDirectory", () => {
     expect(store.status).toBe("complete")
     expect(mcpReads).toEqual([])
   })
+
+  test("clears a stale busy session_status entry the backend no longer reports", async () => {
+    const [store, setStore] = createStore<State>({
+      status: "loading",
+      agent: [],
+      command: [],
+      project: "",
+      projectMeta: undefined,
+      icon: undefined,
+      provider_ready: true,
+      provider,
+      config: {},
+      path: { state: "", config: "", worktree: "/project", directory: "/project", home: "/home" },
+      session: [],
+      sessionTotal: 0,
+      // stale "busy" left over from a dropped session.idle event / server restart
+      session_status: { ses_stale: { type: "busy" } } as State["session_status"],
+      session_working(id: string) {
+        return this.session_status[id]?.type !== "idle"
+      },
+      session_diff: {},
+      todo: {},
+      permission: {},
+      question: {},
+      mcp_ready: true,
+      mcp: {},
+      lsp_ready: true,
+      lsp: [],
+      vcs: undefined,
+      limit: 5,
+      message: {},
+      part: {},
+      part_text_accum_delta: {},
+    })
+
+    await bootstrapDirectory({
+      directory: "/project",
+      scope: ServerScope.local,
+      mcp: false,
+      global: {
+        config: {} satisfies Config,
+        path: { state: "", config: "", worktree: "/project", directory: "/project", home: "/home" },
+        project: [{ id: "project", worktree: "/project" } as Project],
+        provider,
+      },
+      sdk: {
+        app: { agents: async () => ({ data: [{ name: "build", mode: "primary" }] }) },
+        config: { get: async () => ({ data: {} }) },
+        // backend reports no non-idle sessions, so ses_stale must be dropped from the store
+        session: { status: async () => ({ data: {} }) },
+        vcs: { get: async () => ({ data: undefined }) },
+        command: { list: async () => ({ data: [] }) },
+        permission: { list: async () => ({ data: [] }) },
+        question: { list: async () => ({ data: [] }) },
+        mcp: { status: async () => ({ data: {} }) },
+        provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+      } as unknown as OpencodeClient,
+      store,
+      setStore,
+      vcsCache: { setStore() {} } as unknown as VcsCache,
+      loadSessions() {},
+      translate: (key) => key,
+      queryClient: new QueryClient(),
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 80))
+
+    // bare setStore would leave the stale "busy" entry in place; reconcile drops it
+    expect(store.session_status.ses_stale).toBeUndefined()
+  })
 })
 
 describe("query keys", () => {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -238,7 +238,15 @@ export async function bootstrapDirectory(input: {
           .then((data) => input.setStore("agent", data)),
       () =>
         retry(() => input.sdk.config.get().then((x) => input.setStore("config", reconcile(x.data!, { merge: false })))),
-      () => retry(() => input.sdk.session.status().then((x) => input.setStore("session_status", x.data!))),
+      () =>
+        retry(() =>
+          input.sdk.session.status().then((x) =>
+            // reconcile (not a bare setStore) so a stale "busy"/"retry" entry the backend no
+            // longer reports — session.status() only returns non-idle sessions — is actually
+            // removed; otherwise the session shows "working" forever. Mirrors the config line above.
+            input.setStore("session_status", reconcile(x.data ?? {}, { merge: false })),
+          ),
+        ),
       !seededProject &&
         (() => retry(() => input.sdk.project.current()).then((x) => input.setStore("project", x.data!.id))),
       !seededPath &&


### PR DESCRIPTION
### Issue for this PR

Closes #17657

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`session_working(id)` is derived only from `session_status`, but `bootstrap` updated `session_status` from `session.status()` with a plain `setStore` instead of `reconcile`.

`session.status()` returns only non-idle sessions (idle ones are deleted from the in-memory map in `status.ts`), and SolidJS `setStore` merges keys rather than replacing them — so a `busy`/`retry` entry the backend no longer reports was never removed. The session then stayed "working" forever (e.g. after a dropped `session.idle` event, or a server restart that lost its in-memory status map).

The `config` line directly above already uses `reconcile`; this just makes `session_status` consistent with it:

```ts
input.setStore("session_status", reconcile(x.data ?? {}, { merge: false }))
```

### How did you verify your code works?

Added a `bootstrapDirectory` test that seeds a stale `busy` entry, returns `{}` from `session.status()`, and asserts the entry is dropped after bootstrap — it survives with the old `setStore`. Ran `bun test` for the app package locally.

### Screenshots / recordings

N/A — no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
