### PR TITLE
feat(core): models.devのreasoning optionsを反映

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -43,6 +43,21 @@ const Cost = Schema.Struct({
   ),
 })
 
+const ReasoningOption = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("effort"),
+    values: Schema.Array(Schema.NullOr(Schema.String)),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("toggle"),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("budget_tokens"),
+    min: Schema.optional(Schema.Finite),
+    max: Schema.optional(Schema.Finite),
+  }),
+])
+
 export const Model = Schema.Struct({
   id: Schema.String,
   name: Schema.String,
@@ -50,6 +65,7 @@ export const Model = Schema.Struct({
   release_date: Schema.String,
   attachment: Schema.Boolean,
   reasoning: Schema.Boolean,
+  reasoning_options: Schema.optional(Schema.Array(ReasoningOption)),
   temperature: Schema.Boolean,
   tool_call: Schema.Boolean,
   interleaved: Schema.optional(

--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -41,13 +41,32 @@ function cost(input: ModelsDev.Model["cost"]) {
 }
 
 function variants(model: ModelsDev.Model, packageName?: string) {
-  return Object.entries(model.experimental?.modes ?? {}).map(([id, item]) => {
+  const modes = Object.entries(model.experimental?.modes ?? {})
+  if (modes.length === 0) return reasoningOptionVariants(model, packageName)
+  return modes.map(([id, item]) => {
     const request = ModelRequest.normalizeAiSdkOptions(packageName, item.provider?.body ?? {})
     return {
       id: ModelV2.VariantID.make(id),
       headers: { ...(item.provider?.headers ?? {}) },
       ...request,
     }
+  })
+}
+
+function reasoningOptionVariants(model: ModelsDev.Model, packageName?: string) {
+  const effort = model.reasoning_options?.find((item) => item.type === "effort")
+  if (!effort) return []
+  return effort.values.flatMap((value) => {
+    if (typeof value !== "string") return []
+    const request = ModelRequest.normalizeAiSdkOptions(packageName, { reasoningEffort: value })
+    if (request.options.reasoningEffort !== value) return []
+    return [
+      {
+        id: ModelV2.VariantID.make(value),
+        headers: {},
+        ...request,
+      },
+    ]
   })
 }
 

--- a/packages/core/test/plugin/fixtures/models-dev.json
+++ b/packages/core/test/plugin/fixtures/models-dev.json
@@ -10,5 +10,72 @@
     "name": "Local",
     "env": [],
     "models": {}
+  },
+  "zai-coding-plan": {
+    "id": "zai-coding-plan",
+    "name": "Z.AI Coding Plan",
+    "env": [],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.z.ai/api/coding/paas/v4",
+    "models": {
+      "glm-5.2": {
+        "id": "glm-5.2",
+        "name": "GLM-5.2",
+        "family": "glm",
+        "release_date": "2026-06-13",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["high", "max"]
+          }
+        ],
+        "temperature": true,
+        "tool_call": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        }
+      },
+      "mode-priority": {
+        "id": "mode-priority",
+        "name": "Mode Priority",
+        "family": "glm",
+        "release_date": "2026-06-13",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["high", "max"]
+          }
+        ],
+        "temperature": true,
+        "tool_call": true,
+        "experimental": {
+          "modes": {
+            "custom": {
+              "provider": {
+                "body": {
+                  "reasoningEffort": "high"
+                },
+                "headers": {
+                  "x-model-mode": "custom"
+                }
+              }
+            }
+          }
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      }
+    }
   }
 }

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -8,10 +8,12 @@ import { Database } from "@opencode-ai/core/database/database"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Location } from "@opencode-ai/core/location"
+import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { PluginV2 } from "@opencode-ai/core/plugin"
 import { ModelsDevPlugin } from "@opencode-ai/core/plugin/models-dev"
 import { Policy } from "@opencode-ai/core/policy"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { location } from "../fixture/location"
 import { testEffect } from "../lib/effect"
@@ -40,42 +42,92 @@ const layer = Layer.mergeAll(
 )
 const it = testEffect(layer)
 
