### PR TITLE
docs(step2): align tracked closure with reevaluation

### DIFF
--- a/REVIEW_NOTES.md
+++ b/REVIEW_NOTES.md
@@ -6,6 +6,7 @@ Review-Agent 出力を残すための運用ログです。
 
 | Date | PR/Task | Reviewer | Decision | Blocking items | Required remediation | Close status |
 | --- | --- | --- | --- | --- | --- | --- |
+| 2026-06-13 | Step2 gate follow-up closure | codex | pass | 2026-06-12 の D2/D3 hold の再評価済み状態（`report=missing`/log-only が D1/D2/D3 再評価条件を満たす） | `backtest/results/step2_operational_stop_reevaluation_summary.json` と `backtest/results/step2_*_retest.json` を最終根拠化。Task 2026-06-12 の hold 行は履歴保持のみ。 | closed |
 | 2026-06-13 | Step2 gate reevaluation closure (tracked-doc correction) | codex | pass | D2/D3 の task-level hold 記録と旧 `hold` 前提の文言が tracked 文書に残存 | `docs/mt5-report-recovery-runbook.md` / `docs/qwen-wag-dell-task-flow.md` を 2026-06-13 pass 根拠（`backtest/results/step2_operational_stop_reevaluation_summary.json` / `backtest/results/step2_*_retest.json`）と整合させる。`run_d3_recovery.ps1` 系は別タスクに分離、`prompts/` は Step2 closure から除外（廃止運用） | closed |
 | 2026-06-12 | Task D2 / D2-R | qwen3.7-plus | hold | `step2_operational_stop_daily` 分岐を追加し、daily 停止ログに合わせて必須 marker を整理 | `log-only passed=true` で hold 継続。`report` 未生成は evidence 継続で再取得を試行（2026-06-13 pass の履歴保持） | open |
 | 2026-06-12 | Task D3 | qwen3.7-plus | hold | report 回収が `report=missing` のまま継続し、log-only fallback でのみ成立 | report recovery 経路が継続するか、運用上 hold を許容する方針を正式化（2026-06-13 pass の履歴保持） | open |

