### PR TITLE
fix(opencode): match canonically-equivalent Unicode in apply_patch

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -457,7 +457,7 @@ function tryMatch(lines: string[], pattern: string[], startIndex: number, compar
   return -1
 }
 
-function seekSequence(lines: string[], pattern: string[], startIndex: number, eof = false): number {
+export function seekSequence(lines: string[], pattern: string[], startIndex: number, eof = false): number {
   if (pattern.length === 0) return -1
 
   // Pass 1: exact match
@@ -480,7 +480,19 @@ function seekSequence(lines: string[], pattern: string[], startIndex: number, eo
     (a, b) => normalizeUnicode(a.trim()) === normalizeUnicode(b.trim()),
     eof,
   )
-  return normalized
+  if (normalized !== -1) return normalized
+
+  // Pass 5: NFC match (canonical equivalence — combining characters)
+  // Models emit NFC; files on disk may be NFD (macOS filesystems, Cyrillic
+  // content). NFC followed by exact equality only matches canonically-
+  // equivalent text, so this cannot introduce false positives.
+  return tryMatch(
+    lines,
+    pattern,
+    startIndex,
+    (a, b) => a.normalize("NFC").trim() === b.normalize("NFC").trim(),
+    eof,
+  )
 }
 
 function generateUnifiedDiff(oldContent: string, newContent: string): string {

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -3,11 +3,36 @@ import { Effect } from "effect"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { tmpdir } from "os"
-import { Patch } from "../../src/patch"
+import { Patch, seekSequence } from "../../src/patch"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(FSUtil.defaultLayer)
+
+describe("seekSequence", () => {
+  test("matches exact lines", () => {
+    expect(seekSequence(["a", "b", "c"], ["b"], 0)).toBe(1)
+  })
+
+  test("matches NFD file lines against an NFC pattern (canonical equivalence)", () => {
+    // Cyrillic й: NFC = U+0439 (precomposed), NFD = U+0438 + U+0306 (decomposed).
+    // Models emit NFC; files on disk (macOS filesystems, some editors) may be NFD.
+    const nfc = "й"
+    const nfd = nfc.normalize("NFD")
+    expect(nfc).not.toBe(nfd) // distinct byte sequences, identical glyph
+
+    const lines = ["header", nfd, "footer"]
+    const pattern = [nfc]
+
+    // Passes 1-4 (exact/rstrip/trim/punctuation) all miss NFD↔NFC;
+    // Pass 5 (NFC normalization) matches at index 1.
+    expect(seekSequence(lines, pattern, 0)).toBe(1)
+  })
+
+  test("returns -1 when no canonical-equivalent match exists", () => {
+    expect(seekSequence(["abc", "def"], ["й"], 0)).toBe(-1)
+  })
+})
 
 describe("Patch namespace", () => {
   let tempDir: string


### PR DESCRIPTION
## Summary

`apply_patch` fails with `Failed to find expected lines in <file>` when the file on disk and the model's context lines are canonically-equivalent Unicode but different byte sequences (NFC vs NFD). None of the 4 existing `seekSequence` passes handle combining-character equivalence, so any NFD content on disk is permanently unpatchable — the model re-reads, retries, fails, and burns tokens in a loop.

## Root cause

`seekSequence` (`packages/opencode/src/patch/index.ts`) had 4 passes:

1. exact
2. rstrip
3. trim
4. `normalizeUnicode` + trim — but `normalizeUnicode` only maps smart quotes / dashes / ellipsis / NBSP; it never normalizes combining characters.

A file with decomposed `й` (`и` U+0438 + U+0306) can never match a patch containing precomposed `й` (U+0439), even though the strings are canonically equivalent. Models essentially always emit NFC.

## Fix

A 5th pass after pass 4 that normalizes both sides to NFC before comparing:

```ts
return tryMatch(
  lines,
  pattern,
  startIndex,
  (a, b) => a.normalize("NFC").trim() === b.normalize("NFC").trim(),
  eof,
)
```

This is safe: NFC normalization followed by exact equality only matches strings Unicode defines as the same text — no false positives. (Approach proposed by the issue reporter.)

## Test plan

- [x] Added regression tests: exact match, NFD-file ↔ NFC-pattern match (Cyrillic `й`), and a negative case (no false match)
- [x] `packages/opencode` patch suite: 23/23 pass
- [x] No new typecheck errors in `patch/index.ts` (the only typecheck error on `dev` is a pre-existing, unrelated one in `src/bus/global.ts`)

Fixes #31651