### PR TITLE
fix(opencode): avoid search retention for file reads

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,13 +1,14 @@
 export * as FileSystem from "./filesystem"
 
 import path from "path"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Schema, Scope } from "effect"
 import { EventV2 } from "./event"
 import { FSUtil } from "./fs-util"
 import { Location } from "./location"
 import { PositiveInt, RelativePath } from "./schema"
 import { FileSystemSearch } from "./filesystem/search"
 import { Entry, Match } from "./filesystem/schema"
+import { Ripgrep } from "./ripgrep"
 export { Entry, Match, Submatch } from "./filesystem/schema"
 
 export const ReadInput = Schema.Struct({
@@ -67,62 +68,77 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/FileSystem") {}
 
-const baseLayer = Layer.effect(
-  Service,
-  Effect.gen(function* () {
-    const fs = yield* FSUtil.Service
-    const location = yield* Location.Service
-    const search = yield* FileSystemSearch.Service
-    const root = yield* fs.realPath(location.directory).pipe(Effect.orDie)
-    const resolve = Effect.fnUntraced(function* (input?: RelativePath) {
-      const absolute = path.resolve(location.directory, input ?? ".")
-      if (!FSUtil.contains(location.directory, absolute))
-        return yield* Effect.die(new Error("Path escapes the location"))
-      const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
-      if (!FSUtil.contains(root, real)) return yield* Effect.die(new Error("Path escapes the location"))
-      return { absolute, real, directory: location.directory, root }
-    })
-    return Service.of({
-      find: search.find,
-      glob: search.glob,
-      grep: search.grep,
-      read: Effect.fn("FileSystem.read")(function* (input) {
-        const target = yield* resolve(input.path)
-        const info = yield* fs.stat(target.real).pipe(Effect.orDie)
-        if (info.type !== "File") return yield* Effect.die(new Error("Path is not a file"))
-        return {
-          content: yield* fs.readFile(target.real).pipe(Effect.orDie),
-          mime: FSUtil.mimeType(target.real),
-        }
-      }),
-      list: Effect.fn("FileSystem.list")(function* (input = {}) {
-        const target = yield* resolve(input.path)
-        const info = yield* fs.stat(target.real).pipe(Effect.orDie)
-        if (info.type !== "Directory") return yield* Effect.die(new Error("Path is not a directory"))
-        return yield* fs.readDirectoryEntries(target.real).pipe(
-          Effect.orDie,
-          Effect.map((items) =>
-            items
-              .flatMap((item) => {
-                if (item.type !== "file" && item.type !== "directory") return []
-                const absolute = path.join(target.absolute, item.name)
-                const relative = path.relative(target.directory, absolute)
-                return [
-                  new Entry({
-                    path: RelativePath.make(relative + (item.type === "directory" ? path.sep : "")),
-                    type: item.type,
-                    mime: item.type === "directory" ? "application/x-directory" : FSUtil.mimeType(absolute),
-                  }),
-                ]
-              })
-              .sort((a, b) => (a.type === b.type ? a.path.localeCompare(b.path) : a.type === "directory" ? -1 : 1)),
-          ),
-        )
-      }),
-    })
-  }),
-)
+export function baseLayer(searchLayer = FileSystemSearch.defaultLayer.pipe(Layer.provide(Ripgrep.defaultLayer))) {
+  return Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const location = yield* Location.Service
+      const scope = yield* Scope.Scope
+      const searchContext = Layer.merge(Layer.succeed(FSUtil.Service, fs), Layer.succeed(Location.Service, location))
+      const loadSearch = yield* Layer.buildWithScope(searchLayer.pipe(Layer.provide(searchContext)), scope).pipe(
+        Effect.map((context) => Context.get(context, FileSystemSearch.Service)),
+        Effect.cached,
+      )
+      const root = yield* fs.realPath(location.directory).pipe(Effect.orDie)
+      const resolve = Effect.fnUntraced(function* (input?: RelativePath) {
+        const absolute = path.resolve(location.directory, input ?? ".")
+        if (!FSUtil.contains(location.directory, absolute))
+          return yield* Effect.die(new Error("Path escapes the location"))
+        const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
+        if (!FSUtil.contains(root, real)) return yield* Effect.die(new Error("Path escapes the location"))
+        return { absolute, real, directory: location.directory, root }
+      })
+      return Service.of({
+        find: Effect.fn("FileSystem.find")(function* (input) {
+          return yield* (yield* loadSearch).find(input)
+        }),
+        glob: Effect.fn("FileSystem.glob")(function* (input) {
+          yield* resolve(input.path)
+          return yield* (yield* loadSearch).glob(input)
+        }),
+        grep: Effect.fn("FileSystem.grep")(function* (input) {
+          yield* resolve(input.path)
+          return yield* (yield* loadSearch).grep(input)
+        }),
+        read: Effect.fn("FileSystem.read")(function* (input) {
+          const target = yield* resolve(input.path)
+          const info = yield* fs.stat(target.real).pipe(Effect.orDie)
+          if (info.type !== "File") return yield* Effect.die(new Error("Path is not a file"))
+          return {
+            content: yield* fs.readFile(target.real).pipe(Effect.orDie),
+            mime: FSUtil.mimeType(target.real),
+          }
+        }),
+        list: Effect.fn("FileSystem.list")(function* (input = {}) {
+          const target = yield* resolve(input.path)
+          const info = yield* fs.stat(target.real).pipe(Effect.orDie)
+          if (info.type !== "Directory") return yield* Effect.die(new Error("Path is not a directory"))
+          return yield* fs.readDirectoryEntries(target.real).pipe(
+            Effect.orDie,
+            Effect.map((items) =>
+              items
+                .flatMap((item) => {
+                  if (item.type !== "file" && item.type !== "directory") return []
+                  const absolute = path.join(target.absolute, item.name)
+                  const relative = path.relative(target.directory, absolute)
+                  return [
+                    new Entry({
+                      path: RelativePath.make(relative + (item.type === "directory" ? path.sep : "")),
+                      type: item.type,
+                      mime: item.type === "directory" ? "application/x-directory" : FSUtil.mimeType(absolute),
+                    }),
+                  ]
+                })
+                .sort((a, b) => (a.type === b.type ? a.path.localeCompare(b.path) : a.type === "directory" ? -1 : 1)),
+            ),
+          )
+        }),
+      })
+    }),
+  )
+}
 
