### PR TITLE
fix(core): ignore unavailable project copy roots

### DIFF
--- a/packages/core/src/project/copy.ts
+++ b/packages/core/src/project/copy.ts
@@ -245,6 +245,7 @@ export const layer = Layer.effect(
         (sourceDirectory) =>
           Effect.forEach(strategies(), (strategy) =>
             strategy.list(sourceDirectory).pipe(
+              Effect.catchTag("ProjectCopy.DirectoryUnavailableError", () => Effect.succeed([])),
               Effect.map((items) =>
                 items.map((item) => ({
                   directory: item.directory,

--- a/packages/core/test/project-copy.test.ts
+++ b/packages/core/test/project-copy.test.ts
@@ -365,6 +365,18 @@ describe("ProjectCopy", () => {
     }),
   )
 
+  it.live("refresh ignores existing directories that are no longer git checkouts", () =>
+    Effect.gen(function* () {
+      const input = yield* setup()
+      yield* Effect.promise(() => fs.rm(path.join(input.sourceDirectory, ".git"), { recursive: true }))
+      const copy = yield* ProjectCopy.Service
+
+      yield* copy.refresh({ projectID: input.projectID })
+
+      expect(yield* stored(input.projectID)).toEqual([{ directory: input.sourceDirectory, strategy: null }])
+    }),
+  )
+
   it.live("refresh with no roots is a no-op", () =>
     Effect.gen(function* () {
       const copy = yield* ProjectCopy.Service


### PR DESCRIPTION
### Summary

- ignore project copy strategies that cannot use a persisted source directory during refresh
- prevent the move-session dialog from failing when an existing project directory is no longer a Git checkout
- add regression coverage for a persisted directory whose Git metadata has been removed

### Testing

- `bun test test/project-copy.test.ts` in `packages/core`
- `bun typecheck` in `packages/core`
- repository pre-push typecheck (`bun turbo typecheck`)