### PR TITLE
fix(core): swallow EISDIR in readFileStringSafe

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -56,7 +56,13 @@ export namespace FSUtil {
       const readFileStringSafe = Effect.fn("FileSystem.readFileStringSafe")(function* (path: string) {
         return yield* fs
           .readFileString(path)
-          .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
+          .pipe(
+            // NotFound = ENOENT; BadResource = EISDIR (and perms/IO). A "safe"
+            // read must not crash when the path is a directory — the legacy
+            // ConfigPaths.readFile silently skipped all non-ENOENT read errors.
+            Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)),
+            Effect.catchReason("PlatformError", "BadResource", () => Effect.succeed(undefined)),
+          )
       })
 
       const isDir = Effect.fn("FileSystem.isDir")(function* (path: string) {

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -91,6 +91,18 @@ describe("FSUtil", () => {
         expect(result).toBeUndefined()
       }),
     )
+
+    it(
+      "returns undefined for a directory path (EISDIR/BadResource)",
+      Effect.gen(function* () {
+        const fs = yield* FSUtil.Service
+        const filesys = yield* FileSystem.FileSystem
+        const tmp = yield* filesys.makeTempDirectoryScoped()
+
+        const result = yield* fs.readFileStringSafe(tmp)
+        expect(result).toBeUndefined()
+      }),
+    )
   })
 
   describe("readJson / writeJson", () => {


### PR DESCRIPTION
## Summary

`readFileStringSafe` caught `NotFound` (ENOENT) but not `BadResource` (EISDIR). During config bootstrap, opencode probes config paths as legacy bare config files; one of those paths is always a directory (`~/.config/opencode`), so the read throws EISDIR, which went uncaught and crashed the TUI on launch (`Unexpected server error`, exit 133 / SIGTRAP).

This restores the silent-skip semantics of the legacy `ConfigPaths.readFile`, which swallowed all non-ENOENT read errors.

## Root cause

Regression from the `ConfigPaths.readFile` → `AppFileSystem.readFileStringSafe` refactor. The new helper only caught `NotFound`:

\`\`\`ts
return yield* fs
  .readFileString(path)
  .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
\`\`\`

`EISDIR` maps to the `BadResource` platform error tag, which propagated uncaught. The crash path is `Config.load` → `readFileStringSafe(...).pipe(Effect.orDie)` → defect.

## Fix

Also catch `BadResource` (covers EISDIR plus perms/IO errors), matching the "safe" contract and the legacy behavior.

## Test plan

- [x] Added regression test: `readFileStringSafe` on a directory path returns `undefined`
- [x] `packages/core` typecheck (`tsgo --noEmit`) clean
- [x] Full `packages/core` suite: 28/28 filesystem tests pass; the 5 unrelated pre-existing failures (SessionRunnerLLM / schema-doc / Watcher) are environment-dependent and fail identically on the parent commit
- [x] Reproduces pre-fix: reading a directory throws `BadResource`; post-fix returns `undefined`

Fixes #32205