### PR TITLE
docs(ecosystem): add AION time-series harness plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [AION](https://github.com/ztxtech/aion)                                                           | Time-series harness for OpenCode: 4-layer (task/workspace/execution/review) multi-agent system with governance hierarchy, 17 skills, 8 protocols, and leakage prevention. Companion to arXiv:2605.25045 |
 
 ---
 


### PR DESCRIPTION
Adds **[AION](https://github.com/ztxtech/aion)** to the **Plugins** section of the English ecosystem page (`packages/web/src/content/docs/ecosystem.mdx`).

**AION** is a time-series harness for OpenCode: a 4-layer (task / workspace / execution / review) multi-agent system with a governance hierarchy, 17 skills, 8 coordination protocols, and leakage prevention. Companion paper: arXiv:2605.25045.

### Why only the English file?

I deliberately did **not** touch the 17 locale copies under `packages/web/src/content/docs/<locale>/ecosystem.mdx`. The repo's `docs-locale-sync` workflow (`.github/workflows/docs-locale-sync.yml`) auto-syncs locale docs whenever an English doc under `packages/web/src/content/docs/*.mdx` changes on `dev`, and its instructions explicitly say: *"Do not modify English source docs in `packages/web/src/content/docs/*.mdx`"* from inside the sync job. If I had pre-translated the locales, the bot would either conflict with my edits or undo them. Happy to pre-translate the 17 locale files in a follow-up commit if maintainers prefer that flow over the bot.

### Checklist

- [x] One change in one file (English `ecosystem.mdx` only)
- [x] Repo is a public OpenCode plugin (compiles to a single self-contained `.opencode/plugins/aion.js` bundle)
- [x] Plugin is actively maintained (4 releases, last release Jun 14 2026)
- [x] Companion paper on arXiv