### PR TITLE
feat: Add user preferences feature with Markdown storage

### DIFF
--- a/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
+++ b/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
@@ -8,6 +8,7 @@ import { SettingsGeneralV2 } from "./general"
 import { SettingsKeybinds } from "../settings-keybinds"
 import { SettingsProvidersV2 } from "./providers"
 import { SettingsModelsV2 } from "./models"
+import { SettingsPreferencesV2 } from "./preferences"
 import "./settings-v2.css"
 import { SettingsServersV2 } from "./servers"
 
@@ -51,6 +52,10 @@ export const DialogSettings: Component = () => {
                       <Icon name="models" />
                       {language.t("settings.models.title")}
                     </TabsV2.Trigger>
+                    <TabsV2.Trigger value="preferences">
+                      <Icon name="file-text" />
+                      {language.t("settings.preferences.title", "Preferences")}
+                    </TabsV2.Trigger>
                   </div>
                 </div>
               </div>
@@ -75,6 +80,9 @@ export const DialogSettings: Component = () => {
         </TabsV2.Content>
         <TabsV2.Content value="models" class="settings-v2-panel">
           <SettingsModelsV2 />
+        </TabsV2.Content>
+        <TabsV2.Content value="preferences" class="settings-v2-panel">
+          <SettingsPreferencesV2 />
         </TabsV2.Content>
       </TabsV2>
     </Dialog>

--- a/packages/app/src/components/settings-v2/preferences.tsx
+++ b/packages/app/src/components/settings-v2/preferences.tsx
@@ -1,0 +1,123 @@
+import { Component, createResource, createSignal, Show } from "solid-js"
+import { useLanguage } from "@/context/language"
+import { useServerSDK } from "@/context/server-sdk"
+import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
+import { Icon } from "@opencode-ai/ui/icon"
+
+const DEFAULT_PREFERENCES = `# User Preferences
+
+<!-- Edit this file to customize how the AI assistant interacts with you. -->
+<!-- This file is in Markdown format and will be included in the system prompt. -->
+
+## Communication
+
+- Language: Respond in the same language the user uses
+- Verbosity: Concise by default, detailed when asked
+
+## Code Style
+
+- Follow existing project conventions
+- Prefer idiomatic patterns for each language
+
+## Behavior
+
+- Ask for clarification when requirements are ambiguous
+- Explain trade-offs when multiple approaches exist
+`
+
+export const SettingsPreferencesV2: Component = () => {
+  const language = useLanguage()
+  const serverSDK = useServerSDK()
+
+  const [preferences, setPreferences] = createSignal("")
+  const [isDirty, setIsDirty] = createSignal(false)
+  const [isSaving, setIsSaving] = createSignal(false)
+  const [saveStatus, setSaveStatus] = createSignal<"idle" | "success" | "error">("idle")
+
+  const [initialPreferences] = createResource(async () => {
+    try {
+      const response = await serverSDK.client.global.preferences.get()
+      const content = response.data as string
+      return content || DEFAULT_PREFERENCES
+    } catch {
+      return DEFAULT_PREFERENCES
+    }
+  })
+
+  const handleContentChange = (event: Event) => {
+    const target = event.target as HTMLTextAreaElement
+    setPreferences(target.value)
+    setIsDirty(true)
+    setSaveStatus("idle")
+  }
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      await serverSDK.client.global.preferences.update({ body: preferences() })
+      setIsDirty(false)
+      setSaveStatus("success")
+      setTimeout(() => setSaveStatus("idle"), 2000)
+    } catch {
+      setSaveStatus("error")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleReset = async () => {
+    setPreferences(DEFAULT_PREFERENCES)
+    setIsDirty(true)
+    setSaveStatus("idle")
+  }
+
+  return (
+    <div class="flex flex-col gap-4 h-full">
+      <div class="flex items-center justify-between">
+        <div>
+          <h3 class="text-sm font-medium text-foreground-primary">
+            {language.t("settings.preferences.title", "User Preferences")}
+          </h3>
+          <p class="text-xs text-foreground-secondary mt-1">
+            {language.t(
+              "settings.preferences.description",
+              "Customize how the AI assistant interacts with you. Changes are saved in Markdown format and included in the system prompt.",
+            )}
+          </p>
+        </div>
+        <div class="flex items-center gap-2">
+          <ButtonV2 variant="ghost" size="sm" onClick={handleReset}>
+            <Icon name="rotate-ccw" class="size-3.5" />
+            {language.t("settings.preferences.reset", "Reset")}
+          </ButtonV2>
+          <ButtonV2
+            variant="primary"
+            size="sm"
+            onClick={handleSave}
+            disabled={!isDirty() || isSaving()}
+          >
+            <Show when={saveStatus() === "success"}>
+              <Icon name="check" class="size-3.5 text-green-500" />
+            </Show>
+            <Show when={saveStatus() === "error"}>
+              <Icon name="x" class="size-3.5 text-red-500" />
+            </Show>
+            <Show when={saveStatus() === "idle" || saveStatus() === "success"}>
+              {isSaving()
+                ? language.t("settings.preferences.saving", "Saving...")
+                : language.t("settings.preferences.save", "Save")}
+            </Show>
+          </ButtonV2>
+        </div>
+      </div>
+
+      <textarea
+        class="flex-1 w-full min-h-[400px] p-4 font-mono text-sm bg-background-secondary border border-border-primary rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+        value={preferences()}
+        onInput={handleContentChange}
+        placeholder={DEFAULT_PREFERENCES}
+        spellcheck={false}
+      />
+    </div>
+  )
+}

--- a/packages/opencode/src/cli/cmd/preference.ts
+++ b/packages/opencode/src/cli/cmd/preference.ts
@@ -1,0 +1,103 @@
+import { cmd } from "./cmd"
+import { Global } from "@opencode-ai/core/global"
+import path from "path"
+import fs from "fs/promises"
+import { Effect } from "effect"
+import { effectCmd, fail } from "../effect-cmd"
+
+const FILENAME = "preferences.md"
+
+const DEFAULT_CONTENT = `# User Preferences
+
+<!-- Edit this file to customize how the AI assistant interacts with you. -->
+<!-- This file is in Markdown format and will be included in the system prompt. -->
+
+## Communication
+
+- Language: Respond in the same language the user uses
+- Verbosity: Concise by default, detailed when asked
+
+## Code Style
+
+- Follow existing project conventions
+- Prefer idiomatic patterns for each language
+
+## Behavior
+
+- Ask for clarification when requirements are ambiguous
+- Explain trade-offs when multiple approaches exist
+`
+
+const PreferencePathCommand = cmd({
+  command: "path",
+  describe: "show the path to the preferences file",
+  handler: () => {
+    console.log(path.join(Global.Path.config, FILENAME))
+  },
+})
+
+const PreferenceShowCommand = effectCmd({
+  command: "show",
+  describe: "show the contents of the preferences file",
+  instance: false,
+  handler: Effect.fn("Cli.preference.show")(function* () {
+    const filePath = path.join(Global.Path.config, FILENAME)
+    const content = yield* Effect.tryPromise(() => fs.readFile(filePath, "utf-8")).pipe(
+      Effect.catch(() => Effect.succeed(undefined)),
+    )
+    if (content === undefined) {
+      console.log("(preferences file does not exist yet)")
+      return
+    }
+    console.log(content)
+  }),
+})
+
+const PreferenceEditCommand = effectCmd({
+  command: "edit",
+  describe: "open the preferences file in your default editor",
+  instance: false,
+  handler: Effect.fn("Cli.preference.edit")(function* () {
+    const filePath = path.join(Global.Path.config, FILENAME)
+    const exists = yield* Effect.tryPromise(() => fs.access(filePath).then(() => true).catch(() => false))
+    if (!exists) {
+      yield* Effect.tryPromise(() => fs.writeFile(filePath, DEFAULT_CONTENT, "utf-8"))
+      console.log(`Created preferences file: ${filePath}`)
+    }
+    const editor = process.env.EDITOR ?? process.env.VISUAL ?? (process.platform === "win32" ? "notepad" : "vi")
+    const { spawn } = yield* Effect.tryPromise(() => import("child_process"))
+    const child = spawn(editor, [filePath], { stdio: "inherit" })
+    yield* Effect.async<void, Error>((resume: (effect: Effect.Effect<void, Error>) => void) => {
+      child.on("exit", () => resume(Effect.void))
+      child.on("error", (error: Error) => resume(Effect.fail(error)))
+    }).pipe(Effect.mapError((error: Error) => new Error(`Failed to open editor: ${error.message}`)))
+    console.log(`Preferences saved to: ${filePath}`)
+    console.log("Changes will take effect in your next session.")
+  }),
+})
+
+const PreferenceResetCommand = effectCmd({
+  command: "reset",
+  describe: "reset the preferences file to default content",
+  instance: false,
+  handler: Effect.fn("Cli.preference.reset")(function* () {
+    const filePath = path.join(Global.Path.config, FILENAME)
+    yield* Effect.tryPromise(() => fs.writeFile(filePath, DEFAULT_CONTENT, "utf-8")).pipe(
+      Effect.mapError((error: Error) => new Error(`Failed to write preferences: ${error.message}`)),
+    )
+    console.log(`Preferences file reset to default: ${filePath}`)
+  }),
+})
+
+export const PreferenceCommand = cmd({
+  command: "preference <subcommand>",
+  describe: "manage user preferences (stored as Markdown)",
+  builder: (yargs) =>
+    yargs
+      .command(PreferencePathCommand)
+      .command(PreferenceShowCommand)
+      .command(PreferenceEditCommand)
+      .command(PreferenceResetCommand)
+      .demandCommand(1, "Please specify a subcommand"),
+  handler: () => {},
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -29,6 +29,7 @@ import { DbCommand } from "./cli/cmd/db"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
+import { PreferenceCommand } from "./cli/cmd/preference"
 
 const args = hideBin(process.argv)
 
@@ -101,6 +102,7 @@ const cli = yargs(args)
   .command(SessionCommand)
   .command(PluginCommand)
   .command(DbCommand)
+  .command(PreferenceCommand)
   .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||

--- a/packages/opencode/src/preference/preference.ts
+++ b/packages/opencode/src/preference/preference.ts
@@ -1,0 +1,52 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import path from "path"
+import { Context, Effect, Layer } from "effect"
+import { Global } from "@opencode-ai/core/global"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+
+const FILENAME = "preferences.md"
+
+export interface Interface {
+  readonly path: () => Effect.Effect<string>
+  readonly read: () => Effect.Effect<string | undefined, FSUtil.Error>
+  readonly write: (content: string) => Effect.Effect<void, FSUtil.Error>
+  readonly systemPrompt: () => Effect.Effect<string | undefined, FSUtil.Error>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Preference") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const global = yield* Global.Service
+    const fs = yield* FSUtil.Service
+
+    const filePath = path.join(global.config, FILENAME)
+
+    const read = Effect.fn("Preference.read")(function* () {
+      return yield* fs.readFileStringSafe(filePath)
+    })
+
+    const write = Effect.fn("Preference.write")(function* (content: string) {
+      yield* fs.writeFileString(filePath, content)
+    })
+
+    const systemPrompt = Effect.fn("Preference.systemPrompt")(function* () {
+      const content = yield* read()
+      if (!content || !content.trim()) return undefined
+      return `User Preferences (from: ${filePath})\n${content}`
+    })
+
+    return Service.of({
+      path: () => Effect.succeed(filePath),
+      read,
+      write,
+      systemPrompt,
+    })
+  }),
+)
+
+export const defaultLayer = layer.pipe(Layer.provide(Global.layer), Layer.provide(FSUtil.defaultLayer))
+export const node = LayerNode.make(layer, [Global.node, FSUtil.node])
+
+export * as Preference from "./preference"

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
@@ -70,6 +70,7 @@ export const GlobalPaths = {
   config: "/global/config",
   dispose: "/global/dispose",
   upgrade: "/global/upgrade",
+  preferences: "/global/preferences",
 } as const
 
 export const GlobalApi = HttpApi.make("global").add(
@@ -131,6 +132,25 @@ export const GlobalApi = HttpApi.make("global").add(
           identifier: "global.upgrade",
           summary: "Upgrade opencode",
           description: "Upgrade opencode to the specified version or latest if not specified.",
+        }),
+      ),
+      HttpApiEndpoint.get("preferencesGet", GlobalPaths.preferences, {
+        success: described(Schema.String, "User preferences content in Markdown format"),
+      }).annotateMerge(
+        OpenApi.annotations({
+          identifier: "global.preferences.get",
+          summary: "Get user preferences",
+          description: "Retrieve the user preferences stored in Markdown format.",
+        }),
+      ).annotateMerge(HttpApiSchema.asText({ contentType: "text/markdown" })),
+      HttpApiEndpoint.put("preferencesUpdate", GlobalPaths.preferences, {
+        payload: Schema.String,
+        success: described(Schema.String, "Updated user preferences content"),
+      }).annotateMerge(
+        OpenApi.annotations({
+          identifier: "global.preferences.update",
+          summary: "Update user preferences",
+          description: "Update the user preferences stored in Markdown format.",
         }),
       ),
     )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -12,6 +12,7 @@ import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
 import { RootHttpApi } from "../api"
 import { GlobalUpgradeInput } from "../groups/global"
