### PR TITLE
fix(mcp): escape OAuth callback errors

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -26,6 +26,15 @@ const HTML_SUCCESS = `<!DOCTYPE html>
 </body>
 </html>`
 
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
 const HTML_ERROR = (error: string) => `<!DOCTYPE html>
 <html>
 <head>
@@ -42,7 +51,7 @@ const HTML_ERROR = (error: string) => `<!DOCTYPE html>
   <div class="container">
     <h1>Authorization Failed</h1>
     <p>An error occurred during authorization.</p>
-    <div class="error">${error}</div>
+    <div class="error">${escapeHtml(error)}</div>
   </div>
 </body>
 </html>`
@@ -87,7 +96,7 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
   // Enforce state parameter presence
   if (!state) {
     const errorMsg = "Missing required state parameter - potential CSRF attack"
-    res.writeHead(400, { "Content-Type": "text/html" })
+    res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" })
     res.end(HTML_ERROR(errorMsg))
     return
   }
@@ -101,13 +110,13 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
       cleanupStateIndex(state)
       pending.reject(new Error(errorMsg))
     }
-    res.writeHead(200, { "Content-Type": "text/html" })
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
     res.end(HTML_ERROR(errorMsg))
     return
   }
 
   if (!code) {
-    res.writeHead(400, { "Content-Type": "text/html" })
+    res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" })
     res.end(HTML_ERROR("No authorization code provided"))
     return
   }
@@ -115,7 +124,7 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
   // Validate state parameter
   if (!pendingAuths.has(state)) {
     const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
-    res.writeHead(400, { "Content-Type": "text/html" })
+    res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" })
     res.end(HTML_ERROR(errorMsg))
     return
   }
@@ -127,7 +136,7 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
   cleanupStateIndex(state)
   pending.resolve(code)
 
-  res.writeHead(200, { "Content-Type": "text/html" })
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
   res.end(HTML_SUCCESS)
 }
 

--- a/packages/opencode/test/mcp/oauth-callback.test.ts
+++ b/packages/opencode/test/mcp/oauth-callback.test.ts
@@ -31,4 +31,30 @@ describe("McpOAuthCallback.ensureRunning", () => {
     await McpOAuthCallback.ensureRunning("http://127.0.0.1:18000/custom/callback")
     expect(McpOAuthCallback.isRunning()).toBe(true)
   })
+
+  test("escapes provider error markup in callback HTML", async () => {
+    const redirectUri = "http://127.0.0.1:18001/custom/callback"
+    await McpOAuthCallback.ensureRunning(redirectUri)
+
+    const error = `<script>alert("xss" & 'more')</script>`
+    const response = await fetch(
+      `${redirectUri}?state=test&error=access_denied&error_description=${encodeURIComponent(error)}`,
+    )
+    const body = await response.text()
+
+    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8")
+    expect(body).toContain("&lt;script&gt;alert(&quot;xss&quot; &amp; &#39;more&#39;)&lt;/script&gt;")
+    expect(body).not.toContain(error)
+  })
+
+  test("keeps normal provider errors readable", async () => {
+    const redirectUri = "http://127.0.0.1:18002/custom/callback"
+    await McpOAuthCallback.ensureRunning(redirectUri)
+
+    const response = await fetch(
+      `${redirectUri}?state=test&error=access_denied&error_description=${encodeURIComponent("The user denied access")}`,
+    )
+
+    expect(await response.text()).toContain('<div class="error">The user denied access</div>')
+  })
 })


### PR DESCRIPTION
## Summary
- escape provider-controlled OAuth callback errors before rendering HTML
- declare UTF-8 for callback HTML responses
- add regression coverage for hostile markup and readable normal errors

## Tests
- `bun test test/mcp/oauth-callback.test.ts` (6 pass)

Closes #17364
Related to #28567