### PR TITLE
fix(mcp): refresh expired oauth tokens

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -8,6 +8,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { createFetchWithInit } from "@modelcontextprotocol/sdk/shared/transport.js"
 import {
   type LoggingMessageNotification,
   LoggingMessageNotificationSchema,
@@ -212,7 +213,7 @@ export const layer = Layer.effect(
       let authProvider: McpOAuthProvider | undefined
 
       if (!oauthDisabled) {
-        authProvider = new McpOAuthProvider(
+        const provider = new McpOAuthProvider(
           key,
           mcp.url,
           {
@@ -227,6 +228,10 @@ export const layer = Layer.effect(
           },
           auth,
         )
+        authProvider = provider
+        yield* Effect.tryPromise(() =>
+          provider.refreshTokensIfExpired(mcp.headers ? createFetchWithInit(fetch, { headers: mcp.headers }) : undefined),
+        ).pipe(Effect.ignore)
       }
 
       const transports: Array<{ name: string; transport: TransportWithAuth }> = [

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -230,11 +230,15 @@ export const layer = Layer.effect(
           auth,
         )
         authProvider = provider
+        const controller = new AbortController()
         yield* Effect.tryPromise(() =>
           withTimeout(
-            provider.refreshTokensIfExpired(mcp.headers ? createFetchWithInit(fetch, { headers: mcp.headers }) : undefined),
+            provider.refreshTokensIfExpired(
+              mcp.headers ? createFetchWithInit(fetch, { headers: mcp.headers }) : undefined,
+              controller.signal,
+            ),
             connectTimeout,
-          ),
+          ).finally(() => controller.abort()),
         ).pipe(Effect.ignore)
       }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -210,6 +210,7 @@ export const layer = Layer.effect(
           status: { status: "failed" as const, error: `Invalid MCP URL for "${key}"` },
         }
       }
+      const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       let authProvider: McpOAuthProvider | undefined
 
       if (!oauthDisabled) {
@@ -230,7 +231,10 @@ export const layer = Layer.effect(
         )
         authProvider = provider
         yield* Effect.tryPromise(() =>
-          provider.refreshTokensIfExpired(mcp.headers ? createFetchWithInit(fetch, { headers: mcp.headers }) : undefined),
+          withTimeout(
+            provider.refreshTokensIfExpired(mcp.headers ? createFetchWithInit(fetch, { headers: mcp.headers }) : undefined),
+            connectTimeout,
+          ),
         ).pipe(Effect.ignore)
       }
 
@@ -251,7 +255,6 @@ export const layer = Layer.effect(
         },
       ]
 
-      const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       let lastStatus: Status | undefined
 
       for (const { name, transport } of transports) {

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -1,15 +1,18 @@
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
+import { discoverOAuthServerInfo, refreshAuthorization, selectResourceURL } from "@modelcontextprotocol/sdk/client/auth.js"
 import type {
   OAuthClientMetadata,
   OAuthTokens,
   OAuthClientInformation,
   OAuthClientInformationFull,
 } from "@modelcontextprotocol/sdk/shared/auth.js"
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js"
 import { Effect } from "effect"
 import { McpAuth } from "./auth"
 
 const OAUTH_CALLBACK_PORT = 19876
 const OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+const TOKEN_REFRESH_SKEW_SECONDS = 60
 
 export interface McpOAuthConfig {
   clientId?: string
@@ -123,6 +126,28 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.serverUrl,
       ),
     )
+  }
+
+  async refreshTokensIfExpired(fetchFn?: FetchLike): Promise<boolean> {
+    const entry = await Effect.runPromise(this.auth.getForUrl(this.mcpName, this.serverUrl))
+    if (!entry?.tokens?.refreshToken) return false
+    if (!entry.tokens.expiresAt) return false
+    if (entry.tokens.expiresAt > Date.now() / 1000 + TOKEN_REFRESH_SKEW_SECONDS) return false
+
+    const clientInformation = await this.clientInformation()
+    if (!clientInformation) return false
+
+    const info = await discoverOAuthServerInfo(this.serverUrl, { fetchFn })
+    await this.saveTokens(
+      await refreshAuthorization(info.authorizationServerUrl, {
+        metadata: info.authorizationServerMetadata,
+        clientInformation,
+        refreshToken: entry.tokens.refreshToken,
+        resource: await selectResourceURL(this.serverUrl, this, info.resourceMetadata),
+        fetchFn,
+      }),
+    )
+    return true
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -128,7 +128,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     )
   }
 