+function withModelsDevFixture<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = {
+        path: Flag.OPENCODE_MODELS_PATH,
+        disabled: Flag.OPENCODE_DISABLE_MODELS_FETCH,
+      }
+      Flag.OPENCODE_MODELS_PATH = path.join(import.meta.dir, "fixtures", "models-dev.json")
+      Flag.OPENCODE_DISABLE_MODELS_FETCH = true
+      return previous
+    }),
+    () => effect.pipe(Effect.provide(ModelsDev.defaultLayer)),
+    (previous) =>
+      Effect.sync(() => {
+        Flag.OPENCODE_MODELS_PATH = previous.path
+        Flag.OPENCODE_DISABLE_MODELS_FETCH = previous.disabled
+      }),
+  )
+}
+
 describe("ModelsDevPlugin", () => {
   it.effect("registers key methods for providers with environment variables", () =>
-    Effect.acquireUseRelease(
-      Effect.sync(() => {
-        const previous = {
-          path: Flag.OPENCODE_MODELS_PATH,
-          disabled: Flag.OPENCODE_DISABLE_MODELS_FETCH,
-        }
-        Flag.OPENCODE_MODELS_PATH = path.join(import.meta.dir, "fixtures", "models-dev.json")
-        Flag.OPENCODE_DISABLE_MODELS_FETCH = true
-        return previous
+    withModelsDevFixture(
+      Effect.gen(function* () {
+        yield* ModelsDevPlugin.effect
+        const integrations = yield* Integration.Service
+        expect(yield* integrations.list()).toEqual([
+          new Integration.Info({
+            id: Integration.ID.make("acme"),
+            name: "Acme",
+            methods: [
+              new Integration.KeyMethod({ type: "key" }),
+              new Integration.EnvMethod({
+                type: "env",
+                names: ["ACME_API_KEY"],
+              }),
+            ],
+            connections: [],
+          }),
+        ])
       }),
-      () =>
-        Effect.gen(function* () {
-          yield* ModelsDevPlugin.effect
-          const integrations = yield* Integration.Service
-          expect(yield* integrations.list()).toEqual([
-            new Integration.Info({
-              id: Integration.ID.make("acme"),
-              name: "Acme",
-              methods: [
-                new Integration.KeyMethod({ type: "key" }),
-                new Integration.EnvMethod({
-                  type: "env",
-                  names: ["ACME_API_KEY"],
-                }),
-              ],
-              connections: [],
-            }),
-          ])
-        }).pipe(Effect.provide(ModelsDev.defaultLayer)),
-      (previous) =>
-        Effect.sync(() => {
-          Flag.OPENCODE_MODELS_PATH = previous.path
-          Flag.OPENCODE_DISABLE_MODELS_FETCH = previous.disabled
-        }),
+    ),
+  )
+
+  it.effect("synthesizes effort reasoning option variants", () =>
+    withModelsDevFixture(
+      Effect.gen(function* () {
+        yield* ModelsDevPlugin.effect
+        const catalog = yield* Catalog.Service
+        const model = yield* catalog.model.get(ProviderV2.ID.make("zai-coding-plan"), ModelV2.ID.make("glm-5.2"))
+        expect(model.variants).toEqual([
+          {
+            id: ModelV2.VariantID.make("high"),
+            headers: {},
+            generation: {},
+            options: { reasoningEffort: "high" },
+            body: {},
+          },
+          {
+            id: ModelV2.VariantID.make("max"),
+            headers: {},
+            generation: {},
+            options: { reasoningEffort: "max" },
+            body: {},
+          },
+        ])
+      }),
+    ),
+  )
+
+  it.effect("keeps experimental modes higher priority than reasoning options", () =>
+    withModelsDevFixture(
+      Effect.gen(function* () {
+        yield* ModelsDevPlugin.effect
+        const catalog = yield* Catalog.Service
+        const model = yield* catalog.model.get(ProviderV2.ID.make("zai-coding-plan"), ModelV2.ID.make("mode-priority"))
+        expect(model.variants).toEqual([
+          {
+            id: ModelV2.VariantID.make("custom"),
+            headers: { "x-model-mode": "custom" },
+            generation: {},
+            options: { reasoningEffort: "high" },
+            body: {},
+          },
+        ])
+      }),
     ),
   )
 })


### PR DESCRIPTION
## ① なぜ

models.dev が `reasoning_options` を公開し始め、Z.AI Coding Plan の `glm-5.2` でも `high` / `max` の effort variant がカタログ情報として表現されるようになりました。

既存の `experimental.modes` だけを見る実装のままだと、この新しいカタログ表現を opencode 側の model variant として露出できません。

## ② どう実装したか

- `models.dev` の model schema に `reasoning_options` を追加しました。
- `effort` は既存の `ModelRequest.normalizeAiSdkOptions` が `reasoningEffort` として扱える場合だけ variant に合成します。
- `toggle` / `budget_tokens` は wire shape を推測せず、schema で受け入れるだけにしています。
- 既存の `experimental.modes` がある場合は従来通りそちらを優先します。

## ③ 特にレビューしてほしい点

- 未知 provider で `reasoningEffort` を body に直書きしない安全側の判定で問題ないか。
- `experimental.modes` の優先順位を維持したまま、新しい `reasoning_options` を補助的に扱えているか。
- `effort.values` に `null` が含まれる models.dev 現行データを受け入れつつ、variant 化は文字列値だけに限定する方針で問題ないか。

## ④ テスト内容・確認方法

- `packages/core`: `bun test test/plugin/models-dev.test.ts` → 3 pass
- `packages/core`: `bun typecheck` → pass
- `packages/opencode`: `bun test test/provider/transform.test.ts test/plugin/trigger.test.ts --timeout 30000` → 265 pass
- `packages/opencode`: `bun typecheck` → pass
- repo root: `bunx prettier --check packages/core/src/models-dev.ts packages/core/src/plugin/models-dev.ts packages/core/test/plugin/models-dev.test.ts packages/core/test/plugin/fixtures/models-dev.json` → pass
- push hook: `bun turbo typecheck` → 23 successful
