### PR TITLE
fix(opencode): accept hash-prefixed PR numbers

### DIFF
--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -5,14 +5,31 @@ import { Git } from "@/git"
 import { InstanceRef } from "@/effect/instance-ref"
 import { Process } from "@/util/process"
 
+export function parsePrNumber(input: string | number): number | undefined {
+  const normalized = String(input).trim().replace(/^#/, "")
+  if (!/^\d+$/.test(normalized)) return undefined
+  const value = Number(normalized)
+  if (!Number.isSafeInteger(value)) return undefined
+  if (value <= 0) return undefined
+  return value
+}
+
+export function formatInvalidPrNumber(input: string | number) {
+  return `Invalid PR number ${JSON.stringify(String(input))}. Pass a positive integer, optionally prefixed with "#".`
+}
+
 export const PrCommand = effectCmd({
   command: "pr <number>",
   describe: "fetch and checkout a GitHub PR branch, then run opencode",
   builder: (yargs) =>
     yargs.positional("number", {
-      type: "number",
+      type: "string",
       describe: "PR number to checkout",
       demandOption: true,
+      coerce: (value: string | number) => {
+        const parsed = parsePrNumber(value)
+        return parsed ?? value
+      },
     }),
   handler: Effect.fn("Cli.pr")(function* (args) {
     const ctx = yield* InstanceRef
@@ -24,7 +41,8 @@ export const PrCommand = effectCmd({
     const git = yield* Git.Service
     const worktree = ctx.worktree
 
-    const prNumber = args.number
+    const prNumber = parsePrNumber(args.number)
+    if (prNumber === undefined) return yield* fail(formatInvalidPrNumber(args.number))
     const localBranchName = `pr/${prNumber}`
     UI.println(`Fetching and checking out PR #${prNumber}...`)
 
@@ -111,5 +129,6 @@ export const PrCommand = effectCmd({
     // Match legacy throw semantics — propagate as a defect so the top-level
     // index.ts catch handles it identically (exit 1, "Unexpected error" banner).
     if (code !== 0) return yield* Effect.die(new Error(`opencode exited with code ${code}`))
+    return undefined
   }),
 })

--- a/packages/opencode/test/cli/cmd/pr.test.ts
+++ b/packages/opencode/test/cli/cmd/pr.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { formatInvalidPrNumber, parsePrNumber } from "@/cli/cmd/pr"
+
+describe("cli.pr parsePrNumber", () => {
+  test("accepts bare and hash-prefixed positive integers", () => {
+    expect(parsePrNumber("992")).toBe(992)
+    expect(parsePrNumber("#992")).toBe(992)
+    expect(parsePrNumber("  #992  ")).toBe(992)
+  })
+
+  test("rejects malformed PR numbers", () => {
+    expect(parsePrNumber("#")).toBeUndefined()
+    expect(parsePrNumber("")).toBeUndefined()
+    expect(parsePrNumber("abc")).toBeUndefined()
+    expect(parsePrNumber("+3")).toBeUndefined()
+    expect(parsePrNumber("# 992")).toBeUndefined()
+    expect(parsePrNumber("0")).toBeUndefined()
+    expect(parsePrNumber("-3")).toBeUndefined()
+    expect(parsePrNumber("12.5")).toBeUndefined()
+    expect(parsePrNumber("99x")).toBeUndefined()
+    expect(parsePrNumber("##992")).toBeUndefined()
+  })
+
+  test("rejects integers above the safe numeric range", () => {
+    expect(parsePrNumber(`${Number.MAX_SAFE_INTEGER + 1}`)).toBeUndefined()
+  })
+
+  test("quotes invalid input in validation errors", () => {
+    expect(formatInvalidPrNumber("  # 992  ")).toBe(
+      'Invalid PR number "  # 992  ". Pass a positive integer, optionally prefixed with "#".',
+    )
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #32251.

Replaces closed PR #32261.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode pr #992` used to become `NaN` because yargs parsed the positional as a number.

This PR parses the PR number as a string first, accepts `992`, `#992`, and surrounding whitespace, then passes a safe positive integer to `gh pr checkout`.

It rejects malformed input with a quoted error so whitespace is visible.

### How did you verify your code works?

- `bun test test/cli/cmd/pr.test.ts`
- `bun typecheck`
- `bunx oxlint packages/opencode/src/cli/cmd/pr.ts packages/opencode/test/cli/cmd/pr.test.ts`
- `git diff --check`
- tmux CLI smoke with a fake `gh`: `opencode pr #992` called `gh pr checkout 992 --branch pr/992 --force`, and `opencode pr "# 992"` printed `Invalid PR number "# 992"...`

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