-  async refreshTokensIfExpired(fetchFn?: FetchLike): Promise<boolean> {
+  async refreshTokensIfExpired(fetchFn?: FetchLike, signal?: AbortSignal): Promise<boolean> {
     const entry = await Effect.runPromise(this.auth.getForUrl(this.mcpName, this.serverUrl))
     if (!entry?.tokens?.refreshToken) return false
     if (!entry.tokens.expiresAt) return false
@@ -137,14 +137,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
     const clientInformation = await this.clientInformation()
     if (!clientInformation) return false
 
-    const info = await discoverOAuthServerInfo(this.serverUrl, { fetchFn })
+    const request = signal
+      ? (url: string | URL, init?: RequestInit) => (fetchFn ?? fetch)(url, { ...init, signal })
+      : fetchFn
+    const info = await discoverOAuthServerInfo(this.serverUrl, { fetchFn: request })
     await this.saveTokens(
       await refreshAuthorization(info.authorizationServerUrl, {
         metadata: info.authorizationServerMetadata,
         clientInformation,
         refreshToken: entry.tokens.refreshToken,
         resource: await selectResourceURL(this.serverUrl, this, info.resourceMetadata),
-        fetchFn,
+        fetchFn: request,
       }),
     )
     return true

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -3,6 +3,7 @@ import { expect, mock, beforeEach } from "bun:test"
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
+import type { McpAuth } from "../../src/mcp/auth"
 import { testEffect } from "../lib/effect"
 import { TestInstance } from "../fixture/fixture"
 
@@ -52,6 +53,7 @@ let clientCreateCount = 0
 let transportCloseCount = 0
 // Captures the opts passed to each MockStdioTransport, keyed by lastCreatedClientName
 const stdioOptsByName = new Map<string, any>()
+let refreshAuthorizationCalls = 0
 
 function getOrCreateClientState(name?: string): MockClientState {
   const key = name ?? "default"
@@ -139,6 +141,18 @@ void mock.module("@modelcontextprotocol/sdk/client/auth.js", () => ({
   UnauthorizedError: class extends Error {
     constructor() {
       super("Unauthorized")
+    }
+  },
+  discoverOAuthServerInfo: async () => ({ authorizationServerUrl: "https://auth.example.com" }),
+  selectResourceURL: async () => undefined,
+  refreshAuthorization: async () => {
+    refreshAuthorizationCalls++
+    return {
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      refresh_token: "new-refresh-token",
+      expires_in: 3600,
+      scope: "read",
     }
   },
 }))
@@ -238,11 +252,13 @@ beforeEach(() => {
   connectError = "Mock transport cannot connect"
   clientCreateCount = 0
   transportCloseCount = 0
+  refreshAuthorizationCalls = 0
 })
 
 // Import after mocks
 const { MCP } = await import("../../src/mcp/index")
 const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
+const { McpOAuthProvider } = await import("../../src/mcp/oauth-provider")
 
 const it = testEffect(MCP.defaultLayer)
 
@@ -250,6 +266,45 @@ function statusName(status: Record<string, MCPNS.Status> | MCPNS.Status, server:
   if ("status" in status) return status.status
   return status[server]?.status
 }
+
+it.live("McpOAuthProvider refreshes expired stored tokens", () =>
+  Effect.gen(function* () {
+    const entry: McpAuth.Entry = {
+      serverUrl: "https://mcp.example.com/mcp",
+      clientInfo: { clientId: "client-id" },
+      tokens: {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: Date.now() / 1000 - 1,
+      },
+    }
+    const auth: Pick<McpAuth.Interface, "getForUrl" | "updateTokens"> = {
+      getForUrl: () => Effect.succeed(entry),
+      updateTokens: (_mcpName: string, tokens: McpAuth.Tokens, serverUrl?: string) =>
+        Effect.sync(() => {
+          entry.tokens = tokens
+          entry.serverUrl = serverUrl ?? entry.serverUrl
+        }),
+    }
+
+    const refreshed = yield* Effect.promise(() =>
+      new McpOAuthProvider(
+        "remote-server",
+        "https://mcp.example.com/mcp",
+        {},
+        { onRedirect: async () => {} },
+        auth as McpAuth.Interface,
+      ).refreshTokensIfExpired(),
+    )
+
+    expect(refreshed).toBe(true)
+    expect(refreshAuthorizationCalls).toBe(1)
+    if (!entry.tokens) throw new Error("tokens were not saved")
+    expect(entry.tokens.accessToken).toBe("new-access-token")
+    expect(entry.tokens.refreshToken).toBe("new-refresh-token")
+    expect(entry.tokens.expiresAt).toBeGreaterThan(Date.now() / 1000)
+  }),
+)
 
 it.instance(
   "local mcp cwd resolves relative paths against instance directory",

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -307,6 +307,41 @@ it.live("McpOAuthProvider refreshes expired stored tokens", () =>
 )
 
 it.instance(
+  "remote connect bounds expired token refresh by mcp timeout",
+  () =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const original = McpOAuthProvider.prototype.refreshTokensIfExpired
+        McpOAuthProvider.prototype.refreshTokensIfExpired = () => {
+          refreshAuthorizationCalls++
+          return new Promise(() => {})
+        }
+        return original
+      }),
+      () =>
+        MCP.Service.use((mcp: MCPNS.Interface) =>
+          Effect.gen(function* () {
+            lastCreatedClientName = "remote-timeout"
+
+            const result = yield* mcp.add("remote-timeout", {
+              type: "remote",
+              url: "https://mcp.example.com/mcp",
+              timeout: 20,
+            })
+
+            expect(statusName(result.status, "remote-timeout")).toBe("connected")
+            expect(refreshAuthorizationCalls).toBe(1)
+          }),
+        ),
+      (original) =>
+        Effect.sync(() => {
+          McpOAuthProvider.prototype.refreshTokensIfExpired = original
+        }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
   "local mcp cwd resolves relative paths against instance directory",
   () =>
     MCP.Service.use((mcp: MCPNS.Interface) =>

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -54,6 +54,7 @@ let transportCloseCount = 0
 // Captures the opts passed to each MockStdioTransport, keyed by lastCreatedClientName
 const stdioOptsByName = new Map<string, any>()
 let refreshAuthorizationCalls = 0
+let refreshAborted = false
 
 function getOrCreateClientState(name?: string): MockClientState {
   const key = name ?? "default"
@@ -253,6 +254,7 @@ beforeEach(() => {
   clientCreateCount = 0
   transportCloseCount = 0
   refreshAuthorizationCalls = 0
+  refreshAborted = false
 })
 
 // Import after mocks
@@ -307,14 +309,23 @@ it.live("McpOAuthProvider refreshes expired stored tokens", () =>
 )
 
 it.instance(
-  "remote connect bounds expired token refresh by mcp timeout",
+  "remote connect cancels expired token refresh after mcp timeout",
   () =>
     Effect.acquireUseRelease(
       Effect.sync(() => {
         const original = McpOAuthProvider.prototype.refreshTokensIfExpired
-        McpOAuthProvider.prototype.refreshTokensIfExpired = () => {
+        McpOAuthProvider.prototype.refreshTokensIfExpired = (_fetchFn, signal) => {
           refreshAuthorizationCalls++
-          return new Promise(() => {})
+          return new Promise((_, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => {
+                refreshAborted = true
+                reject(signal.reason)
+              },
+              { once: true },
+            )
+          })
         }
         return original
       }),
@@ -331,6 +342,7 @@ it.instance(
 
             expect(statusName(result.status, "remote-timeout")).toBe("connected")
             expect(refreshAuthorizationCalls).toBe(1)
+            expect(refreshAborted).toBe(true)
           }),
         ),
       (original) =>


### PR DESCRIPTION
### Issue for this PR

Related to #28567

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Remote MCP transports currently rely on the MCP SDK to refresh OAuth credentials after the server rejects an expired access token with a 401 response.

This change checks the persisted OAuth expiration time before connecting. When an access token is expired or will expire within 60 seconds, and a refresh token and client registration are available, OpenCode discovers the OAuth authorization server, selects the protected resource indicator, refreshes and persists the tokens, and then creates the MCP transport.

Configured MCP headers are included in OAuth discovery and token requests. Refresh failures remain best-effort so the transport can fall back to the SDK's existing 401-driven authentication behavior. The pre-connect refresh is bounded by the configured MCP timeout and its network work is cancelled when that attempt settles, preventing a timed-out refresh from racing the SDK fallback.

### How did you verify your code works?

- Added coverage for refreshing and persisting an expired stored token.
- Added coverage proving a stalled proactive refresh is aborted after the configured timeout and does not block remote MCP connection.
- Ran `bun test test/mcp/lifecycle.test.ts` in `packages/opencode` (`32` passing).
- Ran `bun typecheck` in `packages/opencode`.
- Confirmed the original PR CI passed typecheck, unit, end-to-end, standards, compliance, and Nix checks.

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR