### PR TITLE
feat(provider): set temperature 1.0 for GLM-5.2

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -484,6 +484,7 @@ export function temperature(model: Provider.Model) {
   if (id.includes("gemini")) return 1.0
   if (id.includes("glm-4.6")) return 1.0
   if (id.includes("glm-4.7")) return 1.0
+  if (id.includes("glm-5.2")) return 1.0
   if (id.includes("minimax-m2")) return 1.0
   if (id.includes("kimi-k2")) {
     // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2576,6 +2576,14 @@ describe("ProviderTransform.temperature - Cohere North", () => {
   })
 })
 
+describe("ProviderTransform.temperature - GLM", () => {
+  for (const id of ["zai/glm-4.6", "zai/glm-4.7", "zai/glm-5.2"]) {
+    test(`${id} defaults to 1.0`, () => {
+      expect(ProviderTransform.temperature({ id } as any)).toBe(1.0)
+    })
+  }
+})
+
 describe("ProviderTransform.variants", () => {
   const createMockModel = (overrides: Partial<any> = {}): any => ({
     id: "test/test-model",


### PR DESCRIPTION
### Issue

Closes #32172

### Summary

Z.AI just released **GLM-5.2** — their latest reasoning model with a 1M context window. The model definition is being added to models.dev in [anomalyco/models.dev#2275](https://github.com/anomalyco/models.dev/pull/2275). Once merged there, opencode will pick it up automatically through the model catalog.

This PR adds the only opencode source change needed: setting `temperature: 1.0` for GLM-5.2, consistent with GLM-4.6 and GLM-4.7. Z.AI docs recommend `temperature: 1.0` for all reasoning models (see [Deep Thinking docs](https://docs.z.ai/guides/capabilities/thinking.md)).

### What already works without changes

| Concern | Why |
|---------|-----|
| Reasoning (thinking) | `transform.ts` auto-enables `thinking: { type: "enabled" }` for all `zai`/`zhipuai` provider IDs |
| Variants (effort) | GLM models return empty variants (toggle, reasoning always-on) — correct for the `thinking.type: enabled/disabled` API |
| Interleaved reasoning | Set via models.dev `interleaved.field = "reasoning_content"` |
| Model metadata | From models.dev PR #2275 |

### Changes

- `packages/opencode/src/provider/transform.ts`: Add `if (id.includes("glm-5.2")) return 1.0` in `temperature()`
- `packages/opencode/test/provider/transform.test.ts`: Add test block covering GLM-4.6, GLM-4.7, and GLM-5.2 temperature

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR