### PR TITLE
fix(command): sort numbered placeholder hints numerically

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -45,7 +45,9 @@ export function hints(template: string) {
   const result: string[] = []
   const numbered = template.match(/\$\d+/g)
   if (numbered) {
-    for (const match of [...new Set(numbered)].sort()) result.push(match)
+    // Sort numerically, not lexicographically, so $2 comes before $10.
+    for (const match of [...new Set(numbered)].sort((a, b) => Number(a.slice(1)) - Number(b.slice(1))))
+      result.push(match)
   }
   if (template.includes("$ARGUMENTS")) result.push("$ARGUMENTS")
   return result

--- a/packages/opencode/test/command/hints.test.ts
+++ b/packages/opencode/test/command/hints.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { hints } from "../../src/command/index"
+
+describe("command hints", () => {
+  test("orders numbered placeholders numerically, not lexicographically", () => {
+    const template = "use $1 $2 $10 $11 $3"
+    expect(hints(template)).toEqual(["$1", "$2", "$3", "$10", "$11"])
+  })
+
+  test("deduplicates repeated placeholders", () => {
+    expect(hints("$1 $1 $2 $2")).toEqual(["$1", "$2"])
+  })
+
+  test("appends $ARGUMENTS after numbered placeholders", () => {
+    expect(hints("$1 $2 $ARGUMENTS")).toEqual(["$1", "$2", "$ARGUMENTS"])
+  })
+
+  test("returns empty list when there are no placeholders", () => {
+    expect(hints("no placeholders here")).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

`Command.hints()` (in `packages/opencode/src/command/index.ts`) collects the `$N` positional-argument placeholders from a command template and sorts them with a bare `Array.sort()`:

```ts
const numbered = template.match(/\$\d+/g)
if (numbered) {
  for (const match of [...new Set(numbered)].sort()) result.push(match)
}
```

`Array.sort()` compares as strings, so once a template has ten or more positional arguments the hints come out lexicographically:

```
$1, $10, $11, $2, $3      ❌
```

instead of numerically:

```
$1, $2, $3, $10, $11      ✅
```

The MCP-prompt branch a few lines down already builds its hints in true numeric order (`hints: prompt.arguments?.map((_, i) => \`$${i + 1}\`)`), so the two code paths that populate the same `hints` field were inconsistent.

## Fix

Sort by the integer after `$`:

```ts
[...new Set(numbered)].sort((a, b) => Number(a.slice(1)) - Number(b.slice(1)))
```

Added `packages/opencode/test/command/hints.test.ts` covering numeric ordering, dedup, `$ARGUMENTS` placement, and the no-placeholder case.

## Verification

Verified the sort logic against all four test cases in isolation:

```
PASS "use $1 $2 $10 $11 $3" -> ["$1","$2","$3","$10","$11"]
PASS "$1 $1 $2 $2"          -> ["$1","$2"]
PASS "$1 $2 $ARGUMENTS"     -> ["$1","$2","$ARGUMENTS"]
PASS "no placeholders here" -> []
OLD lexicographic sort:        ["$1","$10","$11","$2","$3"]
```

(I don't have `bun` installed locally to run the full `bun test` suite, but the added test mirrors the verified logic exactly.)