### PR TITLE
docs: add opencode-sessions-explorer to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-sessions-explorer](https://github.com/iamironz/opencode-sessions-explorer)              | Search, recall, grep, and cost-analyze past OpenCode sessions                                       |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR
N/A

### Type of change
- [x] Documentation

### What does this PR do?
Adds `opencode-sessions-explorer` to the ecosystem plugins table. It's a plugin that exposes the local OpenCode SQLite session database as tools for session recall, full-text search, cost/usage analysis, and session unarchiving.

### How did you verify your code works?
Verified the table row format matches existing entries.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