--- a/REVIEW_NOTES.md
+++ b/REVIEW_NOTES.md
@@ -1,0 +1,23 @@
+# Review Notes
+
+Review-Agent 出力を残すための運用ログです。
+
+## Latest Notes
+
+| Date | PR/Task | Reviewer | Decision | Blocking items | Required remediation | Close status |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-06-13 | Step2 gate reevaluation closure (tracked-doc correction) | codex | pass | D2/D3 の task-level hold 記録と旧 `hold` 前提の文言が tracked 文書に残存 | `docs/mt5-report-recovery-runbook.md` / `docs/qwen-wag-dell-task-flow.md` を 2026-06-13 pass 根拠（`backtest/results/step2_operational_stop_reevaluation_summary.json` / `backtest/results/step2_*_retest.json`）と整合させる。`run_d3_recovery.ps1` 系は別タスクに分離、`prompts/` は Step2 closure から除外（廃止運用） | closed |
+| 2026-06-12 | Task D2 / D2-R | qwen3.7-plus | hold | `step2_operational_stop_daily` 分岐を追加し、daily 停止ログに合わせて必須 marker を整理 | `log-only passed=true` で hold 継続。`report` 未生成は evidence 継続で再取得を試行（2026-06-13 pass の履歴保持） | open |
+| 2026-06-12 | Task D3 | qwen3.7-plus | hold | report 回収が `report=missing` のまま継続し、log-only fallback でのみ成立 | report recovery 経路が継続するか、運用上 hold を許容する方針を正式化（2026-06-13 pass の履歴保持） | open |
+| 2026-06-12 | Task D3-R | qwen3.7-plus | hold | D3-R で `report=missing` が継続。追跡実行で `before=20260612.log|2464710|14:06:25`→`after=20260612.log|2477438|14:18:08`、`logWindowUpdated=updated`、`passed=true` を確認 | `log-only fallback` の実績を追加。次回も missing かつ passed=true なら hold 継続、passed=false 2 回連続なら reject 条件の運用へ移行（2026-06-13 pass の履歴保持） | open |
+| 2026-06-12 | Step2 gate audit follow-up | codex | hold | D2/D3 の既存 hold 証跡は旧 gate 前提。daily/monthly 固有 marker と global marker 禁止を追加し、global も `InpGlobalDDLimit=-0.0005` 固定へ戻した | D1/D2/D3 は現行 gate で再評価する。旧 `log-only passed=true` は完了判断に使わない | open |
+| TBD | - | - | - | - | - | - |
+
+## Review template
+
+- 対象範囲: `MQL5 / Python / ドキュメント / 運用フロー`
+- 重大度: `critical` / `high` / `medium` / `low`
+- 検証結果: `pass` / `hold` / `reject`
+- 重要修正: 事故リスク/数値安定性・ログ改変・安全ゲートの欠落
+
+判定は `DEVELOPMENT.md` の実行証跡とリンクさせ、差し戻し時は理由と再実行条件を明記する。

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -1,0 +1,24 @@
+# Sprint Record
+
+このファイルは `AGENTS.md` の `SPRINT.md` 参照に対応する運用ログです。
+長期計画の詳細は `ROADMAP.md` を参照し、短期の実施結果はここに追記します。
+
+## Current Sprint
+
+| Date | Owner | Scope | Evidence | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 2026-06-13 | opencode | Step2 gate re-evaluation | `backtest/results/step2_global_stop_retest.json`, `backtest/results/step2_daily_stop_retest.json`, `backtest/results/step2_monthly_stop_retest.json`, `backtest/results/task-d1r-20260613.log`, `backtest/results/task-d2r-20260613.log`, `backtest/results/task-d3r-20260613.log`, `backtest/results/step2_operational_stop_reevaluation_summary.json` | pass | Supersedes 2026-06-12 gate-assumption hold rows. D1=`step2_operational_stop`, D2=`step2_operational_stop_daily`, D3=`step2_operational_stop_monthly` all passed current log-only parser gates with `failed_rules=[]`, `warnings=[]`, and `log_window_selected=true`; reports remained missing but `require_report_metrics=false`; Sentinel unblocked by summary validator. |
+| 2026-06-13 | codex | Step2 gate audit follow-up closure | `backtest/results/step2_operational_stop_reevaluation_summary.json`, `backtest/results/step2_*_retest.json` | pass | 2026-06-12 の hold 状態を再評価で再収束。Task D2/D3 の履歴は保持しつつ、現行運用は再評価 pass をもって close とする。 |
+| 2026-06-12 | qwen3.7-plus | D3-R hold (log-only fallback) | `backtest/results/step2_monthly_stop_retest.json`, `backtest/results/task-d3r-20260612.log` | hold | `step2_operational_stop` parser passed (`InpGlobalDDLimit=-0.0005`, `InpRequireExpectedAccountCurrency=false`), report 未生成のため hold |
+| 2026-06-12 | qwen3.7-plus | D1-R hold (log-only fallback) | `backtest/results/step2_global_stop_retest.json`, `backtest/results/20260612.log` | hold | `step2_operational_stop` parser は pass、`report` は未生成。`step2_global_stop` 実行ログは最新更新 |
+| 2026-06-12 | qwen3.7-plus | D2 | `backtest/results/step2_daily_stop_retest.json`, `backtest/results/20260612.log` | hold | `step2_operational_stop_daily` parser へ分岐し、`InpDailyDDLimit` + `Test passed` で log-only `passed=true`。report 未生成のため hold |
+| 2026-06-12 | qwen3.7-plus | D2-R | `backtest/results/step2_daily_stop_retest.json`, `backtest/results/20260612.log`, `C:\Users\wag\Downloads\step2_daily_stop.local.ini` | hold | D2-R 再実行で `step2_operational_stop_daily` を採用し log-only `passed=true`。`daily` 系 marker が一致。report recovery は継続失敗 |
+| 2026-06-12 | qwen3.7-plus | D3 | `backtest/results/step2_monthly_stop_retest.json`, `backtest/results/20260612.log`, `C:\Users\wag\Downloads\step2_monthly_stop.local.ini` | hold | D3 の再実行でも report 未生成。`step2_operational_stop` parser は再生成 log-only で `passed=true`（`global stop` marker 到達）ため hold、notes に `log-only fallback` |
+| 2026-06-12 | qwen3.7-plus | D3-R | `backtest/results/task-d3r-20260612-recovery.log`, `backtest/results/step2_monthly_stop_retest.json`, `backtest/results/20260612.log` | hold | D3-R 再実行。`before=20260612.log|2464710|14:06:25`, `after=20260612.log|2477438|14:18:08`, `report=missing`, `logWindowUpdated=updated`、`parser passed=true`、`failed_rules=[]` |
+| 2026-06-12 | qwen3.7-plus | E | `backtest/results/step2_global_stop_retest.json`, `backtest/results/step2_daily_stop_retest.json`, `backtest/results/step2_monthly_stop_retest.json`, `SPRINT.md` | pass | D1/D2/D3 の result/ログ証跡を整理。Task E 実施完了。 |
+| 2026-06-12 | codex | Step2 gate audit follow-up | `backtest/gate_config.json`, `src/Scripts/tests/test_analyze_mt5_report.py` | hold | 上記 D2/D3 系 evidence は旧 gate に基づく記録。現行 gate は D1=`step2_operational_stop`、D2=`step2_operational_stop_daily`、D3=`step2_operational_stop_monthly` の固有 marker を要求するため再評価が必要 |
+
+## Review
+
+- **Sprint close condition**: 主要計画が更新され、監査で指摘された破綻リンクが解消されていること
+- **Evidence policy**: 実施時の成果・判断は本表に要約記録し、詳細は対象PR / コミットへ遡れるよう保持する

