### PR TITLE
fix(tui): make session scrollbar visible by default with better contrast

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -255,7 +255,7 @@ export function Session() {
   const [timestamps, setTimestamps] = kv.signal<"hide" | "show">("timestamps", "hide")
   const [showDetails, setShowDetails] = kv.signal("tool_details_visibility", true)
   const [showAssistantMetadata, _setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
-  const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
+  const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", true)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
@@ -1175,8 +1175,8 @@ export function Session() {
                   paddingLeft: 1,
                   visible: showScrollbar(),
                   trackOptions: {
-                    backgroundColor: theme.backgroundElement,
-                    foregroundColor: theme.border,
+                    backgroundColor: theme.backgroundPanel,
+                    foregroundColor: theme.textMuted,
                   },
                 }}
                 stickyScroll={true}


### PR DESCRIPTION
## Problem

The right-side scrollbar in the session view is invisible by default on Windows Terminal (and other dark terminals). Two issues:

1. **Default hidden**: the `scrollbar_visible` KV signal defaults to `false` (set by PR #20947), so users must manually toggle it via Ctrl+P → `Toggle session scrollbar`
2. **Invisible colors**: when enabled, the scrollbar track uses `theme.backgroundElement` (#1a1a1a) on `theme.background` (#0a0a0a) and the thumb uses `theme.border` (#262626) — both nearly indistinguishable on dark backgrounds

## Changes

`packages/tui/src/routes/session/index.tsx`:

1. **Default visibility**: changed `scrollbar_visible` KV default from `false` → `true`
2. **Track color**: `backgroundColor` from `theme.backgroundElement` → `theme.backgroundPanel` for subtle visual distinction
3. **Thumb color**: `foregroundColor` from `theme.border` → `theme.textMuted` for a visible gray thumb across all themes

Closes #25981