### PR TITLE
fix(core): catch EISDIR (BadResource) in readFileStringSafe to prevent crash on launch

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -54,9 +54,13 @@ export namespace FSUtil {
       })
 
       const readFileStringSafe = Effect.fn("FileSystem.readFileStringSafe")(function* (path: string) {
-        return yield* fs
-          .readFileString(path)
-          .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
+        return yield* fs.readFileString(path).pipe(
+          Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)),
+          // A probed path that turns out to be a directory yields EISDIR, which the
+          // platform layer reports as BadResource. Treat it like a missing file so
+          // callers walking config locations don't crash on a directory match.
+          Effect.catchReason("PlatformError", "BadResource", () => Effect.succeed(undefined)),
+        )
       })
 
       const isDir = Effect.fn("FileSystem.isDir")(function* (path: string) {

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -91,6 +91,20 @@ describe("FSUtil", () => {
         expect(result).toBeUndefined()
       }),
     )
+
+    it(
+      "returns undefined when the path is a directory (EISDIR)",
+      Effect.gen(function* () {
+        const fs = yield* FSUtil.Service
+        const filesys = yield* FileSystem.FileSystem
+        const tmp = yield* filesys.makeTempDirectoryScoped()
+        const dir = path.join(tmp, "subdir")
+        yield* filesys.makeDirectory(dir)
+
+        const result = yield* fs.readFileStringSafe(dir)
+        expect(result).toBeUndefined()
+      }),
+    )
   })
 
   describe("readJson / writeJson", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #32205

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`readFileStringSafe` in `packages/core/src/fs-util.ts` only caught the `NotFound` PlatformError. When a probed config path happens to be a directory, Node throws `EISDIR`, which Effect maps to the `BadResource` reason. That error slipped past the single `catchReason` and, because config loading wraps these reads in `Effect.orDie` (`packages/opencode/src/config/config.ts` and `packages/core/src/config.ts`), it became a fatal defect — so the TUI crashed on launch whenever a directory sat where a config file was expected.

The fix chains a second `catchReason` for `BadResource` so a directory match returns `undefined`, the same way a missing file already does. Every other PlatformError stays fatal, so genuine read failures still surface.

### How did you verify your code works?

Added a case to the existing `readFileStringSafe` block in `packages/core/test/filesystem/filesystem.test.ts` that creates a temp directory, points `readFileStringSafe` at it, and expects `undefined`. Against the old code that test fails with `EISDIR ... BadResource`; with the fix it passes. Ran `bun test test/filesystem/filesystem.test.ts` from `packages/core` (28 pass / 0 fail), plus `tsgo --noEmit` typecheck and `oxlint`, all clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