--- a/docs/mt5-report-recovery-runbook.md
+++ b/docs/mt5-report-recovery-runbook.md
@@ -1,0 +1,226 @@
+# MT5 Report Recovery Runbook
+
+## 目的
+
+`wag-dell` 上で MT5 CLI 実行時に fresh HTML report が不安定に見つからない問題を、Windows ローカルの generated ini と platform directory 相対 `Report=` で回避する。
+
+この手順の狙いは以下です。
+
+- tracked の `backtest/tester/*.ini` を host 固有 path で汚さない
+- `Report=` の出力先を deterministic に固定する
+- stale report の誤読を防ぐ
+- Task B / C の完了条件を機械的に確認できるようにする
+
+補足: Step2 closure の本フェーズでは `run_d3_recovery.ps1` の再導入は行わず、当該 recovery 運用は別タスクで分離して扱う。
+
+## 監査結果
+
+blocking 問題はありません。採用してよい方針です。
+
+ただし、以下を手順に必須条件として追加します。
+
+1. `Report=` は `reports\...` のような platform 相対パスを使う
+2. 拡張子は `.htm` を明示する
+3. tracked ini は直接編集せず、`wag-dell` 上で local ini を生成する
+4. 実行前に旧 report を削除し、実行後に存在と更新時刻を確認する
+
+## 適用対象
+
+- `step2_baseline`
+- `step2_global_stop`
+- `step2_daily_stop`
+- `step2_monthly_stop`
+
+## 使うパス
+
+### repo 側入力
+
+- `backtest/tester/step2_baseline.ini`
+- `backtest/tester/step2_global_stop.ini`
+- `backtest/tester/step2_daily_stop.ini`
+- `backtest/tester/step2_monthly_stop.ini`
+
+### wag-dell 側 canonical report path
+
+- `reports\step2_baseline.htm`
+- `reports\step2_global_stop.htm`
+- `reports\step2_daily_stop.htm`
+- `reports\step2_monthly_stop.htm`
+
+### wag-dell 側 local ini 生成先
+
+- `C:\Users\wag\Downloads\step2_baseline.local.ini`
+- `C:\Users\wag\Downloads\step2_global_stop.local.ini`
+- `C:\Users\wag\Downloads\step2_daily_stop.local.ini`
+- `C:\Users\wag\Downloads\step2_monthly_stop.local.ini`
+
+## 手順
+
+### 1. base ini を wag-dell にコピーする
+
+Mac 側から実行する。
+
+```bash
+scp backtest/tester/step2_baseline.ini wag-dell:C:/Users/wag/Downloads/
+scp backtest/tester/step2_global_stop.ini wag-dell:C:/Users/wag/Downloads/
+scp backtest/tester/step2_daily_stop.ini wag-dell:C:/Users/wag/Downloads/
+scp backtest/tester/step2_monthly_stop.ini wag-dell:C:/Users/wag/Downloads/
+```
+
+### 2. wag-dell で local ini を生成する
+
+PowerShell で以下を実行する。例は baseline。
+
+```powershell
+$src = 'C:\Users\wag\Downloads\step2_baseline.ini'
+$dst = 'C:\Users\wag\Downloads\step2_baseline.local.ini'
+$platformDir = 'C:\Program Files\Axiory MetaTrader 5'
+$reportsDir = Join-Path $platformDir 'reports'
+$report = 'reports\step2_baseline.htm'
+$reportFullPath = Join-Path $platformDir $report
+
+if (-not (Test-Path $reportsDir)) {
+  New-Item -ItemType Directory -Path $reportsDir
+}
+
+$text = Get-Content -Path $src -Raw
+$text = $text -replace 'Report=.*', "Report=$report"
+Set-Content -Path $dst -Value $text -Encoding ASCII
+```
+
+他の scenario も同じ手順で `Report=` だけ差し替える。
+
+### 3. 実行前に旧 report を削除する
+
+fresh 判定のため、同名 report を削除する。
+
+```powershell
+Remove-Item 'C:\Program Files\Axiory MetaTrader 5\reports\step2_baseline.htm' -ErrorAction SilentlyContinue
+```
+
+必要なら旧 log の時刻も控える。
+
+### 4. local ini で MT5 CLI を実行する
+
+```powershell
+Start-Process -FilePath 'C:\Program Files\Axiory MetaTrader 5\terminal64.exe' `
+  -ArgumentList '/config:C:\Users\wag\Downloads\step2_baseline.local.ini' `
+  -Wait
+```
+
+### 5. report の存在と更新時刻を確認する
+
+```powershell
+Get-Item 'C:\Program Files\Axiory MetaTrader 5\reports\step2_baseline.htm' | Select-Object FullName, Length, LastWriteTime
+```
+
+完了条件:
+
+- file exists
+- `LastWriteTime` が今回実行分
+- size が 0 でない
+
+### 6. tester log の fresh さも確認する
+
+```powershell
+Get-ChildItem 'C:\Users\wag\AppData\Roaming\MetaQuotes\Terminal\ED051E4A9BEE8A33BDDD0F947358B2B2\Tester\logs' |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1 FullName, Length, LastWriteTime
+```
+
+### 7. parser を実行する
+
+baseline のように report metrics 必須の scenario は、必ず `--report` を付ける。
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --report "C:/Program Files/Axiory MetaTrader 5/reports/step2_baseline.htm" \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario default \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_baseline.json
+```
+
+### 8. Step2 系 parser 実行（D1/D2/D3）
+
+Step2 の D1/D2/D3 は log-only fallback が許容されるため、`--report` は任意。
+report が取得できなくても、`--log` のみで parser を実行し、`require_report_metrics=false` 条件で pass を受け入れる。
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_global_stop_retest.json
+
+python3 src/Scripts/analyze_mt5_report.py \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop_daily \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_daily_stop_retest.json
+
+python3 src/Scripts/analyze_mt5_report.py \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop_monthly \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_monthly_stop_retest.json
+```
+
+## 判定
+
+### pass
+
+- smoke が完走する
+- fresh log がある
+- fresh HTML report が platform reports 配下で生成される
+- parser が完走する
+
+### hold
+
+- smoke は通るが report が未生成
+- parser 実行前提の artifact が不足
+- output path だけ不明
+
+### reject
+
+- smoke 自体が失敗
+- report path を相対指定（`Report=...`）に変えても未生成
+- parser が gate failure を返す
+
+## fallback ルール
+
+### Step2 operational stop 系
+
+`backtest/gate_config.json` の Step2 operational stop 系 scenario は `require_report_metrics: false` なので、report 未生成でも log-only で継続可能。
+
+- D1 global stop: `step2_operational_stop`
+- D2 daily stop: `step2_operational_stop_daily`
+- D3 monthly stop: `step2_operational_stop_monthly`
+
+log-only fallback でも、各 scenario 固有の forced input marker と stop marker は必須とする。例えば daily は `InpDailyDDLimit=-0.001` と `CAUTION: Daily Drawdown limit reached`、monthly は `InpMonthlyDDLimit=-0.001` と `WARNING: Monthly Drawdown limit reached` を見る。
+
+### D3 recovery の追跡強化（monthly stop）
+
+- `Task D3` で report が得られない場合でも、次の監査項目を必ず保存する。
+  - 実行前後の `Tester\logs` 最新ファイルの `Name / Length / LastWriteTime`
+  - report 存在確認（有無 / size / mtime）
+  - parser 出力 JSON の `passed` / `failed_rules` / `metrics.log_window_selected`
+- `step2_monthly_stop_retest` の再実行時刻と該当ログファイルの更新時刻を対応付け
+- 月次タスクは `report=missing` が継続しても `passed=true` の log-only なら `hold` のまま記録し、
+  `Notes` に「`log-only fallback`」と `report missing 回数`を明記する。
+- `report=missing` で log-only が `passed=false` のまま再実行しても 2 回続いたら、D3 を `reject` 化し再実行条件を明記する。
+
+### baseline / sentinel 系
+
+`default.require_report_metrics` が `true` のため、report 未生成のまま pass 扱いにしてはいけない。`hold` として止める。
+
+## 禁止事項
+
+- tracked ini に Windows absolute path を直接 commit しない
+- stale report を使わない
+- relative `Report=reports\step2_baseline.htm` のまま stale 判定しない
+- report 未生成なのに baseline を pass 扱いにしない
+
+## 補足
+
+既存の `C:\Program Files\Axiory MetaTrader 5\reports\step2_baseline.htm` は 2026-06-10 時点で存在しており、MT5 自体が report を出力できることは確認済みです。問題は report 能力の欠如ではなく、CLI 実行時の `Report=` 出力先が固定されていないことです。

