### PR TITLE
fix(core): expand tilde in file tool paths

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -48,7 +48,7 @@ export const ripgrepLayer = Layer.effect(
     return Service.of({
       glob: (input) =>
         Effect.gen(function* () {
-          const target = path.resolve(location.directory, input.path ?? ".")
+          const target = path.resolve(location.directory, FSUtil.expandHome(input.path ?? "."))
           const info = yield* fs.stat(target).pipe(Effect.orDie)
           const cwd = info.type === "File" ? path.dirname(target) : target
           return yield* ripgrep
@@ -72,7 +72,7 @@ export const ripgrepLayer = Layer.effect(
         }),
       grep: (input) =>
         Effect.gen(function* () {
-          const target = path.resolve(location.directory, input.path ?? ".")
+          const target = path.resolve(location.directory, FSUtil.expandHome(input.path ?? "."))
           const info = yield* fs.stat(target).pipe(Effect.orDie)
           const cwd = info.type === "File" ? path.dirname(target) : target
           return yield* ripgrep

--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -1,6 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { dirname, isAbsolute, join, relative, resolve as pathResolve, sep } from "path"
 import { realpathSync } from "fs"
+import { homedir } from "os"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
 import { Context, Effect, FileSystem, Layer, Schema } from "effect"
@@ -201,6 +202,22 @@ export namespace FSUtil {
   // Pure helpers that don't need Effect (path manipulation, sync operations)
   export function mimeType(p: string): string {
     return lookup(p) || "application/octet-stream"
+  }
+
+  /**
+   * Expand a leading `~` to the user's home directory.
+   *
+   * Only a path that is exactly `~` or begins with `~/` (and on Windows `~\`)
+   * is expanded; the remainder is joined onto `os.homedir()`. Other `~user`
+   * forms are intentionally left literal because resolving a *named* user's
+   * home directory is platform-specific and out of scope here. This keeps the
+   * expansion escape-safe: only the documented prefixes are touched.
+   */
+  export function expandHome(p: string): string {
+    if (p === "~") return homedir()
+    if (p.startsWith("~/")) return join(homedir(), p.slice(2).replace(/^[\\/]+/u, ""))
+    if (process.platform === "win32" && p.startsWith("~\\")) return join(homedir(), p.slice(2).replace(/^[\\/]+/u, ""))
+    return p
   }
 
   export function normalizePath(p: string): string {

--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -117,8 +117,11 @@ export const layer = Layer.effect(
     })
 
     const resolve = Effect.fn("LocationMutation.resolve")(function* (input: ResolveInput) {
-      const relative = !path.isAbsolute(input.path)
-      const absolute = path.resolve(location.directory, input.path)
+      // Expand a leading `~`/`~/` so a tilde path is treated as the absolute
+      // path it denotes; the isAbsolute/escape checks run against the expansion.
+      const expanded = FSUtil.expandHome(input.path)
+      const relative = !path.isAbsolute(expanded)
+      const absolute = path.resolve(location.directory, expanded)
       const lexicallyInternal = FSUtil.contains(location.directory, absolute)
       if (relative && !lexicallyInternal) return yield* new PathError({ path: input.path, reason: "relative_escape" })
 

--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -4,6 +4,7 @@ import { ToolFailure } from "@opencode-ai/llm"
 import { Effect, Layer, Schema } from "effect"
 import path from "path"
 import { FileSystem } from "../filesystem"
+import { FSUtil } from "../fs-util"
 import { Location } from "../location"
 import { Ripgrep } from "../ripgrep"
 import { RelativePath } from "../schema"
@@ -70,7 +71,7 @@ export const layer = Layer.effectDiscard(
                 agent: context.agent,
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },
               })
-              const cwd = path.resolve(location.directory, input.path ?? ".")
+              const cwd = path.resolve(location.directory, FSUtil.expandHome(input.path ?? "."))
               return yield* ripgrep
                 .glob({
                   cwd,

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -90,7 +90,7 @@ export const layer = Layer.effectDiscard(
                 agent: context.agent,
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },
               })
-              const target = path.resolve(location.directory, input.path ?? ".")
+              const target = path.resolve(location.directory, FSUtil.expandHome(input.path ?? "."))
               const info = yield* fs.stat(target).pipe(Effect.catch(() => Effect.succeed(undefined)))
               return yield* ripgrep
                 .grep({

--- a/packages/core/src/tool/read.ts
+++ b/packages/core/src/tool/read.ts
@@ -53,9 +53,11 @@ export const layer = Layer.effectDiscard(
           },
           execute: (input, context) => {
             return Effect.gen(function* () {
-              const absolute = path.resolve(location.directory, input.path)
-              const selected = path.isAbsolute(input.path) ? path.dirname(absolute) : location.directory
-              if (!path.isAbsolute(input.path) && !FSUtil.contains(location.directory, absolute))
+              // Expand a leading `~`/`~/` first so home paths use the absolute-path read branch.
+              const expanded = FSUtil.expandHome(input.path)
+              const absolute = path.resolve(location.directory, expanded)
+              const selected = path.isAbsolute(expanded) ? path.dirname(absolute) : location.directory
+              if (!path.isAbsolute(expanded) && !FSUtil.contains(location.directory, absolute))
                 return yield* Effect.die(new Error("Path escapes the allowed read root"))
               const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
               const root = yield* fs.realPath(selected).pipe(Effect.orDie)

--- a/packages/core/test/tilde-expansion.test.ts
+++ b/packages/core/test/tilde-expansion.test.ts
@@ -1,0 +1,204 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { beforeEach, describe, expect, test } from "bun:test"
+import { Effect, Exit, Layer } from "effect"
+import { Config } from "@opencode-ai/core/config"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import { Image } from "@opencode-ai/core/image"
+import { Location } from "@opencode-ai/core/location"
+import { LocationMutation } from "@opencode-ai/core/location-mutation"
+import { PermissionV2 } from "@opencode-ai/core/permission"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { SessionV2 } from "@opencode-ai/core/session"
+import { FileSystem } from "@opencode-ai/core/filesystem"
+import { ReadTool } from "@opencode-ai/core/tool/read"
+import { ReadToolFileSystem } from "@opencode-ai/core/tool/read-filesystem"
+import { ToolRegistry } from "@opencode-ai/core/tool/registry"
+import { location } from "./fixture/location"
+import { tmpdir } from "./fixture/tmpdir"
+import { it as effectIt, testEffect } from "./lib/effect"
+import { executeTool, toolIdentity } from "./lib/tool"
+
+const home = os.homedir()
+
+// ---------------------------------------------------------------------------
+// Pure helper: only `~` and `~/` (and `~\` on Windows) expand; `~user` is literal.
+// ---------------------------------------------------------------------------
+describe("FSUtil.expandHome", () => {
+  test('expands a bare "~" to the home directory', () => {
+    expect(FSUtil.expandHome("~")).toBe(home)
+  })
+
+  test('expands a "~/" prefix onto the home directory', () => {
+    expect(FSUtil.expandHome("~/.bashrc")).toBe(path.join(home, ".bashrc"))
+    expect(FSUtil.expandHome("~/nested/file.txt")).toBe(path.join(home, "nested", "file.txt"))
+  })
+
+  test("keeps duplicate separators after ~/ inside the home directory", () => {
+    expect(FSUtil.expandHome("~//nested/file.txt")).toBe(path.join(home, "nested", "file.txt"))
+  })
+
+  test('leaves "~user" forms literal (named-user homes are out of scope)', () => {
+    expect(FSUtil.expandHome("~root")).toBe("~root")
+    expect(FSUtil.expandHome("~alice/file")).toBe("~alice/file")
+  })
+
+  test("leaves ordinary relative and absolute paths untouched", () => {
+    expect(FSUtil.expandHome("src/main.ts")).toBe("src/main.ts")
+    expect(FSUtil.expandHome("./a/../b")).toBe("./a/../b")
+    expect(FSUtil.expandHome("/etc/hosts")).toBe("/etc/hosts")
+    expect(FSUtil.expandHome("file~with~tilde.txt")).toBe("file~with~tilde.txt")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// write/edit resolution flows through LocationMutation.resolve.
+// ---------------------------------------------------------------------------
+function provideMutation(directory: string) {
+  return Effect.provide(
+    LocationMutation.layer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          FSUtil.defaultLayer,
+          Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
+        ),
+      ),
+    ),
+  )
+}
+
+function withTmp<A, E, R>(f: (directory: string) => Effect.Effect<A, E, R>) {
+  return Effect.acquireRelease(
+    Effect.promise(() => tmpdir()),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  ).pipe(Effect.flatMap((tmp) => f(tmp.path)))
+}
+
+describe("LocationMutation tilde expansion (write/edit)", () => {
+  effectIt.live("resolves a ~/ path to a home-directory target instead of a literal ~ folder", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        // A unique probe under the real home directory so the canonical path is deterministic.
+        const name = `opencode-tilde-${process.pid}-${Date.now()}.txt`
+        const target = yield* (yield* LocationMutation.Service).resolve({ path: `~/${name}`, kind: "file" })
+        const realHome = yield* Effect.promise(() => fs.realpath(home))
+
+        expect(target.canonical).toBe(path.join(realHome, name))
+        // Home is outside the active Location, so it is gated as an external directory.
+        expect(target.externalDirectory?.directory).toBe(realHome)
+      }).pipe(provideMutation(directory)),
+    ),
+  )
+
+  effectIt.live('resolves a bare "~" to the home directory', () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const target = yield* (yield* LocationMutation.Service).resolve({ path: "~", kind: "directory" })
+        const realHome = yield* Effect.promise(() => fs.realpath(home))
+        expect(target.canonical).toBe(realHome)
+      }).pipe(provideMutation(directory)),
+    ),
+  )
+
+  effectIt.live("still rejects a genuinely relative path that escapes the Location", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip((yield* LocationMutation.Service).resolve({ path: "../outside.txt" }))
+        expect(error).toMatchObject({ _tag: "LocationMutation.PathError", reason: "relative_escape" })
+      }).pipe(provideMutation(directory)),
+    ),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// read resolution flows through the read tool's own path handling.
+// ---------------------------------------------------------------------------
+const readCalls: AbsolutePath[] = []
+const reader = Layer.succeed(
+  ReadToolFileSystem.Service,
+  ReadToolFileSystem.Service.of({
+    inspect: () => Effect.succeed("file" as const),
+    read: (input) => {
+      readCalls.push(input)
+      return Effect.succeed({
+        uri: "file:///probe",
+        name: "probe",
+        content: "hi",
+        encoding: "utf8",
+        mime: "text/plain",
+      } satisfies FileSystem.Content)
+    },
+    list: () => Effect.succeed(new ReadToolFileSystem.ListPage({ entries: [], truncated: false })),
+  }),
+)
+const permission = Layer.succeed(
+  PermissionV2.Service,
+  PermissionV2.Service.of({
+    assert: () => Effect.void,
+    ask: () => Effect.die("unused"),
+    reply: () => Effect.die("unused"),
+    get: () => Effect.die("unused"),
+    forSession: () => Effect.die("unused"),
+    list: () => Effect.die("unused"),
+  }),
+)
+const registry = ToolRegistry.defaultLayer.pipe(Layer.provide(permission))
+const config = Layer.succeed(Config.Service, Config.Service.of({ entries: () => Effect.succeed([]) }))
+const image = Image.layer.pipe(Layer.provide(config))
+// realPath identity keeps the assertion focused on path resolution, not symlink canonicalization.
+const testFileSystem = Layer.effect(
+  FSUtil.Service,
+  FSUtil.Service.use((fs) => Effect.succeed(FSUtil.Service.of({ ...fs, realPath: (p) => Effect.succeed(p) }))),
+).pipe(Layer.provide(FSUtil.defaultLayer))
+const infrastructure = Layer.mergeAll(
+  testFileSystem,
+  Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(process.cwd()) }))),
+  Global.layerWith({ data: Global.Path.data }),
+)
+const read = ReadTool.layer.pipe(
+  Layer.provide(registry),
+  Layer.provide(reader),
+  Layer.provide(permission),
+  Layer.provide(config),
+  Layer.provide(image),
+  Layer.provide(infrastructure),
+)
+const itRead = testEffect(Layer.mergeAll(registry, reader, permission, config, image, infrastructure, read))
+const sessionID = SessionV2.ID.make("ses_tilde_read_test")
+
+describe("ReadTool tilde expansion", () => {
+  beforeEach(() => {
+    readCalls.length = 0
+  })
+
+  itRead.effect("expands ~/ to an absolute home path and reads it without an escape error", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const name = "opencode-tilde-read-probe.txt"
+      const result = yield* executeTool(registry, {
+        sessionID,
+        ...toolIdentity,
+        call: { type: "tool-call", id: "call-tilde", name: "read", input: { path: `~/${name}` } },
+      })
+      expect(result).toMatchObject({ type: "json" })
+      // Resolution expanded ~ to the home dir; isAbsolute branch treated it as absolute, no escape death.
+      expect(readCalls).toEqual([AbsolutePath.make(path.join(home, name))])
+    }),
+  )
+
+  itRead.effect("still rejects a genuinely relative path that escapes the read root", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      // A relative path that escapes the read root is a guarded defect, never expanded.
+      const exit = yield* executeTool(registry, {
+        sessionID,
+        ...toolIdentity,
+        call: { type: "tool-call", id: "call-escape", name: "read", input: { path: "../escape.txt" } },
+      }).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(readCalls).toEqual([])
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #32223.

Replaces closed PR #32263.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `~` expansion for file-tool paths.

`read`, `write`/`edit`, `glob`, `grep`, and filesystem search now resolve `~` and `~/...` through the user's home directory instead of treating `~` as a literal folder under the current project.

The expansion only handles a bare `~` or a leading `~/` / Windows `~\`. `~user` stays literal.

### How did you verify your code works?

- `bun test test/tilde-expansion.test.ts`
- `bun typecheck`
- `bunx oxlint packages/core/src/fs-util.ts packages/core/src/tool/read.ts packages/core/test/tilde-expansion.test.ts`
- `git diff --check`
- tmux smoke for `FSUtil.expandHome("~//nested/file.txt")`, confirming it stays under `$HOME`

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