-export const layer = baseLayer.pipe(Layer.provide(FileSystemSearch.defaultLayer), Layer.provide(FSUtil.defaultLayer))
+export const layer = baseLayer().pipe(Layer.provide(FSUtil.defaultLayer))
 
 export const locationLayer = layer

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -1,7 +1,7 @@
 export * as FileSystemSearch from "./search"
 
 import path from "path"
-import { Context, Effect, Layer, Scope } from "effect"
+import { Context, Effect, Layer } from "effect"
 import { Fff } from "#fff"
 import fuzzysort from "fuzzysort"
 import { FileSystem } from "../filesystem"
@@ -25,7 +25,15 @@ export const ripgrepLayer = Layer.effect(
     const fs = yield* FSUtil.Service
     const location = yield* Location.Service
     const ripgrep = yield* Ripgrep.Service
-    const scope = yield* Scope.Scope
+    const root = yield* fs.realPath(location.directory).pipe(Effect.orDie)
+    const resolve = Effect.fnUntraced(function* (input?: RelativePath) {
+      const absolute = path.resolve(location.directory, input ?? ".")
+      if (!FSUtil.contains(location.directory, absolute))
+        return yield* Effect.die(new Error("Path escapes the location"))
+      const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
+      if (!FSUtil.contains(root, real)) return yield* Effect.die(new Error("Path escapes the location"))
+      return { absolute, info: yield* fs.stat(real).pipe(Effect.orDie) }
+    })
     const state = {
       files: [] as string[],
       directories: [] as string[],
@@ -44,13 +52,12 @@ export const ripgrepLayer = Layer.effect(
             state.directories = Array.from(directories)
           }),
       })