--- a/docs/qwen-wag-dell-task-flow.md
+++ b/docs/qwen-wag-dell-task-flow.md
@@ -1,0 +1,363 @@
+# Qwen3.7-Plus 向け wag-dell Task A-D 実行順書
+
+## 目的
+
+`wag-dell` 復旧後の MT5 残作業を、`qwen3.7-plus` が 1 task ずつ安全に進められるように整理する。
+
+この文書は以下を統合する。
+
+- Task A-D の全体順序
+- `docs/mt5-report-recovery-runbook.md` の差し込み位置
+- baseline と Step2 operational stop で扱いが異なる点
+- `pass / hold / reject` の使い分け
+
+## 前提
+
+- 1 回の依頼で 1 task だけ実行する
+- compile 前に smoke に進まない
+- stale log/report を使わない
+- include 更新時は single-file sync しない
+- parser 修正と MQL5 修正を同一 task に混ぜない
+
+## Task A-D 全体像
+
+### Task A
+
+- full bundle 配備
+- MetaEditor compile
+- 完了条件: `0 errors, 0 warnings`
+
+### Task B
+
+- baseline smoke 実行
+- fresh log/report 回収
+- report が出ない場合は recovery runbook を差し込む
+
+### Task C
+
+- baseline parser 実行
+- report metrics 必須
+
+### Task D1
+
+- Step2 global stop retest
+
+### Task D2
+
+- Step2 daily stop retest
+
+### Task D3
+
+- Step2 monthly stop retest
+
+## report recovery runbook の差し込み位置
+
+### 基本ルール
+
+`docs/mt5-report-recovery-runbook.md` は **Task B と Task C の間** に入る。
+
+ただし、Step2 operational stop 系では **Task D1-D3 の中でも再利用** する。
+
+### 差し込み位置 1: baseline 系
+
+順序は以下。
+
+1. Task A
+2. Task B baseline smoke
+3. fresh report が取れた
+4. Task C baseline parser
+
+もし Task B で fresh report が取れなければ、以下へ分岐する。
+
+1. Task B baseline smoke
+2. report 未生成
+3. `mt5-report-recovery-runbook` を実行
+4. local ini + platform 相対 report path（`reports\step2_baseline.htm`）で baseline smoke を再実行
+5. report が取れたら Task C へ進む
+6. なお report が無ければ baseline は `hold`
+
+### 差し込み位置 2: Step2 operational stop 系
+
+順序は以下。
+
+1. Task D1 / D2 / D3 を実行
+2. report が取れれば通常どおり parser 実行
+3. report が無ければ `mt5-report-recovery-runbook` を使って platform 相対 path で再実行
+4. なお report が取れない場合でも、D1 / D2 / D3 の各 Step2 scenario では log-only fallback を許す
+
+## 重要な違い
+
+### baseline / sentinel 系
+
+- `backtest/gate_config.json` の `default.require_report_metrics` は `true`
+- HTML report が無ければ parser gate を完了扱いにしない
+- report 未生成のまま次へ進めない
+
+### Step2 operational stop 系
+
+- `backtest/gate_config.json` の D1 / D2 / D3 用 scenario は `require_report_metrics: false`
+- D1: `step2_operational_stop`
+- D2: `step2_operational_stop_daily`
+- D3: `step2_operational_stop_monthly`
+- HTML report が取れなくても log-only parser が可能
+- ただし fresh log は必須
+- ただし 2026-06-13 再評価で `backtest/results/step2_operational_stop_reevaluation_summary.json` が `pass` なら、
+  D1/D2/D3 の最終状態はこの summary で `closed` と扱う。単体 task の hold は運用品質維持のための中間状態。
+
+## parser scenario 名の固定
+
+`qwen3.7-plus` が迷いやすい点なので、ここを固定する。
+
+### Task C baseline
+
+- `--scenario step2_baseline_smoke`
+- `gate_config.json` に専用 entry は無いが、default ルールで評価される
+
+### Task D1 / D2 / D3
+
+- parser の `--scenario` はケース別に固定する
+- output JSON file 名はケース別に分けてよい
+
+例:
+
+- D1 output: `backtest/results/step2_global_stop_retest.json`
+- D2 output: `backtest/results/step2_daily_stop_retest.json`
+- D3 output: `backtest/results/step2_monthly_stop_retest.json`
+
+- D1: `step2_operational_stop`
+- D2: `step2_operational_stop_daily`
+- D3: `step2_operational_stop_monthly`
+
+## 実行順の詳細
+
+### Task A
+
+実行内容:
+
+1. `wag-dell` 接続確認
+2. AXIORY MT5 配備先確認
+3. full bundle 配備
+4. MetaEditor compile
+
+完了条件:
+
+- `0 errors, 0 warnings`
+
+停止条件:
+
+- compile error
+- compile warning
+- 配備先不明
+
+### Task B
+
+実行内容:
+
+1. `step2_baseline.ini` で smoke
+2. fresh log 確認
+3. fresh report 確認
+
+完了条件:
+
+- smoke 完走
+- fresh log 取得
+- fresh report 取得
+
+分岐:
+
+- report が無い場合は `mt5-report-recovery-runbook` へ進む
+
+### Task B-R: report recovery
+
+実行内容:
+
+1. tracked ini を `wag-dell` の `Downloads` にコピー
+2. local ini を生成
+3. `Report=` を platform 相対 `reports\...` に差し替え
+4. 旧 report 削除
+5. local ini で baseline smoke 再実行
+6. report existence / size / mtime 確認
+
+完了条件:
+
+- `C:\Program Files\Axiory MetaTrader 5\reports\step2_baseline.htm` が fresh に生成される
+
+失敗時:
+
+- baseline は `hold`
+- Task C に進まない
+
+### Task C
+
+実行内容:
+
+1. baseline log/report を parser に渡す
+2. `backtest/results/step2_baseline.json` を生成
+
+実行例:
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --report "C:/Program Files/Axiory MetaTrader 5/reports/step2_baseline.htm" \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_baseline_smoke \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_baseline.json
+```
+
+完了条件:
+
+- parser 完走
+- JSON 生成
+- `passed` 判定取得
+
+### Task D1 / D2 / D3
+
+各 task で共通する流れ:
+
+1. 対応 ini で smoke 実行
+2. fresh log 回収
+3. fresh report があれば通常 parser
+4. report が無ければ report recovery
+5. なお report が無くても fresh log があり、該当 parser が通るなら log-only fallback を許す
+
+#### D1 対象
+
+- `step2_global_stop.ini`
+- output: `backtest/results/step2_global_stop_retest.json`
+
+#### D2 対象
+
+- `step2_daily_stop.ini`
+- output: `backtest/results/step2_daily_stop_retest.json`
+
+#### D3 対象
+
+- `step2_monthly_stop.ini`
+- output: `backtest/results/step2_monthly_stop_retest.json`
+
+#### D系 parser 実行例
+
+D1 parser あり（global-stop 型）:
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --report "C:/Program Files/Axiory MetaTrader 5/reports/step2_global_stop.htm" \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_global_stop_retest.json
+```
+
+D1 report なしの log-only fallback:
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_global_stop_retest.json
+```
+
+D2 parser あり（daily-stop 型）:
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --report "C:/Program Files/Axiory MetaTrader 5/reports/step2_daily_stop.htm" \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop_daily \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_daily_stop_retest.json
+```
+
+D2 report なしの log-only fallback:
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop_daily \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_daily_stop_retest.json
+```
+
+D3 parser あり（monthly-stop 型）:
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --report "C:/Program Files/Axiory MetaTrader 5/reports/step2_monthly_stop.htm" \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop_monthly \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_monthly_stop_retest.json
+```
+
+D3 report なしの log-only fallback:
+
+```bash
+python3 src/Scripts/analyze_mt5_report.py \
+  --log "C:/Users/wag/AppData/Roaming/MetaQuotes/Terminal/ED051E4A9BEE8A33BDDD0F947358B2B2/Tester/logs/<TASK_LOG_PATH>" \
+  --scenario step2_operational_stop_monthly \
+  --config backtest/gate_config.json \
+  --out backtest/results/step2_monthly_stop_retest.json
+```
+
+## qwen3.7-plus への依頼単位
+
+`qwen3.7-plus` には 1 回で 1 task だけ渡す。
+
+推奨順:
+
+1. Task A
+2. Task B
+3. Task B-R
+4. Task C
+5. Task D1
+6. Task D1-R
+7. Task D2
+8. Task D2-R
+9. Task D3
+10. Task D3-R
+
+`-R` は report recovery が必要になった時だけ実行する補助 task とする。
+
+## status の使い分け
+
+### pass
+
+- task 本来の完了条件を満たした
+
+### hold
+
+- 実行自体は進んだが、artifact 不足で次工程へ進めない
+- 例: baseline smoke は通ったが fresh report が無い
+
+### reject
+
+- 実行失敗、gate failure、または想定外エラー
+
+### D系の特例
+
+- report 未生成でも log-only parser が通った場合、D系は evidence gathering を継続してよい
+- ただし出力 status は `hold` とし、notes に `log-only fallback` を必ず書く
+- その後 D2 / D3 へ進むことは許可する
+- D3 の場合は report 未生成が継続しても、再実行ごとに `before/after` log メタ情報と recovery 回数を記録する。
+- `log-only passed=true` を 2 回連続で受けた場合は hold を継続しつつ次タスクへ進む運用を許可する。
+- D3 で `log-only passed=false` が 2 回連続したら `Task D3` を即 `reject` とし、
+  marker 要件見直し or parser 分岐の追加を blocker として引き継ぐ。
+- Step2 再評価が `pass` の場合は、`backtest/results/step2_operational_stop_reevaluation_summary.json` を参照して D1/D2/D3 を最終的に `closed` と扱う。
+
+## 実行後に残す evidence
+
+- compile summary
+- tester log path
+- report path
+- parser output JSON path
+- `SPRINT.md` または別 evidence note に残す要約
+
+## 禁止事項
+
+- tracked ini に absolute Windows path を commit しない
+- baseline/sentinel で report 未生成のまま `pass` にしない
+- D系 parser に `step2_global_stop_retest` などを scenario 名として渡さない
+- stale report を使わない
+- 1 回の依頼で複数 task をまとめて実行しない


### PR DESCRIPTION
### Issue for this PR

Closes #32142

### Type of change

- [x] Documentation

### What does this PR do?

This PR is a clean, docs-only follow-up to align Step2 reevaluation closure artifacts after the 2026-06-13 verification.

It updates only tracked documentation files:

- `docs/mt5-report-recovery-runbook.md`
- `docs/qwen-wag-dell-task-flow.md`
- `REVIEW_NOTES.md`
- `SPRINT.md`

The updates:

- Keep historical context while adding a canonical 2026-06-13 closure status.
- Explicitly separate `prompts/` (non-tracked operational material) from tracked docs.
- Consolidate D1/D2/D3 evidence references and close status wording consistently.

This PR does not modify product logic; all operational evidence files and backtest artifacts remain as supporting records for reviewers.

### How did you verify your code works?

- Verified in git diff that only tracked docs are included.
- Confirmed PR checks `check-standards`, `check-compliance`, `add-contributor-label`, `check-duplicates` pass.
- Re-ran `gh` API checks and confirmed only required docs scope is changed.

### Screenshots / recordings

No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
