### PR TITLE
docs(cli): document non-interactive mcp add flags

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -238,7 +238,27 @@ Add an MCP server to your configuration.
 opencode mcp add
 ```
 
-This command will guide you through adding either a local or remote MCP server.
+Run without arguments to interactively add either a local or remote MCP server.
+
+You can also add a server non-interactively by passing a name. This writes the
+server to your global config. Use `--url` for a remote server, or pass the
+command to run after `--` for a local server.
+
+```bash
+# Remote server
+opencode mcp add github --url https://api.githubcopilot.com/mcp --header "Authorization=Bearer {env:GITHUB_TOKEN}"
+
+# Local server
+opencode mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path
+```
+
+| Flag       | Description                                                         |
+| ---------- | ------------------------------------------------------------------- |
+| `--url`    | URL for a remote MCP server.                                        |
+| `--header` | HTTP header for a remote server as `KEY=VALUE`. Repeatable.         |
+| `--env`    | Environment variable for a local server as `KEY=VALUE`. Repeatable. |
+
+Header and environment values support [variable substitution](/docs/config#variables), so secrets like `{env:GITHUB_TOKEN}` are resolved from your environment at runtime.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Fixes #32259.

Replaces closed PR #32267.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Documents the non-interactive `opencode mcp add` form.

The CLI reference now shows remote and local examples, lists `--url`, `--header`, and `--env`, and links to variable substitution docs for `{env:...}` values.

### How did you verify your code works?

- Checked the documented flags against `packages/opencode/src/cli/cmd/mcp.ts`
- `bunx prettier --check packages/web/src/content/docs/cli.mdx`
- `git diff --check`
- tmux readback of the updated `mcp add` docs section

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