-      .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))
+      .pipe(Effect.orDie, Effect.asVoid)
     return Service.of({
       glob: (input) =>
         Effect.gen(function* () {
-          const target = path.resolve(location.directory, input.path ?? ".")
-          const info = yield* fs.stat(target).pipe(Effect.orDie)
-          const cwd = info.type === "File" ? path.dirname(target) : target
+          const target = yield* resolve(input.path)
+          const cwd = target.info.type === "File" ? path.dirname(target.absolute) : target.absolute
           return yield* ripgrep
             .glob({
               cwd,
@@ -62,8 +69,9 @@ export const ripgrepLayer = Layer.effect(
                 result.map(
                   (entry) =>
                     new FileSystem.Entry({
-                      ...entry,
                       path: RelativePath.make(path.relative(location.directory, path.resolve(cwd, entry.path))),
+                      type: entry.type,
+                      mime: entry.mime,
                     }),
                 ),
               ),
@@ -72,14 +80,13 @@ export const ripgrepLayer = Layer.effect(
         }),
       grep: (input) =>
         Effect.gen(function* () {
-          const target = path.resolve(location.directory, input.path ?? ".")
-          const info = yield* fs.stat(target).pipe(Effect.orDie)
-          const cwd = info.type === "File" ? path.dirname(target) : target
+          const target = yield* resolve(input.path)
+          const cwd = target.info.type === "File" ? path.dirname(target.absolute) : target.absolute
           return yield* ripgrep
             .grep({
               cwd,
               pattern: input.pattern,
-              file: info.type === "File" ? path.basename(target) : undefined,
+              file: target.info.type === "File" ? path.basename(target.absolute) : undefined,
               include: input.include,
               limit: input.limit ?? Number.MAX_SAFE_INTEGER,
             })
@@ -88,11 +95,15 @@ export const ripgrepLayer = Layer.effect(
                 result.map(
                   (match) =>
                     new FileSystem.Match({
-                      ...match,
                       entry: new FileSystem.Entry({
-                        ...match.entry,
                         path: RelativePath.make(path.relative(location.directory, path.resolve(cwd, match.entry.path))),
+                        type: match.entry.type,
+                        mime: match.entry.mime,
                       }),
+                      line: match.line,
+                      offset: match.offset,
+                      text: match.text,
+                      submatches: match.submatches,
                     }),
                 ),
               ),
@@ -126,7 +137,17 @@ export const ripgrepLayer = Layer.effect(
 export const fffLayer = Layer.effect(
   Service,
   Effect.gen(function* () {
+    const fs = yield* FSUtil.Service
     const location = yield* Location.Service
+    const root = yield* fs.realPath(location.directory).pipe(Effect.orDie)
+    const resolve = Effect.fnUntraced(function* (input?: RelativePath) {
+      const absolute = path.resolve(location.directory, input ?? ".")
+      if (!FSUtil.contains(location.directory, absolute))
+        return yield* Effect.die(new Error("Path escapes the location"))
+      const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
+      if (!FSUtil.contains(root, real)) return yield* Effect.die(new Error("Path escapes the location"))
+      return real
+    })
     const result = yield* Effect.try({
       try: () =>
         Fff.create({
@@ -141,48 +162,54 @@ export const fffLayer = Layer.effect(
     yield* Effect.addFinalizer(() => Effect.sync(() => result.value.destroy()).pipe(Effect.ignore))
     return Service.of({
       glob: (input) =>
-        Effect.sync(() => {
+        Effect.gen(function* () {
+          yield* resolve(input.path)
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
-          const found = result.value.glob(prefix ? `${prefix}/${input.pattern}` : input.pattern, {
-            pageIndex: 0,
-            pageSize: input.limit,
-          })
-          if (!found.ok) throw found.error
-          return found.value.items.map((item) => {
-            const absolute = path.resolve(location.directory, item.relativePath)
-            return new FileSystem.Entry({
-              path: RelativePath.make(item.relativePath.replaceAll("\\", "/")),
-              type: "file",
-              mime: FSUtil.mimeType(absolute),
+          return yield* Effect.sync(() => {
+            const found = result.value.glob(prefix ? `${prefix}/${input.pattern}` : input.pattern, {
+              pageIndex: 0,
+              pageSize: input.limit,
+            })
+            if (!found.ok) throw found.error
+            return found.value.items.map((item) => {
+              const absolute = path.resolve(location.directory, item.relativePath)
+              return new FileSystem.Entry({
+                path: RelativePath.make(item.relativePath.replaceAll("\\", "/")),
+                type: "file",
+                mime: FSUtil.mimeType(absolute),
+              })
             })
           })
         }),
       grep: (input) =>
-        Effect.sync(() => {
+        Effect.gen(function* () {
+          yield* resolve(input.path)
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
-          const found = result.value.grep(
-            [prefix ? `${prefix}/**` : undefined, input.include, input.pattern]
-              .filter((value) => value !== undefined)
-              .join(" "),
-            { mode: "regex", pageSize: input.limit, timeBudgetMs: 1_500 },
-          )
-          if (!found.ok) throw found.error
-          return found.value.items.map((match) => {
-            const bytes = Buffer.from(match.lineContent)
-            return new FileSystem.Match({
-              entry: new FileSystem.Entry({
-                path: RelativePath.make(match.relativePath.replaceAll("\\", "/")),
-                type: "file",
-                mime: FSUtil.mimeType(match.relativePath),
-              }),
-              line: match.lineNumber,
-              offset: match.byteOffset,
-              text: match.lineContent.length > 2_000 ? match.lineContent.slice(0, 2_000) + "..." : match.lineContent,
-              submatches: match.matchRanges.map(([start, end]) => ({
-                text: bytes.subarray(start, end).toString("utf8"),
-                start,
-                end,
-              })),
+          return yield* Effect.sync(() => {
+            const found = result.value.grep(
+              [prefix ? `${prefix}/**` : undefined, input.include, input.pattern]
+                .filter((value) => value !== undefined)
+                .join(" "),
+              { mode: "regex", pageSize: input.limit, timeBudgetMs: 1_500 },
+            )
+            if (!found.ok) throw found.error
+            return found.value.items.map((match) => {
+              const bytes = Buffer.from(match.lineContent)
+              return new FileSystem.Match({
+                entry: new FileSystem.Entry({
+                  path: RelativePath.make(match.relativePath.replaceAll("\\", "/")),
+                  type: "file",
+                  mime: FSUtil.mimeType(match.relativePath),
+                }),
+                line: match.lineNumber,
+                offset: match.byteOffset,
+                text: match.lineContent.length > 2_000 ? match.lineContent.slice(0, 2_000) + "..." : match.lineContent,
+                submatches: match.matchRanges.map(([start, end]) => ({
+                  text: bytes.subarray(start, end).toString("utf8"),
+                  start,
+                  end,
+                })),
+              })
             })
           })
         }),

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { describe, expect } from "bun:test"
 import { Effect, Exit, Layer } from "effect"
 import { FileSystem } from "@opencode-ai/core/filesystem"
+import { FileSystemSearch } from "@opencode-ai/core/filesystem/search"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Location } from "@opencode-ai/core/location"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
@@ -29,6 +30,44 @@ const withTmp = <A, E, R>(f: (directory: string) => Effect.Effect<A, E, R>) =>
     Effect.promise(() => tmpdir()),
     (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
   ).pipe(Effect.flatMap((tmp) => f(tmp.path)))
+
+const captureSearchIndexLimit = (directory: string, vcs?: Location.Interface["vcs"]) => {
+  const observed = { limit: 0 }
+  return Effect.gen(function* () {
+    const service = yield* FileSystem.Service
+    yield* service.find(new FileSystem.FindInput({ query: "text", limit: 10 }))
+    return observed.limit
+  }).pipe(
+    Effect.provide(
+      FileSystem.baseLayer(
+        FileSystemSearch.ripgrepLayer.pipe(
+          Layer.provide(
+            Layer.succeed(
+              Ripgrep.Service,
+              Ripgrep.Service.of({
+                find: (input) =>
+                  Effect.sync(() => {
+                    observed.limit = input.limit
+                    return []
+                  }),
+                glob: () => Effect.succeed([]),
+                grep: () => Effect.succeed([]),
+              }),
+            ),
+          ),
+        ),
+      ).pipe(
+        Layer.provide(FSUtil.defaultLayer),
+        Layer.provide(
+          Layer.succeed(
+            Location.Service,
+            Location.Service.of(location({ directory: AbsolutePath.make(directory) }, { vcs })),
+          ),
+        ),
+      ),
+    ),
+  )
+}
 
 describe("FileSystem", () => {
   it.live("reads text and binary files", () =>
@@ -68,6 +107,270 @@ describe("FileSystem", () => {
           .pipe(Effect.exit)
         expect(Exit.isFailure(result)).toBe(true)
       }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("rejects search paths that escape the location", () =>
+    withTmp((directory) =>
+      withTmp((outsideDirectory) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.writeFile(path.join(outsideDirectory, "outside.txt"), "needle"))
+          const service = yield* FileSystem.Service
+          const outside = RelativePath.make(path.relative(directory, outsideDirectory))
+          const glob = yield* service
+            .glob(new FileSystem.GlobInput({ pattern: "*.txt", path: outside }))
+            .pipe(Effect.exit)
+          const grep = yield* service
+            .grep(new FileSystem.GrepInput({ pattern: "needle", path: outside }))
+            .pipe(Effect.exit)
+          expect(Exit.isFailure(glob)).toBe(true)
+          expect(Exit.isFailure(grep)).toBe(true)
+        }).pipe(provide(directory)),
+      ),
+    ),
+  )
+
+  it.live("does not initialize search when reading files", () =>
+    withTmp((directory) => {
+      let searchInitializations = 0
+      return Effect.gen(function* () {
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "text.txt"), "hello"))
+        const service = yield* FileSystem.Service
+        const text = yield* service.read({ path: RelativePath.make("text.txt") })
+        expect(new TextDecoder().decode(text.content)).toBe("hello")
+        expect(searchInitializations).toBe(0)
+        expect(yield* service.find(new FileSystem.FindInput({ query: "text", limit: 10 }))).toEqual([])
+        expect(searchInitializations).toBe(1)
+      }).pipe(
+        Effect.provide(
+          FileSystem.baseLayer(
+            Layer.effect(
+              FileSystemSearch.Service,
+              Effect.sync(() => {
+                searchInitializations += 1
+                return FileSystemSearch.Service.of({
+                  find: () => Effect.succeed([]),
+                  glob: () => Effect.succeed([]),
+                  grep: () => Effect.succeed([]),
+                })
+              }),
+            ),
+          ).pipe(
+            Layer.provide(FSUtil.defaultLayer),
+            Layer.provide(
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+              ),
+            ),
+          ),
+        ),
+      )
+    }),
+  )
+
+  it.live("does not initialize search when listing files", () =>
+    withTmp((directory) => {
+      let searchInitializations = 0
+      return Effect.gen(function* () {
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "text.txt"), "hello"))
+        const service = yield* FileSystem.Service
+        expect(yield* service.list()).toEqual([
+          new FileSystem.Entry({
+            path: RelativePath.make("text.txt"),
+            type: "file",
+            mime: "text/plain",
+          }),
+        ])
+        expect(searchInitializations).toBe(0)
+      }).pipe(
+        Effect.provide(
+          FileSystem.baseLayer(
+            Layer.effect(
+              FileSystemSearch.Service,
+              Effect.sync(() => {
+                searchInitializations += 1
+                return FileSystemSearch.Service.of({
+                  find: () => Effect.succeed([]),
+                  glob: () => Effect.succeed([]),
+                  grep: () => Effect.succeed([]),
+                })
+              }),
+            ),
+          ).pipe(
+            Layer.provide(FSUtil.defaultLayer),
+            Layer.provide(
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+              ),
+            ),
+          ),
+        ),
+      )
+    }),
+  )
+
+  it.live("reuses initialized search for repeated searches", () =>
+    withTmp((directory) => {
+      let searchInitializations = 0
+      return Effect.gen(function* () {
+        const service = yield* FileSystem.Service
+        yield* service.find(new FileSystem.FindInput({ query: "text", limit: 10 }))
+        yield* service.find(new FileSystem.FindInput({ query: "text", limit: 10 }))
+        expect(searchInitializations).toBe(1)
+      }).pipe(
+        Effect.provide(
+          FileSystem.baseLayer(
+            Layer.effect(
+              FileSystemSearch.Service,
+              Effect.sync(() => {
+                searchInitializations += 1
+                return FileSystemSearch.Service.of({
+                  find: () => Effect.succeed([]),
+                  glob: () => Effect.succeed([]),
+                  grep: () => Effect.succeed([]),
+                })
+              }),
+            ),
+          ).pipe(
+            Layer.provide(FSUtil.defaultLayer),
+            Layer.provide(
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+              ),
+            ),
+          ),
+        ),
+      )
+    }),
+  )
+
+  it.live("keeps lazy search resources alive until the file system layer closes", () =>
+    withTmp((directory) => {
+      let searchInitializations = 0
+      let searchFinalizations = 0
+      return Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          const service = yield* FileSystem.Service
+          yield* service.find(new FileSystem.FindInput({ query: "text", limit: 10 }))
+          expect(searchInitializations).toBe(1)
+          expect(searchFinalizations).toBe(0)
+        }).pipe(
+          Effect.provide(
+            FileSystem.baseLayer(
+              Layer.effect(
+                FileSystemSearch.Service,
+                Effect.gen(function* () {
+                  searchInitializations += 1
+                  yield* Effect.addFinalizer(() =>
+                    Effect.sync(() => {
+                      searchFinalizations += 1
+                    }),
+                  )
+                  return FileSystemSearch.Service.of({
+                    find: () => Effect.succeed([]),
+                    glob: () => Effect.succeed([]),
+                    grep: () => Effect.succeed([]),
+                  })
+                }),
+              ),
+            ).pipe(
+              Layer.provide(FSUtil.defaultLayer),
+              Layer.provide(
+                Layer.succeed(
+                  Location.Service,
+                  Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+                ),
+              ),
+            ),
+          ),
+        )
+        expect(searchFinalizations).toBe(1)
+      })
+    }),
+  )
+
+  it.live("initializes search once for concurrent first searches", () =>
+    withTmp((directory) => {
+      let searchInitializations = 0
+      return Effect.gen(function* () {
+        const service = yield* FileSystem.Service
+        yield* Effect.all(
+          [
+            service.find(new FileSystem.FindInput({ query: "text", limit: 10 })),
+            service.find(new FileSystem.FindInput({ query: "text", limit: 10 })),
+          ],
+          { concurrency: "unbounded" },
+        )
+        expect(searchInitializations).toBe(1)
+      }).pipe(
+        Effect.provide(
+          FileSystem.baseLayer(
+            Layer.effect(
+              FileSystemSearch.Service,
+              Effect.gen(function* () {
+                searchInitializations += 1
+                yield* Effect.promise(() => Bun.sleep(20))
+                return FileSystemSearch.Service.of({
+                  find: () => Effect.succeed([]),
+                  glob: () => Effect.succeed([]),
+                  grep: () => Effect.succeed([]),
+                })
+              }),
+            ),
+          ).pipe(
+            Layer.provide(FSUtil.defaultLayer),
+            Layer.provide(
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+              ),
+            ),
+          ),
+        ),
+      )
+    }),
+  )
+
+  it.live("loads search results before the first find", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "hello.txt"), "needle"))
+        const found = yield* (yield* FileSystem.Service).find(
+          new FileSystem.FindInput({ query: "hello", type: "file", limit: 10 }),
+        )
+        expect(found.map((entry) => entry.path)).toContain(RelativePath.make("hello.txt"))
+      }).pipe(
+        Effect.provide(
+          FileSystem.baseLayer(FileSystemSearch.ripgrepLayer.pipe(Layer.provide(Ripgrep.defaultLayer))).pipe(
+            Layer.provide(FSUtil.defaultLayer),
+            Layer.provide(
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  )
+
+  it.live("preserves the existing search indexing limits for VCS and non-VCS locations", () =>
+    withTmp((gitDirectory) =>
+      withTmp((plainDirectory) =>
+        Effect.gen(function* () {
+          const git = yield* captureSearchIndexLimit(gitDirectory, {
+            type: "git",
+            store: AbsolutePath.make(path.join(gitDirectory, ".git")),
+          })
+          const plain = yield* captureSearchIndexLimit(plainDirectory)
+          expect(git).toBe(Number.MAX_SAFE_INTEGER)
+          expect(plain).toBe(100_000)
+        }),
+      ),
     ),
   )
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -1,4 +1,5 @@
-import * as InstanceState from "@/effect/instance-state"
+import { InstanceState } from "@/effect/instance-state"
+import type { InstanceContext } from "@/project/instance-context"
 import { FileSystem } from "@opencode-ai/core/filesystem"
 import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
@@ -16,11 +17,12 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
     const ripgrep = yield* Ripgrep.Service
     const locations = yield* LocationServiceMap
 
-    const filesystem = Effect.fnUntraced(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
+    const cachedFilesystem = Effect.fnUntraced(function* <A, E, R>(
+      context: InstanceContext,
+      effect: Effect.Effect<A, E, R>,
+    ) {
       return yield* effect.pipe(
-        Effect.provide(
-          locations.get(Location.Ref.make({ directory: AbsolutePath.make((yield* InstanceState.context).directory) })),
-        ),
+        Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(context.directory) }))),
       )
     })
 
@@ -43,15 +45,18 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
     const findFile = Effect.fn("FileHttpApi.findFile")(function* (ctx: {
       query: { query: string; dirs?: "true" | "false"; type?: "file" | "directory"; limit?: number }
     }) {
-      const directory = (yield* InstanceState.context).directory
+      const context = yield* InstanceState.context
       const limit = ctx.query.limit ?? 10
       const type = ctx.query.type ?? (ctx.query.dirs === "false" ? "file" : undefined)
       const started = performance.now()
-      const found = yield* filesystem(FileSystem.Service.use((fs) => fs.find({ query: ctx.query.query, limit, type })))
+      const found = yield* cachedFilesystem(
+        context,
+        FileSystem.Service.use((fs) => fs.find({ query: ctx.query.query, limit, type })),
+      )
       yield* Effect.logInfo("find file", {
         query: ctx.query.query,
         type,
-        directory,
+        directory: context.directory,
         limit,
         results: found.length,
         duration: Math.round(performance.now() - started),
@@ -64,43 +69,40 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
     })
 
     const list = Effect.fn("FileHttpApi.list")(function* (ctx: { query: { path: string } }) {
-      const directory = (yield* InstanceState.context).directory
-      return yield* filesystem(
-        Effect.gen(function* () {
-          const fs = yield* FileSystem.Service
-          const raw = yield* FSUtil.Service
-          const location = yield* Location.Service
-          const ignored = ignore()
-          const gitignore = yield* raw
-            .readFileString(path.join(location.project.directory, ".gitignore"))
-            .pipe(Effect.catch(() => Effect.succeed("")))
-          if (gitignore) ignored.add(gitignore)
-          const ignorefile = yield* raw
-            .readFileString(path.join(location.project.directory, ".ignore"))
-            .pipe(Effect.catch(() => Effect.succeed("")))
-          if (ignorefile) ignored.add(ignorefile)
-          return (yield* fs.list({ path: RelativePath.make(ctx.query.path) })).map((item) => ({
-            name: path.basename(item.path),
-            path: item.path,
-            absolute: path.resolve(location.directory, item.path),
-            type: item.type,
-            ignored: ignored.ignores(
-              path.relative(location.project.directory, path.resolve(location.directory, item.path)) +
-                (item.type === "directory" ? "/" : ""),
-            ),
-          }))
-        }),
-      )
+      const context = yield* InstanceState.context
+      return yield* Effect.gen(function* () {
+        const fs = yield* FileSystem.Service
+        const raw = yield* FSUtil.Service
+        const location = yield* Location.Service
+        const ignored = ignore()
+        const gitignore = yield* raw
+          .readFileString(path.join(location.project.directory, ".gitignore"))
+          .pipe(Effect.catch(() => Effect.succeed("")))
+        if (gitignore) ignored.add(gitignore)
+        const ignorefile = yield* raw
+          .readFileString(path.join(location.project.directory, ".ignore"))
+          .pipe(Effect.catch(() => Effect.succeed("")))
+        if (ignorefile) ignored.add(ignorefile)
+        return (yield* fs.list({ path: RelativePath.make(ctx.query.path) })).map((item) => ({
+          name: path.basename(item.path),
+          path: item.path,
+          absolute: path.resolve(location.directory, item.path),
+          type: item.type,
+          ignored: ignored.ignores(
+            path.relative(location.project.directory, path.resolve(location.directory, item.path)) +
+              (item.type === "directory" ? "/" : ""),
+          ),
+        }))
+      }).pipe(Effect.provide(directFileSystemLayer(context)))
     })
 
     const content = Effect.fn("FileHttpApi.content")(function* (ctx: { query: { path: string } }) {
-      const directory = (yield* InstanceState.context).directory
-      const file = path.resolve(directory, ctx.query.path)
-      if (!FSUtil.contains(directory, file)) return yield* Effect.die(new Error("Path escapes the location"))
+      const context = yield* InstanceState.context
+      const file = path.resolve(context.directory, ctx.query.path)
+      if (!FSUtil.contains(context.directory, file)) return yield* Effect.die(new Error("Path escapes the location"))
       if (!(yield* FSUtil.Service.use((fs) => fs.existsSafe(file)))) return { type: "text" as const, content: "" }
-      return yield* filesystem(
-        FileSystem.Service.use((fs) => fs.read({ path: RelativePath.make(ctx.query.path) })),
-      ).pipe(
+      return yield* FileSystem.Service.use((fs) => fs.read({ path: RelativePath.make(ctx.query.path) })).pipe(
+        Effect.provide(directFileSystemLayer(context)),
         Effect.flatMap((item) =>
           Effect.gen(function* () {
             const text = item.content.includes(0)
@@ -137,3 +139,25 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
       .handle("status", status)
   }),
 ).pipe(Layer.provide(LocationServiceMap.layer))
+
+function directFileSystemLayer(context: InstanceContext) {
+  // These file read/list routes only need filesystem and location metadata.
+  // Avoid LocationServiceMap here so file browsing does not unnecessarily boot or retain the broader location graph.
+  const isGit = context.project.vcs === "git" && context.worktree !== "/"
+  const projectDirectory = isGit ? context.worktree : path.parse(context.directory).root
+  const location = Layer.succeed(
+    Location.Service,
+    Location.Service.of({
+      directory: AbsolutePath.make(context.directory),
+      project: {
+        id: context.project.id,
+        directory: AbsolutePath.make(projectDirectory),
+      },
+    }),
+  )
+  return Layer.mergeAll(
+    FileSystem.baseLayer().pipe(Layer.provide(FSUtil.defaultLayer), Layer.provide(location)),
+    FSUtil.defaultLayer,
+    location,
+  )
+}

--- a/packages/opencode/test/server/httpapi-file.test.ts
+++ b/packages/opencode/test/server/httpapi-file.test.ts
@@ -51,6 +51,51 @@ describe("file HttpApi", () => {
     expect(await status.json()).toEqual([])
   })
 
+  test("serves binary file content as base64", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Bun.write(path.join(tmp.path, "data.bin"), Buffer.from([0, 1, 2]))
+
+    const response = await request(FilePaths.content, tmp.path, { path: "data.bin" })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      type: "binary",
+      content: "AAEC",
+      encoding: "base64",
+      mimeType: "application/octet-stream",
+    })
+  })
+
+  test("serves missing file content as empty text", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const response = await request(FilePaths.content, tmp.path, { path: "missing.txt" })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ type: "text", content: "" })
+  })
+
+  test("rejects file content paths outside the location", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const response = await request(FilePaths.content, tmp.path, { path: "../outside.txt" })
+
+    expect(response.status).not.toBe(200)
+  })
+
+  test("serves ignored status from the project root", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Bun.write(path.join(tmp.path, ".gitignore"), "ignored.txt\n")
+    await Bun.write(path.join(tmp.path, "ignored.txt"), "ignored")
+
+    const response = await request(FilePaths.list, tmp.path, { path: "." })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toContainEqual(
+      expect.objectContaining({ name: "ignored.txt", path: "ignored.txt", type: "file", ignored: true }),
+    )
+  })
+
   test("serves search endpoints", async () => {
     await using tmp = await tmpdir({ git: true })
     await Bun.write(path.join(tmp.path, "hello.txt"), "needle")


### PR DESCRIPTION
### Issue for this PR

Closes #32237

This may also be related to #20695, but this PR only addresses repeated file route reads initializing and retaining search state.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Repeated `/file/content` reads were going through the cached location file system service. That service can initialize and retain file search state, even though reading one file does not need search.

This changes the file system service so search is loaded lazily. `read` and `list` no longer initialize search. `find`, `glob`, and `grep` still load search when they need it.

The HTTP file handlers now use a direct file system layer for `/file/content` and `/file`. `/find/file` still uses the cached location services because search benefits from being warm.

I also added tests for the important behavior:

- reading a file does not initialize search
- listing files does not initialize search
- repeated and concurrent searches initialize search once
- search resources stay alive until the file system layer closes
- search still returns results when used
- search paths cannot escape the location
- existing VCS and non VCS search limits are preserved
- file list still marks ignored files from the project root

### How did you verify your code works?

I verified this with focused tests, type checks, and a local workload harness.

The harness is outside this repo. It creates temporary workspaces, starts `opencode serve`, calls file routes, and samples `opencode-serve` Resident Set Size during the run.

Focused `/file/content` workload:

- 12 workspaces
- 100 steps
- 80 files per workspace
- 128 KB per file
- Bun 1.3.14
- Windows 11 Home

Before this change:

- retained Resident Set Size growth: `523.1 MB`
- peak Resident Set Size: `993.0 MB`

After this change:

- retained Resident Set Size growth: `59.2 MB`
- peak Resident Set Size: `522.8 MB`
- harness findings: `0`

Warm read latency did not regress in the same run. Warm `/file/content` reads were p50 `34.2 ms`, p95 `55.5 ms`, p99 `66.4 ms`.

I also checked adjacent file routes. `/find/file` still uses the cached search path, and warm search latency stayed in the same range.

Local checks:

- `bun test test/location-filesystem.test.ts` from `packages/core`
- `bun test --timeout 30000 test/server/httpapi-file.test.ts test/server/httpapi-sdk.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/opencode`
- Prettier check
- oxlint
- `git diff --check`

### Screenshots / recordings

N/A. This is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR