### PR TITLE
feat(tui): add session_prompt_spinner slot to the prompt status row

### DIFF
--- a/packages/opencode/specs/tui-plugins.md
+++ b/packages/opencode/specs/tui-plugins.md
@@ -428,6 +428,7 @@ Current host slot names:
 - `home_prompt_right` with props `{ workspace_id? }`
 - `session_prompt` with props `{ session_id, visible?, disabled?, on_submit?, ref? }`
 - `session_prompt_right` with props `{ session_id }`
+- `session_prompt_spinner` with props `{ session_id }` — renders in the status row while the model is generating; hidden when status is idle
 - `home_bottom`
 - `home_footer`
 - `sidebar_title` with props `{ session_id, title, share_url? }`
@@ -441,7 +442,7 @@ Slot notes:
 - `api.slots.register(plugin)` does not return an unregister function.
 - Returned ids are `pluginId`, `pluginId:1`, `pluginId:2`, and so on.
 - Plugin-provided `id` is not allowed.
-- The current host renders `home_logo`, `home_prompt`, and `session_prompt` with `replace`, `home_footer`, `sidebar_title`, and `sidebar_footer` with `single_winner`, and `app`, `app_bottom`, `home_prompt_right`, `session_prompt_right`, `home_bottom`, and `sidebar_content` with the slot library default mode.
+- The current host renders `home_logo`, `home_prompt`, and `session_prompt` with `replace`, `home_footer`, `sidebar_title`, and `sidebar_footer` with `single_winner`, and `app`, `app_bottom`, `home_prompt_right`, `session_prompt_right`, `session_prompt_spinner`, `home_bottom`, and `sidebar_content` with the slot library default mode.
 - `app_bottom` is rendered in normal layout flow below the active route, while `app` is rendered afterward for global app-level UI.
 - Plugins can define custom slot names in `api.slots.register(...)` and render them from plugin UI with `ui.Slot`.
 

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -470,6 +470,9 @@ export type TuiHostSlotMap = {
   session_prompt_right: {
     session_id: string
   }
+  session_prompt_spinner: {
+    session_id: string
+  }
   home_bottom: {}
   home_footer: {}
   sidebar_title: {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -65,6 +65,7 @@ export type PromptProps = {
   ref?: (ref: PromptRef | undefined) => void
   hint?: JSX.Element
   right?: JSX.Element
+  spinner?: JSX.Element
   showPlaceholder?: boolean
   placeholders?: {
     normal?: string[]
@@ -1573,6 +1574,11 @@ export function Prompt(props: PromptProps) {
                     })()}
                   </box>
                 </box>
+                <Show when={props.spinner}>
+                  <box flexDirection="row" gap={1} flexShrink={0}>
+                    {props.spinner}
+                  </box>
+                </Show>
                 <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
                   esc{" "}
                   <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1315,6 +1315,7 @@ export function Session() {
                       }}
                       sessionID={route.sessionID}
                       right={<pluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
+                      spinner={<pluginRuntime.Slot name="session_prompt_spinner" session_id={route.sessionID} />}
                     />
                   </pluginRuntime.Slot>
                 </Show>


### PR DESCRIPTION
## What

Adds a new `session_prompt_spinner` slot to `TuiHostSlotMap` that renders inside the prompt's **status row** — the row that is only visible while the model is generating (when `status !== 'idle'`).

## Why

`session_prompt_right` renders in the meta row, which is always visible regardless of whether the model is generating. Plugins that want to show generation-scoped UI (e.g. a sponsor line that should only appear while waiting for a response) have no way to do this today — they appear at all times.

`session_prompt_spinner` fills that gap: the slot is wrapped in the existing `<Match when={status().type !== "idle"}>` block, so it automatically appears and disappears with the spinner.

## Changes

| File | Change |
|---|---|
| `packages/plugin/src/tui.ts` | Add `session_prompt_spinner: { session_id: string }` to `TuiHostSlotMap` |
| `packages/tui/src/routes/session/index.tsx` | Pass `spinner={<Slot name="session_prompt_spinner" .../>}` to `<Prompt>` |
| `packages/tui/src/component/prompt/index.tsx` | Add `spinner?: JSX.Element` to `PromptProps`; render it between the retry/spinner box and the `esc interrupt` keyhint |
| `packages/opencode/specs/tui-plugins.md` | Document the new slot |

## Rendering position

```
┌─────────────────────────────────────────────────────────┐
│  ⣾  [retry message if any]  [slot content here]  esc    │  ← status row (only during generation)
├─────────────────────────────────────────────────────────┤
│  model · provider                    [right slot here]  │  ← meta row (always visible)
└─────────────────────────────────────────────────────────┘
```

The slot content sits between the spinner/retry message on the left and the `esc interrupt` keyhint on the right.

## Behaviour

- `justifyContent` on the parent box is already `flex-start` (or `space-between` during retry), so the slot content will push naturally toward the center/right without layout changes.
- The slot is only mounted when status is not idle — plugins do not need to gate rendering themselves.
- Rendering mode follows the slot library default (additive), matching `session_prompt_right`.