### PR TITLE
feat(session): add native /goal with persisted per-session goals

### DIFF
--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -37,5 +37,6 @@ export const migrations = (
     import("./migration/20260611035744_credential"),
     import("./migration/20260611192811_lush_chimera"),
     import("./migration/20260612174303_project_dir_strategy"),
+    import("./migration/20260613180000_session_goals"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260613180000_session_goals.ts
+++ b/packages/core/src/database/migration/20260613180000_session_goals.ts
@@ -1,0 +1,29 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260613180000_session_goals",
+  up(tx) {
+    return Effect.gen(function* () {
+      // Create goal table for native per-session persisted goals (issue #27167).
+      yield* tx.run(`
+        CREATE TABLE \`goal\` (
+          \`session_id\` text PRIMARY KEY,
+          \`text\` text NOT NULL,
+          \`status\` text NOT NULL,
+          \`budget_tokens\` integer,
+          \`tokens_used\` integer NOT NULL DEFAULT 0,
+          \`time_ms\` integer NOT NULL DEFAULT 0,
+          \`started_at\` integer NOT NULL,
+          \`paused_at\` integer,
+          \`completed_at\` integer,
+          \`verification\` text,
+          \`time_created\` integer NOT NULL,
+          \`time_updated\` integer NOT NULL,
+          CONSTRAINT \`fk_goal_session_id_session_id_fk\` FOREIGN KEY (\`session_id\`) REFERENCES \`session\`(\`id\`) ON DELETE CASCADE
+        );
+      `)
+      yield* tx.run(`CREATE INDEX \`goal_session_idx\` ON \`goal\` (\`session_id\`);`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/location-layer.ts
+++ b/packages/core/src/location-layer.ts
@@ -40,6 +40,7 @@ import { ToolOutputStore } from "./tool-output-store"
 import { AppProcess } from "./process"
 import { SessionStore } from "./session/store"
 import { SessionTodo } from "./session/todo"
+import { SessionGoal } from "./session/goal"
 import { QuestionV2 } from "./question"
 import { LLMClient } from "@opencode-ai/llm"
 import { RequestExecutor } from "@opencode-ai/llm/route"
@@ -86,12 +87,14 @@ export class LocationServiceMap extends LayerMap.Service<LocationServiceMap>()("
     const skillGuidance = SkillGuidance.locationLayer.pipe(Layer.provide(services))
     const referenceGuidance = ReferenceGuidance.locationLayer.pipe(Layer.provide(services))
     const todos = SessionTodo.layer.pipe(Layer.provide(services))
+    const goals = SessionGoal.layer.pipe(Layer.provide(services))
     const questions = QuestionV2.locationLayer.pipe(Layer.provide(services))
     const builtInTools = BuiltInTools.locationLayer.pipe(
       Layer.provide(services),
       Layer.provide(mutation),
       Layer.provide(resources),
       Layer.provide(todos),
+      Layer.provide(goals),
       Layer.provide(questions),
       Layer.provide(image),
     )
@@ -114,6 +117,7 @@ export class LocationServiceMap extends LayerMap.Service<LocationServiceMap>()("
       mutation,
       resources,
       todos,
+      goals,
       questions,
       model,
       runner,

--- a/packages/core/src/session/goal.ts
+++ b/packages/core/src/session/goal.ts
@@ -1,0 +1,226 @@
+export * as SessionGoal from "./goal"
+
+import { eq } from "drizzle-orm"
+import { Context, Effect, Layer, Schema } from "effect"
+import { Database } from "../database/database"
+import { EventV2 } from "../event"
+import { SessionSchema } from "./schema"
+import { GoalTable } from "./sql"
+
+export const Status = Schema.Literal("active", "paused", "completed")
+export type Status = typeof Status.Type
+
+export const Info = Schema.Struct({
+  text: Schema.String.annotate({ description: "The active goal for this session" }),
+  status: Status,
+  budgetTokens: Schema.optional(Schema.Number).annotate({ description: "Optional token budget for the goal" }),
+  tokensUsed: Schema.Number,
+  timeMs: Schema.Number,
+  startedAt: Schema.Number,
+  pausedAt: Schema.optional(Schema.Number),
+  completedAt: Schema.optional(Schema.Number),
+  verification: Schema.optional(Schema.String),
+}).annotate({ identifier: "SessionGoal.Info" })
+export type Info = typeof Info.Type
+
+export const Event = {
+  Updated: EventV2.define({
+    type: "goal.updated",
+    schema: {
+      sessionID: SessionSchema.ID,
+      goal: Schema.NullOr(Info),
+    },
+  }),
+}
+
+export interface Interface {
+  readonly set: (input: {
+    readonly sessionID: SessionSchema.ID
+    readonly text: string
+    readonly budgetTokens?: number
+  }) => Effect.Effect<Info>
+  readonly update: (input: {
+    readonly sessionID: SessionSchema.ID
+    readonly text?: string
+    readonly status?: Status
+    readonly budgetTokens?: number | null
+    readonly verification?: string
+  }) => Effect.Effect<Info | undefined>
+  readonly pause: (sessionID: SessionSchema.ID) => Effect.Effect<Info | undefined>
+  readonly resume: (sessionID: SessionSchema.ID) => Effect.Effect<Info | undefined>
+  readonly clear: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  readonly get: (sessionID: SessionSchema.ID) => Effect.Effect<Info | undefined>
+  readonly recordUsage: (input: {
+    readonly sessionID: SessionSchema.ID
+    readonly tokens: number
+    readonly durationMs: number
+  }) => Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SessionGoal") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    const events = yield* EventV2.Service
+
+    const now = () => Date.now()
+
+    const read = (sessionID: SessionSchema.ID) =>
+      db
+        .select()
+        .from(GoalTable)
+        .where(eq(GoalTable.session_id, sessionID))
+        .get()
+        .pipe(Effect.orDie)
+
+    const publish = (sessionID: SessionSchema.ID, goal: Info | undefined) =>
+      events.publish(Event.Updated, { sessionID, goal: goal ?? null })
+
+    const toInfo = (row: {
+      text: string
+      status: string
+      budget_tokens: number | null
+      tokens_used: number
+      time_ms: number
+      started_at: number
+      paused_at: number | null
+      completed_at: number | null
+      verification: string | null
+    }): Info => ({
+      text: row.text,
+      status: row.status as Status,
+      budgetTokens: row.budget_tokens ?? undefined,
+      tokensUsed: row.tokens_used,
+      timeMs: row.time_ms,
+      startedAt: row.started_at,
+      pausedAt: row.paused_at ?? undefined,
+      completedAt: row.completed_at ?? undefined,
+      verification: row.verification ?? undefined,
+    })
+
+    const set = Effect.fn("SessionGoal.set")(function* (input: {
+      readonly sessionID: SessionSchema.ID
+      readonly text: string
+      readonly budgetTokens?: number
+    }) {
+      const ts = now()
+      yield* db
+        .insert(GoalTable)
+        .values({
+          session_id: input.sessionID,
+          text: input.text,
+          status: "active",
+          budget_tokens: input.budgetTokens ?? null,
+          tokens_used: 0,
+          time_ms: 0,
+          started_at: ts,
+          paused_at: null,
+          completed_at: null,
+          verification: null,
+          time_created: ts,
+          time_updated: ts,
+        })
+        .onConflictDoUpdate({
+          target: GoalTable.session_id,
+          set: {
+            text: input.text,
+            status: "active",
+            budget_tokens: input.budgetTokens ?? null,
+            paused_at: null,
+            completed_at: null,
+            verification: null,
+            time_updated: ts,
+          },
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const row = yield* read(input.sessionID)
+      const info = row ? toInfo(row) : ({ text: input.text, status: "active", tokensUsed: 0, timeMs: 0, startedAt: ts } as Info)
+      yield* publish(input.sessionID, info)
+      return info
+    })
+
+    const update = Effect.fn("SessionGoal.update")(function* (input: {
+      readonly sessionID: SessionSchema.ID
+      readonly text?: string
+      readonly status?: Status
+      readonly budgetTokens?: number | null
+      readonly verification?: string
+    }) {
+      const current = yield* read(input.sessionID)
+      if (!current) return undefined
+      const ts = now()
+      const next = {
+        text: input.text ?? current.text,
+        status: input.status ?? (current.status as Status),
+        budget_tokens: input.budgetTokens === undefined ? current.budget_tokens : input.budgetTokens,
+        tokens_used: current.tokens_used,
+        time_ms: current.time_ms,
+        started_at: current.started_at,
+        paused_at: current.paused_at,
+        completed_at: current.completed_at,
+        verification: input.verification ?? current.verification,
+        time_updated: ts,
+      }
+      if (input.status === "paused" && !next.paused_at) next.paused_at = ts
+      if (input.status === "active" && next.paused_at) next.paused_at = null
+      if (input.status === "completed" && !next.completed_at) next.completed_at = ts
+      yield* db
+        .update(GoalTable)
+        .set(next)
+        .where(eq(GoalTable.session_id, input.sessionID))
+        .run()
+        .pipe(Effect.orDie)
+      const row = yield* read(input.sessionID)
+      const info = row ? toInfo(row) : undefined
+      yield* publish(input.sessionID, info)
+      return info
+    })
+
+    const pause = Effect.fn("SessionGoal.pause")(function* (sessionID: SessionSchema.ID) {
+      return yield* update({ sessionID, status: "paused" })
+    })
+
+    const resume = Effect.fn("SessionGoal.resume")(function* (sessionID: SessionSchema.ID) {
+      return yield* update({ sessionID, status: "active" })
+    })
+
+    const clear = Effect.fn("SessionGoal.clear")(function* (sessionID: SessionSchema.ID) {
+      yield* db.delete(GoalTable).where(eq(GoalTable.session_id, sessionID)).run().pipe(Effect.orDie)
+      yield* publish(sessionID, undefined)
+    })
+
+    const get = Effect.fn("SessionGoal.get")(function* (sessionID: SessionSchema.ID) {
+      const row = yield* read(sessionID)
+      return row ? toInfo(row) : undefined
+    })
+
+    const recordUsage = Effect.fn("SessionGoal.recordUsage")(function* (input: {
+      readonly sessionID: SessionSchema.ID
+      readonly tokens: number
+      readonly durationMs: number
+    }) {
+      const current = yield* read(input.sessionID)
+      if (!current || (current.status as Status) !== "active") return
+      const ts = now()
+      yield* db
+        .update(GoalTable)
+        .set({
+          tokens_used: current.tokens_used + Math.max(0, Math.floor(input.tokens)),
+          time_ms: current.time_ms + Math.max(0, Math.floor(input.durationMs)),
+          time_updated: ts,
+        })
+        .where(eq(GoalTable.session_id, input.sessionID))
+        .run()
+        .pipe(Effect.orDie)
+      const row = yield* read(input.sessionID)
+      if (row) yield* publish(input.sessionID, toInfo(row))
+    })
+
+    return Service.of({ set, update, pause, resume, clear, get, recordUsage })
+  }),
+)
+
+export const defaultLayer = layer.pipe(Layer.provide(EventV2.defaultLayer), Layer.provide(Database.defaultLayer))

--- a/packages/core/src/session/sql.ts
+++ b/packages/core/src/session/sql.ts
@@ -115,6 +115,27 @@ export const TodoTable = sqliteTable(
   ],
 )
 
+export const GoalTable = sqliteTable(
+  "goal",
+  {
+    session_id: text()
+      .$type<SessionSchema.ID>()
+      .primaryKey()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    text: text().notNull(),
+    status: text().notNull(),
+    budget_tokens: integer(),
+    tokens_used: integer().notNull().default(0),
+    time_ms: integer().notNull().default(0),
+    started_at: integer().notNull(),
+    paused_at: integer(),
+    completed_at: integer(),
+    verification: text(),
+    ...Timestamps,
+  },
+  (table) => [index("goal_session_idx").on(table.session_id)],
+)
+
 export const SessionMessageTable = sqliteTable(
   "session_message",
   {

--- a/packages/core/src/tool/builtins.ts
+++ b/packages/core/src/tool/builtins.ts
@@ -11,6 +11,7 @@ import { ReadTool } from "./read"
 import { ReadToolFileSystem } from "./read-filesystem"
 import { SkillTool } from "./skill"
 import { TodoWriteTool } from "./todowrite"
+import { GoalTool } from "./goal"
 import { WebFetchTool } from "./webfetch"
 import { WebSearchTool } from "./websearch"
 import { WriteTool } from "./write"
@@ -38,6 +39,7 @@ export const locationLayer = Layer.mergeAll(
   ReadTool.layer.pipe(Layer.provide(ReadToolFileSystem.layer)),
   SkillTool.layer,
   TodoWriteTool.layer,
+  GoalTool.layer,
   WebFetchTool.layer,
   WebSearchTool.layer.pipe(Layer.provide(WebSearchTool.defaultConfigLayer)),
   WriteTool.layer,

--- a/packages/core/src/tool/goal.ts
+++ b/packages/core/src/tool/goal.ts
@@ -1,0 +1,77 @@
+export * as GoalTool from "./goal"
+
+import { Effect, Layer, Schema } from "effect"
+import { SessionGoal } from "../session/goal"
+import { Tool } from "./tool"
+import { Tools } from "./tools"
+import { PermissionV2 } from "../permission"
+import { ToolFailure } from "@opencode-ai/llm"
+
+export const name = "goal"
+
+export const Input = Schema.Struct({
+  action: Schema.Literal("update", "pause", "resume", "complete"),
+  text: Schema.optional(Schema.String),
+  verification: Schema.optional(Schema.String),
+})
+export type Input = typeof Input.Type
+
+export const Output = Schema.Struct({
+  goal: Schema.NullOr(SessionGoal.Info),
+})
+export type Output = typeof Output.Type
+
+export const toModelOutput = (output: Output) => (output.goal ? JSON.stringify(output.goal) : "cleared")
+
+export const layer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const tools = yield* Tools.Service
+    const goals = yield* SessionGoal.Service
+    const permission = yield* PermissionV2.Service
+
+    yield* tools
+      .register({
+        [name]: Tool.make({
+          description:
+            "Manage the active per-session goal. Use sparingly. Allowed actions: update (change text), pause, resume, complete (only after verification). Provide verification evidence when completing.",
+          input: Input,
+          output: Output,
+          toModelOutput: ({ output }) => [{ type: "text", text: toModelOutput(output) }],
+          execute: (input, context) =>
+            Effect.gen(function* () {
+              yield* permission.assert({
+                action: "goal",
+                resources: ["*"],
+                save: ["*"],
+                sessionID: context.sessionID,
+                agent: context.agent,
+                source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },
+              })
+              if (input.action === "update") {
+                if (!input.text) return { goal: yield* goals.get(context.sessionID) }
+                const g = yield* goals.update({ sessionID: context.sessionID, text: input.text })
+                return { goal: g ?? (yield* goals.get(context.sessionID)) ?? null }
+              }
+              if (input.action === "pause") {
+                const g = yield* goals.pause(context.sessionID)
+                return { goal: g ?? null }
+              }
+              if (input.action === "resume") {
+                const g = yield* goals.resume(context.sessionID)
+                return { goal: g ?? null }
+              }
+              if (input.action === "complete") {
+                const g = yield* goals.update({
+                  sessionID: context.sessionID,
+                  status: "completed",
+                  verification: input.verification,
+                })
+                return { goal: g ?? null }
+              }
+              return { goal: yield* goals.get(context.sessionID) }
+            }).pipe(Effect.mapError(() => new ToolFailure({ message: "Unable to update goal" }))),
+        }),
+      })
+      .pipe(Effect.orDie)
+  }),
+)

--- a/packages/opencode/src/cli/cmd/run/footer.prompt.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.prompt.tsx
@@ -171,6 +171,10 @@ function parseSlashCommand(text: string, commands: RunCommand[] | undefined) {
     return { type: "none" as const }
   }
 
+  if (head.name === "goal") {
+    return { type: "command" as const, command: { name: "goal", arguments: head.arguments } }
+  }
+
   if (!commands) {
     return { type: "pending" as const }
   }
@@ -417,6 +421,7 @@ export function createPromptState(input: PromptInput): PromptState {
         description: "compose in your external editor",
       } satisfies SlashOption,
       { kind: "slash", name: "new", display: "/new", description: "start a new session" } satisfies SlashOption,
+      { kind: "slash", name: "goal", display: "/goal", description: "set or manage the session goal" } satisfies SlashOption,
       { kind: "slash", name: "exit", display: "/exit", description: "close OpenCode" } satisfies SlashOption,
     ]
     const hidden = new Set(builtins.map((item) => item.name))

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -1273,7 +1273,60 @@ function createLayer(input: StreamInput) {
                   ),
                 )
               : command
-                ? Effect.sync(() => {
+                ? command.name === "goal"
+                  ? Effect.sync(() => {
+                      input.trace?.write("send.goal", { sessionID: input.sessionID, arguments: command.arguments })
+                    }).pipe(
+                      Effect.andThen(
+                        Effect.promise(async () => {
+                          const anySdk = input.sdk as any
+                          const base = (anySdk?.baseUrl || anySdk?._options?.baseUrl || "http://localhost:4096").replace(/\/$/, "")
+                          const url = `${base}/session/${input.sessionID}/goal`
+                          const headers: Record<string, string> = { "content-type": "application/json" }
+                          const defH = anySdk?.headers || anySdk?._def?.headers || {}
+                          for (const [k, v] of Object.entries(defH)) headers[k] = String(v)
+                          const raw = (command.arguments || "").trim()
+                          const lower = raw.toLowerCase()
+                          if (lower === "clear" || lower === "reset") {
+                            await fetch(url, { method: "DELETE", headers })
+                            return
+                          }
+                          if (lower === "pause") {
+                            await fetch(url, { method: "PATCH", headers, body: JSON.stringify({ status: "paused" }) })
+                            return
+                          }
+                          if (lower === "resume") {
+                            await fetch(url, { method: "PATCH", headers, body: JSON.stringify({ status: "active" }) })
+                            return
+                          }
+                          if (lower.startsWith("complete")) {
+                            const note = raw.slice("complete".length).trim() || undefined
+                            await fetch(url, { method: "PATCH", headers, body: JSON.stringify({ status: "completed", verification: note }) })
+                            return
+                          }
+                          if (lower.startsWith("update ")) {
+                            const txt = raw.slice("update ".length).trim()
+                            await fetch(url, { method: "PATCH", headers, body: JSON.stringify({ text: txt }) })
+                            return
+                          }
+                          // default: set the text as the goal
+                          await fetch(url, { method: "POST", headers, body: JSON.stringify({ text: raw }) })
+                        }).pipe(
+                          Effect.tap(() =>
+                            Effect.sync(() => {
+                              input.trace?.write("send.goal.ok", { sessionID: input.sessionID })
+                              item.armed = true
+                              item.live = true
+                            }),
+                          ),
+                          Effect.flatMap(() => Deferred.succeed(item.done, undefined).pipe(Effect.ignore)),
+                          Effect.catch((error) => Deferred.fail(item.done, error).pipe(Effect.ignore)),
+                          Effect.forkIn(scope, { startImmediately: true }),
+                          Effect.asVoid,
+                        ),
+                      ),
+                    )
+                : Effect.sync(() => {
                     input.trace?.write("send.command", { sessionID: input.sessionID, command: command.name })
                   }).pipe(
                     Effect.andThen(

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -9,6 +9,7 @@ import { SessionRevert } from "@/session/revert"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
+import { Goal } from "@/session/goal"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { Snapshot } from "@/snapshot"
 import { Schema, Struct } from "effect"
@@ -74,6 +75,16 @@ export const RevertPayload = Schema.Struct(Struct.omit(SessionRevert.RevertInput
 export const PermissionResponsePayload = Schema.Struct({
   response: PermissionV1.Reply,
 })
+export const GoalSetPayload = Schema.Struct({
+  text: Schema.String,
+  budgetTokens: Schema.optional(Schema.Number),
+})
+export const GoalUpdatePayload = Schema.Struct({
+  text: Schema.optional(Schema.String),
+  status: Schema.optional(Goal.Status),
+  budgetTokens: Schema.optional(Schema.NullOr(Schema.Number)),
+  verification: Schema.optional(Schema.String),
+})
 
 export const SessionPaths = {
   list: root,
@@ -102,6 +113,7 @@ export const SessionPaths = {
   deleteMessage: `${root}/:sessionID/message/:messageID`,
   deletePart: `${root}/:sessionID/message/:messageID/part/:partID`,
   updatePart: `${root}/:sessionID/message/:messageID/part/:partID`,
+  goal: `${root}/:sessionID/goal`,
 } as const
 
 export const SessionApi = HttpApi.make("session")
@@ -430,20 +442,70 @@ export const SessionApi = HttpApi.make("session")
             description: "Delete a part from a message.",
           }),
         ),
-        HttpApiEndpoint.patch("updatePart", SessionPaths.updatePart, {
-          params: { sessionID: SessionID, messageID: MessageID, partID: PartID },
-          query: WorkspaceRoutingQuery,
-          payload: SessionV1.Part,
-          success: described(SessionV1.Part, "Successfully updated part"),
-          error: [HttpApiError.BadRequest, ApiNotFoundError],
-        }).annotateMerge(
-          OpenApi.annotations({
-            identifier: "part.update",
-            description: "Update a part in a message.",
-          }),
-        ),
-      )
-      .annotateMerge(
+         HttpApiEndpoint.patch("updatePart", SessionPaths.updatePart, {
+           params: { sessionID: SessionID, messageID: MessageID, partID: PartID },
+           query: WorkspaceRoutingQuery,
+           payload: SessionV1.Part,
+           success: described(SessionV1.Part, "Successfully updated part"),
+           error: [HttpApiError.BadRequest, ApiNotFoundError],
+         }).annotateMerge(
+           OpenApi.annotations({
+             identifier: "part.update",
+             description: "Update a part in a message.",
+           }),
+         ),
+         HttpApiEndpoint.get("goal", SessionPaths.goal, {
+           params: { sessionID: SessionID },
+           query: WorkspaceRoutingQuery,
+           success: described(Schema.NullOr(Goal.Info), "Session goal"),
+           error: [HttpApiError.BadRequest, ApiNotFoundError],
+         }).annotateMerge(
+           OpenApi.annotations({
+             identifier: "session.goal.get",
+             summary: "Get session goal",
+             description: "Retrieve the active goal for a session, if any.",
+           }),
+         ),
+         HttpApiEndpoint.post("goalSet", SessionPaths.goal, {
+           params: { sessionID: SessionID },
+           query: WorkspaceRoutingQuery,
+           payload: GoalSetPayload,
+           success: described(Goal.Info, "Session goal"),
+           error: [HttpApiError.BadRequest, ApiNotFoundError],
+         }).annotateMerge(
+           OpenApi.annotations({
+             identifier: "session.goal.set",
+             summary: "Set session goal",
+             description: "Create or replace the persisted goal for a session.",
+           }),
+         ),
+         HttpApiEndpoint.patch("goalUpdate", SessionPaths.goal, {
+           params: { sessionID: SessionID },
+           query: WorkspaceRoutingQuery,
+           payload: GoalUpdatePayload,
+           success: described(Goal.Info, "Session goal"),
+           error: [HttpApiError.BadRequest, ApiNotFoundError],
+         }).annotateMerge(
+           OpenApi.annotations({
+             identifier: "session.goal.update",
+             summary: "Update session goal",
+             description: "Update goal text, status, budget, or verification note.",
+           }),
+         ),
+         HttpApiEndpoint.delete("goalClear", SessionPaths.goal, {
+           params: { sessionID: SessionID },
+           query: WorkspaceRoutingQuery,
+           success: described(Schema.Boolean, "Goal cleared"),
+           error: [HttpApiError.BadRequest, ApiNotFoundError],
+         }).annotateMerge(
+           OpenApi.annotations({
+             identifier: "session.goal.clear",
+             summary: "Clear session goal",
+             description: "Remove the goal from the session.",
+           }),
+         ),
+       )
+       .annotateMerge(
         OpenApi.annotations({
           title: "session",
           description: "Experimental HttpApi session routes.",

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -14,6 +14,7 @@ import { SessionRunState } from "@/session/run-state"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
+import { Goal } from "@/session/goal"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Cause, Effect, Option, Schema, Scope } from "effect"
@@ -25,6 +26,8 @@ import {
   CommandPayload,
   DiffQuery,
   ForkPayload,
+  GoalSetPayload,
+  GoalUpdatePayload,
   InitPayload,
   ListQuery,
   MessagesQuery,
@@ -56,6 +59,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const permissionSvc = yield* Permission.Service
     const statusSvc = yield* SessionStatus.Service
     const todoSvc = yield* Todo.Service
+    const goalSvc = yield* Goal.Service
     const summary = yield* SessionSummary.Service
     const events = yield* EventV2Bridge.Service
     const scope = yield* Scope.Scope
@@ -92,6 +96,45 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const todo = Effect.fn("SessionHttpApi.todo")(function* (ctx: { params: { sessionID: SessionID } }) {
       yield* requireSession(ctx.params.sessionID)
       return yield* todoSvc.get(ctx.params.sessionID)
+    })
+
+    const goalGet = Effect.fn("SessionHttpApi.goalGet")(function* (ctx: { params: { sessionID: SessionID } }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* goalSvc.get(ctx.params.sessionID)
+    })
+
+    const goalSet = Effect.fn("SessionHttpApi.goalSet")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof GoalSetPayload.Type
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* goalSvc.set({
+        sessionID: ctx.params.sessionID,
+        text: ctx.payload.text,
+        budgetTokens: ctx.payload.budgetTokens,
+      })
+    })
+
+    const goalUpdate = Effect.fn("SessionHttpApi.goalUpdate")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof GoalUpdatePayload.Type
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      const g = yield* goalSvc.update({
+        sessionID: ctx.params.sessionID,
+        text: ctx.payload.text,
+        status: ctx.payload.status,
+        budgetTokens: ctx.payload.budgetTokens,
+        verification: ctx.payload.verification,
+      })
+      if (!g) return yield* new HttpApiError.NotFound({})
+      return g
+    })
+
+    const goalClear = Effect.fn("SessionHttpApi.goalClear")(function* (ctx: { params: { sessionID: SessionID } }) {
+      yield* requireSession(ctx.params.sessionID)
+      yield* goalSvc.clear(ctx.params.sessionID)
+      return true
     })
 
     const diff = Effect.fn("SessionHttpApi.diff")(function* (ctx: {
@@ -436,5 +479,9 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("deleteMessage", deleteMessage)
       .handle("deletePart", deletePart)
       .handle("updatePart", updatePart)
+      .handle("goal", goalGet)
+      .handle("goalSet", goalSet)
+      .handle("goalUpdate", goalUpdate)
+      .handle("goalClear", goalClear)
   }),
 )

--- a/packages/opencode/src/session/goal.ts
+++ b/packages/opencode/src/session/goal.ts
@@ -1,0 +1,208 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionID } from "./schema"
+import { Effect, Layer, Context, Schema } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { eq } from "drizzle-orm"
+import { GoalTable } from "@opencode-ai/core/session/sql"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { EventV2 } from "@opencode-ai/core/event"
+
+export const Status = Schema.Literals(["active", "paused", "completed"])
+export type Status = Schema.Schema.Type<typeof Status>
+
+export const Info = Schema.Struct({
+  text: Schema.String.annotate({ description: "The active goal for this session" }),
+  status: Status,
+  budgetTokens: Schema.optional(Schema.Number).annotate({ description: "Optional token budget for the goal" }),
+  tokensUsed: Schema.Number,
+  timeMs: Schema.Number,
+  startedAt: Schema.Number,
+  pausedAt: Schema.optional(Schema.Number),
+  completedAt: Schema.optional(Schema.Number),
+  verification: Schema.optional(Schema.String),
+}).annotate({ identifier: "Goal" })
+export type Info = Schema.Schema.Type<typeof Info>
+
+export const Event = {
+  Updated: EventV2.define({
+    type: "goal.updated",
+    schema: {
+      sessionID: SessionID,
+      goal: Schema.NullOr(Info),
+    },
+  }),
+}
+
+export interface Interface {
+  readonly set: (input: { sessionID: SessionID; text: string; budgetTokens?: number }) => Effect.Effect<Info>
+  readonly update: (input: {
+    sessionID: SessionID
+    text?: string
+    status?: Status
+    budgetTokens?: number | null
+    verification?: string
+  }) => Effect.Effect<Info | undefined>
+  readonly pause: (sessionID: SessionID) => Effect.Effect<Info | undefined>
+  readonly resume: (sessionID: SessionID) => Effect.Effect<Info | undefined>
+  readonly clear: (sessionID: SessionID) => Effect.Effect<void>
+  readonly get: (sessionID: SessionID) => Effect.Effect<Info | undefined>
+  readonly recordUsage: (input: { sessionID: SessionID; tokens: number; durationMs: number }) => Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SessionGoal") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const { db } = yield* Database.Service
+
+    const now = () => Date.now()
+
+    const read = (sessionID: SessionID) =>
+      db
+        .select()
+        .from(GoalTable)
+        .where(eq(GoalTable.session_id, sessionID))
+        .get()
+        .pipe(Effect.orDie)
+
+    const toInfo = (row: any): Info => ({
+      text: row.text,
+      status: row.status,
+      budgetTokens: row.budget_tokens ?? undefined,
+      tokensUsed: row.tokens_used,
+      timeMs: row.time_ms,
+      startedAt: row.started_at,
+      pausedAt: row.paused_at ?? undefined,
+      completedAt: row.completed_at ?? undefined,
+      verification: row.verification ?? undefined,
+    })
+
+    const publish = (sessionID: SessionID, goal: Info | undefined) =>
+      events.publish(Event.Updated, { sessionID, goal: goal ?? null })
+
+    const set = Effect.fn("Goal.set")(function* (input: { sessionID: SessionID; text: string; budgetTokens?: number }) {
+      const ts = now()
+      yield* db
+        .insert(GoalTable)
+        .values({
+          session_id: input.sessionID,
+          text: input.text,
+          status: "active",
+          budget_tokens: input.budgetTokens ?? null,
+          tokens_used: 0,
+          time_ms: 0,
+          started_at: ts,
+          paused_at: null,
+          completed_at: null,
+          verification: null,
+          time_created: ts,
+          time_updated: ts,
+        })
+        .onConflictDoUpdate({
+          target: GoalTable.session_id,
+          set: {
+            text: input.text,
+            status: "active",
+            budget_tokens: input.budgetTokens ?? null,
+            paused_at: null,
+            completed_at: null,
+            verification: null,
+            time_updated: ts,
+          },
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const row = yield* read(input.sessionID)
+      const info = row ? toInfo(row) : ({ text: input.text, status: "active", tokensUsed: 0, timeMs: 0, startedAt: ts } as Info)
+      yield* publish(input.sessionID, info)
+      return info
+    })
+
+    const update = Effect.fn("Goal.update")(function* (input: {
+      sessionID: SessionID
+      text?: string
+      status?: Status
+      budgetTokens?: number | null
+      verification?: string
+    }) {
+      const current = yield* read(input.sessionID)
+      if (!current) return undefined
+      const ts = now()
+      const next: any = {
+        text: input.text ?? current.text,
+        status: input.status ?? current.status,
+        budget_tokens: input.budgetTokens === undefined ? current.budget_tokens : input.budgetTokens,
+        tokens_used: current.tokens_used,
+        time_ms: current.time_ms,
+        started_at: current.started_at,
+        paused_at: current.paused_at,
+        completed_at: current.completed_at,
+        verification: input.verification ?? current.verification,
+        time_updated: ts,
+      }
+      if (input.status === "paused" && !next.paused_at) next.paused_at = ts
+      if (input.status === "active" && next.paused_at) next.paused_at = null
+      if (input.status === "completed" && !next.completed_at) next.completed_at = ts
+      yield* db
+        .update(GoalTable)
+        .set(next)
+        .where(eq(GoalTable.session_id, input.sessionID))
+        .run()
+        .pipe(Effect.orDie)
+      const row = yield* read(input.sessionID)
+      const info = row ? toInfo(row) : undefined
+      yield* publish(input.sessionID, info)
+      return info
+    })
+
+    const pause = Effect.fn("Goal.pause")(function* (sessionID: SessionID) {
+      return yield* update({ sessionID, status: "paused" })
+    })
+
+    const resume = Effect.fn("Goal.resume")(function* (sessionID: SessionID) {
+      return yield* update({ sessionID, status: "active" })
+    })
+
+    const clear = Effect.fn("Goal.clear")(function* (sessionID: SessionID) {
+      yield* db.delete(GoalTable).where(eq(GoalTable.session_id, sessionID)).run().pipe(Effect.orDie)
+      yield* publish(sessionID, undefined)
+    })
+
+    const get = Effect.fn("Goal.get")(function* (sessionID: SessionID) {
+      const row = yield* read(sessionID)
+      return row ? toInfo(row) : undefined
+    })
+
+    const recordUsage = Effect.fn("Goal.recordUsage")(function* (input: {
+      sessionID: SessionID
+      tokens: number
+      durationMs: number
+    }) {
+      const current = yield* read(input.sessionID)
+      if (!current || current.status !== "active") return
+      const ts = now()
+      yield* db
+        .update(GoalTable)
+        .set({
+          tokens_used: current.tokens_used + Math.max(0, Math.floor(input.tokens)),
+          time_ms: current.time_ms + Math.max(0, Math.floor(input.durationMs)),
+          time_updated: ts,
+        })
+        .where(eq(GoalTable.session_id, input.sessionID))
+        .run()
+        .pipe(Effect.orDie)
+      const row = yield* read(input.sessionID)
+      if (row) yield* publish(input.sessionID, toInfo(row))
+    })
+
+    return Service.of({ set, update, pause, resume, clear, get, recordUsage })
+  }),
+)
+
+export const defaultLayer = layer.pipe(Layer.provide(EventV2Bridge.defaultLayer), Layer.provide(Database.defaultLayer))
+
+export const node = LayerNode.make(layer, [EventV2Bridge.node, Database.node])
+
+export * as Goal from "./goal"

--- a/packages/opencode/src/storage/schema.ts
+++ b/packages/opencode/src/storage/schema.ts
@@ -1,5 +1,5 @@
 export { AccountTable, AccountStateTable, ControlAccountTable } from "@opencode-ai/core/account/sql"
 export { ProjectTable } from "@opencode-ai/core/project/sql"
-export { SessionTable, MessageTable, PartTable, TodoTable } from "@opencode-ai/core/session/sql"
+export { SessionTable, MessageTable, PartTable, TodoTable, GoalTable } from "@opencode-ai/core/session/sql"
 export { SessionShareTable } from "@opencode-ai/core/share/sql"
 export { WorkspaceTable } from "@opencode-ai/core/control-plane/workspace.sql"


### PR DESCRIPTION
Implements the native /goal feature requested in #27167.

- One persisted goal per session with status (active/paused/completed), optional token budget, and usage accounting (tokens + wall time).
- Client APIs: GET/POST/PATCH/DELETE /session/:sessionID/goal for set, edit, pause/resume, complete (with verification), and clear.
- TUI support via native /goal slash command (set text, update, pause, resume, complete <note>, clear).
- Model-visible tool named 'goal' registered as a built-in with restricted mutation semantics (model may propose complete only with verification evidence).
- Storage, events, layers, and server routes follow the established todo/command precedent.
- Usage hooks allow the runtime to record token/time consumption against the active goal for continuation and budget tracking.

Closes #27167