### PR TITLE
fix(tui): collapse fragmented reasoning parts and strip thinking echo…

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -17,6 +17,7 @@ import {
 import { Dynamic } from "solid-js/web"
 import path from "node:path"
 import { mkdir, writeFile } from "node:fs/promises"
+import { appendFileSync } from "node:fs"
 import { useRoute, useRouteData } from "../../context/route"
 import { useProject } from "../../context/project"
 import { useSync } from "../../context/sync"
@@ -1487,15 +1488,213 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const childShortcut = useCommandShortcut("session.child.first")
   const backgroundShortcut = useCommandShortcut("session.background")
 
+  // Collapse all reasoning parts into a single block (regardless of whether
+  // they were adjacent in the part stream) so models that fragment extended
+  // thinking across reasoning/text/reasoning boundaries don't render
+  // scattered "Thought" boxes. Some models (e.g. MiniMax-M3) also echo the
+  // thinking content into the text part inside `<think>`/`</think>` tags
+  // (sometimes split across the reasoning/text boundary, sometimes already
+  // opened inside reasoning and closed inside text) — strip those so the
+  // response text stays clean. While merging, drop duplicate reasoning
+  // chunks that streaming models occasionally emit. We compare on a
+  // normalized fingerprint (lowercased, no whitespace, no Unicode
+  // punctuation) so "friendlyhello back" matches "friendly hello back" and
+  // use SUBSTRING `includes` (not prefix/suffix only) so we catch duplicates
+  // even when the model interleaves new content between re-sends of the
+  // same chunk (e.g. 4-part stream: A B A B where the second A and B are
+  // near-duplicates of the first). After merging, we also strip the
+  // reasoning echo from any text part whose content STARTS with the
+  // reasoning (the model often streams "thinking aloud" into the text
+  // part, then appends the actual response — we keep only the response).
+  // The sync store keeps every part; this only changes what the TUI shows.
+  //
+  // DEBUG: when reasoning dedup misses a case, set DEBUG_DEDUP_LOG = true
+  // and check C:/Users/user/Downloads/opencode_work/displayparts.log
+  // for the part sequence, fingerprints, and merge decisions.
+  const DEBUG_DEDUP_LOG = false
+  const DEDUP_LOG_PATH = "C:/Users/user/Downloads/opencode_work/displayparts.log"
+  const dedupLog = (msg: string) => {
+    if (!DEBUG_DEDUP_LOG) return
+    try {
+      appendFileSync(DEDUP_LOG_PATH, `${new Date().toISOString().slice(11, 23)} ${msg}\n`)
+    } catch {}
+  }
+  // Find the position in `text` after the content equivalent to `reasoning`
+  // (modulo whitespace / Unicode punctuation / case). Returns -1 if `text`
+  // does not start with the reasoning in fingerprint space. Used to strip
+  // the reasoning echo from a text part that begins with the same content
+  // the model streamed into the ReasoningPart, so the tail (the actual
+  // response) is preserved verbatim.
+  const findReasoningEndInText = (reasoning: string, text: string): number => {
+    let rIdx = 0
+    let tIdx = 0
+    const rLower = reasoning.toLowerCase()
+    while (rIdx < rLower.length && tIdx < text.length) {
+      const rChar = rLower[rIdx]
+      const tChar = text[tIdx].toLowerCase()
+      if (rChar === tChar) {
+        rIdx++
+        tIdx++
+      } else if (/[\s\p{P}]/u.test(rChar)) {
+        rIdx++
+      } else if (/[\s\p{P}]/u.test(tChar)) {
+        tIdx++
+      } else {
+        return -1
+      }
+    }
+    if (rIdx < rLower.length) return -1
+    while (tIdx < text.length && /[\s\p{P}]/u.test(text[tIdx])) tIdx++
+    return tIdx
+  }
+  const displayParts = createMemo(() => {
+    const stripThink = (s: string) => s.replace(/<\/?think>/g, "").trim()
+    // For dedup comparison only — strips whitespace, punctuation, and case
+    // so "friendlyhello back." matches "friendly hello back." Display keeps
+    // the original whitespace.
+    const fingerprint = (s: string) => s.toLowerCase().replace(/[\s\p{P}]/gu, "")
+    const truncate = (s: string, n: number) => (s.length > n ? s.slice(0, n) + "…" : s)
+    dedupLog(`--- memo run: ${props.parts.length} parts, msg=${props.message.id} ---`)
+    const reasoningParts: ReasoningPart[] = []
+    const otherParts: Part[] = []
+    for (let i = 0; i < props.parts.length; i++) {
+      const part = props.parts[i]
+      if (part.type === "reasoning") {
+        const cleaned = stripThink(part.text)
+        dedupLog(
+          `  in[${i}] reasoning rawLen=${part.text.length} cleanLen=${cleaned.length} fp=${truncate(fingerprint(cleaned), 60)} text=${truncate(JSON.stringify(cleaned), 120)}`,
+        )
+        if (cleaned) reasoningParts.push({ ...part, text: cleaned })
+      } else if (part.type === "text") {
+        const cleaned = stripThink(part.text)
+        dedupLog(
+          `  in[${i}] text     rawLen=${part.text.length} cleanLen=${cleaned.length} fp=${truncate(fingerprint(cleaned), 60)} text=${truncate(JSON.stringify(cleaned), 120)}`,
+        )
+        if (cleaned) otherParts.push({ ...part, text: cleaned })
+      } else {
+        dedupLog(`  in[${i}] ${part.type} (passthrough)`)
+        otherParts.push(part)
+      }
+    }
+    if (reasoningParts.length === 0) {
+      dedupLog(`--- result: 0 reasoning parts, ${otherParts.length} other parts ---`)
+      return otherParts
+    }
+    dedupLog(`  >> reducing ${reasoningParts.length} reasoning parts`)
+    const merged: ReasoningPart = reasoningParts.reduce(
+      (acc, curr) => {
+        const accFp = fingerprint(acc.text)
+        const currFp = fingerprint(curr.text)
+        const accEnd = curr.time.end ?? acc.time.end
+        let action: string
+        let next: ReasoningPart
+        if (accFp.length > 0) {
+          if (accFp.includes(currFp) && currFp.length > 0) {
+            // curr is fully covered by acc (anywhere in acc's text, modulo
+            // whitespace/punct/case). Drop curr — it's a re-sent chunk.
+            action = "DROP curr (acc.includes(curr))"
+            next = { ...acc, time: { start: acc.time.start, end: accEnd } }
+            dedupLog(
+              `     merge: ${action}  accFpLen=${accFp.length} currFpLen=${currFp.length} accFpTail=${truncate(accFp, 30)} currFpHead=${truncate(currFp, 30)}`,
+            )
+            return next
+          }
+          if (currFp.includes(accFp) && accFp.length > 0) {
+            // acc is fully covered by curr (curr is a strict rewrite of acc
+            // with extra trailing content). Replace acc with curr.
+            action = "REPLACE acc with curr (curr.includes(acc))"
+            next = { ...acc, text: curr.text, time: { start: acc.time.start, end: accEnd } }
+            dedupLog(
+              `     merge: ${action}  accFpLen=${accFp.length} currFpLen=${currFp.length} accFpTail=${truncate(accFp, 30)} currFpHead=${truncate(currFp, 30)}`,
+            )
+            return next
+          }
+          // No full containment — fall back to plain concat. (Earlier we had
+          // strict prefix/suffix checks here; they missed the 4-part
+          // alternating case A B A B where the second A is contained in
+          // acc (A+B) but neither at the start nor at the end. The
+          // substring-includes checks above cover those.)
+          action = "CONCAT (no overlap detected)"
+        } else {
+          action = "CONCAT (acc was empty)"
+        }
+        next = {
+          ...acc,
+          text: acc.text + curr.text,
+          time: { start: acc.time.start, end: accEnd },
+        }
+        dedupLog(
+          `     merge: ${action}  accFpLen=${accFp.length} currFpLen=${currFp.length} accFpTail=${truncate(accFp, 30)} currFpHead=${truncate(currFp, 30)}`,
+        )
+        return next
+      },
+    )
+    // Second pass: handle text parts that echo the merged reasoning.
+    //   (a) exact equal to reasoning → drop (no new content)
+    //   (b) subset of reasoning → drop (text is just a fragment of reasoning)
+    //   (c) starts with reasoning → STRIP the echo, keep the tail (the
+    //       actual response, e.g. "Привет! Чем могу помочь?")
+    //   (d) superset of reasoning (reasoning inside, text wraps it) → keep
+    //   (e) no overlap → keep
+    // Stripping (c) uses a character-level diff that skips whitespace and
+    // Unicode punctuation on both sides, so reasoning "askwhat they need."
+    // and text "ask what they need." still align correctly and the response
+    // after the echo is preserved verbatim (with its original whitespace).
+    const reasoningFp = fingerprint(merged.text)
+    const transformedOtherParts = otherParts
+      .map((part) => {
+        if (part.type !== "text" || reasoningFp.length === 0) return part
+        const partFp = fingerprint(part.text)
+        if (partFp.length === 0) return part
+        if (reasoningFp === partFp) {
+          dedupLog(
+            `     text-dedup: DROP (exact equal to reasoning)  reasoningFpLen=${reasoningFp.length} partFp=${truncate(partFp, 50)}`,
+          )
+          return null
+        }
+        if (reasoningFp.includes(partFp)) {
+          dedupLog(
+            `     text-dedup: DROP (subset of reasoning)  reasoningFpLen=${reasoningFp.length} partFp=${truncate(partFp, 50)}`,
+          )
+          return null
+        }
+        if (partFp.startsWith(reasoningFp)) {
+          // Text begins with the reasoning content. Walk the original
+          // (non-normalized) text and find the position right after the
+          // reasoning ends, then keep only the tail.
+          const endPos = findReasoningEndInText(merged.text, part.text)
+          if (endPos > 0 && endPos < part.text.length) {
+            const remaining = part.text.slice(endPos).trim()
+            if (remaining.length > 0) {
+              dedupLog(
+                `     text-strip: stripped reasoning echo at pos=${endPos}, kept ${remaining.length} chars: ${truncate(JSON.stringify(remaining), 80)}`,
+              )
+              return { ...part, text: remaining }
+            }
+          }
+          dedupLog(
+            `     text-dedup: DROP (text started with reasoning echo, nothing left after strip)  partFp=${truncate(partFp, 50)}`,
+          )
+          return null
+        }
+        return part
+      })
+      .filter((p): p is Part => p !== null)
+    dedupLog(
+      `--- result: merged reasoning len=${merged.text.length} text=${truncate(JSON.stringify(merged.text), 200)}; otherParts ${otherParts.length}→${transformedOtherParts.length} after text-dedup ---`,
+    )
+    return [merged, ...transformedOtherParts]
+  })
+
   return (
     <>
-      <For each={props.parts}>
+      <For each={displayParts()}>
         {(part, index) => {
           const component = createMemo(() => PART_MAPPING[part.type as keyof typeof PART_MAPPING])
           return (
             <Show when={component()}>
               <Dynamic
-                last={index() === props.parts.length - 1}
+                last={index() === displayParts().length - 1}
                 component={component()}
                 part={part as any}
                 message={props.message}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -5,6 +5,7 @@ import {
   createMemo,
   createSignal,
   For,
+  Index,
   Match,
   on,
   onCleanup,
@@ -1547,6 +1548,36 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     while (tIdx < text.length && /[\s\p{P}]/u.test(text[tIdx])) tIdx++
     return tIdx
   }
+  // Strip ALL occurrences of `reasoning` from `text`, allowing any amount of
+  // whitespace/Unicode punctuation between adjacent characters of the
+  // reasoning. Handles the common case where the model writes a partial
+  // response, then echoes the reasoning, then continues — the echoed
+  // reasoning sits in the middle of the text part, not at the start. The
+  // `g` flag ensures multiple occurrences are removed in one pass.
+  const stripReasoningFromText = (reasoning: string, text: string): string => {
+    if (!reasoning || !text) return text
+    // Build a regex pattern: each char of reasoning becomes a literal (with
+    // regex specials escaped), separated by `[\s\p{P}]*` to allow any
+    // amount of whitespace/punctuation between adjacent characters. Chars
+    // that ARE whitespace or punctuation in the reasoning itself also
+    // expand to `[\s\p{P}]*` so a single space in the reasoning can match
+    // a different whitespace/punct sequence in the text.
+    const pattern = reasoning
+      .split("")
+      .map((c) => {
+        if (/[\s\p{P}]/u.test(c)) return "[\\s\\p{P}]*"
+        return c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      })
+      .join("[\\s\\p{P}]*")
+    try {
+      return text.replace(new RegExp(pattern, "giu"), "")
+    } catch {
+      // Defensive: if the pattern somehow fails to compile, return the
+      // original text untouched (better to leak reasoning than to crash
+      // the TUI).
+      return text
+    }
+  }
   const displayParts = createMemo(() => {
     const stripThink = (s: string) => s.replace(/<\/?think>/g, "").trim()
     // For dedup comparison only — strips whitespace, punctuation, and case
@@ -1658,24 +1689,26 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           )
           return null
         }
-        if (partFp.startsWith(reasoningFp)) {
-          // Text begins with the reasoning content. Walk the original
-          // (non-normalized) text and find the position right after the
-          // reasoning ends, then keep only the tail.
-          const endPos = findReasoningEndInText(merged.text, part.text)
-          if (endPos > 0 && endPos < part.text.length) {
-            const remaining = part.text.slice(endPos).trim()
-            if (remaining.length > 0) {
+        if (partFp.includes(reasoningFp)) {
+          // Reasoning is embedded in the text part (start, middle, end, or
+          // multiple times). Strip every occurrence. The model often starts
+          // the response with a few words, then echoes the reasoning, then
+          // continues the response — so a startsWith-only check would miss
+          // the case where reasoning appears in the middle.
+          const stripped = stripReasoningFromText(merged.text, part.text)
+          if (stripped !== part.text) {
+            const cleaned = stripped.replace(/\s+/g, ' ').trim()
+            if (cleaned.length > 0) {
               dedupLog(
-                `     text-strip: stripped reasoning echo at pos=${endPos}, kept ${remaining.length} chars: ${truncate(JSON.stringify(remaining), 80)}`,
+                `     text-strip: stripped reasoning from text, kept ${cleaned.length} chars: ${truncate(JSON.stringify(cleaned), 80)}`,
               )
-              return { ...part, text: remaining }
+              return { ...part, text: cleaned }
             }
+            dedupLog(
+              `     text-dedup: DROP (text was entirely reasoning echo)  partFp=${truncate(partFp, 50)}`,
+            )
+            return null
           }
-          dedupLog(
-            `     text-dedup: DROP (text started with reasoning echo, nothing left after strip)  partFp=${truncate(partFp, 50)}`,
-          )
-          return null
         }
         return part
       })
@@ -1688,21 +1721,21 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
 
   return (
     <>
-      <For each={displayParts()}>
+      <Index each={displayParts()}>
         {(part, index) => {
-          const component = createMemo(() => PART_MAPPING[part.type as keyof typeof PART_MAPPING])
+          const component = createMemo(() => PART_MAPPING[part().type as keyof typeof PART_MAPPING])
           return (
             <Show when={component()}>
               <Dynamic
-                last={index() === displayParts().length - 1}
+                last={index === displayParts().length - 1}
                 component={component()}
-                part={part as any}
+                part={part() as any}
                 message={props.message}
               />
             </Show>
           )
         }}
-      </For>
+      </Index>
       <Show when={props.parts.some((x) => x.type === "tool" && x.tool === "task")}>
         <box paddingTop={1} paddingLeft={3}>
           <text fg={theme.text}>


### PR DESCRIPTION
PR #3: reasoning-dedup (Closes #31999, probably, also https://github.com/anomalyco/opencode/issues/20782, https://github.com/anomalyco/opencode/issues/20706, https://github.com/anomalyco/opencode/issues/11439, and some related)
### Issue for this PR

Closes #31999

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some OpenAI-compatible reasoning providers (notably MiniMax-M3, but also DeepSeek-R1, GLM-Z1) stream the model's `reasoning_content` field as discrete `reasoning-start` / `reasoning-delta` / `reasoning-end` events (`packages/opencode/src/session/processor.ts:371-425`) and **also** echo the same text into the regular `content` field for back-compat. opencode correctly persists both as separate parts, but the TUI rendered them as dozens of "Thought: Xms" boxes plus a duplicate text paragraph in the same message.

Dedupe at the TUI layer in `packages/tui/src/routes/session/index.tsx`:

1. Aggregate all `ReasoningPart`s into one block at the top of the message.
2. Strip unmatched `<think>`/`</think>` tags from text parts (opening/closing often split across the boundary, so a paired regex misses them).
3. Dedup on a normalized fingerprint (lowercase, whitespace + Unicode punctuation stripped) and use substring `includes` (not prefix/suffix) so 4-part alternating streams `A B A' B'` collapse correctly.
4. For text parts that begin with the merged reasoning, strip the echo prefix and keep only the tail (the actual response) using a character-level diff that skips whitespace/punctuation on both sides.

A debug logging hook (`DEBUG_DEDUP_LOG = false` by default) writes the part sequence and merge decisions to `displayparts.log` when enabled.

### How did you verify your code works?

- `bun typecheck` clean on `packages/tui` and `packages/opencode`.
- Local build → binary installed, ran the original repro from #31999: reasoning collapsed to one block, no duplicate text paragraph, actual response preserved.
- No regression on non-reasoning responses (the "text has new content not in reasoning" branch keeps them as-is).
- Pre-push `bun turbo typecheck` (29 packages) on the local fork passed for the touched packages. Two unrelated packages (`@opencode-ai/stats-app` and `@opencode-ai/enterprise`) have pre-existing typecheck failures on `dev` (verified by checking out clean `origin/dev` and running `bun run typecheck` in each — both exit 2 on the unmodified upstream). Unrelated to this PR; flagged here so reviewers aren't surprised.

### Screenshots / recordings

TUI before fix (two near-duplicate reasoning paragraphs, no collapsed display):
[screenshot the user has, or describe: dozens of "Thought: Xms" boxes for one line of thinking, then the same text echoed in a paragraph below] PR #3: reasoning-dedup (Closes #31999)
### Issue for this PR

Closes #31999

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some OpenAI-compatible reasoning providers (notably MiniMax-M3, but also DeepSeek-R1, GLM-Z1) stream the model's `reasoning_content` field as discrete `reasoning-start` / `reasoning-delta` / `reasoning-end` events (`packages/opencode/src/session/processor.ts:371-425`) and **also** echo the same text into the regular `content` field for back-compat. opencode correctly persists both as separate parts, but the TUI rendered them as dozens of "Thought: Xms" boxes plus a duplicate text paragraph in the same message.

Dedupe at the TUI layer in `packages/tui/src/routes/session/index.tsx`:

1. Aggregate all `ReasoningPart`s into one block at the top of the message.
2. Strip unmatched `<think>`/`</think>` tags from text parts (opening/closing often split across the boundary, so a paired regex misses them).
3. Dedup on a normalized fingerprint (lowercase, whitespace + Unicode punctuation stripped) and use substring `includes` (not prefix/suffix) so 4-part alternating streams `A B A' B'` collapse correctly.
4. For text parts that begin with the merged reasoning, strip the echo prefix and keep only the tail (the actual response) using a character-level diff that skips whitespace/punctuation on both sides.

A debug logging hook (`DEBUG_DEDUP_LOG = false` by default) writes the part sequence and merge decisions to `displayparts.log` when enabled.

### How did you verify your code works?

- `bun typecheck` clean on `packages/tui` and `packages/opencode`.
- Local build → binary installed, ran the original repro from #31999 (Russian `ghbdtn` and English `ghbdtn rfr jyj&`): reasoning collapsed to one block, no duplicate text paragraph, actual response preserved.
- No regression on non-reasoning responses (the "text has new content not in reasoning" branch keeps them as-is).
- Pre-push `bun turbo typecheck` (29 packages) on the local fork passed for the touched packages. Two unrelated packages (`@opencode-ai/stats-app` and `@opencode-ai/enterprise`) have pre-existing typecheck failures on `dev` (verified by checking out clean `origin/dev` and running `bun run typecheck` in each — both exit 2 on the unmodified upstream). Unrelated to this PR; flagged here so reviewers aren't surprised.

### Screenshots / recordings

TUI before fix (two near-duplicate reasoning paragraphs, no collapsed display):
[screenshot the user has, or describe: dozens of "Thought: Xms" boxes for one line of thinking, then the same text echoed in a paragraph below] 
<img width="1629" height="816" alt="image" src="https://github.com/user-attachments/assets/7f175ebc-e429-4ac9-a009-8951883559ed" />


TUI after fix (one merged reasoning block, clean response):
[screenshot: single "Thought: 1.9s" header, single reasoning paragraph, then the response "Hi! How can I help you?" on its own]
<img width="1644" height="424" alt="image" src="https://github.com/user-attachments/assets/45d57ec8-db7d-4be3-a30c-ea3ef5222f50" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


### Follow-on UX fix: smooth reasoning streaming + strip echoes anywhere

While testing the collapse fix on `MiniMax-M3`, two UX issues surfaced
that are fixed in the second commit (`d83c20a`):

- **Re-mount flicker.** Solid's `<For>` uses referential equality for
  keying, so the merged reasoning component was being unmounted and
  remounted on every streaming chunk. The user saw the reasoning text
  "blink" — old content disappeared, then old+new reappeared. Switched
  to `<Index>` (positional keying) so the component is reused; the
  existing `<code streaming={true}>` now appends incrementally.

- **Echoes in the middle of the response.** The original strip logic
  only matched reasoning at the START of the text part. When the
  model wrote a partial response, then echoed the reasoning, then
  continued (common pattern for `MiniMax-M3`), the echo remained
  visible in the response area. New `stripReasoningFromText` finds
  and removes all occurrences of the reasoning content (start/middle/
  end/multiple) using a char-by-char match that tolerates whitespace
  and Unicode punctuation drift.

### Subagent coverage (verified)

The `displayParts` memo at \index.tsx:1581\ operates on \props.parts\ with no session-type filtering. Subagents (spawned via the \	ask\ tool) are separate sessions with \parentID\ set to the invoking session, and re-use the same \AssistantMessage\ component when you navigate to the child session — so the dedup and echo-stripping apply to them automatically. No separate code path is needed.

To verify locally: invoke any subagent that uses a reasoning model (e.g. MiniMax-M3), wait for it to finish, then jump to the child session via the parent session's footer keybind. Expect one collapsed "Thought" block at the top and a clean response, identical to the main assistant.