### PR TITLE
feat(app): add session panels

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -256,11 +256,11 @@ declare global {
     __OPENCODE__?: {
       deepLinks?: string[]
     }
-    api?: {
-      setTitlebar?: (theme: { mode: "light" | "dark" }) => Promise<void>
-      exportDebugLogs?: () => Promise<string>
-    }
   }
+}
+
+type TitlebarAPI = {
+  setTitlebar?: (theme: { mode: "light" | "dark" }) => Promise<void>
 }
 
 function QueryProvider(props: ParentProps) {
@@ -390,7 +390,7 @@ export function AppBaseProviders(props: ParentProps<{ locale?: Locale }>) {
       <Font />
       <ThemeProvider
         onThemeApplied={(_, mode) => {
-          void window.api?.setTitlebar?.({ mode })
+          void (window as Window & { api?: TitlebarAPI }).api?.setTitlebar?.({ mode })
         }}
       >
         <LanguageProvider locale={props.locale}>

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -336,6 +336,18 @@ export const SettingsGeneral: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.general.row.showSessionPanels.title")}
+          description={language.t("settings.general.row.showSessionPanels.description")}
+        >
+          <div data-action="settings-show-session-panels">
+            <Switch
+              checked={settings.general.showSessionPanels()}
+              onChange={(checked) => settings.general.setShowSessionPanels(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.general.row.newLayoutDesigns.title")}
           description={language.t("settings.general.row.newLayoutDesigns.description")}
         >

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -313,6 +313,18 @@ export const SettingsGeneralV2: Component<{
         </SettingsRowV2>
 
         <SettingsRowV2
+          title={language.t("settings.general.row.showSessionPanels.title")}
+          description={language.t("settings.general.row.showSessionPanels.description")}
+        >
+          <div data-action="settings-show-session-panels">
+            <Switch
+              checked={settings.general.showSessionPanels()}
+              onChange={(checked) => settings.general.setShowSessionPanels(checked)}
+            />
+          </div>
+        </SettingsRowV2>
+
+        <SettingsRowV2
           title={language.t("settings.general.row.newLayoutDesigns.title")}
           description={language.t("settings.general.row.newLayoutDesigns.description")}
         >

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -264,6 +264,10 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                   .then((x) => x.data)
                   .catch(() => {}),
             )
+            const sessionTabCount = () =>
+              tabsStore.filter((tab) => tab.type === "session" && tab.server === server.key).length
+            const panelToggleLabel = () =>
+              tabs.panels.tiled() ? language.t("command.tabs.viewAsTabs") : language.t("command.tabs.viewAsPanels")
 
             const matchRoute = (route: LayoutRoute) => {
               if (route.type === "home") return
@@ -358,6 +362,14 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
               const current = currentTab()
 
               return [
+                {
+                  id: "tabs.panel.toggle",
+                  category: language.t("command.category.view"),
+                  title: panelToggleLabel(),
+                  disabled: sessionTabCount() < 2,
+                  hidden: true,
+                  onSelect: () => tabs.panels.toggle(),
+                },
                 {
                   id: "tab.new",
                   category: "tab",
@@ -488,6 +500,21 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                       aria-label={language.t("command.session.new")}
                     />
                   </TooltipV2>
+                </Show>
+                <Show when={sessionTabCount() > 1}>
+                  <Tooltip placement="bottom" value={panelToggleLabel()}>
+                    <IconButtonV2
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="shrink-0"
+                      state={tabs.panels.tiled() ? "pressed" : undefined}
+                      onClick={() => tabs.panels.toggle()}
+                      aria-label={panelToggleLabel()}
+                      aria-pressed={tabs.panels.tiled()}
+                      icon={<IconV2 name={tabs.panels.tiled() ? "status-active" : "status"} />}
+                    />
+                  </Tooltip>
                 </Show>
                 <div class="flex-1" />
                 <TitlebarV2Right state={v2RightState()} />

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -25,6 +25,7 @@ import { readSessionTabsRemovedDetail, SESSION_TABS_REMOVED_EVENT } from "@/comp
 import { useGlobal } from "@/context/global"
 import { ServerConnection, useServer } from "@/context/server"
 import { tabKey, useTabs } from "@/context/tabs"
+import { canTileSessionTabs } from "@/context/tabs-order"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "./command-tooltip-keybind"
 
@@ -264,8 +265,21 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                   .then((x) => x.data)
                   .catch(() => {}),
             )
-            const sessionTabCount = () =>
-              tabsStore.filter((tab) => tab.type === "session" && tab.server === server.key).length
+            const activeSessionServer = () => {
+              const route = layout.route()
+              if (route.type !== "session") return
+              return route.server ?? server.key
+            }
+            const sessionTabCount = () => {
+              const key = activeSessionServer()
+              if (!key) return 0
+              return tabsStore.filter((tab) => tab.type === "session" && tab.server === key).length
+            }
+            const canShowPanelToggle = () =>
+              !!activeSessionServer() &&
+              settings.general.showSessionPanels() &&
+              !mobile() &&
+              canTileSessionTabs(sessionTabCount())
             const panelToggleLabel = () =>
               tabs.panels.tiled() ? language.t("command.tabs.viewAsTabs") : language.t("command.tabs.viewAsPanels")
 
@@ -362,14 +376,15 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
               const current = currentTab()
 
               return [
-                {
-                  id: "tabs.panel.toggle",
-                  category: language.t("command.category.view"),
-                  title: panelToggleLabel(),
-                  disabled: sessionTabCount() < 2,
-                  hidden: true,
-                  onSelect: () => tabs.panels.toggle(),
-                },
+                canShowPanelToggle()
+                  ? {
+                      id: "tabs.panel.toggle",
+                      category: language.t("command.category.view"),
+                      title: panelToggleLabel(),
+                      hidden: true,
+                      onSelect: () => tabs.panels.toggle(),
+                    }
+                  : undefined,
                 {
                   id: "tab.new",
                   category: "tab",
@@ -501,8 +516,8 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                     />
                   </TooltipV2>
                 </Show>
-                <Show when={sessionTabCount() > 1}>
-                  <Tooltip placement="bottom" value={panelToggleLabel()}>
+                <Show when={canShowPanelToggle()}>
+                  <TooltipV2 placement="bottom" value={panelToggleLabel()}>
                     <IconButtonV2
                       type="button"
                       variant="ghost-muted"
@@ -514,7 +529,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                       aria-pressed={tabs.panels.tiled()}
                       icon={<IconV2 name={tabs.panels.tiled() ? "status-active" : "status"} />}
                     />
-                  </Tooltip>
+                  </TooltipV2>
                 </Show>
                 <div class="flex-1" />
                 <TitlebarV2Right state={v2RightState()} />

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -31,6 +31,7 @@ export interface Settings {
     showReasoningSummaries: boolean
     shellToolPartsExpanded: boolean
     editToolPartsExpanded: boolean
+    showSessionPanels: boolean
     showCustomAgents: boolean
     mobileTitlebarPosition: "top" | "bottom"
     newLayoutDesigns?: boolean
@@ -116,6 +117,7 @@ const defaultSettings: Settings = {
     showReasoningSummaries: false,
     shellToolPartsExpanded: false,
     editToolPartsExpanded: false,
+    showSessionPanels: false,
     showCustomAgents: false,
     mobileTitlebarPosition: "top",
   },
@@ -236,6 +238,13 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setEditToolPartsExpanded(value: boolean) {
           setStore("general", "editToolPartsExpanded", value)
+        },
+        showSessionPanels: withFallback(
+          () => store.general?.showSessionPanels,
+          defaultSettings.general.showSessionPanels,
+        ),
+        setShowSessionPanels(value: boolean) {
+          setStore("general", "showSessionPanels", value)
         },
         showCustomAgents,
         setShowCustomAgents(value: boolean) {

--- a/packages/app/src/context/tabs-order.test.ts
+++ b/packages/app/src/context/tabs-order.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { swapTabOrder, type TabOrderItem } from "./tabs-order"
+
+const sessionTab = (sessionId: string): TabOrderItem => ({
+  type: "session",
+  server: "sidecar",
+  sessionId,
+})
+
+describe("swapTabOrder", () => {
+  test("swaps matching tabs by tab identity", () => {
+    const first = sessionTab("first")
+    const second = sessionTab("second")
+    const third = sessionTab("third")
+
+    expect(swapTabOrder([first, second, third], first, third)).toEqual([third, second, first])
+  })
+
+  test("keeps order when either tab is missing", () => {
+    const first = sessionTab("first")
+    const second = sessionTab("second")
+
+    expect(swapTabOrder([first], first, second)).toEqual([first])
+  })
+})

--- a/packages/app/src/context/tabs-order.test.ts
+++ b/packages/app/src/context/tabs-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { swapTabOrder, type TabOrderItem } from "./tabs-order"
+import { canTileSessionTabs, tabOrderKey, type TabOrderItem } from "./tabs-order"
 
 const sessionTab = (sessionId: string): TabOrderItem => ({
   type: "session",
@@ -7,19 +7,17 @@ const sessionTab = (sessionId: string): TabOrderItem => ({
   sessionId,
 })
 
-describe("swapTabOrder", () => {
-  test("swaps matching tabs by tab identity", () => {
-    const first = sessionTab("first")
-    const second = sessionTab("second")
-    const third = sessionTab("third")
-
-    expect(swapTabOrder([first, second, third], first, third)).toEqual([third, second, first])
+describe("tabOrderKey", () => {
+  test("keys session tabs by server and session id", () => {
+    expect(tabOrderKey(sessionTab("first"))).toBe("sidecar\nfirst")
   })
+})
 
-  test("keeps order when either tab is missing", () => {
-    const first = sessionTab("first")
-    const second = sessionTab("second")
-
-    expect(swapTabOrder([first], first, second)).toEqual([first])
+describe("canTileSessionTabs", () => {
+  test("allows only the bounded desktop panel range", () => {
+    expect(canTileSessionTabs(1)).toBe(false)
+    expect(canTileSessionTabs(2)).toBe(true)
+    expect(canTileSessionTabs(4)).toBe(true)
+    expect(canTileSessionTabs(5)).toBe(false)
   })
 })

--- a/packages/app/src/context/tabs-order.ts
+++ b/packages/app/src/context/tabs-order.ts
@@ -9,20 +9,9 @@ export type TabOrderItem =
       draftID: string
     }
 
+export function canTileSessionTabs(count: number) {
+  return count >= 2 && count <= 4
+}
+
 export const tabOrderKey = (tab: TabOrderItem) =>
   tab.type === "draft" ? `draft:${tab.draftID}` : `${tab.server}\n${tab.sessionId}`
-
-export function swapTabOrder<T extends TabOrderItem>(tabs: readonly T[], first: TabOrderItem, second: TabOrderItem) {
-  const firstKey = tabOrderKey(first)
-  const secondKey = tabOrderKey(second)
-  if (firstKey === secondKey) return tabs.slice()
-
-  const firstIndex = tabs.findIndex((tab) => tabOrderKey(tab) === firstKey)
-  const secondIndex = tabs.findIndex((tab) => tabOrderKey(tab) === secondKey)
-  if (firstIndex === -1 || secondIndex === -1) return tabs.slice()
-
-  const next = tabs.slice()
-  next[firstIndex] = tabs[secondIndex]!
-  next[secondIndex] = tabs[firstIndex]!
-  return next
-}

--- a/packages/app/src/context/tabs-order.ts
+++ b/packages/app/src/context/tabs-order.ts
@@ -1,0 +1,28 @@
+export type TabOrderItem =
+  | {
+      type: "session"
+      server: string
+      sessionId: string
+    }
+  | {
+      type: "draft"
+      draftID: string
+    }
+
+export const tabOrderKey = (tab: TabOrderItem) =>
+  tab.type === "draft" ? `draft:${tab.draftID}` : `${tab.server}\n${tab.sessionId}`
+
+export function swapTabOrder<T extends TabOrderItem>(tabs: readonly T[], first: TabOrderItem, second: TabOrderItem) {
+  const firstKey = tabOrderKey(first)
+  const secondKey = tabOrderKey(second)
+  if (firstKey === secondKey) return tabs.slice()
+
+  const firstIndex = tabs.findIndex((tab) => tabOrderKey(tab) === firstKey)
+  const secondIndex = tabs.findIndex((tab) => tabOrderKey(tab) === secondKey)
+  if (firstIndex === -1 || secondIndex === -1) return tabs.slice()
+
+  const next = tabs.slice()
+  next[firstIndex] = tabs[secondIndex]!
+  next[secondIndex] = tabs[firstIndex]!
+  return next
+}

--- a/packages/app/src/context/tabs.tsx
+++ b/packages/app/src/context/tabs.tsx
@@ -10,6 +10,7 @@ import { uuid } from "@/utils/uuid"
 import { SessionTabsRemovedDetail } from "@/components/titlebar-session-events"
 import { sessionHref } from "@/utils/session-route"
 import { createTabMemory } from "./tab-memory"
+import { tabOrderKey } from "./tabs-order"
 
 export type SessionTab = {
   type: "session"
@@ -36,7 +37,7 @@ export const draftHref = (draftID: string) => `/new-session?draftId=${encodeURIC
 export const tabHref = (tab: Tab) =>
   tab.type === "draft" ? draftHref(tab.draftID) : sessionHref(tab.server, tab.sessionId)
 
-export const tabKey = (tab: Tab) => (tab.type === "draft" ? `draft:${tab.draftID}` : `${tab.server}\n${tabHref(tab)}`)
+export const tabKey = tabOrderKey
 
 export function sessionHasOpenTab(tabs: Tab[], server: ServerConnection.Key, session: Session) {
   return tabs.some((tab) => tab.type === "session" && tab.server === server && tab.sessionId === session.id)

--- a/packages/app/src/context/tabs.tsx
+++ b/packages/app/src/context/tabs.tsx
@@ -63,6 +63,7 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
       createStore<Tab[]>([]),
     )
     const [recent, setRecent, , recentReady] = persisted(Persist.global("tabs.recent"), createStore<RecentTab>({}))
+    const [panelStore, setPanelStore] = persisted(Persist.global("tabs.panels"), createStore({ tiled: false }))
 
     const params = useParams()
     const navigate = useNavigate()
@@ -287,6 +288,16 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
       },
     }
 
-    return { ...actions, store, ready, recentReady }
+    const panels = {
+      tiled: () => panelStore.tiled,
+      setTiled(value: boolean) {
+        setPanelStore("tiled", value)
+      },
+      toggle() {
+        setPanelStore("tiled", (value) => !value)
+      },
+    }
+
+    return { ...actions, panels, store, ready, recentReady }
   },
 })

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -861,6 +861,8 @@ export const dict = {
   "settings.general.row.editToolPartsExpanded.title": "Expand edit tool parts",
   "settings.general.row.editToolPartsExpanded.description":
     "Show edit, write, and patch tool parts expanded by default in the timeline",
+  "settings.general.row.showSessionPanels.title": "Session panels",
+  "settings.general.row.showSessionPanels.description": "Show controls to tile open session tabs on desktop",
   "settings.general.row.newLayoutDesigns.title": "New layout and designs",
   "settings.general.row.newLayoutDesigns.description": "Enable the redesigned layout, home, composer, and session UI",
   "settings.general.row.pinchZoom.title": "Pinch to zoom",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -48,6 +48,8 @@ export const dict = {
   "command.session.new": "New session",
   "command.file.open": "Open file",
   "command.tab.close": "Close tab",
+  "command.tabs.viewAsPanels": "View tabs as panels",
+  "command.tabs.viewAsTabs": "View as tabs",
   "command.context.addSelection": "Add selection to context",
   "command.context.addSelection.description": "Add selected lines from the current file",
   "command.input.focus": "Focus input",

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -97,6 +97,21 @@
     width: 100%;
   }
 
+  [data-session-panel-grid] [data-session-panel],
+  [data-session-panel-grid] [data-session-panel] .scroll-view__viewport,
+  [data-session-panel-grid] [data-session-panel] [data-slot="session-turn-message-container"],
+  [data-session-panel-grid] [data-session-panel] [data-slot="session-turn-message-content"],
+  [data-session-panel-grid] [data-session-panel] [data-slot="session-turn-assistant-content"] {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  [data-session-panel-grid] [data-session-panel] [data-slot="session-turn-message-content"],
+  [data-session-panel-grid] [data-session-panel] [data-slot="session-turn-assistant-content"] {
+    overflow-wrap: anywhere;
+  }
+
   @container getting-started (min-width: 17rem) {
     [data-component="getting-started-actions"] {
       flex-direction: row;

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -1,4 +1,4 @@
-import { DataProvider } from "@opencode-ai/session-ui/context"
+import { DataProvider } from "@opencode-ai/session-ui/context/data"
 import { showToast } from "@/utils/toast"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2016,7 +2016,7 @@ export default function Page() {
           </Show>
         </div>
       </div>
-      {composerRegion("dock")}
+      {composerRegion()}
     </div>
   )
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -93,6 +93,7 @@ import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/sessio
 import { useUsageExceededDialogs } from "./session/usage-exceeded-dialogs"
 import { createSessionOwnership } from "./session/session-ownership"
 import { tabHref, tabKey, useTabs as useOpenTabs, type SessionTab } from "@/context/tabs"
+import { canTileSessionTabs } from "@/context/tabs-order"
 import { SessionTextPane } from "@/pages/session/session-text-pane"
 
 type FollowupItem = FollowupDraft & { id: string }
@@ -249,7 +250,15 @@ export default function Page() {
   )
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
-  const panelMode = createMemo(() => newSessionDesign() && isDesktop() && openTabs.panels.tiled() && !!params.id && panelTabs().length > 1)
+  const panelMode = createMemo(
+    () =>
+      newSessionDesign() &&
+      settings.general.showSessionPanels() &&
+      isDesktop() &&
+      openTabs.panels.tiled() &&
+      !!params.id &&
+      canTileSessionTabs(panelTabs().length),
+  )
   const size = createSizing()
   const desktopReviewOpen = createMemo(() => isDesktop() && view().reviewPanel.opened())
   const desktopFileTreeOpen = createMemo(

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -13,6 +13,7 @@ import {
   on,
   onMount,
   untrack,
+  For,
 } from "solid-js"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createMediaQuery } from "@solid-primitives/media"
@@ -37,6 +38,7 @@ import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
 import { usePrompt } from "@/context/prompt"
 import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
 import { useSDK } from "@/context/sdk"
 import { useServerSDK } from "@/context/server-sdk"
 import { useSettings } from "@/context/settings"
@@ -69,6 +71,18 @@ import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useComposerCommands } from "@/pages/session/use-composer-commands"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
+import {
+  normalizePanelState,
+  normalizePanelWeights,
+  panelAvailableSize,
+  panelBoundary,
+  panelHandleOffset,
+  panelMinHeight,
+  panelMinWidth,
+  panelPixels,
+  panelTrackTemplate,
+  resizePanelWeights,
+} from "@/pages/session/panel-layout"
 import { Identifier } from "@/utils/id"
 import { diffs as list } from "@/utils/diffs"
 import { Persist, persisted } from "@/utils/persist"
@@ -77,6 +91,8 @@ import { formatServerError } from "@/utils/server-errors"
 import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/session-route"
 import { useUsageExceededDialogs } from "./session/usage-exceeded-dialogs"
 import { createSessionOwnership } from "./session/session-ownership"
+import { tabHref, useTabs as useOpenTabs, type SessionTab } from "@/context/tabs"
+import { SessionTextPane } from "@/pages/session/session-text-pane"
 
 type FollowupItem = FollowupDraft & { id: string }
 type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
@@ -130,12 +146,23 @@ export default function Page() {
   const prompt = usePrompt()
   const comments = useComments()
   const terminal = useTerminal()
+  const server = useServer()
+  const navigate = useNavigate()
+  const openTabs = useOpenTabs()
   const [searchParams, setSearchParams] = useSearchParams<{ prompt?: string }>()
   const location = useLocation()
-  const navigate = useNavigate()
   const { params, sessionKey, workspaceKey, tabs, view } = useSessionLayout()
   const sessionOwnership = createSessionOwnership(sessionKey)
   const newSessionDesign = createMemo(() => settings.general.newLayoutDesigns())
+  const currentServer = createMemo(() => (params.serverKey ? requireServerKey(params.serverKey) : server.key))
+  const panelTabs = createMemo(() =>
+    openTabs.store.filter((tab): tab is SessionTab => tab.type === "session" && tab.server === currentServer()),
+  )
+  const focusedPanel = (tab: SessionTab) => tab.server === currentServer() && tab.sessionId === params.id
+  const focusPanel = (tab: SessionTab) => {
+    if (focusedPanel(tab)) return
+    navigate(tabHref(tab))
+  }
 
   createEffect(() => {
     if (!prompt.ready()) return
@@ -206,6 +233,7 @@ export default function Page() {
   )
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
+  const panelMode = createMemo(() => newSessionDesign() && isDesktop() && openTabs.panels.tiled() && !!params.id && panelTabs().length > 1)
   const size = createSizing()
   const desktopReviewOpen = createMemo(() => isDesktop() && view().reviewPanel.opened())
   const desktopFileTreeOpen = createMemo(
@@ -305,7 +333,60 @@ export default function Page() {
     ...sessionViewState(),
     newSessionWorktree: "main",
     deferRender: false,
+    panel: {
+      width: 0,
+      height: 0,
+      columns: [] as number[],
+      rows: [] as number[],
+    },
   })
+
+  const panelState = () => normalizePanelState(store.panel)
+  const panelColumnCount = createMemo(() => Math.max(1, isDesktop() ? Math.min(2, panelTabs().length) : 1))
+  const panelRowCount = createMemo(() => Math.max(1, Math.ceil(panelTabs().length / panelColumnCount())))
+  const panelColumnWeights = createMemo(() => normalizePanelWeights(panelState().columns, panelColumnCount()))
+  const panelRowWeights = createMemo(() => normalizePanelWeights(panelState().rows, panelRowCount()))
+  const panelAvailableWidth = createMemo(() => panelAvailableSize(panelState().width, panelColumnCount()))
+  const panelAvailableHeight = createMemo(() => panelAvailableSize(panelState().height, panelRowCount()))
+  const panelColumnPixels = createMemo(() => panelPixels(panelColumnWeights(), panelAvailableWidth()))
+  const panelRowPixels = createMemo(() => panelPixels(panelRowWeights(), panelAvailableHeight()))
+  const panelColumnHandles = createMemo(() =>
+    Array.from({ length: Math.max(0, panelColumnCount() - 1) }, (_, index) => index),
+  )
+  const panelRowHandles = createMemo(() =>
+    Array.from({ length: Math.max(0, panelRowCount() - 1) }, (_, index) => index),
+  )
+  const panelGridStyle = createMemo(() => ({
+    "grid-template-columns": panelTrackTemplate(panelColumnWeights()),
+    "grid-template-rows": panelTrackTemplate(panelRowWeights()),
+  }))
+
+  let panelGrid: HTMLDivElement | undefined
+
+  createResizeObserver(
+    () => panelGrid,
+    ({ width, height }) => {
+      const nextWidth = Math.round(width)
+      const nextHeight = Math.round(height)
+
+      if (panelState().width === nextWidth && panelState().height === nextHeight) return
+      setStore("panel", { ...panelState(), width: nextWidth, height: nextHeight })
+    },
+  )
+
+  function resizePanelColumn(index: number, boundary: number) {
+    const available = panelAvailableWidth()
+    if (available <= 0) return
+    const min = Math.min(panelMinWidth, available / panelColumnCount())
+    setStore("panel", { ...panelState(), columns: resizePanelWeights(panelColumnPixels(), index, boundary, min) })
+  }
+
+  function resizePanelRow(index: number, boundary: number) {
+    const available = panelAvailableHeight()
+    if (available <= 0) return
+    const min = Math.min(panelMinHeight, available / panelRowCount())
+    setStore("panel", { ...panelState(), rows: resizePanelWeights(panelRowPixels(), index, boundary, min) })
+  }
 
   const [followup, setFollowup] = persisted(
     Persist.serverWorkspace(serverSDK().scope, sdk().directory, "followup", ["followup.v1"]),
@@ -1695,7 +1776,153 @@ export default function Page() {
     () => !isDesktop() && settings.general.newLayoutDesigns() && settings.general.mobileTitlebarPosition() === "bottom",
   )
 
-  return (
+  const sessionContent = () => (
+    <Switch>
+      <Match when={params.id && mobileChanges()}>
+        <div class="relative h-full overflow-hidden">
+          {reviewContent({
+            diffStyle: "unified",
+            classes: {
+              root: "pb-8 [&_[data-slot=session-review-list]]:pb-0",
+              header: "px-4 !h-16 !pb-4",
+              container: "px-4",
+            },
+            loadingClass: "px-4 py-4 text-text-weak",
+            emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
+          })}
+        </div>
+      </Match>
+      <Match when={params.id}>
+        <Show when={messagesReady() ? params.id : undefined} keyed>
+          {(_id) => (
+            <MessageTimeline
+              actions={actions}
+              scroll={ui.scroll}
+              onResumeScroll={resumeScroll}
+              setScrollRef={setScrollRef}
+              onScheduleScrollState={scheduleScrollState}
+              onAutoScrollHandleScroll={autoScroll.handleScroll}
+              onMarkScrollGesture={markScrollGesture}
+              hasScrollGesture={hasScrollGesture}
+              onUserScroll={markUserScroll}
+              onHistoryScroll={onHistoryScroll}
+              onAutoScrollInteraction={autoScroll.handleInteraction}
+              shouldAnchorBottom={() =>
+                !location.hash && !store.messageId && !ui.pendingMessage && !autoScroll.userScrolled()
+              }
+              centered={centered()}
+              setContentRef={(el) => {
+                content = el
+                autoScroll.contentRef(el)
+
+                const root = scroller
+                if (root) scheduleScrollState(root)
+              }}
+              userMessages={visibleUserMessages()}
+              setHistoryAnchor={(handlers) => {
+                captureHistoryAnchor = handlers.capture
+                restoreHistoryAnchor = handlers.restore
+              }}
+              anchor={anchor}
+              setRevealMessage={(fn) => {
+                revealMessage = fn
+              }}
+              setScrollToEnd={(fn) => {
+                scrollToEnd = fn
+              }}
+            />
+          )}
+        </Show>
+      </Match>
+      <Match when={true}>
+        <NewSessionView worktree={newSessionWorktree()} />
+      </Match>
+    </Switch>
+  )
+
+  const panelView = () => (
+    <div class="relative size-full overflow-hidden flex flex-col bg-v2-background-bg-deep">
+      {sessionSync() ?? ""}
+      <div class="flex-1 min-h-0 overflow-hidden p-2">
+        <div
+          data-session-panel-grid
+          class="relative size-full min-h-0 overflow-hidden"
+          ref={(el) => {
+            panelGrid = el
+          }}
+        >
+          <div class="size-full min-h-0 grid gap-2 overflow-hidden" style={panelGridStyle()}>
+            <For each={panelTabs()}>
+              {(tab) => {
+                const active = () => focusedPanel(tab)
+                return (
+                  <section
+                    data-session-panel
+                    data-active={active()}
+                    role={active() ? undefined : "button"}
+                    tabIndex={active() ? undefined : 0}
+                    class="min-h-0 min-w-0 max-w-full overflow-hidden rounded-[10px] border border-v2-border-border-base bg-v2-background-bg-layer-01 shadow-[var(--v2-elevation-raised)] outline-none transition-opacity focus-visible:border-v2-border-border-focus data-[active='false']:cursor-pointer data-[active='false']:opacity-70 data-[active='false']:hover:opacity-85"
+                    onClick={() => {
+                      if (!active()) focusPanel(tab)
+                    }}
+                    onKeyDown={(event) => {
+                      if (active()) return
+                      if (event.key !== "Enter" && event.key !== " ") return
+                      event.preventDefault()
+                      focusPanel(tab)
+                    }}
+                  >
+                    <Show when={active()} fallback={<SessionTextPane tab={tab} centered={centered()} />}>
+                      <div class="size-full min-w-0 max-w-full overflow-x-hidden">{sessionContent()}</div>
+                    </Show>
+                  </section>
+                )
+              }}
+            </For>
+          </div>
+
+          <Show when={panelState().width > 0 && panelState().height > 0}>
+            <For each={panelColumnHandles()}>
+              {(index) => {
+                const min = () => Math.min(panelMinWidth, panelAvailableWidth() / panelColumnCount())
+                return (
+                  <ResizeHandle
+                    direction="horizontal"
+                    size={panelBoundary(panelColumnPixels(), index)}
+                    min={min() * (index + 1)}
+                    max={panelAvailableWidth() - min() * (panelColumnCount() - index - 1)}
+                    onResize={(size) => resizePanelColumn(index, size)}
+                    class="absolute top-0 bottom-0 z-30 w-3 -translate-x-1/2 cursor-col-resize [app-region:no-drag] after:absolute after:inset-y-4 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-v2-border-border-focus after:opacity-0 after:transition-opacity hover:after:opacity-100"
+                    style={{ left: `${panelHandleOffset(panelColumnPixels(), index)}px` }}
+                  />
+                )
+              }}
+            </For>
+            <For each={panelRowHandles()}>
+              {(index) => {
+                const min = () => Math.min(panelMinHeight, panelAvailableHeight() / panelRowCount())
+                return (
+                  <ResizeHandle
+                    direction="vertical"
+                    edge="end"
+                    size={panelBoundary(panelRowPixels(), index)}
+                    min={min() * (index + 1)}
+                    max={panelAvailableHeight() - min() * (panelRowCount() - index - 1)}
+                    onResize={(size) => resizePanelRow(index, size)}
+                    class="absolute left-0 right-0 z-30 h-3 -translate-y-1/2 cursor-row-resize [app-region:no-drag] after:absolute after:top-1/2 after:inset-x-4 after:h-px after:-translate-y-1/2 after:bg-v2-border-border-focus after:opacity-0 after:transition-opacity hover:after:opacity-100"
+                    style={{ top: `${panelHandleOffset(panelRowPixels(), index)}px` }}
+                  />
+                )
+              }}
+            </For>
+          </Show>
+        </div>
+      </div>
+      {composerRegion("dock")}
+    </div>
+  )
+
+  const standardView = () => (
     <div class="relative size-full overflow-hidden flex flex-col">
       {sessionSync() ?? ""}
       <SessionHeader />
@@ -1729,69 +1956,7 @@ export default function Page() {
             <Show when={!isDesktop() && !!params.id && settings.general.newLayoutDesigns() && !mobileTabsBottom()}>
               {mobileTabs(true)}
             </Show>
-            <div class="flex-1 min-h-0 overflow-hidden">
-              <Switch>
-                <Match when={params.id && mobileChanges()}>
-                  <div class="relative h-full overflow-hidden">
-                    {reviewContent({
-                      diffStyle: "unified",
-                      classes: {
-                        root: "pb-8 [&_[data-slot=session-review-list]]:pb-0",
-                        header: "px-4 !h-16 !pb-4",
-                        container: "px-4",
-                      },
-                      loadingClass: "px-4 py-4 text-text-weak",
-                      emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
-                    })}
-                  </div>
-                </Match>
-                <Match when={params.id}>
-                  <Show when={messagesReady() ? params.id : undefined} keyed>
-                    {(_id) => (
-                      <MessageTimeline
-                        actions={actions}
-                        scroll={ui.scroll}
-                        onResumeScroll={resumeScroll}
-                        setScrollRef={setScrollRef}
-                        onScheduleScrollState={scheduleScrollState}
-                        onAutoScrollHandleScroll={autoScroll.handleScroll}
-                        onMarkScrollGesture={markScrollGesture}
-                        hasScrollGesture={hasScrollGesture}
-                        onUserScroll={markUserScroll}
-                        onHistoryScroll={onHistoryScroll}
-                        onAutoScrollInteraction={autoScroll.handleInteraction}
-                        shouldAnchorBottom={() =>
-                          !location.hash && !store.messageId && !ui.pendingMessage && !autoScroll.userScrolled()
-                        }
-                        centered={centered()}
-                        setContentRef={(el) => {
-                          content = el
-                          autoScroll.contentRef(el)
-
-                          const root = scroller
-                          if (root) scheduleScrollState(root)
-                        }}
-                        userMessages={visibleUserMessages()}
-                        setHistoryAnchor={(handlers) => {
-                          captureHistoryAnchor = handlers.capture
-                          restoreHistoryAnchor = handlers.restore
-                        }}
-                        anchor={anchor}
-                        setRevealMessage={(fn) => {
-                          revealMessage = fn
-                        }}
-                        setScrollToEnd={(fn) => {
-                          scrollToEnd = fn
-                        }}
-                      />
-                    )}
-                  </Show>
-                </Match>
-                <Match when={true}>
-                  <NewSessionView worktree={newSessionWorktree()} />
-                </Match>
-              </Switch>
-            </div>
+            <div class="flex-1 min-h-0 overflow-hidden">{sessionContent()}</div>
 
             <Show when={(params.id || !newSessionDesign()) && !mobileChanges()}>{(_) => composerRegion()}</Show>
             <Show when={!!params.id && mobileTabsBottom()}>{mobileTabs(true, true)}</Show>
@@ -1833,5 +1998,14 @@ export default function Page() {
 
       <TerminalPanel />
     </div>
+  )
+
+  return (
+    <Show
+      when={panelMode()}
+      fallback={standardView()}
+    >
+      {panelView()}
+    </Show>
   )
 }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -77,6 +77,7 @@ import {
   panelAvailableSize,
   panelBoundary,
   panelHandleOffset,
+  panelItemStyle,
   panelMinHeight,
   panelMinWidth,
   panelPixels,
@@ -91,7 +92,7 @@ import { formatServerError } from "@/utils/server-errors"
 import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/session-route"
 import { useUsageExceededDialogs } from "./session/usage-exceeded-dialogs"
 import { createSessionOwnership } from "./session/session-ownership"
-import { tabHref, useTabs as useOpenTabs, type SessionTab } from "@/context/tabs"
+import { tabHref, tabKey, useTabs as useOpenTabs, type SessionTab } from "@/context/tabs"
 import { SessionTextPane } from "@/pages/session/session-text-pane"
 
 type FollowupItem = FollowupDraft & { id: string }
@@ -163,6 +164,21 @@ export default function Page() {
     if (focusedPanel(tab)) return
     navigate(tabHref(tab))
   }
+  const panelKey = (tab: SessionTab) => tabKey(tab)
+  const clearPanelDrag = () => {
+    setStore("panelDragKey", undefined)
+    setStore("panelDropKey", undefined)
+  }
+  const startPanelDrag = (event: PointerEvent, tab: SessionTab) => {
+    if (event.button !== 0 || !event.isPrimary) return
+    event.preventDefault()
+    event.stopPropagation()
+    setStore("panelDragKey", panelKey(tab))
+    setStore("panelDropKey", undefined)
+  }
+  const panelKeyAt = (event: PointerEvent) =>
+    document.elementFromPoint(event.clientX, event.clientY)?.closest<HTMLElement>("[data-session-panel-key]")?.dataset
+      .sessionPanelKey
 
   createEffect(() => {
     if (!prompt.ready()) return
@@ -339,6 +355,35 @@ export default function Page() {
       columns: [] as number[],
       rows: [] as number[],
     },
+    panelDragKey: undefined as string | undefined,
+    panelDropKey: undefined as string | undefined,
+  })
+
+  makeEventListener(window, "pointermove", (event) => {
+    if (!store.panelDragKey) return
+    const key = panelKeyAt(event)
+    const next = key && key !== store.panelDragKey ? key : undefined
+    if (store.panelDropKey !== next) setStore("panelDropKey", next)
+  })
+
+  makeEventListener(window, "pointerup", (event) => {
+    const sourceKey = store.panelDragKey
+    if (!sourceKey) return
+    const targetKey = panelKeyAt(event)
+    clearPanelDrag()
+    if (!targetKey || sourceKey === targetKey) return
+
+    const source = panelTabs().find((tab) => panelKey(tab) === sourceKey)
+    const target = panelTabs().find((tab) => panelKey(tab) === targetKey)
+    if (!source || !target) return
+
+    const keys = openTabs.store.map(tabKey)
+    const sourceIndex = keys.indexOf(sourceKey)
+    const targetIndex = keys.indexOf(targetKey)
+    if (sourceIndex === -1 || targetIndex === -1) return
+    keys[sourceIndex] = targetKey
+    keys[targetIndex] = sourceKey
+    openTabs.reorder(keys)
   })
 
   const panelState = () => normalizePanelState(store.panel)
@@ -360,17 +405,41 @@ export default function Page() {
     "grid-template-columns": panelTrackTemplate(panelColumnWeights()),
     "grid-template-rows": panelTrackTemplate(panelRowWeights()),
   }))
+  const panelRowHandleStyle = (index: number) => {
+    const top = `${panelHandleOffset(panelRowPixels(), index)}px`
+    if (panelTabs().length === 3 && panelColumnCount() === 2) {
+      return { top, right: "auto", width: `${panelColumnPixels()[0]}px` }
+    }
+    return { top }
+  }
 
   let panelGrid: HTMLDivElement | undefined
+
+  const setPanelSize = (width: number, height: number) => {
+    const nextWidth = Math.round(width)
+    const nextHeight = Math.round(height)
+
+    if (nextWidth <= 0 || nextHeight <= 0) return
+    if (panelState().width === nextWidth && panelState().height === nextHeight) return
+    setStore("panel", { ...panelState(), width: nextWidth, height: nextHeight })
+  }
+
+  const measurePanelGrid = (el = panelGrid) => {
+    const rect = el?.getBoundingClientRect()
+    if (!rect) return
+    setPanelSize(rect.width, rect.height)
+  }
+
+  createEffect(() => {
+    if (!panelMode()) return
+    panelTabs().length
+    requestAnimationFrame(() => measurePanelGrid())
+  })
 
   createResizeObserver(
     () => panelGrid,
     ({ width, height }) => {
-      const nextWidth = Math.round(width)
-      const nextHeight = Math.round(height)
-
-      if (panelState().width === nextWidth && panelState().height === nextHeight) return
-      setStore("panel", { ...panelState(), width: nextWidth, height: nextHeight })
+      setPanelSize(width, height)
     },
   )
 
@@ -1811,6 +1880,7 @@ export default function Page() {
                 !location.hash && !store.messageId && !ui.pendingMessage && !autoScroll.userScrolled()
               }
               centered={centered()}
+              fullWidthHeader={panelMode()}
               setContentRef={(el) => {
                 content = el
                 autoScroll.contentRef(el)
@@ -1849,19 +1919,25 @@ export default function Page() {
           class="relative size-full min-h-0 overflow-hidden"
           ref={(el) => {
             panelGrid = el
+            requestAnimationFrame(() => measurePanelGrid(el))
           }}
         >
           <div class="size-full min-h-0 grid gap-2 overflow-hidden" style={panelGridStyle()}>
             <For each={panelTabs()}>
-              {(tab) => {
+              {(tab, index) => {
                 const active = () => focusedPanel(tab)
+                const style = () => panelItemStyle(index(), panelTabs().length, panelColumnCount())
                 return (
                   <section
                     data-session-panel
+                    data-session-panel-key={panelKey(tab)}
                     data-active={active()}
+                    data-dragging={store.panelDragKey === panelKey(tab)}
+                    data-drop-target={store.panelDropKey === panelKey(tab)}
                     role={active() ? undefined : "button"}
                     tabIndex={active() ? undefined : 0}
-                    class="min-h-0 min-w-0 max-w-full overflow-hidden rounded-[10px] border border-v2-border-border-base bg-v2-background-bg-layer-01 shadow-[var(--v2-elevation-raised)] outline-none transition-opacity focus-visible:border-v2-border-border-focus data-[active='false']:cursor-pointer data-[active='false']:opacity-70 data-[active='false']:hover:opacity-85"
+                    class="group/panel relative min-h-0 min-w-0 max-w-full overflow-hidden rounded-[10px] border border-v2-border-border-base bg-v2-background-bg-layer-01 shadow-[var(--v2-elevation-raised)] outline-none transition-[border-color,opacity] focus-visible:border-v2-border-border-focus data-[active='false']:cursor-pointer data-[active='false']:opacity-70 data-[active='false']:hover:opacity-85 data-[dragging='true']:opacity-40 data-[drop-target='true']:border-v2-border-border-focus data-[drop-target='true']:opacity-100"
+                    style={style()}
                     onClick={() => {
                       if (!active()) focusPanel(tab)
                     }}
@@ -1872,6 +1948,17 @@ export default function Page() {
                       focusPanel(tab)
                     }}
                   >
+                    <div
+                      data-session-panel-header-drag-region
+                      class="absolute left-0 right-14 top-0 z-40 h-12 cursor-grab active:cursor-grabbing [app-region:no-drag]"
+                      onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        if (!active()) focusPanel(tab)
+                      }}
+                      onMouseDown={(event) => event.stopPropagation()}
+                      onPointerDown={(event) => startPanelDrag(event, tab)}
+                    />
                     <Show when={active()} fallback={<SessionTextPane tab={tab} centered={centered()} />}>
                       <div class="size-full min-w-0 max-w-full overflow-x-hidden">{sessionContent()}</div>
                     </Show>
@@ -1887,12 +1974,13 @@ export default function Page() {
                 const min = () => Math.min(panelMinWidth, panelAvailableWidth() / panelColumnCount())
                 return (
                   <ResizeHandle
+                    data-session-panel-resize-handle="column"
                     direction="horizontal"
                     size={panelBoundary(panelColumnPixels(), index)}
                     min={min() * (index + 1)}
                     max={panelAvailableWidth() - min() * (panelColumnCount() - index - 1)}
                     onResize={(size) => resizePanelColumn(index, size)}
-                    class="absolute top-0 bottom-0 z-30 w-3 -translate-x-1/2 cursor-col-resize [app-region:no-drag] after:absolute after:inset-y-4 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-v2-border-border-focus after:opacity-0 after:transition-opacity hover:after:opacity-100"
+                    class="absolute top-0 bottom-0 z-50 w-3 -translate-x-1/2 cursor-col-resize [app-region:no-drag] after:absolute after:inset-y-4 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-v2-border-border-focus after:opacity-0 after:transition-opacity hover:after:opacity-100"
                     style={{ left: `${panelHandleOffset(panelColumnPixels(), index)}px` }}
                   />
                 )
@@ -1903,14 +1991,15 @@ export default function Page() {
                 const min = () => Math.min(panelMinHeight, panelAvailableHeight() / panelRowCount())
                 return (
                   <ResizeHandle
+                    data-session-panel-resize-handle="row"
                     direction="vertical"
                     edge="end"
                     size={panelBoundary(panelRowPixels(), index)}
                     min={min() * (index + 1)}
                     max={panelAvailableHeight() - min() * (panelRowCount() - index - 1)}
                     onResize={(size) => resizePanelRow(index, size)}
-                    class="absolute left-0 right-0 z-30 h-3 -translate-y-1/2 cursor-row-resize [app-region:no-drag] after:absolute after:top-1/2 after:inset-x-4 after:h-px after:-translate-y-1/2 after:bg-v2-border-border-focus after:opacity-0 after:transition-opacity hover:after:opacity-100"
-                    style={{ top: `${panelHandleOffset(panelRowPixels(), index)}px` }}
+                    class="absolute left-0 right-0 z-50 h-3 -translate-y-1/2 cursor-row-resize [app-region:no-drag] after:absolute after:top-1/2 after:inset-x-4 after:h-px after:-translate-y-1/2 after:bg-v2-border-border-focus after:opacity-0 after:transition-opacity hover:after:opacity-100"
+                    style={panelRowHandleStyle(index)}
                   />
                 )
               }}

--- a/packages/app/src/pages/session/panel-layout.test.ts
+++ b/packages/app/src/pages/session/panel-layout.test.ts
@@ -6,6 +6,7 @@ import {
   panelBoundary,
   panelGap,
   panelHandleOffset,
+  panelItemStyle,
   panelPixels,
   panelTrackTemplate,
   resizePanelWeights,
@@ -41,6 +42,18 @@ describe("panel layout", () => {
 
   test("builds minmax tracks so panels can shrink without horizontal overflow", () => {
     expect(panelTrackTemplate([0.25, 0.75])).toBe("minmax(0, 0.25fr) minmax(0, 0.75fr)")
+  })
+
+  test("spans the right panel in three-panel desktop layouts", () => {
+    expect(panelItemStyle(0, 3, 2)).toEqual({ "grid-column": "1", "grid-row": "1" })
+    expect(panelItemStyle(1, 3, 2)).toEqual({ "grid-column": "2", "grid-row": "1 / span 2" })
+    expect(panelItemStyle(2, 3, 2)).toEqual({ "grid-column": "1", "grid-row": "2" })
+  })
+
+  test("keeps normal grid flow outside the three-panel desktop layout", () => {
+    expect(panelItemStyle(0, 2, 2)).toEqual({})
+    expect(panelItemStyle(2, 3, 1)).toEqual({})
+    expect(panelItemStyle(3, 4, 2)).toEqual({})
   })
 
   test("subtracts only visible gaps from available space", () => {

--- a/packages/app/src/pages/session/panel-layout.test.ts
+++ b/packages/app/src/pages/session/panel-layout.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test"
+import {
+  normalizePanelState,
+  normalizePanelWeights,
+  panelAvailableSize,
+  panelBoundary,
+  panelGap,
+  panelHandleOffset,
+  panelPixels,
+  panelTrackTemplate,
+  resizePanelWeights,
+} from "./panel-layout"
+
+describe("panel layout", () => {
+  test("normalizes stale or partially migrated panel state", () => {
+    expect(normalizePanelState(undefined)).toEqual({
+      width: 0,
+      height: 0,
+      columns: [],
+      rows: [],
+    })
+
+    expect(
+      normalizePanelState({
+        width: 900,
+        height: Number.POSITIVE_INFINITY,
+        columns: [2, 1],
+      }),
+    ).toEqual({
+      width: 900,
+      height: 0,
+      columns: [2, 1],
+      rows: [],
+    })
+  })
+
+  test("fills missing and invalid weights with equal tracks", () => {
+    expect(normalizePanelWeights([], 2)).toEqual([0.5, 0.5])
+    expect(normalizePanelWeights([3, -1, Number.NaN], 3)).toEqual([0.6, 0.2, 0.2])
+  })
+
+  test("builds minmax tracks so panels can shrink without horizontal overflow", () => {
+    expect(panelTrackTemplate([0.25, 0.75])).toBe("minmax(0, 0.25fr) minmax(0, 0.75fr)")
+  })
+
+  test("subtracts only visible gaps from available space", () => {
+    expect(panelAvailableSize(1000, 1)).toBe(1000)
+    expect(panelAvailableSize(1000, 3)).toBe(1000 - panelGap * 2)
+  })
+
+  test("computes handle offsets at track boundaries plus half the gap", () => {
+    expect(panelHandleOffset([300, 200], 0)).toBe(304)
+    expect(panelHandleOffset([300, 200, 100], 1)).toBe(512)
+  })
+
+  test("resizes adjacent tracks while preserving total panel width", () => {
+    const weights = resizePanelWeights([300, 300], 0, 420, 180)
+    const pixels = panelPixels(weights, 600)
+
+    expect(pixels.map(Math.round)).toEqual([420, 180])
+    expect(Math.round(pixels.reduce((sum, value) => sum + value, 0))).toBe(600)
+  })
+
+  test("clamps resize at minimum track size", () => {
+    const weights = resizePanelWeights([300, 300], 0, 80, 180)
+
+    expect(panelPixels(weights, 600).map(Math.round)).toEqual([180, 420])
+  })
+
+  test("relaxes the minimum when adjacent tracks are already too small", () => {
+    const weights = resizePanelWeights([120, 120, 760], 0, 220, 180)
+
+    expect(panelPixels(weights, 1000).map(Math.round)).toEqual([120, 120, 760])
+  })
+
+  test("only changes the adjacent pair in multi-track layouts", () => {
+    const weights = resizePanelWeights([200, 300, 500], 1, 620, 180)
+    const pixels = panelPixels(weights, 1000)
+
+    expect(pixels.map(Math.round)).toEqual([200, 420, 380])
+    expect(panelBoundary(pixels, 1)).toBe(620)
+  })
+})

--- a/packages/app/src/pages/session/panel-layout.ts
+++ b/packages/app/src/pages/session/panel-layout.ts
@@ -35,6 +35,12 @@ export function panelTrackTemplate(weights: readonly number[]) {
   return weights.map((weight) => `minmax(0, ${weight}fr)`).join(" ")
 }
 
+export function panelItemStyle(index: number, count: number, columns: number) {
+  if (count !== 3 || columns !== 2) return {}
+  if (index === 1) return { "grid-column": "2", "grid-row": "1 / span 2" }
+  return { "grid-column": "1", "grid-row": index === 2 ? "2" : "1" }
+}
+
 export function panelPixels(weights: readonly number[], available: number) {
   return weights.map((weight) => weight * available)
 }

--- a/packages/app/src/pages/session/panel-layout.ts
+++ b/packages/app/src/pages/session/panel-layout.ts
@@ -1,0 +1,63 @@
+export const panelGap = 8
+export const panelMinWidth = 280
+export const panelMinHeight = 180
+
+export type PanelState = {
+  width: number
+  height: number
+  columns: number[]
+  rows: number[]
+}
+
+export function normalizePanelState(input: Partial<PanelState> | undefined): PanelState {
+  return {
+    width: typeof input?.width === "number" && Number.isFinite(input.width) ? input.width : 0,
+    height: typeof input?.height === "number" && Number.isFinite(input.height) ? input.height : 0,
+    columns: Array.isArray(input?.columns) ? input.columns : [],
+    rows: Array.isArray(input?.rows) ? input.rows : [],
+  }
+}
+
+export function normalizePanelWeights(weights: readonly number[], count: number) {
+  const values = Array.from({ length: count }, (_, index) => {
+    const value = weights[index]
+    return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 1
+  })
+  const total = values.reduce((sum, value) => sum + value, 0)
+  return values.map((value) => value / total)
+}
+
+export function panelAvailableSize(size: number, count: number, gap = panelGap) {
+  return Math.max(0, size - gap * Math.max(0, count - 1))
+}
+
+export function panelTrackTemplate(weights: readonly number[]) {
+  return weights.map((weight) => `minmax(0, ${weight}fr)`).join(" ")
+}
+
+export function panelPixels(weights: readonly number[], available: number) {
+  return weights.map((weight) => weight * available)
+}
+
+export function panelBoundary(pixels: readonly number[], index: number) {
+  return pixels.slice(0, index + 1).reduce((sum, value) => sum + value, 0)
+}
+
+export function panelHandleOffset(pixels: readonly number[], index: number, gap = panelGap) {
+  return panelBoundary(pixels, index) + gap * index + gap / 2
+}
+
+export function resizePanelWeights(pixels: readonly number[], index: number, boundary: number, min: number) {
+  const before = pixels.slice(0, index).reduce((sum, value) => sum + value, 0)
+  const pair = (pixels[index] ?? 0) + (pixels[index + 1] ?? 0)
+  const effectiveMin = Math.min(Number.isFinite(min) ? Math.max(0, min) : 0, pair / 2)
+  const first = Math.min(pair - effectiveMin, Math.max(effectiveMin, boundary - before))
+  const next = pixels.map((value, pixelIndex) => {
+    if (pixelIndex === index) return first
+    if (pixelIndex === index + 1) return pair - first
+    return value
+  })
+  const total = next.reduce((sum, value) => sum + value, 0)
+  if (!Number.isFinite(total) || total <= 0) return normalizePanelWeights(next, next.length)
+  return next.map((value) => value / total)
+}

--- a/packages/app/src/pages/session/session-text-pane.tsx
+++ b/packages/app/src/pages/session/session-text-pane.tsx
@@ -64,7 +64,7 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
   const sync = createMemo(() => {
     const dir = directory()
     if (!dir) return
-    return serverSync().createDirSyncContext(dir)
+    return serverSync().ensureDirSyncContext(dir)
   })
   const messages = createMemo(
     () => sync()?.data.message[props.tab.sessionId] ?? emptyMessages,

--- a/packages/app/src/pages/session/session-text-pane.tsx
+++ b/packages/app/src/pages/session/session-text-pane.tsx
@@ -1,0 +1,377 @@
+import {
+  createEffect,
+  createMemo,
+  For,
+  Index,
+  Show,
+  type Accessor,
+  type JSX,
+} from "solid-js"
+import { createStore } from "solid-js/store"
+import type {
+  AssistantMessage,
+  Message as MessageType,
+  Part as PartType,
+  ToolPart,
+  UserMessage,
+} from "@opencode-ai/sdk/v2/client"
+import { Card } from "@opencode-ai/ui/card"
+import { createAutoScroll } from "@opencode-ai/ui/hooks"
+import {
+  ContextToolGroup,
+  Message,
+  MessageDivider,
+  Part as MessagePart,
+  partDefaultOpen,
+} from "@opencode-ai/ui/message-part"
+import { FileIcon } from "@opencode-ai/ui/file-icon"
+import { useLanguage } from "@/context/language"
+import { useServerSync } from "@/context/server-sync"
+import { useSettings } from "@/context/settings"
+import type { SessionTab } from "@/context/tabs"
+import { decode64 } from "@/utils/base64"
+import { same } from "@/utils/same"
+import { sessionTitle } from "@/utils/session-title"
+import { getFilename } from "@opencode-ai/core/util/path"
+import { MessageComment, Timeline, TimelineRow, type TimelineRowMap } from "./message-timeline.data"
+import { TimelineDiffSummaryRow } from "./message-timeline"
+
+const emptyMessages: MessageType[] = []
+const emptyParts: PartType[] = []
+const emptyTools: ToolPart[] = []
+const emptyAssistantMessages: AssistantMessage[] = []
+const idle = { type: "idle" as const }
+
+type FramedTimelineRow = Exclude<TimelineRow.TimelineRow, { _tag: "BottomSpacer" }>
+type TimelineRowByTag<T extends TimelineRow.TimelineRow["_tag"]> = Extract<TimelineRow.TimelineRow, { _tag: T }>
+
+export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) {
+  const serverSync = useServerSync()
+  const language = useLanguage()
+  const settings = useSettings()
+  const [toolOpen, setToolOpen] = createStore<Record<string, boolean | undefined>>({})
+  const directory = createMemo(() => decode64(props.tab.dirBase64))
+  const sync = createMemo(() => {
+    const dir = directory()
+    if (!dir) return
+    return serverSync.createDirSyncContext(dir)
+  })
+  const messages = createMemo(
+    () => sync()?.data.message[props.tab.sessionId] ?? emptyMessages,
+    emptyMessages,
+    { equals: same },
+  )
+  const loaded = createMemo(() => sync()?.data.message[props.tab.sessionId] !== undefined)
+  const title = createMemo(() => sessionTitle(sync()?.session.get(props.tab.sessionId)?.title))
+  const sessionStatus = createMemo(() => sync()?.data.session_status[props.tab.sessionId] ?? idle)
+  const userMessages = createMemo(
+    () => messages().filter((message): message is UserMessage => message.role === "user"),
+    [] as UserMessage[],
+    { equals: same },
+  )
+  const messageByID = createMemo(() => new Map(messages().map((message) => [message.id, message] as const)))
+  const assistantMessagesByParent = createMemo(() =>
+    messages().reduce((result, message) => {
+      if (message.role !== "assistant" || !message.parentID) return result
+      result.set(message.parentID, [...(result.get(message.parentID) ?? emptyAssistantMessages), message])
+      return result
+    }, new Map<string, AssistantMessage[]>()),
+  )
+  const getMsgParts = (messageID: string) => sync()?.data.part[messageID] ?? emptyParts
+  const getMsgPart = (messageID: string, partID: string) =>
+    getMsgParts(messageID).find((part) => part.id === partID)
+  const rows = createMemo((previous: TimelineRow.TimelineRow[] | undefined) => {
+    const next = [
+      ...userMessages().flatMap((message, index) =>
+        Timeline.constructMessageRows(
+          message,
+          getMsgParts,
+          assistantMessagesByParent().get(message.id) ?? emptyAssistantMessages,
+          index,
+          settings.general.showReasoningSummaries(),
+          sessionStatus().type,
+          false,
+        ),
+      ),
+      new TimelineRow.BottomSpacer(),
+    ]
+    if (!previous || previous.length !== next.length) return next
+    if (!previous.every((item, index) => TimelineRow.equals(item, next[index]!))) return next
+    return previous
+  })
+  const autoScroll = createAutoScroll({
+    working: loaded,
+    bottomThreshold: 8,
+  })
+
+  createEffect(() => {
+    const ctx = sync()
+    if (!ctx) return
+    void ctx.session.sync(props.tab.sessionId).catch(() => {})
+  })
+
+  const turnDurationMs = (userMessageID: string) => {
+    const message = messageByID().get(userMessageID)
+    if (!message || message.role !== "user") return
+    const end = (assistantMessagesByParent().get(userMessageID) ?? emptyAssistantMessages).reduce<number | undefined>(
+      (max, item) => {
+        const completed = item.time.completed
+        if (typeof completed !== "number") return max
+        if (max === undefined) return completed
+        return Math.max(max, completed)
+      },
+      undefined,
+    )
+    if (typeof end !== "number" || end < message.time.created) return
+    return end - message.time.created
+  }
+
+  const assistantCopyPartID = (userMessageID: string) =>
+    (assistantMessagesByParent().get(userMessageID) ?? emptyAssistantMessages)
+      .slice()
+      .reverse()
+      .flatMap((message) => getMsgParts(message.id).slice().reverse())
+      .find((part) => part.type === "text" && !!part.text?.trim())?.id ?? null
+
+  const renderAssistantPartGroup = (row: Accessor<TimelineRowMap["AssistantPart"]>) => {
+    if (row().group.type === "context") {
+      const parts = createMemo(() => {
+        const group = row().group
+        if (group.type !== "context") return emptyTools
+        return group.refs
+          .map((ref) => getMsgPart(ref.messageID, ref.partID))
+          .filter((part): part is ToolPart => part?.type === "tool")
+      })
+
+      return <ContextToolGroup parts={parts()} />
+    }
+
+    const message = createMemo(() => {
+      const group = row().group
+      if (group.type !== "part") return
+      return messageByID().get(group.ref.messageID)
+    })
+    const part = createMemo(() => {
+      const group = row().group
+      if (group.type !== "part") return
+      return getMsgPart(group.ref.messageID, group.ref.partID)
+    })
+    const defaultOpen = createMemo(() => {
+      const item = part()
+      if (!item) return
+      return partDefaultOpen(item, settings.general.shellToolPartsExpanded(), settings.general.editToolPartsExpanded())
+    })
+
+    return (
+      <Show when={message()}>
+        {(message) => (
+          <Show when={part()}>
+            {(part) => (
+              <MessagePart
+                part={part()}
+                message={message()}
+                showAssistantCopyPartID={assistantCopyPartID(row().userMessageID)}
+                turnDurationMs={turnDurationMs(row().userMessageID)}
+                defaultOpen={defaultOpen()}
+                toolOpen={toolOpen[part().id] ?? defaultOpen()}
+                onToolOpenChange={(open) => setToolOpen(part().id, open)}
+                deferToolContent={false}
+                virtualizeDiff={false}
+              />
+            )}
+          </Show>
+        )}
+      </Show>
+    )
+  }
+
+  function TimelineRowFrame(input: { row: Accessor<FramedTimelineRow>; children: JSX.Element }) {
+    const anchor = () => {
+      const row = input.row()
+      return row._tag === "CommentStrip" || (row._tag === "UserMessage" && row.anchor)
+    }
+    const previousUserMessage = () => {
+      const row = input.row()
+      return (row._tag === "CommentStrip" || row._tag === "UserMessage") && row.previousUserMessage
+    }
+    const previousAssistantPart = () => {
+      const row = input.row()
+      return row._tag === "AssistantPart" && row.previousAssistantPart
+    }
+
+    return (
+      <div
+        data-message-id={anchor() ? input.row().userMessageID : undefined}
+        data-timeline-row={input.row()._tag}
+        classList={{
+          "min-w-0 w-full max-w-full": true,
+          "md:max-w-200 2xl:max-w-[1000px]": !!props.centered,
+          "md:mx-auto": !!props.centered,
+          "pt-6": previousUserMessage(),
+          "pt-3": previousAssistantPart(),
+        }}
+      >
+        <div data-component="session-turn" class="min-w-0 w-full relative" style={{ height: "auto" }}>
+          {input.children}
+        </div>
+      </div>
+    )
+  }
+
+  const renderTimelineRow = (row: Accessor<TimelineRow.TimelineRow>) => {
+    switch (row()._tag) {
+      case "CommentStrip": {
+        const commentStripRow = row as Accessor<TimelineRowByTag<"CommentStrip">>
+        const comments = createMemo(() =>
+          getMsgParts(commentStripRow().userMessageID).flatMap((part) => MessageComment.fromPart(part) ?? []),
+        )
+        return (
+          <TimelineRowFrame row={commentStripRow}>
+            <div class="w-full px-4 md:px-5 pb-2">
+              <div class="ml-auto max-w-[82%] overflow-x-auto no-scrollbar">
+                <div class="flex w-max min-w-full justify-end gap-2">
+                  <Index each={comments()}>
+                    {(comment) => (
+                      <div class="shrink-0 max-w-[260px] rounded-[6px] border border-border-weak-base bg-background-stronger px-2.5 py-2">
+                        <div class="flex items-center gap-1.5 min-w-0 text-11-medium text-text-strong">
+                          <FileIcon node={{ path: comment().path, type: "file" }} class="size-3.5 shrink-0" />
+                          <span class="truncate">{getFilename(comment().path)}</span>
+                          <Show when={comment().selection}>
+                            {(selection) => (
+                              <span class="shrink-0 text-text-weak">
+                                {selection().startLine === selection().endLine
+                                  ? `:${selection().startLine}`
+                                  : `:${selection().startLine}-${selection().endLine}`}
+                              </span>
+                            )}
+                          </Show>
+                        </div>
+                        <div class="pt-1 text-12-regular text-text-strong whitespace-pre-wrap break-words">
+                          {comment().comment}
+                        </div>
+                      </div>
+                    )}
+                  </Index>
+                </div>
+              </div>
+            </div>
+          </TimelineRowFrame>
+        )
+      }
+      case "UserMessage": {
+        const userMessageRow = row as Accessor<TimelineRowByTag<"UserMessage">>
+        const message = createMemo(() => {
+          const item = messageByID().get(userMessageRow().userMessageID)
+          if (item?.role === "user") return item
+        })
+        return (
+          <TimelineRowFrame row={userMessageRow}>
+            <Show when={message()}>
+              {(message) => (
+                <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
+                  <div data-slot="session-turn-message-content" aria-live="off">
+                    <Message message={message()} parts={getMsgParts(userMessageRow().userMessageID)} />
+                  </div>
+                </div>
+              )}
+            </Show>
+          </TimelineRowFrame>
+        )
+      }
+      case "TurnDivider": {
+        const turnDividerRow = row as Accessor<TimelineRowByTag<"TurnDivider">>
+        return (
+          <TimelineRowFrame row={turnDividerRow}>
+            <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
+              <div data-slot="session-turn-compaction">
+                <MessageDivider
+                  label={language.t(
+                    turnDividerRow().label === "compaction" ? "ui.messagePart.compaction" : "ui.message.interrupted",
+                  )}
+                />
+              </div>
+            </div>
+          </TimelineRowFrame>
+        )
+      }
+      case "AssistantPart": {
+        const assistantPartRow = row as Accessor<TimelineRowByTag<"AssistantPart">>
+        return (
+          <TimelineRowFrame row={assistantPartRow}>
+            <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
+              <div data-slot="session-turn-assistant-content">{renderAssistantPartGroup(assistantPartRow)}</div>
+            </div>
+          </TimelineRowFrame>
+        )
+      }
+      case "DiffSummary": {
+        const diffSummaryRow = row as Accessor<TimelineRowByTag<"DiffSummary">>
+        return (
+          <TimelineRowFrame row={diffSummaryRow}>
+            <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
+              <TimelineDiffSummaryRow diffs={diffSummaryRow().diffs} />
+            </div>
+          </TimelineRowFrame>
+        )
+      }
+      case "Error": {
+        const errorRow = row as Accessor<TimelineRowByTag<"Error">>
+        return (
+          <TimelineRowFrame row={errorRow}>
+            <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
+              <Card variant="error" class="error-card">
+                {errorRow().text}
+              </Card>
+            </div>
+          </TimelineRowFrame>
+        )
+      }
+      case "Thinking":
+      case "Retry":
+        return null
+      case "BottomSpacer":
+        return <div data-timeline-row="bottom-spacer" aria-hidden="true" class="h-16" />
+    }
+  }
+
+  function TimelineRowView(input: { row: TimelineRow.TimelineRow }) {
+    return renderTimelineRow(() => input.row)
+  }
+
+  return (
+    <div
+      class="relative size-full min-w-0 overflow-x-hidden overflow-y-auto"
+      ref={autoScroll.scrollRef}
+      onScroll={autoScroll.handleScroll}
+      onPointerDown={autoScroll.handleInteraction}
+      style={{ "--sticky-accordion-top": "48px" }}
+    >
+      <div class="min-w-0 w-full max-w-full overflow-x-hidden" ref={autoScroll.contentRef}>
+        <div
+          data-session-title
+          classList={{
+            "sticky top-0 z-30 bg-[linear-gradient(to_bottom,var(--background-stronger)_48px,transparent)]": true,
+            "w-full pb-4 pl-2 pr-3 md:pl-4 md:pr-3": true,
+            "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": !!props.centered,
+          }}
+        >
+          <div class="h-12 w-full flex items-center justify-between gap-2">
+            <div class="flex items-center gap-1 min-w-0 flex-1 pr-3">
+              <div class="flex items-center min-w-0 grow-1">
+                <h1 class="min-w-0 grow truncate text-14-medium text-text-strong">
+                  {title() ?? language.t("session.tab.session")}
+                </h1>
+              </div>
+            </div>
+          </div>
+        </div>
+        <Show
+          when={loaded()}
+          fallback={<div class="px-4 py-3 text-12-regular text-text-weak">{language.t("common.loading")}...</div>}
+        >
+          <For each={rows()}>{(row) => <TimelineRowView row={row} />}</For>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/pages/session/session-text-pane.tsx
+++ b/packages/app/src/pages/session/session-text-pane.tsx
@@ -1,6 +1,7 @@
 import {
   createEffect,
   createMemo,
+  createResource,
   For,
   Index,
   Show,
@@ -26,15 +27,15 @@ import {
 } from "@opencode-ai/ui/message-part"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { useLanguage } from "@/context/language"
+import { useServerSDK } from "@/context/server-sdk"
 import { useServerSync } from "@/context/server-sync"
 import { useSettings } from "@/context/settings"
 import type { SessionTab } from "@/context/tabs"
-import { decode64 } from "@/utils/base64"
 import { same } from "@/utils/same"
 import { sessionTitle } from "@/utils/session-title"
 import { getFilename } from "@opencode-ai/core/util/path"
-import { MessageComment, Timeline, TimelineRow, type TimelineRowMap } from "./message-timeline.data"
-import { TimelineDiffSummaryRow } from "./message-timeline"
+import { MessageComment, Timeline, TimelineRow, type TimelineRowMap } from "./timeline/rows"
+import { TimelineDiffSummaryRow } from "./timeline/message-timeline"
 
 const emptyMessages: MessageType[] = []
 const emptyParts: PartType[] = []
@@ -42,19 +43,28 @@ const emptyTools: ToolPart[] = []
 const emptyAssistantMessages: AssistantMessage[] = []
 const idle = { type: "idle" as const }
 
-type FramedTimelineRow = Exclude<TimelineRow.TimelineRow, { _tag: "BottomSpacer" }>
+type FramedTimelineRow = Exclude<TimelineRow.TimelineRow, { _tag: "TurnGap" }>
 type TimelineRowByTag<T extends TimelineRow.TimelineRow["_tag"]> = Extract<TimelineRow.TimelineRow, { _tag: T }>
 
 export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) {
+  const serverSDK = useServerSDK()
   const serverSync = useServerSync()
   const language = useLanguage()
   const settings = useSettings()
   const [toolOpen, setToolOpen] = createStore<Record<string, boolean | undefined>>({})
-  const directory = createMemo(() => decode64(props.tab.dirBase64))
+  const [session] = createResource(
+    () => props.tab.sessionId,
+    (sessionID) =>
+      serverSDK()
+        .client.session.get({ sessionID })
+        .then((result) => result.data)
+        .catch(() => undefined),
+  )
+  const directory = createMemo(() => session()?.directory)
   const sync = createMemo(() => {
     const dir = directory()
     if (!dir) return
-    return serverSync.createDirSyncContext(dir)
+    return serverSync().createDirSyncContext(dir)
   })
   const messages = createMemo(
     () => sync()?.data.message[props.tab.sessionId] ?? emptyMessages,
@@ -62,7 +72,7 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
     { equals: same },
   )
   const loaded = createMemo(() => sync()?.data.message[props.tab.sessionId] !== undefined)
-  const title = createMemo(() => sessionTitle(sync()?.session.get(props.tab.sessionId)?.title))
+  const title = createMemo(() => sessionTitle(session()?.title ?? sync()?.session.get(props.tab.sessionId)?.title))
   const sessionStatus = createMemo(() => sync()?.data.session_status[props.tab.sessionId] ?? idle)
   const userMessages = createMemo(
     () => messages().filter((message): message is UserMessage => message.role === "user"),
@@ -81,20 +91,17 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
   const getMsgPart = (messageID: string, partID: string) =>
     getMsgParts(messageID).find((part) => part.id === partID)
   const rows = createMemo((previous: TimelineRow.TimelineRow[] | undefined) => {
-    const next = [
-      ...userMessages().flatMap((message, index) =>
-        Timeline.constructMessageRows(
-          message,
-          getMsgParts,
-          assistantMessagesByParent().get(message.id) ?? emptyAssistantMessages,
-          index,
-          settings.general.showReasoningSummaries(),
-          sessionStatus().type,
-          false,
-        ),
+    const next = userMessages().flatMap((message, index) =>
+      Timeline.constructMessageRows(
+        message,
+        getMsgParts,
+        assistantMessagesByParent().get(message.id) ?? emptyAssistantMessages,
+        index,
+        settings.general.showReasoningSummaries(),
+        sessionStatus().type,
+        false,
       ),
-      new TimelineRow.BottomSpacer(),
-    ]
+    )
     if (!previous || previous.length !== next.length) return next
     if (!previous.every((item, index) => TimelineRow.equals(item, next[index]!))) return next
     return previous
@@ -190,10 +197,6 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
       const row = input.row()
       return row._tag === "CommentStrip" || (row._tag === "UserMessage" && row.anchor)
     }
-    const previousUserMessage = () => {
-      const row = input.row()
-      return (row._tag === "CommentStrip" || row._tag === "UserMessage") && row.previousUserMessage
-    }
     const previousAssistantPart = () => {
       const row = input.row()
       return row._tag === "AssistantPart" && row.previousAssistantPart
@@ -207,7 +210,6 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
           "min-w-0 w-full max-w-full": true,
           "md:max-w-200 2xl:max-w-[1000px]": !!props.centered,
           "md:mx-auto": !!props.centered,
-          "pt-6": previousUserMessage(),
           "pt-3": previousAssistantPart(),
         }}
       >
@@ -220,6 +222,8 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
 
   const renderTimelineRow = (row: Accessor<TimelineRow.TimelineRow>) => {
     switch (row()._tag) {
+      case "TurnGap":
+        return <div data-timeline-row="TurnGap" aria-hidden="true" class="h-6" />
       case "CommentStrip": {
         const commentStripRow = row as Accessor<TimelineRowByTag<"CommentStrip">>
         const comments = createMemo(() =>
@@ -329,8 +333,6 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
       case "Thinking":
       case "Retry":
         return null
-      case "BottomSpacer":
-        return <div data-timeline-row="bottom-spacer" aria-hidden="true" class="h-16" />
     }
   }
 
@@ -351,11 +353,15 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
           data-session-title
           classList={{
             "sticky top-0 z-30 bg-[linear-gradient(to_bottom,var(--background-stronger)_48px,transparent)]": true,
-            "w-full pb-4 pl-2 pr-3 md:pl-4 md:pr-3": true,
-            "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": !!props.centered,
+            "w-full pb-4": true,
           }}
         >
-          <div class="h-12 w-full flex items-center justify-between gap-2">
+          <div
+            classList={{
+              "h-12 w-full flex items-center justify-between gap-2 pl-2 pr-3 md:pl-4 md:pr-3": true,
+              "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": !!props.centered,
+            }}
+          >
             <div class="flex items-center gap-1 min-w-0 flex-1 pr-3">
               <div class="flex items-center min-w-0 grow-1">
                 <h1 class="min-w-0 grow truncate text-14-medium text-text-strong">
@@ -370,6 +376,7 @@ export function SessionTextPane(props: { tab: SessionTab; centered?: boolean }) 
           fallback={<div class="px-4 py-3 text-12-regular text-text-weak">{language.t("common.loading")}...</div>}
         >
           <For each={rows()}>{(row) => <TimelineRowView row={row} />}</For>
+          <div aria-hidden="true" class="h-16" />
         </Show>
       </div>
     </div>

--- a/packages/app/src/pages/session/session-text-pane.tsx
+++ b/packages/app/src/pages/session/session-text-pane.tsx
@@ -24,7 +24,7 @@ import {
   MessageDivider,
   Part as MessagePart,
   partDefaultOpen,
-} from "@opencode-ai/ui/message-part"
+} from "@opencode-ai/session-ui/message-part"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { useLanguage } from "@/context/language"
 import { useServerSDK } from "@/context/server-sdk"

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -135,7 +135,7 @@ function TimelineThinkingRow(props: { reasoningHeading?: string; showReasoningSu
   )
 }
 
-function TimelineDiffSummaryRow(props: { diffs: SummaryDiff[] }) {
+export function TimelineDiffSummaryRow(props: { diffs: SummaryDiff[] }) {
   const language = useLanguage()
   const maxFiles = 10
   const [state, setState] = createStore({

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -243,6 +243,7 @@ export function MessageTimeline(props: {
   onAutoScrollInteraction: (event: MouseEvent) => void
   shouldAnchorBottom: () => boolean
   centered: boolean
+  fullWidthHeader?: boolean
   setContentRef: (el: HTMLDivElement) => void
   userMessages: UserMessage[]
   anchor: (id: string) => string
@@ -1301,13 +1302,19 @@ export function MessageTimeline(props: {
                 !settings.general.newLayoutDesigns(),
               "w-full": true,
               "pb-4": true,
-              "pr-3": true,
-              "pl-4": settings.general.newLayoutDesigns(),
-              "pl-2 md:pl-4": !settings.general.newLayoutDesigns(),
-              "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
+              "pr-3": !props.fullWidthHeader,
+              "pl-4": settings.general.newLayoutDesigns() && !props.fullWidthHeader,
+              "pl-2 md:pl-4": !settings.general.newLayoutDesigns() && !props.fullWidthHeader,
+              "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered && !props.fullWidthHeader,
             }}
           >
-            <div class="h-12 w-full flex items-center justify-between gap-2">
+            <div
+              classList={{
+                "h-12 w-full flex items-center justify-between gap-2": true,
+                "pl-2 pr-3 md:pl-4 md:pr-3": !!props.fullWidthHeader,
+                "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered && !!props.fullWidthHeader,
+              }}
+            >
               <div class="flex items-center gap-1 min-w-0 flex-1 pr-3">
                 <div class="flex items-center min-w-0 grow-1">
                   <Show when={parentID()}>

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -1,9 +1,55 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin"
 import { defineConfig } from "electron-vite"
-import appPlugin from "@opencode-ai/app/vite"
+import appPlugin from "../app/vite.js"
 import * as fs from "node:fs/promises"
+import { realpathSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 
 const OPENCODE_SERVER_DIST = "../opencode/dist/node"
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url)).replaceAll("\\", "/")
+const workspacePath = (target: string) => fileURLToPath(new URL(`../${target}`, import.meta.url)).replaceAll("\\", "/")
+const repoPath = (target: string) => fileURLToPath(new URL(`../../${target}`, import.meta.url)).replaceAll("\\", "/")
+const copiedWorkspacePackages = (() => {
+  try {
+    return realpathSync(repoPath("node_modules/@opencode-ai/app")).replaceAll("\\", "/") !== workspacePath("app")
+  } catch {
+    return false
+  }
+})()
+const rendererWorkspaceAliases = [
+  { find: /^@opencode-ai\/app$/, replacement: workspacePath("app/src/index.ts") },
+  { find: /^@opencode-ai\/app\/desktop-menu$/, replacement: workspacePath("app/src/desktop-menu.ts") },
+  { find: /^@opencode-ai\/app\/updater$/, replacement: workspacePath("app/src/updater.ts") },
+  { find: /^@opencode-ai\/app\/wsl\/types$/, replacement: workspacePath("app/src/wsl/types.ts") },
+  { find: /^@opencode-ai\/core\/(.+)$/, replacement: `${workspacePath("core/src")}/$1` },
+  { find: /^@opencode-ai\/sdk$/, replacement: workspacePath("sdk/js/src/index.ts") },
+  { find: /^@opencode-ai\/sdk\/client$/, replacement: workspacePath("sdk/js/src/client.ts") },
+  { find: /^@opencode-ai\/sdk\/server$/, replacement: workspacePath("sdk/js/src/server.ts") },
+  { find: /^@opencode-ai\/sdk\/v2$/, replacement: workspacePath("sdk/js/src/v2/index.ts") },
+  { find: /^@opencode-ai\/sdk\/v2\/client$/, replacement: workspacePath("sdk/js/src/v2/client.ts") },
+  { find: /^@opencode-ai\/sdk\/v2\/gen\/client$/, replacement: workspacePath("sdk/js/src/v2/gen/client/index.ts") },
+  { find: /^@opencode-ai\/sdk\/v2\/server$/, replacement: workspacePath("sdk/js/src/v2/server.ts") },
+  { find: /^@opencode-ai\/ui\/i18n\/(.+)$/, replacement: `${workspacePath("ui/src/i18n")}/$1.ts` },
+  { find: /^@opencode-ai\/ui\/pierre$/, replacement: workspacePath("ui/src/pierre/index.ts") },
+  { find: /^@opencode-ai\/ui\/pierre\/(.+)$/, replacement: `${workspacePath("ui/src/pierre")}/$1.ts` },
+  { find: /^@opencode-ai\/ui\/hooks$/, replacement: workspacePath("ui/src/hooks/index.ts") },
+  { find: /^@opencode-ai\/ui\/context$/, replacement: workspacePath("ui/src/context/index.ts") },
+  { find: /^@opencode-ai\/ui\/context\/(.+)$/, replacement: `${workspacePath("ui/src/context")}/$1.tsx` },
+  { find: /^@opencode-ai\/ui\/styles$/, replacement: workspacePath("ui/src/styles/index.css") },
+  { find: /^@opencode-ai\/ui\/styles\/tailwind$/, replacement: workspacePath("ui/src/styles/tailwind/index.css") },
+  { find: /^@opencode-ai\/ui\/theme$/, replacement: workspacePath("ui/src/theme/index.ts") },
+  { find: /^@opencode-ai\/ui\/theme\/context$/, replacement: workspacePath("ui/src/theme/context.tsx") },
+  { find: /^@opencode-ai\/ui\/theme\/(.+)$/, replacement: `${workspacePath("ui/src/theme")}/$1.ts` },
+  { find: /^@opencode-ai\/ui\/icons\/provider$/, replacement: workspacePath("ui/src/components/provider-icons/types.ts") },
+  { find: /^@opencode-ai\/ui\/icons\/file-type$/, replacement: workspacePath("ui/src/components/file-icons/types.ts") },
+  { find: /^@opencode-ai\/ui\/icons\/app$/, replacement: workspacePath("ui/src/components/app-icons/types.ts") },
+  { find: /^@opencode-ai\/ui\/fonts\/(.+)$/, replacement: `${workspacePath("ui/src/assets/fonts")}/$1` },
+  { find: /^@opencode-ai\/ui\/audio\/(.+)$/, replacement: `${workspacePath("ui/src/assets/audio")}/$1` },
+  { find: /^@opencode-ai\/ui\/v2\/styles\/(.+)$/, replacement: `${workspacePath("ui/src/v2/styles")}/$1` },
+  { find: /^@opencode-ai\/ui\/v2\/(.+)\.css$/, replacement: `${workspacePath("ui/src/v2/components")}/$1.css` },
+  { find: /^@opencode-ai\/ui\/v2\/(.+)$/, replacement: `${workspacePath("ui/src/v2/components")}/$1.tsx` },
+  { find: /^@opencode-ai\/ui\/(.+)$/, replacement: `${workspacePath("ui/src/components")}/$1` },
+]
 
 const channel = (() => {
   const raw = process.env.OPENCODE_CHANNEL
@@ -83,6 +129,21 @@ export default defineConfig({
     plugins: [appPlugin, sentry],
     publicDir: "../../../app/public",
     root: "src/renderer",
+    ...(copiedWorkspacePackages
+      ? {
+          resolve: {
+            alias: rendererWorkspaceAliases,
+          },
+          optimizeDeps: {
+            exclude: ["@opencode-ai/app", "@opencode-ai/core", "@opencode-ai/sdk", "@opencode-ai/ui"],
+          },
+          server: {
+            fs: {
+              allow: [repoRoot],
+            },
+          },
+        }
+      : {}),
     build: {
       sourcemap: true,
       rollupOptions: {

--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -15,7 +15,17 @@
     "noEmit": true,
     "emitDeclarationOnly": false,
     "outDir": "node_modules/.ts-dist",
-    "types": ["vite/client", "node", "electron"]
+    "types": ["vite/client", "node", "electron"],
+    "paths": {
+      "@/*": ["../app/src/*"],
+      "@opencode-ai/app": ["../app/src/index.ts"],
+      "@opencode-ai/app/desktop-menu": ["../app/src/desktop-menu.ts"],
+      "@opencode-ai/app/updater": ["../app/src/updater.ts"],
+      "@opencode-ai/app/wsl/types": ["../app/src/wsl/types.ts"],
+      "@opencode-ai/app/*": ["../app/src/*"],
+      "@opencode-ai/ui": ["../ui/src/index.ts"],
+      "@opencode-ai/ui/*": ["../ui/src/*"]
+    }
   },
   "references": [{ "path": "../app" }],
   "include": ["src", "package.json"],


### PR DESCRIPTION
### Issue for this PR

Addresses part of #18287

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an opt-in tiled panel mode for open session tabs in the desktop app's new UI.

This v1 scope is intentionally bounded:

- Hidden by default behind Settings > General > Session panels.
- Available only on desktop with the new layout enabled.
- Requires an active session route and 2-4 open session tabs on the current server.
- Falls back to normal tabs on mobile, with fewer than 2 session tabs, or with more than 4 session tabs.
- Uses the current server's open session tabs as the panel group; no saved or custom panel groups.

Behavior:

- Reuses the existing shared composer and sends prompts to the focused panel.
- Keeps inactive panels readable but slightly dimmed.
- Supports horizontal and vertical panel resizing.
- Supports swapping panel positions by dragging from each panel header.
- Keeps transcript content constrained to each panel width.
- Preserves server-keyed session routes, mobile navigation, prompt persistence, titlebar session lookup, and upstream timeline navigation behavior.

### How did you verify your code works?

- `npx -y bun@1.3.14 test --preload ./happydom.ts ./src/pages/session/panel-layout.test.ts ./src/context/tabs-order.test.ts` from `packages/app`

### Screenshots / recordings

[Session panels demo recording](https://github.com/oshtz/opencode/releases/download/session-panels-demo-pr-32213/opencode-session-panels-demo-full.mp4)

The recording covers a clean project, three sessions, panel mode, horizontal and vertical resizing, dragging a panel header to swap positions, and sending a follow-up from the shared composer to the focused panel.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR