### PR TITLE
fix(plugin): warn instead of fail on tui plugin loader errors

### DIFF
--- a/packages/opencode/src/plugin/tui/runtime.ts
+++ b/packages/opencode/src/plugin/tui/runtime.ts
@@ -755,18 +755,18 @@ async function resolveExternalPlugins(list: ConfigPlugin.Origin[], wait: () => P
       error(candidate, retry, stage, error, resolved) {
         const spec = candidate.plan.spec
         if (stage === "install") {
-          fail("failed to resolve tui plugin", { path: spec, retry, error })
+          warn("failed to resolve tui plugin", { path: spec, retry, error })
           return
         }
         if (stage === "compatibility") {
-          fail("tui plugin incompatible", { path: spec, retry, error })
+          warn("tui plugin incompatible", { path: spec, retry, error })
           return
         }
         if (stage === "entry") {
-          fail("failed to resolve tui plugin entry", { path: spec, retry, error })
+          warn("failed to resolve tui plugin entry", { path: spec, retry, error })
           return
         }
-        fail("failed to load tui plugin", { path: spec, target: resolved?.entry, retry, error })
+        warn("failed to load tui plugin", { path: spec, target: resolved?.entry, retry, error })
       },
     },
   })


### PR DESCRIPTION
PR #2: plugin-warn
### Issue for this PR



### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/opencode/src/plugin/tui/runtime.ts` was calling `fail()` from the `report.error` callback in `resolveExternalPlugins` for all four error stages (install, compatibility, entry, default). The plugin loader (`PluginLoader.loadExternal`) already filters out failed plugins downstream, so these `fail()` calls were producing noise and, worse, could make the TUI unstartable on a transient plugin error (e.g. a network blip on `git ls-remote` for an external plugin).

Converted all four `fail()` calls to `warn()` — the issue is still surfaced in the log, but the TUI starts regardless.

### How did you verify your code works?

Code inspection: confirmed `PluginLoader.loadExternal` already filters failed plugins at the import site, so the loader-level state isn't affected. Built locally, TUI starts cleanly even with an unresolvable external plugin configured.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR