### PR TITLE
fix(tui): handle move directory errors

### DIFF
--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -73,6 +73,13 @@ export function DialogMoveSession(props: {
         )
         const directories = await sdk.client.project.directories({ projectID }, { throwOnError: true })
         return directories.data ?? []
+      } catch (error) {
+        toast.show({
+          variant: "error",
+          title: "Failed to load project directories",
+          message: errorMessage(error),
+        })
+        return []
       } finally {
         setWorking(false)
       }


### PR DESCRIPTION
## Summary
- catch project directory refresh and listing failures in the move dialog
- surface the API error in a toast
- return an empty directory result so Solid does not propagate a rejected resource to the global fatal error boundary

## Testing
- `git diff --check`
- TUI suite run; unrelated existing sync fixture failures report a missing `Exit` context provider