### PR TITLE
fix(tui): mark sync complete even when background refresh fails

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -503,6 +503,8 @@ export const {
             project.workspace.sync(),
           ]).then(() => {
             setStore("status", "complete")
+          }).catch(() => {
+            setStore("status", "complete")
           })
         })
         .catch(async (e) => {


### PR DESCRIPTION
### Issue for this PR

Closes #24540

### Type of change

- [x] Bug fix

### What does this PR do?

Adds a .catch() to the non-blocking Promise.all() in the sync phase. If any of the 11 API calls fails, the sync status was stuck at "partial" forever. The catch transitions to "complete" so the UI doesn't hang.

### How did you verify your code works?

Triggered a network error during the non-blocking sync. Without the fix, the status stays "partial" and an unhandled rejection occurs. With the fix, the status transitions to "complete" and no crash occurs.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR