### PR TITLE
fix(tui): explicitly register spinner intrinsic to survive bundler tr…

### DIFF
--- a/packages/tui/src/component/spinner.tsx
+++ b/packages/tui/src/component/spinner.tsx
@@ -1,9 +1,17 @@
 import { Show } from "solid-js"
+import { extend } from "@opentui/solid/components"
+import { SpinnerRenderable } from "opentui-spinner"
 import { useTheme } from "../context/theme"
 import { useKV } from "../context/kv"
 import type { JSX } from "@opentui/solid"
 import type { RGBA } from "@opentui/core"
-import "opentui-spinner/solid"
+
+// Register the <spinner> intrinsic element explicitly. The previous
+// side-effect-only `import "opentui-spinner/solid"` got tree-shaken by
+// Bun's bundler at compile time — confirmed by `extend({spinner` being
+// absent from the bundled binary while `dots` (cli-spinners default)
+// was present. Explicit named import + call survives tree-shaking.
+extend({ spinner: SpinnerRenderable })
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 


### PR DESCRIPTION
PR #1: spinner-registration
### Issue for this PR



### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/tui/src/component/spinner.tsx` used a side-effect-only import `import "opentui-spinner/solid"`. Bun's bundler drops side-effect-only imports at compile time, so the `extend({spinner})` registration that lived in that module never reached the binary. Result: `[Reconciler] Unknown component type: spinner` crash the first time the TUI rendered a Spinner (idle indicator, todo list, permission prompt, etc.).

Replaced with a named import of `SpinnerRenderable` and an explicit `extend({spinner: SpinnerRenderable})` call. Both bindings are used, so the bundler can't drop the registration.

### How did you verify your code works?

Built the TUI binary locally, started a session, confirmed the braille spinner renders without the `[Reconciler]` error.

### Screenshots / recordings

N/A — fix for a crash, no visual change beyond "renders correctly".

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR