### PR TITLE
fix(stats): align data header actions to allow all header links to be clickable

### DIFF
--- a/packages/stats/app/src/routes/index.css
+++ b/packages/stats/app/src/routes/index.css
@@ -119,7 +119,8 @@
 }
 
 [data-page="stats"] [data-slot="header-bar"] {
-  display: flex;
+  display: grid;
+  grid-template-columns: 0.5fr 1fr 0.5fr;
   align-items: center;
   gap: 16px;
   min-height: 72px;
@@ -183,10 +184,10 @@
 }
 
 [data-page="stats"] [data-slot="header-actions"] {
-  flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-self: flex-end;
+  grid-column-start: 3;
   gap: 8px;
 }
 
@@ -3509,12 +3510,6 @@
 @media (min-width: 90rem) {
   [data-page="stats"] [data-slot="header-bar"] {
     gap: 32px;
-  }
-
-  [data-page="stats"] [data-slot="brand"],
-  [data-page="stats"] [data-component="section-nav"],
-  [data-page="stats"] [data-slot="header-actions"] {
-    flex: 1 1 0;
   }
 
   [data-page="stats"] [data-slot="brand"] {

--- a/packages/stats/app/src/routes/index.css
+++ b/packages/stats/app/src/routes/index.css
@@ -120,7 +120,7 @@
 
 [data-page="stats"] [data-slot="header-bar"] {
   display: grid;
-  grid-template-columns: 0.5fr 1fr 0.5fr;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 16px;
   min-height: 72px;
@@ -137,11 +137,9 @@
 }
 
 [data-page="stats"] [data-slot="brand"] {
-  flex: 0 0 auto;
   min-width: 0;
   display: flex;
   align-items: center;
-  margin-right: auto;
   color: var(--stats-text);
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #32210

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes issue where the Geo Breakdown link in the header bar was not clickable.

### How did you verify your code works?

- `bun turbo typecheck` via the pre-push hook
- Manual testing

### Screenshots / recordings

#### Before
[Screencast from 2026-06-13 13-08-07.webm](https://github.com/user-attachments/assets/d129cf46-4146-40b2-9ea0-0c5ae6209f93)

#### After
[Screencast from 2026-06-13 12-59-35.webm](https://github.com/user-attachments/assets/b374355f-4121-4dc8-8b57-4c31b8f66f84)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR