### PR TITLE
fix(transform): remove developer note from user-facing error message

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -401,7 +401,7 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
       const name = filename ? `"${filename}"` : modality
       return {
         type: "text" as const,
-        text: `ERROR: Cannot read ${name} (this model does not support ${modality} input). Inform the user.`,
+        text: `ERROR: Cannot read ${name} (this model does not support ${modality} input).`,
       }
     })
 


### PR DESCRIPTION
Fix the error message in `unsupportedParts()` that included "Inform the user." — a developer note that was accidentally left in the user-facing error output.

Before:
```
ERROR: Cannot read "image.png" (this model does not support image input). Inform the user.
```

After:
```
ERROR: Cannot read "image.png" (this model does not support image input).
```