### PR TITLE
feat(app): show git branch in prompt composer

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1130,6 +1130,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (!id) return permission.isAutoAcceptingDirectory(sdk.directory)
     return permission.isAutoAccepting(id, sdk.directory)
   })
+  const branchName = createMemo(() => {
+    if (sync.project?.vcs !== "git") return
+    return sync.data.vcs?.branch
+  })
+  const branchLabel = createMemo(() => {
+    const branch = branchName()
+    if (!branch) return
+    return branch.length > 32 ? `${branch.slice(0, 29)}...` : branch
+  })
 
   const { abort, handleSubmit } = createPromptSubmit({
     info,
@@ -1600,6 +1609,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     <ComposerPickerTrigger state={newProjectTriggerState()} />
                   </Show>
                   <ComposerModelControl state={modelControlState()} />
+                  <Show when={branchLabel()}>
+                    {(branch) => <ComposerBranchBadge branch={branch()} />}
+                  </Show>
                   <Show when={store.mode !== "shell" && showVariantControl()}>
                     <div
                       data-component="prompt-variant-control"
@@ -1983,6 +1995,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                         </Show>
                       </Show>
                     </Show>
+                    <Show when={branchLabel()}>
+                      {(branch) => <ComposerBranchBadge branch={branch()} />}
+                    </Show>
                   </div>
                 </div>
               </div>
@@ -2150,6 +2165,20 @@ function ComposerAgentControl(props: { state: ComposerAgentControlState }) {
           variant="ghost"
         />
       </TooltipKeybind>
+    </div>
+  )
+}
+
+function ComposerBranchBadge(props: { branch: string }) {
+  return (
+    <div
+      data-component="prompt-branch-indicator"
+      class="flex h-7 min-w-0 max-w-[180px] items-center gap-1 rounded-md px-2 text-[13px] font-[440] leading-5 text-v2-text-text-faint"
+      title={props.branch}
+      aria-label={`Current Git branch: ${props.branch}`}
+    >
+      <Icon name="branch" size="small" class="shrink-0 text-v2-icon-icon-muted" />
+      <span class="truncate">{props.branch}</span>
     </div>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #17856

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shows the current Git branch in the prompt composer control row for the web/desktop UI.

The app already syncs VCS data into `sync.data.vcs`, including branch updates. This PR reuses that existing state and renders a small branch badge only when the current project is a Git repository and a branch name is available. No new API call is added.

### How did you verify your code works?

I inspected the existing VCS sync flow and both prompt composer layouts, then kept the change to one component. I could not run the local app/typecheck in this environment because `bun` is not installed on PATH.

### Screenshots / recordings

Not available from this environment because I cannot run the Bun-powered web app here.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR