### PR TITLE
feat(tui): Use opencode-specific tmp filename for 'editor_open'

### DIFF
--- a/packages/tui/src/editor.ts
+++ b/packages/tui/src/editor.ts
@@ -26,7 +26,7 @@ export function normalizePromptContent(content: string) {
 export async function openEditor(input: { value: string; renderer: CliRenderer; cwd?: string; stdin?: EditorStdio }) {
   const editor = process.env.VISUAL || process.env.EDITOR
   if (!editor) return
-  const file = path.join(os.tmpdir(), `${Date.now()}.md`)
+  const file = path.join(os.tmpdir(), `opencode-prompt-${Date.now()}.md`)
   await writeFile(file, input.value)
   input.renderer.suspend()
   input.renderer.currentRenderBuffer.clear()


### PR DESCRIPTION
### Issue for this PR

Closes #32133

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This allows personal editor config to detect & setup custom behaviors in opencode prompt buffers (custom snippets, keybindings, ...).

### How did you verify your code works?

I tried to build with Nix (I'm on NixOS), but the build is failing with:
```
error: This script requires bun@^1.3.14, but you are using bun@1.3.13
      at /build/source/packages/script/src/index.ts:17:13
```

👉 I'm only changing a string, it shouldn't break the project! 😀

### Checklist

- [x] I have tested my changes locally
  (to pass the compliance check, see above)
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
