### PR TITLE
fix(tui): render move errors inline

### DIFF
--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -72,7 +72,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
 
   const [directories, { refetch }] = createResource(
     () => (props.initialRemoving ? undefined : props.projectID),
-    async (projectID) => {
+    async (projectID, info) => {
       try {
         await sdk.client.v2.projectCopy.refresh(
           { projectID, location: { directory: sdk.directory } },
@@ -83,17 +83,22 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
         return directories.data ?? []
       } catch (error) {
         setLoadError(error)
-        return []
+        // Keep any list we already showed so a failed refresh leaves the dialog
+        // usable; only an initial load with no data falls back to the error view.
+        return info.value
       }
     },
   )
   const directoryData = createMemo(() => directories() ?? props.initialDirectories)
+  // Show the locked error view only when we have nothing to display. A refresh
+  // that fails after the list rendered keeps the list and its actions.
+  const showError = createMemo(() => Boolean(loadError()) && !directoryData())
 
   const currentDirectory = createMemo(
     () => replacementCurrent() ?? (props.current?.type === "directory" ? props.current.directory : currentCheckout()),
   )
   const currentRoot = createMemo<ProjectDirectory | undefined>(() => {
-    if (loadError()) return
+    if (showError()) return
     const directory = currentDirectory()
     if (!directory) return
     return (
@@ -104,7 +109,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
   })
 
   const options = createMemo<DialogSelectOption<MoveSessionSelection | undefined>[]>(() => {
-    if (loadError()) return []
+    if (showError()) return []
     const data = directoryData()
     const current = currentRoot()?.directory
     if (directories.loading && !data && !current) return [{ title: "Loading project directories...", value: undefined }]
@@ -273,8 +278,10 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
     if (await removedCurrent(deletingCurrent)) return
   }
 
+  const fullHeight = createMemo(() => Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2)))
+
   return (
-    <box minHeight={loadError() ? 5 : Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
+    <box minHeight={showError() ? 5 : fullHeight()}>
       <DialogSelect
         title="Move session"
         titleView={
@@ -287,10 +294,10 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
             </Show>
           </box>
         }
-        renderFilter={!loadError()}
+        renderFilter={!showError()}
         options={options()}
         emptyView={
-          loadError() ? (
+          showError() ? (
             <box paddingLeft={4} paddingRight={4}>
               <text fg={theme.error} attributes={TextAttributes.BOLD}>
                 Could not load project directories
@@ -299,14 +306,14 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
             </box>
           ) : undefined
         }
-        locked={Boolean(loadError()) || directories.loading || loadedProject.loading || Boolean(removing())}
+        locked={showError() || directories.loading || loadedProject.loading || Boolean(removing())}
         current={current()}
         onSelect={(option) => {
           if (option.value) props.onSelect(option.value)
         }}
         onMove={() => setToDelete(undefined)}
         actions={
-          loadError()
+          showError()
             ? []
             : [
                 {

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -12,7 +12,7 @@ import { useTuiPaths } from "../context/runtime"
 import { Locale } from "../util/locale"
 import { errorMessage } from "../util/error"
 import { useToast } from "../ui/toast"
-import { useBindings, useCommandShortcut } from "../keymap"
+import { useCommandShortcut } from "../keymap"
 import { useProject } from "../context/project"
 import { Spinner } from "./spinner"
 import { DialogWorkspaceFileChanges } from "./dialog-workspace-file-changes"
@@ -59,7 +59,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     ))
   }
 
-  const [loadedProject, loadedProjectActions] = createResource(
+  const [loadedProject] = createResource(
     () => (projectContext.project() === props.projectID ? undefined : props.projectID),
     async (projectID) => {
       try {
@@ -281,11 +281,6 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     if (await removedCurrent(deletingCurrent)) return
   }
 
-  const retry = () => {
-    if (projectLoadError()) void loadedProjectActions.refetch()
-    if (directoryLoadError()) void refetch()
-  }
-
   createEffect(() => dialog.setSize(loadError() ? "medium" : "xlarge"))
 
   return (
@@ -338,59 +333,24 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
         </box>
       }
     >
-      {(error) => (
-        <DialogMoveSessionError
-          error={error()}
-          retry={retry}
-          retrying={
-            (Boolean(projectLoadError()) && loadedProject.loading) ||
-            (Boolean(directoryLoadError()) && directories.loading)
-          }
-        />
-      )}
+      {(error) => <DialogMoveSessionError error={error()} />}
     </Show>
   )
 }
 
-function DialogMoveSessionError(props: { error: unknown; retry: () => void; retrying: boolean }) {
+function DialogMoveSessionError(props: { error: unknown }) {
   const { theme } = useTheme()
-  useBindings(() => ({
-    bindings: [
-      {
-        key: "return",
-        desc: "Retry loading project directories",
-        group: "Dialog",
-        cmd: () => {
-          if (!props.retrying) props.retry()
-        },
-      },
-    ],
-  }))
   return (
-    <box paddingLeft={2} paddingRight={2} paddingBottom={1} gap={1}>
+    <box paddingLeft={2} paddingRight={2} paddingBottom={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
           Move session
         </text>
         <text fg={theme.textMuted}>esc</text>
       </box>
-      <box paddingTop={1} paddingBottom={1} gap={1}>
-        <text fg={theme.error}>Failed to load project directories</text>
+      <box paddingTop={1}>
+        <text fg={theme.text}>Could not load project directories</text>
         <text fg={theme.textMuted}>{errorMessage(props.error)}</text>
-      </box>
-      <box flexDirection="row" justifyContent="flex-end" paddingTop={1}>
-        <box
-          paddingLeft={2}
-          paddingRight={2}
-          backgroundColor={props.retrying ? theme.backgroundElement : theme.primary}
-          onMouseUp={() => {
-            if (!props.retrying) props.retry()
-          }}
-        >
-          <text fg={props.retrying ? theme.textMuted : theme.selectedListItemText}>
-            {props.retrying ? "retrying..." : "enter  retry"}
-          </text>
-        </box>
       </box>
     </box>
   )

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -32,10 +32,6 @@ type DialogMoveSessionProps = {
 }
 
 export function DialogMoveSession(props: DialogMoveSessionProps) {
-  return <DialogMoveSessionContent {...props} />
-}
-
-function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   const dialog = useDialog()
   const sdk = useSDK()
   const dimensions = useTerminalDimensions()
@@ -49,8 +45,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   const [toDelete, setToDelete] = createSignal<string>()
   const [removing, setRemoving] = createSignal(props.initialRemoving)
   const [replacementCurrent, setReplacementCurrent] = createSignal<string>()
-  const [projectLoadError, setProjectLoadError] = createSignal<unknown>()
-  const [directoryLoadError, setDirectoryLoadError] = createSignal<unknown>()
+  const [loadError, setLoadError] = createSignal<unknown>()
   const deleteHint = useCommandShortcut("dialog.move_session.delete")
   onMount(() => dialog.setSize("xlarge"))
 
@@ -60,18 +55,15 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     ))
   }
 
+  // A failed current-checkout lookup only affects which row is highlighted, so
+  // swallow it and let the directory list render without a current marker.
   const [loadedProject] = createResource(
     () => (projectContext.project() === props.projectID ? undefined : props.projectID),
-    async (projectID) => {
-      try {
-        const result = await sdk.client.project.current({}, { throwOnError: true })
-        setProjectLoadError(undefined)
-        return result.data?.id === projectID ? result.data.worktree : undefined
-      } catch (error) {
-        setProjectLoadError(error)
-        return undefined
-      }
-    },
+    (projectID) =>
+      sdk.client.project
+        .current({}, { throwOnError: true })
+        .then((result) => (result.data?.id === projectID ? result.data.worktree : undefined))
+        .catch(() => undefined),
   )
   const currentCheckout = createMemo(() => {
     if (projectContext.project() === props.projectID) return projectContext.instance.path().worktree
@@ -87,16 +79,15 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
           { throwOnError: true },
         )
         const directories = await sdk.client.project.directories({ projectID }, { throwOnError: true })
-        setDirectoryLoadError(undefined)
+        setLoadError(undefined)
         return directories.data ?? []
       } catch (error) {
-        setDirectoryLoadError(error)
+        setLoadError(error)
         return []
       }
     },
   )
   const directoryData = createMemo(() => directories() ?? props.initialDirectories)
-  const loadError = createMemo(() => projectLoadError() ?? directoryLoadError())
 
   const currentDirectory = createMemo(
     () => replacementCurrent() ?? (props.current?.type === "directory" ? props.current.directory : currentCheckout()),

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -72,7 +72,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
 
   const [directories, { refetch }] = createResource(
     () => (props.initialRemoving ? undefined : props.projectID),
-    async (projectID, info) => {
+    async (projectID, info): Promise<ProjectDirectory[] | undefined> => {
       try {
         await sdk.client.v2.projectCopy.refresh(
           { projectID, location: { directory: sdk.directory } },

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -1,6 +1,6 @@
 import { useTerminalDimensions } from "@opentui/solid"
 import { TextAttributes } from "@opentui/core"
-import { createMemo, createResource, createSignal, ErrorBoundary, onMount, Show } from "solid-js"
+import { createEffect, createMemo, createResource, createSignal, Show } from "solid-js"
 import path from "path"
 import { DialogSelect, type DialogSelectOption } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
@@ -32,13 +32,7 @@ type DialogMoveSessionProps = {
 }
 
 export function DialogMoveSession(props: DialogMoveSessionProps) {
-  const dialog = useDialog()
-  onMount(() => dialog.setSize("xlarge"))
-  return (
-    <ErrorBoundary fallback={(error, reset) => <DialogMoveSessionError error={error} retry={reset} />}>
-      <DialogMoveSessionContent {...props} />
-    </ErrorBoundary>
-  )
+  return <DialogMoveSessionContent {...props} />
 }
 
 function DialogMoveSessionContent(props: DialogMoveSessionProps) {
@@ -55,6 +49,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   const [toDelete, setToDelete] = createSignal<string>()
   const [removing, setRemoving] = createSignal(props.initialRemoving)
   const [replacementCurrent, setReplacementCurrent] = createSignal<string>()
+  const [loadError, setLoadError] = createSignal<unknown>()
   const deleteHint = useCommandShortcut("dialog.move_session.delete")
 
   function reopen(initialRemoving?: string) {
@@ -63,11 +58,16 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     ))
   }
 
-  const [loadedProject] = createResource(
+  const [loadedProject, loadedProjectActions] = createResource(
     () => (projectContext.project() === props.projectID ? undefined : props.projectID),
     async (projectID) => {
-      const result = await sdk.client.project.current({}, { throwOnError: true })
-      return result.data?.id === projectID ? result.data.worktree : undefined
+      try {
+        const result = await sdk.client.project.current({}, { throwOnError: true })
+        return result.data?.id === projectID ? result.data.worktree : undefined
+      } catch (error) {
+        setLoadError(error)
+        return undefined
+      }
     },
   )
   const currentCheckout = createMemo(() =>
@@ -85,6 +85,9 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
         )
         const directories = await sdk.client.project.directories({ projectID }, { throwOnError: true })
         return directories.data ?? []
+      } catch (error) {
+        setLoadError(error)
+        return []
       } finally {
         setWorking(false)
       }
@@ -109,8 +112,6 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     const data = directories()
     const current = currentRoot()?.directory
     if (directories.loading && !data && !current) return [{ title: "Loading project directories...", value: undefined }]
-    if (directories.error && !data && !current)
-      return [{ title: "Failed to load project directories", value: undefined }]
     const roots = [...(data ?? [])]
     if (current && !roots.some((item) => item.directory === current)) roots.unshift({ directory: current })
     roots.sort((a, b) => {
@@ -276,51 +277,66 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     if (await removedCurrent(deletingCurrent)) return
   }
 
+  const retry = () => {
+    setLoadError(undefined)
+    void loadedProjectActions.refetch()
+    void refetch()
+  }
+
+  createEffect(() => dialog.setSize(loadError() ? "medium" : "xlarge"))
+
   return (
-    <box minHeight={Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
-      <DialogSelect
-        title="Move session"
-        titleView={
-          <box flexDirection="row" gap={1}>
-            <text fg={theme.text} attributes={TextAttributes.BOLD}>
-              Move session
-            </text>
-            <Show when={working()}>
-              <Spinner />
-            </Show>
-          </box>
-        }
-        options={options()}
-        locked={directories.loading || loadedProject.loading || Boolean(removing())}
-        current={current()}
-        onSelect={(option) => {
-          if (option.value) props.onSelect(option.value)
-        }}
-        onMove={() => setToDelete(undefined)}
-        actions={[
-          {
-            command: "dialog.move_session.new",
-            title: "new",
-            onTrigger: () => props.onSelect({ type: "new" }),
-          },
-          {
-            command: "dialog.move_session.delete",
-            title: "delete",
-            disabled: (option) => {
-              const value = option?.value
-              if (!value || value.type !== "directory" || value.subdirectory) return true
-              return !directories()?.find((item) => item.directory === value.directory)?.strategy
-            },
-            onTrigger: remove,
-          },
-          {
-            command: "dialog.move_session.refresh",
-            title: "refresh",
-            onTrigger: () => void refetch(),
-          },
-        ]}
-      />
-    </box>
+    <Show
+      when={loadError()}
+      fallback={
+        <box minHeight={Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
+          <DialogSelect
+            title="Move session"
+            titleView={
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                  Move session
+                </text>
+                <Show when={working()}>
+                  <Spinner />
+                </Show>
+              </box>
+            }
+            options={options()}
+            locked={directories.loading || loadedProject.loading || Boolean(removing())}
+            current={current()}
+            onSelect={(option) => {
+              if (option.value) props.onSelect(option.value)
+            }}
+            onMove={() => setToDelete(undefined)}
+            actions={[
+              {
+                command: "dialog.move_session.new",
+                title: "new",
+                onTrigger: () => props.onSelect({ type: "new" }),
+              },
+              {
+                command: "dialog.move_session.delete",
+                title: "delete",
+                disabled: (option) => {
+                  const value = option?.value
+                  if (!value || value.type !== "directory" || value.subdirectory) return true
+                  return !directories()?.find((item) => item.directory === value.directory)?.strategy
+                },
+                onTrigger: remove,
+              },
+              {
+                command: "dialog.move_session.refresh",
+                title: "refresh",
+                onTrigger: () => void refetch(),
+              },
+            ]}
+          />
+        </box>
+      }
+    >
+      {(error) => <DialogMoveSessionError error={error()} retry={retry} />}
+    </Show>
   )
 }
 
@@ -338,12 +354,18 @@ function DialogMoveSessionError(props: { error: unknown; retry: () => void }) {
   }))
   return (
     <box paddingLeft={2} paddingRight={2} paddingBottom={1} gap={1}>
-      <text attributes={TextAttributes.BOLD} fg={theme.text}>
-        Failed to load project directories
-      </text>
-      <text fg={theme.error}>{errorMessage(props.error)}</text>
-      <box flexDirection="row" justifyContent="flex-end">
-        <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} onMouseUp={props.retry}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          Move session
+        </text>
+        <text fg={theme.textMuted}>esc</text>
+      </box>
+      <box paddingTop={1} paddingBottom={1} gap={1}>
+        <text fg={theme.error}>Failed to load project directories</text>
+        <text fg={theme.textMuted}>{errorMessage(props.error)}</text>
+      </box>
+      <box flexDirection="row" justifyContent="flex-end" paddingTop={1}>
+        <box paddingLeft={2} paddingRight={2} backgroundColor={theme.primary} onMouseUp={props.retry}>
           <text fg={theme.selectedListItemText}>retry</text>
         </box>
       </box>

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -1,6 +1,6 @@
 import { useTerminalDimensions } from "@opentui/solid"
 import { TextAttributes } from "@opentui/core"
-import { createEffect, createMemo, createResource, createSignal, Show } from "solid-js"
+import { createMemo, createResource, createSignal, onMount, Show } from "solid-js"
 import path from "path"
 import { DialogSelect, type DialogSelectOption } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
@@ -52,6 +52,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   const [projectLoadError, setProjectLoadError] = createSignal<unknown>()
   const [directoryLoadError, setDirectoryLoadError] = createSignal<unknown>()
   const deleteHint = useCommandShortcut("dialog.move_session.delete")
+  onMount(() => dialog.setSize("xlarge"))
 
   function reopen(initialRemoving?: string) {
     dialog.replace(() => (
@@ -112,7 +113,24 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   })
 
   const options = createMemo<DialogSelectOption<MoveSessionSelection | undefined>[]>(() => {
-    if (loadError()) return []
+    const error = loadError()
+    if (error)
+      return [
+        {
+          title: "Could not load project directories",
+          titleView: <span style={{ fg: theme.error }}>Could not load project directories</span>,
+          description: "Close and reopen to try again",
+          details: [errorMessage(error)],
+          category: "Error",
+          categoryView: (
+            <text fg={theme.error} attributes={TextAttributes.BOLD}>
+              Error
+            </text>
+          ),
+          gutter: () => <text fg={theme.error}>!</text>,
+          value: undefined,
+        },
+      ]
     const data = directoryData()
     const current = currentRoot()?.directory
     if (directories.loading && !data && !current) return [{ title: "Loading project directories...", value: undefined }]
@@ -281,77 +299,54 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     if (await removedCurrent(deletingCurrent)) return
   }
 
-  createEffect(() => dialog.setSize(loadError() ? "medium" : "xlarge"))
-
   return (
-    <Show
-      when={loadError()}
-      fallback={
-        <box minHeight={Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
-          <DialogSelect
-            title="Move session"
-            titleView={
-              <box flexDirection="row" gap={1}>
-                <text fg={theme.text} attributes={TextAttributes.BOLD}>
-                  Move session
-                </text>
-                <Show when={working() || directories.loading || loadedProject.loading}>
-                  <Spinner />
-                </Show>
-              </box>
-            }
-            options={options()}
-            locked={directories.loading || loadedProject.loading || Boolean(removing())}
-            current={current()}
-            onSelect={(option) => {
-              if (option.value) props.onSelect(option.value)
-            }}
-            onMove={() => setToDelete(undefined)}
-            actions={[
-              {
-                command: "dialog.move_session.new",
-                title: "new",
-                onTrigger: () => props.onSelect({ type: "new" }),
-              },
-              {
-                command: "dialog.move_session.delete",
-                title: "delete",
-                disabled: (option) => {
-                  const value = option?.value
-                  if (!value || value.type !== "directory" || value.subdirectory) return true
-                  return !directoryData()?.find((item) => item.directory === value.directory)?.strategy
+    <box minHeight={Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
+      <DialogSelect
+        title="Move session"
+        titleView={
+          <box flexDirection="row" gap={1}>
+            <text fg={theme.text} attributes={TextAttributes.BOLD}>
+              Move session
+            </text>
+            <Show when={working() || directories.loading || loadedProject.loading}>
+              <Spinner />
+            </Show>
+          </box>
+        }
+        options={options()}
+        locked={Boolean(loadError()) || directories.loading || loadedProject.loading || Boolean(removing())}
+        current={current()}
+        onSelect={(option) => {
+          if (option.value) props.onSelect(option.value)
+        }}
+        onMove={() => setToDelete(undefined)}
+        actions={
+          loadError()
+            ? []
+            : [
+                {
+                  command: "dialog.move_session.new",
+                  title: "new",
+                  onTrigger: () => props.onSelect({ type: "new" }),
                 },
-                onTrigger: remove,
-              },
-              {
-                command: "dialog.move_session.refresh",
-                title: "refresh",
-                onTrigger: () => void refetch(),
-              },
-            ]}
-          />
-        </box>
-      }
-    >
-      {(error) => <DialogMoveSessionError error={error()} />}
-    </Show>
-  )
-}
-
-function DialogMoveSessionError(props: { error: unknown }) {
-  const { theme } = useTheme()
-  return (
-    <box paddingLeft={2} paddingRight={2} paddingBottom={1}>
-      <box flexDirection="row" justifyContent="space-between">
-        <text attributes={TextAttributes.BOLD} fg={theme.text}>
-          Move session
-        </text>
-        <text fg={theme.textMuted}>esc</text>
-      </box>
-      <box paddingTop={1}>
-        <text fg={theme.text}>Could not load project directories</text>
-        <text fg={theme.textMuted}>{errorMessage(props.error)}</text>
-      </box>
+                {
+                  command: "dialog.move_session.delete",
+                  title: "delete",
+                  disabled: (option) => {
+                    const value = option?.value
+                    if (!value || value.type !== "directory" || value.subdirectory) return true
+                    return !directoryData()?.find((item) => item.directory === value.directory)?.strategy
+                  },
+                  onTrigger: remove,
+                },
+                {
+                  command: "dialog.move_session.refresh",
+                  title: "refresh",
+                  onTrigger: () => void refetch(),
+                },
+              ]
+        }
+      />
     </box>
   )
 }

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -283,7 +283,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   }
 
   return (
-    <box minHeight={Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
+    <box minHeight={loadError() ? 5 : Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
       <DialogSelect
         title="Move session"
         titleView={
@@ -296,14 +296,20 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
             </Show>
           </box>
         }
+        renderFilter={!loadError()}
         options={options()}
         emptyView={
           loadError() ? (
-            <box flexGrow={1} alignItems="center" justifyContent="center" paddingLeft={4} paddingRight={4}>
-              <text fg={theme.error} attributes={TextAttributes.BOLD}>
-                Could not load project directories
-              </text>
-              <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
+            <box paddingLeft={4} paddingRight={4} paddingTop={1} gap={1}>
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.error}>!</text>
+                <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                  Could not load project directories
+                </text>
+              </box>
+              <box paddingLeft={2}>
+                <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
+              </box>
             </box>
           ) : undefined
         }

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -83,8 +83,9 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
         return directories.data ?? []
       } catch (error) {
         setLoadError(error)
-        // Keep any list we already showed so a failed refresh leaves the dialog
-        // usable; only an initial load with no data falls back to the error view.
+        // An initial load with no data surfaces the inline error view below. A
+        // failed refresh intentionally stays quiet and keeps the already-shown
+        // list interactive; reopening the dialog retries the load.
         return info.value
       }
     },

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -300,16 +300,11 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
         options={options()}
         emptyView={
           loadError() ? (
-            <box paddingLeft={4} paddingRight={4} paddingTop={1} gap={1}>
-              <box flexDirection="row" gap={1}>
-                <text fg={theme.error}>!</text>
-                <text fg={theme.text} attributes={TextAttributes.BOLD}>
-                  Could not load project directories
-                </text>
-              </box>
-              <box paddingLeft={2}>
-                <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
-              </box>
+            <box paddingLeft={4} paddingRight={4}>
+              <text fg={theme.error} attributes={TextAttributes.BOLD}>
+                Could not load project directories
+              </text>
+              <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
             </box>
           ) : undefined
         }

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -113,24 +113,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   })
 
   const options = createMemo<DialogSelectOption<MoveSessionSelection | undefined>[]>(() => {
-    const error = loadError()
-    if (error)
-      return [
-        {
-          title: "Could not load project directories",
-          titleView: <span style={{ fg: theme.error }}>Could not load project directories</span>,
-          description: "Close and reopen to try again",
-          details: [errorMessage(error)],
-          category: "Error",
-          categoryView: (
-            <text fg={theme.error} attributes={TextAttributes.BOLD}>
-              Error
-            </text>
-          ),
-          gutter: () => <text fg={theme.error}>!</text>,
-          value: undefined,
-        },
-      ]
+    if (loadError()) return []
     const data = directoryData()
     const current = currentRoot()?.directory
     if (directories.loading && !data && !current) return [{ title: "Loading project directories...", value: undefined }]
@@ -314,6 +297,16 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
           </box>
         }
         options={options()}
+        emptyView={
+          loadError() ? (
+            <box flexGrow={1} alignItems="center" justifyContent="center" paddingLeft={4} paddingRight={4}>
+              <text fg={theme.error} attributes={TextAttributes.BOLD}>
+                Could not load project directories
+              </text>
+              <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
+            </box>
+          ) : undefined
+        }
         locked={Boolean(loadError()) || directories.loading || loadedProject.loading || Boolean(removing())}
         current={current()}
         onSelect={(option) => {

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -49,12 +49,13 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   const [toDelete, setToDelete] = createSignal<string>()
   const [removing, setRemoving] = createSignal(props.initialRemoving)
   const [replacementCurrent, setReplacementCurrent] = createSignal<string>()
-  const [loadError, setLoadError] = createSignal<unknown>()
+  const [projectLoadError, setProjectLoadError] = createSignal<unknown>()
+  const [directoryLoadError, setDirectoryLoadError] = createSignal<unknown>()
   const deleteHint = useCommandShortcut("dialog.move_session.delete")
 
   function reopen(initialRemoving?: string) {
     dialog.replace(() => (
-      <DialogMoveSession {...props} initialDirectories={directories()} initialRemoving={initialRemoving} />
+      <DialogMoveSession {...props} initialDirectories={directoryData()} initialRemoving={initialRemoving} />
     ))
   }
 
@@ -63,53 +64,56 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
     async (projectID) => {
       try {
         const result = await sdk.client.project.current({}, { throwOnError: true })
+        setProjectLoadError(undefined)
         return result.data?.id === projectID ? result.data.worktree : undefined
       } catch (error) {
-        setLoadError(error)
+        setProjectLoadError(error)
         return undefined
       }
     },
   )
-  const currentCheckout = createMemo(() =>
-    projectContext.project() === props.projectID ? projectContext.instance.path().worktree : loadedProject(),
-  )
+  const currentCheckout = createMemo(() => {
+    if (projectContext.project() === props.projectID) return projectContext.instance.path().worktree
+    return loadedProject()
+  })
 
   const [directories, { refetch }] = createResource(
     () => (props.initialRemoving ? undefined : props.projectID),
     async (projectID) => {
-      setWorking(true)
       try {
         await sdk.client.v2.projectCopy.refresh(
           { projectID, location: { directory: sdk.directory } },
           { throwOnError: true },
         )
         const directories = await sdk.client.project.directories({ projectID }, { throwOnError: true })
+        setDirectoryLoadError(undefined)
         return directories.data ?? []
       } catch (error) {
-        setLoadError(error)
+        setDirectoryLoadError(error)
         return []
-      } finally {
-        setWorking(false)
       }
     },
-    { initialValue: props.initialDirectories },
   )
+  const directoryData = createMemo(() => directories() ?? props.initialDirectories)
+  const loadError = createMemo(() => projectLoadError() ?? directoryLoadError())
 
   const currentDirectory = createMemo(
     () => replacementCurrent() ?? (props.current?.type === "directory" ? props.current.directory : currentCheckout()),
   )
   const currentRoot = createMemo<ProjectDirectory | undefined>(() => {
+    if (loadError()) return
     const directory = currentDirectory()
     if (!directory) return
     return (
-      directories()
+      directoryData()
         ?.filter((root) => contains(root.directory, directory))
         .toSorted((a, b) => b.directory.length - a.directory.length)[0] ?? { directory }
     )
   })
 
   const options = createMemo<DialogSelectOption<MoveSessionSelection | undefined>[]>(() => {
-    const data = directories()
+    if (loadError()) return []
+    const data = directoryData()
     const current = currentRoot()?.directory
     if (directories.loading && !data && !current) return [{ title: "Loading project directories...", value: undefined }]
     const roots = [...(data ?? [])]
@@ -207,7 +211,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
 
   async function remove(option: DialogSelectOption<MoveSessionSelection | undefined>) {
     if (!option.value || option.value.type !== "directory" || option.value.subdirectory || removing()) return
-    const data = directories()
+    const data = directoryData()
     const selected = option.value
     const root = data?.find((item) => item.directory === selected.directory)
     if (!root?.strategy) return
@@ -278,9 +282,8 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   }
 
   const retry = () => {
-    setLoadError(undefined)
-    void loadedProjectActions.refetch()
-    void refetch()
+    if (projectLoadError()) void loadedProjectActions.refetch()
+    if (directoryLoadError()) void refetch()
   }
 
   createEffect(() => dialog.setSize(loadError() ? "medium" : "xlarge"))
@@ -297,7 +300,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
                 <text fg={theme.text} attributes={TextAttributes.BOLD}>
                   Move session
                 </text>
-                <Show when={working()}>
+                <Show when={working() || directories.loading || loadedProject.loading}>
                   <Spinner />
                 </Show>
               </box>
@@ -321,7 +324,7 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
                 disabled: (option) => {
                   const value = option?.value
                   if (!value || value.type !== "directory" || value.subdirectory) return true
-                  return !directories()?.find((item) => item.directory === value.directory)?.strategy
+                  return !directoryData()?.find((item) => item.directory === value.directory)?.strategy
                 },
                 onTrigger: remove,
               },
@@ -335,12 +338,21 @@ function DialogMoveSessionContent(props: DialogMoveSessionProps) {
         </box>
       }
     >
-      {(error) => <DialogMoveSessionError error={error()} retry={retry} />}
+      {(error) => (
+        <DialogMoveSessionError
+          error={error()}
+          retry={retry}
+          retrying={
+            (Boolean(projectLoadError()) && loadedProject.loading) ||
+            (Boolean(directoryLoadError()) && directories.loading)
+          }
+        />
+      )}
     </Show>
   )
 }
 
-function DialogMoveSessionError(props: { error: unknown; retry: () => void }) {
+function DialogMoveSessionError(props: { error: unknown; retry: () => void; retrying: boolean }) {
   const { theme } = useTheme()
   useBindings(() => ({
     bindings: [
@@ -348,7 +360,9 @@ function DialogMoveSessionError(props: { error: unknown; retry: () => void }) {
         key: "return",
         desc: "Retry loading project directories",
         group: "Dialog",
-        cmd: props.retry,
+        cmd: () => {
+          if (!props.retrying) props.retry()
+        },
       },
     ],
   }))
@@ -365,8 +379,17 @@ function DialogMoveSessionError(props: { error: unknown; retry: () => void }) {
         <text fg={theme.textMuted}>{errorMessage(props.error)}</text>
       </box>
       <box flexDirection="row" justifyContent="flex-end" paddingTop={1}>
-        <box paddingLeft={2} paddingRight={2} backgroundColor={theme.primary} onMouseUp={props.retry}>
-          <text fg={theme.selectedListItemText}>retry</text>
+        <box
+          paddingLeft={2}
+          paddingRight={2}
+          backgroundColor={props.retrying ? theme.backgroundElement : theme.primary}
+          onMouseUp={() => {
+            if (!props.retrying) props.retry()
+          }}
+        >
+          <text fg={props.retrying ? theme.textMuted : theme.selectedListItemText}>
+            {props.retrying ? "retrying..." : "enter  retry"}
+          </text>
         </box>
       </box>
     </box>

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -279,7 +279,9 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
     if (await removedCurrent(deletingCurrent)) return
   }
 
-  const fullHeight = createMemo(() => Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2)))
+  const fullHeight = createMemo(() =>
+    Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2)),
+  )
 
   return (
     <box minHeight={showError() ? 5 : fullHeight()}>

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -1,6 +1,6 @@
 import { useTerminalDimensions } from "@opentui/solid"
 import { TextAttributes } from "@opentui/core"
-import { createMemo, createResource, createSignal, onMount, Show } from "solid-js"
+import { createMemo, createResource, createSignal, ErrorBoundary, onMount, Show } from "solid-js"
 import path from "path"
 import { DialogSelect, type DialogSelectOption } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
@@ -12,7 +12,7 @@ import { useTuiPaths } from "../context/runtime"
 import { Locale } from "../util/locale"
 import { errorMessage } from "../util/error"
 import { useToast } from "../ui/toast"
-import { useCommandShortcut } from "../keymap"
+import { useBindings, useCommandShortcut } from "../keymap"
 import { useProject } from "../context/project"
 import { Spinner } from "./spinner"
 import { DialogWorkspaceFileChanges } from "./dialog-workspace-file-changes"
@@ -22,14 +22,26 @@ import { useRoute } from "../context/route"
 export type MoveSessionSelection = { type: "directory"; directory: string; subdirectory: boolean } | { type: "new" }
 type ProjectDirectory = ProjectDirectories[number]
 
-export function DialogMoveSession(props: {
+type DialogMoveSessionProps = {
   projectID: string
   current?: MoveSessionSelection
   onSelect: (selection: MoveSessionSelection) => void
   onCurrentChange?: (selection: MoveSessionSelection) => void
   initialDirectories?: ProjectDirectory[]
   initialRemoving?: string
-}) {
+}
+
+export function DialogMoveSession(props: DialogMoveSessionProps) {
+  const dialog = useDialog()
+  onMount(() => dialog.setSize("xlarge"))
+  return (
+    <ErrorBoundary fallback={(error, reset) => <DialogMoveSessionError error={error} retry={reset} />}>
+      <DialogMoveSessionContent {...props} />
+    </ErrorBoundary>
+  )
+}
+
+function DialogMoveSessionContent(props: DialogMoveSessionProps) {
   const dialog = useDialog()
   const sdk = useSDK()
   const dimensions = useTerminalDimensions()
@@ -73,13 +85,6 @@ export function DialogMoveSession(props: {
         )
         const directories = await sdk.client.project.directories({ projectID }, { throwOnError: true })
         return directories.data ?? []
-      } catch (error) {
-        toast.show({
-          variant: "error",
-          title: "Failed to load project directories",
-          message: errorMessage(error),
-        })
-        return []
       } finally {
         setWorking(false)
       }
@@ -271,8 +276,6 @@ export function DialogMoveSession(props: {
     if (await removedCurrent(deletingCurrent)) return
   }
 
-  onMount(() => dialog.setSize("xlarge"))
-
   return (
     <box minHeight={Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2))}>
       <DialogSelect
@@ -317,6 +320,33 @@ export function DialogMoveSession(props: {
           },
         ]}
       />
+    </box>
+  )
+}
+
+function DialogMoveSessionError(props: { error: unknown; retry: () => void }) {
+  const { theme } = useTheme()
+  useBindings(() => ({
+    bindings: [
+      {
+        key: "return",
+        desc: "Retry loading project directories",
+        group: "Dialog",
+        cmd: props.retry,
+      },
+    ],
+  }))
+  return (
+    <box paddingLeft={2} paddingRight={2} paddingBottom={1} gap={1}>
+      <text attributes={TextAttributes.BOLD} fg={theme.text}>
+        Failed to load project directories
+      </text>
+      <text fg={theme.error}>{errorMessage(props.error)}</text>
+      <box flexDirection="row" justifyContent="flex-end">
+        <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} onMouseUp={props.retry}>
+          <text fg={theme.selectedListItemText}>retry</text>
+        </box>
+      </box>
     </box>
   )
 }

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -25,6 +25,7 @@ export interface DialogSelectProps<T> {
   titleView?: JSX.Element
   placeholder?: string
   footer?: JSX.Element
+  emptyView?: JSX.Element
   options: DialogSelectOption<T>[]
   flat?: boolean
   ref?: (ref: DialogSelectRef<T>) => void
@@ -527,9 +528,11 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         <Show
           when={grouped().length > 0}
           fallback={
-            <box paddingLeft={4} paddingRight={4} paddingTop={1}>
-              <text fg={theme.textMuted}>No results found</text>
-            </box>
+            props.emptyView ?? (
+              <box paddingLeft={4} paddingRight={4} paddingTop={1}>
+                <text fg={theme.textMuted}>No results found</text>
+              </box>
+            )
           }
         >
           <scrollbox


### PR DESCRIPTION
## Summary
- keep loading, success, empty, and error states inside the same `DialogSelect` shell
- render request failures as a locked error row with recovery guidance and technical detail
- preserve the normal xlarge dimensions, title, search field, list geometry, and Escape behavior
- hide actions that are not useful while directory loading has failed
- close and reopen `/move` to issue a fresh request

## Terminal verification
Tested interactively with `termctrl` against `bun dev`:
- forced failure renders in the same dialog shape as success
- Escape closes the error state
- reopening `/move` performs a fresh request
- after removing the forced failure, the normal destination list loads and remains selectable

No typecheck was run.