+import { Preference } from "@/preference/preference"
 
 function eventData(data: unknown): Sse.Event {
   return {
@@ -69,6 +70,7 @@ export const globalHandlers = HttpApiBuilder.group(RootHttpApi, "global", (handl
   Effect.gen(function* () {
     const config = yield* Config.Service
     const installation = yield* Installation.Service
+    const preference = yield* Preference.Service
     const bridge = yield* EffectBridge.make()
 
     const health = Effect.fn("GlobalHttpApi.health")(function* () {
@@ -126,6 +128,16 @@ export const globalHandlers = HttpApiBuilder.group(RootHttpApi, "global", (handl
       return result
     })
 
+    const preferencesGet = Effect.fn("GlobalHttpApi.preferencesGet")(function* () {
+      const content = yield* preference.read().pipe(Effect.orElseSucceed(() => undefined))
+      return content ?? ""
+    })
+
+    const preferencesUpdate = Effect.fn("GlobalHttpApi.preferencesUpdate")(function* (ctx: { payload: string }) {
+      yield* preference.write(ctx.payload)
+      return ctx.payload
+    })
+
     const upgradeRaw = Effect.fn("GlobalHttpApi.upgradeRaw")(function* (ctx: {
       request: HttpServerRequest.HttpServerRequest
     }) {
@@ -152,5 +164,7 @@ export const globalHandlers = HttpApiBuilder.group(RootHttpApi, "global", (handl
       .handle("configUpdate", configUpdate)
       .handle("dispose", dispose)
       .handleRaw("upgrade", upgradeRaw)
+      .handle("preferencesGet", preferencesGet)
+      .handle("preferencesUpdate", preferencesUpdate)
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -26,6 +26,7 @@ import { Permission } from "@/permission"
 import { Installation } from "@/installation"
 import { InstanceLayer } from "@/project/instance-layer"
 import { Plugin } from "@/plugin"
+import { Preference } from "@/preference/preference"
 import { Project } from "@/project/project"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { ProjectCopy } from "@opencode-ai/core/project/copy"
@@ -226,6 +227,7 @@ export function createRoutes(
       ModelsDev.defaultLayer,
       Permission.defaultLayer,
       Plugin.defaultLayer,
+      Preference.defaultLayer,
       Project.defaultLayer,
       ProjectV2.defaultLayer,
       ProjectCopy.defaultLayer,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -60,6 +60,7 @@ import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { Preference } from "@/preference/preference"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -124,6 +125,7 @@ export const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
+    const preference = yield* Preference.Service
     const { db } = database
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
@@ -1324,13 +1326,14 @@ export const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, modelMsgs] = yield* Effect.all([
+            const [skills, env, instructions, preferences, modelMsgs] = yield* Effect.all([
               sys.skills(agent),
               sys.environment(model),
               instruction.system().pipe(Effect.orDie),
+              preference.systemPrompt().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
-            const system = [...env, ...instructions, ...(skills ? [skills] : [])]
+            const system = [...env, ...instructions, ...(preferences ? [preferences] : []), ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({
@@ -1573,6 +1576,7 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(SessionSummary.defaultLayer),
     Layer.provide(Image.defaultLayer),
+    Layer.provide(Preference.defaultLayer),
     Layer.provide(
       Layer.mergeAll(
         Agent.defaultLayer,
@@ -1717,6 +1721,7 @@ export const node = LayerNode.make(layer, [
   EventV2Bridge.node,
   RuntimeFlags.node,
   Database.node,
+  Preference.node,
 ])
 
 export * as SessionPrompt from "./prompt"

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -40,6 +40,7 @@ import { DialogModel } from "./component/dialog-model"
 import { useConnected } from "./component/use-connected"
 import { DialogMcp } from "./component/dialog-mcp"
 import { DialogStatus } from "./component/dialog-status"
+import { DialogPreferences } from "./component/dialog-preferences"
 import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
@@ -752,6 +753,15 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         slashName: "status",
         run: () => {
           dialog.replace(() => <DialogStatus />)
+        },
+        category: "System",
+      },
+      {
+        name: "opencode.preferences",
+        title: "Edit preferences",
+        slashName: "preferences",
+        run: () => {
+          dialog.replace(() => <DialogPreferences />)
         },
         category: "System",
       },

--- a/packages/tui/src/component/dialog-preferences.tsx
+++ b/packages/tui/src/component/dialog-preferences.tsx
@@ -1,0 +1,124 @@
+import { createResource, Show } from "solid-js"
+import { useTheme } from "../context/theme"
+import { useDialog } from "../ui/dialog"
+import { useSDK } from "../context/sdk"
+import { useToast } from "../ui/toast"
+import { TextAttributes } from "@opentui/core"
+
+export function DialogPreferences() {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const toast = useToast()
+
+  const fetchPreferences = async (): Promise<string> => {
+    try {
+      const response = await fetch(`${sdk.url}/global/preferences`)
+      if (!response.ok) return ""
+      return await response.text()
+    } catch {
+      return ""
+    }
+  }
+
+  const updatePreferences = async (content: string): Promise<boolean> => {
+    try {
+      const response = await fetch(`${sdk.url}/global/preferences`, {
+        method: "PUT",
+        headers: { "Content-Type": "text/plain" },
+        body: content,
+      })
+      return response.ok
+    } catch {
+      return false
+    }
+  }
+
+  const [preferences] = createResource(fetchPreferences)
+
+  const handleInitialize = async () => {
+    const defaultContent = `# User Preferences
+
+<!-- Edit this file to customize how the AI assistant interacts with you. -->
+<!-- This file is in Markdown format and will be included in the system prompt. -->
+
+## Communication
+
+- Language: Respond in the same language the user uses
+- Verbosity: Concise by default, detailed when asked
+
+## Code Style
+
+- Follow existing project conventions
+- Prefer idiomatic patterns for each language
+
+## Behavior
+
+- Ask for clarification when requirements are ambiguous
+- Explain trade-offs when multiple approaches exist
+`
+    const success = await updatePreferences(defaultContent)
+    if (success) {
+      dialog.clear()
+      toast.show({
+        variant: "success",
+        message: "Default preferences initialized. Use 'opencode preference edit' to edit.",
+        duration: 5000,
+      })
+    } else {
+      toast.show({
+        variant: "error",
+        message: "Failed to initialize preferences",
+      })
+    }
+  }
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          User Preferences
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+
+      <Show when={preferences.loading}>
+        <text fg={theme.textMuted}>Loading preferences...</text>
+      </Show>
+
+      <Show when={!preferences.loading}>
+        <box>
+          <text fg={theme.text}>
+            Preferences are stored in Markdown format and included in the system prompt.
+          </text>
+          <text fg={theme.textMuted}> </text>
+          <text fg={theme.text}>To edit preferences, use one of these methods:</text>
+          <text fg={theme.text}> </text>
+          <box paddingLeft={2}>
+            <text fg={theme.accent}>1. CLI command:</text>
+            <text fg={theme.text}>   opencode preference edit</text>
+            <text fg={theme.text}> </text>
+            <text fg={theme.accent}>2. Direct file edit:</text>
+            <text fg={theme.text}>   ~/.config/opencode/preferences.md</text>
+          </box>
+          <text fg={theme.textMuted}> </text>
+          <Show when={!preferences()}>
+            <box flexDirection="row" gap={2}>
+              <text
+                fg={theme.accent}
+                onMouseUp={handleInitialize}
+              >
+                [Initialize default preferences]
+              </text>
+            </box>
+          </Show>
+          <Show when={preferences()}>
+            <text fg={theme.success}>Preferences file exists.</text>
+          </Show>
+        </box>
+      </Show>
+    </box>
+  )
+}


### PR DESCRIPTION
### Issue for this PR

Closes #32145

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a user preferences feature that stores preferences in Markdown format (`~/.config/opencode/preferences.md`) and automatically injects them into the system prompt sent to AI models.

**Changes:**
- New `Preference` service module for reading/writing preferences
- CLI commands: `opencode preference <path|show|edit|reset>`
- Desktop Settings dialog: new "Preferences" tab with Markdown editor
- TUI: `/preferences` command in command palette
- Global API endpoints: `GET/PUT /global/preferences`
- System prompt integration in session initialization

### How did you verify your code works?

- Ran `bun typecheck` in all affected packages (opencode, app, tui)
- Manually tested CLI commands work correctly
- Verified API endpoints respond correctly
- Tested Desktop and TUI UI components render properly

### Screenshots / recordings

N/A - This is primarily a backend/CLI feature with simple UI components

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR