### PR TITLE
docs: clarify lsp configuration

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -51,6 +51,10 @@ OpenCode comes with several built-in LSP servers for popular languages:
 LSP is disabled by default. When enabled, servers start when one of the above file extensions is detected and the requirements are met.
 
 :::note
+The `lsp` config enables LSP server integration and diagnostics. The separate [`lsp` tool](/docs/tools#lsp-experimental) is experimental and still requires `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` (or `OPENCODE_EXPERIMENTAL=true`).
+:::
+
+:::note
 You can disable automatic LSP server downloads by setting the `OPENCODE_DISABLE_LSP_DOWNLOAD` environment variable to `true`.
 :::
 

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -5,7 +5,7 @@ description: Manage the tools an LLM can use.
 
 Tools allow the LLM to perform actions in your codebase. OpenCode comes with a set of built-in tools, but you can extend it with [custom tools](/docs/custom-tools) or [MCP servers](/docs/mcp-servers).
 
-By default, all tools are **enabled** and don't need permission to run. You can control tool behavior through [permissions](/docs/permissions).
+By default, non-experimental tools are **enabled** and don't need permission to run. Experimental tools may require their own feature flag, which is noted in the tool's section. You can control tool behavior through [permissions](/docs/permissions).
 
 ---
 
@@ -153,7 +153,7 @@ Search for files using glob patterns like `**/*.js` or `src/**/*.ts`. Returns ma
 
 ### lsp (experimental)
 
-Interact with your configured LSP servers to get code intelligence features like definitions, references, hover info, and call hierarchy.
+Interact with your configured LSP servers to get code intelligence features like definitions, references, hover info, and call hierarchy. This experimental tool is separate from the [`lsp` configuration](/docs/lsp), which enables LSP server integration and diagnostics.
 
 :::note
 This tool is only available when `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` (or `OPENCODE_EXPERIMENTAL=true`).


### PR DESCRIPTION
### Issue for this PR

Closes #30954

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Clarifies the difference between enabling LSP server integration with the `lsp` config and enabling the separate experimental `lsp` tool.

The tools page now says experimental tools can require feature flags, and the LSP page notes that `"lsp": true` enables server integration and diagnostics, not the experimental tool.

### How did you verify your code works?

Docs-only change. Verified locally with:

- `git diff --check`
- source review of the affected docs pages and the runtime flag reference:
- `packages/web/src/content/docs/tools.mdx`
- `packages/web/src/content/docs/lsp.mdx`
- `packages/opencode/src/effect/runtime-flags.ts`

Docs build was not run because this local environment does not have Bun installed.

### Screenshots / recordings

N/A, docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR