### PR TITLE
fix(tui): retry SSE on initial connection failure

### DIFF
--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -88,10 +88,18 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         while (true) {
           if (abort.signal.aborted || ctrl.signal.aborted) break
 
-          const events = await sdk.global.event({
-            signal: ctrl.signal,
-            sseMaxRetryAttempts: 0,
-          })
+          let events
+          try {
+            events = await sdk.global.event({
+              signal: ctrl.signal,
+              sseMaxRetryAttempts: 0,
+            })
+          } catch {
+            attempt += 1
+            const backoff = Math.min(retryDelay * 2 ** (attempt - 1), maxRetryDelay)
+            await new Promise((resolve) => setTimeout(resolve, backoff))
+            continue
+          }
 
           if (Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
             // Start syncing workspaces, it's important to do this after


### PR DESCRIPTION
### Issue for this PR

Closes #32175

### Type of change

- [x] Bug fix

### What does this PR do?

Wraps the initial sdk.global.event() call in a try-catch so connection failures trigger the retry loop instead of being silently swallowed. Previously only disconnections after a successful connection were retried.

### How did you verify your code works?

Tested by simulating a connection failure before the server is ready. The TUI now retries and connects once the server becomes available.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR